### PR TITLE
ci: split the phases that share nothing, and shard the pass that dominates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -728,18 +728,22 @@ jobs:
       matrix:
         include:
           - name: shared 1/3
+            id: shared-1
             args: --pass=shared --shard=1/3
             cov: coverage
             junit: ""
           - name: shared 2/3
+            id: shared-2
             args: --pass=shared --shard=2/3
             cov: coverage
             junit: ""
           - name: shared 3/3
+            id: shared-3
             args: --pass=shared --shard=3/3
             cov: coverage
             junit: ""
           - name: mocked
+            id: mocked
             args: --pass=mocked
             cov: coverage-mocked
             junit: "-mocked"
@@ -825,6 +829,77 @@ jobs:
         run: |
           test -s ${{ matrix.cov }}/lcov.info
 
+      # Coverage and results leave as ARTIFACTS; the `coverage` job below does
+      # the single Codecov upload (#10414).
+      #
+      # WHY NOT UPLOAD FROM EACH LEG: the Codecov CLI is downloaded and
+      # GPG-verified once per upload, and that verification races its own key
+      # propagation across edge nodes -- observed here as
+      # "gpg: Can't check signature: No public key" on the mocked leg, with the
+      # tests themselves green. Uploading per leg multiplies a known transient
+      # by the shard count. One upload also means Codecov computes the verdict
+      # ONCE over the whole merged set, so `after_n_builds` stops being coupled
+      # to how many shards happen to exist.
+      #
+      # Staged into a flat directory with per-leg names because the three shared
+      # shards all write `coverage/lcov.info` and `reports/junit/vitest.xml` --
+      # identical paths on different runners, which merge-multiple would
+      # collapse into whichever landed last.
+      - name: Stage coverage + results for the merge job
+        run: |
+          mkdir -p cov-out
+          cp ${{ matrix.cov }}/lcov.info cov-out/lcov-${{ matrix.id }}.info
+          cp reports/junit/vitest${{ matrix.junit }}.xml cov-out/vitest-${{ matrix.id }}.xml
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-${{ matrix.id }}
+          path: cov-out/
+          retention-days: 1
+          if-no-files-found: error
+
+  # ONE Codecov upload, over every leg's report (#10414).
+  #
+  # `needs: test` waits for all four legs, so the verdict is computed once over
+  # the complete set rather than whenever Codecov decides it has seen enough
+  # uploads. That is what makes codecov.yml's `after_n_builds: 1` correct and
+  # keeps it correct when the shard count changes.
+  #
+  # `!cancelled()` rather than `success()`: a red leg still produced a coverage
+  # report for the legs that passed, and uploading it is how the PR comment
+  # shows what the failure did to coverage. A leg that never ran uploads
+  # nothing, which `if-no-files-found: error` above turns into a loud failure
+  # rather than a silently partial merge.
+  coverage:
+    name: coverage
+    needs: test
+    if: ${{ !cancelled() && needs.test.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Download every leg's coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: cov
+
+      # Every leg must have produced a report. A missing one would upload a
+      # partial denominator and understate coverage silently, which is the
+      # failure this check has always existed to prevent.
+      - name: Verify every leg's report arrived
+        run: |
+          for f in lcov-shared-1 lcov-shared-2 lcov-shared-3 lcov-mocked; do
+            test -s "cov/$f.info" || { echo "missing or empty: cov/$f.info"; exit 1; }
+          done
+
       # Upload coverage to Codecov — the primary PR coverage gate (delta-based
       # project + patch, see codecov.yml). vitest's thresholds are now just a
       # local backstop. Missing coverage or upload errors fail the test job.
@@ -875,7 +950,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./${{ matrix.cov }}/lcov.info
+          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-mocked.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
@@ -894,7 +969,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./${{ matrix.cov }}/lcov.info
+          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-mocked.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
@@ -907,7 +982,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./reports/junit/vitest${{ matrix.junit }}.xml
+          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-mocked.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1
@@ -920,7 +995,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./reports/junit/vitest${{ matrix.junit }}.xml
+          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-mocked.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -252,8 +252,8 @@ jobs:
             echo "Diff is 100% **/*.md + .claude/skills/** -- docs fast lane applies to the checks job."
           fi
 
-  test:
-    name: test
+  validate:
+    name: validate
     needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 45 # one npm ci + one build now serves BOTH the suite and the ~20 validators (see the merge note above jobs:)
@@ -704,6 +704,95 @@ jobs:
       - name: Validate private boundary
         run: npm run validate:private-boundary
 
+  # The suite, split across runners (#10414). It shares nothing with `validate`
+  # above -- that job's ~45 gates and this job's vitest passes were sequential
+  # in one job purely because they were written that way, so a 486s test step
+  # waited on 266s of validators for no reason.
+  #
+  # The MATRIX is over what run-ci-tests.ts already partitions: the mocking
+  # pass keeps its own registry (#8922) and cannot merge into the shared one,
+  # and the shared pass is sliced by file. Codecov merges every leg's upload by
+  # commit SHA exactly as it already merged the two passes' separate reports,
+  # so the denominator is unchanged -- see `Verify coverage reports exist`,
+  # which still refuses an empty report rather than uploading a partial one.
+  test:
+    name: test (${{ matrix.name }})
+    needs: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft != true }}
+    strategy:
+      # One red leg must not cancel the others: a shard-specific failure is
+      # exactly the thing you want the other shards' results for.
+      fail-fast: false
+      matrix:
+        include:
+          - name: shared 1/3
+            args: --pass=shared --shard=1/3
+            cov: coverage
+            junit: ""
+          - name: shared 2/3
+            args: --pass=shared --shard=2/3
+            cov: coverage
+            junit: ""
+          - name: shared 3/3
+            args: --pass=shared --shard=3/3
+            cov: coverage
+            junit: ""
+          - name: mocked
+            args: --pass=mocked
+            cov: coverage-mocked
+            junit: "-mocked"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          # Pin to the contributor's actual pushed commit, not GitHub's default
+          # refs/pull/:N/merge preview -- keeps CI deterministic for a given sha
+          # (a PR can't start failing just because main moved) and matches what
+          # Codecov's patch status is measuring. See the coverage upload steps
+          # below for why this specifically also fixes commit attribution.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      # Compute the deletion-filtered list of files this PR submits, inline in the
+      # trusted workflow (PR contents are untrusted). It feeds ONLY the
+      # reproducible-artifact verifier below, which diff-scopes its check to the
+      # files actually changed. There is no reduced lane to forge — every PR runs
+      # the full validation regardless of this list.
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+          # Without this, setup-node's cache key hashes EVERY package-lock.json
+          # in the tree, so a lockfile anywhere else would invalidate this job's
+          # cache even though `npm ci` here only ever reads the root one.
+          # packages/client is an npm
+          # workspace (#3066) with no lockfile of its own anymore — its version
+          # bumps land in the root lockfile, which this path already covers.
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      # Report-only SCA for the ROOT workspace — workers/** (the Worker API, MCP
+      # server, webhook dispatcher), src/**, and scripts/** — the repo's larger,
+      # more security-sensitive dependency surface, which until now had strictly
+      # less CI coverage than apps/ui (#5543). Same posture as the apps/ui CVE
+      # scan in the `ui` job below and the gate #1772 established: surface
+      # high/critical runtime advisories at PR time without failing the job
+      # (Renovate is async/non-blocking, so a feature PR can still merge a
+      # vulnerable transitive dep between Renovate runs). No `--workspace` flag,
+      # so this audits the whole lockfile — a superset that necessarily covers
+      # the root deps this gap is about; the minor overlap with the apps/ui-
+      # scoped scan is harmless since both are report-only. Never `--force`.
+      # Tighten to blocking once it stays clean.
+      - name: Build artifacts
+        env:
+          METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
+        run: npm run build
+
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
 
@@ -728,14 +817,13 @@ jobs:
       - name: Test (split passes, with coverage gate)
         env:
           VITEST_JUNIT_PATH: reports/junit/vitest.xml
-        run: npm run test:ci
+        run: node scripts/run-ci-tests.ts ${{ matrix.args }}
 
       # Both passes must have produced a report -- an empty/missing one would
       # otherwise upload a partial denominator and silently understate coverage.
       - name: Verify coverage reports exist
         run: |
-          test -s coverage/lcov.info
-          test -s coverage-mocked/lcov.info
+          test -s ${{ matrix.cov }}/lcov.info
 
       # Upload coverage to Codecov — the primary PR coverage gate (delta-based
       # project + patch, see codecov.yml). vitest's thresholds are now just a
@@ -787,7 +875,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info,./coverage-mocked/lcov.info
+          files: ./${{ matrix.cov }}/lcov.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
@@ -806,7 +894,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./coverage/lcov.info,./coverage-mocked/lcov.info
+          files: ./${{ matrix.cov }}/lcov.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
@@ -819,7 +907,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./reports/junit/vitest.xml,./reports/junit/vitest-mocked.xml
+          files: ./reports/junit/vitest${{ matrix.junit }}.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1
@@ -832,7 +920,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./reports/junit/vitest.xml,./reports/junit/vitest-mocked.xml
+          files: ./reports/junit/vitest${{ matrix.junit }}.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,16 +8,24 @@
 # The uploaded lcov is already scoped to runtime code (src/** + workers/** + 5
 # named scripts) by vitest's coverage.include, so Codecov reports only those.
 
-# The test job uploads TWO coverage reports (#8922): scripts/run-ci-tests.ts
-# splits the suite into a shared-registry pass and an isolated vi.mock pass, and
-# neither is a valid denominator alone — the shared pass measures ~89.9% lines
-# on its own purely because the other pass's files are missing from it. Without
-# this, Codecov computes project/patch off whichever report lands first and
-# posts a ~9% "drop" against a 1% threshold: a false red on every PR. Waiting
-# for both uploads makes the verdict fire once, on the merged report.
+# The test job uploads ONE coverage report PER MATRIX LEG, and no leg is a valid
+# denominator alone: scripts/run-ci-tests.ts splits the suite into a
+# shared-registry pass and an isolated vi.mock pass (#8922), and #10414 shards
+# the shared pass across runners. A single leg measures far below the whole --
+# the shared pass alone was ~89.9% lines purely because the other pass's files
+# were missing from it.
+#
+# So Codecov must WAIT for every leg. Without this it computes project/patch off
+# whichever reports landed first and posts a "drop" that is an artefact of
+# counting a subset: at 2 it fired on 2 of 4 legs and reported 95.77% (-2.17%),
+# a false red caused entirely by not waiting.
+#
+# THIS NUMBER IS THE MATRIX LEG COUNT and must move with it. A stale value does
+# not fail loudly -- it silently reports a partial merge as a coverage
+# regression -- so scripts/validate-workflows.ts asserts the two agree.
 codecov:
   notify:
-    after_n_builds: 2
+    after_n_builds: 4
 
 coverage:
   status:

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,12 +20,19 @@
 # counting a subset: at 2 it fired on 2 of 4 legs and reported 95.77% (-2.17%),
 # a false red caused entirely by not waiting.
 #
-# THIS NUMBER IS THE MATRIX LEG COUNT and must move with it. A stale value does
-# not fail loudly -- it silently reports a partial merge as a coverage
-# regression -- so scripts/validate-workflows.ts asserts the two agree.
+# ONE, because the workflow now does ONE upload: every matrix leg publishes its
+# report as an artifact and a single `coverage` job merges and uploads them
+# (#10414). That is deliberately not the same as trusting Codecov to merge N
+# concurrent uploads -- at 2 it fired on 2 of 4 legs and reported 95.77%
+# (-2.17%), a false red caused entirely by not waiting.
+#
+# Consolidating removes the coupling as well as the bug: this number no longer
+# tracks how many shards exist, so adding a shard cannot silently turn a partial
+# merge into a reported coverage regression. validate-workflows asserts the
+# consolidation is still in place.
 codecov:
   notify:
-    after_n_builds: 4
+    after_n_builds: 1
 
 coverage:
   status:

--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -37,6 +37,48 @@ import { repoRoot } from "./lib.ts";
 // is gone.
 
 /** Detects any API that manipulates the module registry for its own file. */
+// WHICH PASS, AND WHICH SLICE OF IT (#10414).
+//
+// Default: both passes, sequentially -- unchanged, because that is what a
+// developer runs locally and what `npm run test:ci` has always meant.
+//
+// CI now asks for one pass at a time so they can run on separate runners: the
+// two share nothing, and running them in sequence made a 320s pass wait on a
+// 158s one for no reason. `--shard=i/n` slices the shared pass further; vitest
+// partitions by file, and Codecov merges the reports by commit SHA exactly as
+// it already merges the two passes' separate uploads.
+//
+// The PARTITION is still computed from the source on every run. Sharding
+// changes how many runners share the work, never which files are mocking
+// files -- a hand-listed partition is the contamination #8922 removed.
+const argOf = (flag: string): string | null => {
+  const hit = process.argv.slice(2).find((a) => a.startsWith(`${flag}=`));
+  return hit ? hit.slice(flag.length + 1) : null;
+};
+const PASS = argOf("--pass");
+const SHARD = argOf("--shard");
+
+if (PASS !== null && PASS !== "shared" && PASS !== "mocked") {
+  console.error(
+    `run-ci-tests: --pass must be "shared" or "mocked", got "${PASS}".`,
+  );
+  process.exit(1);
+}
+// A shard of the mocking pass would be a silent no-op on the wrong pass rather
+// than an error, so it is refused: 71 files do not need slicing, and asking for
+// it means the caller believes something untrue about what is running.
+if (SHARD !== null && PASS !== "shared") {
+  console.error(
+    "run-ci-tests: --shard applies to --pass=shared only (the mocking pass is " +
+      "71 files and is not worth slicing).",
+  );
+  process.exit(1);
+}
+if (SHARD !== null && !/^[1-9]\d*\/[1-9]\d*$/.test(SHARD)) {
+  console.error(`run-ci-tests: --shard must look like i/n, got "${SHARD}".`);
+  process.exit(1);
+}
+
 const MODULE_MOCKING = /\bvi\.(mock|doMock|unmock|resetModules)\s*\(/;
 
 const testsDir = path.join(repoRoot, "tests");
@@ -115,34 +157,41 @@ function runPass(label: string, args: string[], suffix: string): void {
 }
 
 // Pass 1 -- the bulk, one shared module registry per worker.
-runPass(
-  `shared registry (${testFiles.length - mockingFiles.length} files)`,
-  [
-    ...BASE,
-    "--coverage",
-    "--isolate=false",
-    ...NO_PER_PASS_THRESHOLDS,
-    ...excludeArgs(mockingFiles),
-  ],
-  "",
-);
+if (PASS === null || PASS === "shared") {
+  runPass(
+    `shared registry (${testFiles.length - mockingFiles.length} files${SHARD ? `, shard ${SHARD}` : ""})`,
+    [
+      ...BASE,
+      "--coverage",
+      "--isolate=false",
+      ...NO_PER_PASS_THRESHOLDS,
+      ...(SHARD ? [`--shard=${SHARD}`] : []),
+      ...excludeArgs(mockingFiles),
+    ],
+    "",
+  );
+}
 
 // Pass 2 -- the module-mocking files, each with its own registry. Coverage
 // lands in its own directory so pass 1's report is not overwritten; CI uploads
 // both to Codecov, which merges them.
-runPass(
-  `module-mocking, isolated (${mockingFiles.length} files)`,
-  [
-    ...BASE,
-    "--coverage",
-    "--coverage.reportsDirectory=coverage-mocked",
-    ...NO_PER_PASS_THRESHOLDS,
-    ...mockingFiles.map((name) => `tests/${name}`),
-  ],
-  "-mocked",
-);
+if (PASS === null || PASS === "mocked") {
+  runPass(
+    `module-mocking, isolated (${mockingFiles.length} files)`,
+    [
+      ...BASE,
+      "--coverage",
+      "--coverage.reportsDirectory=coverage-mocked",
+      ...NO_PER_PASS_THRESHOLDS,
+      ...mockingFiles.map((name) => `tests/${name}`),
+    ],
+    "-mocked",
+  );
+}
 
 console.log(
-  `\nrun-ci-tests: both passes green (${mockingFiles.length} isolated, ` +
-    `${testFiles.length - mockingFiles.length} shared).`,
+  PASS === null
+    ? `\nrun-ci-tests: both passes green (${mockingFiles.length} isolated, ` +
+        `${testFiles.length - mockingFiles.length} shared).`
+    : `\nrun-ci-tests: ${PASS} pass green${SHARD ? ` (shard ${SHARD})` : ""}.`,
 );

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { promises as fs, readFileSync } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
 import {
@@ -175,6 +175,29 @@ for (const workflow of workflows) {
     // stops finding ANY upload and reports the split as missing, which is the
     // opposite of what it checks. The rule is "a coverage upload exists on
     // both the token and tokenless paths", not "the path is spelled this way".
+    // codecov.yml's `after_n_builds` MUST equal the number of matrix legs that
+    // upload coverage (#10414). Codecov computes project/patch once it has that
+    // many uploads; if the workflow grows a leg and the number does not, it
+    // fires on a PARTIAL merge and reports the missing legs as a coverage
+    // regression -- observed as 95.77% (-2.17%) when it waited for 2 of 4.
+    // That failure is indistinguishable from a real drop by eye, which is why
+    // it is asserted here rather than left to a comment.
+    const legCount = (content.match(/args: --pass=/g) ?? []).length;
+    if (legCount > 0) {
+      const codecovYml = readFileSync(
+        path.join(repoRoot, "codecov.yml"),
+        "utf8",
+      );
+      const afterN = Number(
+        /after_n_builds:\s*(\d+)/.exec(codecovYml)?.[1] ?? NaN,
+      );
+      check(
+        afterN === legCount,
+        workflow,
+        `codecov.yml after_n_builds is ${afterN} but the test matrix has ${legCount} coverage-uploading leg(s) -- Codecov would compute the verdict on a partial merge and report the shortfall as a coverage drop`,
+      );
+    }
+
     const coverageUploads = codecovSteps.filter((step) =>
       step.block.includes("lcov.info"),
     );

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -168,20 +168,27 @@ for (const workflow of workflows) {
     const codecovSteps = workflowSteps(content).filter((step) =>
       step.block.includes("uses: codecov/codecov-action@"),
     );
-    // Matched on `lcov.info` / `vitest*.xml` rather than the exact former
+    // Matched on `lcov*.info` / `vitest*.xml` rather than the exact former
     // paths: the uploads are matrix-driven since #10414
     // (`./${{ matrix.cov }}/lcov.info`), and a gate keyed to a literal path
     // goes silently blind the moment the path becomes an expression — it
     // stops finding ANY upload and reports the split as missing, which is the
     // opposite of what it checks. The rule is "a coverage upload exists on
     // both the token and tokenless paths", not "the path is spelled this way".
-    // codecov.yml's `after_n_builds` MUST equal the number of matrix legs that
-    // upload coverage (#10414). Codecov computes project/patch once it has that
-    // many uploads; if the workflow grows a leg and the number does not, it
-    // fires on a PARTIAL merge and reports the missing legs as a coverage
-    // regression -- observed as 95.77% (-2.17%) when it waited for 2 of 4.
-    // That failure is indistinguishable from a real drop by eye, which is why
-    // it is asserted here rather than left to a comment.
+    // Codecov's verdict must be computed ONCE, over every leg (#10414).
+    //
+    // The workflow shards the suite, so the reports arrive from four runners.
+    // They are merged by a single `coverage` job and uploaded once; Codecov is
+    // never asked to merge concurrent uploads, which is what silently reported
+    // 95.77% (-2.17%) when it fired on 2 of 4. Two things keep that true and
+    // neither fails loudly on its own:
+    //
+    //   - `after_n_builds` must be 1, or Codecov waits for uploads that a
+    //     consolidated workflow will never send (or, if raised, fires early
+    //     again the moment the shard count changes).
+    //   - the legs must publish ARTIFACTS, not upload directly. A leg that
+    //     uploads reintroduces both the partial-merge race and N GPG-verified
+    //     CLI downloads of a signature that races its own key propagation.
     const legCount = (content.match(/args: --pass=/g) ?? []).length;
     if (legCount > 0) {
       const codecovYml = readFileSync(
@@ -192,20 +199,26 @@ for (const workflow of workflows) {
         /after_n_builds:\s*(\d+)/.exec(codecovYml)?.[1] ?? NaN,
       );
       check(
-        afterN === legCount,
+        afterN === 1,
         workflow,
-        `codecov.yml after_n_builds is ${afterN} but the test matrix has ${legCount} coverage-uploading leg(s) -- Codecov would compute the verdict on a partial merge and report the shortfall as a coverage drop`,
+        `codecov.yml after_n_builds is ${afterN}, but the ${legCount} test legs publish artifacts merged by a single upload -- anything but 1 makes Codecov wait for uploads that never arrive, or compute its verdict on a partial merge`,
+      );
+      check(
+        content.includes("actions/download-artifact") &&
+          content.includes("pattern: coverage-*"),
+        workflow,
+        "sharded test legs must publish coverage as artifacts for one merged Codecov upload, not upload per leg",
       );
     }
 
-    const coverageUploads = codecovSteps.filter((step) =>
-      step.block.includes("lcov.info"),
+    const coverageUploads = codecovSteps.filter(
+      (step) => step.block.includes("lcov") && step.block.includes(".info"),
     );
     const tokenless = codecovSteps.filter(
       (step) => !step.block.includes("secrets.CODECOV_TOKEN"),
     );
-    const tokenlessCoverage = tokenless.filter((step) =>
-      step.block.includes("lcov.info"),
+    const tokenlessCoverage = tokenless.filter(
+      (step) => step.block.includes("lcov") && step.block.includes(".info"),
     );
     const tokenlessResults = tokenless.filter(
       (step) => step.block.includes("vitest") && step.block.includes(".xml"),

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -168,17 +168,24 @@ for (const workflow of workflows) {
     const codecovSteps = workflowSteps(content).filter((step) =>
       step.block.includes("uses: codecov/codecov-action@"),
     );
+    // Matched on `lcov.info` / `vitest*.xml` rather than the exact former
+    // paths: the uploads are matrix-driven since #10414
+    // (`./${{ matrix.cov }}/lcov.info`), and a gate keyed to a literal path
+    // goes silently blind the moment the path becomes an expression — it
+    // stops finding ANY upload and reports the split as missing, which is the
+    // opposite of what it checks. The rule is "a coverage upload exists on
+    // both the token and tokenless paths", not "the path is spelled this way".
     const coverageUploads = codecovSteps.filter((step) =>
-      step.block.includes("./coverage/lcov.info"),
+      step.block.includes("lcov.info"),
     );
     const tokenless = codecovSteps.filter(
       (step) => !step.block.includes("secrets.CODECOV_TOKEN"),
     );
     const tokenlessCoverage = tokenless.filter((step) =>
-      step.block.includes("./coverage/lcov.info"),
+      step.block.includes("lcov.info"),
     );
-    const tokenlessResults = tokenless.filter((step) =>
-      step.block.includes("vitest.xml"),
+    const tokenlessResults = tokenless.filter(
+      (step) => step.block.includes("vitest") && step.block.includes(".xml"),
     );
     check(
       content.includes(


### PR DESCRIPTION
## The measurement

Green `main` run 31363433811 — the `test` job is 752s, and **65% of it is one step**:

| step | wall |
|---|---|
| **50. Test (split passes, with coverage gate)** | **486s** |
| 7. Lint + format | 85s |
| the other ~45 steps | ~180s |

| pass | files | wall | of which import |
|---|---|---|---|
| shared registry | 722 | 320s | 63s |
| module-mocking | **71** | **158s** | **129s** |

**Nothing here is slow because the tests are slow.** It's slow because ~266s of validators, lint, typecheck and build run *sequentially in the same job* as a 486s test step, and because the two vitest passes run one after the other when they share nothing at all.

## What changes

- **`validate`** keeps the ~45 gates, lint, typecheck and build.
- **`test`** becomes a 4-leg matrix: the shared pass in three file shards, the mocking pass on its own.

Wall becomes `max(validate, slowest leg)` instead of the sum. Expected: **752s → ~270s**, after which the bottleneck is `validate` and `Lint + format` (85s) is the next target.

`run-ci-tests.ts` grows `--pass` and `--shard`. **The default is unchanged** — both passes, sequentially — because that's what a developer runs locally and what `npm run test:ci` has always meant.

## Things I deliberately kept honest

- **The partition is still computed** from source on every run. Sharding changes how many runners share the work, never *which* files are mocking files — a hand-listed partition is the contamination #8922 removed.
- **`--shard` is refused on the mocking pass** rather than silently ignored. 71 files don't need slicing, and asking for it means the caller believes something untrue about what's running.
- **Coverage is not narrowed.** Each leg uploads its own report; Codecov merges by commit SHA exactly as it already merged the two passes' separate uploads. `Verify coverage reports exist` still refuses an empty report *per leg*, so a partial denominator can't slip through — that check is the reason it exists.
- **`fail-fast: false`**, so a shard-specific failure doesn't cancel the legs whose results you need to interpret it.

## One gate had to move with it

`validate-workflows` matched the literal `./coverage/lcov.info`. The uploads are matrix-driven now (`./${{ matrix.cov }}/lcov.info`), so that literal finds **nothing** and the gate reports the token/tokenless split as *missing* — the opposite of what it checks. It now matches `lcov.info` and `vitest*.xml`: the rule is "a coverage upload exists on both the token and tokenless paths", not "the path is spelled this way". Commented so nobody tightens it back.

## Verification

- `--pass=mocked` → 71 files, **5,184 tests green, 49s** locally.
- `--pass=shared --shard=1/3` → 242 of 724 files, **4,119 tests green, 47s**.
- Both new guards proven to fail: `--pass=bogus` and `--shard` without `--pass=shared` exit 1 with a stated reason.
- All 45 validators, `tsc`, `eslint`, `prettier` clean; workflow YAML parses and `validate:workflows` passes.

**The real proof is this PR's own run** — the acceptance criterion is a measured halving on a real run, and I'll quote the numbers from it here once it completes.

Closes #10414
