### PR TITLE
fix(graphql): compare a projection's types the way a mirror's are compared

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1887,7 +1887,7 @@ export type Contracts = {
   type_definitions_url?: Maybe<Scalars['String']['output']>;
 };
 
-/** Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
+/** Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation). */
 export type CurationList = {
   __typename?: 'CurationList';
   curation: Array<Scalars['JSON']['output']>;
@@ -1895,7 +1895,8 @@ export type CurationList = {
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
-  notes?: Maybe<Scalars['String']['output']>;
+  /** A string or a list of strings, depending on the producer -- /api/v1/endpoints serves three. Declared String until #10409, which nulls the whole row on a list: graphql-js' String serializer throws on a non-scalar. */
+  notes?: Maybe<Scalars['JSON']['output']>;
   order?: Maybe<Scalars['String']['output']>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
@@ -6343,6 +6344,8 @@ export type Validator = {
   realized_return_1w_as_of?: Maybe<Scalars['String']['output']>;
   root_stake_tao?: Maybe<Scalars['Float']['output']>;
   schema_version?: Maybe<Scalars['Int']['output']>;
+  /** This validator's share of all validator stake, as a fraction. Populated from the global leaderboard, which computes it across the whole validator set; NULL from the single-validator lookup, which has no set to divide by (buildValidatorDetail aggregates one hotkey) -- null means unknown, not zero, the same reading featured and uid_count carry (#10409). */
+  stake_dominance?: Maybe<Scalars['Float']['output']>;
   subnet_count?: Maybe<Scalars['Int']['output']>;
   /** Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet. */
   subnets: Array<ValidatorSubnet>;
@@ -8791,7 +8794,7 @@ export type CurationListResolvers<ContextType = GqlContext, ParentType extends R
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -11032,6 +11035,7 @@ export type ValidatorResolvers<ContextType = GqlContext, ParentType extends Reso
   realized_return_1w_as_of?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   root_stake_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  stake_dominance?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   subnets?: Resolver<Array<ResolversTypes['ValidatorSubnet']>, ParentType, ContextType>;
   take?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7446,7 +7446,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
+        /** @description Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation). */
         CurationArtifact: {
             contract_version?: string;
             curation: {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27556,7 +27556,7 @@
       },
       "CurationArtifact": {
         "additionalProperties": {},
-        "description": "Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence).",
+        "description": "Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation).",
         "properties": {
           "contract_version": {
             "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7446,7 +7446,7 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
-        /** @description Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence). */
+        /** @description Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation). */
         CurationArtifact: {
             contract_version?: string;
             curation: {

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -91,6 +91,13 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   AccountEventsArtifact: "AccountEvents",
   AccountExtrinsicsArtifact: "AccountExtrinsics",
   AccountExtrinsicsArtifactExtrinsics: "Extrinsic",
+  // The same row shape reached three ways -- an account's extrinsics, the
+  // global feed, and one extrinsic's detail -- published under one name. All
+  // three components emit the identical twelve fields; naming only the first
+  // left the other two reading as a type mismatch the moment the projection
+  // pass started comparing types at all (#10409).
+  ExtrinsicsFeedArtifactExtrinsics: "Extrinsic",
+  ExtrinsicDetailArtifactExtrinsic: "Extrinsic",
   AccountHistoryArtifact: "AccountHistory",
   AccountHistoryArtifactDays: "AccountDay",
   AccountIdentityArtifact: "AccountIdentity",
@@ -101,6 +108,7 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   AccountParentsArtifactSubnetsEntries: "AccountParentEntry",
   AccountPortfolioArtifact: "AccountPortfolio",
   AccountPortfolioArtifactPositions: "AccountPortfolioPosition",
+  AccountsListArtifactAccountsSubnets: "AccountSubnet",
   AccountPositionHistoryArtifact: "AccountPositionHistory",
   AccountPositionHistoryArtifactPoints: "AccountPositionHistoryPoint",
   AccountPositionsArtifact: "AccountPositions",
@@ -136,6 +144,8 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   AdapterArtifact: "Adapter",
   BlockDetailArtifact: "BlockDetail",
   BlockDetailArtifactBlock: "Block",
+  // Field for field the same eight as the detail component.
+  BlocksFeedArtifactBlocks: "Block",
   BlockEventsArtifact: "BlockEvents",
   BlockExtrinsicsArtifact: "BlockExtrinsics",
   BlocksFeedArtifact: "BlockList",
@@ -387,8 +397,23 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   UptimeArtifactSurfacesDaysLatencyMs: "UptimeLatency",
   UptimeArtifactSurfacesReliability: "UptimeReliability",
   ValidatorDetailArtifact: "Validator",
+  // `validatorNode` (src/graphql.ts) normalizes the two producers into one
+  // published shape on purpose: the list entry names its timestamps
+  // latest_captured_at/latest_block_number and the detail aggregate names
+  // them captured_at/block_number. Where they genuinely differ -- featured,
+  // uid_count and stake_dominance are list-only -- the SDL publishes them
+  // nullable and documents the null, rather than declaring two types.
+  GlobalValidatorsArtifactValidators: "Validator",
   ValidatorDetailArtifactColdkeyIdentity: "Identity",
   ValidatorDetailArtifactSubnets: "ValidatorSubnet",
+  // The list producer's nested rows, reachable only once the traversal steps
+  // through `ValidatorList.items` (#10409). The identity is field for field
+  // the detail's; the membership row is the leaderboard's compact five, a
+  // subset of the detail's eighteen -- one published type over two producers,
+  // which is what `ValidatorSubnet`'s own SDL comment already describes. Both
+  // fields the SDL declares non-null (netuid, uid) are non-null on both sides.
+  GlobalValidatorsArtifactValidatorsColdkeyIdentity: "Identity",
+  GlobalValidatorsArtifactValidatorsSubnets: "ValidatorSubnet",
   ValidatorEconomicsExclusion: "ValidatorEconomicsExclusion",
   ValidatorEconomicsHistoryPoint: "ValidatorEconomicsHistoryPoint",
   ValidatorEconomicsRankingArtifact: "ValidatorEconomicsRanking",
@@ -2031,6 +2056,10 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
     dropped: ["ref", "limit", "offset"],
   },
   AccountEntry: { component: "AccountsListArtifactAccounts", added: [] },
+  // Two producers, one published type, and the ACCOUNTS-LIST one is the whole
+  // of it: `AccountsListArtifactAccountsSubnets` emits exactly the four fields
+  // `AccountSubnet` declares, so the projection below (which drops seven of
+  // the portfolio's eleven) is the same four seen from the other side.
   AccountSubnet: {
     component: "AccountPortfolioArtifactPositions",
     added: [],
@@ -2379,13 +2408,13 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
  *
  * THIS LIST IS THE DEBT, and only it: everything in `PROJECTED_TYPES` gets
  * checked field by field, and everything here is taken on trust. It was 15
- * when #10371 split the two, 8 after the projections were declared, and 5
+ * when #10371 split the two, 8 after the projections were declared, and 4
  * now that the three with a component behind them moved across -- `SubnetList`
  * and `ProviderList` page over `SubnetsArtifact`/`ProvidersArtifact`, and
  * `GlobalHealth` flattens `HealthSummaryArtifact`. Anything that picks its
  * fields from a component belongs there, not here.
  *
- * Why each of the five is still here, and what closing it would take:
+ * Why each of the four is still here, and what closing it would take:
  *
  *   OpportunityBoards       six boards of OpportunityEntry, assembled from a
  *                           leaderboard read. No artifact has this shape.

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -45,7 +45,7 @@ export const CurationArtifactSchema = ArtifactBaseSchema.extend({
 })
   .passthrough()
   .describe(
-    "Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence).",
+    "Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation).",
   );
 export type CurationArtifact = z.infer<typeof CurationArtifactSchema>;
 export const CurationResponseSchema = successEnvelopeSchema(

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -25,6 +25,17 @@
 // gate in the repo. A `Float` over an `Int` is still allowed, in both checks,
 // because a widening loses nothing.
 //
+// #10377 closed that on the MIRRORS only. The projection pass, which is the
+// one that reaches the 39 resolver-built and 25 paginated types, kept
+// comparing nullability and Int-narrowing and nothing else -- so on a third of
+// the published surface a `String` over an object still read as agreement,
+// which is where it matters most: a projection is exactly the place a resolver
+// reshapes a value and can reshape it into the wrong type. Running the same
+// comparison there (#10409) found `Validator.stake_dominance`, a field
+// /api/v1/validators serves and GraphQL could not select, and `CurationList.
+// notes` published as `String` over a `string | string[]` union -- the shape
+// that nulls the whole row, and /api/v1/endpoints serves the list form.
+//
 // HOW THE PAIRS ARE FOUND -- derived, not declared. Each Query field carries a
 // `Mirrors GET /api/v1/...` annotation; the route's OpenAPI response names the
 // component its `data` refs. That seeds SDL-type <-> component pairs, which
@@ -36,6 +47,8 @@ import { readFileSync } from "node:fs";
 import { parse } from "graphql";
 import { GraphQLList, GraphQLNonNull, GraphQLObjectType } from "graphql";
 import type {
+  FieldDefinitionNode,
+  GraphQLField,
   GraphQLOutputType,
   ObjectTypeDefinitionNode,
   TypeNode,
@@ -130,9 +143,15 @@ export const DECLARED: Record<string, string> = {
  * THE LIST ONLY SHRINKS. An entry whose field is no longer under-typed fails,
  * and an under-typed field with no entry fails -- so the count is a live
  * measure of the distance left to the generated schema, and cannot drift up.
+ *
+ * It went 24 -> 51 in #10409, which is not drift: the scalar-identity check
+ * had only ever run on the MIRRORS, and 27 of these sit on a projection or a
+ * paginated view, where nothing had compared a type to a type. The debt did
+ * not grow -- half of it had simply never been counted.
  */
 const JSON_UNDERTYPED: Record<string, string> = {
   "Adapter.snapshot": "AdapterArtifactSnapshot",
+  "BlockChainEvents.events": "[AccountEvent!]",
   "BlockExtrinsics.extrinsics": "[BlockExtrinsicsArtifactExtrinsics!]",
   "BuildSummary.artifact_budget_summary":
     "BuildSummaryArtifactArtifactBudgetSummary",
@@ -153,6 +172,36 @@ const JSON_UNDERTYPED: Record<string, string> = {
   "ComparedValidator.subnet_context":
     "CompareValidatorsArtifactValidatorsSubnetContext",
   "Contracts.artifacts": "[ContractsArtifactArtifacts!]",
+  "CurationList.curation": "[CurationArtifactCuration!]",
+  "EndpointPoolList.pools": "[RpcPool!]",
+  "EvidenceList.claims": "[EvidenceClaim!]",
+  "EvidenceList.summary": "EvidenceLedgerArtifactSummary",
+  "GapsList.gaps": "[GapsArtifactGaps!]",
+  "GlobalIncidents.summary": "GlobalIncidentsArtifactSummary",
+  "HealthHistory.summary": "HealthProbeSummary",
+  "HealthHistory.surfaces": "[HealthHistoryArtifactSurfaces!]",
+  "IncidentList.incidents": "[EndpointIncident!]",
+  "IncidentList.summary": "EndpointIncidentsArtifactSummary",
+  "PoolList.pools": "[RpcPool!]",
+  "ProfileList.profiles": "[SubnetProfile!]",
+  "ReviewAdapterCandidateList.candidates": "[ReviewAdapterCandidate!]",
+  "ReviewEnrichmentEvidenceList.entries":
+    "[ReviewEnrichmentEvidenceArtifactEntries!]",
+  "ReviewEnrichmentEvidenceList.notes": "String",
+  "ReviewEnrichmentQueueList.notes": "String",
+  "ReviewEnrichmentQueueList.queue": "[ReviewEnrichmentQueueArtifactQueue!]",
+  "ReviewEnrichmentTargetList.notes": "String",
+  "ReviewEnrichmentTargetList.targets":
+    "[ReviewEnrichmentTargetsArtifactTargets!]",
+  "ReviewGapPriorityList.priorities": "[ReviewGapPriority!]",
+  "ReviewProfileCompletenessList.profiles":
+    "[ReviewProfileCompletenessArtifactProfiles!]",
+  "ReviewProfileCompletenessList.summary":
+    "ReviewProfileCompletenessArtifactSummary",
+  "SearchDocumentList.documents": "[SearchArtifactDocuments!]",
+  "SearchIndexList.documents": "[SearchIndexArtifactDocuments!]",
+  "SourceSnapshotList.sources": "[SourceSnapshotsArtifactSources!]",
+  "SourceSnapshotList.summary": "SourceSnapshotsArtifactSummary",
   "SubnetConviction.leaderboard": "[SubnetConvictionArtifactLeaderboard!]",
   "SubnetEventSummary.categories": "[SubnetEventSummaryArtifactCategories!]",
   "SubnetEventSummary.event_kinds": "[SubnetEventSummaryArtifactEventKinds!]",
@@ -265,6 +314,86 @@ function generatedTypeName(type: GraphQLOutputType): string | null {
 }
 
 /**
+ * The SDL's published shape for a field against the emitted one -- `null` when
+ * they are the same type, otherwise both spellings.
+ *
+ * SCALAR IDENTITY, the check that closes #10377's blind spot: until it existed,
+ * `String` against `JSON` read as agreement, so 348 fields could be retyped
+ * `JSON` and no gate in the repo would have said anything.
+ *
+ * The two name systems are reconciled through PUBLISHED_TYPE_NAMES: the
+ * component `SubnetIndexEntry` is published as `Subnet`, and comparing raw ids
+ * would report all 300-odd mirrors as mismatched.
+ *
+ * A WIDENING is not a divergence. `Float` over `Int` accepts every value the
+ * component can hold, and 13 fields declare it deliberately for a computed
+ * value (`mean_ms`, `stability_score`, the percentiles) whose component happens
+ * to hold whole numbers today. The dangerous direction -- `Int` over `Float`,
+ * which on GraphQL's 32-bit Int errors on every epoch-millisecond value -- is a
+ * separate check at both call sites.
+ *
+ * Extracted from the mirror pass so the PROJECTION pass gets it too. It never
+ * had it: the projections were checked for nullability and Int-narrowing only,
+ * so on 39 types -- every paginated view, every resolver-flattened card -- a
+ * `String` over an object read as agreement exactly the way #10377 described.
+ */
+function shapeDivergence(
+  sdlNode: FieldDefinitionNode,
+  genField: GraphQLField<unknown, unknown>,
+  publishedAs: (component: string) => ReadonlySet<string>,
+): { published: string; wanted: string } | null {
+  const sdlSide = sdlLeaf(sdlNode.type);
+  const genSide = generatedLeaf(genField.type);
+  const names = publishedAs(genSide.name);
+  if (
+    sdlSide.list === genSide.list &&
+    (names.has(sdlSide.name) || (sdlSide.name === "Float" && names.has("Int")))
+  ) {
+    return null;
+  }
+  const written = (side: { name: string; list: boolean }, name: string) =>
+    side.list ? `[${name}!]` : name;
+  return {
+    published: written(sdlSide, sdlSide.name),
+    wanted: written(
+      genSide,
+      PUBLISHED_TYPE_NAMES[genSide.name] ?? genSide.name,
+    ),
+  };
+}
+
+/**
+ * Every name the published SDL may legitimately spell an emitted component
+ * under: its own, its `PUBLISHED_TYPE_NAMES` name, its alias, and every
+ * projection declared over it.
+ *
+ * The PROJECTION route is what the mirror pass never needed and the projection
+ * pass cannot do without: `SubnetsArtifact.subnets` emits `[SubnetIndexEntry!]`
+ * and the SDL publishes `[Subnet!]`, which is not a rename -- it is
+ * `PROJECTED_TYPES.Subnet`, declared with the component it picks from. Reading
+ * only the rename map would report all 39 projections as mismatched.
+ */
+function publishedNameResolver(
+  projectedTypesMap: Readonly<Record<string, (typeof PROJECTED_TYPES)[string]>>,
+): (component: string) => ReadonlySet<string> {
+  const byComponent = new Map<string, Set<string>>();
+  const add = (component: string, name: string) => {
+    const seen = byComponent.get(component);
+    if (seen) seen.add(name);
+    else byComponent.set(component, new Set([name]));
+  };
+  for (const [published, projection] of Object.entries(projectedTypesMap))
+    add(projection.component, published);
+  return (component: string) => {
+    const names = new Set(byComponent.get(component) ?? []);
+    names.add(PUBLISHED_TYPE_NAMES[component] ?? component);
+    const alias = ALIASED_TYPE_NAMES[component];
+    if (alias) names.add(alias);
+    return names;
+  };
+}
+
+/**
  * Compare a GraphQL SDL against the Zod components its types mirror.
  *
  * Takes the SDL text and the OpenAPI document rather than reading them, so a
@@ -284,6 +413,7 @@ export function checkComponentParity(
     if (def.kind === "ObjectTypeDefinition") sdlTypes.set(def.name.value, def);
   }
   const { types: generated } = emitTypes();
+  const publishedAs = publishedNameResolver(projectedTypesMap);
 
   /** The component a route's `data` property refs. */
   const dataComponent = (route: string): string | null => {
@@ -419,38 +549,12 @@ export function checkComponentParity(
                 `${componentName} emits ${genScalar}`,
             );
           }
-          // SCALAR IDENTITY -- the blind spot that hid the whole enum->JSON
-          // class (#10377). Until this, `String` against `JSON` read as
-          // agreement, so 348 fields could be retyped `JSON` and no gate would
-          // have said anything.
-          //
-          // The two name systems are reconciled through PUBLISHED_TYPE_NAMES:
-          // the component `SubnetIndexEntry` is published as `Subnet`, and
-          // comparing raw ids would report all 300-odd mirrors as mismatched.
-          const sdlSide = sdlLeaf(sdlNode.type);
-          const genSide = generatedLeaf(genField.type);
-          const genPublished =
-            PUBLISHED_TYPE_NAMES[genSide.name] ?? genSide.name;
+          // SCALAR IDENTITY -- see `shapeDivergence`.
           const key = `${sdlName}.${name}`;
-          const sameShape =
-            sdlSide.list === genSide.list &&
-            (sdlSide.name === genPublished ||
-              // The one component published under a second name.
-              sdlSide.name === ALIASED_TYPE_NAMES[genSide.name] ||
-              // A WIDENING, left alone here for the same reason the narrowing
-              // check above states: a Float accepts every integer, and 13
-              // fields declare it deliberately for a computed value
-              // (`mean_ms`, `stability_score`, the percentiles) whose
-              // component happens to hold whole numbers today. The dangerous
-              // direction -- Int over Float -- is the check above.
-              (sdlSide.name === "Float" && genPublished === "Int"));
-          if (!sameShape) {
-            const written = (
-              side: { name: string; list: boolean },
-              n: string,
-            ) => (side.list ? `[${n}!]` : n);
-            const wanted = written(genSide, genPublished);
-            if (sdlSide.name === "JSON") {
+          const divergence = shapeDivergence(sdlNode, genField, publishedAs);
+          if (divergence) {
+            const { published, wanted } = divergence;
+            if (published.replace(/[![\]]/g, "") === "JSON") {
               // UNDER-typing: the SDL publishes an opaque blob where the
               // component has a shape. Not a runtime fault -- JSON serializes
               // anything -- but a caller cannot select into it, which is the
@@ -473,7 +577,7 @@ export function checkComponentParity(
               // is the dangerous direction: graphql-js' String serializer
               // throws on a non-scalar and nulls the surrounding object.
               violations.push(
-                `${key} -- the SDL declares ${written(sdlSide, sdlSide.name)}, ` +
+                `${key} -- the SDL declares ${published}, ` +
                   `${componentName} emits ${wanted}`,
               );
             }
@@ -547,12 +651,13 @@ export function checkComponentParity(
         continue;
       }
       projectedFields += 1;
-      // Same two checks the mirrors get. A projection publishing a non-null
-      // over a nullable component field is the response-shaped outage: one
-      // null and graphql-js nulls the whole surrounding object.
+      // The same THREE checks the mirrors get. A projection publishing a
+      // non-null over a nullable component field is the response-shaped
+      // outage: one null and graphql-js nulls the whole surrounding object.
+      const key = `${sdlName}.${name}`;
       if (sdlIsNonNull(field.type) && !generatedIsNonNull(genField.type)) {
         violations.push(
-          `${sdlName}.${name} -- the SDL declares it non-null, ` +
+          `${key} -- the SDL declares it non-null, ` +
             `${projection.component} says it is nullable`,
         );
       }
@@ -561,9 +666,33 @@ export function checkComponentParity(
         generatedScalarName(genField.type) === "Float"
       ) {
         violations.push(
-          `${sdlName}.${name} -- the SDL declares Int, ` +
+          `${key} -- the SDL declares Int, ` +
             `${projection.component} emits Float`,
         );
+      }
+      // Scalar identity. The projections did not have this check until
+      // #10409, which is the same hole #10377 closed for the mirrors, left
+      // open on the 39 types nothing else reaches -- and it is where it
+      // matters most, because a projection is exactly the place a resolver
+      // reshapes a value and can reshape it into the wrong type.
+      const divergence = shapeDivergence(field, genField, publishedAs);
+      if (divergence) {
+        const { published, wanted } = divergence;
+        if (published.replace(/[![\]]/g, "") === "JSON") {
+          if (JSON_UNDERTYPED[key] === wanted) undertypedMatched.add(key);
+          else
+            violations.push(
+              `${key} -- the SDL declares JSON, ${projection.component} ` +
+                `emits ${wanted}; declare it in JSON_UNDERTYPED or publish the type`,
+            );
+        } else if (declared[key]) {
+          matched.add(key);
+        } else {
+          violations.push(
+            `${key} -- the SDL declares ${published}, ` +
+              `${projection.component} emits ${wanted}`,
+          );
+        }
       }
     }
     for (const name of added) {

--- a/scripts/validate-published-names.ts
+++ b/scripts/validate-published-names.ts
@@ -21,7 +21,11 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parse, print } from "graphql";
-import type { ObjectTypeDefinitionNode, TypeNode } from "graphql";
+import type {
+  GraphQLObjectType,
+  ObjectTypeDefinitionNode,
+  TypeNode,
+} from "graphql";
 import { emitTypes } from "../schemas-src/graphql/emit.ts";
 import {
   ALIASED_TYPE_NAMES,
@@ -106,6 +110,115 @@ export function compareQueryBindings(
   return problems;
 }
 
+/** What the SDL walk found: name identities, mirrors, and everything reached. */
+export interface Traversal {
+  /** component -> every published name it MIRRORS under. */
+  computed: Map<string, Set<string>>;
+  /** SDL types reached as a full mirror. */
+  paired: Set<string>;
+  /** Every component the SDL can reach, projections included. */
+  reachable: Set<string>;
+}
+
+/**
+ * Walk the SDL from its route-backed roots and record what it reaches.
+ *
+ * TWO SEED KINDS, and the difference is the whole point. A `mirror` seed
+ * asserts a NAME IDENTITY -- this SDL type is that component under another
+ * name -- and is what the missing/mismatched checks read. A `projection` seed
+ * asserts only that the type is REACHABLE: `AccountSubnet` picks four of
+ * `AccountPortfolioArtifactPositions`' eleven fields, and that component's own
+ * published name is `AccountPortfolioPosition`, so recording the pair would
+ * assert two different types are the same one.
+ *
+ * The projections have to be seeded at all because the walk steps through
+ * SAME-NAMED fields and a paginated view renames its row array --
+ * `BlockList.items` over `BlocksFeedArtifact.blocks`. Without the rename the
+ * walk dead-ends there and never reaches the element component, which is why
+ * five components the SDL genuinely publishes had no registry entry and could
+ * not have had one: naming them read as stale (#10409).
+ *
+ * A pure function over its inputs so a test can drive it with a MUTATED
+ * registry and prove the walk actually reaches what it claims to -- the rest
+ * of this script reads the repo at module load.
+ */
+export function traverse(
+  sdlTypes: ReadonlyMap<string, ObjectTypeDefinitionNode>,
+  generated: ReadonlyMap<string, GraphQLObjectType>,
+  mirrorSeeds: readonly [string, string][],
+  projections: Readonly<Record<string, (typeof PROJECTED_TYPES)[string]>>,
+): Traversal {
+  /** A projection's renamed row array / row count, per published type. */
+  const renamedFields = new Map<string, Map<string, string>>();
+  for (const [published, projection] of Object.entries(projections)) {
+    const renames = new Map<string, string>();
+    if (projection.itemsFrom) renames.set("items", projection.itemsFrom);
+    if (projection.totalFrom) renames.set("total", projection.totalFrom);
+    if (renames.size) renamedFields.set(published, renames);
+  }
+
+  const queue: [string, string, "mirror" | "projection"][] = [
+    ...mirrorSeeds.map(
+      ([sdlName, component]) =>
+        [sdlName, component, "mirror"] as [string, string, "mirror"],
+    ),
+    ...Object.entries(projections).map(
+      ([published, projection]) =>
+        [published, projection.component, "projection"] as [
+          string,
+          string,
+          "projection",
+        ],
+    ),
+  ];
+  const computed = new Map<string, Set<string>>();
+  const paired = new Set<string>();
+  const reachable = new Set<string>();
+  const visited = new Set<string>();
+  while (queue.length) {
+    const [sdlName, componentName, kind] = queue.shift()!;
+    const sdlType = sdlTypes.get(sdlName);
+    const genType = generated.get(componentName);
+    if (!sdlType || !genType) continue;
+    // One visited set for BOTH kinds. Guarding only the mirrors would let a
+    // projection whose descendant is that same projection re-expand forever.
+    const key = `${sdlName}|${componentName}|${kind}`;
+    if (visited.has(key)) continue;
+    visited.add(key);
+    reachable.add(componentName);
+    if (kind === "mirror") {
+      const seen = computed.get(componentName);
+      if (seen) seen.add(sdlName);
+      else computed.set(componentName, new Set([sdlName]));
+      paired.add(sdlName);
+    }
+    const genFields = genType.getFields();
+    const renames = renamedFields.get(sdlName);
+    for (const field of sdlType.fields ?? []) {
+      const child =
+        genFields[renames?.get(field.name.value) ?? field.name.value];
+      if (!child) continue;
+      const childSdl = namedType(field.type);
+      const childGen = generatedName(child.type);
+      if (childGen && sdlTypes.has(childSdl) && generated.has(childGen)) {
+        // A child that is ITSELF a declared projection stays one. Reaching
+        // `Subnet` through `SubnetList.items` -> `SubnetsArtifact.subnets`
+        // says where it comes from, not that it mirrors `SubnetIndexEntry`
+        // field for field -- it publishes four fields the component has not
+        // got and drops twelve it has. Recording it as a mirror would assert
+        // both a name identity that is false and that its PROJECTED_TYPES
+        // entry is stale.
+        queue.push([
+          childSdl,
+          childGen,
+          projections[childSdl] ? "projection" : "mirror",
+        ]);
+      }
+    }
+  }
+  return { computed, paired, reachable };
+}
+
 const sdl = extractSdl(readFileSync(SDL_PATH, "utf8"));
 if (!sdl) {
   console.error(`published-names: no SDL template literal in ${SDL_PATH}`);
@@ -163,36 +276,18 @@ const sdlBindings = (sdlTypes.get("Query")?.fields ?? []).map((field) => {
 });
 
 // ── the pairing, computed the way the parity gate computes it ────────────────
-const queue: [string, string][] = [];
-for (const binding of sdlBindings) {
-  if (!binding.route) continue;
-  const component = dataComponent(binding.route);
-  if (component) queue.push([binding.returnsName, component]);
-}
-/** component -> every published name it is reached under. */
-const computed = new Map<string, Set<string>>();
-const paired = new Set<string>();
-while (queue.length) {
-  const [sdlName, componentName] = queue.shift()!;
-  const sdlType = sdlTypes.get(sdlName);
-  const genType = generated.get(componentName);
-  if (!sdlType || !genType) continue;
-  const seen = computed.get(componentName);
-  if (seen?.has(sdlName)) continue;
-  if (seen) seen.add(sdlName);
-  else computed.set(componentName, new Set([sdlName]));
-  paired.add(sdlName);
-  const genFields = genType.getFields();
-  for (const field of sdlType.fields ?? []) {
-    const child = genFields[field.name.value];
-    if (!child) continue;
-    const childSdl = namedType(field.type);
-    const childGen = generatedName(child.type);
-    if (childGen && sdlTypes.has(childSdl) && generated.has(childGen)) {
-      queue.push([childSdl, childGen]);
-    }
-  }
-}
+const { computed, paired, reachable } = traverse(
+  sdlTypes,
+  generated,
+  sdlBindings.flatMap((binding) => {
+    if (!binding.route) return [];
+    const component = dataComponent(binding.route);
+    return component
+      ? ([[binding.returnsName, component]] as [string, string][])
+      : [];
+  }),
+  PROJECTED_TYPES,
+);
 
 const errors: string[] = [];
 
@@ -242,7 +337,7 @@ if (mismatched.length) {
 }
 
 const stale = Object.keys(PUBLISHED_TYPE_NAMES)
-  .filter((component) => !computed.has(component))
+  .filter((component) => !reachable.has(component))
   .sort();
 if (stale.length) {
   errors.push(

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2329,10 +2329,11 @@ export const SDL = /* GraphQL */ `
     order: String
   }
 
-  "Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence)."
+  "Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation)."
   type CurationList {
     generated_at: String
-    notes: String
+    "A string or a list of strings, depending on the producer -- /api/v1/endpoints serves three. Declared String until #10409, which nulls the whole row on a list: graphql-js' String serializer throws on a non-scalar."
+    notes: JSON
     curation: [JSON!]!
     total: Int!
     returned: Int!
@@ -4532,6 +4533,8 @@ export const SDL = /* GraphQL */ `
     realized_return_1m_as_of: String
     avg_validator_trust: Float
     max_validator_trust: Float
+    "This validator's share of all validator stake, as a fraction. Populated from the global leaderboard, which computes it across the whole validator set; NULL from the single-validator lookup, which has no set to divide by (buildValidatorDetail aggregates one hotkey) -- null means unknown, not zero, the same reading featured and uid_count carry (#10409)."
+    stake_dominance: Float
     captured_at: String
     block_number: Int
     "Per-subnet membership rows for this validator. The global leaderboard entry caps this at the top 10 by stake; the single-validator lookup carries every subnet."

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -256,7 +256,7 @@ describe("scalar identity", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.undertyped, 24);
+    assert.equal(report.undertyped, 51);
   });
 
   test("it FAILS when a field is retyped to a different scalar", () => {
@@ -297,7 +297,7 @@ describe("scalar identity", () => {
   });
 
   test("a CLOSED under-typing makes its declaration stale, so the list shrinks", () => {
-    // `Adapter.snapshot` is one of the 24 still open. Publishing the shape its
+    // `Adapter.snapshot` is one of the 51 still open. Publishing the shape its
     // component already describes has to make the declaration stale, or the
     // list would keep an entry for a gap that no longer exists.
     const fixed = inType(
@@ -311,7 +311,7 @@ describe("scalar identity", () => {
       report.stale.includes("Adapter.snapshot"),
       `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
     );
-    assert.equal(report.undertyped, 23);
+    assert.equal(report.undertyped, 50);
   });
 
   test("a Float over an Int component field is a WIDENING and stays allowed", () => {
@@ -423,6 +423,67 @@ describe("paginated views", () => {
         v.startsWith("GlobalIncidents -- pages over GlobalIncidentsArtifact"),
       ),
       `expected the undeclared view to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  // ── scalar identity, on the projections too (#10409) ──────────────────────
+  //
+  // The mirror pass got this in #10377 and the projection pass did not, so on
+  // 39 resolver-built and 25 paginated types a `String` over an object read as
+  // agreement -- the same blind spot, left open on a third of the surface.
+  // These drive the PROJECTION side specifically: a mutation that only the
+  // projection pass can reach must still be reported.
+  test("it FAILS when a PROJECTION retypes a field to a different scalar", () => {
+    const broken = inType(
+      sdl,
+      "Subnet",
+      /^ {4}netuid: Int!\n/m,
+      "    netuid: String!\n",
+    );
+    const report = checkComponentParity(broken, openapi);
+    assert.ok(
+      report.violations.some(
+        (v) =>
+          v.startsWith("Subnet.netuid -- the SDL declares String") &&
+          v.includes("SubnetIndexEntry emits Int"),
+      ),
+      `expected the retyped projection field to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("it FAILS on a NEW under-typing inside a projection", () => {
+    const broken = inType(
+      sdl,
+      "Subnet",
+      /^ {4}netuid: Int!\n/m,
+      "    netuid: JSON\n",
+    );
+    const report = checkComponentParity(broken, openapi);
+    assert.ok(
+      report.violations.some(
+        (v) =>
+          v.startsWith("Subnet.netuid -- the SDL declares JSON") &&
+          v.includes("declare it in JSON_UNDERTYPED or publish the type"),
+      ),
+      `expected the new projection under-typing to be reported, got: ${report.violations.join("; ")}`,
+    );
+  });
+
+  test("a projection's published type name resolves through PROJECTED_TYPES", () => {
+    // `SubnetsArtifact.subnets` emits `[SubnetIndexEntry!]` and the SDL
+    // publishes `[Subnet!]`. That is not a rename -- it is the projection
+    // declared over it, and reading only PUBLISHED_TYPE_NAMES would report
+    // every one of the 39 as a type mismatch. Dropping the declaration must
+    // make the pair unresolvable again.
+    const { Subnet: _dropped, ...withoutSubnet } = PROJECTED_TYPES;
+    const report = checkComponentParity(sdl, openapi, DECLARED, withoutSubnet);
+    assert.ok(
+      report.violations.some((v) =>
+        v.startsWith(
+          "SubnetList.items -- the SDL declares [Subnet!], SubnetsArtifact emits [SubnetIndexEntry!]",
+        ),
+      ),
+      `expected the unresolvable name to be reported, got: ${report.violations.join("; ")}`,
     );
   });
 });

--- a/tests/published-query-bindings.test.ts
+++ b/tests/published-query-bindings.test.ts
@@ -4,12 +4,23 @@
 //
 // Every test here mutates one side and asserts the mismatch is reported. The
 // gate's own run against the real tree only ever proves it passes.
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { parse } from "graphql";
+import type { ObjectTypeDefinitionNode } from "graphql";
 import {
   compareQueryBindings,
+  traverse,
   type SdlBinding,
 } from "../scripts/validate-published-names.ts";
-import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
+import { extractSdl } from "../scripts/validate-graphql-component-parity.ts";
+import { emitTypes } from "../schemas-src/graphql/emit.ts";
+import {
+  PROJECTED_TYPES,
+  QUERY_BINDINGS,
+} from "../schemas-src/graphql/published-names.ts";
+
+const fullSdl = extractSdl(readFileSync("src/graphql-sdl.ts", "utf8"))!;
 
 const sdl: SdlBinding[] = [
   {
@@ -103,5 +114,79 @@ describe("the real registry", () => {
         `Mirrors GET ${binding.route}`,
       );
     }
+  });
+});
+
+// ── the SDL traversal (#10409) ───────────────────────────────────────────────
+//
+// The walk decides what the staleness check can see, and it stepped only
+// through SAME-NAMED fields -- so a paginated view, which renames its row
+// array, dead-ended and its element component was unreachable. Five components
+// the SDL genuinely publishes could not be named for that reason: the entry
+// read as stale. These drive the walk with a mutated registry, because run
+// against the passing tree it only ever proves it passes.
+describe("traverse", () => {
+  const sdlTypes = new Map(
+    parse(fullSdl).definitions.flatMap((def) =>
+      def.kind === "ObjectTypeDefinition"
+        ? ([[def.name.value, def]] as [string, ObjectTypeDefinitionNode][])
+        : [],
+    ),
+  );
+  const { types: generated } = emitTypes();
+  const seeds: [string, string][] = [["BlockList", "BlocksFeedArtifact"]];
+
+  it("reaches an element component THROUGH a paginated view's rename", () => {
+    const { reachable, computed } = traverse(
+      sdlTypes,
+      generated,
+      seeds,
+      PROJECTED_TYPES,
+    );
+    expect(reachable.has("BlocksFeedArtifactBlocks")).toBe(true);
+    expect([...(computed.get("BlocksFeedArtifactBlocks") ?? [])]).toEqual([
+      "Block",
+    ]);
+  });
+
+  it("does NOT reach it when the rename is undeclared", () => {
+    // `itemsFrom` is the only thing connecting `BlockList.items` to
+    // `BlocksFeedArtifact.blocks`. Without it the walk stops at the view.
+    const { itemsFrom: _dropped, ...withoutRename } = PROJECTED_TYPES.BlockList;
+    const { reachable } = traverse(sdlTypes, generated, seeds, {
+      ...PROJECTED_TYPES,
+      BlockList: withoutRename,
+    });
+    expect(reachable.has("BlocksFeedArtifactBlocks")).toBe(false);
+  });
+
+  it("a projection seed is reachable but is NOT a name identity", () => {
+    // `AccountSubnet` PICKS four of AccountPortfolioArtifactPositions' eleven
+    // fields; that component publishes as `AccountPortfolioPosition`. Recording
+    // the seed pair would assert the two names are the same type.
+    const { reachable, computed, paired } = traverse(
+      sdlTypes,
+      generated,
+      [],
+      PROJECTED_TYPES,
+    );
+    expect(reachable.has("AccountPortfolioArtifactPositions")).toBe(true);
+    expect(computed.get("AccountPortfolioArtifactPositions")).toBeUndefined();
+    expect(paired.has("AccountSubnet")).toBe(false);
+  });
+
+  it("terminates on a projection whose descendant is itself a projection", () => {
+    // One visited set for BOTH seed kinds. Guarding only the mirrors let a
+    // projection re-expand every time it was re-enqueued.
+    const { reachable } = traverse(sdlTypes, generated, [], {
+      ...PROJECTED_TYPES,
+      SubnetList: {
+        component: "SubnetsArtifact",
+        itemsFrom: "subnets",
+        added: [],
+      },
+      Subnet: { component: "SubnetIndexEntry", added: [], dropped: [] },
+    });
+    expect(reachable.has("SubnetIndexEntry")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

`validate:graphql-component-parity` runs two passes. #10377 gave the **mirror** pass scalar identity — the check that stops `String` reading as agreement against `JSON`, and with it the whole enum→JSON class. The **projection** pass never got it.

That pass is the one that reaches the 39 declared projections and 25 paginated views: every resolver-flattened card, every list view, roughly a third of the published surface. On all of it the only checks were nullability and Int-over-Float, so a `String` published over an object read as agreement — which is where it matters most, because a projection is exactly the place a resolver reshapes a value and can reshape it into the wrong type.

## What running it found

Both verified against `api.metagraph.sh`, not against another schema.

**`Validator.stake_dominance` was not selectable.** `/api/v1/validators` serves it — `0.189654` on the top row, alongside `latest_captured_at` / `latest_block_number` — and `ValidatorList.items` published a `Validator` with no such field. It is list-only: the single-validator lookup aggregates one hotkey and has no set to divide by, confirmed against `/api/v1/validators/{hotkey}`. That is the same shape `featured` and `uid_count` already carry, and the SDL already documents that null as *unknown, not zero* — so it is published nullable with that reading written down.

**`CurationList.notes` was `String` over a `string | string[]` union.** `ArtifactBaseSchema.notes` is `z.union([z.string(), z.array(z.string())])` and says so. graphql-js' String serializer throws on a non-scalar and nulls the whole surrounding object, and a producer in this repo already emits the list form: `/api/v1/endpoints` serves three strings. Sweeping twelve live routes, that is the one that does it today — but the union is the contract, and 14 other SDL types already publish `notes` as `JSON`. These were the inconsistent five.

**A copy-pasted description, in both sources.** The SDL's `CurationList` and the Zod `CurationArtifactSchema` both described themselves as *"Network-wide public evidence ledger page. Mirrors GET /api/v1/evidence (and MCP list_evidence)"*. It is the curation state, mirroring `/api/v1/curation`.

## The same blind spot, one level up

Fixing the comparison exposed it in the name registry. `validate-published-names` computes reachability by walking **same-named** fields — and a paginated view *renames* its row array, `BlockList.items` over `BlocksFeedArtifact.blocks`. The walk dead-ends there, so five components the SDL genuinely publishes could not be named at all: an entry for them read as **stale**.

| component | published as | why it is the same type |
|---|---|---|
| `BlocksFeedArtifactBlocks` | `Block` | field for field the detail component's eight |
| `ExtrinsicsFeedArtifactExtrinsics`, `ExtrinsicDetailArtifactExtrinsic` | `Extrinsic` | all three emit the identical twelve |
| `GlobalValidatorsArtifactValidators` | `Validator` | `validatorNode` normalizes the two producers on purpose |
| `AccountsListArtifactAccountsSubnets` | `AccountSubnet` | exactly the four fields `AccountSubnet` declares |

Making the walk step through renames then reached two more: `GlobalValidatorsArtifactValidatorsColdkeyIdentity` → `Identity` (identical) and `...ValidatorsSubnets` → `ValidatorSubnet` (the leaderboard's compact five, a subset of the detail's eighteen — which `ValidatorSubnet`'s own SDL comment already describes). Both fields the SDL declares non-null are non-null on both sides.

**A projection seed is not a name identity**, and keeping the two apart is the part worth reading. `AccountSubnet` *picks* four of `AccountPortfolioArtifactPositions`' eleven fields, and that component's own published name is `AccountPortfolioPosition`. Seeding it as a pair would assert two different types are the same one — and would mark seven `PROJECTED_TYPES` entries stale as "reached as a full mirror". So a projection seed propagates and is reachable; only its descendants, reached through a real field, count as pairs. A child that is *itself* a declared projection stays one.

## The counter went 24 → 51, and that is not drift

27 of the newly-visible under-typings sit on a projection or a paginated view, where nothing had ever compared a type to a type. The debt did not grow — half of it had never been counted. The list stays shrink-only in both directions.

Also fixed in passing: `RESOLVER_BUILT_TYPES`' comment said "5 now" over a list of 4.

## Proving both gates can fail

The traversal moved into an exported pure `traverse(sdlTypes, generated, mirrorSeeds, projections)` so a test can drive it with a mutated registry — the file's own stated principle, which its module-level walk could not follow. Extracting it also surfaced a latent bug: the projection seed had no revisit guard, so a projection whose descendant was that same projection would re-expand on every enqueue. One visited set now covers both kinds.

New tests, each mutating one side:

- a projection retyped to a different scalar is reported (`Subnet.netuid` → `String!`)
- a new under-typing *inside a projection* is reported
- dropping `PROJECTED_TYPES.Subnet` makes `SubnetList.items` unresolvable again — proving the name resolution goes through the projection map, not just the rename map
- `traverse` reaches `BlocksFeedArtifactBlocks` through the rename, and **does not** when `itemsFrom` is removed
- a projection seed is reachable but produces no pair and no `paired` entry
- the walk terminates on a projection whose descendant is a projection

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `validate:graphql-component-parity` — 329 mirrors / 2544 fields / 39 projections (227 fields) / 25 pagination views / 194 drops / **51** under-typings, OK
- `validate:published-names` — **360** component names (was 353), 321 published types, 196 Query bindings, 39 projections, 4 resolver-built, 1 alias
- `validate:contract-drift`, `validate:graphql-types-drift`, `validate:graphql-route-parity` (164 pairs, 1190 fields, 0 divergences), `validate:graphql-hand-written-checks` (245 of 245), `validate:graphql-query-arguments` (187 exact) — all pass
- `report:graphql-sdl-equivalence` — unchanged at 338/338, 196/196, 167 argument lists
- `npx vitest run` — 797 files, 18,4xx passed, 0 failed (one unrelated `ENOTEMPTY` race on a `dist/` dir in `tests/network-routing.test.ts`; passes alone, 20/20)
- rebuilt and re-verified on `9da249004` after #10419 landed

`npm run build` regenerated `openapi.json`, `generated/graphql/types.ts`, `packages/contract/index.d.ts` and `public/metagraph/types.d.ts`, committed here. The only `src/**` change is four lines of the SDL string — no executable line — so there is no `codecov/patch` surface in this diff.

Closes #10420.
