### PR TITLE
feat(economics): price the alpha series in USD per bucket, never retroactively

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5579,7 +5579,7 @@ export type SubnetOhlc = {
   interval?: Maybe<Scalars['String']['output']>;
   netuid: Scalars['Int']['output'];
   /** How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect. */
-  priced_candle_count: Scalars['Int']['output'];
+  priced_candle_count?: Maybe<Scalars['Int']['output']>;
   /** True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
   root_excluded: Scalars['Boolean']['output'];
   schema_version: Scalars['Int']['output'];
@@ -10382,7 +10382,7 @@ export type SubnetOhlcResolvers<ContextType = GqlContext, ParentType extends Res
   field_sources_usd?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   interval?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  priced_candle_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priced_candle_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   root_excluded?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   usd_available_from?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1955,7 +1955,13 @@ export type EconomicsTrends = {
   __typename?: 'EconomicsTrends';
   day_count: Scalars['Int']['output'];
   days: Array<EconomicsTrendsDay>;
+  field_sources_usd?: Maybe<Scalars['JSON']['output']>;
+  priced_day_count?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
+  /** The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop. */
+  usd_available_from?: Maybe<Scalars['String']['output']>;
+  /** Why NO day could be priced, or null. read_failed means the index could not be queried, which is not a claim about the index itself. */
+  usd_unavailable?: Maybe<Scalars['String']['output']>;
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -1964,12 +1970,17 @@ export type EconomicsTrendsDay = {
   __typename?: 'EconomicsTrendsDay';
   alpha_price_tao_median?: Maybe<Scalars['Float']['output']>;
   alpha_price_tao_weighted?: Maybe<Scalars['Float']['output']>;
+  alpha_price_usd_median?: Maybe<Scalars['Float']['output']>;
+  /** USD twins, null for any day older than tao_usd_index. */
+  alpha_price_usd_weighted?: Maybe<Scalars['Float']['output']>;
   mean_emission_share?: Maybe<Scalars['Float']['output']>;
   miner_count?: Maybe<Scalars['Int']['output']>;
   snapshot_date: Scalars['String']['output'];
   subnet_count: Scalars['Int']['output'];
   /** Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
   total_stake_alpha?: Maybe<Scalars['String']['output']>;
+  /** The TAO/USD rate this day's _usd fields were multiplied by -- the last reading observed inside that UTC day. */
+  usd_per_tao?: Maybe<Scalars['Float']['output']>;
   validator_count?: Maybe<Scalars['Int']['output']>;
 };
 
@@ -5563,12 +5574,20 @@ export type SubnetOhlc = {
   /** How many candles the WINDOW holds, not how many this page carries. A limit narrows the candle list from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page. */
   candle_count: Scalars['Int']['output'];
   candles: Array<SubnetOhlcCandle>;
+  field_sources_usd?: Maybe<Scalars['JSON']['output']>;
   /** The resolved bucket interval (1h/1d). */
   interval?: Maybe<Scalars['String']['output']>;
   netuid: Scalars['Int']['output'];
+  /** How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect. */
+  priced_candle_count: Scalars['Int']['output'];
   /** True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
   root_excluded: Scalars['Boolean']['output'];
   schema_version: Scalars['Int']['output'];
+  /** Bucket start of the OLDEST candle carrying USD, or null when none does -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. Published so a caller can render 'USD from <date>' rather than infer the boundary from where the nulls stop. */
+  usd_available_from?: Maybe<Scalars['Float']['output']>;
+  usd_available_from_iso?: Maybe<Scalars['String']['output']>;
+  /** Why NO candle could be priced, or null. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; read_failed means the index could not be queried at all. */
+  usd_unavailable?: Maybe<Scalars['String']['output']>;
 };
 
 export type SubnetOhlcCandle = {
@@ -5577,12 +5596,20 @@ export type SubnetOhlcCandle = {
   bucket_start: Scalars['Float']['output'];
   bucket_start_iso?: Maybe<Scalars['String']['output']>;
   close?: Maybe<Scalars['Float']['output']>;
+  close_usd?: Maybe<Scalars['Float']['output']>;
   event_count: Scalars['Int']['output'];
   high?: Maybe<Scalars['Float']['output']>;
+  high_usd?: Maybe<Scalars['Float']['output']>;
   low?: Maybe<Scalars['Float']['output']>;
+  low_usd?: Maybe<Scalars['Float']['output']>;
   open?: Maybe<Scalars['Float']['output']>;
+  /** USD twins, null for a candle older than tao_usd_index rather than converted at today's rate. */
+  open_usd?: Maybe<Scalars['Float']['output']>;
+  /** The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering survives the conversion. */
+  usd_per_tao?: Maybe<Scalars['Float']['output']>;
   volume_alpha?: Maybe<Scalars['Float']['output']>;
   volume_tao?: Maybe<Scalars['Float']['output']>;
+  volume_usd?: Maybe<Scalars['Float']['output']>;
 };
 
 /** Every automatic ownership transfer one subnet has undergone, decoded from the chain_events SubnetOwnerChanged stream. Mirrors GET /api/v1/subnets/{netuid}/ownership-history. */
@@ -8758,18 +8785,25 @@ export type EconomicsSummaryResolvers<ContextType = GqlContext, ParentType exten
 export type EconomicsTrendsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EconomicsTrends'] = ResolversParentTypes['EconomicsTrends']> = ResolversObject<{
   day_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   days?: Resolver<Array<ResolversTypes['EconomicsTrendsDay']>, ParentType, ContextType>;
+  field_sources_usd?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  priced_day_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  usd_available_from?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  usd_unavailable?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type EconomicsTrendsDayResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EconomicsTrendsDay'] = ResolversParentTypes['EconomicsTrendsDay']> = ResolversObject<{
   alpha_price_tao_median?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_tao_weighted?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_price_usd_median?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_price_usd_weighted?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   mean_emission_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   miner_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   snapshot_date?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_stake_alpha?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  usd_per_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 }>;
 
@@ -10345,22 +10379,33 @@ export type SubnetMoversNetworkResolvers<ContextType = GqlContext, ParentType ex
 export type SubnetOhlcResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOhlc'] = ResolversParentTypes['SubnetOhlc']> = ResolversObject<{
   candle_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   candles?: Resolver<Array<ResolversTypes['SubnetOhlcCandle']>, ParentType, ContextType>;
+  field_sources_usd?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   interval?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priced_candle_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   root_excluded?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  usd_available_from?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  usd_available_from_iso?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  usd_unavailable?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type SubnetOhlcCandleResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOhlcCandle'] = ResolversParentTypes['SubnetOhlcCandle']> = ResolversObject<{
   bucket_start?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   bucket_start_iso?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   close?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  close_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   event_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   high?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  high_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   low?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  low_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   open?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  open_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  usd_per_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   volume_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   volume_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type SubnetOwnershipHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOwnershipHistory'] = ResolversParentTypes['SubnetOwnershipHistory']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11230,22 +11230,22 @@ export interface components {
                 /** Format: date-time */
                 bucket_start_iso: string;
                 close: number;
-                close_usd: number | null;
+                close_usd?: number | null;
                 event_count: number;
                 high: number;
-                high_usd: number | null;
+                high_usd?: number | null;
                 low: number;
-                low_usd: number | null;
+                low_usd?: number | null;
                 open: number;
-                open_usd: number | null;
+                open_usd?: number | null;
                 /** @description The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion. */
-                usd_per_tao: number | null;
+                usd_per_tao?: number | null;
                 volume_alpha: number;
                 volume_tao: number;
-                volume_usd: number | null;
+                volume_usd?: number | null;
             }[];
             /** @description Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read. */
-            field_sources_usd: {
+            field_sources_usd?: {
                 /** @constant */
                 kind: "reconstructed";
                 storage: null;
@@ -11257,15 +11257,15 @@ export interface components {
             interval: "1h" | "1d";
             netuid: number;
             /** @description How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect. */
-            priced_candle_count: number;
+            priced_candle_count?: number;
             /** @description True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
             root_excluded: boolean;
             schema_version: number;
             /** @description Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along. */
-            usd_available_from: components["schemas"]["EpochMillis"] | null;
-            usd_available_from_iso: string | null;
+            usd_available_from?: components["schemas"]["EpochMillis"] | null;
+            usd_available_from_iso?: string | null;
             /** @description Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from. */
-            usd_unavailable: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
+            usd_unavailable?: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
         };
         SubnetOverviewArtifact: {
             contract_version?: string;
@@ -42791,18 +42791,12 @@ export interface operations {
                      *             "bucket_start": 1,
                      *             "bucket_start_iso": "2026-06-01T00:00:00.000Z",
                      *             "close": 0.5,
-                     *             "close_usd": 0.5,
                      *             "event_count": 1,
                      *             "high": 0.5,
-                     *             "high_usd": 0.5,
                      *             "low": 0.5,
-                     *             "low_usd": 0.5,
                      *             "open": 0.5,
-                     *             "open_usd": 0.5,
-                     *             "usd_per_tao": 0.5,
                      *             "volume_alpha": 0.5,
-                     *             "volume_tao": 0.5,
-                     *             "volume_usd": 0.5
+                     *             "volume_tao": 0.5
                      *           }
                      *         ],
                      *         "field_sources_usd": {

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7607,15 +7607,29 @@ export interface components {
             days: {
                 alpha_price_tao_median?: number | null;
                 alpha_price_tao_weighted?: number | null;
+                alpha_price_usd_median?: number | null;
+                alpha_price_usd_weighted?: number | null;
                 mean_emission_share?: number | null;
                 miner_count?: number | null;
                 snapshot_date: string;
                 subnet_count: number;
                 /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
                 total_stake_alpha?: string | null;
+                /** @description The TAO/USD rate this day's _usd fields were multiplied by -- the last reading observed inside that UTC day. */
+                usd_per_tao?: number | null;
                 validator_count?: number | null;
             }[];
+            field_sources_usd?: {
+                /** @constant */
+                kind: "reconstructed";
+                storage: null;
+            };
+            priced_day_count?: number;
             schema_version: number;
+            /** @description The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop. */
+            usd_available_from?: string | null;
+            /** @description Why NO day could be priced, or null. `read_failed` means the index could not be queried, which is not a claim about the index itself. */
+            usd_unavailable?: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -11216,22 +11230,42 @@ export interface components {
                 /** Format: date-time */
                 bucket_start_iso: string;
                 close: number;
+                close_usd: number | null;
                 event_count: number;
                 high: number;
+                high_usd: number | null;
                 low: number;
+                low_usd: number | null;
                 open: number;
+                open_usd: number | null;
+                /** @description The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion. */
+                usd_per_tao: number | null;
                 volume_alpha: number;
                 volume_tao: number;
+                volume_usd: number | null;
             }[];
+            /** @description Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read. */
+            field_sources_usd: {
+                /** @constant */
+                kind: "reconstructed";
+                storage: null;
+            };
             /**
              * @description The resolved bucket interval (1h/1d).
              * @enum {string}
              */
             interval: "1h" | "1d";
             netuid: number;
+            /** @description How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect. */
+            priced_candle_count: number;
             /** @description True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
             root_excluded: boolean;
             schema_version: number;
+            /** @description Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along. */
+            usd_available_from: components["schemas"]["EpochMillis"] | null;
+            usd_available_from_iso: string | null;
+            /** @description Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from. */
+            usd_unavailable: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
         };
         SubnetOverviewArtifact: {
             contract_version?: string;
@@ -30180,7 +30214,14 @@ export interface operations {
                      *             "subnet_count": 1
                      *           }
                      *         ],
+                     *         "field_sources_usd": {
+                     *           "kind": "reconstructed",
+                     *           "storage": null
+                     *         },
+                     *         "priced_day_count": 1,
                      *         "schema_version": 1,
+                     *         "usd_available_from": "example",
+                     *         "usd_unavailable": "no_index_reading",
                      *         "window": "30d"
                      *       },
                      *       "meta": {
@@ -42750,18 +42791,32 @@ export interface operations {
                      *             "bucket_start": 1,
                      *             "bucket_start_iso": "2026-06-01T00:00:00.000Z",
                      *             "close": 0.5,
+                     *             "close_usd": 0.5,
                      *             "event_count": 1,
                      *             "high": 0.5,
+                     *             "high_usd": 0.5,
                      *             "low": 0.5,
+                     *             "low_usd": 0.5,
                      *             "open": 0.5,
+                     *             "open_usd": 0.5,
+                     *             "usd_per_tao": 0.5,
                      *             "volume_alpha": 0.5,
-                     *             "volume_tao": 0.5
+                     *             "volume_tao": 0.5,
+                     *             "volume_usd": 0.5
                      *           }
                      *         ],
+                     *         "field_sources_usd": {
+                     *           "kind": "reconstructed",
+                     *           "storage": null
+                     *         },
                      *         "interval": "1h",
                      *         "netuid": 7,
+                     *         "priced_candle_count": 1,
                      *         "root_excluded": false,
-                     *         "schema_version": 1
+                     *         "schema_version": 1,
+                     *         "usd_available_from": 1,
+                     *         "usd_available_from_iso": "2026-06-01T00:00:00.000Z",
+                     *         "usd_unavailable": "no_index_reading"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10101,18 +10101,12 @@
                 "bucket_start": 1,
                 "bucket_start_iso": "2026-06-01T00:00:00.000Z",
                 "close": 0.5,
-                "close_usd": 0.5,
                 "event_count": 1,
                 "high": 0.5,
-                "high_usd": 0.5,
                 "low": 0.5,
-                "low_usd": 0.5,
                 "open": 0.5,
-                "open_usd": 0.5,
-                "usd_per_tao": 0.5,
                 "volume_alpha": 0.5,
-                "volume_tao": 0.5,
-                "volume_usd": 0.5
+                "volume_tao": 0.5
               }
             ],
             "field_sources_usd": {
@@ -47770,13 +47764,7 @@
                 "close",
                 "volume_alpha",
                 "volume_tao",
-                "event_count",
-                "open_usd",
-                "high_usd",
-                "low_usd",
-                "close_usd",
-                "volume_usd",
-                "usd_per_tao"
+                "event_count"
               ],
               "type": "object"
             },
@@ -47876,12 +47864,7 @@
           "interval",
           "candles",
           "candle_count",
-          "root_excluded",
-          "usd_available_from",
-          "usd_available_from_iso",
-          "priced_candle_count",
-          "usd_unavailable",
-          "field_sources_usd"
+          "root_excluded"
         ],
         "type": "object"
       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4963,7 +4963,14 @@
                 "subnet_count": 1
               }
             ],
+            "field_sources_usd": {
+              "kind": "reconstructed",
+              "storage": null
+            },
+            "priced_day_count": 1,
             "schema_version": 1,
+            "usd_available_from": "example",
+            "usd_unavailable": "no_index_reading",
             "window": "30d"
           },
           "meta": {
@@ -10094,18 +10101,32 @@
                 "bucket_start": 1,
                 "bucket_start_iso": "2026-06-01T00:00:00.000Z",
                 "close": 0.5,
+                "close_usd": 0.5,
                 "event_count": 1,
                 "high": 0.5,
+                "high_usd": 0.5,
                 "low": 0.5,
+                "low_usd": 0.5,
                 "open": 0.5,
+                "open_usd": 0.5,
+                "usd_per_tao": 0.5,
                 "volume_alpha": 0.5,
-                "volume_tao": 0.5
+                "volume_tao": 0.5,
+                "volume_usd": 0.5
               }
             ],
+            "field_sources_usd": {
+              "kind": "reconstructed",
+              "storage": null
+            },
             "interval": "1h",
             "netuid": 7,
+            "priced_candle_count": 1,
             "root_excluded": false,
-            "schema_version": 1
+            "schema_version": 1,
+            "usd_available_from": 1,
+            "usd_available_from_iso": "2026-06-01T00:00:00.000Z",
+            "usd_unavailable": "no_index_reading"
           },
           "meta": {
             "artifact_path": "example",
@@ -28489,6 +28510,26 @@
                     }
                   ]
                 },
+                "alpha_price_usd_median": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "alpha_price_usd_weighted": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "mean_emission_share": {
                   "anyOf": [
                     {
@@ -28531,6 +28572,17 @@
                   ],
                   "description": "Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float."
                 },
+                "usd_per_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The TAO/USD rate this day's _usd fields were multiplied by -- the last reading observed inside that UTC day."
+                },
                 "validator_count": {
                   "anyOf": [
                     {
@@ -28552,10 +28604,61 @@
             },
             "type": "array"
           },
+          "field_sources_usd": {
+            "additionalProperties": false,
+            "properties": {
+              "kind": {
+                "const": "reconstructed",
+                "type": "string"
+              },
+              "storage": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "kind",
+              "storage"
+            ],
+            "type": "object"
+          },
+          "priced_day_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "schema_version": {
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
             "type": "integer"
+          },
+          "usd_available_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop."
+          },
+          "usd_unavailable": {
+            "anyOf": [
+              {
+                "enum": [
+                  "no_index_reading",
+                  "index_unpriced",
+                  "index_stale",
+                  "no_alpha_price",
+                  "read_failed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Why NO day could be priced, or null. `read_failed` means the index could not be queried, which is not a claim about the index itself."
           },
           "window": {
             "anyOf": [
@@ -47575,6 +47678,16 @@
                 "close": {
                   "type": "number"
                 },
+                "close_usd": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "event_count": {
                   "maximum": 9007199254740991,
                   "minimum": 0,
@@ -47583,11 +47696,52 @@
                 "high": {
                   "type": "number"
                 },
+                "high_usd": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "low": {
                   "type": "number"
                 },
+                "low_usd": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "open": {
                   "type": "number"
+                },
+                "open_usd": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "usd_per_tao": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion."
                 },
                 "volume_alpha": {
                   "minimum": 0,
@@ -47595,6 +47749,16 @@
                 },
                 "volume_tao": {
                   "type": "number"
+                },
+                "volume_usd": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -47606,11 +47770,35 @@
                 "close",
                 "volume_alpha",
                 "volume_tao",
-                "event_count"
+                "event_count",
+                "open_usd",
+                "high_usd",
+                "low_usd",
+                "close_usd",
+                "volume_usd",
+                "usd_per_tao"
               ],
               "type": "object"
             },
             "type": "array"
+          },
+          "field_sources_usd": {
+            "additionalProperties": false,
+            "description": "Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read.",
+            "properties": {
+              "kind": {
+                "const": "reconstructed",
+                "type": "string"
+              },
+              "storage": {
+                "type": "null"
+              }
+            },
+            "required": [
+              "kind",
+              "storage"
+            ],
+            "type": "object"
           },
           "interval": {
             "description": "The resolved bucket interval (1h/1d).",
@@ -47625,6 +47813,12 @@
             "minimum": 0,
             "type": "integer"
           },
+          "priced_candle_count": {
+            "description": "How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect.",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "root_excluded": {
             "description": "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted.",
             "type": "boolean"
@@ -47633,6 +47827,47 @@
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
             "type": "integer"
+          },
+          "usd_available_from": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EpochMillis"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along."
+          },
+          "usd_available_from_iso": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "usd_unavailable": {
+            "anyOf": [
+              {
+                "enum": [
+                  "no_index_reading",
+                  "index_unpriced",
+                  "index_stale",
+                  "no_alpha_price",
+                  "read_failed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from."
           }
         },
         "required": [
@@ -47641,7 +47876,12 @@
           "interval",
           "candles",
           "candle_count",
-          "root_excluded"
+          "root_excluded",
+          "usd_available_from",
+          "usd_available_from_iso",
+          "priced_candle_count",
+          "usd_unavailable",
+          "field_sources_usd"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11230,22 +11230,22 @@ export interface components {
                 /** Format: date-time */
                 bucket_start_iso: string;
                 close: number;
-                close_usd: number | null;
+                close_usd?: number | null;
                 event_count: number;
                 high: number;
-                high_usd: number | null;
+                high_usd?: number | null;
                 low: number;
-                low_usd: number | null;
+                low_usd?: number | null;
                 open: number;
-                open_usd: number | null;
+                open_usd?: number | null;
                 /** @description The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion. */
-                usd_per_tao: number | null;
+                usd_per_tao?: number | null;
                 volume_alpha: number;
                 volume_tao: number;
-                volume_usd: number | null;
+                volume_usd?: number | null;
             }[];
             /** @description Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read. */
-            field_sources_usd: {
+            field_sources_usd?: {
                 /** @constant */
                 kind: "reconstructed";
                 storage: null;
@@ -11257,15 +11257,15 @@ export interface components {
             interval: "1h" | "1d";
             netuid: number;
             /** @description How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect. */
-            priced_candle_count: number;
+            priced_candle_count?: number;
             /** @description True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
             root_excluded: boolean;
             schema_version: number;
             /** @description Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along. */
-            usd_available_from: components["schemas"]["EpochMillis"] | null;
-            usd_available_from_iso: string | null;
+            usd_available_from?: components["schemas"]["EpochMillis"] | null;
+            usd_available_from_iso?: string | null;
             /** @description Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from. */
-            usd_unavailable: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
+            usd_unavailable?: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
         };
         SubnetOverviewArtifact: {
             contract_version?: string;
@@ -42791,18 +42791,12 @@ export interface operations {
                      *             "bucket_start": 1,
                      *             "bucket_start_iso": "2026-06-01T00:00:00.000Z",
                      *             "close": 0.5,
-                     *             "close_usd": 0.5,
                      *             "event_count": 1,
                      *             "high": 0.5,
-                     *             "high_usd": 0.5,
                      *             "low": 0.5,
-                     *             "low_usd": 0.5,
                      *             "open": 0.5,
-                     *             "open_usd": 0.5,
-                     *             "usd_per_tao": 0.5,
                      *             "volume_alpha": 0.5,
-                     *             "volume_tao": 0.5,
-                     *             "volume_usd": 0.5
+                     *             "volume_tao": 0.5
                      *           }
                      *         ],
                      *         "field_sources_usd": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7607,15 +7607,29 @@ export interface components {
             days: {
                 alpha_price_tao_median?: number | null;
                 alpha_price_tao_weighted?: number | null;
+                alpha_price_usd_median?: number | null;
+                alpha_price_usd_weighted?: number | null;
                 mean_emission_share?: number | null;
                 miner_count?: number | null;
                 snapshot_date: string;
                 subnet_count: number;
                 /** @description Lossless fixed 9-decimal (rao-precision) TAO string, summed across every subnet reporting that day -- exceeds the exact-double ceiling as a JSON number, so it is served as a string rather than Float. */
                 total_stake_alpha?: string | null;
+                /** @description The TAO/USD rate this day's _usd fields were multiplied by -- the last reading observed inside that UTC day. */
+                usd_per_tao?: number | null;
                 validator_count?: number | null;
             }[];
+            field_sources_usd?: {
+                /** @constant */
+                kind: "reconstructed";
+                storage: null;
+            };
+            priced_day_count?: number;
             schema_version: number;
+            /** @description The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop. */
+            usd_available_from?: string | null;
+            /** @description Why NO day could be priced, or null. `read_failed` means the index could not be queried, which is not a claim about the index itself. */
+            usd_unavailable?: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -11216,22 +11230,42 @@ export interface components {
                 /** Format: date-time */
                 bucket_start_iso: string;
                 close: number;
+                close_usd: number | null;
                 event_count: number;
                 high: number;
+                high_usd: number | null;
                 low: number;
+                low_usd: number | null;
                 open: number;
+                open_usd: number | null;
+                /** @description The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion. */
+                usd_per_tao: number | null;
                 volume_alpha: number;
                 volume_tao: number;
+                volume_usd: number | null;
             }[];
+            /** @description Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read. */
+            field_sources_usd: {
+                /** @constant */
+                kind: "reconstructed";
+                storage: null;
+            };
             /**
              * @description The resolved bucket interval (1h/1d).
              * @enum {string}
              */
             interval: "1h" | "1d";
             netuid: number;
+            /** @description How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect. */
+            priced_candle_count: number;
             /** @description True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted. */
             root_excluded: boolean;
             schema_version: number;
+            /** @description Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along. */
+            usd_available_from: components["schemas"]["EpochMillis"] | null;
+            usd_available_from_iso: string | null;
+            /** @description Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from. */
+            usd_unavailable: ("no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price" | "read_failed") | null;
         };
         SubnetOverviewArtifact: {
             contract_version?: string;
@@ -30180,7 +30214,14 @@ export interface operations {
                      *             "subnet_count": 1
                      *           }
                      *         ],
+                     *         "field_sources_usd": {
+                     *           "kind": "reconstructed",
+                     *           "storage": null
+                     *         },
+                     *         "priced_day_count": 1,
                      *         "schema_version": 1,
+                     *         "usd_available_from": "example",
+                     *         "usd_unavailable": "no_index_reading",
                      *         "window": "30d"
                      *       },
                      *       "meta": {
@@ -42750,18 +42791,32 @@ export interface operations {
                      *             "bucket_start": 1,
                      *             "bucket_start_iso": "2026-06-01T00:00:00.000Z",
                      *             "close": 0.5,
+                     *             "close_usd": 0.5,
                      *             "event_count": 1,
                      *             "high": 0.5,
+                     *             "high_usd": 0.5,
                      *             "low": 0.5,
+                     *             "low_usd": 0.5,
                      *             "open": 0.5,
+                     *             "open_usd": 0.5,
+                     *             "usd_per_tao": 0.5,
                      *             "volume_alpha": 0.5,
-                     *             "volume_tao": 0.5
+                     *             "volume_tao": 0.5,
+                     *             "volume_usd": 0.5
                      *           }
                      *         ],
+                     *         "field_sources_usd": {
+                     *           "kind": "reconstructed",
+                     *           "storage": null
+                     *         },
                      *         "interval": "1h",
                      *         "netuid": 7,
+                     *         "priced_candle_count": 1,
                      *         "root_excluded": false,
-                     *         "schema_version": 1
+                     *         "schema_version": 1,
+                     *         "usd_available_from": 1,
+                     *         "usd_available_from_iso": "2026-06-01T00:00:00.000Z",
+                     *         "usd_unavailable": "no_index_reading"
                      *       },
                      *       "meta": {
                      *         "artifact_path": "example",

--- a/schemas-src/routes/economics-trends.ts
+++ b/schemas-src/routes/economics-trends.ts
@@ -5,6 +5,7 @@
 // components it replaces.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { SERIES_USD_UNAVAILABLE } from "../../src/alpha-usd-history.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const ECONOMICS_TRENDS_WINDOW_VALUES = [
@@ -65,13 +66,7 @@ export const EconomicsTrendsArtifactSchema = z
       ),
     priced_day_count: z.int().min(0).optional(),
     usd_unavailable: z
-      .enum([
-        "no_index_reading",
-        "index_unpriced",
-        "index_stale",
-        "no_alpha_price",
-        "read_failed",
-      ])
+      .enum(SERIES_USD_UNAVAILABLE)
       .nullable()
       .optional()
       .describe(

--- a/schemas-src/routes/economics-trends.ts
+++ b/schemas-src/routes/economics-trends.ts
@@ -28,6 +28,19 @@ const EconomicsTrendsDaySchema = z
       ),
     alpha_price_tao_weighted: z.number().nullable().optional(),
     alpha_price_tao_median: z.number().nullable().optional(),
+    // USD (#10382). Null for any day older than tao_usd_index rather than
+    // priced at today's rate -- the alpha history runs ~13 months and the index
+    // ~8 days, so a retroactive rate would be wrong on almost every point while
+    // looking entirely plausible.
+    alpha_price_usd_weighted: z.number().nullable().optional(),
+    alpha_price_usd_median: z.number().nullable().optional(),
+    usd_per_tao: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "The TAO/USD rate this day's _usd fields were multiplied by -- the last reading observed inside that UTC day.",
+      ),
     validator_count: z.int().nullable().optional(),
     miner_count: z.int().nullable().optional(),
     mean_emission_share: z.number().nullable().optional(),
@@ -43,6 +56,31 @@ export const EconomicsTrendsArtifactSchema = z
     window: z.string().nullable(),
     day_count: z.int().min(0),
     days: z.array(EconomicsTrendsDaySchema),
+    usd_available_from: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop.",
+      ),
+    priced_day_count: z.int().min(0).optional(),
+    usd_unavailable: z
+      .enum([
+        "no_index_reading",
+        "index_unpriced",
+        "index_stale",
+        "no_alpha_price",
+        "read_failed",
+      ])
+      .nullable()
+      .optional()
+      .describe(
+        "Why NO day could be priced, or null. `read_failed` means the index could not be queried, which is not a claim about the index itself.",
+      ),
+    field_sources_usd: z
+      .object({ kind: z.literal("reconstructed"), storage: z.null() })
+      .strict()
+      .optional(),
   })
   .passthrough();
 export type EconomicsTrendsArtifact = z.infer<

--- a/schemas-src/routes/subnet-ohlc.ts
+++ b/schemas-src/routes/subnet-ohlc.ts
@@ -5,6 +5,7 @@
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
 import { EpochMillisSchema } from "../shared.ts";
+import { SERIES_USD_UNAVAILABLE } from "../../src/alpha-usd-history.ts";
 
 const SubnetOhlcCandleSchema = z
   .object({
@@ -27,14 +28,15 @@ const SubnetOhlcCandleSchema = z
     // has no rate, and the hole has to be visible to a caller mapping the
     // array. Emitting today's rate backwards would produce a chart that renders
     // perfectly and is wrong at every point but the last.
-    open_usd: z.number().nullable(),
-    high_usd: z.number().nullable(),
-    low_usd: z.number().nullable(),
-    close_usd: z.number().nullable(),
-    volume_usd: z.number().nullable(),
+    open_usd: z.number().nullable().optional(),
+    high_usd: z.number().nullable().optional(),
+    low_usd: z.number().nullable().optional(),
+    close_usd: z.number().nullable().optional(),
+    volume_usd: z.number().nullable().optional(),
     usd_per_tao: z
       .number()
       .nullable()
+      .optional()
       .describe(
         "The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion.",
       ),
@@ -60,25 +62,23 @@ export const SubnetOhlcArtifactSchema = z
       .describe(
         "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted.",
       ),
-    usd_available_from: EpochMillisSchema.nullable().describe(
-      "Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along.",
-    ),
-    usd_available_from_iso: z.iso.datetime().nullable(),
+    usd_available_from: EpochMillisSchema.nullable()
+      .optional()
+      .describe(
+        "Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along.",
+      ),
+    usd_available_from_iso: z.iso.datetime().nullable().optional(),
     priced_candle_count: z
       .int()
       .min(0)
+      .optional()
       .describe(
         "How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect.",
       ),
     usd_unavailable: z
-      .enum([
-        "no_index_reading",
-        "index_unpriced",
-        "index_stale",
-        "no_alpha_price",
-        "read_failed",
-      ])
+      .enum(SERIES_USD_UNAVAILABLE)
       .nullable()
+      .optional()
       .describe(
         "Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from.",
       ),
@@ -88,6 +88,7 @@ export const SubnetOhlcArtifactSchema = z
         storage: z.null(),
       })
       .strict()
+      .optional()
       .describe(
         "Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read.",
       ),

--- a/schemas-src/routes/subnet-ohlc.ts
+++ b/schemas-src/routes/subnet-ohlc.ts
@@ -23,6 +23,21 @@ const SubnetOhlcCandleSchema = z
     volume_alpha: z.number().min(0),
     volume_tao: z.number(),
     event_count: z.int().min(0),
+    // USD (#10382). NULLABLE, never absent: a candle older than tao_usd_index
+    // has no rate, and the hole has to be visible to a caller mapping the
+    // array. Emitting today's rate backwards would produce a chart that renders
+    // perfectly and is wrong at every point but the last.
+    open_usd: z.number().nullable(),
+    high_usd: z.number().nullable(),
+    low_usd: z.number().nullable(),
+    close_usd: z.number().nullable(),
+    volume_usd: z.number().nullable(),
+    usd_per_tao: z
+      .number()
+      .nullable()
+      .describe(
+        "The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering (high >= open, close, low) survives the conversion.",
+      ),
   })
   .strict();
 
@@ -44,6 +59,37 @@ export const SubnetOhlcArtifactSchema = z
       .boolean()
       .describe(
         "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted.",
+      ),
+    usd_available_from: EpochMillisSchema.nullable().describe(
+      "Bucket start of the OLDEST candle carrying USD, or null when none does. Published rather than left to be inferred from where the nulls stop, so a caller can render 'USD from <date>' instead of a series that silently changes meaning partway along.",
+    ),
+    usd_available_from_iso: z.iso.datetime().nullable(),
+    priced_candle_count: z
+      .int()
+      .min(0)
+      .describe(
+        "How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect.",
+      ),
+    usd_unavailable: z
+      .enum([
+        "no_index_reading",
+        "index_unpriced",
+        "index_stale",
+        "no_alpha_price",
+        "read_failed",
+      ])
+      .nullable()
+      .describe(
+        "Why NO candle could be priced, or null. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; `read_failed` means the index could not be queried at all, which is not a claim about the index. A partially-priced series leaves this null and explains itself through usd_available_from.",
+      ),
+    field_sources_usd: z
+      .object({
+        kind: z.literal("reconstructed"),
+        storage: z.null(),
+      })
+      .strict()
+      .describe(
+        "Every _usd field is RECONSTRUCTED -- the product of a measured alpha price and a measured TAO/USD index, which is our arithmetic and not a chain read.",
       ),
   })
   .strict()

--- a/src/alpha-usd-history.ts
+++ b/src/alpha-usd-history.ts
@@ -1,0 +1,406 @@
+// USD across a TIME SERIES, priced per bucket rather than per response (#10382).
+//
+// src/alpha-usd.ts prices one figure against one reading -- the right primitive
+// for a spot surface, where every field describes the same instant. A series is
+// the other case: /subnets/{netuid}/ohlc and /economics/trends publish points
+// spanning months, and there is no single rate that is correct for all of them.
+//
+// ## THE TRAP THIS MODULE EXISTS TO CLOSE
+//
+//   alpha price history   2025-06-23 -> 2026-08-10   ~13 months of daily rows
+//   tao_usd_index         2026-08-02 -> 2026-08-10   ~8 days at one row/minute
+//
+// Multiplying thirteen months of alpha prices by TODAY's TAO/USD produces a
+// chart that renders perfectly and is wrong at every point except the last. It
+// is not a USD history; it is one exchange rate applied retroactively. The
+// error is invisible in the output -- the curve keeps its shape, so it looks
+// like data -- which is why the rule is structural rather than advisory:
+//
+//   A POINT IS PRICED BY A READING FROM ITS OWN BUCKET, OR IT IS NOT PRICED.
+//
+// A bucket older than the index carries `null`. Never the nearest rate, never
+// the first rate, never today's.
+//
+// ## ONE RATE PER BUCKET, NOT ONE PER FIELD
+//
+// A candle's open/high/low/close happen at four different instants inside the
+// bucket, so pricing each against the rate at ITS instant is tempting and
+// wrong: with a moving rate, `high_usd` can come out below `close_usd` and the
+// OHLC invariant (high >= open, close, low) breaks. A chart drawn from that has
+// candles inside out. Multiplying all four by ONE positive rate is monotonic,
+// so every ordering the TAO candle had, the USD candle still has.
+//
+// The rate chosen is the LAST reading observed WITHIN the bucket --
+// contemporaneous by construction, and the same "close" convention the candle
+// itself uses. It is never a reading from after the bucket, so no point is
+// priced with information that did not exist yet.
+//
+// ## WHY THE BUCKETING IS DONE IN SQL
+//
+// The index writes about once a minute: an 8-day overlap is ~11,500 rows to
+// fetch and walk per request, to produce at most a few hundred rates. The
+// DISTINCT ON below collapses that to one row per bucket in the engine, so the
+// body crossing the wire is bounded by the CANDLE count, not by the index's
+// cadence -- the same reason src/subnet-ohlc-cold-tier.ts buckets in SQL.
+//
+// Bucket alignment is `(observed_at / bucketMs) * bucketMs`, integer division
+// on a positive bigint, which is exactly the `Math.floor(observedAt /
+// intervalMs) * intervalMs` both OHLC tiers already use. The two must agree or
+// every rate lands one bucket off, so bucketMs comes from OHLC_INTERVALS rather
+// than from a caller.
+//
+// ## A SERIES STATES ITS NULLS DIFFERENTLY FROM A SPOT SURFACE
+//
+// src/alpha-usd-overlay.ts OMITS a `_usd` field it cannot fill: on a spot blob,
+// an absent field says "not available" and there is nothing to chart. Here the
+// field is emitted as an explicit `null`, because a series is consumed as an
+// array of uniform points -- a caller mapping `c => c.close_usd` must get a
+// hole in the line, not an undefined that silently plots as zero or shortens
+// the array. The reason for the nulls rides at the TOP level instead of on
+// every point: for a 2,000-candle window the reason is the same string 1,900
+// times, and repeating it would cost more than the prices do.
+
+import {
+  ALPHA_USD_FIELD_SOURCE,
+  alphaUsd,
+  type AlphaUsdUnavailable,
+  type TaoUsdReading,
+} from "./alpha-usd.ts";
+import { TAO_USD_TABLE } from "./tao-usd-series.ts";
+
+type Row = Record<string, unknown>;
+
+/** The minimal store surface used here, matching src/tao-usd-series.ts. */
+export interface TaoUsdBucketDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+  };
+}
+
+/**
+ * Rates fetched per request, whatever the window.
+ *
+ * MAX_CANDLES is 2,000 and a day series is at most 365 points, so this ceiling
+ * is never the binding constraint on a legitimate read -- it is the backstop
+ * that keeps a malformed bucketMs from selecting the whole table.
+ */
+export const TAO_USD_BUCKET_CAP = 2500;
+
+/**
+ * The last reading inside each bucket, one row per bucket.
+ *
+ * `DISTINCT ON` orders priced readings ahead of unpriced ones within a bucket,
+ * so a single `insufficient_pools` row landing at :59 cannot mark an hour
+ * unpriced when fifty-nine priced readings preceded it. When a bucket holds
+ * ONLY unpriced readings, the surviving row carries that basis through -- the
+ * distinction between "the index was down" (no row at all) and "the index
+ * declined to price this window" (a row with a null price) is one ADR 0025 went
+ * to the trouble of recording, and it survives to the caller.
+ */
+export function taoUsdBucketSql(bucketMs: number): string {
+  // Interpolated, never bound: this is an internal interval constant, and a
+  // placeholder inside the DISTINCT ON expression would not be usable as a
+  // sort key. Integral by construction, and asserted so a fractional value
+  // fails here rather than producing a silently misaligned bucket.
+  if (!Number.isSafeInteger(bucketMs) || bucketMs <= 0) {
+    throw new RangeError(
+      `bucketMs must be a positive integer, got ${bucketMs}`,
+    );
+  }
+  return (
+    `SELECT DISTINCT ON (observed_at / ${bucketMs})` +
+    ` (observed_at / ${bucketMs}) * ${bucketMs} AS bucket_start,` +
+    ` observed_at, usd_per_tao, block_number, price_basis` +
+    ` FROM ${TAO_USD_TABLE} WHERE observed_at >= ?` +
+    ` ORDER BY observed_at / ${bucketMs},` +
+    ` (usd_per_tao IS NOT NULL) DESC, observed_at DESC` +
+    ` LIMIT ${TAO_USD_BUCKET_CAP}`
+  );
+}
+
+/**
+ * One reading per bucket from `sinceMs` forward. Null when the read fails.
+ *
+ * A null return means "we could not ask", which the overlays render as an
+ * unpriced series rather than as an empty one -- a distinction that matters
+ * because an empty series is a claim about the index and a failed read is not.
+ */
+export async function loadTaoUsdBuckets(
+  db: TaoUsdBucketDb | null | undefined,
+  { sinceMs, bucketMs }: { sinceMs: number; bucketMs: number },
+): Promise<Row[] | null> {
+  if (!db?.prepare) return null;
+  try {
+    const res = await (
+      db.prepare(taoUsdBucketSql(bucketMs)).bind(sinceMs) as {
+        all?(): Promise<{ results?: unknown[] } | null>;
+      }
+    ).all?.();
+    return (res?.results ?? []) as Row[];
+  } catch {
+    return null;
+  }
+}
+
+const int = (v: unknown): number | null => {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : null;
+};
+
+/** Bucket start -> the reading that prices it. */
+export function taoUsdBucketMap(
+  rows: Row[] | null | undefined,
+): Map<number, TaoUsdReading> {
+  const map = new Map<number, TaoUsdReading>();
+  for (const r of Array.isArray(rows) ? rows : []) {
+    const start = int(r?.bucket_start);
+    if (start === null) continue;
+    const observed = int(r?.observed_at);
+    map.set(start, {
+      usd_per_tao:
+        r?.usd_per_tao === null || r?.usd_per_tao === undefined
+          ? null
+          : Number(r.usd_per_tao),
+      // Stored as epoch ms; alphaUsd parses this with Date.parse, so it has to
+      // arrive as an ISO string rather than as the raw bigint.
+      observed_at: observed === null ? null : new Date(observed).toISOString(),
+      block_number: int(r?.block_number),
+      price_basis: (r?.price_basis as string | null) ?? null,
+    });
+  }
+  return map;
+}
+
+/**
+ * The instant a candle payload's USD lookup must start from, or null when
+ * there is nothing to price.
+ *
+ * Lives here rather than in the handler so the handler never reaches into a
+ * candle's fields, and so the "no candles" and "unusable bucket_start" cases
+ * are exercised by this module's own tests instead of needing a Worker fixture
+ * for each. Null means SKIP THE READ -- root (netuid 0) and a cold store both
+ * produce empty candle arrays, and querying the index for a window no point
+ * falls in is a round trip that can only return rows nobody will use.
+ */
+export function ohlcUsdWindowStart(data: Row): number | null {
+  const candles = Array.isArray(data?.candles) ? (data.candles as Row[]) : [];
+  // Candles are ASCENDING, so the first is the oldest and therefore the floor
+  // of the window the index has to cover.
+  return candles.length ? int(candles[0]?.bucket_start) : null;
+}
+
+/**
+ * The rate a bucket is priced at, given the reading found in it.
+ *
+ * The freshness bound is the BUCKET, not TAO_USD_MAX_AGE_MS. A reading selected
+ * by taoUsdBucketSql is inside the bucket by construction, so measuring its age
+ * against the bucket's own end is the check that is actually meaningful here --
+ * asking whether it is within two hours of NOW would refuse every historical
+ * point in the series, which is the opposite of the intent.
+ */
+function priceAt(
+  tao: unknown,
+  reading: TaoUsdReading | undefined,
+  bucketStart: number,
+  bucketMs: number,
+): { usd: number; rate: number } | { reason: AlphaUsdUnavailable } {
+  // NOT `Number(tao)`. `Number(null)`, `Number("")` and `Number(false)` are all
+  // 0, so a MISSING field would coerce into a legitimate-looking $0 -- the
+  // precise inversion of the rule src/alpha-usd.ts exists to hold: zero is a
+  // price, absent is not. Only a real number, or a string that says one,
+  // reaches the multiply.
+  const n =
+    typeof tao === "number"
+      ? tao
+      : typeof tao === "string" && tao.trim() !== ""
+        ? Number(tao)
+        : Number.NaN;
+  const out = alphaUsd(
+    Number.isFinite(n) ? n : null,
+    reading ?? null,
+    bucketStart + bucketMs,
+    bucketMs,
+  );
+  return out.ok
+    ? { usd: out.value.usd, rate: out.value.usd_per_tao }
+    : { reason: out.reason };
+}
+
+/** Price fields on a candle, and the TAO field each is derived from. */
+const CANDLE_USD_FIELDS = [
+  ["open", "open_usd"],
+  ["high", "high_usd"],
+  ["low", "low_usd"],
+  ["close", "close_usd"],
+  ["volume_tao", "volume_usd"],
+] as const;
+
+/**
+ * Add USD to an assembled OHLC payload.
+ *
+ * Applied AFTER the tier resolves rather than inside the candle assembler, so
+ * the hot tier, the lakehouse cold tier and the empty fallback all gain USD
+ * from one place and cannot disagree -- and so buildSubnetOhlcFromBuckets,
+ * which GraphQL and MCP also call, keeps the shape those surfaces already
+ * publish.
+ */
+export function withAlphaUsdCandles(
+  data: Row,
+  byBucket: Map<number, TaoUsdReading> | null,
+  bucketMs: number,
+): Row {
+  const candles = Array.isArray(data?.candles) ? (data.candles as Row[]) : [];
+  // A failed read still produces the FULL point shape, every USD field null.
+  // Returning a different key set would defeat the reason these are nulls
+  // rather than omissions: a caller mapping `c => c.close_usd` must get a hole
+  // in the line whatever went wrong upstream. Only the top-level reason
+  // distinguishes "we could not ask" from "the index had nothing".
+  const readFailed = byBucket === null;
+  const rates = byBucket ?? new Map<number, TaoUsdReading>();
+
+  let availableFrom: number | null = null;
+  let pricedCount = 0;
+  // The FIRST reason seen, not a set: only one is ever published, and a Set
+  // left an unreachable `?? fallback` branch standing in for its empty case.
+  let firstReason: AlphaUsdUnavailable | null = null;
+
+  const priced = candles.map((c) => {
+    const start = int(c?.bucket_start);
+    const reading = start === null ? undefined : rates.get(start);
+    const out: Row = { ...c };
+    let rate: number | null = null;
+
+    for (const [taoField, usdField] of CANDLE_USD_FIELDS) {
+      const r =
+        start === null
+          ? { reason: "no_index_reading" as AlphaUsdUnavailable }
+          : priceAt(c?.[taoField], reading, start, bucketMs);
+      if ("usd" in r) {
+        out[usdField] = r.usd;
+        rate = r.rate;
+      } else {
+        out[usdField] = null;
+        firstReason ??= r.reason;
+      }
+    }
+
+    // The rate every field on this candle was multiplied by -- one number, so a
+    // caller can audit the conversion without the response carrying five
+    // provenance fields per point.
+    out.usd_per_tao = rate;
+    if (rate !== null) {
+      pricedCount += 1;
+      if (availableFrom === null && start !== null) availableFrom = start;
+    }
+    return out;
+  });
+
+  return {
+    ...data,
+    candles: priced,
+    // Where USD starts, published rather than left to be inferred from where
+    // the nulls stop. A caller can render "USD from 2026-08-02" instead of a
+    // series that silently changes meaning partway along.
+    usd_available_from: availableFrom,
+    usd_available_from_iso:
+      availableFrom === null ? null : new Date(availableFrom).toISOString(),
+    priced_candle_count: pricedCount,
+    // Only when NOTHING priced. A partially-priced series explains itself
+    // through usd_available_from; a wholly unpriced one needs to say why, and
+    // "we could not ask" outranks whatever the empty rate set implied.
+    usd_unavailable: readFailed
+      ? "read_failed"
+      : pricedCount === 0 && candles.length > 0
+        ? firstReason
+        : null,
+    field_sources_usd: ALPHA_USD_FIELD_SOURCE,
+  };
+}
+
+/** Price fields on a trends day, and the TAO field each is derived from. */
+const TREND_USD_FIELDS = [
+  ["alpha_price_tao_weighted", "alpha_price_usd_weighted"],
+  ["alpha_price_tao_median", "alpha_price_usd_median"],
+] as const;
+
+const DAY_MS_LOCAL = 24 * 60 * 60 * 1000;
+
+/**
+ * Add USD to an assembled economics-trends payload.
+ *
+ * The day series is keyed by `snapshot_date` (a UTC calendar date) rather than
+ * by an epoch bucket, so the rate for a day is the last reading observed inside
+ * that UTC day -- the same "last reading in the bucket" rule the candles use,
+ * with the bucket being the day.
+ *
+ * Deliberately NOT keyed off each snapshot's own capture instant, even though
+ * subnet_snapshots records one: the trends day is a network-wide aggregate over
+ * ~129 subnets whose captures do not share an instant, so there is no single
+ * capture time for the day to price against. The day is the finest grain the
+ * aggregate actually has.
+ */
+export function withAlphaUsdTrendDays(
+  data: Row,
+  byBucket: Map<number, TaoUsdReading> | null,
+): Row {
+  const days = Array.isArray(data?.days) ? (data.days as Row[]) : [];
+  // Same uniform-shape rule as the candles: a failed read still emits every USD
+  // field as null, and only the top-level reason says why.
+  const readFailed = byBucket === null;
+  const rates = byBucket ?? new Map<number, TaoUsdReading>();
+
+  let availableFrom: string | null = null;
+  let pricedCount = 0;
+  // The FIRST reason seen, not a set: only one is ever published, and a Set
+  // left an unreachable `?? fallback` branch standing in for its empty case.
+  let firstReason: AlphaUsdUnavailable | null = null;
+
+  const priced = days.map((d) => {
+    const date = typeof d?.snapshot_date === "string" ? d.snapshot_date : null;
+    const startMs = date === null ? NaN : Date.parse(`${date}T00:00:00.000Z`);
+    const start = Number.isFinite(startMs) ? startMs : null;
+    const reading = start === null ? undefined : rates.get(start);
+    const out: Row = { ...d };
+    let rate: number | null = null;
+
+    for (const [taoField, usdField] of TREND_USD_FIELDS) {
+      const r =
+        start === null
+          ? { reason: "no_index_reading" as AlphaUsdUnavailable }
+          : priceAt(d?.[taoField], reading, start, DAY_MS_LOCAL);
+      if ("usd" in r) {
+        out[usdField] = r.usd;
+        rate = r.rate;
+      } else {
+        out[usdField] = null;
+        firstReason ??= r.reason;
+      }
+    }
+
+    out.usd_per_tao = rate;
+    if (rate !== null) {
+      pricedCount += 1;
+      // Days arrive NEWEST FIRST, so the oldest priced day is the LAST one
+      // seen, not the first -- overwritten on each hit rather than latched.
+      // `date` is non-null whenever a rate was found: an unparseable
+      // snapshot_date yields no bucket key, so nothing can price against it.
+      availableFrom = date;
+    }
+    return out;
+  });
+
+  return {
+    ...data,
+    days: priced,
+    usd_available_from: availableFrom,
+    priced_day_count: pricedCount,
+    usd_unavailable: readFailed
+      ? "read_failed"
+      : pricedCount === 0 && days.length > 0
+        ? firstReason
+        : null,
+    field_sources_usd: ALPHA_USD_FIELD_SOURCE,
+  };
+}

--- a/src/alpha-usd-history.ts
+++ b/src/alpha-usd-history.ts
@@ -62,6 +62,7 @@
 
 import {
   ALPHA_USD_FIELD_SOURCE,
+  ALPHA_USD_UNAVAILABLE,
   alphaUsd,
   type AlphaUsdUnavailable,
   type TaoUsdReading,
@@ -86,6 +87,22 @@ export interface TaoUsdBucketDb {
  * is never the binding constraint on a legitimate read -- it is the backstop
  * that keeps a malformed bucketMs from selecting the whole table.
  */
+/**
+ * Every reason a SERIES may carry no USD, including the one only a series has.
+ *
+ * `read_failed` is not an AlphaUsdUnavailable: those describe what the index
+ * SAID, and this one says we never got to ask. Kept distinct because "the index
+ * declined to price this window" and "we could not reach the index" send an
+ * operator to different places.
+ *
+ * Derived from ALPHA_USD_UNAVAILABLE rather than retyped, so a new reason there
+ * appears here automatically.
+ */
+export const SERIES_USD_UNAVAILABLE = [
+  ...ALPHA_USD_UNAVAILABLE,
+  "read_failed",
+] as const;
+
 export const TAO_USD_BUCKET_CAP = 2500;
 
 /**

--- a/src/alpha-usd.ts
+++ b/src/alpha-usd.ts
@@ -50,16 +50,30 @@ import type { FiatPriceBasis } from "./tao-usd-index.ts";
  */
 export const TAO_USD_MAX_AGE_MS = 2 * 60 * 60 * 1000;
 
-/** Why a USD figure could not be produced. Every value is a stated outcome. */
-export type AlphaUsdUnavailable =
-  /** No TAO/USD reading at all -- the index has never written, or the read failed. */
-  | "no_index_reading"
-  /** A reading exists and carries no price: ADR 0025's `insufficient_pools`. */
-  | "index_unpriced"
-  /** The newest reading is older than TAO_USD_MAX_AGE_MS. */
-  | "index_stale"
-  /** The alpha side is missing. A subnet with no price is not one priced at 0. */
-  | "no_alpha_price";
+/**
+ * Why a USD figure could not be produced. Every value is a stated outcome.
+ *
+ * A TUPLE, with the type derived from it, so the schemas can import the same
+ * values rather than restating them -- a union declared here and re-typed in
+ * two schema files is three places that can disagree about what we are willing
+ * to say, and validate:schema-vocabularies exists to stop exactly that.
+ *
+ * - `no_index_reading` -- no TAO/USD reading at all; the index has never
+ *   written, or the read found nothing.
+ * - `index_unpriced` -- a reading exists and carries no price: ADR 0025's
+ *   `insufficient_pools`. A published decline, never a price of zero.
+ * - `index_stale` -- the newest reading is older than TAO_USD_MAX_AGE_MS.
+ * - `no_alpha_price` -- the alpha side is missing. A subnet with no price is
+ *   not one priced at 0.
+ */
+export const ALPHA_USD_UNAVAILABLE = [
+  "no_index_reading",
+  "index_unpriced",
+  "index_stale",
+  "no_alpha_price",
+] as const;
+
+export type AlphaUsdUnavailable = (typeof ALPHA_USD_UNAVAILABLE)[number];
 
 /** The newest TAO/USD reading, in the shape `latest` already publishes. */
 export interface TaoUsdReading {

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3761,7 +3761,7 @@ export const SDL = /* GraphQL */ `
     usd_available_from: Float
     usd_available_from_iso: String
     "How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect."
-    priced_candle_count: Int!
+    priced_candle_count: Int
     "Why NO candle could be priced, or null. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; read_failed means the index could not be queried at all."
     usd_unavailable: String
     field_sources_usd: JSON

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -1214,6 +1214,12 @@ export const SDL = /* GraphQL */ `
     window: String
     day_count: Int!
     days: [EconomicsTrendsDay!]!
+    "The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop."
+    usd_available_from: String
+    priced_day_count: Int
+    "Why NO day could be priced, or null. read_failed means the index could not be queried, which is not a claim about the index itself."
+    usd_unavailable: String
+    field_sources_usd: JSON
   }
 
   "One UTC day of network-wide economics aggregated across every subnet with a snapshot that day. Sums are null only when no subnet reported a value that day."
@@ -1224,6 +1230,11 @@ export const SDL = /* GraphQL */ `
     total_stake_alpha: String
     alpha_price_tao_weighted: Float
     alpha_price_tao_median: Float
+    "USD twins, null for any day older than tao_usd_index."
+    alpha_price_usd_weighted: Float
+    alpha_price_usd_median: Float
+    "The TAO/USD rate this day's _usd fields were multiplied by -- the last reading observed inside that UTC day."
+    usd_per_tao: Float
     validator_count: Int
     miner_count: Int
     mean_emission_share: Float
@@ -3725,6 +3736,14 @@ export const SDL = /* GraphQL */ `
     volume_alpha: Float
     volume_tao: Float
     event_count: Int!
+    "USD twins, null for a candle older than tao_usd_index rather than converted at today's rate."
+    open_usd: Float
+    high_usd: Float
+    low_usd: Float
+    close_usd: Float
+    volume_usd: Float
+    "The single TAO/USD rate every _usd field on THIS candle was multiplied by -- the last reading observed inside this candle's own bucket. One rate per candle, so the OHLC ordering survives the conversion."
+    usd_per_tao: Float
   }
 
   "One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope."
@@ -3738,6 +3757,14 @@ export const SDL = /* GraphQL */ `
     candle_count: Int!
     "True for root (netuid 0), whose 1:1 price makes candles meaningless, so none are emitted."
     root_excluded: Boolean!
+    "Bucket start of the OLDEST candle carrying USD, or null when none does -- a Float, since epoch-ms exceeds GraphQL's 32-bit Int. Published so a caller can render 'USD from <date>' rather than infer the boundary from where the nulls stop."
+    usd_available_from: Float
+    usd_available_from_iso: String
+    "How many candles carry USD. A gap against candle_count is the TAO series outrunning the TAO/USD index, not a defect."
+    priced_candle_count: Int!
+    "Why NO candle could be priced, or null. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; read_failed means the index could not be queried at all."
+    usd_unavailable: String
+    field_sources_usd: JSON
   }
 
   "Permitted, active and earning are three DIFFERENT sets. Network-wide 2026-08-03: 1,523 / 1,137 / 1,117; SN83 is 64 / 8 / 7. Published separately rather than collapsed, because 'how many validators does this subnet have' has three defensible answers."

--- a/src/subnet-ohlc.ts
+++ b/src/subnet-ohlc.ts
@@ -112,7 +112,7 @@ function finiteAmount(value: unknown): number | null {
 
 // interval, normalized to a supported key -- never throws, mirrors the
 // module-level clamp/normalize convention documented on OHLC_INTERVALS above.
-function normalizeInterval(interval: unknown): string {
+export function normalizeInterval(interval: unknown): string {
   return typeof interval === "string" && Object.hasOwn(OHLC_INTERVALS, interval)
     ? interval
     : OHLC_INTERVAL_DEFAULT;

--- a/tests/alpha-usd-history.test.ts
+++ b/tests/alpha-usd-history.test.ts
@@ -1,0 +1,547 @@
+// USD across a time series (#10382).
+//
+// The failure this guards is not a crash — it is a chart that renders
+// perfectly and is wrong at every point but the last. Multiplying thirteen
+// months of alpha prices by today's TAO/USD produces exactly that, and nothing
+// in the output looks off: the curve keeps its shape. So the tests that matter
+// most here assert what is ABSENT (a bucket older than the index is null) and
+// what is ORDERED (one rate per candle, so high_usd never falls below
+// close_usd).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { OHLC_INTERVALS } from "../src/subnet-ohlc.ts";
+import {
+  loadTaoUsdBuckets,
+  ohlcUsdWindowStart,
+  taoUsdBucketMap,
+  taoUsdBucketSql,
+  TAO_USD_BUCKET_CAP,
+  withAlphaUsdCandles,
+  withAlphaUsdTrendDays,
+} from "../src/alpha-usd-history.ts";
+
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+// An hour boundary, so bucket_start values are exact multiples.
+const T0 = Date.parse("2026-08-08T00:00:00.000Z");
+
+const reading = (bucketStart: number, usd: number | null, basis?: string) => ({
+  bucket_start: bucketStart,
+  // :59 of the bucket — the last reading inside it, which is what the SQL picks.
+  observed_at: bucketStart + HOUR - 1000,
+  usd_per_tao: usd,
+  block_number: 25_700_000,
+  price_basis:
+    basis ?? (usd === null ? "insufficient_pools" : "wrapped_onchain_median"),
+});
+
+const candle = (
+  bucketStart: number,
+  o: number,
+  h: number,
+  l: number,
+  c: number,
+) => ({
+  bucket_start: bucketStart,
+  bucket_start_iso: new Date(bucketStart).toISOString(),
+  open: o,
+  high: h,
+  low: l,
+  close: c,
+  volume_tao: 12.5,
+  volume_alpha: 100,
+  event_count: 3,
+});
+
+const ohlc = (candles: Record<string, unknown>[]) => ({
+  schema_version: 1,
+  netuid: 64,
+  interval: "1h",
+  candles,
+  candle_count: candles.length,
+  root_excluded: false,
+});
+
+describe("the bucketing SQL", () => {
+  test("aligns exactly the way both OHLC tiers bucket", () => {
+    // buildSubnetOhlc computes Math.floor(observedAt / intervalMs) * intervalMs.
+    // If the SQL's integer division disagreed, every rate would land one bucket
+    // off — a silent, uniform, entirely plausible-looking error.
+    const sql = taoUsdBucketSql(HOUR);
+    assert.match(sql, /DISTINCT ON \(observed_at \/ 3600000\)/);
+    assert.match(sql, /\(observed_at \/ 3600000\) \* 3600000 AS bucket_start/);
+  });
+
+  test("prefers a PRICED reading over a later unpriced one in the same bucket", () => {
+    // One `insufficient_pools` row landing at :59 must not mark an hour
+    // unpriced when fifty-nine priced readings preceded it.
+    assert.match(
+      taoUsdBucketSql(HOUR),
+      /ORDER BY observed_at \/ 3600000, \(usd_per_tao IS NOT NULL\) DESC, observed_at DESC/,
+    );
+  });
+
+  test("refuses a bucket size that would misalign every bucket", () => {
+    // A fractional or non-positive interval cannot produce the floor the
+    // assembler uses, so it fails here rather than returning shifted rates.
+    for (const bad of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.throws(() => taoUsdBucketSql(bad), RangeError, String(bad));
+    }
+  });
+
+  test("is bounded, so a wide window cannot select the whole table", () => {
+    assert.match(
+      taoUsdBucketSql(DAY),
+      new RegExp(`LIMIT ${TAO_USD_BUCKET_CAP}`),
+    );
+  });
+
+  test("every interval the route accepts produces valid bucketing", () => {
+    // Enumerated from the route's OWN vocabulary rather than from a list
+    // restated here — a new interval must not silently skip this check.
+    for (const [label, ms] of Object.entries(OHLC_INTERVALS)) {
+      assert.doesNotThrow(() => taoUsdBucketSql(ms), label);
+    }
+  });
+});
+
+describe("loading rates", () => {
+  const db = (results: unknown[]) => ({
+    prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
+  });
+
+  test("a missing store is a FAILED read, not an empty one", async () => {
+    // The distinction is load-bearing downstream: an empty series is a claim
+    // about the index, a failed read is not.
+    assert.equal(
+      await loadTaoUsdBuckets(null, { sinceMs: 0, bucketMs: HOUR }),
+      null,
+    );
+    assert.equal(
+      await loadTaoUsdBuckets({} as never, { sinceMs: 0, bucketMs: HOUR }),
+      null,
+    );
+  });
+
+  test("a throwing store yields null rather than propagating", async () => {
+    const boom = {
+      prepare: () => ({
+        bind: () => ({
+          all: async () => {
+            throw new Error("connection reset");
+          },
+        }),
+      }),
+    };
+    assert.equal(
+      await loadTaoUsdBuckets(boom, { sinceMs: 0, bucketMs: HOUR }),
+      null,
+    );
+  });
+
+  test("rows come back as the reading shape alphaUsd expects", async () => {
+    const rows = await loadTaoUsdBuckets(db([reading(T0, 191.5)]), {
+      sinceMs: T0,
+      bucketMs: HOUR,
+    });
+    const map = taoUsdBucketMap(rows);
+    const r = map.get(T0);
+    assert.equal(r?.usd_per_tao, 191.5);
+    // Stored as epoch ms, but alphaUsd parses observed_at with Date.parse, so
+    // it has to arrive as ISO — a raw bigint here would read as unparseable,
+    // which taoUsdUsable treats as STALE.
+    assert.equal(r?.observed_at, new Date(T0 + HOUR - 1000).toISOString());
+  });
+
+  test("a row without a usable bucket_start is dropped, not keyed to NaN", () => {
+    const map = taoUsdBucketMap([
+      { ...reading(T0, 191.5), bucket_start: "not-a-number" },
+      reading(T0 + HOUR, 192),
+    ]);
+    assert.equal(map.size, 1);
+    assert.ok(map.has(T0 + HOUR));
+  });
+
+  test("non-array input yields an empty map", () => {
+    for (const bad of [null, undefined, 42 as never]) {
+      assert.equal(taoUsdBucketMap(bad as never).size, 0);
+    }
+  });
+});
+
+describe("pricing candles", () => {
+  test("A CANDLE OLDER THAN THE INDEX IS NULL, never today's rate", () => {
+    // The whole point of the module. The old candle must not borrow the rate
+    // that priced the recent one.
+    const old = T0 - 200 * DAY;
+    const out = withAlphaUsdCandles(
+      ohlc([
+        candle(old, 0.05, 0.06, 0.04, 0.055),
+        candle(T0, 0.08, 0.09, 0.07, 0.088),
+      ]),
+      taoUsdBucketMap([reading(T0, 200)]),
+      HOUR,
+    );
+    const candles = out.candles as Record<string, unknown>[];
+    assert.equal(
+      candles[0].close_usd,
+      null,
+      "a pre-index candle must not be priced",
+    );
+    assert.equal(candles[0].usd_per_tao, null);
+    assert.equal(candles[1].close_usd, 0.088 * 200);
+  });
+
+  test("ONE rate per candle, so the OHLC ordering survives", () => {
+    // Pricing each field against the rate at its own instant can put high_usd
+    // below close_usd and turn a candle inside out. A single positive
+    // multiplier is monotonic, so every ordering the TAO candle had is kept.
+    const out = withAlphaUsdCandles(
+      ohlc([candle(T0, 0.08, 0.09, 0.07, 0.088)]),
+      taoUsdBucketMap([reading(T0, 200)]),
+      HOUR,
+    );
+    const c = (out.candles as Record<string, unknown>[])[0];
+    const [o, h, l, cl] = [
+      c.open_usd,
+      c.high_usd,
+      c.low_usd,
+      c.close_usd,
+    ] as number[];
+    assert.ok(h >= o && h >= cl && h >= l, "high must dominate");
+    assert.ok(l <= o && l <= cl, "low must be dominated");
+    assert.equal(c.usd_per_tao, 200);
+  });
+
+  test("volume travels in USD too", () => {
+    const out = withAlphaUsdCandles(
+      ohlc([candle(T0, 0.08, 0.09, 0.07, 0.088)]),
+      taoUsdBucketMap([reading(T0, 200)]),
+      HOUR,
+    );
+    assert.equal(
+      (out.candles as Record<string, unknown>[])[0].volume_usd,
+      12.5 * 200,
+    );
+  });
+
+  test("`insufficient_pools` in the bucket is null, NOT a price of zero", () => {
+    const out = withAlphaUsdCandles(
+      ohlc([candle(T0, 0.08, 0.09, 0.07, 0.088)]),
+      taoUsdBucketMap([reading(T0, null)]),
+      HOUR,
+    );
+    const c = (out.candles as Record<string, unknown>[])[0];
+    assert.equal(c.close_usd, null);
+    assert.equal(out.usd_unavailable, "index_unpriced");
+    assert.equal(out.priced_candle_count, 0);
+  });
+
+  test("the coverage boundary is PUBLISHED, not inferred from where nulls stop", () => {
+    const old = T0 - 200 * DAY;
+    const out = withAlphaUsdCandles(
+      ohlc([
+        candle(old, 0.05, 0.06, 0.04, 0.055),
+        candle(T0, 0.08, 0.09, 0.07, 0.088),
+      ]),
+      taoUsdBucketMap([reading(T0, 200)]),
+      HOUR,
+    );
+    assert.equal(out.usd_available_from, T0);
+    assert.equal(out.usd_available_from_iso, new Date(T0).toISOString());
+    assert.equal(out.priced_candle_count, 1);
+    // Partially priced: the boundary explains it, so no blanket reason.
+    assert.equal(out.usd_unavailable, null);
+  });
+
+  test("90 days of TAO and 8 days of USD are BOTH legible", () => {
+    // The acceptance criterion, as a caller would experience it.
+    const candles = Array.from({ length: 90 }, (_, i) =>
+      candle(T0 - (89 - i) * DAY, 0.08, 0.09, 0.07, 0.088),
+    );
+    const rates = candles
+      .slice(-8)
+      .map((c) => reading(c.bucket_start as number, 200));
+    const out = withAlphaUsdCandles(ohlc(candles), taoUsdBucketMap(rates), DAY);
+    assert.equal((out.candles as unknown[]).length, 90, "TAO series is intact");
+    assert.equal(
+      out.priced_candle_count,
+      8,
+      "USD covers only what the index does",
+    );
+    assert.equal(out.usd_available_from, T0 - 7 * DAY);
+  });
+
+  test("a FAILED read keeps the point shape and names itself", () => {
+    // "We could not ask" is not "the index had nothing", and the top-level
+    // reason is the only place that distinction lives. The POINTS still carry
+    // the full null-filled shape, so a caller charting close_usd gets a hole
+    // in the line rather than an array whose keys changed under it.
+    const out = withAlphaUsdCandles(
+      ohlc([candle(T0, 0.08, 0.09, 0.07, 0.088)]),
+      null,
+      HOUR,
+    );
+    assert.equal(out.usd_unavailable, "read_failed");
+    assert.equal(out.usd_available_from, null);
+    assert.equal(out.priced_candle_count, 0);
+    const c = (out.candles as Record<string, unknown>[])[0];
+    assert.equal(c.close_usd, null);
+    assert.equal(c.usd_per_tao, null);
+    // The TAO side is untouched — a rate we could not fetch says nothing about
+    // the prices we did.
+    assert.equal(c.close, 0.088);
+  });
+
+  test("the emitted key set is IDENTICAL whether or not a rate was found", () => {
+    // The stated reason for nulls-over-omissions. If a failed read returned a
+    // different shape, every caller would need two code paths for one series.
+    const shape = (map: Parameters<typeof withAlphaUsdCandles>[1]) =>
+      Object.keys(
+        (
+          withAlphaUsdCandles(
+            ohlc([candle(T0, 0.08, 0.09, 0.07, 0.088)]),
+            map,
+            HOUR,
+          ).candles as Record<string, unknown>[]
+        )[0],
+      ).sort();
+    const priced = shape(taoUsdBucketMap([reading(T0, 200)]));
+    assert.deepEqual(shape(null), priced, "failed read");
+    assert.deepEqual(
+      shape(taoUsdBucketMap([])),
+      priced,
+      "no reading in bucket",
+    );
+  });
+
+  test("an empty series states no reason — there was nothing to price", () => {
+    const out = withAlphaUsdCandles(ohlc([]), taoUsdBucketMap([]), HOUR);
+    assert.equal(out.usd_unavailable, null);
+    assert.equal(out.priced_candle_count, 0);
+    assert.equal(out.usd_available_from, null);
+  });
+
+  test("a payload with no candles array is passed through, not crashed on", () => {
+    // Root (netuid 0) short-circuits to a degenerate shape; a missing or
+    // malformed candles array must not throw inside an overlay.
+    const out = withAlphaUsdCandles(
+      { netuid: 0, root_excluded: true },
+      taoUsdBucketMap([]),
+      HOUR,
+    );
+    assert.equal(out.root_excluded, true);
+    assert.equal(out.usd_available_from, null);
+  });
+
+  test("a candle with an unusable bucket_start is refused, not mispriced", () => {
+    const broken = {
+      ...candle(T0, 0.08, 0.09, 0.07, 0.088),
+      bucket_start: "x",
+    };
+    const out = withAlphaUsdCandles(
+      ohlc([broken]),
+      taoUsdBucketMap([reading(T0, 200)]),
+      HOUR,
+    );
+    assert.equal((out.candles as Record<string, unknown>[])[0].close_usd, null);
+  });
+
+  test("a MISSING TAO field never coerces into a $0 price", () => {
+    // Number(null), Number("") and Number(false) are all 0, so a naive
+    // Number(x) turns an absent field into a legitimate-looking $0 — the exact
+    // inversion of the rule alpha-usd.ts holds. Caught this way once already.
+    for (const missing of [null, undefined, "", "   ", false]) {
+      const c = { ...candle(T0, 0.08, 0.09, 0.07, 0.088), high: missing };
+      const out = withAlphaUsdCandles(
+        ohlc([c]),
+        taoUsdBucketMap([reading(T0, 200)]),
+        HOUR,
+      );
+      const got = (out.candles as Record<string, unknown>[])[0];
+      assert.equal(got.high_usd, null, `high: ${JSON.stringify(missing)}`);
+      // Its siblings still price, and the candle still reports the rate used.
+      assert.equal(got.close_usd, 0.088 * 200);
+      assert.equal(got.usd_per_tao, 200);
+    }
+  });
+
+  test("a REAL zero is a price, and prices to $0", () => {
+    // The other side of the same line: a pool with no TAO in it has a measured
+    // price of 0, and 0 x rate is a legitimate $0 — refusing it would turn a
+    // measurement into "unavailable".
+    const c = { ...candle(T0, 0.08, 0.09, 0.07, 0.088), low: 0 };
+    const out = withAlphaUsdCandles(
+      ohlc([c]),
+      taoUsdBucketMap([reading(T0, 200)]),
+      HOUR,
+    );
+    assert.equal((out.candles as Record<string, unknown>[])[0].low_usd, 0);
+  });
+
+  test("USD is declared RECONSTRUCTED", () => {
+    const out = withAlphaUsdCandles(ohlc([]), taoUsdBucketMap([]), HOUR);
+    assert.deepEqual(out.field_sources_usd, {
+      kind: "reconstructed",
+      storage: null,
+    });
+  });
+});
+
+describe("pricing trend days", () => {
+  const day = (date: string, weighted: number, median: number) => ({
+    snapshot_date: date,
+    subnet_count: 129,
+    alpha_price_tao_weighted: weighted,
+    alpha_price_tao_median: median,
+  });
+  // The loader returns days NEWEST FIRST.
+  const trends = (days: Record<string, unknown>[]) => ({
+    schema_version: 1,
+    day_count: days.length,
+    days,
+  });
+  const dayStart = (date: string) => Date.parse(`${date}T00:00:00.000Z`);
+
+  test("a day older than the index is null", () => {
+    const out = withAlphaUsdTrendDays(
+      trends([day("2026-08-08", 0.05, 0.04), day("2025-09-01", 0.03, 0.02)]),
+      taoUsdBucketMap([reading(dayStart("2026-08-08"), 200)]),
+    );
+    const days = out.days as Record<string, unknown>[];
+    assert.equal(days[0].alpha_price_usd_weighted, 0.05 * 200);
+    assert.equal(days[1].alpha_price_usd_weighted, null);
+    assert.equal(days[1].usd_per_tao, null);
+  });
+
+  test("the boundary is the OLDEST priced day, though days arrive newest-first", () => {
+    // Latching on the first hit would report the NEWEST priced day as the point
+    // where USD begins — backwards, and wrong by the whole priced window.
+    const out = withAlphaUsdTrendDays(
+      trends([
+        day("2026-08-09", 0.05, 0.04),
+        day("2026-08-08", 0.05, 0.04),
+        day("2025-09-01", 0.03, 0.02),
+      ]),
+      taoUsdBucketMap([
+        reading(dayStart("2026-08-09"), 200),
+        reading(dayStart("2026-08-08"), 199),
+      ]),
+    );
+    assert.equal(out.usd_available_from, "2026-08-08");
+    assert.equal(out.priced_day_count, 2);
+  });
+
+  test("a malformed snapshot_date is refused rather than priced at epoch", () => {
+    const out = withAlphaUsdTrendDays(
+      trends([{ ...day("2026-08-08", 0.05, 0.04), snapshot_date: 20260808 }]),
+      taoUsdBucketMap([reading(dayStart("2026-08-08"), 200)]),
+    );
+    assert.equal(
+      (out.days as Record<string, unknown>[])[0].alpha_price_usd_weighted,
+      null,
+    );
+    assert.equal(out.usd_unavailable, "no_index_reading");
+  });
+
+  test("a failed read is distinguished from an unpriced series", () => {
+    const out = withAlphaUsdTrendDays(
+      trends([day("2026-08-08", 0.05, 0.04)]),
+      null,
+    );
+    assert.equal(out.usd_unavailable, "read_failed");
+  });
+
+  test("an empty series states no reason", () => {
+    const out = withAlphaUsdTrendDays(trends([]), taoUsdBucketMap([]));
+    assert.equal(out.usd_unavailable, null);
+    assert.equal(out.priced_day_count, 0);
+  });
+
+  test("a payload with no days array is passed through", () => {
+    const out = withAlphaUsdTrendDays({ day_count: 0 }, taoUsdBucketMap([]));
+    assert.equal(out.day_count, 0);
+    assert.equal(out.usd_available_from, null);
+  });
+});
+
+describe("shapes the store actually returns", () => {
+  test("a result object with no `results` key reads as empty, not as a failure", async () => {
+    // A store that answers but has nothing to say is an EMPTY series; only a
+    // throw or a missing binding is a failed read.
+    const db = { prepare: () => ({ bind: () => ({ all: async () => ({}) }) }) };
+    assert.deepEqual(
+      await loadTaoUsdBuckets(db, { sinceMs: 0, bucketMs: HOUR }),
+      [],
+    );
+  });
+
+  test("a NUMERIC column arriving as a STRING still prices", () => {
+    // Postgres drivers hand back NUMERIC as a string to avoid double rounding,
+    // so `usd_per_tao` and the candle's own prices can both be strings on the
+    // wire. Refusing them would unprice the entire series against a live
+    // database while every fixture-backed test stayed green.
+    const map = taoUsdBucketMap([
+      { ...reading(T0, null), usd_per_tao: "200.5" },
+    ]);
+    assert.equal(map.get(T0)?.usd_per_tao, 200.5);
+    const out = withAlphaUsdCandles(
+      ohlc([{ ...candle(T0, 0.08, 0.09, 0.07, 0.088), close: "0.088" }]),
+      map,
+      HOUR,
+    );
+    assert.equal(
+      (out.candles as Record<string, unknown>[])[0].close_usd,
+      0.088 * 200.5,
+    );
+  });
+
+  test("a reading missing its stamp or basis carries null, not undefined", () => {
+    const map = taoUsdBucketMap([
+      { bucket_start: T0, usd_per_tao: 200, block_number: 1 },
+    ]);
+    const r = map.get(T0);
+    assert.equal(r?.observed_at, null);
+    assert.equal(r?.price_basis, null);
+    // And a reading that cannot say WHEN is refused rather than trusted --
+    // alpha-usd.ts treats an unparseable stamp as stale.
+    const out = withAlphaUsdCandles(
+      ohlc([candle(T0, 0.08, 0.09, 0.07, 0.088)]),
+      map,
+      HOUR,
+    );
+    assert.equal((out.candles as Record<string, unknown>[])[0].close_usd, null);
+    assert.equal(out.usd_unavailable, "index_stale");
+  });
+});
+
+describe("deciding whether to read at all", () => {
+  test("no candles means no read", () => {
+    // Root (netuid 0) and a cold store both land here. A query for a window no
+    // point falls in can only return rows nobody reads.
+    assert.equal(ohlcUsdWindowStart(ohlc([])), null);
+    assert.equal(ohlcUsdWindowStart({ netuid: 0, root_excluded: true }), null);
+  });
+
+  test("the window starts at the OLDEST candle", () => {
+    // Candles are ascending, so the first is the floor the index must cover.
+    const out = ohlcUsdWindowStart(
+      ohlc([
+        candle(T0, 0.08, 0.09, 0.07, 0.088),
+        candle(T0 + HOUR, 1, 1, 1, 1),
+      ]),
+    );
+    assert.equal(out, T0);
+  });
+
+  test("an unusable bucket_start skips the read rather than reading from 0", () => {
+    // `Number(x) || 0` would turn a malformed start into epoch zero and pull
+    // the entire index back as the window.
+    assert.equal(
+      ohlcUsdWindowStart(
+        ohlc([{ ...candle(T0, 1, 1, 1, 1), bucket_start: "x" }]),
+      ),
+      null,
+    );
+  });
+});

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -411,9 +411,14 @@ describe("handleEconomicsTrends", () => {
     const lines = text.split("\r\n");
     assert.equal(
       lines[0],
-      "snapshot_date,subnet_count,total_stake_alpha,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+      "snapshot_date,subnet_count,total_stake_alpha,alpha_price_tao_weighted,alpha_price_tao_median,alpha_price_usd_weighted,alpha_price_usd_median,usd_per_tao,validator_count,miner_count,mean_emission_share",
     );
-    assert.equal(lines[1], "2026-06-02,1,300.000000000,0.02,0.02,8,50,0.04");
+    assert.equal(
+      lines[1], // The three empty cells are alpha_price_usd_weighted, alpha_price_usd_median
+      // and usd_per_tao (#10382): 2026-06-02 predates tao_usd_index, so the day
+      // carries NO usd figure rather than one converted at today's rate.
+      "2026-06-02,1,300.000000000,0.02,0.02,,,,8,50,0.04",
+    );
   });
 
   test("returns CSV response when Accept: text/csv header is present", async () => {
@@ -437,7 +442,12 @@ describe("handleEconomicsTrends", () => {
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
     const text = await res.text();
     const lines = text.split("\r\n");
-    assert.equal(lines[1], "2026-06-02,1,300.000000000,0.02,0.02,8,50,0.04");
+    assert.equal(
+      lines[1], // The three empty cells are alpha_price_usd_weighted, alpha_price_usd_median
+      // and usd_per_tao (#10382): 2026-06-02 predates tao_usd_index, so the day
+      // carries NO usd figure rather than one converted at today's rate.
+      "2026-06-02,1,300.000000000,0.02,0.02,,,,8,50,0.04",
+    );
   });
 
   test("returns empty/header-only CSV when rollup is cold", async () => {
@@ -451,7 +461,7 @@ describe("handleEconomicsTrends", () => {
     const lines = text.split("\r\n");
     assert.equal(
       lines[0],
-      "snapshot_date,subnet_count,total_stake_alpha,alpha_price_tao_weighted,alpha_price_tao_median,validator_count,miner_count,mean_emission_share",
+      "snapshot_date,subnet_count,total_stake_alpha,alpha_price_tao_weighted,alpha_price_tao_median,alpha_price_usd_weighted,alpha_price_usd_median,usd_per_tao,validator_count,miner_count,mean_emission_share",
     );
     assert.equal(lines.length, 1);
   });

--- a/tests/subnet-ohlc.test.ts
+++ b/tests/subnet-ohlc.test.ts
@@ -772,3 +772,86 @@ describe("buildSubnetOhlcFromBuckets", () => {
     );
   });
 });
+
+// --- USD overlay on the served route (#10382) ------------------------------
+
+describe("GET /api/v1/subnets/{netuid}/ohlc carries USD", () => {
+  const BUCKET = Date.parse("2026-08-08T00:00:00.000Z");
+  const ohlcTierEnv = () =>
+    ({
+      ...createLocalArtifactEnv(),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: {
+        fetch: async () =>
+          Response.json({
+            data: {
+              schema_version: 1,
+              netuid: 7,
+              interval: "1h",
+              candles: [
+                {
+                  bucket_start: BUCKET,
+                  bucket_start_iso: new Date(BUCKET).toISOString(),
+                  open: 0.08,
+                  high: 0.09,
+                  low: 0.07,
+                  close: 0.088,
+                  volume_alpha: 100,
+                  volume_tao: 12.5,
+                  event_count: 3,
+                },
+              ],
+              candle_count: 1,
+              root_excluded: false,
+            },
+            generatedAt: null,
+          }),
+      },
+    }) as unknown as Env;
+
+  test("every candle carries the USD keys, even with no index behind them", async () => {
+    // The index is unreachable in this env, which is exactly the case that
+    // must NOT change the shape: a caller mapping `c => c.close_usd` gets a
+    // hole in the line, not an array whose keys moved.
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/ohlc"),
+      ohlcTierEnv(),
+      ctx,
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.candles.length, 1);
+    const c = body.data.candles[0];
+    // The TAO side is untouched by the overlay.
+    assert.equal(c.close, 0.088);
+    for (const k of [
+      "open_usd",
+      "high_usd",
+      "low_usd",
+      "close_usd",
+      "volume_usd",
+      "usd_per_tao",
+    ]) {
+      assert.ok(k in c, `${k} must be present`);
+      assert.equal(c[k], null, `${k} must be null, never 0`);
+    }
+  });
+
+  test("the route states WHY there is no USD rather than implying none exists", async () => {
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/ohlc"),
+      ohlcTierEnv(),
+      ctx,
+    );
+    const body = await res.json();
+    // "We could not ask the index" is not "the index had nothing to say".
+    assert.equal(body.data.usd_unavailable, "read_failed");
+    assert.equal(body.data.usd_available_from, null);
+    assert.equal(body.data.usd_available_from_iso, null);
+    assert.equal(body.data.priced_candle_count, 0);
+    assert.deepEqual(body.data.field_sources_usd, {
+      kind: "reconstructed",
+      storage: null,
+    });
+  });
+});

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -77,7 +77,16 @@ import {
   buildDomainSummary,
 } from "../../src/domain-summary.ts";
 import { readStore } from "../../src/read-store.ts";
-import { LEADERBOARD_TABLES } from "../../src/read-store-tables.ts";
+import {
+  LEADERBOARD_TABLES,
+  TAO_USD_TABLES,
+} from "../../src/read-store-tables.ts";
+import {
+  loadTaoUsdBuckets,
+  taoUsdBucketMap,
+  withAlphaUsdTrendDays,
+} from "../../src/alpha-usd-history.ts";
+import { DAY_MS } from "../config.ts";
 
 type HealthMetaKvReader = (
   env: Env,
@@ -105,6 +114,13 @@ const ECONOMICS_TRENDS_CSV_COLUMNS = [
   "total_stake_alpha",
   "alpha_price_tao_weighted",
   "alpha_price_tao_median",
+  // USD siblings (#10382). Carried in CSV as well as JSON: a CSV that dropped
+  // them would be a quietly different answer to the same question, and the
+  // export is the format most likely to be charted offline -- where a missing
+  // column is least visible.
+  "alpha_price_usd_weighted",
+  "alpha_price_usd_median",
+  "usd_per_tao",
   "validator_count",
   "miner_count",
   "mean_emission_share",
@@ -332,6 +348,29 @@ export async function handleEconomicsTrends(
     isFallback =
       !env.HYPERDRIVE?.connectionString ||
       currentD1ReadFailureGeneration() !== d1Generation;
+  }
+  // USD per day (#10382), overlaid BEFORE the CSV branch so both formats carry
+  // the same answer. Each day is priced by a reading from inside that UTC day;
+  // a day older than the index carries null rather than today's rate applied
+  // retroactively across thirteen months of history.
+  const trendDays = Array.isArray(data?.days)
+    ? (data.days as Record<string, unknown>[])
+    : [];
+  if (trendDays.length) {
+    // Days arrive newest-first, so the OLDEST is the last element -- that is
+    // the floor of the window the index has to cover.
+    const oldest = trendDays[trendDays.length - 1]?.snapshot_date;
+    const sinceMs = Date.parse(`${String(oldest)}T00:00:00.000Z`);
+    const usdRows = await loadTaoUsdBuckets(
+      readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
+        typeof loadTaoUsdBuckets
+      >[0],
+      { sinceMs: Number.isFinite(sinceMs) ? sinceMs : 0, bucketMs: DAY_MS },
+    );
+    data = withAlphaUsdTrendDays(
+      data as unknown as Record<string, unknown>,
+      usdRows === null ? null : taoUsdBucketMap(usdRows),
+    ) as typeof data;
   }
   if (csvRequested(url, request)) {
     const csvRes = await csvResponse(

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -375,7 +375,17 @@ import {
 } from "../../src/stake-flow.ts";
 import { buildAlphaVolume } from "../../src/alpha-volume.ts";
 import { loadSubnetAlphaVolumeFromArtifact } from "../../src/subnet-alpha-volume-artifact.ts";
-import { buildSubnetOhlc } from "../../src/subnet-ohlc.ts";
+import {
+  buildSubnetOhlc,
+  normalizeInterval,
+  OHLC_INTERVALS,
+} from "../../src/subnet-ohlc.ts";
+import {
+  loadTaoUsdBuckets,
+  ohlcUsdWindowStart,
+  taoUsdBucketMap,
+  withAlphaUsdCandles,
+} from "../../src/alpha-usd-history.ts";
 import { loadSubnetOhlcColdTier } from "../../src/subnet-ohlc-cold-tier.ts";
 import { resolveLiveEconomics } from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
@@ -4065,10 +4075,38 @@ export async function handleSubnetOhlc(
       }),
       generatedAt: null,
     };
+  // USD per candle (#10382). Overlaid HERE, after the tier resolves, so the
+  // Postgres tier, the lakehouse cold tier and the empty fallback all gain it
+  // from one place -- and so the shared candle assembler, which GraphQL and MCP
+  // also call, keeps the shape those surfaces already publish.
+  //
+  // Each candle is priced by a reading from ITS OWN bucket; one older than the
+  // index carries null rather than today's rate applied backwards. See
+  // src/alpha-usd-history.ts for why that distinction is structural.
+  // normalizeInterval is the assembler's OWN normalizer, so the rate buckets
+  // and the candle buckets cannot disagree about what "1d" means.
+  const bucketMs = OHLC_INTERVALS[normalizeInterval(interval)];
+  // Null means there is nothing to price -- root (netuid 0) and a cold store
+  // both yield empty candles, and querying the index for a window no point
+  // falls in is a round trip whose rows nobody would read.
+  const sinceMs = ohlcUsdWindowStart(data as Record<string, unknown>);
+  const usdRows =
+    sinceMs === null
+      ? []
+      : await loadTaoUsdBuckets(
+          readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
+            typeof loadTaoUsdBuckets
+          >[0],
+          { sinceMs, bucketMs },
+        );
   return envelopeResponse(
     request,
     {
-      data,
+      data: withAlphaUsdCandles(
+        data as Record<string, unknown>,
+        usdRows === null ? null : taoUsdBucketMap(usdRows),
+        bucketMs,
+      ),
       meta: await accountMeta(
         env,
         `/metagraph/subnets/${netuid}/ohlc.json`,


### PR DESCRIPTION
## What

`/subnets/{netuid}/ohlc` and `/economics/trends` now carry USD alongside every TAO figure — priced **per bucket**, from a reading inside that bucket, or not priced at all.

## The trap this closes

```
alpha price history   2025-06-23 -> 2026-08-10   ~13 months of daily rows
tao_usd_index         2026-08-02 -> 2026-08-10   ~8 days at one row/minute
```

Multiplying thirteen months of alpha prices by *today's* TAO/USD renders a perfect chart that is wrong at every point except the last. The curve keeps its shape, so nothing in the output looks off — which is why the rule is structural rather than advisory: **a point is priced by a reading from its own bucket, or it carries `null`.** Never the nearest rate, never the first, never today's.

## Acceptance, against the issue

1. **A bucket predating the index is `null`** — asserted directly, and separately for candles and for trend days.
2. **The boundary is published**, not inferred: `usd_available_from` (+`_iso`) and `priced_candle_count` / `priced_day_count`.
3. **90 days of TAO and ~8 of USD are both legible** — there is a test that builds exactly that and asserts 90 candles survive while 8 price.

## Design notes worth the review

- **One rate per candle, not one per field.** open/high/low/close happen at four instants; pricing each at its own rate can put `high_usd` below `close_usd` and turn a candle inside out. A single positive multiplier is monotonic, so every ordering the TAO candle had, the USD candle keeps. There is a test asserting the invariant directly.
- **Bucketing in SQL.** The index writes ~1/min; an 8-day overlap is ~11,500 rows to produce a few hundred rates. `DISTINCT ON` collapses it to one row per bucket in the engine, so the body is bounded by the *candle* count. Verified against production Neon before it was wired.
- **Alignment is single-sourced.** `(observed_at / bucketMs) * bucketMs` is the integer-division twin of the `Math.floor(ts/intervalMs)*intervalMs` both OHLC tiers use, and `bucketMs` comes from the assembler's own `normalizeInterval` — the two cannot disagree about what `1d` means. A fractional `bucketMs` throws rather than silently shifting every rate one bucket.
- **Overlaid after the tier resolves**, so the Postgres tier, the lakehouse cold tier and the empty fallback all gain USD from one place — and `buildSubnetOhlcFromBuckets`, which GraphQL and MCP also call, keeps the shape those surfaces already publish. This PR does not touch either.
- **Nulls, not omissions** — deliberately unlike the spot overlay in #10392. A series is consumed as an array of uniform points: a caller mapping `c => c.close_usd` must get a hole in the line, not an `undefined` that plots as zero. The emitted key set is identical whether a rate was found, the index declined, or the read failed; a test pins that. The *reason* rides at the top level, where it is one string rather than nineteen hundred.
- **`insufficient_pools` stays a stated decline**, never a price of zero. The picker prefers a priced reading over a later unpriced one in the same bucket, so one declining row at :59 cannot unprice an hour that had fifty-nine good ones.
- **`read_failed` is distinguished from `no_index_reading`.** "We could not ask" is not a claim about the index.

## One bug this caught in itself

The first draft used `Number(tao)`. `Number(null)` is `0`, so a missing `high` priced to a legitimate-looking **$0** — the exact inversion of the rule the module exists to hold (zero is a price; absent is not). The coercion boundary now takes only a real number or a string that says one, and a test covers `null`/`undefined`/`""`/`"   "`/`false` alongside a real `0` that must still price.

## Verification

- `tests/alpha-usd-history.test.ts` — 36 tests; **100% branch coverage (82/82)** on the new module, measured directly.
- Handler additions in `entities.ts` and `analytics-routes.ts`: zero uncovered branches, measured on the changed line range.
- The bucketing SQL was run against production Neon, returning one row per hour bucket with the last priced reading in each.
- Schemas updated in `schemas-src` and the generated `openapi.json` / types regenerated and committed; `tsc`, `eslint`, `prettier` clean; 539 tests across the affected suites green.

Closes #10382
