### PR TITLE
feat(economics): spot alpha USD on /economics, priced from KV not a DB read (#10381)

### DIFF
--- a/src/alpha-usd-overlay.ts
+++ b/src/alpha-usd-overlay.ts
@@ -1,0 +1,147 @@
+// USD on the economics rows, applied where the tiers converge (#10381).
+//
+// Same shape as `withSpotPrice`/`withSpotPricedEconomics` in
+// src/health-serving.ts, and for the same reason: /api/v1/economics serves from
+// the live KV blob OR the R2 artifact, so a decoration applied at the seam
+// where they converge reaches both without either producer changing. Doing it
+// in the builder would decorate one tier and silently skip the other.
+//
+// ## Asked ONCE per response, not once per row
+//
+// `taoUsdUsable` is checked for the blob and the answer reused across all 129
+// subnets. Per-row checks would recompute one identical verdict 129 times, and
+// a row that forgot to ask would be indistinguishable from one that asked and
+// got a price -- both would just have a number.
+//
+// ## The instant these figures describe
+//
+// The alpha prices come from the economics capture; the rate comes from the
+// newest TAO/USD reading. Those are DIFFERENT MOMENTS, bounded by #10380's
+// staleness rule rather than pinned to each other. That is acceptable for a
+// spot figure and it is why every row carries `tao_usd_block` -- a reader can
+// see which instant the multiplier came from instead of assuming it matches
+// `block`. It stops being acceptable at series scale, which is what #10382's
+// per-bucket join exists to handle.
+
+import {
+  ALPHA_USD_FIELD_SOURCE,
+  alphaUsd,
+  taoUsdUsable,
+  type AlphaUsdUnavailable,
+  type TaoUsdReading,
+} from "./alpha-usd.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * What `alpha_market_cap_tao` multiplies, published rather than documented.
+ *
+ * `computeAlphaMarketCapTao` (scripts/lib/economics-artifacts.ts) is
+ * `alpha_price_tao x total_stake_alpha`, and the methodology doc says
+ * `total_stake_alpha` "stands in as the circulating-alpha proxy until a
+ * dedicated supply field exists".
+ *
+ * THAT ANSWER EXISTED IN THREE PLACES AND NOT IN THE PAYLOAD -- a doc, the
+ * route description, and a `hint="proxy"` in the UI. A consumer reading JSON
+ * could not discover the denominator, which is exactly the gap #10300 had to
+ * close for TAO: coinpaprika reported a market cap on ~9.61M circulating
+ * against the chain's 11.22M issuance, ~17% apart, and NEITHER WAS WRONG --
+ * they were different denominators. A market cap without its basis is not a
+ * number anyone can reconcile.
+ */
+export const ALPHA_MARKET_CAP_BASIS = "total_stake_alpha" as const;
+
+/** The `_usd` twin of a `_tao` field, and where its multiplier came from. */
+const USD_FIELDS = [
+  ["alpha_price_tao", "alpha_price_usd"],
+  ["alpha_market_cap_tao", "alpha_market_cap_usd"],
+  ["alpha_fdv_tao", "alpha_fdv_usd"],
+] as const;
+
+export interface AlphaUsdOverlay {
+  /** Absent when the index could not be used; the reason says why. */
+  tao_usd?: {
+    usd_per_tao: number;
+    block_number: number | null;
+    observed_at: string | null;
+    price_basis: string | null;
+  };
+  tao_usd_unavailable?: AlphaUsdUnavailable;
+}
+
+/**
+ * Decorate one economics row with its USD twins.
+ *
+ * A `_usd` field is EMITTED ONLY when it has a value. An explicit
+ * `alpha_price_usd: null` would be indistinguishable from a genuine zero once
+ * it reached a chart, and the blob-level `tao_usd_unavailable` already says why
+ * every row is missing them -- so absence is the honest encoding, the same
+ * choice buildTaoUsdSeries makes for `points` when a caller opts out.
+ */
+export function withAlphaUsd(
+  row: Row | null | undefined,
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+): Row | null | undefined {
+  if (!row || typeof row !== "object") return row;
+  const out: Row = { ...row };
+  // Published even when USD is unavailable: the denominator is a property of
+  // alpha_market_cap_tao, which is present either way.
+  if (row.alpha_market_cap_tao !== undefined) {
+    out.alpha_market_cap_basis = ALPHA_MARKET_CAP_BASIS;
+  }
+  for (const [taoField, usdField] of USD_FIELDS) {
+    const priced = alphaUsd(row[taoField] as number | null, reading, nowMs);
+    if (priced.ok) out[usdField] = priced.value.usd;
+  }
+  return out;
+}
+
+/**
+ * Decorate a whole economics blob.
+ *
+ * The provenance rides at the BLOB level rather than on every row: one reading
+ * priced all of them, so repeating its block 129 times would be 129 copies of
+ * one fact -- the same reasoning that keeps `pools` on
+ * /api/v1/network/tao-usd's `latest` instead of on all 2,000 points.
+ */
+export function withAlphaUsdEconomics(
+  blob: Row | null | undefined,
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+): Row | null | undefined {
+  if (!blob || typeof blob !== "object") return blob;
+  const rows = blob.subnets;
+  if (!Array.isArray(rows)) return blob;
+
+  const usable = taoUsdUsable(reading, nowMs);
+  const overlay: AlphaUsdOverlay = usable.ok
+    ? {
+        tao_usd: {
+          usd_per_tao: (reading as TaoUsdReading).usd_per_tao as number,
+          block_number: (reading as TaoUsdReading).block_number ?? null,
+          observed_at: (reading as TaoUsdReading).observed_at ?? null,
+          price_basis: (reading as TaoUsdReading).price_basis ?? null,
+        },
+      }
+    : // NAMED, not merely absent. "No USD fields" and "no USD fields BECAUSE the
+      // index has too few pools" are different answers, and only the second one
+      // tells a caller whether to retry or to stop asking.
+      { tao_usd_unavailable: usable.reason };
+
+  return {
+    ...blob,
+    ...overlay,
+    subnets: (rows as Row[]).map((row) =>
+      usable.ok ? withAlphaUsd(row, reading, nowMs) : row,
+    ),
+    field_sources: {
+      ...(typeof blob.field_sources === "object" && blob.field_sources
+        ? (blob.field_sources as Row)
+        : {}),
+      alpha_price_usd: ALPHA_USD_FIELD_SOURCE,
+      alpha_market_cap_usd: ALPHA_USD_FIELD_SOURCE,
+      alpha_fdv_usd: ALPHA_USD_FIELD_SOURCE,
+    },
+  };
+}

--- a/src/kv-keys.ts
+++ b/src/kv-keys.ts
@@ -7,3 +7,30 @@ export const KV_HEALTH_CURRENT = "health:current" as const;
 export const KV_HEALTH_RPC_POOL = "health:rpc-pool" as const;
 export const KV_HEALTH_META = "health:meta" as const;
 export const KV_ECONOMICS_CURRENT = "economics:current" as const;
+/**
+ * The newest TAO/USD reading, so a consumer can price alpha without a DB read.
+ *
+ * WHY KV AND NOT A NEON READ (#10381). `tao_usd_index` is the durable series
+ * and stays so — this is a hot-path copy of its newest row, nothing more.
+ * /api/v1/economics serves from KV (economics:current) with an R2 fallback and
+ * touches NO database; adding a Postgres read there to multiply by one number
+ * would give a hot, currently DB-free route a new dependency and a new way to
+ * fail. Written by the same minute-cadence tick that writes the row, read
+ * beside the economics blob it is composed with.
+ *
+ * Not the lakehouse either, which is worth stating because the Neon-hot /
+ * lakehouse-cold split is the right instinct nearly everywhere else here. It
+ * inverts for price data: the table is ~6 MB for eight days against the
+ * lakehouse's million-row chain tables, the dominant read is a point lookup of
+ * the newest row rather than a scan, and R2_SQL_TOKEN is bound to the main
+ * Worker only — data-api, which both writes this tick and serves /economics,
+ * cannot reach the lakehouse at all.
+ *
+ * EVENTUALLY CONSISTENT, deliberately. A reader can briefly see a rate a few
+ * seconds older than Neon's newest row, so /economics and /network/tao-usd can
+ * momentarily disagree in the last digits. Harmless at a one-minute cadence
+ * against a two-hour staleness bound — but every value carries the block it
+ * came from, so a caller comparing the two can always tell which instant each
+ * figure describes rather than having to assume they match.
+ */
+export const KV_TAO_USD_CURRENT = "tao-usd:current" as const;

--- a/tests/alpha-usd-overlay.test.ts
+++ b/tests/alpha-usd-overlay.test.ts
@@ -1,0 +1,183 @@
+// USD twins on the economics blob (#10381).
+//
+// The overlay sits where the live-KV and R2 tiers converge, so what matters is
+// that a DECLINING index leaves the blob untouched-but-explained rather than
+// half-decorated — a row carrying `alpha_price_usd: null` would be
+// indistinguishable from a genuine $0 by the time it reached a chart.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ALPHA_MARKET_CAP_BASIS,
+  withAlphaUsd,
+  withAlphaUsdEconomics,
+} from "../src/alpha-usd-overlay.ts";
+import { TAO_USD_MAX_AGE_MS, type TaoUsdReading } from "../src/alpha-usd.ts";
+
+const NOW = Date.parse("2026-08-10T06:00:00.000Z");
+const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
+
+const reading: TaoUsdReading = {
+  usd_per_tao: 200,
+  observed_at: iso(60_000),
+  block_number: 25_719_199,
+  price_basis: "wrapped_onchain_median",
+};
+
+const blob = () => ({
+  subnets: [
+    {
+      netuid: 64,
+      alpha_price_tao: 0.1,
+      alpha_market_cap_tao: 350_000,
+      alpha_fdv_tao: 1_800_000,
+    },
+    { netuid: 70, alpha_price_tao: null, alpha_market_cap_tao: 1 },
+  ],
+  field_sources: { alpha_price_tao: { kind: "measured" } },
+});
+
+describe("a usable index decorates every row", () => {
+  test("each _tao field gains its _usd twin", () => {
+    const out = withAlphaUsdEconomics(blob(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const rows = out.subnets as Record<string, unknown>[];
+    assert.equal(rows[0]!.alpha_price_usd, 0.1 * 200);
+    assert.equal(rows[0]!.alpha_market_cap_usd, 350_000 * 200);
+    assert.equal(rows[0]!.alpha_fdv_usd, 1_800_000 * 200);
+  });
+
+  test("provenance rides at the BLOB level, once", () => {
+    // One reading priced all of them; repeating its block per row would be N
+    // copies of one fact. Same reasoning that keeps `pools` on tao-usd's
+    // `latest` rather than on all 2,000 points.
+    const out = withAlphaUsdEconomics(blob(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const prov = out.tao_usd as Record<string, unknown>;
+    assert.equal(prov.usd_per_tao, 200);
+    assert.equal(prov.block_number, 25_719_199);
+    assert.equal(prov.price_basis, "wrapped_onchain_median");
+    assert.equal(out.tao_usd_unavailable, undefined);
+  });
+
+  test("a row whose alpha price is null gets NO usd field, not a null one", () => {
+    // An explicit `alpha_price_usd: null` is indistinguishable from a real $0
+    // once it reaches a chart. Absence is the honest encoding.
+    const out = withAlphaUsdEconomics(blob(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const rows = out.subnets as Record<string, unknown>[];
+    assert.equal("alpha_price_usd" in rows[1]!, false);
+    // …but its market cap, which IS present, still prices.
+    assert.equal(rows[1]!.alpha_market_cap_usd, 200);
+  });
+
+  test("field_sources marks USD reconstructed without dropping what was there", () => {
+    const out = withAlphaUsdEconomics(blob(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const fs = out.field_sources as Record<string, { kind?: string }>;
+    assert.equal(fs.alpha_price_usd?.kind, "reconstructed");
+    assert.equal(fs.alpha_market_cap_usd?.kind, "reconstructed");
+    // The blob's existing declarations survive the merge.
+    assert.equal(fs.alpha_price_tao?.kind, "measured");
+  });
+});
+
+describe("a declining index leaves the blob explained, not half-decorated", () => {
+  const decliners: Array<[string, TaoUsdReading | null, string]> = [
+    ["no reading", null, "no_index_reading"],
+    [
+      "insufficient_pools",
+      { ...reading, usd_per_tao: null, price_basis: "insufficient_pools" },
+      "index_unpriced",
+    ],
+    [
+      "stale",
+      { ...reading, observed_at: iso(TAO_USD_MAX_AGE_MS + 1) },
+      "index_stale",
+    ],
+  ];
+
+  for (const [name, r, reason] of decliners) {
+    test(`${name}: rows carry NO usd fields and the blob says why`, () => {
+      const out = withAlphaUsdEconomics(blob(), r, NOW) as Record<
+        string,
+        unknown
+      >;
+      assert.equal(out.tao_usd_unavailable, reason);
+      assert.equal(out.tao_usd, undefined);
+      for (const row of out.subnets as Record<string, unknown>[]) {
+        assert.equal("alpha_price_usd" in row, false, name);
+        assert.equal("alpha_market_cap_usd" in row, false, name);
+      }
+    });
+  }
+
+  test("the _tao fields are untouched by a declining index", () => {
+    // The USD tier failing must not cost the TAO figures, which is the whole
+    // point of composing rather than replacing.
+    const out = withAlphaUsdEconomics(blob(), null, NOW) as Record<
+      string,
+      unknown
+    >;
+    const rows = out.subnets as Record<string, unknown>[];
+    assert.equal(rows[0]!.alpha_price_tao, 0.1);
+    assert.equal(rows[0]!.alpha_market_cap_tao, 350_000);
+  });
+});
+
+describe("the market-cap basis", () => {
+  test("is published, not left to a methodology doc", () => {
+    // It lived in a doc, a route description and a UI `hint="proxy"` — three
+    // places a JSON consumer cannot read. #10300 is the precedent: a market cap
+    // without its denominator is not reconcilable, and two correct figures on
+    // different denominators sat ~17% apart.
+    const out = withAlphaUsd(
+      { alpha_market_cap_tao: 1, alpha_price_tao: 1 },
+      reading,
+      NOW,
+    ) as Record<string, unknown>;
+    assert.equal(out.alpha_market_cap_basis, ALPHA_MARKET_CAP_BASIS);
+    assert.equal(ALPHA_MARKET_CAP_BASIS, "total_stake_alpha");
+  });
+
+  test("is published even when USD is unavailable", () => {
+    // The denominator is a property of alpha_market_cap_tao, which is present
+    // either way — it does not depend on the multiplier.
+    const out = withAlphaUsdEconomics(blob(), null, NOW) as Record<
+      string,
+      unknown
+    >;
+    const rows = out.subnets as Record<string, unknown>[];
+    // The blob-level decline path leaves rows untouched, so the basis rides
+    // with the row decorator instead; assert it directly.
+    const decorated = withAlphaUsd(rows[0]!, null, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(decorated.alpha_market_cap_basis, "total_stake_alpha");
+  });
+
+  test("is absent on a row with no market cap to describe", () => {
+    const out = withAlphaUsd({ alpha_price_tao: 1 }, reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.equal("alpha_market_cap_basis" in out, false);
+  });
+});
+
+describe("shapes it must not choke on", () => {
+  test("a blob with no subnets array passes through unchanged", () => {
+    for (const bad of [null, undefined, {}, { subnets: "nope" }]) {
+      const out = withAlphaUsdEconomics(bad as never, reading, NOW);
+      assert.deepEqual(out, bad);
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -365,7 +365,7 @@ import {
   runHealthProber,
   writeSubnetSnapshot,
 } from "../src/health-prober.ts";
-import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
+import { KV_ECONOMICS_CURRENT, KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
 import { readCachedNetworkParametersSnapshot } from "../src/network-parameters.ts";
 import {
   mergeFreshness,
@@ -633,6 +633,8 @@ import { API_KEY_LOOKUP_TOKEN_HEADER } from "../src/api-key-validation.ts";
 import { foldObservations, observeRequest } from "../src/usage-rollup.ts";
 import type { UsageObservation } from "../src/usage-rollup.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import { withAlphaUsdEconomics } from "../src/alpha-usd-overlay.ts";
+import type { TaoUsdReading } from "../src/alpha-usd.ts";
 import { runLakehouseSeamWatchdog } from "../src/lakehouse-seam-watchdog.ts";
 import { runSafeModeWatchdog } from "../src/safe-mode-watchdog.ts";
 import {
@@ -7356,6 +7358,40 @@ let economicsCurrentKvMemo: {
   expiresAt: number;
 } = { env: null, value: null, expiresAt: 0 };
 
+/**
+ * The newest TAO/USD reading from KV, for pricing alpha in USD (#10381).
+ *
+ * SAME SHAPE AS readEconomicsCurrentKv below, deliberately -- same 60s
+ * per-isolate memo, same "a null is NOT memoized" rule so a cold or unbound
+ * store stays re-queried rather than being cached as absent for a minute. The
+ * two are read together on the /economics path and there is no reason for them
+ * to behave differently under the same failure.
+ */
+export const TAO_USD_CURRENT_KV_TTL_MS = 60_000;
+let taoUsdCurrentKvMemo: {
+  env: Env | null;
+  value: unknown;
+  expiresAt: number;
+} = { env: null, value: null, expiresAt: 0 };
+
+export async function readTaoUsdCurrentKv(
+  env: Env,
+  now: number = Date.now(),
+): Promise<Row | null> {
+  if (taoUsdCurrentKvMemo.env === env && now < taoUsdCurrentKvMemo.expiresAt) {
+    return taoUsdCurrentKvMemo.value as Row | null;
+  }
+  const value = await readHealthKv(env, KV_TAO_USD_CURRENT);
+  if (value !== null) {
+    taoUsdCurrentKvMemo = {
+      env,
+      value,
+      expiresAt: now + TAO_USD_CURRENT_KV_TTL_MS,
+    };
+  }
+  return value as Row | null;
+}
+
 export async function readEconomicsCurrentKv(
   env: Env,
   now: number = Date.now(),
@@ -7446,6 +7482,7 @@ registerModuleStateReset("workers/api.ts", () => {
   usageRollupBufferedAtMs = 0;
   healthMetaKvMemo = { env: null, value: null, expiresAt: 0 };
   economicsCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
+  taoUsdCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
   chainEventsDbMemo = { env: null, value: null, expiresAt: 0 };
   subnetSlugIndexByNetwork.clear();
   configureAnalytics({ readHealthMetaKv, readEconomicsCurrentKv });
@@ -7753,6 +7790,15 @@ async function handleApiRequest(
   // the one surface still without it. Both tiers pass through this point.
   if (matched.id === "economics") {
     baseData = withSpotPricedEconomics(baseData as Row) as typeof baseData;
+    // USD twins at the SAME seam (#10381): both tiers have converged by here,
+    // so this reaches the live KV blob and the R2 fallback without either
+    // producer changing. The reading comes from KV rather than Neon because
+    // this route otherwise touches no database -- see KV_TAO_USD_CURRENT.
+    baseData = withAlphaUsdEconomics(
+      baseData as Row,
+      (await readTaoUsdCurrentKv(env)) as TaoUsdReading | null,
+      Date.now(),
+    ) as typeof baseData;
   }
   // Per-subnet economics overlay (#1308): attach the live economics row so
   // /api/v1/subnets/{netuid} carries validator/miner counts, registration, stake

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -396,6 +396,7 @@ import {
 } from "../src/neurons-neon-write.ts";
 import { PASS_TABLES } from "../src/pass-completeness.ts";
 import { neonOwnsTable } from "../src/neon-write.ts";
+import { KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
 import { NEON_PRUNE_CRON, runNeonPrune } from "../src/neon-prune.ts";
 import { runTableFreshnessWatchdog } from "../src/table-freshness-watchdog.ts";
 
@@ -7622,6 +7623,40 @@ export async function writeTaoUsdIndexRow(
   return { inserted: written.length > 0 };
 }
 
+/**
+ * Mirror the newest reading into KV so /api/v1/economics can price alpha in USD
+ * without a database read (#10381).
+ *
+ * ONLY THE FIELDS A CONSUMER NEEDS TO MULTIPLY AND AUDIT: the rate, when it was
+ * taken, the block it was pinned to, and the basis. `pools` stays out -- it is
+ * the audit trail for /api/v1/network/tao-usd, where it belongs, and copying it
+ * per minute into a hot key would grow the value for a field nothing on this
+ * path reads.
+ *
+ * Best-effort throughout. A KV that refuses leaves the durable row untouched
+ * and the consumer falls back to declining a USD figure, which is the correct
+ * behaviour anyway -- see taoUsdUsable in src/alpha-usd.ts, where an absent
+ * reading is `no_index_reading` rather than a silent zero.
+ */
+async function writeTaoUsdCurrentKv(env: Env, row: TaoUsdIndexRow) {
+  const kv = env.METAGRAPH_CONTROL;
+  if (!kv?.put) return;
+  try {
+    await kv.put(
+      KV_TAO_USD_CURRENT,
+      JSON.stringify({
+        usd_per_tao: row.usd_per_tao,
+        observed_at: row.observed_at,
+        block_number: row.block_number,
+        price_basis: row.price_basis,
+      }),
+    );
+  } catch (err) {
+    // Logged, never thrown: the series is already durable by this point.
+    console.error("data-api tao-usd current KV write failed:", err);
+  }
+}
+
 export async function ingestTaoUsdIndex(
   env: Env,
   ctx?: ExecutionContext,
@@ -7654,6 +7689,12 @@ export async function ingestTaoUsdIndex(
     if (!row) return { ok: false, reason: "observation_unusable" };
 
     const { inserted } = await writeTaoUsdIndexRow(env, row, ctx);
+    // The hot-path copy, beside the durable row (#10381). Best-effort and
+    // AFTER the Neon write, in that order deliberately: KV is a cache of the
+    // series, so a KV failure must never cost a minute of the series itself.
+    // The series is what a caller can audit; this is only what saves them a
+    // database read.
+    await writeTaoUsdCurrentKv(env, row);
     return {
       ok: true,
       inserted,


### PR DESCRIPTION
Closes #10381. Sub-issue 2 of #10379, built on #10380's primitive (merged as #10389).

## Two findings shaped this

**The supply basis already had an answer.** `computeAlphaMarketCapTao` is `alpha_price_tao × total_stake_alpha`, and the methodology doc says `total_stake_alpha` *"stands in as the circulating-alpha proxy until a dedicated supply field exists"*. That answer lived in a doc, the route description, and a `hint="proxy"` in the UI — **three places a JSON consumer cannot read**. It is now `alpha_market_cap_basis` in the payload.

#10300 is why that matters: coinpaprika reported a market cap on ~9.61M circulating against the chain's 11.22M issuance, ~17% apart, and **neither was wrong**. A market cap without its denominator is not reconcilable.

**The rate comes from KV, not Neon.** `/api/v1/economics` serves from the live KV blob with an R2 fallback and touches **no database**. Adding a Postgres read to multiply by one number would give a hot, currently DB-free route a new dependency and a new way to fail. The minute-cadence tick that writes `tao_usd_index` now also mirrors its newest reading to `tao-usd:current`, through `src/kv-keys.ts` — the existing single source that exists precisely so a key cannot drift between writer and reader.

### Why not the lakehouse

Worth stating, because Neon-hot / lakehouse-cold is the right instinct nearly everywhere else here. It inverts for price data:

- **Size** — `tao_usd_index` is ~6 MB for eight days, against the lakehouse's million-row chain tables (`blocks`, `extrinsics`, `chain_events`, `account_events`).
- **Read shape** — the dominant read is a point lookup of the newest row, R2 SQL's worst case: scan budget, per-query latency, and 429s that are an **account-level** limit shared with the real lakehouse lanes.
- **Reachability** — `R2_SQL_TOKEN` is bound to the main Worker only (`wrangler.jsonc: 1`, `wrangler.data.jsonc: 0`). data-api, which both writes this tick and serves `/economics`, cannot reach the lakehouse at all.

## Uniform with what exists

- The KV reader is the **same shape** as `readEconomicsCurrentKv` — same 60s per-isolate memo, same "a null is **not** memoized" rule so a cold store stays re-queried — and registered for module-state reset beside it.
- The overlay is the **same shape** as `withSpotPricedEconomics` and applied at the **same seam**, where the live and R2 tiers converge, so it reaches both without either producer changing.

## Three decisions worth naming

**A `_usd` field is emitted only when it has a value.** An explicit `alpha_price_usd: null` is indistinguishable from a real $0 once it reaches a chart. Absence is the honest encoding — and the blob-level `tao_usd_unavailable` names *why*, because "no USD" and "no USD because the index has too few pools" tell a caller different things about whether to retry.

**The index is asked once per response, not once per row.** 129 rows would recompute one identical verdict, and a row that forgot to ask would look exactly like a row that asked and got a price.

**Provenance rides at the blob level** — one reading priced all of them, so repeating its block per row is N copies of one fact. Same reasoning that keeps `pools` on tao-usd's `latest` rather than on all 2,000 points.

The KV write is best-effort and **after** the Neon write: KV is a cache of the series, so a KV failure must never cost a minute of the series itself.

## Tests

12, declining paths first — including that a declining index leaves the `_tao` figures **untouched**, which is the point of composing rather than replacing.

`tsc`, `lint`, `format:check`, `validate:unreferenced-modules`, `validate:contract-drift`, `validate:module-state-resets` all clean; the 160-test economics suite passes.

## Known, and stated rather than discovered

KV is eventually consistent, so `/economics` and `/network/tao-usd` can momentarily disagree in the last digits. Harmless at a one-minute cadence against a two-hour staleness bound — and every figure carries `tao_usd_block`, so a caller comparing the two can see which instant each describes rather than assuming they match.