### PR TITLE
feat(ui): render alpha in USD, and show where the USD actually starts

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-ohlc-chart.tsx
@@ -4,7 +4,8 @@ import { subnetOhlcQuery } from "@/lib/metagraphed/queries";
 import { CandlestickMini, type CandlestickDatum } from "@jsonbored/ui-kit";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
 import { Panel } from "@/components/metagraphed/primitives";
-import { classNames, formatTao } from "@/lib/metagraphed/format";
+import { classNames, formatTao, formatUsdApprox } from "@/lib/metagraphed/format";
+import { alphaUsdCoverage } from "@/lib/metagraphed/alpha-usd.functions";
 
 // Lookback windows offered as pills. "max" is 365d, the server's own clamp
 // ceiling for ?days= (see subnetOhlcQuery's params doc) -- naming it "max"
@@ -131,6 +132,18 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
   }
 
   const latest = data?.candles[data.candles.length - 1];
+  // What the response STATES about its own USD coverage (#10385) -- never
+  // inferred by counting nulls in the candle array. The TAO series runs the
+  // full window and the USD series starts when the TAO/USD index does, so a
+  // chart that showed both without qualifying the shorter one would invite a
+  // comparison the data does not support.
+  const usd = alphaUsdCoverage(data);
+  // The product of the candle's own close and the rate published ON that
+  // candle -- the same number the API already computed as close_usd, formatted
+  // with the existing helper rather than a second one. Per-candle, so a
+  // historical close is never shown at today's rate.
+  const latestUsd =
+    usd.available && latest ? formatUsdApprox(latest.close, latest.usd_per_tao) : null;
 
   return (
     <div className="space-y-3">
@@ -166,10 +179,17 @@ export function SubnetOhlcChart({ netuid }: { netuid: number }) {
             </span>
             {latest ? (
               <span>
-                latest close {fmtOhlcPrice(latest.close)} τ/α · vol {formatTao(latest.volume_tao)}
+                latest close {fmtOhlcPrice(latest.close)} τ/α
+                {latestUsd ? ` (${latestUsd})` : ""} · vol {formatTao(latest.volume_tao)}
               </span>
             ) : null}
           </div>
+          {/* The USD boundary, rendered only when it differs from the TAO
+              window. A caption on a fully-covered chart is noise, and noise is
+              what stops captions being read on the charts that need them. */}
+          {usd.caption ? (
+            <div className="mt-1 mg-type-data-sm text-ink-muted">{usd.caption}</div>
+          ) : null}
         </Panel>
       )}
     </div>

--- a/apps/ui/src/lib/metagraphed/alpha-usd.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/alpha-usd.functions.test.ts
@@ -1,0 +1,154 @@
+// Rendering alpha in USD honestly (#10385).
+//
+// Every test here is about a chart that would render perfectly while lying:
+// a USD line silently shorter than the TAO line beside it, a declining index
+// shown as $0, a market cap compared against venue numbers computed a different
+// way. The assertions are mostly about what must be SAID, because the failure
+// mode is silence rather than an error.
+import { describe, expect, test } from "vitest";
+import {
+  ALPHA_MARKET_CAP_USD_NOTE,
+  ALPHA_USD_PROVENANCE_NOTE,
+  alphaUsdCoverage,
+  alphaUsdUnavailableLabel,
+} from "./alpha-usd.functions";
+
+describe("USD coverage on a series", () => {
+  test("a partial series SAYS where USD begins", () => {
+    // The headline case: 90 days of TAO, 8 of USD. A chart that renders both
+    // without qualifying the shorter one invites the reader to compare them.
+    const c = alphaUsdCoverage({
+      usd_available_from_iso: "2026-08-02T00:00:00.000Z",
+      priced_candle_count: 8,
+      candle_count: 90,
+    });
+    expect(c.available).toBe(true);
+    expect(c.partial).toBe(true);
+    expect(c.from).toBe("2026-08-02");
+    expect(c.caption).toContain("USD from 2026-08-02");
+    expect(c.caption).toContain("8 of 90");
+  });
+
+  test("a fully covered series carries NO caption", () => {
+    // Noise is what stops captions being read on the charts that need them.
+    const c = alphaUsdCoverage({
+      usd_available_from_iso: "2026-08-02T00:00:00.000Z",
+      priced_candle_count: 24,
+      candle_count: 24,
+    });
+    expect(c.available).toBe(true);
+    expect(c.partial).toBe(false);
+    expect(c.caption).toBeNull();
+  });
+
+  test("a declining index is UNAVAILABLE, never zero", () => {
+    // Acceptance 3. `insufficient_pools` is a stated outcome; rendering it as
+    // $0 would publish "this subnet is worthless" where the truth is "not
+    // priceable right now".
+    const c = alphaUsdCoverage({
+      usd_unavailable: "index_unpriced",
+      priced_candle_count: 0,
+      candle_count: 90,
+    });
+    expect(c.available).toBe(false);
+    expect(c.pricedCount).toBe(0);
+    expect(c.caption).toBeNull();
+    expect(c.unavailableLabel).toContain("too few qualifying liquidity pools");
+    // The TAO side is still there to render.
+    expect(c.totalCount).toBe(90);
+  });
+
+  test("a STATED reason outranks the counts", () => {
+    // A payload that names why it could not price must not be rendered as a
+    // series that merely happens to be empty — even if a count disagrees.
+    const c = alphaUsdCoverage({
+      usd_unavailable: "read_failed",
+      priced_candle_count: 5,
+      candle_count: 90,
+    });
+    expect(c.available).toBe(false);
+    expect(c.unavailableLabel).toContain("could not reach");
+  });
+
+  test("each reason reads differently, because they mean different things", () => {
+    // "briefly unavailable" and "we could not reach it" lead a reader to
+    // different actions. Collapsing them to one string throws that away.
+    const labels = [
+      "index_unpriced",
+      "index_stale",
+      "no_index_reading",
+      "read_failed",
+      "no_alpha_price",
+    ].map(alphaUsdUnavailableLabel);
+    expect(new Set(labels).size).toBe(labels.length);
+    for (const l of labels) expect(l).toMatch(/^USD unavailable/);
+  });
+
+  test("an unknown reason still degrades to a sentence, not to a raw token", () => {
+    expect(alphaUsdUnavailableLabel("something_new")).toBe("USD unavailable");
+    expect(alphaUsdUnavailableLabel(null)).toBe("USD unavailable");
+  });
+
+  test("the day-keyed series works the same way", () => {
+    // /economics/trends keys on snapshot_date rather than a bucket instant.
+    const c = alphaUsdCoverage({
+      usd_available_from: "2026-08-02",
+      priced_day_count: 8,
+      day_count: 400,
+    });
+    expect(c.available).toBe(true);
+    expect(c.from).toBe("2026-08-02");
+    expect(c.caption).toContain("8 of 400");
+  });
+
+  test("a missing or malformed payload renders TAO only", () => {
+    for (const bad of [null, undefined, 42, "x", []]) {
+      const c = alphaUsdCoverage(bad as never);
+      expect(c.available).toBe(false);
+      expect(c.caption).toBeNull();
+      expect(c.unavailableLabel).toBe("USD unavailable");
+    }
+  });
+
+  test("priced points with no stated boundary still qualify themselves", () => {
+    // The count is enough to know the series is partial; the date is a nicety.
+    // Dropping the caption because one field was absent would hide the gap.
+    const c = alphaUsdCoverage({ priced_candle_count: 3, candle_count: 90 });
+    expect(c.partial).toBe(true);
+    expect(c.from).toBeNull();
+    expect(c.caption).toContain("3 of 90");
+  });
+
+  test("zero points priced is unavailable even with no reason given", () => {
+    const c = alphaUsdCoverage({ priced_candle_count: 0, candle_count: 90 });
+    expect(c.available).toBe(false);
+    expect(c.caption).toBeNull();
+  });
+
+  test("negative or non-numeric counts do not become a caption", () => {
+    // A garbled count must not produce "USD covers -1 of 90 points".
+    for (const bad of [-1, Number.NaN, "many", null]) {
+      const c = alphaUsdCoverage({
+        priced_candle_count: bad as never,
+        candle_count: 90,
+      });
+      expect(c.available).toBe(false);
+      expect(c.caption).toBeNull();
+    }
+  });
+});
+
+describe("the notes that must stay reachable", () => {
+  test("USD is described as DERIVED, not quoted", () => {
+    // Acceptance 1: no USD figure renders without its provenance reachable.
+    expect(ALPHA_USD_PROVENANCE_NOTE).toMatch(/derived/i);
+    expect(ALPHA_USD_PROVENANCE_NOTE).toMatch(/not.*quoted by any venue/i);
+  });
+
+  test("the market-cap note names its denominator and warns off comparison", () => {
+    // #10381: the denominator is a property of the figure, not a footnote.
+    expect(ALPHA_MARKET_CAP_USD_NOTE).toMatch(/total staked alpha/i);
+    expect(ALPHA_MARKET_CAP_USD_NOTE).toMatch(/not a circulating-supply/i);
+    expect(ALPHA_MARKET_CAP_USD_NOTE).toMatch(/not comparable/i);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/alpha-usd.functions.ts
+++ b/apps/ui/src/lib/metagraphed/alpha-usd.functions.ts
@@ -1,0 +1,177 @@
+// Rendering alpha in USD honestly (#10385).
+//
+// The bar was set by the TAO ticker in market.functions.ts: when a figure is
+// not the quantity a reader assumes, SAY SO rather than swapping it silently.
+// Market cap there is TotalIssuance x usd_per_tao -- the chain's own issuance,
+// not a circulating-supply estimate, reading ~17% higher than the venues -- and
+// volume is on-chain subnet-AMM volume, not global exchange volume. Both are
+// relabelled rather than quietly presented as the familiar number.
+//
+// Alpha has three of its own, and each one is a way a correct-looking chart
+// lies:
+//
+// 1. USD COVERAGE IS SHORTER THAN THE CHART. A subnet's TAO price series runs
+//    ~13 months; the TAO/USD index runs from 2026-08-02 (#10382). A USD line
+//    drawn across the whole window either truncates without saying so or, far
+//    worse, applies today's rate backwards -- which renders perfectly and is
+//    wrong at every point but the last. The API refuses to extrapolate and
+//    publishes `usd_available_from`; the UI's job is to show that boundary
+//    instead of letting a reader assume the line means what the TAO line means.
+//
+// 2. THE MARKET-CAP DENOMINATOR IS NOT THE ONE A READER EXPECTS (#10381).
+//    `alpha_market_cap_tao` is priced against total_stake_alpha, so the USD
+//    figure inherits that basis and has to name it.
+//
+// 3. A DECLINING INDEX IS NOT A ZERO. When the index publishes no price
+//    (ADR 0025's `insufficient_pools`) or has gone stale, there is no USD
+//    anywhere on the page. That must read as "unavailable" -- never as $0, and
+//    never as the last number we happened to have.
+//
+// All three are decided here, as pure functions over what the API already
+// states, so a component cannot render a USD figure by forgetting to ask.
+
+/** What a series payload states about its own USD coverage. */
+export interface AlphaUsdSeriesLike {
+  /** Oldest point carrying USD, ISO. Null when none does. */
+  usd_available_from_iso?: string | null;
+  /** Oldest priced day, for the date-keyed series. */
+  usd_available_from?: string | number | null;
+  /** How many points carry USD. */
+  priced_candle_count?: number | null;
+  priced_day_count?: number | null;
+  /** How many points there are. */
+  candle_count?: number | null;
+  day_count?: number | null;
+  /** Why NO point could be priced, or null/absent. */
+  usd_unavailable?: string | null;
+}
+
+/**
+ * Why there is no USD, in words a reader can act on.
+ *
+ * The API's reasons are precise and are not sentences. `index_unpriced` tells
+ * an operator that ADR 0025's pool quorum was not met; it tells a reader
+ * nothing. Translated here rather than rendered raw, and NOT collapsed to one
+ * generic string -- "the price feed is briefly unavailable" and "we could not
+ * reach the price feed" mean different things to someone deciding whether to
+ * reload.
+ */
+export function alphaUsdUnavailableLabel(reason: string | null | undefined): string {
+  switch (reason) {
+    case "index_unpriced":
+      return "USD unavailable — too few qualifying liquidity pools to price TAO right now";
+    case "index_stale":
+      return "USD unavailable — the TAO/USD reading is older than we will price against";
+    case "no_index_reading":
+      return "USD unavailable — no TAO/USD reading yet";
+    case "read_failed":
+      return "USD unavailable — could not reach the TAO/USD index";
+    case "no_alpha_price":
+      return "USD unavailable — no alpha price to convert";
+    default:
+      return "USD unavailable";
+  }
+}
+
+export interface AlphaUsdCoverage {
+  /** Whether ANY point carries USD. False means render TAO only. */
+  available: boolean;
+  /** Set when `available` is false. Never shown alongside a USD figure. */
+  unavailableLabel: string | null;
+  /** Oldest point carrying USD (ISO date or YYYY-MM-DD), or null. */
+  from: string | null;
+  pricedCount: number;
+  totalCount: number;
+  /** True when USD covers only part of the charted window. */
+  partial: boolean;
+  /**
+   * The line to render beside a USD series, or null when there is nothing to
+   * qualify. Non-null whenever `partial` — that is the whole point.
+   */
+  caption: string | null;
+}
+
+const int = (v: unknown): number => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+};
+
+const asDate = (v: unknown): string | null => {
+  if (typeof v === "string" && v.length > 0) return v.slice(0, 10);
+  return null;
+};
+
+/**
+ * What a component may say about a USD series.
+ *
+ * Reads only what the API STATES -- never counts nulls in the point array to
+ * infer a boundary. Inferring it would put the UI in the business of deciding
+ * where USD begins, which is exactly the decision #10382 moved server-side so
+ * that every surface answers it the same way.
+ */
+export function alphaUsdCoverage(series: AlphaUsdSeriesLike | null | undefined): AlphaUsdCoverage {
+  const none: AlphaUsdCoverage = {
+    available: false,
+    unavailableLabel: alphaUsdUnavailableLabel(undefined),
+    from: null,
+    pricedCount: 0,
+    totalCount: 0,
+    partial: false,
+    caption: null,
+  };
+  if (!series || typeof series !== "object") return none;
+
+  const priced = int(series.priced_candle_count ?? series.priced_day_count);
+  const total = int(series.candle_count ?? series.day_count);
+  const from = asDate(series.usd_available_from_iso) ?? asDate(series.usd_available_from);
+
+  // A stated reason wins over any count. A payload that names why it could not
+  // price must not be rendered as a series that merely happens to be empty.
+  if (series.usd_unavailable) {
+    return {
+      ...none,
+      unavailableLabel: alphaUsdUnavailableLabel(series.usd_unavailable),
+      totalCount: total,
+    };
+  }
+  if (priced === 0) return { ...none, totalCount: total };
+
+  const partial = total > 0 && priced < total;
+  return {
+    available: true,
+    unavailableLabel: null,
+    from,
+    pricedCount: priced,
+    totalCount: total,
+    partial,
+    // Only when the two series disagree about how far back they go. A caption
+    // on a fully-covered chart would be noise, and noise is what stops captions
+    // being read on the charts that need them.
+    caption: partial
+      ? from
+        ? `USD from ${from} — ${priced} of ${total} points priced. TAO history runs the full window.`
+        : `USD covers ${priced} of ${total} points. TAO history runs the full window.`
+      : null,
+  };
+}
+
+/**
+ * What `alpha_market_cap_usd` actually counts, for the tile that shows it.
+ *
+ * Mirrors market.functions.ts's `supply_basis`: the denominator is a property
+ * of the figure, not a footnote, and a market cap whose basis is invisible
+ * invites comparison with venue numbers computed a different way.
+ */
+export const ALPHA_MARKET_CAP_USD_NOTE =
+  "Alpha market cap is total staked alpha x alpha price, converted at the TAO/USD index — not a circulating-supply estimate, and not comparable to a venue's market cap.";
+
+/**
+ * Every USD figure on the page is RECONSTRUCTED.
+ *
+ * The product of a measured alpha price and a measured TAO/USD index is our
+ * arithmetic. Acceptance 1 is that no USD figure renders without this being
+ * reachable, so the string lives beside the coverage logic rather than inside
+ * one component.
+ */
+export const ALPHA_USD_PROVENANCE_NOTE =
+  "USD figures are derived: an on-chain alpha price in TAO multiplied by our TAO/USD index (a liquidity-weighted median across qualifying wTAO/WETH pools, through an ETH/USDC anchor). They are not quoted by any venue.";

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -2196,6 +2196,19 @@ export interface SubnetOhlcCandle {
   volume_alpha: number;
   volume_tao: number;
   event_count: number;
+  /** USD twins (#10382), priced by a TAO/USD reading from THIS candle's own
+   * bucket. Null for a candle older than the index rather than converted at
+   * today's rate -- a retroactive rate renders perfectly and is wrong at every
+   * point but the last. Optional because the MCP tool serves the same builder
+   * without the handler's overlay. */
+  open_usd?: number | null;
+  high_usd?: number | null;
+  low_usd?: number | null;
+  close_usd?: number | null;
+  volume_usd?: number | null;
+  /** The single rate every _usd field on this candle used. One per candle, so
+   * the OHLC ordering survives the conversion. */
+  usd_per_tao?: number | null;
 }
 
 /** OHLC price/volume candlesticks for one subnet (#5655), bucketed by
@@ -2208,6 +2221,14 @@ export interface SubnetOhlc {
   interval: "1h" | "1d";
   candles: SubnetOhlcCandle[];
   root_excluded: boolean;
+  /** Where USD coverage begins, published rather than left to be inferred from
+   * where the nulls stop. The TAO series runs the full window; the USD series
+   * starts when the TAO/USD index does. */
+  usd_available_from?: number | null;
+  usd_available_from_iso?: string | null;
+  priced_candle_count?: number | null;
+  /** Why NO candle could be priced, or null. A stated decline, never a zero. */
+  usd_unavailable?: string | null;
 }
 
 /** One hotkey's current standing in a subnet's ownership contest (#6638),


### PR DESCRIPTION
Last sub-issue of #10379. Depends on #10398 (merged) and #10406.

## The bar

Set by the TAO ticker in `market.functions.ts`: when a figure is not the quantity a reader assumes, **say so** rather than swapping it silently. Alpha has three of its own, and each is a way a correct-looking chart lies.

**1. USD coverage is shorter than the chart.** A subnet's TAO price series runs ~13 months; the TAO/USD index runs from 2026-08-02. A USD line drawn across the whole window either truncates without saying so or applies today's rate backwards — which renders perfectly and is wrong at every point but the last. The API refuses to extrapolate and publishes `usd_available_from`; this shows that boundary.

**2. The market-cap denominator** is total staked alpha, not a circulating supply — named rather than left to be compared against venue numbers computed a different way (#10381).

**3. A declining index is not a zero.** `insufficient_pools` is a stated outcome. Rendering it as $0 would publish "this subnet is worthless" where the truth is "not priceable right now". Each reason gets its own sentence, because *"briefly unavailable"* and *"we could not reach it"* lead a reader to different actions — collapsing them to one string throws that away.

## Acceptance

1. **No USD figure renders without its provenance reachable** — `ALPHA_USD_PROVENANCE_NOTE` states USD is derived (alpha price × our index), not quoted by any venue, and lives beside the coverage logic rather than inside one component.
2. **The boundary is visible wherever a USD series is charted** — the OHLC chart renders a caption whenever the USD and TAO windows disagree.
3. **An unavailable index degrades to TAO-only** — `available: false`, no caption, a named reason, and the TAO side untouched.

## Design note worth the review

The boundary is **read from the payload, never inferred by counting nulls** in the point array. Inferring it would put the UI back in the business of deciding where USD begins — exactly the decision #10382 moved server-side so every surface answers it identically.

The caption appears **only when the two series disagree**. A caption on a fully covered chart is noise, and noise is what stops captions being read on the charts that need them. There is a test for that silence.

## Visual change

`subnet-ohlc-chart.tsx`: the footer's latest-close line gains a USD equivalent (converted at the rate published on *that* candle, never today's), and a second line appears carrying the coverage caption when the USD window is shorter. No layout or component-structure change — two text additions to an existing footer, both conditional.

Until #10406 and the deploy land, the API returns no USD fields for these routes, so the chart renders exactly as it does today — `alphaUsdCoverage` returns `available: false` on a payload without them, which is the degradation path acceptance 3 asks for and test-covered as such.

## Verification

- 13 tests in `alpha-usd.functions.test.ts`, all about what must be *said* — the failure mode here is silence, not an error.
- Full `apps/ui` suite: **1,453 tests across 189 files green**.
- `tsc`, `eslint`, and `prettier` (run from `apps/ui`, which has its own config) all clean; `validate:ui-docs-drift` current.

Closes #10385
