### PR TITLE
feat(graphql): check the 25 paginated views instead of skipping them

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10067,7 +10067,7 @@ export interface components {
         }) | null;
         SearchArtifact: {
             contract_version?: string;
-            document_count?: number;
+            document_count: number;
             /** @description Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON. */
             documents: {
                 artifact_path: string;
@@ -10094,7 +10094,7 @@ export interface components {
         /** @description Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index). */
         SearchIndexArtifact: {
             contract_version?: string;
-            document_count?: number;
+            document_count: number;
             documents: {
                 artifact_path: string;
                 categories?: string[];

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11719,18 +11719,7 @@ export interface components {
         SubnetTrajectoryArtifact: {
             /** @description Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short. */
             deltas: {
-                [key: string]: ({
-                    alpha_in_pool?: number | null;
-                    alpha_out_pool?: number | null;
-                    completeness_score?: number | null;
-                    endpoint_count?: number | null;
-                    from_date: string;
-                    surface_count?: number | null;
-                    tao_in_pool_tao?: number | null;
-                    to_date: string;
-                } & {
-                    [key: string]: unknown;
-                }) | null;
+                [key: string]: components["schemas"]["SubnetTrajectoryDelta"] | null;
             };
             netuid: number;
             point_count: number;
@@ -11752,6 +11741,18 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+        } & {
+            [key: string]: unknown;
+        };
+        SubnetTrajectoryDelta: {
+            alpha_in_pool?: number | null;
+            alpha_out_pool?: number | null;
+            completeness_score?: number | null;
+            endpoint_count?: number | null;
+            from_date: string;
+            surface_count?: number | null;
+            tao_in_pool_tao?: number | null;
+            to_date: string;
         } & {
             [key: string]: unknown;
         };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -41220,6 +41220,7 @@
         "required": [
           "generated_at",
           "schema_version",
+          "document_count",
           "documents"
         ],
         "type": "object"
@@ -41319,6 +41320,7 @@
         "required": [
           "generated_at",
           "schema_version",
+          "document_count",
           "documents"
         ],
         "type": "object"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -50308,80 +50308,7 @@
             "additionalProperties": {
               "anyOf": [
                 {
-                  "additionalProperties": {},
-                  "properties": {
-                    "alpha_in_pool": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "alpha_out_pool": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "completeness_score": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "endpoint_count": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "from_date": {
-                      "type": "string"
-                    },
-                    "surface_count": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "tao_in_pool_tao": {
-                      "anyOf": [
-                        {
-                          "type": "number"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "to_date": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "from_date",
-                    "to_date"
-                  ],
-                  "type": "object"
+                  "$ref": "#/components/schemas/SubnetTrajectoryDelta"
                 },
                 {
                   "type": "null"
@@ -50562,6 +50489,88 @@
           "point_count",
           "points",
           "deltas"
+        ],
+        "type": "object"
+      },
+      "SubnetTrajectoryDelta": {
+        "additionalProperties": {},
+        "properties": {
+          "alpha_in_pool": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_out_pool": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeness_score": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "endpoint_count": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "from_date": {
+            "type": "string"
+          },
+          "surface_count": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tao_in_pool_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "to_date": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from_date",
+          "to_date"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10067,7 +10067,7 @@ export interface components {
         }) | null;
         SearchArtifact: {
             contract_version?: string;
-            document_count?: number;
+            document_count: number;
             /** @description Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON. */
             documents: {
                 artifact_path: string;
@@ -10094,7 +10094,7 @@ export interface components {
         /** @description Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index). */
         SearchIndexArtifact: {
             contract_version?: string;
-            document_count?: number;
+            document_count: number;
             documents: {
                 artifact_path: string;
                 categories?: string[];

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11719,18 +11719,7 @@ export interface components {
         SubnetTrajectoryArtifact: {
             /** @description Latest-vs-window-ago deltas -- one entry per window (7d, 30d) that has a prior point to compare against; empty when the series is too short. */
             deltas: {
-                [key: string]: ({
-                    alpha_in_pool?: number | null;
-                    alpha_out_pool?: number | null;
-                    completeness_score?: number | null;
-                    endpoint_count?: number | null;
-                    from_date: string;
-                    surface_count?: number | null;
-                    tao_in_pool_tao?: number | null;
-                    to_date: string;
-                } & {
-                    [key: string]: unknown;
-                }) | null;
+                [key: string]: components["schemas"]["SubnetTrajectoryDelta"] | null;
             };
             netuid: number;
             point_count: number;
@@ -11752,6 +11741,18 @@ export interface components {
                 [key: string]: unknown;
             })[];
             schema_version: number;
+        } & {
+            [key: string]: unknown;
+        };
+        SubnetTrajectoryDelta: {
+            alpha_in_pool?: number | null;
+            alpha_out_pool?: number | null;
+            completeness_score?: number | null;
+            endpoint_count?: number | null;
+            from_date: string;
+            surface_count?: number | null;
+            tao_in_pool_tao?: number | null;
+            to_date: string;
         } & {
             [key: string]: unknown;
         };

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -1851,6 +1851,52 @@ export interface ProjectedType {
  * scalar narrowing -- and that is what the projection pass now checks.
  */
 export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
+  // ── the three that DO have a component behind them (#10404) ───────────────
+  //
+  // `subnets` and `providers` are the two Query fields with `route: null` --
+  // they read a published artifact directly rather than mirroring an
+  // /api/v1 route -- so the traversal cannot reach their list types and both
+  // sat in RESOLVER_BUILT_TYPES, unchecked. The projection pass does not need
+  // the traversal: naming the component is enough.
+  SubnetList: {
+    component: "SubnetsArtifact",
+    itemsFrom: "subnets",
+    added: ["total", "next_cursor"],
+    dropped: [
+      "contract_version",
+      "generated_at",
+      "notes",
+      "schema_version",
+      "network",
+      "source",
+    ],
+  },
+  ProviderList: {
+    component: "ProvidersArtifact",
+    itemsFrom: "providers",
+    added: ["total", "next_cursor"],
+    dropped: ["contract_version", "generated_at", "notes", "schema_version"],
+  },
+  // A flattened card: the artifact's own fields plus the counts the resolver
+  // derives from `global.status_counts`, which is a record GraphQL cannot
+  // name. The five it takes straight from the component are checked now; the
+  // nine it computes stay declared.
+  GlobalHealth: {
+    component: "HealthSummaryArtifact",
+    added: [
+      "status",
+      "ok_count",
+      "degraded_count",
+      "failed_count",
+      "unknown_count",
+      "avg_latency_ms",
+      "latency_sample_count",
+      "last_checked",
+      "last_ok",
+      "surface_count",
+    ],
+    dropped: ["contract_version", "schema_version", "global", "source"],
+  },
   Subnet: {
     component: "SubnetIndexEntry",
     added: ["health", "economics", "surfaces", "endpoints"],
@@ -2314,18 +2360,32 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
 /**
  * Types a resolver builds, with no component behind them.
  *
- * A pagination view (`{items, total, next_cursor}`) is the resolver's shape,
- * not a mirror of the artifact it pages over, and the remaining entries are
- * hand-shaped cards. The generator emits these from the resolver side; the
- * component emitter never sees them.
+ * THIS LIST IS THE DEBT, and only it: everything in `PROJECTED_TYPES` gets
+ * checked field by field, and everything here is taken on trust. It was 15
+ * when #10371 split the two, 8 after the projections were declared, and 5
+ * now that the three with a component behind them moved across -- `SubnetList`
+ * and `ProviderList` page over `SubnetsArtifact`/`ProvidersArtifact`, and
+ * `GlobalHealth` flattens `HealthSummaryArtifact`. Anything that picks its
+ * fields from a component belongs there, not here.
  *
- * Anything that picks its fields from a component belongs in `PROJECTED_TYPES`
- * instead, where it gets checked.
+ * Why each of the five is still here, and what closing it would take:
+ *
+ *   OpportunityBoards       six boards of OpportunityEntry, assembled from a
+ *                           leaderboard read. No artifact has this shape.
+ *   SubnetTrajectoryDelta   the artifact keys `deltas` by window ('7d'/'30d'),
+ *                           which are not valid GraphQL field names, so the
+ *                           resolver turns the record into a list carrying
+ *                           `window`. Modelling the record's VALUE as a named
+ *                           Zod schema would close it.
+ *   EmissionGateChange      the flattened form of a three-arm union
+ *                           (param/subnet/flow), each arm carrying only its
+ *                           own fields. GraphQL could express it as a union;
+ *                           the SDL chose one type with everything nullable.
+ *   Subscription            a root type, not a component.
+ *   ChainEvent              the subscription payload -- the #4980 NOTIFY
+ *                           shape, which no REST route serves.
  */
 export const RESOLVER_BUILT_TYPES: readonly string[] = [
-  "SubnetList",
-  "ProviderList",
-  "GlobalHealth",
   "OpportunityBoards",
   "SubnetTrajectoryDelta",
   "EmissionGateChange",

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -1809,6 +1809,25 @@ export interface ProjectedType {
    * typo'd or invented field is a failure rather than a silent extra.
    */
   readonly added: readonly string[];
+  /**
+   * Component fields the view deliberately does not republish, each of which
+   * must BE a component field (a typo fails) and must be ABSENT from the SDL
+   * (a stale entry fails). So the list only shrinks, and a field quietly
+   * disappearing from a published type is a failure rather than a silence.
+   *
+   * Absent on the projections that drop nothing.
+   */
+  readonly dropped?: readonly string[];
+  /**
+   * The component field a paginated view's `items` array renames (#10404).
+   *
+   * `BlockList.items` IS `BlocksFeedArtifact.blocks` -- one field under two
+   * names, not a dropped one and an invented one. Declaring the rename is what
+   * lets the element type be compared at all.
+   */
+  readonly itemsFrom?: string;
+  /** The component row count a paginated view's `total` renames (#10404). */
+  readonly totalFrom?: string;
 }
 
 /**
@@ -1835,19 +1854,461 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
   Subnet: {
     component: "SubnetIndexEntry",
     added: ["health", "economics", "surfaces", "endpoints"],
+    dropped: [
+      "block",
+      "candidate_count",
+      "contact",
+      "contact_present",
+      "dashboard_url",
+      "derived_categories",
+      "derived_description",
+      "discord",
+      "discord_url",
+      "github_commits_weekly",
+      "github_languages",
+      "github_last_push_at",
+      "github_stars",
+      "github_releases",
+      "github_unreachable",
+      "mechanism_count",
+      "native_name",
+      "native_name_quality",
+      "native_slug",
+      "participant_count",
+      "partnership",
+      "registered_at_block",
+      "registry_observed_count",
+      "social",
+      "source_repo",
+      "tempo",
+      "updated_at",
+    ],
   },
-  Provider: { component: "Provider", added: ["subnets", "endpoints"] },
-  Surface: { component: "Surface", added: [] },
-  Endpoint: { component: "EndpointResource", added: [] },
+  Provider: {
+    component: "Provider",
+    added: ["subnets", "endpoints"],
+    dropped: ["schema_version", "social", "team_url", "cluster_id"],
+  },
+  Surface: {
+    component: "Surface",
+    added: [],
+    dropped: [
+      "auth",
+      "curation_level",
+      "probe",
+      "quality_signals",
+      "rate_limit",
+      "rate_limit_notes",
+      "review",
+      "verification",
+    ],
+  },
+  Endpoint: {
+    component: "EndpointResource",
+    added: [],
+    dropped: [
+      "archive_support",
+      "chain",
+      "error",
+      "health_stale",
+      "method_support",
+      "method_tested",
+      "monitoring_policy",
+      "observed_at",
+      "pool_eligibility_reasons",
+      "publication_state",
+      "rate_limit_notes",
+      "rpc_method_count",
+      "score_reasons",
+      "reliability_score",
+      "reliability_grade",
+    ],
+  },
   SubnetHealth: { component: "HealthSubnetSummary", added: [] },
   OpportunityEntry: {
     component: "SubnetDetailArtifactEconomics",
     added: ["validator_headroom"],
+    dropped: [
+      "alpha_fdv_tao",
+      "alpha_in_emission",
+      "alpha_out_emission",
+      "alpha_in_pool",
+      "alpha_market_cap_tao",
+      "alpha_out_pool",
+      "alpha_price_change_1h",
+      "alpha_price_change_1m",
+      "spot_price_tao",
+      "block",
+      "emission_enabled",
+      "excess_tao",
+      "first_emission_block",
+      "max_stake_alpha",
+      "miner_readiness",
+      "miner_burned_fraction",
+      "owner_coldkey",
+      "owner_hotkey",
+      "subnet_volume_tao",
+      "subtoken_enabled",
+      "moving_price_pinned",
+      "registration_allowed_pinned",
+      "registered_at_block",
+      "subnet_mechanism",
+      "tao_in_emission_tao",
+      "tao_in_pool_tao",
+    ],
   },
-  ExtrinsicDetail: { component: "ExtrinsicDetailArtifact", added: [] },
-  BlockChainEvents: { component: "BlockEventsArtifact", added: [] },
+  ExtrinsicDetail: {
+    component: "ExtrinsicDetailArtifact",
+    added: [],
+    dropped: ["schema_version", "events"],
+  },
+  BlockChainEvents: {
+    component: "BlockEventsArtifact",
+    added: [],
+    dropped: ["ref", "limit", "offset"],
+  },
   AccountEntry: { component: "AccountsListArtifactAccounts", added: [] },
-  AccountSubnet: { component: "AccountPortfolioArtifactPositions", added: [] },
+  AccountSubnet: {
+    component: "AccountPortfolioArtifactPositions",
+    added: [],
+    dropped: [
+      "role",
+      "active",
+      "rank",
+      "trust",
+      "incentive",
+      "dividends",
+      "yield",
+    ],
+  },
+
+  // ── paginated views (#10404) ──────────────────────────────────────────────
+  //
+  // These 25 were SKIPPED wholesale by the parity gate, on the rule "two or
+  // more pagination fields the component lacks means this is a view, not a
+  // mirror". True of the paging and false of everything else: 158
+  // non-pagination fields sat behind that skip, 94 of them component fields
+  // the view does not publish. Most are the artifact envelope
+  // (schema_version/contract_version/generated_at/notes), which a view has no
+  // reason to republish -- but `EndpointList.health_source`,
+  // `GlobalIncidents.min_incident_samples` and `EconomicsList.field_sources`
+  // are the caveats that say whether a number was measured, and dropping them
+  // is the confident-zeros class (#9803) reached through the one door nothing
+  // was looking at.
+  //
+  // Declared as projections instead, so every rule a projection gets applies
+  // to them and a NEW drop is a failure.
+  AccountList: {
+    component: "AccountsListArtifact",
+    itemsFrom: "accounts",
+    totalFrom: "account_count",
+    added: [],
+    dropped: ["schema_version", "limit"],
+  },
+  BlockList: {
+    component: "BlocksFeedArtifact",
+    itemsFrom: "blocks",
+    totalFrom: "block_count",
+    added: [],
+    dropped: ["schema_version", "limit", "offset"],
+  },
+  CurationList: {
+    component: "CurationArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version"],
+  },
+  EconomicsList: {
+    component: "EconomicsArtifact",
+    added: ["total", "next_cursor"],
+    dropped: [
+      "contract_version",
+      "generated_at",
+      "notes",
+      "schema_version",
+      "captured_at",
+      "network",
+      "chain_state",
+      "field_sources",
+    ],
+  },
+  EndpointList: {
+    component: "EndpointsArtifact",
+    itemsFrom: "endpoints",
+    added: ["total", "next_cursor"],
+    dropped: [
+      "contract_version",
+      "generated_at",
+      "notes",
+      "schema_version",
+      "source",
+      "operational_observed_at",
+      "health_source",
+      "summary",
+    ],
+  },
+  EndpointPoolList: {
+    component: "EndpointPoolsArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: [
+      "contract_version",
+      "schema_version",
+      "disabled_proxy_contract",
+      "eligibility_policy",
+      "provider_scores",
+    ],
+  },
+  EvidenceList: {
+    component: "EvidenceLedgerArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "notes"],
+  },
+  ExtrinsicList: {
+    component: "ExtrinsicsFeedArtifact",
+    itemsFrom: "extrinsics",
+    totalFrom: "extrinsic_count",
+    added: [],
+    dropped: ["schema_version", "limit", "offset"],
+  },
+  GapsList: {
+    component: "GapsArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version"],
+  },
+  GlobalIncidents: {
+    component: "GlobalIncidentsArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["min_incident_samples"],
+  },
+  HealthHistory: {
+    component: "HealthHistoryArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: [
+      "contract_version",
+      "generated_at",
+      "notes",
+      "schema_version",
+      "source",
+      "probe_started_at",
+      "probe_finished_at",
+    ],
+  },
+  IncidentList: {
+    component: "EndpointIncidentsArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version", "source"],
+  },
+  PoolList: {
+    component: "RpcPoolsArtifact",
+    added: [
+      "operational_observed_at",
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: [
+      "contract_version",
+      "schema_version",
+      "disabled_proxy_contract",
+      "eligibility_policy",
+      "provider_scores",
+    ],
+  },
+  ProfileList: {
+    component: "SubnetProfilesArtifact",
+    added: [
+      "captured_at",
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: [
+      "contract_version",
+      "generated_at",
+      "notes",
+      "schema_version",
+      "summary",
+    ],
+  },
+  ReviewAdapterCandidateList: {
+    component: "ReviewAdapterCandidatesArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version", "summary"],
+  },
+  ReviewEnrichmentEvidenceList: {
+    component: "ReviewEnrichmentEvidenceArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version", "summary"],
+  },
+  ReviewEnrichmentQueueList: {
+    component: "ReviewEnrichmentQueueArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version", "summary"],
+  },
+  ReviewEnrichmentTargetList: {
+    component: "ReviewEnrichmentTargetsArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version", "groups", "summary"],
+  },
+  ReviewGapPriorityList: {
+    component: "ReviewGapPrioritiesArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version"],
+  },
+  ReviewProfileCompletenessList: {
+    component: "ReviewProfileCompletenessArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "schema_version"],
+  },
+  SearchDocumentList: {
+    component: "SearchArtifact",
+    totalFrom: "document_count",
+    added: ["next_cursor"],
+    dropped: ["contract_version", "generated_at", "notes", "schema_version"],
+  },
+  SearchIndexList: {
+    component: "SearchIndexArtifact",
+    totalFrom: "document_count",
+    added: ["returned", "limit", "cursor", "next_cursor", "sort", "order"],
+    dropped: ["contract_version", "notes", "schema_version"],
+  },
+  SourceSnapshotList: {
+    component: "SourceSnapshotsArtifact",
+    added: [
+      "total",
+      "returned",
+      "limit",
+      "cursor",
+      "next_cursor",
+      "sort",
+      "order",
+    ],
+    dropped: ["contract_version", "notes"],
+  },
+  SurfaceList: {
+    component: "SurfacesArtifact",
+    itemsFrom: "surfaces",
+    added: ["total", "next_cursor"],
+    dropped: ["contract_version", "generated_at", "notes", "schema_version"],
+  },
+  ValidatorList: {
+    component: "GlobalValidatorsArtifact",
+    itemsFrom: "validators",
+    totalFrom: "validator_count",
+    added: ["next_cursor"],
+    dropped: ["schema_version", "limit"],
+  },
 };
 
 /**

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -1851,6 +1851,15 @@ export interface ProjectedType {
  * scalar narrowing -- and that is what the projection pass now checks.
  */
 export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
+  // The `deltas` record's VALUE, registered as its own component so the
+  // published type has something to be compared against (#10404). `window` is
+  // the record's KEY, which the resolver lifts into the row because "7d" and
+  // "30d" are not valid GraphQL field names.
+  SubnetTrajectoryDelta: {
+    component: "SubnetTrajectoryDelta",
+    added: ["window"],
+    dropped: [],
+  },
   // ── the three that DO have a component behind them (#10404) ───────────────
   //
   // `subnets` and `providers` are the two Query fields with `route: null` --
@@ -2372,11 +2381,6 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
  *
  *   OpportunityBoards       six boards of OpportunityEntry, assembled from a
  *                           leaderboard read. No artifact has this shape.
- *   SubnetTrajectoryDelta   the artifact keys `deltas` by window ('7d'/'30d'),
- *                           which are not valid GraphQL field names, so the
- *                           resolver turns the record into a list carrying
- *                           `window`. Modelling the record's VALUE as a named
- *                           Zod schema would close it.
  *   EmissionGateChange      the flattened form of a three-arm union
  *                           (param/subnet/flow), each arm carrying only its
  *                           own fields. GraphQL could express it as a union;
@@ -2387,7 +2391,6 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
  */
 export const RESOLVER_BUILT_TYPES: readonly string[] = [
   "OpportunityBoards",
-  "SubnetTrajectoryDelta",
   "EmissionGateChange",
   "Subscription",
   "ChainEvent",

--- a/schemas-src/openapi-registry.ts
+++ b/schemas-src/openapi-registry.ts
@@ -247,7 +247,10 @@ import {
   SubnetYieldHistoryArtifactSchema,
 } from "./routes/subnet-yield.ts";
 import { SubnetMoversArtifactSchema } from "./routes/subnet-movers.ts";
-import { SubnetTrajectoryArtifactSchema } from "./routes/subnet-trajectory.ts";
+import {
+  SubnetTrajectoryArtifactSchema,
+  SubnetTrajectoryDeltaSchema,
+} from "./routes/subnet-trajectory.ts";
 import {
   SubnetLeaseArtifactSchema,
   SubnetLeaseHistoryArtifactSchema,
@@ -659,6 +662,12 @@ register(SubnetYieldArtifactSchema, "SubnetYieldArtifact");
 register(SubnetYieldHistoryArtifactSchema, "SubnetYieldHistoryArtifact");
 register(SubnetMoversArtifactSchema, "SubnetMoversArtifact");
 register(SubnetTrajectoryArtifactSchema, "SubnetTrajectoryArtifact");
+// The VALUE of the `deltas` record (#10404). The record itself is keyed by
+// window and stays JSON in GraphQL -- "7d"/"30d" are not field names -- but
+// the value has a fixed shape, and registering it is what lets the published
+// `SubnetTrajectoryDelta` type be compared against something instead of
+// sitting in RESOLVER_BUILT_TYPES where nothing checks it.
+register(SubnetTrajectoryDeltaSchema, "SubnetTrajectoryDelta");
 register(SubnetLeaseArtifactSchema, "SubnetLeaseArtifact");
 register(SubnetLeaseHistoryArtifactSchema, "SubnetLeaseHistoryArtifact");
 register(CrowdloansArtifactSchema, "CrowdloansArtifact");

--- a/schemas-src/routes/evidence-search.ts
+++ b/schemas-src/routes/evidence-search.ts
@@ -177,7 +177,14 @@ const SearchDocumentSchema = z
   .strict();
 
 export const SearchArtifactSchema = ArtifactBaseSchema.extend({
-  document_count: z.int().min(0).optional(),
+  // Required, not optional (#10404). BOTH builders --
+  // `scripts/build-artifacts.ts`'s search index and its slim companion --
+  // set `document_count: documents.length` unconditionally, and
+  // `scripts/validate.ts` asserts the two agree, so there is no path that
+  // omits it. GraphQL had it right (`total: Int!`) and the component
+  // disagreed; nothing compared them until the paginated views stopped being
+  // skipped. Production serves 3768 on both routes.
+  document_count: z.int().min(0),
   documents: z
     .array(SearchDocumentSchema)
     .describe(
@@ -204,7 +211,14 @@ const SearchIndexDocumentSchema = z
   .strict();
 
 export const SearchIndexArtifactSchema = ArtifactBaseSchema.extend({
-  document_count: z.int().min(0).optional(),
+  // Required, not optional (#10404). BOTH builders --
+  // `scripts/build-artifacts.ts`'s search index and its slim companion --
+  // set `document_count: documents.length` unconditionally, and
+  // `scripts/validate.ts` asserts the two agree, so there is no path that
+  // omits it. GraphQL had it right (`total: Int!`) and the component
+  // disagreed; nothing compared them until the paginated views stopped being
+  // skipped. Production serves 3768 on both routes.
+  document_count: z.int().min(0),
   documents: z.array(SearchIndexDocumentSchema),
 }).describe(
   "Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index).",

--- a/schemas-src/routes/subnet-trajectory.ts
+++ b/schemas-src/routes/subnet-trajectory.ts
@@ -12,13 +12,20 @@ import { successEnvelopeSchema } from "../envelope.ts";
  * (`to` minus `from`), not a level -- a negative `tao_in_pool_tao` means the
  * pool shrank over the window, and the two dates say which two observations
  * were subtracted. */
-const SubnetTrajectoryDeltaSchema = z
+export const SubnetTrajectoryDeltaSchema = z
   .object({
     from_date: z.string(),
     to_date: z.string(),
-    completeness_score: z.number().nullable().optional(),
-    surface_count: z.number().nullable().optional(),
-    endpoint_count: z.number().nullable().optional(),
+    // `z.int()`, matching the POINT schema above rather than the `z.number()`
+    // this used to declare (#10404). The two describe the same three fields --
+    // a point's value and a difference of two of them -- and `src/health-
+    // serving.ts` runs every point through `roundInt()` before `diff()`
+    // subtracts a pair, so a fractional delta is unreachable. GraphQL had it
+    // right (`Int`) and the component disagreed; nothing compared them while
+    // the type sat in RESOLVER_BUILT_TYPES.
+    completeness_score: z.int().nullable().optional(),
+    surface_count: z.int().nullable().optional(),
+    endpoint_count: z.int().nullable().optional(),
     tao_in_pool_tao: z.number().nullable().optional(),
     alpha_in_pool: z.number().nullable().optional(),
     alpha_out_pool: z.number().nullable().optional(),

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -101,7 +101,7 @@ const PAGINATION_FIELDS = new Set([
  * this script, so a fix cannot leave a stale exemption behind -- the same
  * idiom the MCP input-parity and tier-cascade gates use.
  */
-const DECLARED: Record<string, string> = {
+export const DECLARED: Record<string, string> = {
   "EmissionGateChanges.changes":
     "the component is a three-arm union (param/subnet/flow changes, each " +
     "carrying only its own fields) and the emitter answers JSON for a " +
@@ -133,6 +133,13 @@ const DECLARED: Record<string, string> = {
  */
 const JSON_UNDERTYPED: Record<string, string> = {
   "Adapter.snapshot": "AdapterArtifactSnapshot",
+  // Landed on main between this check being written (#10400) and the
+  // `field_sources_usd` provenance block being added (#10392) -- each PR was
+  // green against its own base and red together, which is what a gate added
+  // in parallel with the thing it measures always risks. Unlike
+  // `field_sources`, which is a record keyed by field name and honestly JSON,
+  // this one is a fixed `{kind, storage}` object.
+  "EconomicsTrends.field_sources_usd": "EconomicsTrendsArtifactFieldSourcesUsd",
   "BlockEvents.events": "[AccountEvent!]",
   "BlockExtrinsics.extrinsics": "[BlockExtrinsicsArtifactExtrinsics!]",
   "BuildSummary.artifact_budget_summary":
@@ -155,6 +162,7 @@ const JSON_UNDERTYPED: Record<string, string> = {
     "CompareValidatorsArtifactValidatorsSubnetContext",
   "Contracts.artifacts": "[ContractsArtifactArtifacts!]",
   "SubnetConviction.king": "String",
+  "SubnetOhlc.field_sources_usd": "SubnetOhlcArtifactFieldSourcesUsd",
   "SubnetConviction.leaderboard": "[SubnetConvictionArtifactLeaderboard!]",
   "SubnetEventSummary.categories": "[SubnetEventSummaryArtifactCategories!]",
   "SubnetEventSummary.event_kinds": "[SubnetEventSummaryArtifactEventKinds!]",
@@ -179,6 +187,8 @@ export interface ParityReport {
   /** Declared projections checked -- see `PROJECTED_TYPES` (#10214). */
   projectedTypes: number;
   projectedFields: number;
+  /** Component fields a projection declares it does not republish (#10404). */
+  droppedFields: number;
 }
 
 /** Pull the SDL out of the TypeScript template literal that holds it. */
@@ -277,6 +287,9 @@ export function checkComponentParity(
   sdl: string,
   openapi: OpenApiDocument,
   declared: Record<string, string> = DECLARED,
+  projectedTypesMap: Readonly<
+    Record<string, (typeof PROJECTED_TYPES)[string]>
+  > = PROJECTED_TYPES,
 ): ParityReport {
   const sdlTypes = new Map<string, ObjectTypeDefinitionNode>();
   for (const def of parse(sdl).definitions) {
@@ -341,6 +354,7 @@ export function checkComponentParity(
   let projectedTypes = 0;
   let projectedFields = 0;
   const undertypedMatched = new Set<string>();
+  let droppedFields = 0;
 
   for (const [sdlName, components] of paired) {
     const sdlFields = new Set(
@@ -352,7 +366,20 @@ export function checkComponentParity(
         (f) => PAGINATION_FIELDS.has(f) && !genNames.includes(f),
       );
       if (addedPagination.length >= 2) {
-        projections.push(`${sdlName} <- ${componentName}`);
+        // A paginated view, not a mirror -- but skipping it wholesale is what
+        // hid 158 fields (#10404). It has to be DECLARED, and the projection
+        // pass below applies every rule a projection gets.
+        const declaredView = projectedTypesMap[sdlName];
+        if (declaredView?.component === componentName) {
+          projections.push(`${sdlName} <- ${componentName}`);
+          continue;
+        }
+        violations.push(
+          `${sdlName} -- pages over ${componentName} and is not declared in ` +
+            `PROJECTED_TYPES, so nothing checks the ` +
+            `${genNames.filter((n) => !PAGINATION_FIELDS.has(n)).length} field(s) ` +
+            `behind its paging`,
+        );
         continue;
       }
       comparedTypes += 1;
@@ -486,7 +513,7 @@ export function checkComponentParity(
   // the traversal above only reaches a type through a `Mirrors GET` annotation
   // and a resolver-built type has none. All fifteen were reached by zero
   // gates.
-  for (const [sdlName, projection] of Object.entries(PROJECTED_TYPES)) {
+  for (const [sdlName, projection] of Object.entries(projectedTypesMap)) {
     const sdlType = sdlTypes.get(sdlName);
     const genType = generated.get(projection.component);
     if (!sdlType) {
@@ -505,9 +532,23 @@ export function checkComponentParity(
     const genFields = genType.getFields();
     const added = new Set(projection.added);
     const usedAdded = new Set<string>();
+    // A paginated view RENAMES the component's row array and row count rather
+    // than dropping them, so the element type and the count are compared under
+    // the published name (#10404).
+    const renamed = new Map<string, string>();
+    if (projection.itemsFrom) renamed.set("items", projection.itemsFrom);
+    if (projection.totalFrom) renamed.set("total", projection.totalFrom);
+    for (const [published, source] of renamed) {
+      if (!genFields[source]) {
+        violations.push(
+          `${sdlName}.${published} -- declared as renaming ` +
+            `${projection.component}.${source}, which the component does not publish`,
+        );
+      }
+    }
     for (const field of sdlType.fields ?? []) {
       const name = field.name.value;
-      const genField = genFields[name];
+      const genField = genFields[renamed.get(name) ?? name];
       if (!genField) {
         if (added.has(name)) usedAdded.add(name);
         else
@@ -545,6 +586,41 @@ export function checkComponentParity(
         );
       }
     }
+    // Both directions on `dropped`, which is what makes the list shrink-only:
+    // a name the component does not publish is a typo, and a name the SDL now
+    // publishes is a closed gap whose declaration was left behind.
+    const publishedNames = new Set(
+      (sdlType.fields ?? []).map((field) => field.name.value),
+    );
+    for (const name of projection.dropped ?? []) {
+      if (!genFields[name]) {
+        violations.push(
+          `${sdlName}.${name} -- declared as dropped, but ` +
+            `${projection.component} publishes no such field`,
+        );
+        continue;
+      }
+      if (publishedNames.has(name)) {
+        violations.push(
+          `${sdlName}.${name} -- declared as dropped, and the SDL publishes it`,
+        );
+        continue;
+      }
+      droppedFields += 1;
+    }
+    // Completeness, so `dropped` is the WHOLE set rather than a sample: every
+    // component field the projection does not publish must be named. Without
+    // this the list would shrink honestly and still say nothing about a field
+    // that vanished after it was written.
+    for (const name of Object.keys(genFields)) {
+      if (publishedNames.has(name)) continue;
+      if (projection.dropped?.includes(name)) continue;
+      if ([...renamed.values()].includes(name)) continue;
+      violations.push(
+        `${sdlName}.${name} -- ${projection.component} publishes it, the ` +
+          `projection neither publishes nor declares it dropped`,
+      );
+    }
   }
 
   return {
@@ -561,6 +637,7 @@ export function checkComponentParity(
     projections,
     projectedTypes,
     projectedFields,
+    droppedFields,
   };
 }
 
@@ -580,7 +657,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     `graphql-component-parity: ${report.comparedTypes} mirror type(s), ` +
       `${report.comparedFields} field(s) compared, ` +
       `${report.projectedTypes} declared projection(s) (${report.projectedFields} field(s)), ` +
-      `${report.projections.length} pagination view(s) skipped, ` +
+      `${report.projections.length} pagination view(s), ` +
+      `${report.droppedFields} declared drop(s), ` +
       `${report.undertyped} JSON under-typing(s) left to close.`,
   );
   if (report.violations.length) {

--- a/scripts/validate-published-names.ts
+++ b/scripts/validate-published-names.ts
@@ -293,7 +293,38 @@ const staleResolverBuilt = declaredResolverBuilt.filter(
   (name) => !unpaired.includes(name),
 );
 const bothLists = declaredResolverBuilt.filter((name) => projected.has(name));
-const projectedButReached = [...projected].filter((name) => paired.has(name));
+// A projection the traversal reaches AS A FULL MIRROR is a stale declaration:
+// the parity gate compares it field-for-field and the entry does nothing. A
+// PAGINATED view is reached too and is NOT stale -- the traversal is how the
+// parity gate pairs it, and it stays a projection because it publishes a
+// subset under its own paging (#10404). The test is the parity gate's own:
+// does it add two or more pagination fields its component lacks?
+const PAGINATION_FIELDS = new Set([
+  "items",
+  "total",
+  "returned",
+  "limit",
+  "cursor",
+  "next_cursor",
+  "sort",
+  "order",
+  "offset",
+]);
+const isPaginatedView = (name: string): boolean => {
+  const projection = PROJECTED_TYPES[name];
+  const genType = projection && generated.get(projection.component);
+  if (!genType) return false;
+  const componentFields = new Set(Object.keys(genType.getFields()));
+  const added = (sdlTypes.get(name)?.fields ?? []).filter(
+    (field) =>
+      PAGINATION_FIELDS.has(field.name.value) &&
+      !componentFields.has(field.name.value),
+  );
+  return added.length >= 2;
+};
+const projectedButReached = [...projected].filter(
+  (name) => paired.has(name) && !isPaginatedView(name),
+);
 if (missingResolverBuilt.length) {
   errors.push(
     `${missingResolverBuilt.length} SDL type(s) no component reaches, and neither PROJECTED_TYPES nor RESOLVER_BUILT_TYPES accounts for:\n` +

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -5,6 +5,7 @@ import { GraphQLObjectType } from "graphql";
 import { emitTypes, pascalCase } from "../schemas-src/graphql/emit.ts";
 import { PROJECTED_TYPES } from "../schemas-src/graphql/published-names.ts";
 import {
+  DECLARED,
   checkComponentParity,
   extractSdl,
   type OpenApiDocument,
@@ -251,11 +252,11 @@ describe("declared projections (#10214)", () => {
 // `JSON` read as agreement, so an emitter that retyped 348 fields as JSON
 // would have passed every gate in the repo.
 describe("scalar identity", () => {
-  test("28 JSON under-typings are declared, and all of them are live", () => {
+  test("every JSON under-typing is declared, and all of them are live", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.undertyped, 28);
+    assert.equal(report.undertyped, 30);
   });
 
   test("it FAILS when a field is retyped to a different scalar", () => {
@@ -307,7 +308,7 @@ describe("scalar identity", () => {
       report.stale.includes("SubnetConviction.king"),
       `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
     );
-    assert.equal(report.undertyped, 27);
+    assert.equal(report.undertyped, 29);
   });
 
   test("a Float over an Int component field is a WIDENING and stays allowed", () => {
@@ -319,6 +320,103 @@ describe("scalar identity", () => {
       !report.violations.some((v) =>
         v.includes("ChainTurnoverNetwork.stability_score"),
       ),
+    );
+  });
+});
+
+// Paginated views (#10404). They used to be SKIPPED wholesale on the rule "two
+// or more pagination fields the component lacks means this is a view" -- true
+// of the paging and false of the 158 fields behind it.
+describe("paginated views", () => {
+  test("all 25 are declared, and their drops are the whole set", () => {
+    const report = checkComponentParity(sdl, openapi);
+    assert.deepEqual(report.violations, []);
+    assert.equal(report.projections.length, 25);
+    assert.equal(report.droppedFields, 180);
+  });
+
+  test("it FAILS when a component field is neither published nor declared dropped", () => {
+    // The whole point: a field vanishing from a published view used to be a
+    // silence. `min_incident_samples` is the threshold behind an incident
+    // count -- the confident-zeros class (#9803).
+    const report = checkComponentParity(sdl, openapi, DECLARED, {
+      ...PROJECTED_TYPES,
+      GlobalIncidents: {
+        ...PROJECTED_TYPES.GlobalIncidents,
+        dropped: [],
+      },
+    });
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith(
+          "GlobalIncidents.min_incident_samples -- GlobalIncidentsArtifact publishes it",
+        ),
+      ),
+      `expected the undeclared drop to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("a STALE drop fails, so the list only shrinks", () => {
+    const report = checkComponentParity(sdl, openapi, DECLARED, {
+      ...PROJECTED_TYPES,
+      GlobalIncidents: {
+        ...PROJECTED_TYPES.GlobalIncidents,
+        dropped: [
+          ...(PROJECTED_TYPES.GlobalIncidents.dropped ?? []),
+          "surfaces",
+        ],
+      },
+    });
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith(
+          "GlobalIncidents.surfaces -- declared as dropped, and the SDL publishes it",
+        ),
+      ),
+      `expected the stale drop to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("a drop naming a field the component does not publish is a typo", () => {
+    const report = checkComponentParity(sdl, openapi, DECLARED, {
+      ...PROJECTED_TYPES,
+      GlobalIncidents: {
+        ...PROJECTED_TYPES.GlobalIncidents,
+        dropped: [
+          ...(PROJECTED_TYPES.GlobalIncidents.dropped ?? []),
+          "min_incident_sample",
+        ],
+      },
+    });
+    assert.ok(
+      report.violations.some((v) => v.includes("publishes no such field")),
+      `expected the typo to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("a rename that names a field the component lacks fails", () => {
+    // `items` IS the component's row array under another name; declaring the
+    // wrong source silently compares nothing.
+    const report = checkComponentParity(sdl, openapi, DECLARED, {
+      ...PROJECTED_TYPES,
+      BlockList: { ...PROJECTED_TYPES.BlockList, itemsFrom: "rows" },
+    });
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith("BlockList.items -- declared as renaming"),
+      ),
+      `expected the bad rename to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("an UNDECLARED paginated view is a violation, not a skip", () => {
+    const { GlobalIncidents: _dropped, ...withoutOne } = PROJECTED_TYPES;
+    const report = checkComponentParity(sdl, openapi, DECLARED, withoutOne);
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith("GlobalIncidents -- pages over GlobalIncidentsArtifact"),
+      ),
+      `expected the undeclared view to be reported, got: ${report.violations.join("; ")}`,
     );
   });
 });

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -332,7 +332,10 @@ describe("paginated views", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.equal(report.projections.length, 25);
-    assert.equal(report.droppedFields, 180);
+    // Every projection's drops, not just the paginated ones -- `dropped` is
+    // the whole set on all 38, which is what makes an undeclared drop a
+    // failure rather than a silence.
+    assert.equal(report.droppedFields, 194);
   });
 
   test("it FAILS when a component field is neither published nor declared dropped", () => {


### PR DESCRIPTION
## Summary

The parity gate skipped a type **wholesale** when it carried two or more pagination fields its component lacks. The reason was sound — `EndpointList {items, total, next_cursor}` over `EndpointsArtifact {endpoints, summary, …}` is a view, and comparing it field-for-field compares a view to its source — but the rule dropped the view's **content** along with its paging.

**25 pairs, 158 non-pagination fields behind the skip, 94 of them component fields the view does not publish.**

They are now declared projections, and every rule a projection gets applies to them:

```
graphql-component-parity: 325 mirror types, 2513 fields compared,
  39 declared projections (227 fields), 25 pagination views,
  194 declared drops, 30 JSON under-typings left to close.
```

Was: 10 projections, 132 fields, and 25 types nothing looked at.

## It found the class it was built to find

`SearchDocumentList.total` and `SearchIndexList.total` are `Int!` over a component whose `document_count` is **optional** — a non-null over a nullable, which is the #10215 shape: one null and graphql-js nulls the whole `SearchDocumentList` object.

The Zod is the wrong one, and it is decidable rather than a judgement call: both builders in `scripts/build-artifacts.ts` set `document_count: documents.length` unconditionally, `scripts/validate.ts` asserts the two agree, and production serves `3768` on both routes. `.optional()` published a possibility neither builder can express — the same correction as `Provider.netuids` (#10371) and `ScoreDistribution` (#10378), found the same way.

## And it caught main going red

`validate:graphql-component-parity`'s scalar-identity check (#10400) and the `field_sources_usd` provenance block (#10392) were each green against their own base and **red together** — `field_sources_usd` is a fixed `{kind, storage}` object the SDL publishes as `JSON`. Both are declared here with that written down. Unlike `field_sources`, which is keyed by field name and honestly `JSON`.

## What the declarations say

`ProjectedType` gains three fields, so a view describes itself completely:

- `itemsFrom` / `totalFrom` — the component field the view's `items` array and `total` count **rename**. `BlockList.items` IS `BlocksFeedArtifact.blocks`: one field under two names, not a dropped one and an invented one. Declaring the rename is what lets the element type be compared at all.
- `dropped` — every component field the view does not republish, checked in **both** directions: a name the component does not publish is a typo, a name the SDL now publishes is a closed gap whose declaration was left behind, and a component field that is neither published nor declared is a violation. So the list is the whole set, and it only shrinks.

Most of the 194 drops are the artifact envelope (`schema_version`, `contract_version`, `generated_at`, `notes`) a view has no reason to republish. Some are not, and they are now visible instead of invisible: `EndpointList.health_source` (*probe-derived / missing-probe / not-monitored* — whether a health number was measured at all), `GlobalIncidents.min_incident_samples` (the threshold behind an incident count), `EconomicsList.field_sources`, `EndpointPoolList.eligibility_policy`. Each is a candidate to **add** to its view; that is a published-schema change and belongs in its own PR, which is exactly what a shrink-only list is for.

`validate-published-names`' `projectedButReached` check learned the difference too: a projection reached as a full mirror is stale, a paginated view reached by the traversal is not — the traversal is how the parity gate pairs it.

## And the unchecked-debt list halved

`RESOLVER_BUILT_TYPES` is the list of published types nothing checks — everything in `PROJECTED_TYPES` is compared field by field, everything there is taken on trust. It was 15 when #10371 split the two. **It is 4 now**, because four of the eight did have something behind them:

- `SubnetList` pages over `SubnetsArtifact`, `ProviderList` over `ProvidersArtifact`. Both sat unchecked only because their Query fields have `route: null` — they read a published artifact rather than mirroring an `/api/v1` route, so the traversal cannot reach them. The projection pass does not need the traversal: naming the component is enough.
- `GlobalHealth` flattens `HealthSummaryArtifact`; its five component-derived fields are checked now, the nine it computes stay declared.
- `SubnetTrajectoryDelta` is the `deltas` record's **value**, which already had a Zod schema — just an unregistered one. Registering it gives the published type something to be compared against, and comparing it immediately found the same defect class again: the delta schema declared `completeness_score`/`surface_count`/`endpoint_count` as `z.number()` while the POINT schema in the same file declares them `z.int()`, and `src/health-serving.ts` runs every point through `roundInt()` before `diff()` subtracts a pair — a fractional delta is unreachable. Tightened to match.

The four that remain each carry a written note saying why and what would close it: `OpportunityBoards` (six boards assembled from a leaderboard read, no artifact has the shape), `EmissionGateChange` (the flattened form of a three-arm union), `Subscription` (a root type), `ChainEvent` (the #4980 NOTIFY payload, which no REST route serves).

Final counts: **39 declared projections (227 fields), 194 declared drops, 4 resolver-built types.**

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run build` + `validate:contract-drift` — passed; `openapi.json`, `packages/contract/index.d.ts`, `public/metagraph/types.d.ts` regenerated and committed
- `validate:graphql-component-parity` — 325 mirrors / 2513 fields / 39 projections / 194 drops, OK
- `validate:published-names` — 349 components, 318 published types, 196 bindings, 39 projections, 4 resolver-built, OK
- `validate:graphql-query-arguments` — 187 exact, OK; `validate:graphql-route-parity` — 0 divergences
- `npx vitest run` — 795 files, **18,381 passed**, 11 skipped, 0 failed

Six new tests drive `checkComponentParity` with a mutated projection map and assert it fires on: an undeclared drop, a stale drop, a drop naming a field the component lacks, a rename pointing at a field the component lacks, and an undeclared paginated view. `checkComponentParity` takes the projection map as a parameter so a test can mutate it without touching the registry.

No `src/**` or `workers/**` line changed, so there is no `codecov/patch` surface in this diff.

Closes #10404.
