### PR TITLE
fix(graphql): serve call_args decoded, as REST and MCP do

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2212,8 +2212,8 @@ export type EvmAddressMapping = {
 export type Extrinsic = {
   __typename?: 'Extrinsic';
   block_number?: Maybe<Scalars['Int']['output']>;
-  /** JSON-encoded decoded call arguments. */
-  call_args?: Maybe<Scalars['String']['output']>;
+  /** Decoded call arguments, as REST and MCP serve them: a list of {name, type, value} objects for a keyed call, or the positional tuple for one that has no names. Served as the JSON scalar rather than a JSON-encoded String (#10391) so all three surfaces answer the same shape -- ChainEvent.args, which carries the same duality, was already JSON. */
+  call_args?: Maybe<Scalars['JSON']['output']>;
   call_function?: Maybe<Scalars['String']['output']>;
   call_module?: Maybe<Scalars['String']['output']>;
   extrinsic_hash?: Maybe<Scalars['String']['output']>;
@@ -8957,7 +8957,7 @@ export type EvmAddressMappingResolvers<ContextType = GqlContext, ParentType exte
 
 export type ExtrinsicResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Extrinsic'] = ResolversParentTypes['Extrinsic']> = ResolversObject<{
   block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  call_args?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  call_args?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   call_function?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   call_module?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   extrinsic_hash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3936,8 +3936,8 @@ export const SDL = /* GraphQL */ `
     signer: String
     call_module: String
     call_function: String
-    "JSON-encoded decoded call arguments."
-    call_args: String
+    "Decoded call arguments, as REST and MCP serve them: a list of {name, type, value} objects for a keyed call, or the positional tuple for one that has no names. Served as the JSON scalar rather than a JSON-encoded String (#10391) so all three surfaces answer the same shape -- ChainEvent.args, which carries the same duality, was already JSON."
+    call_args: JSON
     success: Boolean
     fee_tao: Float
     tip_tao: Float

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1833,11 +1833,6 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
   };
 }
 
-// formatExtrinsic's call_args is a decoded JS value (object/array/null), but
-// the SDL exposes it as an opaque JSON-encoded String (no custom JSON scalar
-// exists in this schema yet) -- stringify it here rather than letting
-// graphql-js' default String serializer coerce the object via `String(...)`
-// (which would silently produce "[object Object]").
 // REST's turnoverChangeDetail block, normalized into the SubnetTurnoverChanges
 // type. Absent when the caller did not set the changes toggle and on the cold
 // buildTurnover([]) fallback, both of which resolve the field to null rather
@@ -1881,13 +1876,19 @@ function turnoverChangesNode(detail: Row | null | undefined) {
   };
 }
 
+// A malformed/absent row resolves to null rather than an empty object, which
+// is what the nullable `Extrinsic` positions expect.
+//
+// `call_args` used to be JSON.stringify'd here, because the SDL declared it a
+// String and graphql-js' String serializer would have coerced the decoded
+// object via `String(...)` into "[object Object]". It is the JSON scalar now
+// (#10391): REST and MCP both serve the decoded value, GraphQL served a
+// JSON-encoded copy of it, and the comment justifying that said "no custom
+// JSON scalar exists in this schema yet" -- `scalar JSON` is the SDL's first
+// declaration and 116 fields already use it, `ChainEvent.args` (the sibling
+// with the same object-or-array duality) among them.
 function extrinsicNode(extrinsic: Row) {
-  if (!extrinsic) return null;
-  return {
-    ...extrinsic,
-    call_args:
-      extrinsic.call_args == null ? null : JSON.stringify(extrinsic.call_args),
-  };
+  return extrinsic ?? null;
 }
 
 // buildGlobalValidators' per-hotkey entries carry featured/uid_count/
@@ -7397,8 +7398,8 @@ const rootValue = {
         offset: safeOffset,
         nextCursor: null,
       });
-    // Reuse extrinsicNode (the same mapper the extrinsics feed uses) so
-    // call_args is JSON-encoded to the String field identically here.
+    // Reuse extrinsicNode (the same mapper the extrinsics feed uses) so a
+    // malformed row degrades identically here.
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4043,7 +4043,7 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     });
   });
 
-  test("sudo: resolves Postgres-tier rows from the Sudo feed, JSON-encoding call_args", async () => {
+  test("sudo: resolves Postgres-tier rows from the Sudo feed, serving call_args decoded", async () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: dataApi(
@@ -4081,10 +4081,9 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     const item = body.data.sudo.items[0];
     assert.equal(item.call_module, "Sudo");
     assert.equal(item.success, true);
-    assert.equal(
-      item.call_args,
-      JSON.stringify([{ name: "call", value: "setWeights" }]),
-    );
+    // Decoded, exactly as REST and MCP serve it -- the JSON scalar carries
+    // the value rather than a JSON-encoded copy of it (#10391).
+    assert.deepEqual(item.call_args, [{ name: "call", value: "setWeights" }]);
   });
 
   test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module", async () => {
@@ -4285,7 +4284,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     });
   });
 
-  test("extrinsics: resolves Postgres-tier rows, JSON-encoding call_args", async () => {
+  test("extrinsics: resolves Postgres-tier rows, serving call_args decoded", async () => {
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: dataApi(
@@ -4323,10 +4322,8 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     const item = body.data.extrinsics.items[0];
     assert.equal(item.call_module, "SubtensorModule");
     assert.equal(item.success, true);
-    assert.equal(
-      item.call_args,
-      JSON.stringify([{ name: "netuid", value: 1 }]),
-    );
+    // Decoded, exactly as REST and MCP serve it (#10391).
+    assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
   });
 
   test("extrinsics: exposes the action-sentence summary field, and null for an unmatched call (#8525)", async () => {
@@ -4677,10 +4674,8 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     assert.equal(item.call_module, "AdminUtils");
     assert.equal(item.call_function, "sudo_set_weights_set_rate_limit");
     assert.equal(item.success, true);
-    assert.equal(
-      item.call_args,
-      JSON.stringify([{ name: "netuid", value: 1 }]),
-    );
+    // Decoded, exactly as REST and MCP serve it (#10391).
+    assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
   });
 
   test("governance_config_changes: a partial Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -8325,10 +8320,8 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
     assert.equal(item.call_module, "SubtensorModule");
     assert.equal(item.call_function, "register");
     assert.equal(item.success, true);
-    assert.equal(
-      item.call_args,
-      JSON.stringify([{ name: "netuid", value: 1 }]),
-    );
+    // Decoded, exactly as REST and MCP serve it (#10391).
+    assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
   });
 
   test("ss58 + pagination/block-range args are forwarded on the Postgres-tier request path", async () => {


### PR DESCRIPTION
## Summary

The same field, two shapes, measured against production:

```
REST     GET /api/v1/extrinsics?limit=1  ->  call_args: array(1)
GraphQL  { extrinsics(limit:1){ items { call_args } } }
                                         ->  call_args: "[{\"name\":\"transaction\",…"
```

REST and MCP serve the decoded value — a list of `{name, type, value}` argument objects. GraphQL served a JSON-encoded string of it, and the schema said `String`, which truthfully describes what is sent and misleads about what it means: a caller reading both surfaces has to know that one needs a second `JSON.parse`.

The reason recorded in `src/graphql.ts` had gone stale:

> the SDL exposes it as an opaque JSON-encoded String (**no custom JSON scalar exists in this schema yet**)

`scalar JSON` is the SDL's **first declaration** and 116 fields already use it — `ChainEvent.args`, the sibling carrying the identical object-or-array duality (`decodeChainEventArgs`, #8825), among them. The stringify was right when it was written and outlived its reason; the `[object Object]` hazard it guarded against is exactly what the `JSON` scalar removes.

The Zod agrees with REST: `call_args: z.unknown()` in `account-extrinsics.ts` and `extrinsics.ts`, which the emitter types `JSON`. So the generated SDL already wants `JSON` here, and #10214 could not cut over while the resolver stringified.

## Change

- `Extrinsic.call_args: JSON` in the SDL, with a description saying what the value is rather than how it is encoded.
- `extrinsicNode()` drops the `JSON.stringify` and keeps only its null guard; both stale comments replaced with why the field is `JSON`.
- The four tests that asserted the encoded form now assert the decoded one.

Affects every field of type `Extrinsic`: `extrinsics`, `account_extrinsics`, `block_extrinsics`, `extrinsic`, `sudo`, `governance_config_changes`, and their `{network}` twins.

**This is a published-shape change.** A client currently receiving a string will receive the parsed value. It is the direction that makes GraphQL agree with the other two surfaces rather than diverge from them (#10217), and landing it on its own rather than inside the generator cutover is deliberate — a shape change buried in a 5,000-line regeneration is one nobody can review.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run build:graphql-types` — `generated/graphql/types.ts` regenerated and committed; `validate:graphql-types-drift` current
- `validate:graphql-route-parity` — 162 pairs, 1153 fields, 0 divergences
- `validate:graphql-component-parity` — 321 mirrors / 2474 fields, OK
- `validate:published-names`, `validate:graphql-hand-written-checks` (245 of 245) — pass
- `npx vitest run tests/graphql.test.ts` — 1100 passed
- Patch coverage: the one changed executable line in `src/**` is `return extrinsic ?? null;` — statement hit 9×, both `??` branches hit (9 / 2) by `tests/graphql.test.ts` alone.

Closes #10391.
