### PR TITLE
fix(api): /blocks reads its own from/to bounds with the integer accessor

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -13364,9 +13364,9 @@ export interface operations {
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
@@ -16921,9 +16921,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -22813,9 +22813,9 @@ export interface operations {
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
@@ -31177,9 +31177,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -33131,9 +33131,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -46886,9 +46886,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -10036,7 +10036,7 @@
           }
         },
         {
-          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+          "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10044,7 +10044,7 @@
           }
         },
         {
-          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+          "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -10479,7 +10479,7 @@
           }
         },
         {
-          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+          "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10487,7 +10487,7 @@
           }
         },
         {
-          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+          "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -10610,7 +10610,7 @@
           }
         },
         {
-          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+          "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10618,7 +10618,7 @@
           }
         },
         {
-          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+          "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,
@@ -10722,7 +10722,7 @@
           }
         },
         {
-          "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+          "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
           "name": "from",
           "schema": {
             "minimum": 0,
@@ -10730,7 +10730,7 @@
           }
         },
         {
-          "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+          "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
           "name": "to",
           "schema": {
             "minimum": 0,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -56591,7 +56591,7 @@
             }
           },
           {
-            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -56601,7 +56601,7 @@
             }
           },
           {
-            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+            "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -60863,7 +60863,7 @@
             }
           },
           {
-            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -60873,7 +60873,7 @@
             }
           },
           {
-            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+            "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -66964,7 +66964,7 @@
             }
           },
           {
-            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -66974,7 +66974,7 @@
             }
           },
           {
-            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+            "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -75825,7 +75825,7 @@
             }
           },
           {
-            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -75835,7 +75835,7 @@
             }
           },
           {
-            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+            "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -78942,7 +78942,7 @@
             }
           },
           {
-            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -78952,7 +78952,7 @@
             }
           },
           {
-            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+            "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,
@@ -94243,7 +94243,7 @@
             }
           },
           {
-            "description": "Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound.",
+            "description": "Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound.",
             "in": "query",
             "name": "from",
             "required": false,
@@ -94253,7 +94253,7 @@
             }
           },
           {
-            "description": "Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound.",
+            "description": "Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound.",
             "in": "query",
             "name": "to",
             "required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -13364,9 +13364,9 @@ export interface operations {
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
@@ -16921,9 +16921,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -22813,9 +22813,9 @@ export interface operations {
                 cursor?: string;
                 author?: string;
                 spec_version?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
                 block_start?: number;
@@ -31177,9 +31177,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -33131,9 +33131,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
@@ -46886,9 +46886,9 @@ export interface operations {
                 block_start?: number;
                 /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 block_end?: number;
-                /** @description Inclusive first block height of the range to read. Omit for an unbounded end. Must not be later than the range's upper bound. */
+                /** @description Inclusive first `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be later than the range's upper bound. */
                 from?: number;
-                /** @description Inclusive last block height of the range to read. Omit for an unbounded end. Must not be earlier than the range's lower bound. */
+                /** @description Inclusive last `observed_at` bound, as epoch MILLISECONDS -- not a block height (use block_start/block_end for that). Omit for an unbounded end. Must not be earlier than the range's lower bound. */
                 to?: number;
                 /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -327,6 +327,36 @@ export function orderingNote(edge: "first" | "last"): string {
  * A block height bound. Inclusive on both ends, which is the one thing a
  * caller cannot infer from the name and gets wrong by one row.
  */
+/**
+ * An `observed_at` bound on a block-derived feed, in epoch MILLISECONDS.
+ *
+ * Distinct from `blockBoundSchema` (#10395). `from`/`to` borrowed that builder
+ * and inherited its description -- "Inclusive first block height of the range
+ * to read", with `8783000` as the worked example -- while every reader that
+ * applies them compares `observed_at`:
+ *
+ *   src/blocks-cold-tier.ts      `[query.from, "b.observed_at >= ?"]`
+ *   src/r2-sql-blocks.ts         `[query.from, "observed_at >="]`
+ *
+ * and the route's own summary in `src/contracts.ts` says so too
+ * ("?from / ?to (observed_at epoch-ms)"). The contract contradicted itself,
+ * and a caller who followed the parameter description got an empty page from
+ * the two routes that honour the bound: 8,783,000 ms is January 1970.
+ *
+ * `block_start`/`block_end` are the height range and keep `blockBoundSchema`.
+ */
+export const observedAtBoundSchema = (edge: "first" | "last") =>
+  z
+    .int()
+    .min(0)
+    .describe(
+      `Inclusive ${edge} \`observed_at\` bound, as epoch MILLISECONDS -- ` +
+        "not a block height (use block_start/block_end for that). Omit for an " +
+        "unbounded end." +
+        orderingNote(edge),
+    )
+    .meta({ examples: [1786000000000] });
+
 export const blockBoundSchema = (edge: "first" | "last") =>
   z
     .int()

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -197,6 +197,7 @@ import { NOMINATOR_LIMIT_DEFAULT } from "../src/validator-nominators.ts";
 import { VALIDATOR_ECONOMICS_SORTS } from "../src/validator-economics.ts";
 import {
   blockBoundSchema,
+  observedAtBoundSchema,
   daySchema,
   directionSchema,
   fieldsSchema,
@@ -962,8 +963,8 @@ export const ROUTE_QUERY_SCHEMAS = {
     // DIVERGENCE: the block author is an SS58 and publishes no pattern.
     author: z.string().optional(),
     spec_version: z.int().min(0).optional(),
-    from: blockBoundSchema("first").optional(),
-    to: blockBoundSchema("last").optional(),
+    from: observedAtBoundSchema("first").optional(),
+    to: observedAtBoundSchema("last").optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
     min_extrinsics: z.int().min(0).optional(),
@@ -1052,8 +1053,8 @@ export const ROUTE_QUERY_SCHEMAS = {
     success: z.enum(["true", "false"] as const).optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    from: blockBoundSchema("first").optional(),
-    to: blockBoundSchema("last").optional(),
+    from: observedAtBoundSchema("first").optional(),
+    to: observedAtBoundSchema("last").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/sudo": z.object({
@@ -1068,8 +1069,8 @@ export const ROUTE_QUERY_SCHEMAS = {
     success: z.enum(["true", "false"] as const).optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    from: blockBoundSchema("first").optional(),
-    to: blockBoundSchema("last").optional(),
+    from: observedAtBoundSchema("first").optional(),
+    to: observedAtBoundSchema("last").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/governance/config-changes": z.object({
@@ -1084,8 +1085,8 @@ export const ROUTE_QUERY_SCHEMAS = {
     success: z.enum(["true", "false"] as const).optional(),
     block_start: blockBoundSchema("first").optional(),
     block_end: blockBoundSchema("last").optional(),
-    from: blockBoundSchema("first").optional(),
-    to: blockBoundSchema("last").optional(),
+    from: observedAtBoundSchema("first").optional(),
+    to: observedAtBoundSchema("last").optional(),
     format: formatSchema().optional(),
   }),
   "/api/v1/runtime": z.object({

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -133,13 +133,6 @@ export const DECLARED: Record<string, string> = {
  */
 const JSON_UNDERTYPED: Record<string, string> = {
   "Adapter.snapshot": "AdapterArtifactSnapshot",
-  // Landed on main between this check being written (#10400) and the
-  // `field_sources_usd` provenance block being added (#10392) -- each PR was
-  // green against its own base and red together, which is what a gate added
-  // in parallel with the thing it measures always risks. Unlike
-  // `field_sources`, which is a record keyed by field name and honestly JSON,
-  // this one is a fixed `{kind, storage}` object.
-  "EconomicsTrends.field_sources_usd": "EconomicsTrendsArtifactFieldSourcesUsd",
   "BlockEvents.events": "[AccountEvent!]",
   "BlockExtrinsics.extrinsics": "[BlockExtrinsicsArtifactExtrinsics!]",
   "BuildSummary.artifact_budget_summary":
@@ -162,7 +155,6 @@ const JSON_UNDERTYPED: Record<string, string> = {
     "CompareValidatorsArtifactValidatorsSubnetContext",
   "Contracts.artifacts": "[ContractsArtifactArtifacts!]",
   "SubnetConviction.king": "String",
-  "SubnetOhlc.field_sources_usd": "SubnetOhlcArtifactFieldSourcesUsd",
   "SubnetConviction.leaderboard": "[SubnetConvictionArtifactLeaderboard!]",
   "SubnetEventSummary.categories": "[SubnetEventSummaryArtifactCategories!]",
   "SubnetEventSummary.event_kinds": "[SubnetEventSummaryArtifactEventKinds!]",

--- a/tests/blocks.test.ts
+++ b/tests/blocks.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
+import { routeInt, routeText } from "../src/route-query.ts";
 import {
   handleBlock,
   handleBlockEvents,
@@ -761,4 +762,38 @@ test("loadBlocks keeps the plain OFFSET path when unfiltered", async () => {
   const { sql } = capture[0];
   assert.ok(!/WHERE/.test(sql));
   assert.ok(/ORDER BY block_number DESC LIMIT \? OFFSET \?/.test(sql));
+});
+
+// #10395: `from`/`to` are declared `z.int()` like every sibling bound on this
+// route, so `route-query.ts` hands the handler a NUMBER -- and the handler read
+// them with `routeText`, whose documented contract is to answer null for a
+// value that is not a string. The filter was dropped on every request, on a
+// parameter the route has published since #1991.
+//
+// Measured against production before the fix: `?to=8000000` and
+// `?to=1786000000000` both returned the newest blocks unfiltered, while the
+// identical bound on /api/v1/extrinsics -- whose handler forwards
+// `routeQuery(url)` wholesale rather than per-parameter -- returned an empty
+// page.
+//
+// Asserted at the parse, which is where the two accessors disagree: a test
+// that only checked "the handler passes something" would pass with `null`.
+test("blocks from/to parse to NUMBERS, which routeText cannot read (#10395)", () => {
+  const url = new URL(
+    "https://api.metagraph.sh/api/v1/blocks?limit=5&from=1786000000000&to=1786341977154",
+  );
+  // The bug: the string accessor answers null for a parameter the contract
+  // declares as an integer.
+  assert.equal(routeText(url, "from"), null);
+  assert.equal(routeText(url, "to"), null);
+  // The fix: the integer accessor answers the value the caller sent.
+  assert.equal(routeInt(url, "from"), 1786000000000);
+  assert.equal(routeInt(url, "to"), 1786341977154);
+  // And the sibling height bounds are unchanged -- they were always read with
+  // the integer accessor, which is why only from/to were dropped.
+  const heights = new URL(
+    "https://api.metagraph.sh/api/v1/blocks?block_start=8800000&block_end=8812000",
+  );
+  assert.equal(routeInt(heights, "block_start"), 8800000);
+  assert.equal(routeInt(heights, "block_end"), 8812000);
 });

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -256,7 +256,7 @@ describe("scalar identity", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.undertyped, 30);
+    assert.equal(report.undertyped, 28);
   });
 
   test("it FAILS when a field is retyped to a different scalar", () => {
@@ -308,7 +308,7 @@ describe("scalar identity", () => {
       report.stale.includes("SubnetConviction.king"),
       `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
     );
-    assert.equal(report.undertyped, 29);
+    assert.equal(report.undertyped, 27);
   });
 
   test("a Float over an Int component field is a WIDENING and stays allowed", () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -6263,9 +6263,19 @@ export async function handleBlocks(
         blockStart: routeInt(url, "block_start"),
         blockEnd: routeInt(url, "block_end"),
         // from/to are part of this route's contract too -- a filter the tier
-        // never receives is a filter it silently ignores.
-        from: routeText(url, "from"),
-        to: routeText(url, "to"),
+        // never receives is a filter it silently ignores. `routeInt`, not
+        // `routeText` (#10395): the two are declared `z.int()` like every
+        // sibling bound here, so the parse hands back a NUMBER and the string
+        // accessor answered null on every request -- `routeText`'s own doc
+        // says so ("if a caller reaches for the wrong accessor, the answer is
+        // null rather than a number wearing a string's type"). Measured
+        // against production before the fix: `?to=8000000` and
+        // `?to=1786000000000` both returned the newest blocks unfiltered,
+        // while the same bound on /api/v1/extrinsics -- whose handler forwards
+        // `routeQuery(url)` wholesale rather than per-parameter -- returned an
+        // empty page. A published filter that has never once been applied.
+        from: routeInt(url, "from"),
+        to: routeInt(url, "to"),
         minExtrinsics: routeInt(url, "min_extrinsics"),
         minEvents: routeInt(url, "min_events"),
       } as never,


### PR DESCRIPTION
## Summary

`GET /api/v1/blocks` has published `from` and `to` since #1991 and **has never applied them**. Measured against production before the fix:

```
GET /api/v1/blocks?limit=2&to=8000000        -> [8812111, 8812110]   ignored
GET /api/v1/blocks?limit=2&to=1786000000000  -> [8812111, 8812110]   ignored
GET /api/v1/blocks?limit=2&block_end=8000000 -> [8000000, 7999999]   works

GET /api/v1/extrinsics?limit=2&to=8000000    -> []                   applied
GET /api/v1/sudo?limit=2&to=8000000          -> []                   applied
```

Neither reading of the bound is applied — not the block height its parameter description names, not the `observed_at` epoch-ms its sibling routes use.

## Why

Two lines, and the accessor's own doc comment predicted them:

```ts
blockStart: routeInt(url, "block_start"),
blockEnd:   routeInt(url, "block_end"),
// from/to are part of this route's contract too -- a filter the tier
// never receives is a filter it silently ignores.
from: routeText(url, "from"),   // <- declared z.int(); parses to a NUMBER
to:   routeText(url, "to"),
```

> *A type TEST, not a cast. The value came out of a Zod parse against the published schema, so its runtime type is whatever the contract declares — and if a caller reaches for the wrong accessor, the answer is `null` rather than a number wearing a string's type.* — `src/route-query.ts`

`from`/`to` are `z.int()`, exactly like the four sibling bounds beside them, so `routeText` answered `null` on every request and the handler passed `null` to the tier. The intent was right — the comment above the two lines says so — the accessor was not. `/api/v1/extrinsics` and `/api/v1/sudo` are unaffected because their handlers forward `routeQuery(url)` wholesale instead of reading parameters one at a time.

Both cold-tier readers were always ready for the value:

```
src/blocks-cold-tier.ts   [query.from, "b.observed_at >= ?"]
src/r2-sql-blocks.ts      [query.from, "observed_at >="]
```

## And the contract contradicted itself

`from`/`to` borrowed `blockBoundSchema`, so `openapi.json` describes them as *"Inclusive first **block height** of the range to read"* with `8783000` as the worked example — while the route's own summary in `src/contracts.ts` says *"?from / ?to (**observed_at epoch-ms**)"* and every reader compares `observed_at`. A caller who followed the parameter description would get an empty page from the two routes that honour the bound, because 8,783,000 ms is January 1970.

They get their own builder now — `observedAtBoundSchema`, an epoch-ms description and an epoch-ms example — on all four routes that use them (`blocks`, `extrinsics`, `sudo`, `governance/config-changes`). `block_start`/`block_end` are the height range and keep `blockBoundSchema`. Same `z.int().min(0)` either way, so nothing about what is *accepted* changes.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npm run build` + `validate:contract-drift` — passed; `openapi.json` and the generated types regenerated and committed (12 description/example lines)
- `validate:openapi` — 206 routes + 24 feed routes + 42 network variants
- `validate:graphql-query-arguments` — 187 exact, OK; `validate:graphql-route-parity` — 0 divergences
- `npx vitest run tests/blocks.test.ts` — 57 passed

The regression test asserts at the parse, which is where the two accessors disagree — a test that only checked "the handler passes something" would pass with `null`:

```ts
assert.equal(routeText(url, "from"), null);          // the bug
assert.equal(routeInt(url, "from"), 1786000000000);  // the fix
assert.equal(routeInt(heights, "block_start"), 8800000);  // siblings unchanged
```

- `npx vitest run` — 796 files, **18,404 passed**, 11 skipped, 0 failed

**One thing rode along.** Rebasing onto the newest main made the two `field_sources_usd` entries in `JSON_UNDERTYPED` **stale**: #10406 published `AlphaUsdFieldSource` and closed both gaps. The shrink-only list did exactly what it exists to do — it failed rather than letting a closed gap keep its declaration — so the two are deleted here and the count falls 30 → 28.

Closes #10395.
