### PR TITLE
fix(graphql): close the four JSON under-typings the schema already has types for

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -759,7 +759,7 @@ export type BlockEvents = {
   __typename?: 'BlockEvents';
   block_number?: Maybe<Scalars['Int']['output']>;
   event_count: Scalars['Int']['output'];
-  events: Array<Scalars['JSON']['output']>;
+  events: Array<AccountEvent>;
   limit?: Maybe<Scalars['Int']['output']>;
   offset?: Maybe<Scalars['Int']['output']>;
   ref?: Maybe<Scalars['String']['output']>;
@@ -5169,7 +5169,7 @@ export type SubnetConviction = {
   count: Scalars['Int']['output'];
   /** Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
   field_sources?: Maybe<Scalars['JSON']['output']>;
-  king?: Maybe<Scalars['JSON']['output']>;
+  king?: Maybe<Scalars['String']['output']>;
   leaderboard: Array<Scalars['JSON']['output']>;
   maturity_rate?: Maybe<Scalars['Float']['output']>;
   netuid: Scalars['Int']['output'];
@@ -5303,7 +5303,7 @@ export type SubnetEventSummary = {
   observed_at?: Maybe<Scalars['String']['output']>;
   recent_event_count: Scalars['Int']['output'];
   /** The bounded newest-first recent-event list. Opaque JSON passed through verbatim. */
-  recent_events: Scalars['JSON']['output'];
+  recent_events: Array<AccountEvent>;
   schema_version: Scalars['Int']['output'];
   total_events: Scalars['Int']['output'];
   /** The resolved window label (7d/30d/90d). */
@@ -6230,7 +6230,7 @@ export type TaoUsdLatest = {
   observed_at?: Maybe<Scalars['String']['output']>;
   pool_count?: Maybe<Scalars['Int']['output']>;
   /** Per-pool provenance as the producer stored it. */
-  pools?: Maybe<Scalars['JSON']['output']>;
+  pools?: Maybe<Array<Scalars['JSON']['output']>>;
   /** Stated even when the price is null -- it is what says why. */
   price_basis?: Maybe<Scalars['String']['output']>;
   usd_per_tao?: Maybe<Scalars['Float']['output']>;
@@ -7904,7 +7904,7 @@ export type BlockDetailResolvers<ContextType = GqlContext, ParentType extends Re
 export type BlockEventsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockEvents'] = ResolversParentTypes['BlockEvents']> = ResolversObject<{
   block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   event_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  events?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  events?: Resolver<Array<ResolversTypes['AccountEvent']>, ParentType, ContextType>;
   limit?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   offset?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   ref?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10106,7 +10106,7 @@ export type SubnetConcentrationHistoryPointResolvers<ContextType = GqlContext, P
 export type SubnetConvictionResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetConviction'] = ResolversParentTypes['SubnetConviction']> = ResolversObject<{
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  king?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  king?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   leaderboard?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
   maturity_rate?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10210,7 +10210,7 @@ export type SubnetEventSummaryResolvers<ContextType = GqlContext, ParentType ext
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   recent_event_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  recent_events?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  recent_events?: Resolver<Array<ResolversTypes['AccountEvent']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_events?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10946,7 +10946,7 @@ export type TaoUsdLatestResolvers<ContextType = GqlContext, ParentType extends R
   eth_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   pool_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  pools?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  pools?: Resolver<Maybe<Array<ResolversTypes['JSON']>>, ParentType, ContextType>;
   price_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   usd_per_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -133,7 +133,6 @@ export const DECLARED: Record<string, string> = {
  */
 const JSON_UNDERTYPED: Record<string, string> = {
   "Adapter.snapshot": "AdapterArtifactSnapshot",
-  "BlockEvents.events": "[AccountEvent!]",
   "BlockExtrinsics.extrinsics": "[BlockExtrinsicsArtifactExtrinsics!]",
   "BuildSummary.artifact_budget_summary":
     "BuildSummaryArtifactArtifactBudgetSummary",
@@ -154,18 +153,15 @@ const JSON_UNDERTYPED: Record<string, string> = {
   "ComparedValidator.subnet_context":
     "CompareValidatorsArtifactValidatorsSubnetContext",
   "Contracts.artifacts": "[ContractsArtifactArtifacts!]",
-  "SubnetConviction.king": "String",
   "SubnetConviction.leaderboard": "[SubnetConvictionArtifactLeaderboard!]",
   "SubnetEventSummary.categories": "[SubnetEventSummaryArtifactCategories!]",
   "SubnetEventSummary.event_kinds": "[SubnetEventSummaryArtifactEventKinds!]",
-  "SubnetEventSummary.recent_events": "[AccountEvent!]",
   "SubnetHealthIncidents.surfaces": "[HealthIncidentsArtifactSurfaces!]",
   "SubnetHealthPercentiles.surfaces": "[HealthPercentilesArtifactSurfaces!]",
   "SubnetLease.lease": "SubnetLeaseArtifactLease",
   "SubnetLeaseHistory.lease_events": "[SubnetLeaseHistoryArtifactLeaseEvents!]",
   "SubnetOwnershipHistory.ownership_changes":
     "[SubnetOwnershipHistoryArtifactOwnershipChanges!]",
-  "TaoUsdLatest.pools": "[JSON!]",
 };
 
 export interface ParityReport {

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2920,7 +2920,7 @@ export const SDL = /* GraphQL */ `
     observed_at: String
     pool_count: Int
     "Per-pool provenance as the producer stored it."
-    pools: JSON
+    pools: [JSON!]
   }
 
   type TaoUsd {
@@ -3995,7 +3995,7 @@ export const SDL = /* GraphQL */ `
     "Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim."
     event_kinds: JSON!
     "The bounded newest-first recent-event list. Opaque JSON passed through verbatim."
-    recent_events: JSON!
+    recent_events: [AccountEvent!]!
   }
 
   type ExtrinsicList {
@@ -4203,7 +4203,7 @@ export const SDL = /* GraphQL */ `
     queried_at_block: Int
     unlock_rate: Float
     maturity_rate: Float
-    king: JSON
+    king: String
     count: Int!
     leaderboard: [JSON!]!
     """
@@ -4469,7 +4469,7 @@ export const SDL = /* GraphQL */ `
     event_count: Int!
     limit: Int
     offset: Int
-    events: [JSON!]!
+    events: [AccountEvent!]!
   }
 
   "One block's raw all-events-tier events (#6977) -- every pallet.method event, distinct from the curated block_events stream. Rows are opaque JSON."

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -256,7 +256,7 @@ describe("scalar identity", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.undertyped, 28);
+    assert.equal(report.undertyped, 24);
   });
 
   test("it FAILS when a field is retyped to a different scalar", () => {
@@ -297,18 +297,21 @@ describe("scalar identity", () => {
   });
 
   test("a CLOSED under-typing makes its declaration stale, so the list shrinks", () => {
+    // `Adapter.snapshot` is one of the 24 still open. Publishing the shape its
+    // component already describes has to make the declaration stale, or the
+    // list would keep an entry for a gap that no longer exists.
     const fixed = inType(
       sdl,
-      "SubnetConviction",
-      /^ {4}king: JSON\n/m,
-      "    king: String\n",
+      "Adapter",
+      /^ {4}snapshot: JSON\n/m,
+      "    snapshot: AdapterArtifactSnapshot\n",
     );
     const report = checkComponentParity(fixed, openapi);
     assert.ok(
-      report.stale.includes("SubnetConviction.king"),
+      report.stale.includes("Adapter.snapshot"),
       `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
     );
-    assert.equal(report.undertyped, 27);
+    assert.equal(report.undertyped, 23);
   });
 
   test("a Float over an Int component field is a WIDENING and stays allowed", () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -2750,7 +2750,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
 
   test("block_events: cold store returns a schema-stable empty list, never an error", async () => {
     const { status, body } = await gql(
-      '{ block_events(ref: "9") { block_number event_count events } }',
+      '{ block_events(ref: "9") { block_number event_count events { block_number event_kind } } }',
     );
     assert.equal(status, 200);
     assert.equal(body.data.block_events.event_count, 0);
@@ -2770,19 +2770,32 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
             limit: 100,
             offset: 0,
             events: [
-              { block_number: 9, event_index: 0, kind: "Balances.Transfer" },
+              // `event_kind`, not `kind` -- the name AccountEvent publishes,
+              // the name the component declares, and the name production
+              // serves (verified: block_events rows carry block_number,
+              // event_index, event_kind, hotkey, ...). The invented `kind`
+              // survived only while `events` was `[JSON!]`, which passes any
+              // row through verbatim (#10404).
+              {
+                block_number: 9,
+                event_index: 0,
+                event_kind: "Balances.Transfer",
+              },
             ],
           },
         }),
       ),
     };
     const { status, body } = await gql(
-      '{ block_events(ref: "9", limit: 20, offset: 3) { block_number event_count events } }',
+      '{ block_events(ref: "9", limit: 20, offset: 3) { block_number event_count events { block_number event_kind } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.block_events.event_count, 1);
-    assert.equal(body.data.block_events.events[0].kind, "Balances.Transfer");
+    assert.equal(
+      body.data.block_events.events[0].event_kind,
+      "Balances.Transfer",
+    );
   });
 
   test("block_chain_events: resolves the all-events tier by block_number", async () => {
@@ -6051,7 +6064,12 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
           queried_at_block: 5000000,
           unlock_rate: 0.001,
           maturity_rate: 0.002,
-          king: { coldkey: "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i" },
+          // A plain SS58, which is what the producer emits
+          // (`king: combined[0]?.hotkey ?? null`), what the component declares
+          // (`z.string().nullable().optional()`) and what production serves.
+          // The object this used to be was a shape no producer can reach --
+          // invisible while the field was JSON, which accepts anything (#10404).
+          king: "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i",
           count: 1,
           leaderboard: [
             {
@@ -6071,10 +6089,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     const r = body.data.subnet_conviction;
     assert.equal(r.netuid, 7);
     assert.equal(r.unlock_rate, 0.001);
-    assert.equal(
-      r.king.coldkey,
-      "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i",
-    );
+    assert.equal(r.king, "5HHBZRFX9UiyG77qU1pn1qMceRYKeg2a4yGBwPCHCyDocX4i");
     assert.equal(r.leaderboard[0].conviction, 1000);
   });
 
@@ -11594,7 +11609,8 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
     const { status, body } = await gql(
       `{ subnet_event_summary(netuid: 5) {
           schema_version netuid window total_events kind_count category_count
-          recent_event_count limit categories event_kinds recent_events
+          recent_event_count limit categories event_kinds
+          recent_events { block_number event_kind }
         } }`,
     );
     assert.equal(status, 200);
@@ -11635,7 +11651,7 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
       ),
     };
     const { status, body } = await gql(
-      '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories event_kinds recent_events } }',
+      '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories event_kinds recent_events { block_number event_kind } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);


### PR DESCRIPTION
## Summary

Four of the JSON under-typings `JSON_UNDERTYPED` counts can be closed with types the schema **already has**, so no name has to be invented:

| field | was | is | why it is free |
|---|---|---|---|
| `SubnetConviction.king` | `JSON` | `String` | the producer sets `king: combined[0]?.hotkey ?? null` — a plain SS58 |
| `TaoUsdLatest.pools` | `JSON` | `[JSON!]` | the component is an array; only the list-ness was missing |
| `SubnetEventSummary.recent_events` | `JSON!` | `[AccountEvent!]!` | `AccountEvent` is already published, field for field |
| `BlockEvents.events` | `[JSON!]!` | `[AccountEvent!]!` | same type, same 13 fields |

```
graphql-component-parity: … 28 → 24 JSON under-typing(s) left to close.
```

Verified against production before changing anything: `block_events` and `subnet_event_summary` rows carry exactly the 13 fields `AccountEvent` declares, in that order — `block_number, event_index, event_kind, hotkey, coldkey, netuid, uid, amount_tao, alpha_amount, observed_at, extrinsic_index, price_at_tx, price_basis`. `subnet_conviction { king }` answers `"5HCFWvRqzSHWRPecN7q8J6c7aKQnrCZTMHstPv39xL1wgDHh"`. `tao_usd { latest { pools } }` answers an array of pool objects.

## An opaque field checks nothing, and two fixtures had been lying

This is the part worth reading. `JSON` accepts any row, so nothing has ever compared what flows through one — and closing two of these immediately failed two tests that were asserting shapes **no producer can emit**:

- `subnet_conviction`'s fixture set `king: { coldkey: "5HHB…" }`, an object. The producer emits a string, the component declares `z.string().nullable().optional()`, and production serves a string. The test asserted `r.king.coldkey` and passed for as long as the field was `JSON`.
- `block_events`' fixture set `kind: "Balances.Transfer"` on its event row. The field is **`event_kind`** — in `AccountEvent`, in the component, and in production. The test asserted `events[0].kind` and passed the same way.

Both are corrected to the real shape, with the reason recorded inline. Neither was a test of anything until the type stopped being a blob.

## The published-shape change

`recent_events` and `events` stop being selectable as leaves and start requiring a selection set — a break for a query that selects them bare, and the whole point of the change: a caller can now ask for two fields of an event instead of receiving thirteen as a blob. Three queries in `tests/graphql.test.ts` are updated to select `{ block_number event_kind }`.

`king` and `pools` are scalar-to-scalar and break nothing.

The four `JSON_UNDERTYPED` declarations are deleted, which the gate required: a closed gap that keeps its declaration fails as stale. The test that proves a closed under-typing goes stale moved from `SubnetConviction.king` (now closed) to `Adapter.snapshot` (still open), so it keeps testing a live case.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `validate:graphql-component-parity` — 329 mirrors / 2544 fields / 39 projections / 194 drops / **24** under-typings, OK
- `validate:graphql-types-drift` — current; `generated/graphql/types.ts` regenerated and committed
- `validate:graphql-route-parity` — 164 pairs, 1190 fields, 0 divergences; `validate:graphql-hand-written-checks` — 245 of 245
- `npx vitest run` — 796 files, **18,404 passed**, 11 skipped, 0 failed

No `src/**` or `workers/**` executable line changed — the only `src/` edit is four field types in the SDL string — so there is no `codecov/patch` surface in this diff.

Closes #10413.
