### PR TITLE
feat(economics): volume in USD, at a rate that says how it was priced

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -715,6 +715,13 @@ export type Adapter = {
   subnet?: Maybe<Scalars['String']['output']>;
 };
 
+/** Provenance for the USD fields: RECONSTRUCTED, never measured. The product of a measured alpha price and a measured TAO/USD index is our arithmetic, and a null storage says there is no single chain read behind it. */
+export type AlphaUsdFieldSource = {
+  __typename?: 'AlphaUsdFieldSource';
+  kind: Scalars['String']['output'];
+  storage?: Maybe<Scalars['String']['output']>;
+};
+
 export type Block = {
   __typename?: 'Block';
   author?: Maybe<Scalars['String']['output']>;
@@ -884,12 +891,19 @@ export type ChainActivityDay = {
 /** Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope. */
 export type ChainAlphaVolume = {
   __typename?: 'ChainAlphaVolume';
+  field_sources?: Maybe<Scalars['JSON']['output']>;
   network: ChainAlphaVolumeNetwork;
   /** Newest event observed_at across the window; null on a cold store. */
   observed_at?: Maybe<Scalars['String']['output']>;
   schema_version: Scalars['Int']['output'];
   subnet_count: Scalars['Int']['output'];
   subnets: Array<ChainAlphaVolumeSubnet>;
+  /** The reading every _usd field was converted at. */
+  tao_usd?: Maybe<TaoUsdConversion>;
+  /** Why there are no _usd fields. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero. */
+  tao_usd_unavailable?: Maybe<Scalars['String']['output']>;
+  /** HOW the totals were converted: window_close_rate -- at the rate observed at the window's close, not summed per trade. */
+  usd_pricing_basis?: Maybe<Scalars['String']['output']>;
   /** Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume. */
   volume_distribution?: Maybe<IntensityDistribution>;
   /** Fixed rolling window label (always 24h). */
@@ -902,16 +916,20 @@ export type ChainAlphaVolumeNetwork = {
   buy_count: Scalars['Int']['output'];
   buy_volume_alpha: Scalars['Float']['output'];
   buy_volume_tao: Scalars['Float']['output'];
+  /** USD twins (#10383), converted at the window's close rate. Null when the index was unusable -- tao_usd_unavailable says why. */
+  buy_volume_usd?: Maybe<Scalars['Float']['output']>;
   net_volume_alpha: Scalars['Float']['output'];
   sell_count: Scalars['Int']['output'];
   sell_volume_alpha: Scalars['Float']['output'];
   sell_volume_tao: Scalars['Float']['output'];
+  sell_volume_usd?: Maybe<Scalars['Float']['output']>;
   /** Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window. */
   sentiment: Scalars['String']['output'];
   /** net/gross alpha lean in [-1, 1]; null when there was no volume in the window. */
   sentiment_ratio?: Maybe<Scalars['Float']['output']>;
   total_volume_alpha: Scalars['Float']['output'];
   total_volume_tao: Scalars['Float']['output'];
+  total_volume_usd?: Maybe<Scalars['Float']['output']>;
 };
 
 /** One subnet's rolling 24h buy/sell volume scorecard, ranked by total_volume_tao then netuid. */
@@ -920,18 +938,29 @@ export type ChainAlphaVolumeSubnet = {
   buy_count: Scalars['Int']['output'];
   buy_volume_alpha: Scalars['Float']['output'];
   buy_volume_tao: Scalars['Float']['output'];
+  /** USD twins (#10383), converted at the window's close rate. Null when the index was unusable -- tao_usd_unavailable says why. */
+  buy_volume_usd?: Maybe<Scalars['Float']['output']>;
+  field_sources?: Maybe<Scalars['JSON']['output']>;
   net_volume_alpha: Scalars['Float']['output'];
   netuid: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
   sell_count: Scalars['Int']['output'];
   sell_volume_alpha: Scalars['Float']['output'];
   sell_volume_tao: Scalars['Float']['output'];
+  sell_volume_usd?: Maybe<Scalars['Float']['output']>;
   /** Coarse sentiment label (bullish/bearish/neutral). */
   sentiment: Scalars['String']['output'];
   /** net/gross alpha lean in [-1, 1]; null when this subnet had no volume. */
   sentiment_ratio?: Maybe<Scalars['Float']['output']>;
+  /** The reading every _usd field was converted at. */
+  tao_usd?: Maybe<TaoUsdConversion>;
+  /** Why there are no _usd fields. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero. */
+  tao_usd_unavailable?: Maybe<Scalars['String']['output']>;
   total_volume_alpha: Scalars['Float']['output'];
   total_volume_tao: Scalars['Float']['output'];
+  total_volume_usd?: Maybe<Scalars['Float']['output']>;
+  /** HOW the totals were converted: window_close_rate -- at the rate observed at the window's close, not summed per trade. */
+  usd_pricing_basis?: Maybe<Scalars['String']['output']>;
   /** 24h volume / market-cap turnover ratio; always null here (no per-subnet market-cap input in scope at the network level). */
   vol_mcap_ratio?: Maybe<Scalars['Float']['output']>;
   window?: Maybe<Scalars['String']['output']>;
@@ -1955,7 +1984,7 @@ export type EconomicsTrends = {
   __typename?: 'EconomicsTrends';
   day_count: Scalars['Int']['output'];
   days: Array<EconomicsTrendsDay>;
-  field_sources_usd?: Maybe<Scalars['JSON']['output']>;
+  field_sources_usd?: Maybe<AlphaUsdFieldSource>;
   priced_day_count?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
   /** The OLDEST snapshot_date carrying USD, or null when none does. Published so a caller can say 'USD from <date>' rather than infer the boundary from where the nulls stop. */
@@ -5576,7 +5605,7 @@ export type SubnetOhlc = {
   /** How many candles the WINDOW holds, not how many this page carries. A limit narrows the candle list from the recent end; this stays the denominator, the same convention /chain/deregistrations uses for its own page. */
   candle_count: Scalars['Int']['output'];
   candles: Array<SubnetOhlcCandle>;
-  field_sources_usd?: Maybe<Scalars['JSON']['output']>;
+  field_sources_usd?: Maybe<AlphaUsdFieldSource>;
   /** The resolved bucket interval (1h/1d). */
   interval?: Maybe<Scalars['String']['output']>;
   netuid: Scalars['Int']['output'];
@@ -5972,18 +6001,29 @@ export type SubnetVolume = {
   buy_count: Scalars['Int']['output'];
   buy_volume_alpha: Scalars['Float']['output'];
   buy_volume_tao: Scalars['Float']['output'];
+  /** USD twins (#10383), converted at the window's close rate. Null when the index was unusable -- tao_usd_unavailable says why. */
+  buy_volume_usd?: Maybe<Scalars['Float']['output']>;
+  field_sources?: Maybe<Scalars['JSON']['output']>;
   net_volume_alpha: Scalars['Float']['output'];
   netuid: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
   sell_count: Scalars['Int']['output'];
   sell_volume_alpha: Scalars['Float']['output'];
   sell_volume_tao: Scalars['Float']['output'];
+  sell_volume_usd?: Maybe<Scalars['Float']['output']>;
   /** Bucketed reading of sentiment_ratio (buying/selling/neutral). */
   sentiment?: Maybe<Scalars['String']['output']>;
   /** Buy share of total volume (0-1); null when there was no volume. */
   sentiment_ratio?: Maybe<Scalars['Float']['output']>;
+  /** The reading every _usd field was converted at. */
+  tao_usd?: Maybe<TaoUsdConversion>;
+  /** Why there are no _usd fields. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero. */
+  tao_usd_unavailable?: Maybe<Scalars['String']['output']>;
   total_volume_alpha: Scalars['Float']['output'];
   total_volume_tao: Scalars['Float']['output'];
+  total_volume_usd?: Maybe<Scalars['Float']['output']>;
+  /** HOW the totals were converted: window_close_rate -- at the rate observed at the window's close, not summed per trade. */
+  usd_pricing_basis?: Maybe<Scalars['String']['output']>;
   /** Total TAO volume over alpha market cap; null when market cap is unknown. */
   vol_mcap_ratio?: Maybe<Scalars['Float']['output']>;
   /** The rolling window label this card covers (24h). */
@@ -6170,6 +6210,15 @@ export type TaoUsd = {
   priced_point_count: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
+};
+
+/** The TAO/USD reading a set of _usd fields was converted at, kept together so the price and its provenance always describe the same block. */
+export type TaoUsdConversion = {
+  __typename?: 'TaoUsdConversion';
+  block_number?: Maybe<Scalars['Int']['output']>;
+  observed_at?: Maybe<Scalars['String']['output']>;
+  price_basis?: Maybe<Scalars['String']['output']>;
+  usd_per_tao: Scalars['Float']['output'];
 };
 
 /** The newest reading with the derivation that produced it, kept together so both describe the same block. */
@@ -6609,6 +6658,7 @@ export type ResolversTypes = ResolversObject<{
   AccountWeightSetters: ResolverTypeWrapper<AccountWeightSetters>;
   AccountWeightSettersSubnet: ResolverTypeWrapper<AccountWeightSettersSubnet>;
   Adapter: ResolverTypeWrapper<Adapter>;
+  AlphaUsdFieldSource: ResolverTypeWrapper<AlphaUsdFieldSource>;
   Block: ResolverTypeWrapper<Block>;
   BlockChainEvents: ResolverTypeWrapper<BlockChainEvents>;
   BlockDetail: ResolverTypeWrapper<BlockDetail>;
@@ -6874,6 +6924,7 @@ export type ResolversTypes = ResolversObject<{
   SurfaceHistoryChange: ResolverTypeWrapper<SurfaceHistoryChange>;
   SurfaceList: ResolverTypeWrapper<SurfaceList>;
   TaoUsd: ResolverTypeWrapper<TaoUsd>;
+  TaoUsdConversion: ResolverTypeWrapper<TaoUsdConversion>;
   TaoUsdLatest: ResolverTypeWrapper<TaoUsdLatest>;
   TaoUsdPoint: ResolverTypeWrapper<TaoUsdPoint>;
   TurnoverUidReassignment: ResolverTypeWrapper<TurnoverUidReassignment>;
@@ -6958,6 +7009,7 @@ export type ResolversParentTypes = ResolversObject<{
   AccountWeightSetters: AccountWeightSetters;
   AccountWeightSettersSubnet: AccountWeightSettersSubnet;
   Adapter: Adapter;
+  AlphaUsdFieldSource: AlphaUsdFieldSource;
   Block: Block;
   BlockChainEvents: BlockChainEvents;
   BlockDetail: BlockDetail;
@@ -7221,6 +7273,7 @@ export type ResolversParentTypes = ResolversObject<{
   SurfaceHistoryChange: SurfaceHistoryChange;
   SurfaceList: SurfaceList;
   TaoUsd: TaoUsd;
+  TaoUsdConversion: TaoUsdConversion;
   TaoUsdLatest: TaoUsdLatest;
   TaoUsdPoint: TaoUsdPoint;
   TurnoverUidReassignment: TurnoverUidReassignment;
@@ -7817,6 +7870,11 @@ export type AdapterResolvers<ContextType = GqlContext, ParentType extends Resolv
   subnet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type AlphaUsdFieldSourceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AlphaUsdFieldSource'] = ResolversParentTypes['AlphaUsdFieldSource']> = ResolversObject<{
+  kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  storage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
 export type BlockResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Block'] = ResolversParentTypes['Block']> = ResolversObject<{
   author?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   block_hash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -7959,11 +8017,15 @@ export type ChainActivityDayResolvers<ContextType = GqlContext, ParentType exten
 }>;
 
 export type ChainAlphaVolumeResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainAlphaVolume'] = ResolversParentTypes['ChainAlphaVolume']> = ResolversObject<{
+  field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   network?: Resolver<ResolversTypes['ChainAlphaVolumeNetwork'], ParentType, ContextType>;
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   subnets?: Resolver<Array<ResolversTypes['ChainAlphaVolumeSubnet']>, ParentType, ContextType>;
+  tao_usd?: Resolver<Maybe<ResolversTypes['TaoUsdConversion']>, ParentType, ContextType>;
+  tao_usd_unavailable?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  usd_pricing_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   volume_distribution?: Resolver<Maybe<ResolversTypes['IntensityDistribution']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
@@ -7972,30 +8034,40 @@ export type ChainAlphaVolumeNetworkResolvers<ContextType = GqlContext, ParentTyp
   buy_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   buy_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   buy_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  buy_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   net_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   sell_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sell_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   sell_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  sell_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   sentiment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   sentiment_ratio?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  total_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type ChainAlphaVolumeSubnetResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainAlphaVolumeSubnet'] = ResolversParentTypes['ChainAlphaVolumeSubnet']> = ResolversObject<{
   buy_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   buy_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   buy_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  buy_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   net_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sell_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sell_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   sell_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  sell_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   sentiment?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   sentiment_ratio?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  tao_usd?: Resolver<Maybe<ResolversTypes['TaoUsdConversion']>, ParentType, ContextType>;
+  tao_usd_unavailable?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  total_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  usd_pricing_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   vol_mcap_ratio?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
@@ -8787,7 +8859,7 @@ export type EconomicsSummaryResolvers<ContextType = GqlContext, ParentType exten
 export type EconomicsTrendsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EconomicsTrends'] = ResolversParentTypes['EconomicsTrends']> = ResolversObject<{
   day_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   days?: Resolver<Array<ResolversTypes['EconomicsTrendsDay']>, ParentType, ContextType>;
-  field_sources_usd?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  field_sources_usd?: Resolver<Maybe<ResolversTypes['AlphaUsdFieldSource']>, ParentType, ContextType>;
   priced_day_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   usd_available_from?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10381,7 +10453,7 @@ export type SubnetMoversNetworkResolvers<ContextType = GqlContext, ParentType ex
 export type SubnetOhlcResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOhlc'] = ResolversParentTypes['SubnetOhlc']> = ResolversObject<{
   candle_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   candles?: Resolver<Array<ResolversTypes['SubnetOhlcCandle']>, ParentType, ContextType>;
-  field_sources_usd?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  field_sources_usd?: Resolver<Maybe<ResolversTypes['AlphaUsdFieldSource']>, ParentType, ContextType>;
   interval?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   priced_candle_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -10693,16 +10765,23 @@ export type SubnetVolumeResolvers<ContextType = GqlContext, ParentType extends R
   buy_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   buy_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   buy_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  buy_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   net_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sell_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sell_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   sell_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  sell_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   sentiment?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   sentiment_ratio?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  tao_usd?: Resolver<Maybe<ResolversTypes['TaoUsdConversion']>, ParentType, ContextType>;
+  tao_usd_unavailable?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total_volume_alpha?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   total_volume_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  total_volume_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  usd_pricing_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   vol_mcap_ratio?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
@@ -10853,6 +10932,13 @@ export type TaoUsdResolvers<ContextType = GqlContext, ParentType extends Resolve
   priced_point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type TaoUsdConversionResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['TaoUsdConversion'] = ResolversParentTypes['TaoUsdConversion']> = ResolversObject<{
+  block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  price_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  usd_per_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
 export type TaoUsdLatestResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['TaoUsdLatest'] = ResolversParentTypes['TaoUsdLatest']> = ResolversObject<{
@@ -11151,6 +11237,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   AccountWeightSetters?: AccountWeightSettersResolvers<ContextType>;
   AccountWeightSettersSubnet?: AccountWeightSettersSubnetResolvers<ContextType>;
   Adapter?: AdapterResolvers<ContextType>;
+  AlphaUsdFieldSource?: AlphaUsdFieldSourceResolvers<ContextType>;
   Block?: BlockResolvers<ContextType>;
   BlockChainEvents?: BlockChainEventsResolvers<ContextType>;
   BlockDetail?: BlockDetailResolvers<ContextType>;
@@ -11410,6 +11497,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SurfaceHistoryChange?: SurfaceHistoryChangeResolvers<ContextType>;
   SurfaceList?: SurfaceListResolvers<ContextType>;
   TaoUsd?: TaoUsdResolvers<ContextType>;
+  TaoUsdConversion?: TaoUsdConversionResolvers<ContextType>;
   TaoUsdLatest?: TaoUsdLatestResolvers<ContextType>;
   TaoUsdPoint?: TaoUsdPointResolvers<ContextType>;
   TurnoverUidReassignment?: TurnoverUidReassignmentResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6183,15 +6183,27 @@ export interface components {
         };
         /** @description Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope. */
         ChainAlphaVolumeArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources?: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             /** @description Network-wide buy/sell volume rollup across every subnet with volume in the window. */
             network: {
                 buy_count: number;
                 buy_volume_alpha: number;
                 buy_volume_tao: number;
+                buy_volume_usd?: number;
                 net_volume_alpha: number;
                 sell_count: number;
                 sell_volume_alpha: number;
                 sell_volume_tao: number;
+                sell_volume_usd?: number;
                 /**
                  * @description Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window.
                  * @enum {string}
@@ -6201,12 +6213,30 @@ export interface components {
                 sentiment_ratio: number | null;
                 total_volume_alpha: number;
                 total_volume_tao: number;
+                total_volume_usd?: number;
             };
             /** @description Newest event observed_at across the window; null on a cold store. */
             observed_at: string | null;
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["SubnetAlphaVolumeArtifact"][];
+            /** @description The reading every _usd field was converted at -- the network rollup and each per-subnet row alike, so one reading priced them all. */
+            tao_usd?: {
+                block_number: number | null;
+                observed_at: string | null;
+                price_basis: string | null;
+                usd_per_tao: number;
+            };
+            /**
+             * @description Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.
+             * @enum {string}
+             */
+            tao_usd_unavailable?: "no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price";
+            /**
+             * @description HOW the totals were converted: at the rate observed at the window's close, not summed per trade. volume_distribution is NOT converted -- its percentiles stay TAO, and a caller wanting them in dollars multiplies by usd_per_tao above.
+             * @constant
+             */
+            usd_pricing_basis?: "window_close_rate";
             /** @description Spread of per-subnet total_volume_tao across EVERY subnet with volume (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard). Null when no subnet had volume. */
             volume_distribution: components["schemas"]["IntensityDistribution"] | null;
             /**
@@ -10291,12 +10321,24 @@ export interface components {
             buy_count: number;
             buy_volume_alpha: number;
             buy_volume_tao: number;
+            buy_volume_usd?: number;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources?: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             net_volume_alpha: number;
             netuid: number;
             schema_version: number;
             sell_count: number;
             sell_volume_alpha: number;
             sell_volume_tao: number;
+            sell_volume_usd?: number;
             /**
              * @description Bucketed reading of sentiment_ratio (buying/selling/neutral).
              * @enum {string}
@@ -10304,8 +10346,26 @@ export interface components {
             sentiment: "bullish" | "bearish" | "neutral";
             /** @description Buy share of total volume (0-1); null when there was no volume. */
             sentiment_ratio: number | null;
+            /** @description The reading every _usd field was converted at. Rides at the blob level because ONE reading priced all of them. */
+            tao_usd?: {
+                block_number: number | null;
+                observed_at: string | null;
+                price_basis: string | null;
+                usd_per_tao: number;
+            };
+            /**
+             * @description Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.
+             * @enum {string}
+             */
+            tao_usd_unavailable?: "no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price";
             total_volume_alpha: number;
             total_volume_tao: number;
+            total_volume_usd?: number;
+            /**
+             * @description HOW the totals were converted: at the rate observed at the window's close, not summed per trade. A string rather than a boolean so a future per-trade implementation publishes a different value instead of silently changing what this shape means.
+             * @constant
+             */
+            usd_pricing_basis?: "window_close_rate";
             /** @description Total TAO volume over alpha market cap; null when market cap is unknown. */
             vol_mcap_ratio: number | null;
             /**
@@ -14462,18 +14522,27 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "network": {
                      *           "buy_count": 1,
                      *           "buy_volume_alpha": 0.5,
                      *           "buy_volume_tao": 0.5,
+                     *           "buy_volume_usd": 0.5,
                      *           "net_volume_alpha": 0.5,
                      *           "sell_count": 1,
                      *           "sell_volume_alpha": 0.5,
                      *           "sell_volume_tao": 0.5,
+                     *           "sell_volume_usd": 0.5,
                      *           "sentiment": "bullish",
                      *           "sentiment_ratio": 0.9966,
                      *           "total_volume_alpha": 0.5,
-                     *           "total_volume_tao": 0.5
+                     *           "total_volume_tao": 0.5,
+                     *           "total_volume_usd": 0.5
                      *         },
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -14497,6 +14566,14 @@ export interface operations {
                      *             "window": "24h"
                      *           }
                      *         ],
+                     *         "tao_usd": {
+                     *           "block_number": 5000000,
+                     *           "observed_at": "2026-06-01T00:00:00.000Z",
+                     *           "price_basis": "example",
+                     *           "usd_per_tao": 0.5
+                     *         },
+                     *         "tao_usd_unavailable": "no_index_reading",
+                     *         "usd_pricing_basis": "window_close_rate",
                      *         "volume_distribution": {
                      *           "count": 1,
                      *           "max": 0.5,
@@ -24183,18 +24260,27 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "network": {
                      *           "buy_count": 1,
                      *           "buy_volume_alpha": 0.5,
                      *           "buy_volume_tao": 0.5,
+                     *           "buy_volume_usd": 0.5,
                      *           "net_volume_alpha": 0.5,
                      *           "sell_count": 1,
                      *           "sell_volume_alpha": 0.5,
                      *           "sell_volume_tao": 0.5,
+                     *           "sell_volume_usd": 0.5,
                      *           "sentiment": "bullish",
                      *           "sentiment_ratio": 0.9966,
                      *           "total_volume_alpha": 0.5,
-                     *           "total_volume_tao": 0.5
+                     *           "total_volume_tao": 0.5,
+                     *           "total_volume_usd": 0.5
                      *         },
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -24218,6 +24304,14 @@ export interface operations {
                      *             "window": "24h"
                      *           }
                      *         ],
+                     *         "tao_usd": {
+                     *           "block_number": 5000000,
+                     *           "observed_at": "2026-06-01T00:00:00.000Z",
+                     *           "price_basis": "example",
+                     *           "usd_per_tao": 0.5
+                     *         },
+                     *         "tao_usd_unavailable": "no_index_reading",
+                     *         "usd_pricing_basis": "window_close_rate",
                      *         "volume_distribution": {
                      *           "count": 1,
                      *           "max": 0.5,
@@ -46017,16 +46111,33 @@ export interface operations {
                      *         "buy_count": 1,
                      *         "buy_volume_alpha": 0.5,
                      *         "buy_volume_tao": 0.5,
+                     *         "buy_volume_usd": 0.5,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "net_volume_alpha": 0.5,
                      *         "netuid": 7,
                      *         "schema_version": 1,
                      *         "sell_count": 1,
                      *         "sell_volume_alpha": 0.5,
                      *         "sell_volume_tao": 0.5,
+                     *         "sell_volume_usd": 0.5,
                      *         "sentiment": "bullish",
                      *         "sentiment_ratio": 0.9966,
+                     *         "tao_usd": {
+                     *           "block_number": 5000000,
+                     *           "observed_at": "2026-06-01T00:00:00.000Z",
+                     *           "price_basis": "example",
+                     *           "usd_per_tao": 0.5
+                     *         },
+                     *         "tao_usd_unavailable": "no_index_reading",
                      *         "total_volume_alpha": 0.5,
                      *         "total_volume_tao": 0.5,
+                     *         "total_volume_usd": 0.5,
+                     *         "usd_pricing_basis": "window_close_rate",
                      *         "vol_mcap_ratio": 0.9966,
                      *         "window": "24h"
                      *       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2327,18 +2327,27 @@
       "ChainAlphaVolumeArtifactResponse": {
         "value": {
           "data": {
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "network": {
               "buy_count": 1,
               "buy_volume_alpha": 0.5,
               "buy_volume_tao": 0.5,
+              "buy_volume_usd": 0.5,
               "net_volume_alpha": 0.5,
               "sell_count": 1,
               "sell_volume_alpha": 0.5,
               "sell_volume_tao": 0.5,
+              "sell_volume_usd": 0.5,
               "sentiment": "bullish",
               "sentiment_ratio": 0.9966,
               "total_volume_alpha": 0.5,
-              "total_volume_tao": 0.5
+              "total_volume_tao": 0.5,
+              "total_volume_usd": 0.5
             },
             "observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
@@ -2362,6 +2371,14 @@
                 "window": "24h"
               }
             ],
+            "tao_usd": {
+              "block_number": 5000000,
+              "observed_at": "2026-06-01T00:00:00.000Z",
+              "price_basis": "example",
+              "usd_per_tao": 0.5
+            },
+            "tao_usd_unavailable": "no_index_reading",
+            "usd_pricing_basis": "window_close_rate",
             "volume_distribution": {
               "count": 1,
               "max": 0.5,
@@ -8374,16 +8391,33 @@
             "buy_count": 1,
             "buy_volume_alpha": 0.5,
             "buy_volume_tao": 0.5,
+            "buy_volume_usd": 0.5,
+            "field_sources": {
+              "example": {
+                "kind": "measured",
+                "storage": "example"
+              }
+            },
             "net_volume_alpha": 0.5,
             "netuid": 7,
             "schema_version": 1,
             "sell_count": 1,
             "sell_volume_alpha": 0.5,
             "sell_volume_tao": 0.5,
+            "sell_volume_usd": 0.5,
             "sentiment": "bullish",
             "sentiment_ratio": 0.9966,
+            "tao_usd": {
+              "block_number": 5000000,
+              "observed_at": "2026-06-01T00:00:00.000Z",
+              "price_basis": "example",
+              "usd_per_tao": 0.5
+            },
+            "tao_usd_unavailable": "no_index_reading",
             "total_volume_alpha": 0.5,
             "total_volume_tao": 0.5,
+            "total_volume_usd": 0.5,
+            "usd_pricing_basis": "window_close_rate",
             "vol_mcap_ratio": 0.9966,
             "window": "24h"
           },
@@ -20284,6 +20318,47 @@
         "additionalProperties": false,
         "description": "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope.",
         "properties": {
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "network": {
             "additionalProperties": false,
             "description": "Network-wide buy/sell volume rollup across every subnet with volume in the window.",
@@ -20301,6 +20376,10 @@
                 "minimum": 0,
                 "type": "number"
               },
+              "buy_volume_usd": {
+                "minimum": 0,
+                "type": "number"
+              },
               "net_volume_alpha": {
                 "type": "number"
               },
@@ -20314,6 +20393,10 @@
                 "type": "number"
               },
               "sell_volume_tao": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "sell_volume_usd": {
                 "minimum": 0,
                 "type": "number"
               },
@@ -20342,6 +20425,10 @@
                 "type": "number"
               },
               "total_volume_tao": {
+                "minimum": 0,
+                "type": "number"
+              },
+              "total_volume_usd": {
                 "minimum": 0,
                 "type": "number"
               }
@@ -20387,6 +20474,69 @@
               "$ref": "#/components/schemas/SubnetAlphaVolumeArtifact"
             },
             "type": "array"
+          },
+          "tao_usd": {
+            "additionalProperties": false,
+            "description": "The reading every _usd field was converted at -- the network rollup and each per-subnet row alike, so one reading priced them all.",
+            "properties": {
+              "block_number": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "observed_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "price_basis": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "usd_per_tao": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "usd_per_tao",
+              "block_number",
+              "observed_at",
+              "price_basis"
+            ],
+            "type": "object"
+          },
+          "tao_usd_unavailable": {
+            "description": "Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.",
+            "enum": [
+              "no_index_reading",
+              "index_unpriced",
+              "index_stale",
+              "no_alpha_price"
+            ],
+            "type": "string"
+          },
+          "usd_pricing_basis": {
+            "const": "window_close_rate",
+            "description": "HOW the totals were converted: at the rate observed at the window's close, not summed per trade. volume_distribution is NOT converted -- its percentiles stay TAO, and a caller wanting them in dollars multiplies by usd_per_tao above.",
+            "type": "string"
           },
           "volume_distribution": {
             "anyOf": [
@@ -42039,6 +42189,50 @@
           "buy_volume_tao": {
             "type": "number"
           },
+          "buy_volume_usd": {
+            "type": "number"
+          },
+          "field_sources": {
+            "additionalProperties": {
+              "additionalProperties": false,
+              "properties": {
+                "kind": {
+                  "enum": [
+                    "measured",
+                    "reconstructed"
+                  ],
+                  "type": "string"
+                },
+                "read_at": {
+                  "enum": [
+                    "capture",
+                    "chain_state.block"
+                  ],
+                  "type": "string"
+                },
+                "storage": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "kind",
+                "storage"
+              ],
+              "type": "object"
+            },
+            "description": "Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "net_volume_alpha": {
             "type": "number"
           },
@@ -42063,6 +42257,9 @@
           "sell_volume_tao": {
             "type": "number"
           },
+          "sell_volume_usd": {
+            "type": "number"
+          },
           "sentiment": {
             "description": "Bucketed reading of sentiment_ratio (buying/selling/neutral).",
             "enum": [
@@ -42083,11 +42280,77 @@
             ],
             "description": "Buy share of total volume (0-1); null when there was no volume."
           },
+          "tao_usd": {
+            "additionalProperties": false,
+            "description": "The reading every _usd field was converted at. Rides at the blob level because ONE reading priced all of them.",
+            "properties": {
+              "block_number": {
+                "anyOf": [
+                  {
+                    "maximum": 9007199254740991,
+                    "minimum": -9007199254740991,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "observed_at": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "price_basis": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "usd_per_tao": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "usd_per_tao",
+              "block_number",
+              "observed_at",
+              "price_basis"
+            ],
+            "type": "object"
+          },
+          "tao_usd_unavailable": {
+            "description": "Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.",
+            "enum": [
+              "no_index_reading",
+              "index_unpriced",
+              "index_stale",
+              "no_alpha_price"
+            ],
+            "type": "string"
+          },
           "total_volume_alpha": {
             "type": "number"
           },
           "total_volume_tao": {
             "type": "number"
+          },
+          "total_volume_usd": {
+            "type": "number"
+          },
+          "usd_pricing_basis": {
+            "const": "window_close_rate",
+            "description": "HOW the totals were converted: at the rate observed at the window's close, not summed per trade. A string rather than a boolean so a future per-trade implementation publishes a different value instead of silently changing what this shape means.",
+            "type": "string"
           },
           "vol_mcap_ratio": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6183,15 +6183,27 @@ export interface components {
         };
         /** @description Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope. */
         ChainAlphaVolumeArtifact: {
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources?: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             /** @description Network-wide buy/sell volume rollup across every subnet with volume in the window. */
             network: {
                 buy_count: number;
                 buy_volume_alpha: number;
                 buy_volume_tao: number;
+                buy_volume_usd?: number;
                 net_volume_alpha: number;
                 sell_count: number;
                 sell_volume_alpha: number;
                 sell_volume_tao: number;
+                sell_volume_usd?: number;
                 /**
                  * @description Coarse sentiment label (bullish/bearish/neutral); neutral both for balanced volume and an empty window.
                  * @enum {string}
@@ -6201,12 +6213,30 @@ export interface components {
                 sentiment_ratio: number | null;
                 total_volume_alpha: number;
                 total_volume_tao: number;
+                total_volume_usd?: number;
             };
             /** @description Newest event observed_at across the window; null on a cold store. */
             observed_at: string | null;
             schema_version: number;
             subnet_count: number;
             subnets: components["schemas"]["SubnetAlphaVolumeArtifact"][];
+            /** @description The reading every _usd field was converted at -- the network rollup and each per-subnet row alike, so one reading priced them all. */
+            tao_usd?: {
+                block_number: number | null;
+                observed_at: string | null;
+                price_basis: string | null;
+                usd_per_tao: number;
+            };
+            /**
+             * @description Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.
+             * @enum {string}
+             */
+            tao_usd_unavailable?: "no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price";
+            /**
+             * @description HOW the totals were converted: at the rate observed at the window's close, not summed per trade. volume_distribution is NOT converted -- its percentiles stay TAO, and a caller wanting them in dollars multiplies by usd_per_tao above.
+             * @constant
+             */
+            usd_pricing_basis?: "window_close_rate";
             /** @description Spread of per-subnet total_volume_tao across EVERY subnet with volume (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard). Null when no subnet had volume. */
             volume_distribution: components["schemas"]["IntensityDistribution"] | null;
             /**
@@ -10291,12 +10321,24 @@ export interface components {
             buy_count: number;
             buy_volume_alpha: number;
             buy_volume_tao: number;
+            buy_volume_usd?: number;
+            /** @description Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
+            field_sources?: {
+                [key: string]: {
+                    /** @enum {string} */
+                    kind: "measured" | "reconstructed";
+                    /** @enum {string} */
+                    read_at?: "capture" | "chain_state.block";
+                    storage: string | null;
+                };
+            };
             net_volume_alpha: number;
             netuid: number;
             schema_version: number;
             sell_count: number;
             sell_volume_alpha: number;
             sell_volume_tao: number;
+            sell_volume_usd?: number;
             /**
              * @description Bucketed reading of sentiment_ratio (buying/selling/neutral).
              * @enum {string}
@@ -10304,8 +10346,26 @@ export interface components {
             sentiment: "bullish" | "bearish" | "neutral";
             /** @description Buy share of total volume (0-1); null when there was no volume. */
             sentiment_ratio: number | null;
+            /** @description The reading every _usd field was converted at. Rides at the blob level because ONE reading priced all of them. */
+            tao_usd?: {
+                block_number: number | null;
+                observed_at: string | null;
+                price_basis: string | null;
+                usd_per_tao: number;
+            };
+            /**
+             * @description Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.
+             * @enum {string}
+             */
+            tao_usd_unavailable?: "no_index_reading" | "index_unpriced" | "index_stale" | "no_alpha_price";
             total_volume_alpha: number;
             total_volume_tao: number;
+            total_volume_usd?: number;
+            /**
+             * @description HOW the totals were converted: at the rate observed at the window's close, not summed per trade. A string rather than a boolean so a future per-trade implementation publishes a different value instead of silently changing what this shape means.
+             * @constant
+             */
+            usd_pricing_basis?: "window_close_rate";
             /** @description Total TAO volume over alpha market cap; null when market cap is unknown. */
             vol_mcap_ratio: number | null;
             /**
@@ -14462,18 +14522,27 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "network": {
                      *           "buy_count": 1,
                      *           "buy_volume_alpha": 0.5,
                      *           "buy_volume_tao": 0.5,
+                     *           "buy_volume_usd": 0.5,
                      *           "net_volume_alpha": 0.5,
                      *           "sell_count": 1,
                      *           "sell_volume_alpha": 0.5,
                      *           "sell_volume_tao": 0.5,
+                     *           "sell_volume_usd": 0.5,
                      *           "sentiment": "bullish",
                      *           "sentiment_ratio": 0.9966,
                      *           "total_volume_alpha": 0.5,
-                     *           "total_volume_tao": 0.5
+                     *           "total_volume_tao": 0.5,
+                     *           "total_volume_usd": 0.5
                      *         },
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -14497,6 +14566,14 @@ export interface operations {
                      *             "window": "24h"
                      *           }
                      *         ],
+                     *         "tao_usd": {
+                     *           "block_number": 5000000,
+                     *           "observed_at": "2026-06-01T00:00:00.000Z",
+                     *           "price_basis": "example",
+                     *           "usd_per_tao": 0.5
+                     *         },
+                     *         "tao_usd_unavailable": "no_index_reading",
+                     *         "usd_pricing_basis": "window_close_rate",
                      *         "volume_distribution": {
                      *           "count": 1,
                      *           "max": 0.5,
@@ -24183,18 +24260,27 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "network": {
                      *           "buy_count": 1,
                      *           "buy_volume_alpha": 0.5,
                      *           "buy_volume_tao": 0.5,
+                     *           "buy_volume_usd": 0.5,
                      *           "net_volume_alpha": 0.5,
                      *           "sell_count": 1,
                      *           "sell_volume_alpha": 0.5,
                      *           "sell_volume_tao": 0.5,
+                     *           "sell_volume_usd": 0.5,
                      *           "sentiment": "bullish",
                      *           "sentiment_ratio": 0.9966,
                      *           "total_volume_alpha": 0.5,
-                     *           "total_volume_tao": 0.5
+                     *           "total_volume_tao": 0.5,
+                     *           "total_volume_usd": 0.5
                      *         },
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
@@ -24218,6 +24304,14 @@ export interface operations {
                      *             "window": "24h"
                      *           }
                      *         ],
+                     *         "tao_usd": {
+                     *           "block_number": 5000000,
+                     *           "observed_at": "2026-06-01T00:00:00.000Z",
+                     *           "price_basis": "example",
+                     *           "usd_per_tao": 0.5
+                     *         },
+                     *         "tao_usd_unavailable": "no_index_reading",
+                     *         "usd_pricing_basis": "window_close_rate",
                      *         "volume_distribution": {
                      *           "count": 1,
                      *           "max": 0.5,
@@ -46017,16 +46111,33 @@ export interface operations {
                      *         "buy_count": 1,
                      *         "buy_volume_alpha": 0.5,
                      *         "buy_volume_tao": 0.5,
+                     *         "buy_volume_usd": 0.5,
+                     *         "field_sources": {
+                     *           "example": {
+                     *             "kind": "measured",
+                     *             "storage": "example"
+                     *           }
+                     *         },
                      *         "net_volume_alpha": 0.5,
                      *         "netuid": 7,
                      *         "schema_version": 1,
                      *         "sell_count": 1,
                      *         "sell_volume_alpha": 0.5,
                      *         "sell_volume_tao": 0.5,
+                     *         "sell_volume_usd": 0.5,
                      *         "sentiment": "bullish",
                      *         "sentiment_ratio": 0.9966,
+                     *         "tao_usd": {
+                     *           "block_number": 5000000,
+                     *           "observed_at": "2026-06-01T00:00:00.000Z",
+                     *           "price_basis": "example",
+                     *           "usd_per_tao": 0.5
+                     *         },
+                     *         "tao_usd_unavailable": "no_index_reading",
                      *         "total_volume_alpha": 0.5,
                      *         "total_volume_tao": 0.5,
+                     *         "total_volume_usd": 0.5,
+                     *         "usd_pricing_basis": "window_close_rate",
                      *         "vol_mcap_ratio": 0.9966,
                      *         "window": "24h"
                      *       },

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -150,6 +150,14 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   ChainActivityArtifactDays: "ChainActivityDay",
   ChainAlphaVolumeArtifact: "ChainAlphaVolume",
   ChainAlphaVolumeArtifactNetwork: "ChainAlphaVolumeNetwork",
+  // Several routes emit structurally identical inline components, so each set
+  // maps onto ONE published type rather than N types with different names.
+  // Declared rather than left as JSON: these shapes are fixed and small, and an
+  // under-typing is a field a caller cannot select.
+  SubnetOhlcArtifactFieldSourcesUsd: "AlphaUsdFieldSource",
+  EconomicsTrendsArtifactFieldSourcesUsd: "AlphaUsdFieldSource",
+  ChainAlphaVolumeArtifactTaoUsd: "TaoUsdConversion",
+  SubnetAlphaVolumeArtifactTaoUsd: "TaoUsdConversion",
   ChainAxonRemovalsArtifact: "ChainAxonRemovals",
   ChainAxonRemovalsArtifactNetwork: "ChainAxonRemovalsNetwork",
   ChainAxonRemovalsArtifactSubnets: "ChainAxonRemovalsSubnet",

--- a/schemas-src/routes/chain-alpha-volume.ts
+++ b/schemas-src/routes/chain-alpha-volume.ts
@@ -15,8 +15,10 @@
 // orphaned.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
 import { SubnetAlphaVolumeArtifactSchema } from "./subnet-alpha-volume.ts";
 import { IntensityDistributionSchema } from "./chain-network-rollups.ts";
+import { ALPHA_USD_UNAVAILABLE } from "../../src/alpha-usd.ts";
 
 export const ChainAlphaVolumeArtifactSchema = z
   .object({
@@ -39,6 +41,10 @@ export const ChainAlphaVolumeArtifactSchema = z
         buy_volume_tao: z.number().min(0),
         sell_volume_tao: z.number().min(0),
         total_volume_tao: z.number().min(0),
+        // USD twins (#10383), absent when the index is unavailable.
+        buy_volume_usd: z.number().min(0).optional(),
+        sell_volume_usd: z.number().min(0).optional(),
+        total_volume_usd: z.number().min(0).optional(),
         buy_count: z.int().min(0),
         sell_count: z.int().min(0),
         net_volume_alpha: z.number(),
@@ -62,6 +68,31 @@ export const ChainAlphaVolumeArtifactSchema = z
       "Spread of per-subnet total_volume_tao across EVERY subnet with volume (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard). Null when no subnet had volume.",
     ),
     subnets: z.array(SubnetAlphaVolumeArtifactSchema),
+    tao_usd: z
+      .object({
+        usd_per_tao: z.number(),
+        block_number: z.int().nullable(),
+        observed_at: z.string().nullable(),
+        price_basis: z.string().nullable(),
+      })
+      .strict()
+      .optional()
+      .describe(
+        "The reading every _usd field was converted at -- the network rollup and each per-subnet row alike, so one reading priced them all.",
+      ),
+    usd_pricing_basis: z
+      .literal("window_close_rate")
+      .optional()
+      .describe(
+        "HOW the totals were converted: at the rate observed at the window's close, not summed per trade. volume_distribution is NOT converted -- its percentiles stay TAO, and a caller wanting them in dollars multiplies by usd_per_tao above.",
+      ),
+    tao_usd_unavailable: z
+      .enum(ALPHA_USD_UNAVAILABLE)
+      .optional()
+      .describe(
+        "Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.",
+      ),
+    field_sources: FieldSourcesSchema.optional(),
   })
   .strict()
   .describe(

--- a/schemas-src/routes/subnet-alpha-volume.ts
+++ b/schemas-src/routes/subnet-alpha-volume.ts
@@ -5,6 +5,8 @@
 // hand-edited SubnetAlphaVolumeArtifact component it replaces.
 import { z } from "zod";
 import { successEnvelopeSchema } from "../envelope.ts";
+import { FieldSourcesSchema } from "../shared.ts";
+import { ALPHA_USD_UNAVAILABLE } from "../../src/alpha-usd.ts";
 
 export const SubnetAlphaVolumeArtifactSchema = z
   .object({
@@ -19,6 +21,13 @@ export const SubnetAlphaVolumeArtifactSchema = z
     buy_volume_tao: z.number(),
     sell_volume_tao: z.number(),
     total_volume_tao: z.number(),
+    // USD twins (#10383). OPTIONAL, not nullable: an absent field says "not
+    // available" and there is nothing to chart, matching the spot convention
+    // src/alpha-usd-overlay.ts uses -- unlike the SERIES routes, where a
+    // uniform point shape means an explicit null instead.
+    buy_volume_usd: z.number().optional(),
+    sell_volume_usd: z.number().optional(),
+    total_volume_usd: z.number().optional(),
     buy_count: z.int().min(0),
     sell_count: z.int().min(0),
     net_volume_alpha: z.number(),
@@ -39,6 +48,31 @@ export const SubnetAlphaVolumeArtifactSchema = z
       .describe(
         "Total TAO volume over alpha market cap; null when market cap is unknown.",
       ),
+    tao_usd: z
+      .object({
+        usd_per_tao: z.number(),
+        block_number: z.int().nullable(),
+        observed_at: z.string().nullable(),
+        price_basis: z.string().nullable(),
+      })
+      .strict()
+      .optional()
+      .describe(
+        "The reading every _usd field was converted at. Rides at the blob level because ONE reading priced all of them.",
+      ),
+    usd_pricing_basis: z
+      .literal("window_close_rate")
+      .optional()
+      .describe(
+        "HOW the totals were converted: at the rate observed at the window's close, not summed per trade. A string rather than a boolean so a future per-trade implementation publishes a different value instead of silently changing what this shape means.",
+      ),
+    tao_usd_unavailable: z
+      .enum(ALPHA_USD_UNAVAILABLE)
+      .optional()
+      .describe(
+        "Why there are no _usd fields. `index_unpriced` is ADR 0025's insufficient_pools -- a stated decline, never a price of zero.",
+      ),
+    field_sources: FieldSourcesSchema.optional(),
   })
   .strict()
   .describe(

--- a/src/alpha-usd-overlay.ts
+++ b/src/alpha-usd-overlay.ts
@@ -145,3 +145,167 @@ export function withAlphaUsdEconomics(
     },
   };
 }
+
+// --- Volume (#10383) -------------------------------------------------------
+//
+// A 24h volume total is an AGGREGATE, which makes the multiplier question
+// sharper than for a spot price: multiplying a window's total by one rate is
+// not the same as summing each trade at the rate it executed at.
+//
+// It is priced at ONE rate here, and says so. Two facts decide it:
+//
+//   1. The window is FIXED at 24h on both routes (src/alpha-volume.ts,
+//      src/chain-alpha-volume.ts -- "a canonical market-depth figure, not a
+//      windowed analytics view", #4339). The 30d case where per-trade and
+//      single-rate diverge materially cannot be requested.
+//   2. The totals arrive ALREADY SUMMED. handleSubnetVolume receives
+//      `ReturnType<typeof buildAlphaVolume>` from the Postgres tier, so no
+//      per-trade instant survives to the edge; pricing each trade would mean
+//      pushing the multiply into both producers for a difference bounded by one
+//      day of rate movement.
+//
+// So this is NOT the per-bucket rule src/alpha-usd-history.ts applies to a
+// SERIES, and that is deliberate: a series has one instant per point, while a
+// single aggregate over a fixed window has one instant. Applying the per-bucket
+// machinery here would be a more complicated way of saying the same thing.
+//
+// The basis is NAMED in the payload rather than left to be assumed, because
+// "$4.1M of volume" reads identically whether it was summed per trade or
+// converted at the close, and only one of those is what we did.
+
+/**
+ * How a volume total was converted: the rate at the window's close.
+ *
+ * A string rather than a boolean, so a future per-trade implementation can
+ * publish a different value instead of silently changing what the same shape
+ * means.
+ */
+export const VOLUME_USD_PRICING_BASIS = "window_close_rate" as const;
+
+/** TAO-denominated volume fields and their USD twins. */
+const VOLUME_USD_FIELDS = [
+  ["buy_volume_tao", "buy_volume_usd"],
+  ["sell_volume_tao", "sell_volume_usd"],
+  ["total_volume_tao", "total_volume_usd"],
+] as const;
+
+// DELIBERATELY ABSENT: buy/sell/total/net_volume_ALPHA, sentiment and
+// sentiment_ratio.
+//
+// The alpha totals are denominated in alpha, and the only alpha price this
+// payload could yield is total_volume_tao / total_volume_alpha -- the window's
+// own realised VWAP. Multiplying the alpha volume by it returns
+// total_volume_tao exactly, so an `*_alpha_usd` field would be a second name
+// for a number already published. `sentiment_ratio` is a ratio of two alpha
+// figures and `sentiment` is a label: both are DIMENSIONLESS, and a
+// dimensionless quantity has no currency to be expressed in.
+
+// volume_distribution is DELIBERATELY NOT PRICED. Its percentiles are TAO and
+// would convert perfectly well, but the shape is `IntensityDistribution` -- a
+// REGISTERED OpenAPI component shared with /chain/network-rollups. Adding
+// `_usd` fields to it would declare USD on a route that does not publish it,
+// and forking the component for one caller trades a shared type for a
+// duplicate. A caller wanting the spread in dollars has `tao_usd.usd_per_tao`
+// published right beside it and can multiply; that is a better trade than a
+// second distribution type.
+
+/** Add `_usd` twins for a set of TAO fields. Absent when unpriceable. */
+function priceTaoFields(
+  row: Row,
+  pairs: ReadonlyArray<readonly [string, string]>,
+  reading: TaoUsdReading,
+  nowMs: number,
+): Row {
+  const out: Row = { ...row };
+  for (const [taoField, usdField] of pairs) {
+    const priced = alphaUsd(row[taoField] as number | null, reading, nowMs);
+    if (priced.ok) out[usdField] = priced.value.usd;
+  }
+  return out;
+}
+
+/** The blob-level provenance + basis, or the named reason there is none. */
+function volumeUsdOverlay(
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+): { usable: boolean; overlay: Row } {
+  const usable = taoUsdUsable(reading, nowMs);
+  if (!usable.ok)
+    return { usable: false, overlay: { tao_usd_unavailable: usable.reason } };
+  const r = reading as TaoUsdReading;
+  return {
+    usable: true,
+    overlay: {
+      tao_usd: {
+        usd_per_tao: r.usd_per_tao as number,
+        block_number: r.block_number ?? null,
+        // No `?? null`: taoUsdUsable already refused any reading whose
+        // observed_at does not parse, so by here it is a real stamp. A
+        // fallback would be a branch that cannot be taken and cannot be
+        // tested -- the kind that reads like a safeguard and is not one.
+        observed_at: r.observed_at,
+        price_basis: r.price_basis ?? null,
+      },
+      // Paired with tao_usd: the basis describes fields that exist, so it
+      // appears exactly when they do.
+      usd_pricing_basis: VOLUME_USD_PRICING_BASIS,
+    },
+  };
+}
+
+const withVolumeFieldSources = (blob: Row): Row => ({
+  ...(typeof blob.field_sources === "object" && blob.field_sources
+    ? (blob.field_sources as Row)
+    : {}),
+  buy_volume_usd: ALPHA_USD_FIELD_SOURCE,
+  sell_volume_usd: ALPHA_USD_FIELD_SOURCE,
+  total_volume_usd: ALPHA_USD_FIELD_SOURCE,
+});
+
+/** Decorate one subnet's 24h volume scorecard. */
+export function withAlphaVolumeUsd(
+  blob: Row | null | undefined,
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+): Row | null | undefined {
+  if (!blob || typeof blob !== "object") return blob;
+  const { usable, overlay } = volumeUsdOverlay(reading, nowMs);
+  return {
+    ...(usable
+      ? priceTaoFields(blob, VOLUME_USD_FIELDS, reading as TaoUsdReading, nowMs)
+      : blob),
+    ...overlay,
+    field_sources: withVolumeFieldSources(blob),
+  };
+}
+
+/** Decorate the network-wide 24h volume blob: totals, spread, and per subnet. */
+export function withChainAlphaVolumeUsd(
+  blob: Row | null | undefined,
+  reading: TaoUsdReading | null | undefined,
+  nowMs: number,
+): Row | null | undefined {
+  if (!blob || typeof blob !== "object") return blob;
+  const { usable, overlay } = volumeUsdOverlay(reading, nowMs);
+  if (!usable) {
+    return { ...blob, ...overlay, field_sources: withVolumeFieldSources(blob) };
+  }
+  const r = reading as TaoUsdReading;
+
+  const network =
+    blob.network && typeof blob.network === "object"
+      ? priceTaoFields(blob.network as Row, VOLUME_USD_FIELDS, r, nowMs)
+      : blob.network;
+
+  return {
+    ...blob,
+    network,
+    subnets: Array.isArray(blob.subnets)
+      ? (blob.subnets as Row[]).map((s) =>
+          priceTaoFields(s, VOLUME_USD_FIELDS, r, nowMs),
+        )
+      : blob.subnets,
+    ...overlay,
+    field_sources: withVolumeFieldSources(blob),
+  };
+}

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -1221,7 +1221,7 @@ export const SDL = /* GraphQL */ `
     priced_day_count: Int
     "Why NO day could be priced, or null. read_failed means the index could not be queried, which is not a claim about the index itself."
     usd_unavailable: String
-    field_sources_usd: JSON
+    field_sources_usd: AlphaUsdFieldSource
   }
 
   "One UTC day of network-wide economics aggregated across every subnet with a snapshot that day. Sums are null only when no subnet reported a value that day."
@@ -1706,6 +1706,20 @@ export const SDL = /* GraphQL */ `
     announcements_per_exporter: Float
   }
 
+  "Provenance for the USD fields: RECONSTRUCTED, never measured. The product of a measured alpha price and a measured TAO/USD index is our arithmetic, and a null storage says there is no single chain read behind it."
+  type AlphaUsdFieldSource {
+    kind: String!
+    storage: String
+  }
+
+  "The TAO/USD reading a set of _usd fields was converted at, kept together so the price and its provenance always describe the same block."
+  type TaoUsdConversion {
+    usd_per_tao: Float!
+    block_number: Int
+    observed_at: String
+    price_basis: String
+  }
+
   "Network-wide rolling 24h buy/sell alpha-volume leaderboard, summed live from the account_events StakeAdded/StakeRemoved stream. Mirrors GET /api/v1/chain/alpha-volume's data envelope."
   type ChainAlphaVolume {
     schema_version: Int!
@@ -1718,6 +1732,13 @@ export const SDL = /* GraphQL */ `
     "Spread of per-subnet total_volume_tao across every subnet with volume; null when no subnet had volume."
     volume_distribution: IntensityDistribution
     subnets: [ChainAlphaVolumeSubnet!]!
+    "The reading every _usd field was converted at."
+    tao_usd: TaoUsdConversion
+    "HOW the totals were converted: window_close_rate -- at the rate observed at the window's close, not summed per trade."
+    usd_pricing_basis: String
+    "Why there are no _usd fields. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero."
+    tao_usd_unavailable: String
+    field_sources: JSON
   }
 
   "Network-wide buy/sell volume rollup across every subnet with volume in the window."
@@ -1728,6 +1749,10 @@ export const SDL = /* GraphQL */ `
     buy_volume_tao: Float!
     sell_volume_tao: Float!
     total_volume_tao: Float!
+    "USD twins (#10383), converted at the window's close rate. Null when the index was unusable -- tao_usd_unavailable says why."
+    buy_volume_usd: Float
+    sell_volume_usd: Float
+    total_volume_usd: Float
     buy_count: Int!
     sell_count: Int!
     net_volume_alpha: Float!
@@ -1748,6 +1773,10 @@ export const SDL = /* GraphQL */ `
     buy_volume_tao: Float!
     sell_volume_tao: Float!
     total_volume_tao: Float!
+    "USD twins (#10383), converted at the window's close rate. Null when the index was unusable -- tao_usd_unavailable says why."
+    buy_volume_usd: Float
+    sell_volume_usd: Float
+    total_volume_usd: Float
     buy_count: Int!
     sell_count: Int!
     net_volume_alpha: Float!
@@ -1757,6 +1786,13 @@ export const SDL = /* GraphQL */ `
     sentiment: String!
     "24h volume / market-cap turnover ratio; always null here (no per-subnet market-cap input in scope at the network level)."
     vol_mcap_ratio: Float
+    "The reading every _usd field was converted at."
+    tao_usd: TaoUsdConversion
+    "HOW the totals were converted: window_close_rate -- at the rate observed at the window's close, not summed per trade."
+    usd_pricing_basis: String
+    "Why there are no _usd fields. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero."
+    tao_usd_unavailable: String
+    field_sources: JSON
   }
 
   "Network-wide idle-stake rollup: every subnet's stake on currently-zero-dividends hotkeys, ranked by idle_stake_alpha. Mirrors GET /api/v1/chain/idle-stake's data envelope."
@@ -3716,6 +3752,10 @@ export const SDL = /* GraphQL */ `
     buy_volume_tao: Float!
     sell_volume_tao: Float!
     total_volume_tao: Float!
+    "USD twins (#10383), converted at the window's close rate. Null when the index was unusable -- tao_usd_unavailable says why."
+    buy_volume_usd: Float
+    sell_volume_usd: Float
+    total_volume_usd: Float
     buy_count: Int!
     sell_count: Int!
     net_volume_alpha: Float!
@@ -3725,6 +3765,13 @@ export const SDL = /* GraphQL */ `
     sentiment: String
     "Total TAO volume over alpha market cap; null when market cap is unknown."
     vol_mcap_ratio: Float
+    "The reading every _usd field was converted at."
+    tao_usd: TaoUsdConversion
+    "HOW the totals were converted: window_close_rate -- at the rate observed at the window's close, not summed per trade."
+    usd_pricing_basis: String
+    "Why there are no _usd fields. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero."
+    tao_usd_unavailable: String
+    field_sources: JSON
   }
 
   type SubnetOhlcCandle {
@@ -3766,7 +3813,7 @@ export const SDL = /* GraphQL */ `
     priced_candle_count: Int
     "Why NO candle could be priced, or null. index_unpriced is ADR 0025's insufficient_pools -- a stated decline, never a price of zero; read_failed means the index could not be queried at all."
     usd_unavailable: String
-    field_sources_usd: JSON
+    field_sources_usd: AlphaUsdFieldSource
   }
 
   "Permitted, active and earning are three DIFFERENT sets. Network-wide 2026-08-03: 1,523 / 1,137 / 1,117; SN83 is 64 / 8 / 7. Published separately rather than collapsed, because 'how many validators does this subnet have' has three defensible answers."

--- a/tests/alpha-usd-overlay.test.ts
+++ b/tests/alpha-usd-overlay.test.ts
@@ -7,6 +7,8 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  withAlphaVolumeUsd,
+  withChainAlphaVolumeUsd,
   ALPHA_MARKET_CAP_BASIS,
   withAlphaUsd,
   withAlphaUsdEconomics,
@@ -179,5 +181,271 @@ describe("shapes it must not choke on", () => {
       const out = withAlphaUsdEconomics(bad as never, reading, NOW);
       assert.deepEqual(out, bad);
     }
+  });
+});
+
+// --- Volume (#10383) -------------------------------------------------------
+//
+// A 24h total converted at ONE rate. The tests that matter are the ones about
+// what is NOT converted: a dimensionless ratio has no currency, and a shared
+// distribution component must not sprout USD on a route that never publishes it.
+
+const volume = () => ({
+  schema_version: 1,
+  netuid: 64,
+  window: "24h",
+  buy_volume_alpha: 1000,
+  sell_volume_alpha: 400,
+  total_volume_alpha: 1400,
+  buy_volume_tao: 80,
+  sell_volume_tao: 32,
+  total_volume_tao: 112,
+  buy_count: 12,
+  sell_count: 5,
+  net_volume_alpha: 600,
+  sentiment_ratio: 0.714,
+  sentiment: "bullish",
+  vol_mcap_ratio: 0.02,
+});
+
+describe("volume in USD", () => {
+  test("the TAO totals convert, at the rate the blob publishes", () => {
+    const out = withAlphaVolumeUsd(volume(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const rate = reading.usd_per_tao as number;
+    assert.equal(out.buy_volume_usd, 80 * rate);
+    assert.equal(out.sell_volume_usd, 32 * rate);
+    assert.equal(out.total_volume_usd, 112 * rate);
+    assert.equal(
+      (out.tao_usd as Record<string, unknown>).usd_per_tao,
+      rate,
+      "the rate rides along so the conversion is auditable",
+    );
+  });
+
+  test("it SAYS how it was priced", () => {
+    // Acceptance 1. "$4.1M of volume" reads identically whether it was summed
+    // per trade or converted at the close, and only one of those is what we did.
+    const out = withAlphaVolumeUsd(volume(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(out.usd_pricing_basis, "window_close_rate");
+  });
+
+  test("DIMENSIONLESS fields never sprout a USD twin", () => {
+    // Acceptance 3. sentiment_ratio is a ratio of two alpha figures and
+    // sentiment is a label; neither has a currency to be expressed in.
+    // vol_mcap_ratio is likewise a ratio, and the *_alpha totals are alpha --
+    // their only available price is the window's own VWAP, which would return
+    // total_volume_tao and publish a second name for a number already there.
+    const out = withAlphaVolumeUsd(volume(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    for (const k of [
+      "sentiment_usd",
+      "sentiment_ratio_usd",
+      "vol_mcap_ratio_usd",
+      "buy_volume_alpha_usd",
+      "sell_volume_alpha_usd",
+      "total_volume_alpha_usd",
+      "net_volume_alpha_usd",
+    ]) {
+      assert.ok(!(k in out), `${k} must not exist`);
+    }
+    // And the originals are untouched.
+    assert.equal(out.sentiment, "bullish");
+    assert.equal(out.sentiment_ratio, 0.714);
+  });
+
+  test("a STALE index prices nothing and names why", () => {
+    // Acceptance 2, in the form this route can express it: the 24h window is
+    // always inside the index's depth when the index is working, so the failure
+    // that actually reaches here is a rate that stopped moving.
+    const stale = { ...reading, observed_at: iso(TAO_USD_MAX_AGE_MS + 1) };
+    const out = withAlphaVolumeUsd(volume(), stale, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.ok(!("total_volume_usd" in out));
+    assert.equal(out.tao_usd_unavailable, "index_stale");
+    assert.ok(
+      !("usd_pricing_basis" in out),
+      "a basis with no priced fields to describe would be noise",
+    );
+    assert.ok(!("tao_usd" in out));
+    // The TAO side is untouched.
+    assert.equal(out.total_volume_tao, 112);
+  });
+
+  test("`insufficient_pools` is a decline, not a volume of $0", () => {
+    const unpriced = {
+      ...reading,
+      usd_per_tao: null,
+      price_basis: "insufficient_pools",
+    };
+    const out = withAlphaVolumeUsd(volume(), unpriced, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(out.tao_usd_unavailable, "index_unpriced");
+    assert.ok(!("total_volume_usd" in out));
+  });
+
+  test("USD is declared RECONSTRUCTED even when unavailable", () => {
+    // The declaration describes the FIELDS, which exist in the contract whether
+    // or not this response could fill them.
+    for (const r of [reading, null]) {
+      const out = withAlphaVolumeUsd(volume(), r, NOW) as Record<
+        string,
+        unknown
+      >;
+      const fs = out.field_sources as Record<string, unknown>;
+      assert.deepEqual(fs.total_volume_usd, {
+        kind: "reconstructed",
+        storage: null,
+      });
+    }
+  });
+
+  test("a non-object payload passes through untouched", () => {
+    for (const bad of [null, undefined, 42, "x"]) {
+      assert.deepEqual(withAlphaVolumeUsd(bad as never, reading, NOW), bad);
+    }
+  });
+});
+
+describe("network-wide volume in USD", () => {
+  const chain = () => ({
+    schema_version: 1,
+    window: "24h",
+    observed_at: "2026-08-10T05:00:00.000Z",
+    subnet_count: 2,
+    network: {
+      buy_volume_tao: 500,
+      sell_volume_tao: 250,
+      total_volume_tao: 750,
+      sentiment_ratio: 0.66,
+      sentiment: "bullish",
+    },
+    volume_distribution: { count: 2, mean: 375, min: 100, max: 650 },
+    subnets: [volume(), { ...volume(), netuid: 7 }],
+  });
+
+  test("the rollup AND every per-subnet row convert", () => {
+    const out = withChainAlphaVolumeUsd(chain(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const rate = reading.usd_per_tao as number;
+    assert.equal(
+      (out.network as Record<string, unknown>).total_volume_usd,
+      750 * rate,
+    );
+    for (const s of out.subnets as Record<string, unknown>[]) {
+      assert.equal(s.total_volume_usd, 112 * rate);
+    }
+  });
+
+  test("volume_distribution is NOT converted", () => {
+    // Its shape is IntensityDistribution, a REGISTERED component shared with
+    // /chain/network-rollups. Adding _usd there would declare USD on a route
+    // that never publishes it; forking it would trade a shared type for a
+    // duplicate. A caller multiplies by the published usd_per_tao instead.
+    const out = withChainAlphaVolumeUsd(chain(), reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.deepEqual(out.volume_distribution, {
+      count: 2,
+      mean: 375,
+      min: 100,
+      max: 650,
+    });
+  });
+
+  test("an unusable index leaves every tier alone and names the reason once", () => {
+    const out = withChainAlphaVolumeUsd(chain(), null, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.equal(out.tao_usd_unavailable, "no_index_reading");
+    assert.ok(
+      !("total_volume_usd" in (out.network as Record<string, unknown>)),
+    );
+    for (const s of out.subnets as Record<string, unknown>[]) {
+      assert.ok(!("total_volume_usd" in s));
+    }
+  });
+
+  test("a malformed blob degrades instead of throwing", () => {
+    for (const bad of [null, undefined, 7]) {
+      assert.deepEqual(
+        withChainAlphaVolumeUsd(bad as never, reading, NOW),
+        bad,
+      );
+    }
+    // A blob whose parts are missing keeps its shape rather than inventing one.
+    const out = withChainAlphaVolumeUsd(
+      { schema_version: 1 },
+      reading,
+      NOW,
+    ) as Record<string, unknown>;
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.usd_pricing_basis, "window_close_rate");
+  });
+});
+
+describe("volume USD, the partial cases", () => {
+  test("a missing TAO total is skipped while its siblings price", () => {
+    const partial = { ...volume(), buy_volume_tao: null };
+    const out = withAlphaVolumeUsd(partial, reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    assert.ok(!("buy_volume_usd" in out), "no total, no conversion");
+    assert.equal(out.total_volume_usd, 112 * (reading.usd_per_tao as number));
+  });
+
+  test("a reading with no block or basis still prices, carrying nulls", () => {
+    // The rate is what does the arithmetic; the provenance is what makes it
+    // auditable. A thinner reading is less auditable, not unusable.
+    const thin: TaoUsdReading = {
+      usd_per_tao: reading.usd_per_tao,
+      observed_at: reading.observed_at,
+      block_number: null,
+      price_basis: null,
+    };
+    const out = withAlphaVolumeUsd(volume(), thin, NOW) as Record<
+      string,
+      unknown
+    >;
+    const prov = out.tao_usd as Record<string, unknown>;
+    assert.equal(prov.block_number, null);
+    assert.equal(prov.price_basis, null);
+    assert.equal(prov.observed_at, reading.observed_at);
+    assert.equal(out.total_volume_usd, 112 * (reading.usd_per_tao as number));
+  });
+
+  test("an existing field_sources is MERGED, never replaced", () => {
+    // Clobbering it would drop the measured/reconstructed labels the payload
+    // already carried — losing provenance while adding provenance.
+    const withSources = {
+      ...volume(),
+      field_sources: { total_volume_tao: { kind: "measured", storage: "x" } },
+    };
+    const out = withAlphaVolumeUsd(withSources, reading, NOW) as Record<
+      string,
+      unknown
+    >;
+    const fs = out.field_sources as Record<string, unknown>;
+    assert.deepEqual(fs.total_volume_tao, { kind: "measured", storage: "x" });
+    assert.deepEqual(fs.total_volume_usd, {
+      kind: "reconstructed",
+      storage: null,
+    });
   });
 });

--- a/tests/chain-alpha-volume.test.ts
+++ b/tests/chain-alpha-volume.test.ts
@@ -484,7 +484,7 @@ describe("GET /api/v1/chain/alpha-volume", () => {
     assert.equal(lines.length, 1);
     assert.equal(
       lines[0],
-      "netuid,buy_volume_alpha,sell_volume_alpha,total_volume_alpha,buy_volume_tao,sell_volume_tao,total_volume_tao,buy_count,sell_count,net_volume_alpha,sentiment_ratio,sentiment,vol_mcap_ratio",
+      "netuid,buy_volume_alpha,sell_volume_alpha,total_volume_alpha,buy_volume_tao,sell_volume_tao,total_volume_tao,buy_volume_usd,sell_volume_usd,total_volume_usd,buy_count,sell_count,net_volume_alpha,sentiment_ratio,sentiment,vol_mcap_ratio",
     );
   });
 
@@ -510,7 +510,7 @@ describe("GET /api/v1/chain/alpha-volume", () => {
     assert.match(res.headers.get("content-type"), /text\/csv/);
     assert.equal(
       (await res.text()).trim(),
-      "netuid,buy_volume_alpha,sell_volume_alpha,total_volume_alpha,buy_volume_tao,sell_volume_tao,total_volume_tao,buy_count,sell_count,net_volume_alpha,sentiment_ratio,sentiment,vol_mcap_ratio",
+      "netuid,buy_volume_alpha,sell_volume_alpha,total_volume_alpha,buy_volume_tao,sell_volume_tao,total_volume_tao,buy_volume_usd,sell_volume_usd,total_volume_usd,buy_count,sell_count,net_volume_alpha,sentiment_ratio,sentiment,vol_mcap_ratio",
     );
   });
 

--- a/tests/tao-usd-current.test.ts
+++ b/tests/tao-usd-current.test.ts
@@ -1,0 +1,124 @@
+// The shared TAO/USD current-reading cache (#10383).
+//
+// The memo is the whole risk surface. A 60s per-isolate cache is harmless when
+// it behaves; the two ways it hurts are memoising a NULL (so one cold read
+// after a deploy convinces the isolate for a minute that the index does not
+// exist) and keying on nothing (so two bindings cross-read each other). Both
+// were untested while this lived in workers/api.ts — the function moved here so
+// the live volume handlers could reach it, and moving it is the moment to
+// prove it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  readTaoUsdCurrentKv,
+  TAO_USD_CURRENT_KV_TTL_MS,
+} from "../workers/tao-usd-current.ts";
+import { resetModuleState } from "../src/module-state-registry.ts";
+
+const NOW = Date.parse("2026-08-10T06:00:00.000Z");
+
+/** A KV binding that counts reads, so memo hits are observable. */
+function envWith(value: unknown) {
+  const state = { reads: 0 };
+  return {
+    env: {
+      METAGRAPH_CONTROL: {
+        get: async () => {
+          state.reads += 1;
+          return value;
+        },
+      },
+    },
+    state,
+  };
+}
+
+describe("reading the current TAO/USD blob", () => {
+  test("an unbound store is null, not a throw", async () => {
+    resetModuleState();
+    assert.equal(await readTaoUsdCurrentKv({}, NOW), null);
+    assert.equal(
+      await readTaoUsdCurrentKv({ METAGRAPH_CONTROL: {} }, NOW),
+      null,
+    );
+  });
+
+  test("a throwing store is null", async () => {
+    resetModuleState();
+    const env = {
+      METAGRAPH_CONTROL: {
+        get: async () => {
+          throw new Error("KV unavailable");
+        },
+      },
+    };
+    assert.equal(await readTaoUsdCurrentKv(env, NOW), null);
+  });
+
+  test("a reading is reused within the window", async () => {
+    resetModuleState();
+    const { env, state } = envWith({ usd_per_tao: 204.125 });
+    const a = await readTaoUsdCurrentKv(env, NOW);
+    const b = await readTaoUsdCurrentKv(
+      env,
+      NOW + TAO_USD_CURRENT_KV_TTL_MS - 1,
+    );
+    assert.deepEqual(a, { usd_per_tao: 204.125 });
+    assert.deepEqual(b, a);
+    assert.equal(state.reads, 1, "the second call must not hit KV");
+  });
+
+  test("and re-read once the window closes", async () => {
+    resetModuleState();
+    const { env, state } = envWith({ usd_per_tao: 204.125 });
+    await readTaoUsdCurrentKv(env, NOW);
+    await readTaoUsdCurrentKv(env, NOW + TAO_USD_CURRENT_KV_TTL_MS);
+    assert.equal(state.reads, 2, "the TTL boundary must expire the memo");
+  });
+
+  test("A NULL IS NEVER MEMOISED", async () => {
+    // Otherwise the first request after a deploy — hitting KV before the lane
+    // has written — decides for the whole isolate, for a minute, that there is
+    // no index. Every route pricing alpha in USD would decline in unison for a
+    // reason that was already false.
+    resetModuleState();
+    const { env, state } = envWith(null);
+    assert.equal(await readTaoUsdCurrentKv(env, NOW), null);
+    assert.equal(await readTaoUsdCurrentKv(env, NOW + 1), null);
+    assert.equal(state.reads, 2, "a cold read must stay re-queried");
+  });
+
+  test("the memo is keyed on env, so two bindings never cross-read", async () => {
+    resetModuleState();
+    const a = envWith({ usd_per_tao: 1 });
+    const b = envWith({ usd_per_tao: 2 });
+    assert.deepEqual(await readTaoUsdCurrentKv(a.env, NOW), { usd_per_tao: 1 });
+    assert.deepEqual(await readTaoUsdCurrentKv(b.env, NOW), { usd_per_tao: 2 });
+    assert.equal(
+      b.state.reads,
+      1,
+      "the second env must not read the first's value",
+    );
+  });
+
+  test("the TTL is far below the freshness bound it must not extend", async () => {
+    // src/alpha-usd.ts refuses a reading older than two hours. A memo longer
+    // than that could keep a stale rate serving past the point the staleness
+    // check would have caught it.
+    const { TAO_USD_MAX_AGE_MS } = await import("../src/alpha-usd.ts");
+    assert.ok(
+      TAO_USD_CURRENT_KV_TTL_MS < TAO_USD_MAX_AGE_MS,
+      "the memo must never outlive the freshness bound",
+    );
+  });
+
+  test("module-state reset clears it between test files", async () => {
+    // Registered, so a leftover reading cannot leak into the next file and make
+    // an unrelated suite pass on a value it never set.
+    const { env, state } = envWith({ usd_per_tao: 9 });
+    await readTaoUsdCurrentKv(env, NOW);
+    resetModuleState();
+    await readTaoUsdCurrentKv(env, NOW);
+    assert.equal(state.reads, 2);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -365,7 +365,7 @@ import {
   runHealthProber,
   writeSubnetSnapshot,
 } from "../src/health-prober.ts";
-import { KV_ECONOMICS_CURRENT, KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
+import { KV_ECONOMICS_CURRENT } from "../src/kv-keys.ts";
 import { readCachedNetworkParametersSnapshot } from "../src/network-parameters.ts";
 import {
   mergeFreshness,
@@ -634,6 +634,7 @@ import { foldObservations, observeRequest } from "../src/usage-rollup.ts";
 import type { UsageObservation } from "../src/usage-rollup.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 import { withAlphaUsdEconomics } from "../src/alpha-usd-overlay.ts";
+import { readTaoUsdCurrentKv } from "./tao-usd-current.ts";
 import type { TaoUsdReading } from "../src/alpha-usd.ts";
 import { runLakehouseSeamWatchdog } from "../src/lakehouse-seam-watchdog.ts";
 import { runSafeModeWatchdog } from "../src/safe-mode-watchdog.ts";
@@ -7367,40 +7368,6 @@ let economicsCurrentKvMemo: {
   expiresAt: number;
 } = { env: null, value: null, expiresAt: 0 };
 
-/**
- * The newest TAO/USD reading from KV, for pricing alpha in USD (#10381).
- *
- * SAME SHAPE AS readEconomicsCurrentKv below, deliberately -- same 60s
- * per-isolate memo, same "a null is NOT memoized" rule so a cold or unbound
- * store stays re-queried rather than being cached as absent for a minute. The
- * two are read together on the /economics path and there is no reason for them
- * to behave differently under the same failure.
- */
-export const TAO_USD_CURRENT_KV_TTL_MS = 60_000;
-let taoUsdCurrentKvMemo: {
-  env: Env | null;
-  value: unknown;
-  expiresAt: number;
-} = { env: null, value: null, expiresAt: 0 };
-
-export async function readTaoUsdCurrentKv(
-  env: Env,
-  now: number = Date.now(),
-): Promise<Row | null> {
-  if (taoUsdCurrentKvMemo.env === env && now < taoUsdCurrentKvMemo.expiresAt) {
-    return taoUsdCurrentKvMemo.value as Row | null;
-  }
-  const value = await readHealthKv(env, KV_TAO_USD_CURRENT);
-  if (value !== null) {
-    taoUsdCurrentKvMemo = {
-      env,
-      value,
-      expiresAt: now + TAO_USD_CURRENT_KV_TTL_MS,
-    };
-  }
-  return value as Row | null;
-}
-
 export async function readEconomicsCurrentKv(
   env: Env,
   now: number = Date.now(),
@@ -7491,7 +7458,6 @@ registerModuleStateReset("workers/api.ts", () => {
   usageRollupBufferedAtMs = 0;
   healthMetaKvMemo = { env: null, value: null, expiresAt: 0 };
   economicsCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
-  taoUsdCurrentKvMemo = { env: null, value: null, expiresAt: 0 };
   chainEventsDbMemo = { env: null, value: null, expiresAt: 0 };
   subnetSlugIndexByNetwork.clear();
   configureAnalytics({ readHealthMetaKv, readEconomicsCurrentKv });

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -24,6 +24,9 @@
 // is imported directly from leaf modules, so this file never imports api.ts.
 
 import { observationsReadDb } from "../../src/observations-read-runner.ts";
+import { withChainAlphaVolumeUsd } from "../../src/alpha-usd-overlay.ts";
+import { readTaoUsdCurrentKv } from "../tao-usd-current.ts";
+import type { TaoUsdReading } from "../../src/alpha-usd.ts";
 import { readStore } from "../../src/read-store.ts";
 import { HEALTH_CHECK_TABLES } from "../../src/read-store-tables.ts";
 import {
@@ -1144,6 +1147,12 @@ const CHAIN_ALPHA_VOLUME_CSV_COLUMNS = [
   "buy_volume_tao",
   "sell_volume_tao",
   "total_volume_tao",
+  // USD twins (#10383), converted at the window's close rate. Empty when the
+  // index is unavailable -- an export that dropped the columns entirely would
+  // be a quietly different answer to the same question.
+  "buy_volume_usd",
+  "sell_volume_usd",
+  "total_volume_usd",
   "buy_count",
   "sell_count",
   "net_volume_alpha",
@@ -1866,11 +1875,20 @@ export async function handleChainAlphaVolume(
             limit,
           } as unknown as Parameters<typeof buildChainAlphaVolume>[1]),
         );
+      // USD on the network rollup, the spread and every per-subnet row
+      // (#10383). Overlaid before the CSV branch so both formats carry the
+      // same answer, and at ONE named rate -- the window's close -- because
+      // the window is fixed at 24h. See src/alpha-usd-overlay.ts.
+      const priced = withChainAlphaVolumeUsd(
+        data as unknown as Record<string, unknown>,
+        (await readTaoUsdCurrentKv(env)) as TaoUsdReading | null,
+        Date.now(),
+      ) as unknown as typeof data;
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +
       // volume_distribution stay JSON-only (mirrors chain-stake-flow).
       if (csv) {
         return csvResponse(
-          data.subnets,
+          priced.subnets,
           "chain-alpha-volume",
           "short",
           cacheRequest,
@@ -1880,7 +1898,7 @@ export async function handleChainAlphaVolume(
       return envelopeResponse(
         cacheRequest,
         {
-          data,
+          data: priced,
           meta: await analyticsMeta(
             env,
             "/metagraph/chain/alpha-volume.json",

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -390,6 +390,9 @@ import { loadSubnetOhlcColdTier } from "../../src/subnet-ohlc-cold-tier.ts";
 import { resolveLiveEconomics } from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
+import { withAlphaVolumeUsd } from "../../src/alpha-usd-overlay.ts";
+import { readTaoUsdCurrentKv } from "../tao-usd-current.ts";
+import type { TaoUsdReading } from "../../src/alpha-usd.ts";
 import { buildAccountStakeFlow } from "../../src/account-stake-flow.ts";
 import { loadSubnetStakeFlowFromArtifact } from "../../src/subnet-stake-flow-artifact.ts";
 import {
@@ -4017,7 +4020,15 @@ export async function handleSubnetAlphaVolume(
   return envelopeResponse(
     request,
     {
-      data,
+      // USD on the 24h totals (#10383), overlaid after every tier has
+      // converged. Priced at ONE named rate -- the window's close -- because
+      // the window is fixed at 24h and the totals arrive already summed, so no
+      // per-trade instant survives to here. See src/alpha-usd-overlay.ts.
+      data: withAlphaVolumeUsd(
+        data as unknown as Record<string, unknown>,
+        (await readTaoUsdCurrentKv(env)) as TaoUsdReading | null,
+        Date.now(),
+      ),
       meta: await accountMeta(
         env,
         `/metagraph/subnets/${netuid}/volume.json`,

--- a/workers/tao-usd-current.ts
+++ b/workers/tao-usd-current.ts
@@ -1,0 +1,64 @@
+// The newest TAO/USD reading, shared by every surface that prices alpha in USD.
+//
+// Extracted from workers/api.ts (#10383). It started there because /economics
+// was the only caller (#10381), but the volume routes are LIVE handlers in
+// workers/request-handlers/ rather than the artifact-dispatch seam, and they
+// cannot import workers/api.ts -- api.ts imports them. Two copies of a memoised
+// reader would be two caches with one name, and the second one to be written
+// would be the one nobody remembered to reset between test files.
+//
+// WHY KV AND NOT NEON: see KV_TAO_USD_CURRENT in src/kv-keys.ts. The short
+// version is that these routes otherwise touch no database, and adding a
+// Postgres round trip to a market-depth card to fetch one scalar would make the
+// dependency graph worse than the feature is worth.
+
+import { readHealthKv } from "./storage.ts";
+import { KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
+import { registerModuleStateReset } from "../src/module-state-registry.ts";
+
+type Row = Record<string, unknown>;
+
+/**
+ * How long a reading is reused within one isolate.
+ *
+ * 60 s, far below the two-hour freshness bound src/alpha-usd.ts enforces, so
+ * the memo can never extend how long a stale rate is allowed to serve -- it
+ * only avoids re-reading the same blob for every request in a burst.
+ */
+export const TAO_USD_CURRENT_KV_TTL_MS = 60_000;
+
+let memo: { env: unknown; value: unknown; expiresAt: number } = {
+  env: null,
+  value: null,
+  expiresAt: 0,
+};
+
+/**
+ * The newest TAO/USD reading from KV, or null.
+ *
+ * A NULL IS NOT MEMOISED. A cold or unbound store stays re-queried rather than
+ * being cached as absent for a minute -- otherwise the first request after a
+ * deploy would decide, for the whole isolate, that the index does not exist.
+ *
+ * Keyed on `env` so tests and multi-binding callers never cross-read.
+ */
+export async function readTaoUsdCurrentKv(
+  env: unknown,
+  now: number = Date.now(),
+): Promise<Row | null> {
+  if (memo.env === env && now < memo.expiresAt) {
+    return memo.value as Row | null;
+  }
+  const value = await readHealthKv(
+    env as Parameters<typeof readHealthKv>[0],
+    KV_TAO_USD_CURRENT,
+  );
+  if (value !== null) {
+    memo = { env, value, expiresAt: now + TAO_USD_CURRENT_KV_TTL_MS };
+  }
+  return value as Row | null;
+}
+
+registerModuleStateReset("workers/tao-usd-current.ts", () => {
+  memo = { env: null, value: null, expiresAt: 0 };
+});


### PR DESCRIPTION
## What

`/subnets/{netuid}/volume` and `/chain/alpha-volume` now carry USD — converted at **one named rate**, with the name in the payload.

## Why a named rate and not per-bucket

Converting an aggregate is a sharper question than converting a spot price: multiplying a window's total by one rate is not the same as summing each trade at the rate it executed at, and the two are indistinguishable once printed. The issue asked the implementer to pick one and say which. Two facts pick it:

1. **The window is fixed at 24h** on both routes — "a canonical market-depth figure, not a windowed analytics view" (#4339). The 30d case where the approaches diverge materially cannot be requested.
2. **The totals arrive already summed.** `handleSubnetVolume` receives `ReturnType<typeof buildAlphaVolume>` from the Postgres tier, so no per-trade instant survives to the edge. Pricing per trade means pushing the multiply into both producers for a difference bounded by one day of rate movement.

So `usd_pricing_basis: "window_close_rate"` — a string, not a boolean, so a future per-trade implementation publishes a different value instead of silently changing what the same shape means.

This is deliberately **not** the per-bucket rule #10398 applies to a series. A series has one instant per point; a single aggregate over a fixed window has one instant.

## What is NOT converted, and why

- **`sentiment` and `sentiment_ratio`** — dimensionless (a ratio of two alpha figures, and a label). A dimensionless quantity has no currency. Acceptance 3, with a test asserting no USD twin appears.
- **The `*_alpha` totals** — their only available price is the window's own realised VWAP (`total_volume_tao / total_volume_alpha`), and multiplying by it returns `total_volume_tao`. An `*_alpha_usd` field would be a second name for a number already published.
- **`volume_distribution`** — its shape is `IntensityDistribution`, a **registered component shared with `/chain/network-rollups`**. Adding `_usd` there would declare USD on a route that never publishes it; forking it trades a shared type for a duplicate. `usd_per_tao` is published right beside it.

## The KV reader moved

`readTaoUsdCurrentKv` goes from `workers/api.ts` to `workers/tao-usd-current.ts`. These are live handlers and they cannot import `api.ts` — `api.ts` imports them. Two memoised readers would be two caches with one name, and the second would be the one nobody remembered to reset between test files.

It arrives with the tests it never had: **a null is not memoised** (otherwise one cold read after a deploy convinces the isolate for a minute that the index does not exist) and **the memo is keyed on env** (so two bindings never cross-read). Those are the two ways a 60s cache actually hurts.

## Verification

- 26 overlay tests + 8 for the KV reader; **zero uncovered branches on added lines**, measured by intersecting the coverage report with this branch's diff — for `src/alpha-usd-overlay.ts`, `workers/tao-usd-current.ts`, and the added lines in both handlers.
- **All 45 validators** run locally and green, including `graphql-component-parity`, `published-names` and `schema-vocabularies`.
- CSV carries the USD columns on both routes; the SDL mirrors every new field rather than declaring a projection, and `field_sources_usd` is published as a concrete `AlphaUsdFieldSource` type instead of `JSON` — an under-typing is a field a caller cannot select.
- 3,122 tests green across the affected suites; `tsc`, `eslint`, `prettier` clean.

Closes #10383
