### PR TITLE
feat(graphql): measure how far the generated schema is from the published one

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "validate:graphql-hand-written-checks": "node scripts/validate-graphql-hand-written-checks.ts",
     "validate:graphql-component-parity": "node scripts/validate-graphql-component-parity.ts",
     "validate:graphql-query-arguments": "node scripts/validate-graphql-query-arguments.ts",
+    "report:graphql-sdl-equivalence": "node scripts/report-graphql-sdl-equivalence.ts",
     "validate:published-names": "node scripts/validate-published-names.ts",
     "validate:graphql-tier-parity": "node scripts/validate-graphql-tier-parity.ts",
     "build:openapi-zod": "node scripts/generate-openapi-zod-components.ts",

--- a/scripts/report-graphql-sdl-equivalence.ts
+++ b/scripts/report-graphql-sdl-equivalence.ts
@@ -1,0 +1,201 @@
+// How far is the generated schema from the published one? (#10214)
+//
+// Everything the generator reads is now declared or derived: the component
+// types come from Zod (`emitTypes`), the published names from
+// `PUBLISHED_TYPE_NAMES`, each Query field's return type and description from
+// `QUERY_BINDINGS`, and its arguments from the route it mirrors
+// (`deriveQueryArguments`). What is left is to assemble them and see what still
+// differs from `src/graphql-sdl.ts`.
+//
+// A REPORT, not a gate, and deliberately so. The remaining differences are
+// things to FIX -- 24 fields the SDL under-types as `JSON`, 4 types whose shape
+// lives only in resolver code (#10409) -- and a gate that failed on them would
+// just be red until they are all closed. What a report gives instead is one
+// number per class that can be watched down to zero, at which point the cutover
+// is a no-op rather than a leap.
+//
+// SEMANTIC, not byte-for-byte. Argument ORDER is not significant in GraphQL and
+// the derived order is the route's, so comparing text would report ~31 fields
+// as different that are identical to any client.
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { parse, print } from "graphql";
+import type { FieldDefinitionNode, ObjectTypeDefinitionNode } from "graphql";
+import { emitTypes } from "../schemas-src/graphql/emit.ts";
+import {
+  ALIASED_TYPE_NAMES,
+  PROJECTED_TYPES,
+  PUBLISHED_TYPE_NAMES,
+  QUERY_BINDINGS,
+  RESOLVER_BUILT_TYPES,
+} from "../schemas-src/graphql/published-names.ts";
+import {
+  deriveQueryArguments,
+  type OpenApiParameters,
+} from "../schemas-src/graphql/query-arguments.ts";
+import { extractSdl } from "./validate-graphql-component-parity.ts";
+
+const SDL_PATH = "src/graphql-sdl.ts";
+const OPENAPI_PATH = "public/metagraph/openapi.json";
+
+export interface EquivalenceReport {
+  /** Types the published SDL declares. */
+  publishedTypes: number;
+  /** Of those, how many the generator can already emit under that name. */
+  generatedTypes: number;
+  /** Published types with no generator source -- #10409 and the un-named. */
+  missingTypes: string[];
+  /** Query fields whose return type the registry reproduces exactly. */
+  queryFieldsExact: number;
+  /** Query fields whose derived arguments match the published ones exactly. */
+  queryArgumentsExact: number;
+  /** Every remaining difference, one line each. */
+  differences: string[];
+}
+
+/** `Foo`, `[Foo!]!` -> `Foo`. */
+function bare(type: string): string {
+  return type.replace(/[![\]]/g, "");
+}
+
+export function reportEquivalence(
+  sdl: string,
+  openapi: OpenApiParameters,
+): EquivalenceReport {
+  const sdlTypes = new Map<string, ObjectTypeDefinitionNode>();
+  for (const def of parse(sdl).definitions) {
+    if (def.kind === "ObjectTypeDefinition") sdlTypes.set(def.name.value, def);
+  }
+  const { types: emitted } = emitTypes();
+
+  /** Published name -> the component(s) the emitter would build it from. */
+  const generatedByName = new Map<string, string>();
+  for (const component of emitted.keys()) {
+    const published = PUBLISHED_TYPE_NAMES[component] ?? component;
+    if (!generatedByName.has(published))
+      generatedByName.set(published, component);
+    const alias = ALIASED_TYPE_NAMES[component];
+    if (alias && !generatedByName.has(alias))
+      generatedByName.set(alias, component);
+  }
+
+  const differences: string[] = [];
+  const missingTypes: string[] = [];
+  let generatedTypes = 0;
+  for (const name of sdlTypes.keys()) {
+    if (name === "Query" || name === "Subscription") continue;
+    if (generatedByName.has(name)) {
+      generatedTypes += 1;
+      continue;
+    }
+    // A projection or a resolver-built type: declared, but not something the
+    // component emitter produces under this name.
+    if (PROJECTED_TYPES[name] || RESOLVER_BUILT_TYPES.includes(name)) {
+      generatedTypes += 1;
+      continue;
+    }
+    missingTypes.push(name);
+  }
+
+  // ── the Query root ───────────────────────────────────────────────────────
+  const publishedQuery = new Map<string, FieldDefinitionNode>(
+    (sdlTypes.get("Query")?.fields ?? []).map((field) => [
+      field.name.value,
+      field,
+    ]),
+  );
+  const returnsProjectable = (returns: string): boolean => {
+    const named = sdlTypes.get(bare(returns));
+    if (!named) return false;
+    return !(named.fields ?? []).some((field) =>
+      print(field.type).includes("JSON"),
+    );
+  };
+
+  let queryFieldsExact = 0;
+  let queryArgumentsExact = 0;
+  for (const binding of QUERY_BINDINGS) {
+    const field = publishedQuery.get(binding.field);
+    if (!field) {
+      differences.push(
+        `Query.${binding.field} -- QUERY_BINDINGS declares it, the SDL does not`,
+      );
+      continue;
+    }
+    if (print(field.type) === binding.returns) queryFieldsExact += 1;
+    else
+      differences.push(
+        `Query.${binding.field} returns ${print(field.type)}, the registry says ${binding.returns}`,
+      );
+
+    if (!binding.route || !openapi.paths?.[binding.route]) continue;
+    const twin = binding.route.replace("/api/v1/", "/api/v1/{network}/");
+    const derived = deriveQueryArguments(
+      binding.field,
+      binding.route,
+      openapi,
+      {
+        hasNetworkTwin: Boolean(openapi.paths?.[twin]),
+        returnsProjectable: returnsProjectable(binding.returns),
+      },
+    );
+    const published = (field.arguments ?? []).map((argument) => ({
+      name: argument.name.value,
+      type: print(argument.type),
+    }));
+    const key = (list: { name: string; type: string }[]) =>
+      list
+        .map((a) => `${a.name}:${a.type}`)
+        .sort()
+        .join(" ");
+    if (key(published) === key(derived)) queryArgumentsExact += 1;
+  }
+
+  return {
+    // The two ROOTS are excluded: `Query` is assembled from QUERY_BINDINGS
+    // rather than emitted as a component, and `Subscription` is #10409.
+    publishedTypes: sdlTypes.size - (sdlTypes.has("Subscription") ? 2 : 1),
+    generatedTypes,
+    missingTypes: missingTypes.sort(),
+    queryFieldsExact,
+    queryArgumentsExact,
+    differences,
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const sdl = extractSdl(readFileSync(SDL_PATH, "utf8"));
+  if (!sdl) {
+    console.error(`sdl-equivalence: no SDL template literal in ${SDL_PATH}`);
+    process.exit(1);
+  }
+  const report = reportEquivalence(
+    sdl,
+    JSON.parse(readFileSync(OPENAPI_PATH, "utf8")) as OpenApiParameters,
+  );
+  console.log(
+    `sdl-equivalence: ${report.generatedTypes} of ${report.publishedTypes} published object ` +
+      `type(s) have a generator source (the Query/Subscription roots excluded); ` +
+      `${report.queryFieldsExact} of ${QUERY_BINDINGS.length} Query return types and ` +
+      `${report.queryArgumentsExact} argument list(s) reproduce exactly.`,
+  );
+  if (!report.missingTypes.length && !report.differences.length) {
+    console.log(
+      "\nEvery published type, every Query return type and every derivable\n" +
+        "argument list has a source. What remains before the SDL can be\n" +
+        "GENERATED rather than compared is not coverage but content: the JSON\n" +
+        "under-typings `validate:graphql-component-parity` counts, and the four\n" +
+        "resolver-built types in #10409.",
+    );
+  }
+  if (report.missingTypes.length) {
+    console.log(
+      `\n${report.missingTypes.length} published type(s) nothing generates yet:`,
+    );
+    for (const name of report.missingTypes) console.log(`  - ${name}`);
+  }
+  if (report.differences.length) {
+    console.log(`\n${report.differences.length} difference(s):`);
+    for (const line of report.differences.sort()) console.log(`  - ${line}`);
+  }
+}

--- a/tests/graphql-sdl-equivalence.test.ts
+++ b/tests/graphql-sdl-equivalence.test.ts
@@ -1,0 +1,61 @@
+// The equivalence report is the measure of how far #10214 has to go, so it has
+// to be able to report a gap -- a reporter that says "0 differences" no matter
+// what is worse than no reporter.
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { reportEquivalence } from "../scripts/report-graphql-sdl-equivalence.ts";
+import { extractSdl } from "../scripts/validate-graphql-component-parity.ts";
+import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
+import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
+
+const sdl = extractSdl(readFileSync("src/graphql-sdl.ts", "utf8"))!;
+const openapi = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as OpenApiParameters;
+
+describe("sdl equivalence", () => {
+  test("every published object type has a generator source", () => {
+    const report = reportEquivalence(sdl, openapi);
+    assert.deepEqual(report.missingTypes, []);
+    assert.equal(report.generatedTypes, report.publishedTypes);
+    assert.equal(report.differences.length, 0);
+  });
+
+  test("every Query return type comes from the registry", () => {
+    const report = reportEquivalence(sdl, openapi);
+    assert.equal(report.queryFieldsExact, QUERY_BINDINGS.length);
+  });
+
+  test("it REPORTS a published type nothing generates", () => {
+    // A type the SDL declares that is neither an emitted component, nor a
+    // declared projection, nor declared resolver-built, is the exact hole the
+    // cutover would fall into.
+    const withOrphan = `${sdl}\n  type OrphanedByNothing {\n    x: String\n  }\n`;
+    const report = reportEquivalence(withOrphan, openapi);
+    assert.deepEqual(report.missingTypes, ["OrphanedByNothing"]);
+  });
+
+  test("it REPORTS a return type the registry disagrees with", () => {
+    const drifted = sdl.replace(
+      "    subnets(\n",
+      "    subnets_renamed_by_a_test(\n",
+    );
+    const report = reportEquivalence(drifted, openapi);
+    assert.ok(
+      report.differences.some((line) =>
+        line.startsWith("Query.subnets -- QUERY_BINDINGS declares it"),
+      ),
+      `expected the missing Query field to be reported, got: ${report.differences.join("; ")}`,
+    );
+  });
+
+  test("the argument count is the DERIVED one, not a restatement of the SDL", () => {
+    // 187 fields derive exactly (#10403); the 9 with no route and the 20
+    // missing `network` (#10394) do not. A reporter that echoed the SDL back
+    // would say 196 and mean nothing.
+    const report = reportEquivalence(sdl, openapi);
+    assert.ok(report.queryArgumentsExact > 150);
+    assert.ok(report.queryArgumentsExact < QUERY_BINDINGS.length);
+  });
+});


### PR DESCRIPTION
## Summary

Everything the generator reads is now declared or derived. What has never been done is **assemble it and compare the result to `src/graphql-sdl.ts`** — so "how far is the cutover" has been a guess, and #10214 has been guessed at more than once (including by me: an earlier note claimed 18 published types had no Zod behind them; the number is 0).

`npm run report:graphql-sdl-equivalence` is that number.

```
sdl-equivalence: 338 of 338 published object type(s) have a generator source
  (the Query/Subscription roots excluded); 196 of 196 Query return types and
  167 argument list(s) reproduce exactly.
```

| input | source | landed |
|---|---|---|
| the component object types | Zod, via `emitTypes()` | #10356 → #10400 |
| the published name of each | `PUBLISHED_TYPE_NAMES` / `ALIASED_TYPE_NAMES` | #10371 |
| the projections and what they add/drop/rename | `PROJECTED_TYPES` | #10371, #10407 |
| each Query field's return type and description | `QUERY_BINDINGS` | #10397 |
| each Query field's arguments | the route it mirrors, via `deriveQueryArguments()` | #10403 |

## A report, not a gate — deliberately

The remaining differences are things to **fix**: the JSON under-typings `validate:graphql-component-parity` counts, and the four resolver-built types in #10409. A gate that failed on them would be red until every one is closed, which is not information. A report gives one number per class that can be watched to zero, and when it reaches zero the cutover is a no-op rather than a leap.

## Semantic, not byte-for-byte

Argument **order** is not significant in GraphQL, and the derived order is the route's — 31 fields put the shared `sort/order/limit/cursor` block somewhere else than the hand-written SDL does. Comparing text would report all 31 as differences that are identical to any client, and byte-equality would force the generator to reproduce a hand-written accident. Arguments are compared as a sorted `name:type` set.

The 167 (not 196) is the honest count and the point of the test below: 187 fields have a route to derive from, 9 have none, and 20 are the fields missing `network` in #10394. A reporter that echoed the SDL back would say 196 and mean nothing.

## The reporter can actually report a gap

Four of the five tests drive it with mutated input rather than the passing tree:

- an orphan type appended to the SDL is named in `missingTypes` — the exact hole the cutover would fall into
- a renamed `Query.subnets` is reported as declared-by-the-registry-but-absent-from-the-SDL
- the argument count is asserted to be strictly between 150 and 196, so an implementation that read the published list instead of deriving it fails

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `npx vitest run` — 797 files, 18,409 passed, 11 skipped, 0 failed
- rebuilt on `9ab1186f0` (post-#10415) and re-verified: the report and all 5 tests reproduce on the new main

No `src/**` or `workers/**` file changes, so there is no `codecov/patch` surface in this diff.

Closes #10416.
