### PR TITLE
fix(graphql): declare epoch-millisecond instants so they cannot be published as Int

### DIFF
--- a/.github/workflows/check-graphql-int-range.yml
+++ b/.github/workflows/check-graphql-int-range.yml
@@ -1,0 +1,69 @@
+name: Check GraphQL Int range
+
+# Does any field GraphQL publishes as `Int` carry a value Int cannot hold?
+# (#10386)
+#
+# GraphQL's Int is 32-bit signed. An epoch-millisecond value overflows it, and
+# a non-null Int carrying one raises on every request and nulls its whole
+# surrounding object -- what `EndpointIncidentWindow.started_at` did from the
+# day the surface shipped until someone read the SDL (#10215).
+#
+# No static gate can see it. `z.int()` stamps the JS safe-integer ceiling on
+# every integer, so the declared maximum says nothing; `openapi.json` accepts
+# the value; and the component-parity gate deliberately allows Float-over-Int
+# as a widening. Only the real values expose the overflow, so this measures
+# them: every published GET route, walked beside the emitted GraphQL type.
+#
+# Out of band rather than in CI, for the same reason its four conformance
+# siblings are: it needs production data, and a check that cannot run on a
+# pull request should not pretend to.
+on:
+  schedule:
+    # Daily, and LAST of the daily sweeps so none of them is hitting the same
+    # Worker at once: check-response-conformance 06:41, check-mcp-conformance
+    # 07:17, check-graphql-conformance 07:53, check-cross-surface-values 08:31,
+    # check-operation-latency 09:23, then this.
+    - cron: "59 9 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-graphql-int-range
+  cancel-in-progress: false
+
+jobs:
+  int-range:
+    name: Measure every published value against GraphQL's Int
+    runs-on: ubuntu-latest
+    # ~200 routes with a 15s pause every 20 to stay under the anonymous rate
+    # limit is ~4 minutes; the ceiling leaves room for backoff without letting
+    # a hung fetch hold a runner all day.
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Measure every published value against GraphQL's Int
+        run: |
+          node scripts/check-graphql-int-range.ts | tee int-range.log
+          {
+            echo '## GraphQL Int range'
+            echo '```'
+            cat int-range.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "conformance:latency": "node scripts/check-operation-latency.ts",
     "conformance:adversarial": "node scripts/check-adversarial-surface.ts",
     "conformance:graphql": "node scripts/check-graphql-conformance.ts",
+    "conformance:graphql-int-range": "node scripts/check-graphql-int-range.ts",
     "conformance:mcp": "node scripts/check-mcp-conformance.ts",
     "lint": "eslint .",
     "format:check": "prettier --check .",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5915,7 +5915,7 @@ export interface components {
                 event_index: number | null;
                 extrinsic_index?: number | null;
                 method: string | null;
-                observed_at?: number | null;
+                observed_at?: components["schemas"]["EpochMillis"] | null;
                 pallet: string | null;
                 phase?: string | null;
                 /** @description Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525). */
@@ -6443,7 +6443,7 @@ export interface components {
                 event_index: number | null;
                 extrinsic_index?: number | null;
                 method: string | null;
-                observed_at?: number | null;
+                observed_at?: components["schemas"]["EpochMillis"] | null;
                 pallet: string | null;
                 phase?: string | null;
                 summary?: string | null;
@@ -7935,6 +7935,8 @@ export interface components {
             monitored_count: number;
             pool_eligible_count: number;
         };
+        /** @description An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int. */
+        EpochMillis: number;
         ErrorEnvelope: {
             data: null;
             error: {
@@ -8254,9 +8256,9 @@ export interface components {
                 incident_count: number;
                 incidents: ({
                     duration_ms: number;
-                    ended_at: number;
+                    ended_at: components["schemas"]["EpochMillis"];
                     failed_samples: number;
-                    started_at: number;
+                    started_at: components["schemas"]["EpochMillis"];
                 } & {
                     [key: string]: unknown;
                 })[];
@@ -8400,9 +8402,9 @@ export interface components {
                 incident_count: number;
                 incidents: ({
                     duration_ms: number;
-                    ended_at: number;
+                    ended_at: components["schemas"]["EpochMillis"];
                     failed_samples: number;
-                    started_at: number;
+                    started_at: components["schemas"]["EpochMillis"];
                 } & {
                     [key: string]: unknown;
                 })[];
@@ -9800,34 +9802,35 @@ export interface components {
                 avg_latency_ms: number | null;
                 errors: number;
                 requests: number;
-                ts: number;
+                /** @description Bucket start, as epoch milliseconds. */
+                ts: components["schemas"]["EpochMillis"];
             } & {
                 [key: string]: unknown;
             })[];
             /** @description What the answer is actually about, as opposed to what window was asked for. */
             coverage: {
                 /** @description Epoch ms of the newest measured event across every contributing store, or null when nothing was measured. */
-                end: number | null;
+                end: components["schemas"]["EpochMillis"] | null;
                 /** @description The sub-range summary.latency_ms p50/p95 describe, or null when nothing measured them. Counts are additive across disjoint ranges; percentiles are not, so they stay scoped to the one store that has a percentile function. */
                 latency_percentiles: ({
-                    end: number | null;
-                    start: number | null;
+                    end: components["schemas"]["EpochMillis"] | null;
+                    start: components["schemas"]["EpochMillis"] | null;
                 } & {
                     [key: string]: unknown;
                 }) | null;
                 /** @description One entry per contributing store, oldest first. Two non-adjacent entries mean the window has a hole between them that no store covers. */
                 segments: ({
                     /** @description Epoch ms of this store's newest measured event in the window. */
-                    end: number | null;
+                    end: components["schemas"]["EpochMillis"] | null;
                     /** @description Which store measured it: analytics-engine (live capture) or lakehouse (frozen history). */
                     source: string;
                     /** @description Epoch ms of this store's oldest measured event in the window. */
-                    start: number | null;
+                    start: components["schemas"]["EpochMillis"] | null;
                 } & {
                     [key: string]: unknown;
                 })[];
                 /** @description Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured. */
-                start: number | null;
+                start: components["schemas"]["EpochMillis"] | null;
             } & {
                 [key: string]: unknown;
             };
@@ -9858,7 +9861,7 @@ export interface components {
              * @description When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.
              * @example 1786099339000
              */
-            observed_at?: number | null;
+            observed_at?: components["schemas"]["EpochMillis"] | null;
             schema_version: number;
             source: string;
             /** @description Window-total rollup for RPC reverse-proxy traffic. */
@@ -11209,7 +11212,7 @@ export interface components {
             candle_count: number;
             candles: {
                 /** @description Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. */
-                bucket_start: number;
+                bucket_start: components["schemas"]["EpochMillis"];
                 /** Format: date-time */
                 bucket_start_iso: string;
                 close: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18661,9 +18661,7 @@
                 "observed_at": {
                   "anyOf": [
                     {
-                      "maximum": 9007199254740991,
-                      "minimum": -9007199254740991,
-                      "type": "integer"
+                      "$ref": "#/components/schemas/EpochMillis"
                     },
                     {
                       "type": "null"
@@ -21891,9 +21889,7 @@
                 "observed_at": {
                   "anyOf": [
                     {
-                      "maximum": 9007199254740991,
-                      "minimum": -9007199254740991,
-                      "type": "integer"
+                      "$ref": "#/components/schemas/EpochMillis"
                     },
                     {
                       "type": "null"
@@ -30202,6 +30198,12 @@
         ],
         "type": "object"
       },
+      "EpochMillis": {
+        "description": "An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int.",
+        "maximum": 9007199254740991,
+        "minimum": 0,
+        "type": "integer"
+      },
       "ErrorEnvelope": {
         "additionalProperties": false,
         "properties": {
@@ -31977,9 +31979,7 @@
                         "type": "integer"
                       },
                       "ended_at": {
-                        "maximum": 9007199254740991,
-                        "minimum": -9007199254740991,
-                        "type": "integer"
+                        "$ref": "#/components/schemas/EpochMillis"
                       },
                       "failed_samples": {
                         "maximum": 9007199254740991,
@@ -31987,9 +31987,7 @@
                         "type": "integer"
                       },
                       "started_at": {
-                        "maximum": 9007199254740991,
-                        "minimum": -9007199254740991,
-                        "type": "integer"
+                        "$ref": "#/components/schemas/EpochMillis"
                       }
                     },
                     "required": [
@@ -32835,9 +32833,7 @@
                         "type": "integer"
                       },
                       "ended_at": {
-                        "maximum": 9007199254740991,
-                        "minimum": -9007199254740991,
-                        "type": "integer"
+                        "$ref": "#/components/schemas/EpochMillis"
                       },
                       "failed_samples": {
                         "maximum": 9007199254740991,
@@ -32845,9 +32841,7 @@
                         "type": "integer"
                       },
                       "started_at": {
-                        "maximum": 9007199254740991,
-                        "minimum": -9007199254740991,
-                        "type": "integer"
+                        "$ref": "#/components/schemas/EpochMillis"
                       }
                     },
                     "required": [
@@ -39756,9 +39750,8 @@
                   "type": "integer"
                 },
                 "ts": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
+                  "$ref": "#/components/schemas/EpochMillis",
+                  "description": "Bucket start, as epoch milliseconds."
                 }
               },
               "required": [
@@ -39778,9 +39771,7 @@
               "end": {
                 "anyOf": [
                   {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/EpochMillis"
                   },
                   {
                     "type": "null"
@@ -39797,9 +39788,7 @@
                       "end": {
                         "anyOf": [
                           {
-                            "maximum": 9007199254740991,
-                            "minimum": -9007199254740991,
-                            "type": "integer"
+                            "$ref": "#/components/schemas/EpochMillis"
                           },
                           {
                             "type": "null"
@@ -39809,9 +39798,7 @@
                       "start": {
                         "anyOf": [
                           {
-                            "maximum": 9007199254740991,
-                            "minimum": -9007199254740991,
-                            "type": "integer"
+                            "$ref": "#/components/schemas/EpochMillis"
                           },
                           {
                             "type": "null"
@@ -39840,9 +39827,7 @@
                     "end": {
                       "anyOf": [
                         {
-                          "maximum": 9007199254740991,
-                          "minimum": -9007199254740991,
-                          "type": "integer"
+                          "$ref": "#/components/schemas/EpochMillis"
                         },
                         {
                           "type": "null"
@@ -39857,9 +39842,7 @@
                     "start": {
                       "anyOf": [
                         {
-                          "maximum": 9007199254740991,
-                          "minimum": -9007199254740991,
-                          "type": "integer"
+                          "$ref": "#/components/schemas/EpochMillis"
                         },
                         {
                           "type": "null"
@@ -39880,9 +39863,7 @@
               "start": {
                 "anyOf": [
                   {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/EpochMillis"
                   },
                   {
                     "type": "null"
@@ -40016,9 +39997,7 @@
           "observed_at": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": -9007199254740991,
-                "type": "integer"
+                "$ref": "#/components/schemas/EpochMillis"
               },
               {
                 "type": "null"
@@ -47585,10 +47564,8 @@
               "additionalProperties": false,
               "properties": {
                 "bucket_start": {
-                  "description": "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int.",
-                  "maximum": 9007199254740991,
-                  "minimum": -9007199254740991,
-                  "type": "integer"
+                  "$ref": "#/components/schemas/EpochMillis",
+                  "description": "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int."
                 },
                 "bucket_start_iso": {
                   "format": "date-time",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5915,7 +5915,7 @@ export interface components {
                 event_index: number | null;
                 extrinsic_index?: number | null;
                 method: string | null;
-                observed_at?: number | null;
+                observed_at?: components["schemas"]["EpochMillis"] | null;
                 pallet: string | null;
                 phase?: string | null;
                 /** @description Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525). */
@@ -6443,7 +6443,7 @@ export interface components {
                 event_index: number | null;
                 extrinsic_index?: number | null;
                 method: string | null;
-                observed_at?: number | null;
+                observed_at?: components["schemas"]["EpochMillis"] | null;
                 pallet: string | null;
                 phase?: string | null;
                 summary?: string | null;
@@ -7935,6 +7935,8 @@ export interface components {
             monitored_count: number;
             pool_eligible_count: number;
         };
+        /** @description An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int. */
+        EpochMillis: number;
         ErrorEnvelope: {
             data: null;
             error: {
@@ -8254,9 +8256,9 @@ export interface components {
                 incident_count: number;
                 incidents: ({
                     duration_ms: number;
-                    ended_at: number;
+                    ended_at: components["schemas"]["EpochMillis"];
                     failed_samples: number;
-                    started_at: number;
+                    started_at: components["schemas"]["EpochMillis"];
                 } & {
                     [key: string]: unknown;
                 })[];
@@ -8400,9 +8402,9 @@ export interface components {
                 incident_count: number;
                 incidents: ({
                     duration_ms: number;
-                    ended_at: number;
+                    ended_at: components["schemas"]["EpochMillis"];
                     failed_samples: number;
-                    started_at: number;
+                    started_at: components["schemas"]["EpochMillis"];
                 } & {
                     [key: string]: unknown;
                 })[];
@@ -9800,34 +9802,35 @@ export interface components {
                 avg_latency_ms: number | null;
                 errors: number;
                 requests: number;
-                ts: number;
+                /** @description Bucket start, as epoch milliseconds. */
+                ts: components["schemas"]["EpochMillis"];
             } & {
                 [key: string]: unknown;
             })[];
             /** @description What the answer is actually about, as opposed to what window was asked for. */
             coverage: {
                 /** @description Epoch ms of the newest measured event across every contributing store, or null when nothing was measured. */
-                end: number | null;
+                end: components["schemas"]["EpochMillis"] | null;
                 /** @description The sub-range summary.latency_ms p50/p95 describe, or null when nothing measured them. Counts are additive across disjoint ranges; percentiles are not, so they stay scoped to the one store that has a percentile function. */
                 latency_percentiles: ({
-                    end: number | null;
-                    start: number | null;
+                    end: components["schemas"]["EpochMillis"] | null;
+                    start: components["schemas"]["EpochMillis"] | null;
                 } & {
                     [key: string]: unknown;
                 }) | null;
                 /** @description One entry per contributing store, oldest first. Two non-adjacent entries mean the window has a hole between them that no store covers. */
                 segments: ({
                     /** @description Epoch ms of this store's newest measured event in the window. */
-                    end: number | null;
+                    end: components["schemas"]["EpochMillis"] | null;
                     /** @description Which store measured it: analytics-engine (live capture) or lakehouse (frozen history). */
                     source: string;
                     /** @description Epoch ms of this store's oldest measured event in the window. */
-                    start: number | null;
+                    start: components["schemas"]["EpochMillis"] | null;
                 } & {
                     [key: string]: unknown;
                 })[];
                 /** @description Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured. */
-                start: number | null;
+                start: components["schemas"]["EpochMillis"] | null;
             } & {
                 [key: string]: unknown;
             };
@@ -9858,7 +9861,7 @@ export interface components {
              * @description When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.
              * @example 1786099339000
              */
-            observed_at?: number | null;
+            observed_at?: components["schemas"]["EpochMillis"] | null;
             schema_version: number;
             source: string;
             /** @description Window-total rollup for RPC reverse-proxy traffic. */
@@ -11209,7 +11212,7 @@ export interface components {
             candle_count: number;
             candles: {
                 /** @description Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. */
-                bucket_start: number;
+                bucket_start: components["schemas"]["EpochMillis"];
                 /** Format: date-time */
                 bucket_start_iso: string;
                 close: number;

--- a/schemas-src/graphql/emit.ts
+++ b/schemas-src/graphql/emit.ts
@@ -91,6 +91,29 @@ export function componentSchemas(): Record<string, SchemaNode> {
   return generated.schemas as Record<string, SchemaNode>;
 }
 
+/**
+ * Registered components that are a SCALAR in GraphQL, not an object type.
+ *
+ * `EpochMillis` is an epoch-millisecond instant. GraphQL's `Int` is 32-bit
+ * signed and every real epoch-ms value overflows it -- 1786323600000 against a
+ * ceiling of 2147483647 -- so a non-null `Int` carrying one raises on every
+ * request and nulls its whole surrounding object (#10215). Publishing it as
+ * `Float` is the only spelling GraphQL has for the value, which is what the
+ * hand-written SDL always did.
+ *
+ * This replaces a `/_at$/` test on the field name (#10386). The name was
+ * standing in for a fact the schema never stated -- `z.int()` stamps the JS
+ * safe-integer ceiling on every integer, count and instant alike, so
+ * "maximum exceeds Int32" is true of all of them and the type genuinely
+ * cannot tell. The heuristic rescued 7 fields and missed 8 that production
+ * proves overflow, `SubnetOhlcArtifact.candles[].bucket_start` on 1371 of
+ * 1371 observed candles among them. A DURATION (`duration_ms`, `age_ms`) is a
+ * span rather than an instant and stays `z.int()` -> `Int`.
+ */
+const SCALAR_COMPONENTS: Readonly<Record<string, GraphQLScalarType>> = {
+  EpochMillis: GraphQLFloat,
+};
+
 /** `#/components/schemas/Foo` -> `Foo`; anything else -> null. */
 function refName(node: SchemaNode): string | null {
   const ref = node?.$ref;
@@ -297,6 +320,10 @@ export function emitTypes(): EmittedTypes {
 
     const ref = refName(node);
     if (ref) {
+      // Before resolving: a few registered components ARE a GraphQL scalar,
+      // and which one is a fact about the component rather than its shape.
+      const scalar = SCALAR_COMPONENTS[ref];
+      if (scalar) return scalar;
       const target = resolve(ref);
       if (!target) return JSONScalar;
       // A registered component is not necessarily an OBJECT. The registry
@@ -357,30 +384,14 @@ export function emitTypes(): EmittedTypes {
       return GraphQLString;
     }
 
-    // An INSTANT is a Float, not an Int. GraphQL's Int is 32-bit and every
-    // epoch-millisecond value overflows it -- 1786228205841 against a ceiling
-    // of 2147483647 -- so a non-null one nulls its whole parent list on every
-    // request. The hand-written SDL did exactly that on
-    // `EndpointIncidentWindow.started_at`/`ended_at`, unnoticed until #10215
-    // executed the fields; this is the rule that stops the generated SDL
-    // reintroducing it.
-    //
-    // Keyed on the FIELD NAME because the type cannot tell: `z.int()` stamps
-    // the JS safe-integer ceiling on every integer, count and instant alike,
-    // so "maximum exceeds Int32" is true of all of them. `_at` on an integer
-    // means an epoch value on this surface -- verified: the two that exist are
-    // the two that were broken. A DURATION (`duration_ms`, `age_ms`) is a span
-    // rather than an instant and stays an Int unless separately declared
-    // beyond the range.
-    //
-    // Off `path`, whose last segment IS the field name. #10269 tested
-    // `fallbackName` instead, which is the name a NESTED OBJECT would be given
-    // (`ChainEventsFeedArtifactEventsObservedAt`) and never ends in `_at` --
-    // so the rule shipped inert and the SDL fix in that change was doing all
-    // the work. The gate below is what caught it.
-    if (node.type === "integer") {
-      return /_at$/.test(path) ? GraphQLFloat : GraphQLInt;
-    }
+    // An INSTANT is a Float, not an Int -- but that is decided ABOVE, by the
+    // `EpochMillis` component, not here. Until #10386 this branch tested the
+    // field name (`/_at$/`) because a bare `z.int()` cannot say whether it
+    // holds a count or an epoch. The name rescued 7 fields and missed 8 that
+    // production proves overflow Int32, so the fact moved into the schema.
+    // Everything reaching this line is a plain integer: a count, a block
+    // height, a netuid, a duration in ms.
+    if (node.type === "integer") return GraphQLInt;
     if (node.type === "number") return GraphQLFloat;
     if (node.type === "boolean") return GraphQLBoolean;
     if (node.type === "string") return GraphQLString;

--- a/schemas-src/openapi-registry.ts
+++ b/schemas-src/openapi-registry.ts
@@ -59,6 +59,7 @@ import {
   HealthStatusSchema,
   PartnershipMetadataSchema,
   PartnershipTierSchema,
+  EpochMillisSchema,
   ScoreDistributionSchema,
   SubnetStatusSchema,
   SubnetTypeSchema,
@@ -789,6 +790,12 @@ register(ValidatorNominatorsArtifactSchema, "ValidatorNominatorsArtifact");
 // of $ref'ing the hand-edited component, so it no longer counts.)
 register(ConcentrationMetricsSchema, "ConcentrationMetrics");
 register(ScoreDistributionSchema, "ScoreDistribution");
+// An epoch-MILLISECOND instant (#10386). Registered so the schema STATES the
+// fact rather than leaving it to a field name: `z.int()` stamps the JS
+// safe-integer ceiling on every integer, count and instant alike, so the type
+// alone cannot tell one from the other, and GraphQL's Int is 32-bit. The
+// GraphQL emitter maps this id to Float; a `z.int()` stays Int.
+register(EpochMillisSchema, "EpochMillis");
 
 // Batch 8 (#8062) additions. Only the 18 top-level route artifacts (each
 // required -- schemaRefForArtifactPath binds its route to exactly this

--- a/schemas-src/routes/block-chain-events.ts
+++ b/schemas-src/routes/block-chain-events.ts
@@ -21,6 +21,7 @@
 // fully orphaned as of this batch.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { EpochMillisSchema } from "../shared.ts";
 
 const ChainEventSchema = z
   .object({
@@ -36,7 +37,7 @@ const ChainEventSchema = z
       .optional(),
     phase: z.string().nullable().optional(),
     extrinsic_index: z.int().nullable().optional(),
-    observed_at: z.int().nullable().optional(),
+    observed_at: EpochMillisSchema.nullable().optional(),
     // #8525: deterministic human-readable action sentence for this event's
     // pallet.method, or null when no template matches -- never a
     // guessed/partial sentence.

--- a/schemas-src/routes/chain-events.ts
+++ b/schemas-src/routes/chain-events.ts
@@ -20,6 +20,7 @@
 // component key becomes fully orphaned.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { EpochMillisSchema } from "../shared.ts";
 
 const ChainEventSchema = z
   .object({
@@ -35,7 +36,7 @@ const ChainEventSchema = z
       .optional(),
     phase: z.string().nullable().optional(),
     extrinsic_index: z.int().nullable().optional(),
-    observed_at: z.int().nullable().optional(),
+    observed_at: EpochMillisSchema.nullable().optional(),
     // #8525: deterministic human-readable action sentence for this event's
     // pallet.method, or null when no template matches -- never a
     // guessed/partial sentence.

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -35,7 +35,7 @@
 // dedicated, route-local HealthSubnetSurfaceSchema instead.
 import { z } from "zod";
 import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
-import { HealthStatusSchema } from "../shared.ts";
+import { EpochMillisSchema, HealthStatusSchema } from "../shared.ts";
 import { ClassificationSchema, SurfaceKindSchema } from "./subnet-detail.ts";
 import { HealthSubnetSummarySchema } from "./health.ts";
 import { HEALTH_TREND_WINDOW_VALUES } from "../../src/route-limits.ts";
@@ -180,8 +180,8 @@ export type BulkHealthTrendsQuery = z.infer<typeof BulkHealthTrendsQuerySchema>;
 
 const GlobalIncidentEntrySchema = z
   .object({
-    started_at: z.int(),
-    ended_at: z.int(),
+    started_at: EpochMillisSchema,
+    ended_at: EpochMillisSchema,
     // #8824: (ended_at - started_at) + PROBE_CADENCE_MS -- the observed
     // failed span plus one probe cadence, since the outage began sometime in
     // the interval before started_at and ended sometime in the interval
@@ -350,8 +350,8 @@ export type HealthSurface = z.infer<typeof HealthSurfaceSchema>;
 
 const HealthIncidentEntrySchema = z
   .object({
-    started_at: z.int(),
-    ended_at: z.int(),
+    started_at: EpochMillisSchema,
+    ended_at: EpochMillisSchema,
     // #8824: (ended_at - started_at) + PROBE_CADENCE_MS -- the observed
     // failed span plus one probe cadence, since the outage began sometime in
     // the interval before started_at and ended sometime in the interval

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -32,7 +32,7 @@ import {
   DisabledProxyContractSchema,
   EndpointEligibilityPolicySchema,
 } from "./endpoint-pool-policy.ts";
-import { HttpUrlSchema } from "../shared.ts";
+import { EpochMillisSchema, HttpUrlSchema } from "../shared.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import { BittensorNetworkSchema, HealthStatusSchema } from "../shared.ts";
@@ -346,7 +346,7 @@ const RpcUsageNetworkRowSchema = z
 
 const RpcUsageBucketSchema = z
   .object({
-    ts: z.int().min(0),
+    ts: EpochMillisSchema.describe("Bucket start, as epoch milliseconds."),
     requests: z.int().min(0),
     errors: z.int().min(0),
     avg_latency_ms: z.int().nullable(),
@@ -362,8 +362,8 @@ const RpcUsageBucketSchema = z
 // publishing only `window` is what let a two-hour answer ship labelled `7d`.
 const RpcUsageCoverageRangeSchema = z
   .object({
-    start: z.int().nullable(),
-    end: z.int().nullable(),
+    start: EpochMillisSchema.nullable(),
+    end: EpochMillisSchema.nullable(),
   })
   .passthrough()
   .describe("An epoch-ms span.");
@@ -375,36 +375,24 @@ const RpcUsageCoverageSegmentSchema = z
       .describe(
         "Which store measured it: analytics-engine (live capture) or lakehouse (frozen history).",
       ),
-    start: z
-      .int()
-      .nullable()
-      .describe(
-        "Epoch ms of this store's oldest measured event in the window.",
-      ),
-    end: z
-      .int()
-      .nullable()
-      .describe(
-        "Epoch ms of this store's newest measured event in the window.",
-      ),
+    start: EpochMillisSchema.nullable().describe(
+      "Epoch ms of this store's oldest measured event in the window.",
+    ),
+    end: EpochMillisSchema.nullable().describe(
+      "Epoch ms of this store's newest measured event in the window.",
+    ),
   })
   .passthrough()
   .describe("One store's contribution to an rpc_usage answer.");
 
 const RpcUsageCoverageSchema = z
   .object({
-    start: z
-      .int()
-      .nullable()
-      .describe(
-        "Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured.",
-      ),
-    end: z
-      .int()
-      .nullable()
-      .describe(
-        "Epoch ms of the newest measured event across every contributing store, or null when nothing was measured.",
-      ),
+    start: EpochMillisSchema.nullable().describe(
+      "Epoch ms of the oldest measured event across every contributing store, or null when nothing was measured.",
+    ),
+    end: EpochMillisSchema.nullable().describe(
+      "Epoch ms of the newest measured event across every contributing store, or null when nothing was measured.",
+    ),
     segments: z
       .array(RpcUsageCoverageSegmentSchema)
       .describe(
@@ -439,9 +427,7 @@ export const RpcUsageArtifactSchema = z
     // example carries a real stamp rather than a bare `1`, because the unit is
     // the whole point of the field and a placeholder integer teaches a reader
     // nothing about it.
-    observed_at: z
-      .int()
-      .nullable()
+    observed_at: EpochMillisSchema.nullable()
       .optional()
       .describe(
         "When this telemetry was observed, as epoch MILLISECONDS -- not an ISO-8601 string like this file's other observed_at fields. Request-scoped rather than build-scoped: it stamps the read, not a published artifact.",

--- a/schemas-src/routes/subnet-ohlc.ts
+++ b/schemas-src/routes/subnet-ohlc.ts
@@ -4,14 +4,17 @@
 // hand-edited SubnetOhlcArtifact/SubnetOhlcCandle components it replaces.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { EpochMillisSchema } from "../shared.ts";
 
 const SubnetOhlcCandleSchema = z
   .object({
-    bucket_start: z
-      .int()
-      .describe(
-        "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int.",
-      ),
+    // EpochMillis, not z.int(): the description already SAID "a Float, since
+    // epoch-ms exceeds GraphQL's 32-bit Int" and the emitter published Int
+    // anyway, because prose is not a fact a generator can read (#10386).
+    // Production serves 1786323600000 here on 1371 of 1371 observed candles.
+    bucket_start: EpochMillisSchema.describe(
+      "Bucket start as epoch milliseconds -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int.",
+    ),
     bucket_start_iso: z.iso.datetime(),
     open: z.number(),
     high: z.number(),

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -11,6 +11,32 @@
 import { z } from "zod";
 import { QUERY_ENUMS } from "./query-enums.ts";
 
+/**
+ * An epoch-MILLISECOND instant, published as an integer (#10386).
+ *
+ * Registered as its own component so the schema STATES that a field is an
+ * instant instead of leaving it to a spelling. GraphQL's `Int` is 32-bit
+ * signed and every real epoch-ms value overflows it -- 1786323600000 against
+ * a ceiling of 2147483647 -- and a non-null `Int` carrying one raises on
+ * every request and nulls its whole surrounding object (#10215, which
+ * `EndpointIncidentWindow.started_at` shipped with until it was found by
+ * hand). `schemas-src/graphql/emit.ts` maps this component id to `Float`.
+ *
+ * The type alone cannot tell: `z.int()` stamps the JS safe-integer ceiling on
+ * every integer, count and instant alike, so "maximum exceeds Int32" is true
+ * of all of them. The emitter stood a `/_at$/` name test in for the missing
+ * fact, which rescued 7 fields and missed 8 that production proves overflow
+ * -- `candles[].bucket_start` on 1371 of 1371 observed candles, and the six
+ * `rpc-usage` coverage bounds. Use this schema for an instant; a DURATION
+ * (`duration_ms`, `age_ms`) is a span, not an instant, and stays `z.int()`.
+ */
+export const EpochMillisSchema = z
+  .int()
+  .min(0)
+  .describe(
+    "An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int.",
+  );
+
 /** One vocabulary, owned by the leaf module so routes AND tools can import it
  * without the cycle that owning it on a route would create (#9799). */
 export const NATIVE_NAME_QUALITY_VALUES = [

--- a/scripts/check-graphql-int-range.ts
+++ b/scripts/check-graphql-int-range.ts
@@ -1,0 +1,241 @@
+// Does any field GraphQL publishes as `Int` carry a value Int cannot hold?
+// (#10386)
+//
+// GraphQL's `Int` is 32-bit signed. An epoch-millisecond value is ~1.79e12, so
+// a non-null `Int` field holding one raises on EVERY request and, because the
+// error propagates, nulls the whole surrounding object -- the #10215 class,
+// which `EndpointIncidentWindow.started_at` shipped with until someone read
+// the SDL and noticed.
+//
+// WHY NO STATIC GATE CAN SEE THIS. `z.int()` stamps the JS safe-integer
+// ceiling on every integer, count and instant alike, so "the declared maximum
+// exceeds Int32" is true of all ~1,100 of them and says nothing. The published
+// contract is equally blind: `check-response-conformance` validates against
+// `openapi.json`, where `{type: "integer", maximum: 9007199254740991}` accepts
+// 1786323600000 happily. And `validate:graphql-component-parity` deliberately
+// ALLOWS `Float`-over-`Int` as a widening, because 26 fields rely on it. The
+// overflow belongs to GraphQL's scalar alone, and only the real values expose
+// it.
+//
+// So this measures the real values. It walks each live response alongside the
+// EMITTED GraphQL type for that component, so it knows exactly which scalar a
+// leaf would be published as, and fails on any `Int` leaf beyond the range.
+// Run against production out of band, like its conformance siblings: a check
+// that needs production data should not pretend to run on a pull request.
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import {
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from "graphql";
+import type { GraphQLOutputType } from "graphql";
+import { API_ROUTES } from "../src/contracts.ts";
+import { emitTypes } from "../schemas-src/graphql/emit.ts";
+import { apiRouteUrl } from "./smoke-live-api.ts";
+
+const BASE = process.env.CONFORMANCE_API_BASE || "https://api.metagraph.sh";
+const SPEC_PATH =
+  process.env.CONFORMANCE_SPEC_PATH || "public/metagraph/openapi.json";
+
+/** GraphQL's Int is a signed 32-bit integer (graphql-js GRAPHQL_MAX_INT). */
+export const GRAPHQL_MAX_INT = 2147483647;
+
+export interface Overflow {
+  route: string;
+  /** Dotted path into the response `data`, arrays written `[]`. */
+  path: string;
+  value: number;
+  /** The component field that would be published as Int. */
+  field: string;
+}
+
+/** Only the sliver of the OpenAPI document this script reads. */
+export interface OpenApiDocument {
+  paths?: Record<
+    string,
+    {
+      get?: {
+        responses?: Record<
+          string,
+          {
+            content?: Record<
+              string,
+              {
+                schema?: {
+                  allOf?: { properties?: { data?: { $ref?: string } } }[];
+                };
+              }
+            >;
+          }
+        >;
+      };
+    }
+  >;
+}
+
+/** The component a route's `data` property refs, or null. */
+export function dataComponent(
+  openapi: OpenApiDocument,
+  route: string,
+): string | null {
+  const schema =
+    openapi.paths?.[route]?.get?.responses?.["200"]?.content?.[
+      "application/json"
+    ]?.schema;
+  for (const part of schema?.allOf ?? []) {
+    const ref = part?.properties?.data?.$ref;
+    if (typeof ref === "string")
+      return ref.replace("#/components/schemas/", "");
+  }
+  return null;
+}
+
+/**
+ * Walk a live response beside the GraphQL type that would publish it, and
+ * report every numeric leaf typed `Int` whose value is out of range.
+ *
+ * Exported so a test can drive it with a synthetic payload: a gate that has
+ * only ever run against a passing tree proves nothing.
+ */
+export function findOverflows(
+  data: unknown,
+  type: GraphQLOutputType,
+  route: string,
+  path = "",
+  typePath = "",
+): Overflow[] {
+  let current: GraphQLOutputType = type;
+  while (current instanceof GraphQLNonNull) current = current.ofType;
+
+  if (current instanceof GraphQLList) {
+    if (!Array.isArray(data)) return [];
+    return data.flatMap((item) =>
+      findOverflows(item, current.ofType, route, `${path}[]`, typePath),
+    );
+  }
+
+  if (current instanceof GraphQLObjectType) {
+    if (!data || typeof data !== "object" || Array.isArray(data)) return [];
+    const fields = current.getFields();
+    const found: Overflow[] = [];
+    for (const [key, value] of Object.entries(
+      data as Record<string, unknown>,
+    )) {
+      const field = fields[key];
+      // A key the component does not publish is REST's business, not
+      // GraphQL's -- it can never be selected, so it can never overflow.
+      if (!field) continue;
+      found.push(
+        ...findOverflows(
+          value,
+          field.type,
+          route,
+          `${path}.${key}`,
+          `${current.name}.${key}`,
+        ),
+      );
+    }
+    return found;
+  }
+
+  if (current !== GraphQLInt) return [];
+  if (typeof data !== "number" || Math.abs(data) <= GRAPHQL_MAX_INT) return [];
+  return [{ route, path: path || "(root)", value: data, field: typePath }];
+}
+
+async function main(): Promise<void> {
+  const openapi = JSON.parse(
+    readFileSync(SPEC_PATH, "utf8"),
+  ) as OpenApiDocument;
+  const { types } = emitTypes();
+  const today = new Date().toISOString().slice(0, 10);
+
+  const overflows: Overflow[] = [];
+  let checked = 0;
+  let skipped = 0;
+
+  for (const route of API_ROUTES as unknown as {
+    path: string;
+    method: string;
+  }[]) {
+    if (route.method !== "GET") continue;
+    const component = dataComponent(openapi, route.path);
+    const type = component ? types.get(component) : null;
+    if (!type) {
+      skipped += 1; // no component, or one the emitter answers no type for
+      continue;
+    }
+
+    let url: string;
+    try {
+      // The smoke runner's fixture substitutions, rather than a second set of
+      // sample ids that could drift from it.
+      url = apiRouteUrl(route.path, today);
+    } catch {
+      skipped += 1; // unsubstitutable placeholder (needs a discovered id)
+      continue;
+    }
+
+    let body: { ok?: boolean; data?: unknown } | null;
+    try {
+      const response = await fetch(new URL(url, BASE), {
+        signal: AbortSignal.timeout(30_000),
+      });
+      body = response.status === 200 ? await response.json() : null;
+    } catch {
+      skipped += 1; // network/timeout: not drift
+      continue;
+    }
+    // A degraded tier answers a schema-stable EMPTY body and passes, correctly:
+    // this measures the values that ARE served, not whether any were.
+    if (!body?.ok) {
+      skipped += 1;
+      continue;
+    }
+
+    checked += 1;
+    overflows.push(...findOverflows(body.data, type, route.path));
+
+    // Paced under the anonymous rate limit (100 req / 60s per IP).
+    if (checked % 20 === 0) await new Promise((r) => setTimeout(r, 15_000));
+  }
+
+  console.log(
+    `graphql-int-range: ${checked} route(s) measured, ${skipped} skipped, ` +
+      `${overflows.length} value(s) beyond GraphQL's Int.`,
+  );
+
+  if (overflows.length === 0) {
+    console.log("graphql-int-range: OK");
+    return;
+  }
+
+  // One line per distinct FIELD, not per value: `candles[].bucket_start`
+  // overflows on all 1,371 candles and is one bug.
+  const byField = new Map<string, { count: number; sample: Overflow }>();
+  for (const overflow of overflows) {
+    const entry = byField.get(overflow.field);
+    if (entry) entry.count += 1;
+    else byField.set(overflow.field, { count: 1, sample: overflow });
+  }
+  console.error(
+    `\n${byField.size} field(s) publish a value GraphQL's 32-bit Int cannot hold:`,
+  );
+  for (const [field, { count, sample }] of byField) {
+    console.error(
+      `  - ${field} -- ${count} value(s), e.g. ${sample.value} at ` +
+        `${sample.route}${sample.path}`,
+    );
+  }
+  console.error(
+    "\nA non-null Int field carrying one of these errors on every request and " +
+      "nulls\nits whole surrounding object. Model the field with " +
+      "`EpochMillisSchema` if it is an\ninstant, or declare the right scalar " +
+      "for it in emit.ts's SCALAR_COMPONENTS.",
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/tests/graphql-int-range.test.ts
+++ b/tests/graphql-int-range.test.ts
@@ -1,0 +1,192 @@
+// The Int-range gate (#10386): does it actually fail?
+//
+// A gate only ever run against a passing tree proves nothing, so every test
+// here drives `findOverflows` with a payload that SHOULD trip it and asserts
+// it does -- plus the emitter assertions that pin the fix itself, so an
+// `EpochMillis` field silently reverting to `z.int()` fails here rather than
+// in production on the first query that selects it.
+import { describe, expect, it } from "vitest";
+import {
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from "graphql";
+import {
+  GRAPHQL_MAX_INT,
+  dataComponent,
+  findOverflows,
+} from "../scripts/check-graphql-int-range.ts";
+import { emitTypes } from "../schemas-src/graphql/emit.ts";
+
+const EPOCH_MS = 1786323600000;
+
+const Candle = new GraphQLObjectType({
+  name: "Candle",
+  fields: {
+    bucket_start: { type: new GraphQLNonNull(GraphQLInt) },
+    safe_start: { type: new GraphQLNonNull(GraphQLFloat) },
+    event_count: { type: new GraphQLNonNull(GraphQLInt) },
+  },
+});
+const Artifact = new GraphQLObjectType({
+  name: "Artifact",
+  fields: {
+    candles: { type: new GraphQLList(new GraphQLNonNull(Candle)) },
+    netuid: { type: GraphQLInt },
+  },
+});
+
+describe("findOverflows", () => {
+  it("reports an Int field carrying an epoch-millisecond value", () => {
+    const found = findOverflows(
+      {
+        netuid: 1,
+        candles: [
+          { bucket_start: EPOCH_MS, safe_start: EPOCH_MS, event_count: 4 },
+        ],
+      },
+      Artifact,
+      "/api/v1/subnets/{netuid}/ohlc",
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0].field).toBe("Candle.bucket_start");
+    expect(found[0].value).toBe(EPOCH_MS);
+    expect(found[0].path).toBe(".candles[].bucket_start");
+  });
+
+  it("says nothing about the same value published as Float", () => {
+    const found = findOverflows(
+      { candles: [{ bucket_start: 1, safe_start: EPOCH_MS, event_count: 4 }] },
+      Artifact,
+      "/route",
+    );
+    expect(found).toEqual([]);
+  });
+
+  it("passes at the boundary and fails one past it", () => {
+    const at = findOverflows({ netuid: GRAPHQL_MAX_INT }, Artifact, "/route");
+    expect(at).toEqual([]);
+    const past = findOverflows(
+      { netuid: GRAPHQL_MAX_INT + 1 },
+      Artifact,
+      "/route",
+    );
+    expect(past).toHaveLength(1);
+  });
+
+  it("catches a NEGATIVE value past the range too", () => {
+    const found = findOverflows(
+      { netuid: -(GRAPHQL_MAX_INT + 1) },
+      Artifact,
+      "/route",
+    );
+    expect(found).toHaveLength(1);
+  });
+
+  it("reports every offending element, not just the first", () => {
+    const found = findOverflows(
+      {
+        candles: [
+          { bucket_start: EPOCH_MS, safe_start: 0, event_count: 1 },
+          { bucket_start: EPOCH_MS + 1, safe_start: 0, event_count: 1 },
+        ],
+      },
+      Artifact,
+      "/route",
+    );
+    expect(found).toHaveLength(2);
+  });
+
+  it("ignores a response key the component does not publish", () => {
+    // REST may serve more than GraphQL exposes. A key with no field can never
+    // be selected, so it can never overflow -- reporting it would be noise.
+    const found = findOverflows(
+      { rest_only_epoch: EPOCH_MS },
+      Artifact,
+      "/route",
+    );
+    expect(found).toEqual([]);
+  });
+});
+
+describe("dataComponent", () => {
+  it("reads the component a route's data property refs", () => {
+    expect(
+      dataComponent(
+        {
+          paths: {
+            "/r": {
+              get: {
+                responses: {
+                  "200": {
+                    content: {
+                      "application/json": {
+                        schema: {
+                          allOf: [
+                            {},
+                            {
+                              properties: {
+                                data: { $ref: "#/components/schemas/Thing" },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "/r",
+      ),
+    ).toBe("Thing");
+  });
+
+  it("answers null for a route with no data ref", () => {
+    expect(dataComponent({ paths: {} }, "/r")).toBeNull();
+  });
+});
+
+describe("the emitted types (#10386)", () => {
+  const { types } = emitTypes();
+
+  // The eight production proved overflow, plus the seven the deleted `_at`
+  // rule used to rescue -- named individually so a revert names the field it
+  // broke rather than a count.
+  const INSTANTS: [string, string][] = [
+    ["SubnetOhlcArtifactCandles", "bucket_start"],
+    ["RpcUsageArtifactBuckets", "ts"],
+    ["RpcUsageArtifactCoverage", "start"],
+    ["RpcUsageArtifactCoverage", "end"],
+    ["RpcUsageArtifactCoverageSegments", "start"],
+    ["RpcUsageArtifactCoverageSegments", "end"],
+    ["RpcUsageArtifactCoverageLatencyPercentiles", "start"],
+    ["RpcUsageArtifactCoverageLatencyPercentiles", "end"],
+    ["RpcUsageArtifact", "observed_at"],
+    ["GlobalIncidentsArtifactSurfacesIncidents", "started_at"],
+    ["GlobalIncidentsArtifactSurfacesIncidents", "ended_at"],
+    ["HealthIncidentsArtifactSurfacesIncidents", "started_at"],
+    ["HealthIncidentsArtifactSurfacesIncidents", "ended_at"],
+    ["ChainEventsFeedArtifactEvents", "observed_at"],
+    ["BlockChainEventsArtifactEvents", "observed_at"],
+  ];
+
+  it.each(INSTANTS)("%s.%s is a Float, not a 32-bit Int", (type, field) => {
+    const emitted = types.get(type);
+    expect(emitted, `${type} is not an emitted type`).toBeDefined();
+    expect(String(emitted!.getFields()[field]?.type)).toMatch(/^Float!?$/);
+  });
+
+  it("a DURATION stays an Int -- a span is not an instant", () => {
+    const incident = types.get("GlobalIncidentsArtifactSurfacesIncidents")!;
+    expect(String(incident.getFields().duration_ms.type)).toBe("Int!");
+  });
+
+  it("EpochMillis is a scalar, never published as an object type", () => {
+    expect(types.has("EpochMillis")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Eight fields would have been published as a 32-bit `Int` for values that overflow it. Found by measuring the emitter against **production** rather than against another schema, and fixed by putting the fact in the schema instead of in a field-name heuristic.

GraphQL's `Int` is 32-bit signed (2,147,483,647). An epoch-millisecond value is ~1.79e12, so a non-null `Int` carrying one raises on *every* request and, because the error propagates, nulls its whole surrounding object — the #10215 class that `EndpointIncidentWindow.started_at` shipped with until someone read the SDL.

`emit.ts` guarded exactly one spelling of that:

```ts
if (node.type === "integer") {
  return /_at$/.test(path) ? GraphQLFloat : GraphQLInt;
}
```

Sweeping all 204 published GET routes against `api.metagraph.sh` (200 answered) and recording every numeric leaf beyond Int32:

| leaf | observed max | occurrences |
|---|---|---|
| `SubnetOhlcArtifact.candles[].bucket_start` | 1786323600000 | 1371/1371 |
| `RpcUsageArtifact.buckets[].ts` | 1786338000000 | 163/163 |
| `RpcUsageArtifact.coverage.start` / `.end` | 1786339310000 | 1/1 each |
| `RpcUsageArtifact.coverage.segments[].start` / `.end` | 1786339310000 | 1/1 each |
| `RpcUsageArtifact.coverage.latency_percentiles.start` / `.end` | 1786339310000 | 1/1 each |

Every one is `z.int()`, so the emitter types it `Int`; every one is `Float` in the hand-written SDL. `subnet-ohlc.ts`'s own description already said *"a Float, since epoch-ms exceeds GraphQL's 32-bit Int"* — the fact was known and written in prose, where no generator could read it.

## The fix — the schema states the fact

A registered `EpochMillis` component in `schemas-src/shared.ts`, used at all 15 epoch-millisecond sites (the 8 above plus the 7 the `_at` rule rescued). `emit.ts` maps the component id to `Float` through a `SCALAR_COMPONENTS` table, and the name heuristic is deleted.

The type alone could never tell: `z.int()` stamps the JS safe-integer ceiling on every integer, count and instant alike, so "maximum exceeds Int32" is true of all ~1,100 of them. `openapi.json` gains one named component in place of 15 inline copies, so REST and MCP read the same annotation, and a DURATION (`duration_ms`, `age_ms`) stays `z.int()` → `Int`.

## And a gate that measures the real values

`scripts/check-graphql-int-range.ts` walks each live response **beside the emitted GraphQL type**, so it knows exactly which scalar a leaf would be published as, and fails on any `Int` leaf out of range. Scheduled daily at 09:59, last of the conformance sweeps.

No existing gate could have caught this: `check-response-conformance` validates against `openapi.json`, where `{type: "integer", maximum: 9007199254740991}` accepts 1786323600000 happily, and `validate:graphql-component-parity` deliberately allows `Float`-over-`Int` as a widening because 26 fields rely on it.

**Proven to fail.** With `SCALAR_COMPONENTS` disabled, against production:

```
- SubnetOhlcArtifactCandles.bucket_start -- 1371 value(s), e.g. 1778565600000
- RpcUsageArtifactBuckets.ts -- 163 value(s), e.g. 1785754800000
- GlobalIncidentsArtifactSurfacesIncidents.started_at -- 115 value(s)
- GlobalIncidentsArtifactSurfacesIncidents.ended_at -- 115 value(s)
- ChainEventsFeedArtifactEvents.observed_at -- 50 value(s)
- RpcUsageArtifact.observed_at / coverage.start / coverage.end
- RpcUsageArtifactCoverageSegments.start / .end
- RpcUsageArtifactCoverageLatencyPercentiles.start / .end
                                    ... 12 field(s)
```

With it enabled: `200 route(s) measured, 5 skipped, 0 value(s) beyond GraphQL's Int.`

`tests/graphql-int-range.test.ts` drives `findOverflows` with payloads that should trip it (including the boundary, one past it, a negative, and a key the component does not publish), and pins all 15 emitted fields as `Float` so a silent revert to `z.int()` fails here rather than on the first query that selects it.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run validate` — exit 0
- `npm run build` + `validate:contract-drift` — passed; `openapi.json`, `packages/contract/index.d.ts` and `public/metagraph/types.d.ts` regenerated and committed
- `validate:graphql-component-parity` — 321 mirrors / 2474 fields / 14 projections, OK
- `validate:published-names`, `validate:graphql-route-parity` (0 divergences), `validate:graphql-types-drift` — all pass
- `npx vitest run` — 790 files, **18,283 passed**, 11 skipped, 0 failed
- `node scripts/check-graphql-int-range.ts` against production — OK

No `src/**` or `workers/**` line changed, so there is no `codecov/patch` surface in this diff.

Closes #10386.
