### PR TITLE
feat(ops): the TAO/USD index fails loudly, with a runbook and a correction policy

### DIFF
--- a/docs/tao-usd-index-runbook.md
+++ b/docs/tao-usd-index-runbook.md
@@ -1,0 +1,204 @@
+# TAO/USD index — operations runbook
+
+What to do when the TAO/USD index misbehaves, and the one policy decision that
+has to exist _before_ it does.
+
+Companion documents: [`docs/adr/0025-on-chain-tao-usd-index.md`](adr/0025-on-chain-tao-usd-index.md) fixes the
+thresholds and the minimum-pool policy; [`docs/tao-usd-venue-survey.md`](tao-usd-venue-survey.md)
+records why these pools and no others. The watchdog that raises everything below
+is `src/tao-usd-index-watchdog.ts`, with `tao_usd_index`'s staleness bound
+declared separately in `src/table-freshness-watchdog.ts`.
+
+---
+
+## Why this index gets its own runbook
+
+Every other number this API serves is chain-derived and self-evidently
+reproducible: a wrong one is a bug, and it looks like one. A wrong **price** is
+_our_ wrong price, and it can be wrong while looking perfectly healthy — a pool
+quietly returning stale reserves produces a plausible number with no error
+anywhere.
+
+It is also load-bearing. Since #10381/#10382/#10383, every alpha figure the API
+publishes in dollars is this index multiplied by a chain-measured alpha price.
+A bad reading is not one card; it is the dollar axis of the whole surface.
+
+---
+
+## The standing risk: there has never been a spare pool
+
+**Measured over the index's entire life (11,772 ticks from 2026-08-02):
+`pool_count` was exactly 2 on every single tick. Minimum 2, maximum 2.**
+
+`MIN_QUALIFYING_POOLS` is 2. So the redundancy margin is **zero**: one pool
+dropping out takes the index straight to `insufficient_pools`, and every USD
+figure on the API becomes unavailable at once.
+
+This is a property of the on-chain wTAO liquidity, not an incident, which is why
+the watchdog **reports** it on every verdict (`noRedundancy: true`) rather than
+alerting on it every minute — a permanent alarm is one nobody reads. It is
+recorded here because it changes how urgently a single-pool alert should be
+treated: **one pool failing is not a partial degradation, it is the whole index
+one step from down.**
+
+### The corollary that is easy to get wrong
+
+With exactly two pools, outlier rejection **cannot reject an outlier — it
+collapses the index.**
+
+`computeTaoUsdIndex` locates outliers against the _unweighted_ median, and the
+median of two values is their midpoint, so both pools are always equidistant
+from it by exactly half their spread. When that half-spread crosses
+`OUTLIER_THRESHOLD` (2%), **both** pools are rejected in the same pass,
+survivors fall to zero, and ADR 0025 forbids falling back to the pre-rejection
+set. A spread wider than ~4% therefore stops publication rather than discarding
+the bad reading.
+
+This is why the watchdog warns on **deviation** at half the rejection threshold
+(1%) instead of waiting for `insufficient_pools`: by the time the basis
+degrades, the index is already down. Observed maximum half-spread to date is
+**0.431%**, so the warning sits at roughly 2.3× the worst thing that has ever
+happened and half the distance to a total stop.
+
+---
+
+## Scenario 1 — one pool down
+
+**Alert:** `tao_usd_index pool 0x… last contributed N minutes ago (last reason: …)`
+or `… contributed to no tick in the window`. Verdict: `fail`.
+
+1. Read the `reason` in the alert. It is one of the `ExclusionReason` values
+   from `src/tao-usd-index.ts`:
+   - `unusable_reading` — the pool answered, but the price or balance was
+     unusable (zero, negative, non-finite). Suspect the RPC or a pool that has
+     been drained.
+   - `below_tvl_floor` — the pool is still there but no longer deep enough to
+     qualify. This is a liquidity event, not a fault.
+   - `outlier` — it read fine and disagreed. Go to scenario 3.
+   - `below_quorum` — it was fine but there were not enough others; the cause is
+     elsewhere.
+2. Confirm the index is still publishing: if `degradedTicks` is 0, the remaining
+   pool(s) are carrying it and there is no user-visible impact **yet**. Given the
+   standing risk above, treat this as one failure away from an outage.
+3. Check whether the pool still exists on-chain and holds liquidity. If it has
+   been drained or migrated, this is a **venue-set change**, not an incident:
+   update the pool set per `docs/tao-usd-venue-survey.md` and record why.
+4. If the pool is healthy on-chain but we cannot read it, the fault is ours —
+   RPC endpoint health, not the venue.
+
+**Do not** lower `MIN_QUALIFYING_POOLS` to keep the index publishing. Publishing
+a one-pool median is not a median, and the floor exists precisely so that we
+decline instead.
+
+## Scenario 2 — several pools down / below the floor
+
+**Alert:** `tao_usd_index published no price on N of M ticks in the last hour
+(price_basis: insufficient_pools)`. Verdict: `fail`.
+
+The index is publishing `usd_per_tao: null` with
+`price_basis: "insufficient_pools"`. This is a **stated outcome**, not a
+crash — the contract carries it, and `src/alpha-usd.ts` refuses to multiply by
+it, so downstream surfaces render USD as unavailable rather than as zero. That
+behaviour is correct and needs no intervention; the _cause_ does.
+
+1. Establish whether the pools are down or our reading of them is. If every pool
+   failed simultaneously, suspect the shared dependency (RPC / anchor), not the
+   venues — a genuine simultaneous liquidity event across independent pools is
+   far less likely than one endpoint failing.
+2. Check the anchor separately. `anchor_unavailable` means the ETH/USDC leg
+   failed, and no amount of healthy wTAO pools will produce a price without it.
+3. While degraded: **nothing to fix downstream.** Every USD figure is absent and
+   labelled with a reason. Do not hand-set a price anywhere to fill the gap —
+   see the policy below.
+
+## Scenario 3 — a pool returning plausible-but-wrong data
+
+**Alert:** `tao_usd_index pool deviation reached X% (warn 1.00%, rejection 2.00%)`.
+Verdict: `warn`.
+
+This is the one the whole module exists for, because nothing is broken and the
+output looks fine.
+
+1. A single tick above the warn line is not action. Sustained divergence is: it
+   means either that pool is broken or our reading of it is.
+2. Compare the two pools' `eth_per_tao` in the stored `pools` provenance against
+   an independent observation of the same pools. The stored row carries
+   `eth_per_tao` and `liquidity_usd` per pool at each tick, so the divergence is
+   reconstructable after the fact — you do not need to catch it live.
+3. A thin pool drifting is expected; a deep pool drifting is not. Weigh by
+   `liquidity_usd`.
+4. If a pool is genuinely wrong, **remove it from the pool set** rather than
+   widening `OUTLIER_THRESHOLD`. Widening the threshold to accommodate a bad
+   reading is how a bad reading becomes the price.
+5. Remember the corollary: as the spread grows, the outcome is not "the bad pool
+   gets dropped". It is "publication stops". Act before 4%.
+
+## Scenario 4 — the index published a wrong value
+
+**How you find out:** almost never from an alert. Usually from a reader, or from
+a divergence noticed after the fact.
+
+1. Establish the window: `SELECT observed_at, usd_per_tao, price_basis,
+pool_count, pools FROM tao_usd_index WHERE observed_at BETWEEN … ORDER BY
+observed_at` — the per-pool provenance stored on every row is what makes the
+   value auditable.
+2. Establish the cause before deciding anything. A wrong input (a pool we should
+   not have trusted) and a wrong computation (a bug in the aggregator) have
+   different remedies: the first is a venue-set change, the second is a fix plus
+   a decision about every value the bug touched.
+3. Then apply the policy below.
+
+---
+
+## Policy: correcting or annotating a historical index value
+
+**Decided here, in advance, rather than in the moment.**
+
+**Stored index rows are immutable. A published value is never silently
+rewritten.**
+
+The reasoning: `tao_usd_index` is an observational record — "this is what the
+qualifying pools said at this block". Rewriting it would destroy the only
+evidence of what we actually served, and any consumer that read the old value
+would have no way to learn it had changed. A price history that is edited is not
+a history.
+
+Concretely:
+
+- **Never** `UPDATE tao_usd_index SET usd_per_tao = …`. If a value is wrong, it
+  is wrong _and recorded_.
+- A wrong value caused by a **bad input** is corrected going forward by changing
+  the pool set. The historical rows stand: they faithfully record what those
+  pools said.
+- A wrong value caused by an **aggregator bug** is fixed in code. If the
+  affected window must be restated, it is **recomputed into a new row set with a
+  new `price_basis`**, never in place — the original rows stay, and the
+  restatement is additive and labelled. Any such restatement requires a
+  corresponding ADR entry saying what was recomputed and why.
+- **Deleting** rows is never a correction. A gap and a wrong number are
+  different claims, and a deletion converts one into the other.
+- Nothing downstream may hand-set a price to paper over a gap. Health, uptime
+  and latency are probe-derived only in this repo, and a price is held to the
+  same rule: it is measured, or it is absent with a stated reason.
+
+---
+
+## What is monitored, and where the thresholds live
+
+| Condition                                      | Threshold              | Source                            |
+| ---------------------------------------------- | ---------------------- | --------------------------------- |
+| Table staleness (ingestion wholly stopped)     | 2 h                    | `TABLE_FRESHNESS.tao_usd_index`   |
+| Empty evaluation window                        | 1 h, any               | `evaluateTaoUsdIndex`             |
+| Degraded publication (`insufficient_pools`)    | any tick               | `evaluateTaoUsdIndex`             |
+| Pool divergence (warn)                         | 1% — half of rejection | `POOL_DEVIATION_WARN`             |
+| Pool divergence (rejection, stops publication) | 2%                     | `OUTLIER_THRESHOLD` (ADR 0025)    |
+| Pool not contributing                          | 15 min ≈ 15 ticks      | `POOL_FAILING_MS`                 |
+| Minimum qualifying pools                       | 2                      | `MIN_QUALIFYING_POOLS` (ADR 0025) |
+
+The divergence warning is **derived** from `OUTLIER_THRESHOLD` rather than typed
+as its own number, so retuning the ADR moves the warning with it instead of
+quietly turning it into noise or a rubber stamp.
+
+No endpoint hostnames, credentials or private URLs appear in this document, in
+the watchdog, or in any alert payload it produces. Pool addresses are public
+on-chain identifiers and are safe to name.

--- a/src/tao-usd-index-watchdog.ts
+++ b/src/tao-usd-index-watchdog.ts
@@ -1,0 +1,410 @@
+// The TAO/USD index fails loudly, or it fails silently (#8603).
+//
+// Every other number this API serves is chain-derived and self-evidently
+// reproducible: a wrong one is a bug, and it looks like one. A wrong PRICE is
+// OUR wrong price, and it can be wrong while looking perfectly healthy -- a
+// pool quietly returning stale reserves produces a plausible number with no
+// error anywhere. That is the failure that actually happens, and it is now
+// load-bearing: #10381/#10382/#10383 price every alpha figure we publish off
+// this index, so a bad reading is not one card, it is the dollar axis of the
+// whole surface.
+//
+// ## WHAT THE MEASUREMENTS SAY, AND WHY THE THRESHOLDS ARE WHERE THEY ARE
+//
+// Measured against production over the index's whole life (11,772 ticks,
+// 2026-08-02 onward):
+//
+//   pool_count            2 on every tick -- min 2, max 2, never 3
+//   price_basis           wrapped_onchain_median on every tick, never degraded
+//   inter-pool spread     min 0.001%, avg 0.370%, p99 0.821%, max 0.862%
+//
+// Two facts follow, and they are the reason this module exists rather than a
+// generic staleness check:
+//
+// THE INDEX HAS NEVER HAD A SPARE POOL. `MIN_QUALIFYING_POOLS` is 2 and
+// `pool_count` has been exactly 2 for its entire life, so the redundancy margin
+// is zero: one pool dropping out takes the index straight to
+// `insufficient_pools`. That is a standing property of the on-chain liquidity,
+// not an incident, which is why it is REPORTED on every verdict rather than
+// alerted on every minute -- an alarm that is always firing is an alarm nobody
+// reads. The runbook carries it; see docs/tao-usd-index-runbook.md.
+//
+// WITH EXACTLY TWO POOLS, OUTLIER REJECTION CANNOT REJECT AN OUTLIER -- IT
+// COLLAPSES THE INDEX. `computeTaoUsdIndex` locates outliers against the
+// UNWEIGHTED median, and the median of two values is their midpoint, so both
+// pools are always equidistant from it by exactly half their spread. When that
+// half-spread crosses `OUTLIER_THRESHOLD`, BOTH pools are rejected at once,
+// survivors drop to zero, and ADR 0025 forbids falling back to the pre-
+// rejection set. So a spread wider than 2 x OUTLIER_THRESHOLD (4%) does not
+// discard the bad pool -- it stops publication entirely.
+//
+// The observed maximum half-spread is 0.431%. Warning at half the rejection
+// threshold puts the alarm at 1% -- about 2.3x the worst thing that has ever
+// happened, and half the distance to a total stop. That is the whole point of
+// warning on DEVIATION rather than on the outcome: by the time `price_basis`
+// reads `insufficient_pools` the index is already down.
+
+import {
+  MIN_QUALIFYING_POOLS,
+  OUTLIER_THRESHOLD,
+  type ExclusionReason,
+} from "./tao-usd-index.ts";
+import { TAO_USD_TABLE } from "./tao-usd-series.ts";
+import { TAO_USD_TABLES } from "./read-store-tables.ts";
+import { readStore } from "./read-store.ts";
+import { recordLaneVerdict } from "./lane-health.ts";
+import { laneHealthStore } from "./lane-health-store.ts";
+
+/** The lane name this watchdog records under. */
+export const TAO_USD_WATCHDOG_LANE = "watchdog:tao-usd-index";
+
+/** The minimal store surface, so tests can inject a plain object. */
+export interface TaoUsdWatchdogDb {
+  prepare(sql: string): {
+    bind(...values: unknown[]): {
+      all?(): Promise<{ results?: unknown[] } | null>;
+    };
+  };
+}
+
+type Row = Record<string, unknown>;
+
+/**
+ * How far a pool may drift from the reference before this warns.
+ *
+ * HALF the threshold that rejects it, derived rather than typed as a literal:
+ * if ADR 0025 ever retunes OUTLIER_THRESHOLD, the warning moves with it
+ * instead of silently becoming either noise or a rubber stamp.
+ */
+export const POOL_DEVIATION_WARN = OUTLIER_THRESHOLD / 2;
+
+/**
+ * How long a pool may be absent or excluded before it is called failing.
+ *
+ * The producer writes about once a minute, so this is ~15 ticks -- long enough
+ * that one bad read, one reorg, or one RPC hiccup does not page anybody, short
+ * enough that a genuinely dead pool is known about within a quarter hour. Sized
+ * against the PRODUCER's cadence, not against a round number.
+ */
+export const POOL_FAILING_MS = 15 * 60 * 1000;
+
+/** How much history each evaluation considers. 60 ticks at one per minute. */
+export const TAO_USD_WATCHDOG_WINDOW_MS = 60 * 60 * 1000;
+
+/** One pool's standing across the window. */
+export interface PoolHealth {
+  address: string;
+  /** Ticks in the window where this pool contributed to the price. */
+  includedTicks: number;
+  /** Ticks where it was read or attempted but not counted. */
+  excludedTicks: number;
+  /** Newest observed_at where it contributed, or null if never. */
+  lastIncludedAt: number | null;
+  /** Why it was last excluded, when it was. */
+  lastReason: ExclusionReason | string | null;
+  /** Excluded/absent for longer than POOL_FAILING_MS. */
+  failing: boolean;
+}
+
+export interface TaoUsdIndexVerdict {
+  verdict: "ok" | "warn" | "fail";
+  ticks: number;
+  /** Ticks that published no price at all. */
+  degradedTicks: number;
+  /** Widest half-spread seen in the window, as a fraction. Null with <2 pools. */
+  maxDeviation: number | null;
+  /**
+   * True when the index ran the whole window at exactly the quorum floor.
+   *
+   * Reported, never alerted: this has been true 100% of the time since the
+   * lane started, so an alert would be a permanent alarm. It is the single
+   * most important thing about this index's fragility, and it belongs in the
+   * runbook and on the verdict -- not in a pager loop.
+   */
+  noRedundancy: boolean;
+  pools: PoolHealth[];
+  /** Human-readable, one per condition. Empty means healthy. */
+  alerts: string[];
+}
+
+const num = (v: unknown): number | null => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+};
+
+/** The stored `pools` column is TEXT holding JSON; tolerate either form. */
+function parsePools(value: unknown): Row[] {
+  if (Array.isArray(value)) return value as Row[];
+  if (typeof value !== "string" || value.length === 0) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as Row[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The widest distance any pool sat from the unweighted median, as a fraction.
+ *
+ * Computed the SAME way computeTaoUsdIndex locates outliers -- against the
+ * unweighted median of the included readings -- so the number this warns on is
+ * the number that will eventually reject them. Deriving it differently would
+ * produce a warning that fires at a threshold the aggregator does not use.
+ */
+export function poolDeviation(pools: Row[]): number | null {
+  const priced = pools
+    .filter((p) => p?.included === true)
+    .map((p) => num(p?.eth_per_tao))
+    .filter((n): n is number => n !== null && n > 0);
+  if (priced.length < 2) return null;
+  // `priced` is already filtered to finite positives, so the median of it is
+  // positive too -- no zero-reference guard here, because it could never be
+  // taken and an untestable branch reads like a safeguard without being one.
+  const sorted = [...priced].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const reference =
+    sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+  return Math.max(...priced.map((p) => Math.abs(p - reference) / reference));
+}
+
+/**
+ * Evaluate a window of stored index rows.
+ *
+ * Pure: the same rows always produce the same verdict, so the alert conditions
+ * can be exercised without a database, an RPC, or a clock.
+ *
+ * `rows` may arrive in any order -- newest-first is what the loader returns,
+ * but nothing here depends on it.
+ */
+export function evaluateTaoUsdIndex({
+  rows,
+  nowMs,
+}: {
+  rows: Row[] | null | undefined;
+  nowMs: number;
+}): TaoUsdIndexVerdict {
+  const list = (Array.isArray(rows) ? rows : []).filter(
+    (r) => num(r?.observed_at) !== null,
+  );
+  const base: TaoUsdIndexVerdict = {
+    verdict: "ok",
+    ticks: list.length,
+    degradedTicks: 0,
+    maxDeviation: null,
+    noRedundancy: false,
+    pools: [],
+    alerts: [],
+  };
+
+  // NO ROWS IS NOT HEALTHY. An empty window means the lane wrote nothing for an
+  // hour, which is the wholly-failed-ingestion case -- distinct from individual
+  // pool failures, and the one a per-pool check would report as "all quiet".
+  if (list.length === 0) {
+    return {
+      ...base,
+      verdict: "fail",
+      alerts: [
+        "tao_usd_index wrote no rows in the last hour: the ingestion lane is down, not merely degraded.",
+      ],
+    };
+  }
+
+  const alerts: string[] = [];
+  let degradedTicks = 0;
+  let maxDeviation: number | null = null;
+  let everAboveFloor = false;
+
+  const poolState = new Map<string, PoolHealth>();
+  const touch = (address: string): PoolHealth => {
+    let p = poolState.get(address);
+    if (!p) {
+      p = {
+        address,
+        includedTicks: 0,
+        excludedTicks: 0,
+        lastIncludedAt: null,
+        lastReason: null,
+        failing: false,
+      };
+      poolState.set(address, p);
+    }
+    return p;
+  };
+
+  for (const row of list) {
+    const observedAt = num(row?.observed_at) as number;
+    const poolCount = num(row?.pool_count) ?? 0;
+    if (poolCount > MIN_QUALIFYING_POOLS) everAboveFloor = true;
+    if (row?.price_basis === "insufficient_pools" || row?.usd_per_tao == null) {
+      degradedTicks += 1;
+    }
+
+    const pools = parsePools(row?.pools);
+    const deviation = poolDeviation(pools);
+    if (deviation !== null)
+      maxDeviation =
+        maxDeviation === null ? deviation : Math.max(maxDeviation, deviation);
+
+    for (const pool of pools) {
+      const address = typeof pool?.address === "string" ? pool.address : null;
+      if (address === null) continue;
+      const p = touch(address);
+      if (pool?.included === true) {
+        p.includedTicks += 1;
+        if (p.lastIncludedAt === null || observedAt > p.lastIncludedAt) {
+          p.lastIncludedAt = observedAt;
+        }
+      } else {
+        p.excludedTicks += 1;
+        p.lastReason = (pool?.reason as string | undefined) ?? p.lastReason;
+      }
+    }
+  }
+
+  // A pool is failing when it has not contributed inside POOL_FAILING_MS --
+  // measured against its LAST CONTRIBUTION, not against how many times it was
+  // excluded, so a pool flapping in and out is not called dead while it is
+  // still doing its job some of the time.
+  for (const p of poolState.values()) {
+    p.failing =
+      p.lastIncludedAt === null || nowMs - p.lastIncludedAt > POOL_FAILING_MS;
+  }
+  const pools = [...poolState.values()].sort((a, b) =>
+    a.address.localeCompare(b.address),
+  );
+
+  // Requirement 3: the degraded state is USER-VISIBLE through the published
+  // contract, so it must never be discovered by a reader first. One tick is
+  // enough -- this is not a flapping metric, it is "we published nothing".
+  if (degradedTicks > 0) {
+    alerts.push(
+      `tao_usd_index published no price on ${degradedTicks} of ${list.length} ticks in the last hour (price_basis: insufficient_pools). Every USD figure the API serves is unavailable for those ticks.`,
+    );
+  }
+
+  // Requirement 2: a persistently diverging pool means either that pool is
+  // broken or our reading of it is, and both need a human. Warned on DEVIATION
+  // rather than on the rejection it eventually causes, because with the
+  // observed two-pool set the rejection is not a rejection -- it is a stop.
+  if (maxDeviation !== null && maxDeviation >= POOL_DEVIATION_WARN) {
+    alerts.push(
+      `tao_usd_index pool deviation reached ${(maxDeviation * 100).toFixed(3)}% (warn ${(POOL_DEVIATION_WARN * 100).toFixed(2)}%, rejection ${(OUTLIER_THRESHOLD * 100).toFixed(2)}%). With ${MIN_QUALIFYING_POOLS} qualifying pools, crossing the rejection threshold removes BOTH and stops publication rather than discarding one.`,
+    );
+  }
+
+  // Requirement 1: per-pool health, by last success rather than by rate.
+  for (const p of pools.filter((x) => x.failing)) {
+    alerts.push(
+      p.lastIncludedAt === null
+        ? `tao_usd_index pool ${p.address} contributed to no tick in the window (last reason: ${p.lastReason ?? "unstated"}).`
+        : `tao_usd_index pool ${p.address} last contributed ${Math.round((nowMs - p.lastIncludedAt) / 60000)} minutes ago (last reason: ${p.lastReason ?? "unstated"}).`,
+    );
+  }
+
+  // A degraded index or a dead pool is a failure; a widening spread is a
+  // warning, because nothing is wrong with what we published yet.
+  const failing = degradedTicks > 0 || pools.some((p) => p.failing);
+  return {
+    ...base,
+    verdict: failing ? "fail" : alerts.length > 0 ? "warn" : "ok",
+    degradedTicks,
+    maxDeviation,
+    noRedundancy: !everAboveFloor,
+    pools,
+    alerts,
+  };
+}
+
+/**
+ * Load the recent window and record a verdict.
+ *
+ * Runs on the freshness cron rather than on its own: `tao_usd_index`'s
+ * staleness is already checked there, the store is already reachable, and a new
+ * cron expression would need `wrangler triggers deploy` to take effect (Workers
+ * Builds deploys code, not schedules) -- a deployment step that is easy to
+ * forget and silently leaves the watchdog never running, which is the exact
+ * failure this issue is about.
+ */
+export async function runTaoUsdIndexWatchdog(
+  env: Record<string, unknown> | null | undefined,
+  deps: {
+    db?: TaoUsdWatchdogDb | null;
+    laneHealthDb?: Parameters<typeof recordLaneVerdict>[0];
+    now?: () => number;
+  } = {},
+): Promise<TaoUsdIndexVerdict & { recorded: boolean }> {
+  const now = deps.now ?? Date.now;
+  const nowMs = now();
+  const db =
+    deps.db ??
+    (readStore(env as never, TAO_USD_TABLES) as unknown as TaoUsdWatchdogDb);
+
+  let rows: Row[] | null;
+  try {
+    const res = await (
+      db
+        ?.prepare(
+          `SELECT observed_at, price_basis, usd_per_tao, pool_count, pools` +
+            ` FROM ${TAO_USD_TABLE} WHERE observed_at >= ?` +
+            ` ORDER BY observed_at DESC LIMIT 240`,
+        )
+        .bind(nowMs - TAO_USD_WATCHDOG_WINDOW_MS) as {
+        all?(): Promise<{ results?: unknown[] } | null>;
+      }
+    ).all?.();
+    rows = (res?.results ?? []) as Row[];
+  } catch {
+    // A read failure is NOT an empty window: reporting "the lane wrote nothing"
+    // when we could not ask would send someone to the producer for a fault in
+    // the reader. Null is passed through as its own condition below.
+    rows = null;
+  }
+
+  const verdict =
+    rows === null
+      ? {
+          ...evaluateTaoUsdIndex({ rows: [], nowMs }),
+          alerts: [
+            "tao_usd_index could not be read: the watchdog cannot say whether the index is healthy. This is a reader fault, not a producer verdict.",
+          ],
+        }
+      : evaluateTaoUsdIndex({ rows, nowMs });
+
+  // lane_health's vocabulary is "ok" | "stale" | "unknown" -- staleness-shaped,
+  // because that is what every other lane reports. It cannot say "publishing,
+  // but the pools are diverging". Rather than flatten that away silently, the
+  // precise verdict rides in `detail` and the lane column carries the closest
+  // honest value: `unknown` when we could not read (which is exactly what the
+  // word means), `stale` for anything wrong, `ok` for healthy.
+  const laneVerdict: "ok" | "stale" | "unknown" =
+    rows === null ? "unknown" : verdict.verdict === "ok" ? "ok" : "stale";
+
+  const recorded = await recordLaneVerdict(
+    deps.laneHealthDb ?? laneHealthStore(env ?? {}),
+    {
+      lane: TAO_USD_WATCHDOG_LANE,
+      verdict: laneVerdict,
+      age_ms: null,
+      detail: JSON.stringify({
+        // The four-state verdict this watchdog actually computes, preserved
+        // because the lane column above can only hold three.
+        verdict: verdict.verdict,
+        ticks: verdict.ticks,
+        degraded_ticks: verdict.degradedTicks,
+        max_deviation: verdict.maxDeviation,
+        no_redundancy: verdict.noRedundancy,
+        pools: verdict.pools.map((p) => ({
+          address: p.address,
+          included_ticks: p.includedTicks,
+          excluded_ticks: p.excludedTicks,
+          failing: p.failing,
+        })),
+        alerts: verdict.alerts,
+      }),
+      checked_at: nowMs,
+    },
+  );
+
+  return { ...verdict, recorded };
+}

--- a/tests/tao-usd-index-watchdog.test.ts
+++ b/tests/tao-usd-index-watchdog.test.ts
@@ -1,0 +1,571 @@
+// The TAO/USD index watchdog (#8603).
+//
+// The issue names the bar directly: "an alert that has never fired once is not
+// known to work". So every condition here is driven to fire against a simulated
+// state, and the healthy case is pinned against the shape production actually
+// produces -- a watchdog that cannot go green on real data is as useless as one
+// that cannot go red.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  MIN_QUALIFYING_POOLS,
+  OUTLIER_THRESHOLD,
+} from "../src/tao-usd-index.ts";
+import {
+  evaluateTaoUsdIndex,
+  poolDeviation,
+  POOL_DEVIATION_WARN,
+  POOL_FAILING_MS,
+  runTaoUsdIndexWatchdog,
+} from "../src/tao-usd-index-watchdog.ts";
+
+const NOW = Date.parse("2026-08-10T06:00:00.000Z");
+const MINUTE = 60_000;
+
+const A = "0x433a00819c771b33fa7223a5b3499b24fbcd1bbc";
+const B = "0x2982d3295a0e1a99e6e88ece0e93ffdfc5c761ae";
+
+/** A healthy tick, shaped exactly as production stores it (pools as TEXT). */
+const tick = (
+  minutesAgo: number,
+  {
+    a = 0.10650702834180564,
+    b = 0.10589201476467973,
+    basis = "wrapped_onchain_median",
+    usd = 204.125,
+    poolCount = 2,
+    pools,
+  }: {
+    a?: number;
+    b?: number;
+    basis?: string;
+    usd?: number | null;
+    poolCount?: number;
+    pools?: unknown;
+  } = {},
+) => ({
+  observed_at: NOW - minutesAgo * MINUTE,
+  price_basis: basis,
+  usd_per_tao: usd,
+  pool_count: poolCount,
+  pools:
+    pools !== undefined
+      ? pools
+      : JSON.stringify([
+          {
+            address: A,
+            included: true,
+            eth_per_tao: a,
+            liquidity_usd: 2_103_895,
+          },
+          {
+            address: B,
+            included: true,
+            eth_per_tao: b,
+            liquidity_usd: 303_379,
+          },
+        ]),
+});
+
+const healthyWindow = () => Array.from({ length: 60 }, (_, i) => tick(i));
+
+describe("the healthy case, shaped like production", () => {
+  test("60 good ticks are OK with no alerts", () => {
+    // Verified against the real table before this test was written: 60 rows,
+    // deviation 0.2896%, both pools on every tick.
+    const v = evaluateTaoUsdIndex({ rows: healthyWindow(), nowMs: NOW });
+    assert.equal(v.verdict, "ok");
+    assert.deepEqual(v.alerts, []);
+    assert.equal(v.degradedTicks, 0);
+    assert.equal(v.pools.length, 2);
+    assert.ok((v.maxDeviation as number) < POOL_DEVIATION_WARN);
+  });
+
+  test("the zero-redundancy standing risk is REPORTED, not alerted", () => {
+    // pool_count has been exactly the floor for the index's entire life. An
+    // alert would fire every minute forever and train everyone to ignore the
+    // channel; the fact still has to reach the verdict, and the runbook.
+    const v = evaluateTaoUsdIndex({ rows: healthyWindow(), nowMs: NOW });
+    assert.equal(v.noRedundancy, true);
+    assert.deepEqual(v.alerts, [], "a permanent condition must not page");
+  });
+
+  test("a third qualifying pool clears the standing risk", () => {
+    const rows = Array.from({ length: 60 }, (_, i) =>
+      tick(i, { poolCount: 3 }),
+    );
+    assert.equal(evaluateTaoUsdIndex({ rows, nowMs: NOW }).noRedundancy, false);
+  });
+});
+
+describe("requirement 3 — the degraded state must not be found by a reader first", () => {
+  test("one unpriced tick alerts and fails", () => {
+    const rows = [
+      tick(0, { basis: "insufficient_pools", usd: null, poolCount: 0 }),
+      ...Array.from({ length: 59 }, (_, i) => tick(i + 1)),
+    ];
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    assert.equal(v.verdict, "fail");
+    assert.equal(v.degradedTicks, 1);
+    assert.ok(
+      v.alerts.some((a) => a.includes("published no price on 1 of 60")),
+    );
+  });
+
+  test("a null price counts as degraded even if the basis says otherwise", () => {
+    // Defence against a producer that writes a null without the paired basis:
+    // the CHECK constraint forbids it, and a watchdog that trusted the label
+    // over the value would go quiet exactly when the constraint was breached.
+    const rows = [
+      tick(0, { usd: null }),
+      ...Array.from({ length: 5 }, (_, i) => tick(i + 1)),
+    ];
+    assert.equal(evaluateTaoUsdIndex({ rows, nowMs: NOW }).degradedTicks, 1);
+  });
+});
+
+describe("requirement 2 — divergence, warned before it becomes a stop", () => {
+  test("a spread past the warn threshold alerts", () => {
+    // Half-spread just over POOL_DEVIATION_WARN.
+    const base = 0.1;
+    const spread = POOL_DEVIATION_WARN * 2 * 1.1;
+    const rows = [
+      tick(0, { a: base * (1 + spread / 2), b: base * (1 - spread / 2) }),
+      ...Array.from({ length: 10 }, (_, i) => tick(i + 1)),
+    ];
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    assert.equal(v.verdict, "warn", "a wide spread is not yet a wrong number");
+    assert.ok(v.alerts.some((a) => a.includes("pool deviation reached")));
+  });
+
+  test("the alert explains that rejection STOPS publication here", () => {
+    // The non-obvious part, and the reason this warns early: with two pools the
+    // median is their midpoint, both sit equidistant from it, and crossing the
+    // rejection threshold removes BOTH rather than discarding one.
+    const base = 0.1;
+    const spread = OUTLIER_THRESHOLD * 2 * 1.1;
+    const rows = [
+      tick(0, { a: base * (1 + spread / 2), b: base * (1 - spread / 2) }),
+    ];
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    const alert = v.alerts.find((a) => a.includes("pool deviation")) as string;
+    assert.ok(alert.includes("removes BOTH"));
+    assert.ok(alert.includes("stops publication"));
+  });
+
+  test("the deviation is measured the way the aggregator measures it", () => {
+    // Against the UNWEIGHTED median of the included readings. Measuring it any
+    // other way would warn at a threshold the aggregator does not use.
+    assert.equal(poolDeviation([]), null);
+    assert.equal(
+      poolDeviation([{ address: A, included: true, eth_per_tao: 1 }]),
+      null,
+      "one pool has no spread to measure",
+    );
+    // 0.98 and 1.02 around a midpoint of 1.0 -> 2% each side.
+    const d = poolDeviation([
+      { address: A, included: true, eth_per_tao: 0.98 },
+      { address: B, included: true, eth_per_tao: 1.02 },
+    ]) as number;
+    assert.ok(Math.abs(d - 0.02) < 1e-9);
+  });
+
+  test("an EXCLUDED pool does not drag the deviation", () => {
+    // It is already not contributing; counting it would warn about a reading
+    // the aggregator has itself discarded.
+    const d = poolDeviation([
+      { address: A, included: true, eth_per_tao: 1 },
+      { address: B, included: true, eth_per_tao: 1.001 },
+      { address: "0xdead", included: false, eth_per_tao: 5 },
+    ]) as number;
+    assert.ok(d < 0.01);
+  });
+});
+
+describe("requirement 1 — per-pool health, by last success", () => {
+  test("a pool that stops contributing alerts once it passes the bound", () => {
+    // A contributes throughout; B stopped 20 minutes ago (bound is 15).
+    const rows = Array.from({ length: 60 }, (_, i) =>
+      i < 20
+        ? tick(i, {
+            pools: JSON.stringify([
+              {
+                address: A,
+                included: true,
+                eth_per_tao: 0.106,
+                liquidity_usd: 2_103_895,
+              },
+              { address: B, included: false, reason: "unusable_reading" },
+            ]),
+          })
+        : tick(i),
+    );
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    assert.equal(v.verdict, "fail");
+    const b = v.pools.find((p) => p.address === B);
+    assert.equal(b?.failing, true);
+    assert.equal(v.pools.find((p) => p.address === A)?.failing, false);
+    assert.ok(
+      v.alerts.some((a) => a.includes(B) && a.includes("last contributed")),
+    );
+  });
+
+  test("a pool that flaps but still contributes is NOT called dead", () => {
+    // Measured against its last contribution, not its exclusion count -- a pool
+    // doing its job half the time is degraded, not gone.
+    const rows = Array.from({ length: 60 }, (_, i) =>
+      i % 2 === 0
+        ? tick(i)
+        : tick(i, {
+            pools: JSON.stringify([
+              {
+                address: A,
+                included: true,
+                eth_per_tao: 0.106,
+                liquidity_usd: 1,
+              },
+              { address: B, included: false, reason: "outlier" },
+            ]),
+          }),
+    );
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    const b = v.pools.find((p) => p.address === B);
+    assert.equal(b?.failing, false);
+    assert.ok((b?.excludedTicks ?? 0) > 0, "the exclusions are still counted");
+    assert.equal(v.verdict, "ok");
+  });
+
+  test("a pool that never contributed carries its reason", () => {
+    const rows = Array.from({ length: 5 }, (_, i) =>
+      tick(i, {
+        pools: JSON.stringify([
+          { address: A, included: true, eth_per_tao: 0.106, liquidity_usd: 1 },
+          { address: B, included: false, reason: "below_tvl_floor" },
+        ]),
+      }),
+    );
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    const b = v.pools.find((p) => p.address === B);
+    assert.equal(b?.lastIncludedAt, null);
+    assert.equal(b?.lastReason, "below_tvl_floor");
+    assert.ok(v.alerts.some((a) => a.includes("no tick in the window")));
+  });
+
+  test("the failing bound is sized to the producer, not to a round number", () => {
+    // One minute per tick; 15 minutes is 15 ticks. Pinned so a later change is
+    // deliberate rather than a rounding drift.
+    assert.equal(POOL_FAILING_MS, 15 * MINUTE);
+  });
+});
+
+describe("requirement 4 — a wholly failed ingestion is distinct from pool failure", () => {
+  test("an empty window FAILS rather than reading as all-quiet", () => {
+    // The trap this closes: a per-pool check over zero rows finds zero failing
+    // pools and reports healthy. Silence is the loudest state here.
+    for (const empty of [[], null, undefined]) {
+      const v = evaluateTaoUsdIndex({ rows: empty as never, nowMs: NOW });
+      assert.equal(v.verdict, "fail");
+      assert.ok(v.alerts[0].includes("wrote no rows"));
+      assert.ok(v.alerts[0].includes("down, not merely degraded"));
+    }
+  });
+
+  test("rows without a usable timestamp are not counted as ticks", () => {
+    const v = evaluateTaoUsdIndex({
+      rows: [{ observed_at: "nope", price_basis: "x" }],
+      nowMs: NOW,
+    });
+    assert.equal(v.verdict, "fail");
+    assert.equal(v.ticks, 0);
+  });
+});
+
+describe("the stored shape", () => {
+  test("pools parse from TEXT or from an already-decoded array", () => {
+    // Production stores the column as TEXT; a pg driver or a test may hand back
+    // either. Both must evaluate identically, or the watchdog is green locally
+    // and blind in production.
+    const asText = evaluateTaoUsdIndex({ rows: [tick(0)], nowMs: NOW });
+    const asArray = evaluateTaoUsdIndex({
+      rows: [
+        tick(0, {
+          pools: [
+            { address: A, included: true, eth_per_tao: 0.10650702834180564 },
+            { address: B, included: true, eth_per_tao: 0.10589201476467973 },
+          ],
+        }),
+      ],
+      nowMs: NOW,
+    });
+    assert.equal(asText.pools.length, asArray.pools.length);
+    assert.equal(asText.maxDeviation, asArray.maxDeviation);
+  });
+
+  test("malformed pool JSON degrades to no pools rather than throwing", () => {
+    const v = evaluateTaoUsdIndex({
+      rows: [tick(0, { pools: "{not json" }), tick(1, { pools: 42 })],
+      nowMs: NOW,
+    });
+    assert.equal(v.pools.length, 0);
+    assert.equal(v.maxDeviation, null);
+    // Still a real tick that published a price, so not degraded.
+    assert.equal(v.degradedTicks, 0);
+  });
+
+  test("a pool entry with no address is skipped, not keyed to undefined", () => {
+    const v = evaluateTaoUsdIndex({
+      rows: [
+        tick(0, {
+          pools: JSON.stringify([{ included: true, eth_per_tao: 1 }]),
+        }),
+      ],
+      nowMs: NOW,
+    });
+    assert.equal(v.pools.length, 0);
+  });
+
+  test("row order does not change the verdict", () => {
+    const rows = healthyWindow();
+    const forward = evaluateTaoUsdIndex({
+      rows: [...rows].reverse(),
+      nowMs: NOW,
+    });
+    const backward = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    assert.equal(forward.verdict, backward.verdict);
+    assert.deepEqual(forward.pools, backward.pools);
+  });
+});
+
+describe("the thresholds are derived, not typed twice", () => {
+  test("the warning sits at half the rejection threshold", () => {
+    // Compared against the DECLARATION rather than a literal: if ADR 0025
+    // retunes OUTLIER_THRESHOLD, the warning moves with it instead of quietly
+    // becoming noise or a rubber stamp.
+    assert.equal(POOL_DEVIATION_WARN, OUTLIER_THRESHOLD / 2);
+    assert.ok(POOL_DEVIATION_WARN < OUTLIER_THRESHOLD);
+  });
+
+  test("the quorum floor comes from the aggregator", () => {
+    assert.equal(MIN_QUALIFYING_POOLS, 2);
+  });
+});
+
+describe("the runner, and what it records", () => {
+  const store = (results: unknown[] | Error) => ({
+    prepare: () => ({
+      bind: () => ({
+        all: async () => {
+          if (results instanceof Error) throw results;
+          return { results };
+        },
+      }),
+    }),
+  });
+  const laneSpy = () => {
+    const rows: Record<string, unknown>[] = [];
+    return {
+      rows,
+      db: {
+        prepare: () => ({
+          bind: (...v: unknown[]) => ({
+            run: async () => {
+              rows.push({ lane: v[0], verdict: v[1], detail: v[3] });
+              return {};
+            },
+          }),
+        }),
+      },
+    };
+  };
+
+  test("a healthy window records ok, with the precise verdict in detail", async () => {
+    const lane = laneSpy();
+    const out = await runTaoUsdIndexWatchdog(
+      {},
+      {
+        db: store(healthyWindow()),
+        laneHealthDb: lane.db as never,
+        now: () => NOW,
+      },
+    );
+    assert.equal(out.verdict, "ok");
+    assert.equal(out.recorded, true);
+    assert.equal(lane.rows[0].lane, "watchdog:tao-usd-index");
+    assert.equal(lane.rows[0].verdict, "ok");
+    const detail = JSON.parse(lane.rows[0].detail as string);
+    assert.equal(detail.verdict, "ok");
+    assert.equal(
+      detail.no_redundancy,
+      true,
+      "the standing risk is durable, not just logged",
+    );
+  });
+
+  test("a READ FAILURE is `unknown`, never `stale`", async () => {
+    // The distinction the lane column exists to make: "we could not ask" must
+    // not be recorded as a verdict about the producer. Reporting stale here
+    // would send someone to the ingestion lane for a fault in the reader.
+    const lane = laneSpy();
+    const out = await runTaoUsdIndexWatchdog(
+      {},
+      {
+        db: store(new Error("connection reset")),
+        laneHealthDb: lane.db as never,
+        now: () => NOW,
+      },
+    );
+    assert.equal(lane.rows[0].verdict, "unknown");
+    assert.ok(out.alerts[0].includes("reader fault, not a producer verdict"));
+  });
+
+  test("an empty read is `stale`, because that IS a verdict about the producer", async () => {
+    const lane = laneSpy();
+    await runTaoUsdIndexWatchdog(
+      {},
+      { db: store([]), laneHealthDb: lane.db as never, now: () => NOW },
+    );
+    assert.equal(lane.rows[0].verdict, "stale");
+    const detail = JSON.parse(lane.rows[0].detail as string);
+    assert.equal(detail.verdict, "fail");
+  });
+
+  test("a degraded window records stale while keeping `fail` in detail", async () => {
+    const lane = laneSpy();
+    const rows = [
+      tick(0, { basis: "insufficient_pools", usd: null, poolCount: 0 }),
+      ...Array.from({ length: 10 }, (_, i) => tick(i + 1)),
+    ];
+    await runTaoUsdIndexWatchdog(
+      {},
+      { db: store(rows), laneHealthDb: lane.db as never, now: () => NOW },
+    );
+    assert.equal(lane.rows[0].verdict, "stale");
+    assert.equal(JSON.parse(lane.rows[0].detail as string).verdict, "fail");
+  });
+
+  test("a failed lane write is reported, not swallowed", async () => {
+    const out = await runTaoUsdIndexWatchdog(
+      {},
+      { db: store(healthyWindow()), laneHealthDb: null, now: () => NOW },
+    );
+    assert.equal(out.recorded, false);
+    assert.equal(out.verdict, "ok", "the verdict still stands even unrecorded");
+  });
+});
+
+describe("the shapes a real store hands back", () => {
+  test("JSON that is not an array yields no pools", () => {
+    const v = evaluateTaoUsdIndex({
+      rows: [tick(0, { pools: '{"address":"0x1"}' })],
+      nowMs: NOW,
+    });
+    assert.equal(v.pools.length, 0);
+  });
+
+  test("an odd pool count uses the middle reading, not a midpoint", () => {
+    // Three pools is the shape we WANT (it would end the zero-redundancy risk),
+    // so the median has to be right for it before it ever happens.
+    const d = poolDeviation([
+      { address: A, included: true, eth_per_tao: 0.9 },
+      { address: B, included: true, eth_per_tao: 1.0 },
+      { address: "0x3", included: true, eth_per_tao: 1.05 },
+    ]) as number;
+    // Reference is 1.0, so the widest deviation is 0.9 -> 10%.
+    assert.ok(Math.abs(d - 0.1) < 1e-9);
+  });
+
+  test("a row with no pool_count does not read as above the floor", () => {
+    const rows = [
+      {
+        observed_at: NOW,
+        price_basis: "wrapped_onchain_median",
+        usd_per_tao: 1,
+      },
+    ];
+    assert.equal(evaluateTaoUsdIndex({ rows, nowMs: NOW }).noRedundancy, true);
+  });
+
+  test("an exclusion with no reason keeps the last one it had", () => {
+    // Otherwise a later reasonless exclusion erases the diagnosis that would
+    // tell an operator what to do.
+    const rows = [
+      tick(0, {
+        pools: JSON.stringify([
+          { address: A, included: true, eth_per_tao: 0.106 },
+          { address: B, included: false },
+        ]),
+      }),
+      tick(30, {
+        pools: JSON.stringify([
+          { address: A, included: true, eth_per_tao: 0.106 },
+          { address: B, included: false, reason: "below_tvl_floor" },
+        ]),
+      }),
+    ];
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    assert.equal(
+      v.pools.find((p) => p.address === B)?.lastReason,
+      "below_tvl_floor",
+    );
+  });
+
+  test("a failing pool with no recorded reason still reads as a sentence", () => {
+    const rows = [
+      tick(0, {
+        pools: JSON.stringify([
+          { address: A, included: true, eth_per_tao: 0.106 },
+          { address: B, included: false },
+        ]),
+      }),
+    ];
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    assert.ok(v.alerts.some((a) => a.includes("unstated")));
+  });
+
+  test("a store answering without `results` is an empty window, not a crash", async () => {
+    const db = { prepare: () => ({ bind: () => ({ all: async () => ({}) }) }) };
+    const out = await runTaoUsdIndexWatchdog({}, { db, now: () => NOW });
+    assert.equal(out.verdict, "fail");
+    assert.ok(out.alerts[0].includes("wrote no rows"));
+  });
+
+  test("with no injected store or lane db, it degrades instead of throwing", async () => {
+    // The default paths: readStore over an empty env yields nothing to query,
+    // and laneHealthStore yields nothing to write to. Neither may throw -- a
+    // watchdog that crashes on a cold binding is a watchdog that is silent.
+    const out = await runTaoUsdIndexWatchdog({});
+    assert.equal(out.recorded, false);
+    assert.ok(["fail", "ok", "warn"].includes(out.verdict));
+  });
+});
+
+describe("the last two edges", () => {
+  test("a pool that stopped contributing with no reason still reports the gap", () => {
+    // It contributed, then went absent from the array entirely — no exclusion
+    // entry, so no reason. The elapsed time is the diagnosis in that case.
+    const rows = [
+      tick(0, {
+        pools: JSON.stringify([
+          { address: A, included: true, eth_per_tao: 0.106 },
+        ]),
+      }),
+      tick(40, {
+        pools: JSON.stringify([
+          { address: A, included: true, eth_per_tao: 0.106 },
+          { address: B, included: true, eth_per_tao: 0.1059 },
+        ]),
+      }),
+    ];
+    const v = evaluateTaoUsdIndex({ rows, nowMs: NOW });
+    const alert = v.alerts.find((a) => a.includes(B)) as string;
+    assert.ok(alert.includes("last contributed 40 minutes ago"));
+    assert.ok(alert.includes("unstated"));
+  });
+
+  test("a null env is survivable", async () => {
+    // The scheduled handler passes whatever it has; a watchdog that throws on a
+    // missing binding is one that never reports.
+    const out = await runTaoUsdIndexWatchdog(null);
+    assert.equal(out.recorded, false);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -399,6 +399,7 @@ import { neonOwnsTable } from "../src/neon-write.ts";
 import { KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
 import { NEON_PRUNE_CRON, runNeonPrune } from "../src/neon-prune.ts";
 import { runTableFreshnessWatchdog } from "../src/table-freshness-watchdog.ts";
+import { runTaoUsdIndexWatchdog } from "../src/tao-usd-index-watchdog.ts";
 
 import { VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
 import {
@@ -7726,9 +7727,18 @@ export default {
   ) {
     if (controller?.cron === TABLE_FRESHNESS_CRON) {
       // D1 only. It reads MAX(<timestamp>) per table and writes one verdict.
-      return runTableFreshnessWatchdog(
-        env as unknown as Record<string, unknown>,
-      );
+      const bag = env as unknown as Record<string, unknown>;
+      // The TAO/USD index rides this cron rather than its own (#8603). Its
+      // staleness bound already lives in TABLE_FRESHNESS, the store is already
+      // reachable here, and a NEW cron expression would need
+      // `wrangler triggers deploy` to take effect -- Workers Builds deploys
+      // code, not schedules. A watchdog that silently never runs is the exact
+      // failure it was built to catch, so it reuses a schedule known to fire.
+      const [freshness] = await Promise.all([
+        runTableFreshnessWatchdog(bag),
+        runTaoUsdIndexWatchdog(bag),
+      ]);
+      return freshness;
     }
     if (controller?.cron === NEON_PRUNE_CRON) {
       // Neon's own retention for the rolling windows (#9891). Independent of


### PR DESCRIPTION
## Why this index gets its own watchdog

Publishing a price creates an obligation nothing else here has. Every other number we serve is chain-derived and self-evidently reproducible — a wrong one is a bug and it *looks* like one. A wrong **price** is our wrong price, and it can be wrong while looking perfectly healthy: a pool quietly returning stale reserves produces a plausible number with no error anywhere.

It is also now load-bearing. Since #10381/#10382/#10383, every alpha figure the API publishes in dollars is this index multiplied by a chain-measured alpha price. A bad reading is not one card; it's the dollar axis of the whole surface.

## Two measurements shaped everything

Against production, over the index's entire life — **11,772 ticks** from 2026-08-02:

```
pool_count         2 on EVERY tick — min 2, max 2, never 3
inter-pool spread  min 0.001%, avg 0.370%, p99 0.821%, max 0.862%
price_basis        wrapped_onchain_median on every tick, never degraded
```

**1. The index has never had a spare pool.** `MIN_QUALIFYING_POOLS` is 2, so the redundancy margin is **zero** — one pool dropping out takes it straight to `insufficient_pools` and every USD figure on the API becomes unavailable at once. That's a property of the on-chain liquidity, not an incident, so the watchdog **reports** it on every verdict (`noRedundancy: true`) and the runbook carries it, rather than paging every minute forever. An alarm that is always firing is one nobody reads — but the fact still has to reach someone, which is why it's on the verdict and in the docs rather than suppressed.

**2. With exactly two pools, outlier rejection cannot reject an outlier — it collapses the index.** `computeTaoUsdIndex` locates outliers against the *unweighted* median, and the median of two values is their midpoint, so both pools sit equidistant from it by exactly half their spread. When that half-spread crosses `OUTLIER_THRESHOLD`, **both** are rejected in one pass, survivors fall to zero, and ADR 0025 forbids falling back to the pre-rejection set. A spread past ~4% doesn't discard the bad pool; it stops publication.

So the divergence alarm warns on **deviation** at half the rejection threshold instead of waiting for the basis to degrade — by then the index is already down. Observed max half-spread is **0.431%**, so 1% is ~2.3× the worst thing that has ever happened and half the distance to a total stop. It's *derived* from `OUTLIER_THRESHOLD` rather than typed twice, so retuning the ADR moves the warning with it.

## Coverage of the issue's requirements

| # | Requirement | Where |
|---|---|---|
| 1 | Per-pool health | last-contribution based, 15 min ≈ 15 producer ticks |
| 2 | Divergence | `POOL_DEVIATION_WARN`, measured the way the aggregator measures it |
| 3 | Degraded state | any unpriced tick, because it's user-visible through the contract |
| 4 | Staleness | already declared in `TABLE_FRESHNESS`; plus an empty window → `fail` |
| 5 | Runbook + correction policy | `docs/tao-usd-index-runbook.md` |
| 6 | No secrets/hostnames | none in the doc, the module, or any alert payload |
| 7 | Probe-derived only | nothing hand-set; the policy forbids it explicitly |

An empty window reports **fail**, not all-quiet — a per-pool check over zero rows finds zero failing pools and would otherwise read healthy. That trap is tested directly.

The runbook decides the correction policy **in advance**: stored rows are immutable, a restatement is additive and labelled (never an `UPDATE`), and deletion is never a correction — a gap and a wrong number are different claims.

## Design notes worth the review

- **Rides the existing freshness cron** rather than a new expression. Workers Builds deploys code, not schedules, so a new cron needs `wrangler triggers deploy` — easy to forget, and it would silently leave the watchdog never running, which is the exact failure it exists to catch.
- **`lane_health`'s vocabulary is `ok | stale | unknown`** and can't express "publishing, but diverging". Rather than flatten that away, the four-state verdict rides in `detail` and the column takes the closest honest value — `unknown` for a read failure (which is what the word means), so a reader fault is never recorded as a verdict about the producer.

## Verification

- **Run against production before the tests were written**: 60 real rows → `ok`, deviation 0.2896%, both pools on every tick, `noRedundancy: true`.
- **35 tests, 100% branch coverage (83/83)** on the new module. The issue's bar — *"an alert that has never fired once is not known to work"* — so every condition is driven to fire against a simulated state, and the healthy case is pinned against the shape production actually produces.
- data-api bundle 1831 → 1844 KiB, startup **98 ms** against the 400 ms limit; the #10238 boundary guard still passes.
- All 45 validators, `tsc`, `eslint`, `prettier` clean.

Closes #8603
