### PR TITLE
feat(graphql): give the four unchecked types a Zod source

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6521,6 +6521,48 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One live chain event as the firehose broadcasts it. Only the fields relevant to the event's table are populated. */
+        ChainFirehoseEvent: {
+            /** @description account_events only */
+            amount_tao?: number | null;
+            /** @description blocks only */
+            block_hash?: string | null;
+            block_number: number;
+            /** @description extrinsics only */
+            call_function?: string | null;
+            /** @description extrinsics only */
+            call_module?: string | null;
+            /** @description account_events only */
+            coldkey?: string | null;
+            /** @description blocks only */
+            event_count?: number | null;
+            /** @description chain_events / account_events (event index within the block) */
+            event_index?: number | null;
+            /** @description account_events only -- the curated kind (e.g. Transfer, StakeAdded) */
+            event_kind?: string | null;
+            /** @description blocks only */
+            extrinsic_count?: number | null;
+            /** @description extrinsics only */
+            extrinsic_index?: number | null;
+            /** @description account_events only */
+            hotkey?: string | null;
+            /** @description chain_events only */
+            method?: string | null;
+            /** @description account_events only */
+            netuid?: number | null;
+            observed_at?: string | null;
+            /** @description chain_events only */
+            pallet?: string | null;
+            /** @description extrinsics only */
+            signer?: string | null;
+            /** @description extrinsics only */
+            success?: boolean | null;
+            /**
+             * @description Which source table this event came from.
+             * @enum {string}
+             */
+            table: "blocks" | "extrinsics" | "chain_events" | "account_events";
+        };
         ChainHoldersArtifact: {
             captured_at: string | null;
             /** @description Present ONLY on a decline. An empty subnets list WITHOUT this block is a measurement. */
@@ -7564,57 +7606,7 @@ export interface components {
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
-            subnets: {
-                alpha_fdv_tao: number | null;
-                alpha_in_emission?: number | null;
-                alpha_in_pool: number | null;
-                alpha_market_cap_tao: number | null;
-                alpha_out_emission?: number | null;
-                alpha_out_pool: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
-                alpha_price_change_1d?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
-                alpha_price_change_1h?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
-                alpha_price_change_1m?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
-                alpha_price_change_7d?: number | null;
-                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
-                alpha_price_tao: number | null;
-                block?: number | null;
-                emission_enabled?: boolean | null;
-                emission_share: number | null;
-                excess_tao?: number | null;
-                first_emission_block?: number | null;
-                max_stake_alpha: number | null;
-                max_uids: number;
-                max_validators: number;
-                miner_burned_fraction?: number | null;
-                miner_count: number;
-                miner_readiness?: number | null;
-                moving_price_pinned?: number | null;
-                name: string;
-                netuid: number;
-                open_slots?: number | null;
-                owner_coldkey: string | null;
-                owner_hotkey: string | null;
-                /** @description SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one. */
-                registered_at_block?: number | null;
-                registration_allowed: boolean;
-                registration_allowed_pinned?: boolean | null;
-                registration_cost_tao: number | null;
-                slug: string;
-                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
-                spot_price_tao?: number | null;
-                /** @description SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom. */
-                subnet_mechanism?: number | null;
-                subnet_volume_tao: number | null;
-                subtoken_enabled?: boolean | null;
-                tao_in_emission_tao?: number | null;
-                tao_in_pool_tao: number | null;
-                total_stake_alpha: number | null;
-                validator_count: number;
-            }[];
+            subnets: components["schemas"]["SubnetEconomics"][];
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
@@ -7674,6 +7666,24 @@ export interface components {
             /** Format: date-time */
             observed_at: string;
             predates_capture: boolean;
+        };
+        /** @description One recorded change to the emission gate. Shape varies by kind: a param entry has no netuid, a subnet entry has no numeric value. */
+        EmissionGateChange: {
+            block_number: number | null;
+            enabled?: boolean | null;
+            is_set?: boolean | null;
+            item?: string | null;
+            /** @enum {string} */
+            kind: "param" | "subnet" | "flow";
+            netuid?: number | null;
+            /** Format: date-time */
+            observed_at: string;
+            param?: string | null;
+            predates_capture: boolean;
+            previous_enabled?: boolean | null;
+            previous_value?: number | null;
+            source?: ("governance" | "runtime_recomputed") | null;
+            value?: number | null;
         };
         EmissionGateChangesArtifact: {
             change_count: number;
@@ -8990,6 +9000,17 @@ export interface components {
             })[];
         } & {
             [key: string]: unknown;
+        };
+        /** @description The economic opportunity boards, ranked. The same ranking /api/v1/registry/leaderboards serves, re-keyed to GraphQL field names. */
+        OpportunityBoards: {
+            biggest_alpha_gain_1d: components["schemas"]["SubnetEconomics"][];
+            biggest_alpha_gain_7d: components["schemas"]["SubnetEconomics"][];
+            cheapest_registration: components["schemas"]["SubnetEconomics"][];
+            highest_emission: components["schemas"]["SubnetEconomics"][];
+            observed_at: string | null;
+            open_slots: components["schemas"]["SubnetEconomics"][];
+            validator_headroom: components["schemas"]["SubnetEconomics"][];
+            with_economics_count: number;
         };
         PaginationMeta: {
             collection: string;
@@ -10661,57 +10682,7 @@ export interface components {
             candidate_surfaces: components["schemas"]["CandidateSurface"][];
             candidates?: components["schemas"]["CandidateSurface"][];
             contract_version?: string;
-            economics?: {
-                alpha_fdv_tao: number | null;
-                alpha_in_emission?: number | null;
-                alpha_in_pool: number | null;
-                alpha_market_cap_tao: number | null;
-                alpha_out_emission?: number | null;
-                alpha_out_pool: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
-                alpha_price_change_1d?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
-                alpha_price_change_1h?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
-                alpha_price_change_1m?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
-                alpha_price_change_7d?: number | null;
-                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
-                alpha_price_tao: number | null;
-                block?: number | null;
-                emission_enabled?: boolean | null;
-                emission_share: number | null;
-                excess_tao?: number | null;
-                first_emission_block?: number | null;
-                max_stake_alpha: number | null;
-                max_uids: number;
-                max_validators: number;
-                miner_burned_fraction?: number | null;
-                miner_count: number;
-                miner_readiness?: number | null;
-                moving_price_pinned?: number | null;
-                name: string;
-                netuid: number;
-                open_slots?: number | null;
-                owner_coldkey: string | null;
-                owner_hotkey: string | null;
-                /** @description SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one. */
-                registered_at_block?: number | null;
-                registration_allowed: boolean;
-                registration_allowed_pinned?: boolean | null;
-                registration_cost_tao: number | null;
-                slug: string;
-                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
-                spot_price_tao?: number | null;
-                /** @description SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom. */
-                subnet_mechanism?: number | null;
-                subnet_volume_tao: number | null;
-                subtoken_enabled?: boolean | null;
-                tao_in_emission_tao?: number | null;
-                tao_in_pool_tao: number | null;
-                total_stake_alpha: number | null;
-                validator_count: number;
-            };
+            economics?: components["schemas"]["SubnetEconomics"];
             endpoints?: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             generated_at: string;
@@ -10724,6 +10695,57 @@ export interface components {
             verified_surfaces?: components["schemas"]["Surface"][];
         } & {
             [key: string]: unknown;
+        };
+        SubnetEconomics: {
+            alpha_fdv_tao: number | null;
+            alpha_in_emission?: number | null;
+            alpha_in_pool: number | null;
+            alpha_market_cap_tao: number | null;
+            alpha_out_emission?: number | null;
+            alpha_out_pool: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
+            alpha_price_change_1d?: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
+            alpha_price_change_1h?: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
+            alpha_price_change_1m?: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
+            alpha_price_change_7d?: number | null;
+            /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
+            alpha_price_tao: number | null;
+            block?: number | null;
+            emission_enabled?: boolean | null;
+            emission_share: number | null;
+            excess_tao?: number | null;
+            first_emission_block?: number | null;
+            max_stake_alpha: number | null;
+            max_uids: number;
+            max_validators: number;
+            miner_burned_fraction?: number | null;
+            miner_count: number;
+            miner_readiness?: number | null;
+            moving_price_pinned?: number | null;
+            name: string;
+            netuid: number;
+            open_slots?: number | null;
+            owner_coldkey: string | null;
+            owner_hotkey: string | null;
+            /** @description SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one. */
+            registered_at_block?: number | null;
+            registration_allowed: boolean;
+            registration_allowed_pinned?: boolean | null;
+            registration_cost_tao: number | null;
+            slug: string;
+            /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
+            spot_price_tao?: number | null;
+            /** @description SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom. */
+            subnet_mechanism?: number | null;
+            subnet_volume_tao: number | null;
+            subtoken_enabled?: boolean | null;
+            tao_in_emission_tao?: number | null;
+            tao_in_pool_tao: number | null;
+            total_stake_alpha: number | null;
+            validator_count: number;
         };
         SubnetEndpointsArtifact: {
             contract_version?: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22350,6 +22350,228 @@
         ],
         "type": "object"
       },
+      "ChainFirehoseEvent": {
+        "additionalProperties": false,
+        "description": "One live chain event as the firehose broadcasts it. Only the fields relevant to the event's table are populated.",
+        "properties": {
+          "amount_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "account_events only"
+          },
+          "block_hash": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "blocks only"
+          },
+          "block_number": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "call_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "extrinsics only"
+          },
+          "call_module": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "extrinsics only"
+          },
+          "coldkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "account_events only"
+          },
+          "event_count": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "blocks only"
+          },
+          "event_index": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "chain_events / account_events (event index within the block)"
+          },
+          "event_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "account_events only -- the curated kind (e.g. Transfer, StakeAdded)"
+          },
+          "extrinsic_count": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "blocks only"
+          },
+          "extrinsic_index": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "extrinsics only"
+          },
+          "hotkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "account_events only"
+          },
+          "method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "chain_events only"
+          },
+          "netuid": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "account_events only"
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pallet": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "chain_events only"
+          },
+          "signer": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "extrinsics only"
+          },
+          "success": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "extrinsics only"
+          },
+          "table": {
+            "description": "Which source table this event came from.",
+            "enum": [
+              "blocks",
+              "extrinsics",
+              "chain_events",
+              "account_events"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "table",
+          "block_number"
+        ],
+        "type": "object"
+      },
       "ChainHoldersArtifact": {
         "additionalProperties": {},
         "properties": {
@@ -28131,421 +28353,7 @@
           },
           "subnets": {
             "items": {
-              "additionalProperties": false,
-              "properties": {
-                "alpha_fdv_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "alpha_in_emission": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "alpha_in_pool": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "alpha_market_cap_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "alpha_out_emission": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "alpha_out_pool": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "alpha_price_change_1d": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227)."
-                },
-                "alpha_price_change_1h": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."
-                },
-                "alpha_price_change_1m": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227)."
-                },
-                "alpha_price_change_7d": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227)."
-                },
-                "alpha_price_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
-                },
-                "block": {
-                  "anyOf": [
-                    {
-                      "maximum": 9007199254740991,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "emission_enabled": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "emission_share": {
-                  "anyOf": [
-                    {
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "excess_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "first_emission_block": {
-                  "anyOf": [
-                    {
-                      "maximum": 9007199254740991,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "max_stake_alpha": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "max_uids": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "max_validators": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "miner_burned_fraction": {
-                  "anyOf": [
-                    {
-                      "maximum": 1,
-                      "minimum": 0,
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "miner_count": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "miner_readiness": {
-                  "anyOf": [
-                    {
-                      "maximum": 100,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "moving_price_pinned": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "name": {
-                  "type": "string"
-                },
-                "netuid": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "open_slots": {
-                  "anyOf": [
-                    {
-                      "maximum": 9007199254740991,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "owner_coldkey": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "owner_hotkey": {
-                  "anyOf": [
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "registered_at_block": {
-                  "anyOf": [
-                    {
-                      "maximum": 9007199254740991,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one."
-                },
-                "registration_allowed": {
-                  "type": "boolean"
-                },
-                "registration_allowed_pinned": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "registration_cost_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "slug": {
-                  "type": "string"
-                },
-                "spot_price_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average."
-                },
-                "subnet_mechanism": {
-                  "anyOf": [
-                    {
-                      "maximum": 9007199254740991,
-                      "minimum": 0,
-                      "type": "integer"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ],
-                  "description": "SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom."
-                },
-                "subnet_volume_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "subtoken_enabled": {
-                  "anyOf": [
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "tao_in_emission_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "tao_in_pool_tao": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "total_stake_alpha": {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                },
-                "validator_count": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                }
-              },
-              "required": [
-                "alpha_fdv_tao",
-                "alpha_in_pool",
-                "alpha_market_cap_tao",
-                "alpha_out_pool",
-                "alpha_price_tao",
-                "emission_share",
-                "max_stake_alpha",
-                "max_uids",
-                "max_validators",
-                "miner_count",
-                "name",
-                "netuid",
-                "owner_coldkey",
-                "owner_hotkey",
-                "registration_allowed",
-                "registration_cost_tao",
-                "slug",
-                "subnet_volume_tao",
-                "tao_in_pool_tao",
-                "total_stake_alpha",
-                "validator_count"
-              ],
-              "type": "object"
+              "$ref": "#/components/schemas/SubnetEconomics"
             },
             "type": "array"
           },
@@ -28895,6 +28703,143 @@
           "item",
           "netuid",
           "is_set"
+        ],
+        "type": "object"
+      },
+      "EmissionGateChange": {
+        "additionalProperties": false,
+        "description": "One recorded change to the emission gate. Shape varies by kind: a param entry has no netuid, a subnet entry has no numeric value.",
+        "properties": {
+          "block_number": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "is_set": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "item": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "kind": {
+            "enum": [
+              "param",
+              "subnet",
+              "flow"
+            ],
+            "type": "string"
+          },
+          "netuid": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "observed_at": {
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z))$",
+            "type": "string"
+          },
+          "param": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "predates_capture": {
+            "type": "boolean"
+          },
+          "previous_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "previous_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source": {
+            "anyOf": [
+              {
+                "enum": [
+                  "governance",
+                  "runtime_recomputed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "observed_at",
+          "block_number",
+          "predates_capture"
         ],
         "type": "object"
       },
@@ -35820,6 +35765,74 @@
           "surface_count",
           "kinds",
           "surfaces"
+        ],
+        "type": "object"
+      },
+      "OpportunityBoards": {
+        "additionalProperties": false,
+        "description": "The economic opportunity boards, ranked. The same ranking /api/v1/registry/leaderboards serves, re-keyed to GraphQL field names.",
+        "properties": {
+          "biggest_alpha_gain_1d": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "biggest_alpha_gain_7d": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "cheapest_registration": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "highest_emission": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "open_slots": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "validator_headroom": {
+            "items": {
+              "$ref": "#/components/schemas/SubnetEconomics"
+            },
+            "type": "array"
+          },
+          "with_economics_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "observed_at",
+          "with_economics_count",
+          "open_slots",
+          "cheapest_registration",
+          "highest_emission",
+          "validator_headroom",
+          "biggest_alpha_gain_1d",
+          "biggest_alpha_gain_7d"
         ],
         "type": "object"
       },
@@ -43993,421 +44006,7 @@
             "type": "string"
           },
           "economics": {
-            "additionalProperties": false,
-            "properties": {
-              "alpha_fdv_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "alpha_in_emission": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "alpha_in_pool": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "alpha_market_cap_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "alpha_out_emission": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "alpha_out_pool": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "alpha_price_change_1d": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227)."
-              },
-              "alpha_price_change_1h": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."
-              },
-              "alpha_price_change_1m": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227)."
-              },
-              "alpha_price_change_7d": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227)."
-              },
-              "alpha_price_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
-              },
-              "block": {
-                "anyOf": [
-                  {
-                    "maximum": 9007199254740991,
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "emission_enabled": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "emission_share": {
-                "anyOf": [
-                  {
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "excess_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "first_emission_block": {
-                "anyOf": [
-                  {
-                    "maximum": 9007199254740991,
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "max_stake_alpha": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "max_uids": {
-                "maximum": 9007199254740991,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "max_validators": {
-                "maximum": 9007199254740991,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "miner_burned_fraction": {
-                "anyOf": [
-                  {
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "miner_count": {
-                "maximum": 9007199254740991,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "miner_readiness": {
-                "anyOf": [
-                  {
-                    "maximum": 100,
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "moving_price_pinned": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "name": {
-                "type": "string"
-              },
-              "netuid": {
-                "maximum": 9007199254740991,
-                "minimum": 0,
-                "type": "integer"
-              },
-              "open_slots": {
-                "anyOf": [
-                  {
-                    "maximum": 9007199254740991,
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "owner_coldkey": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "owner_hotkey": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "registered_at_block": {
-                "anyOf": [
-                  {
-                    "maximum": 9007199254740991,
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one."
-              },
-              "registration_allowed": {
-                "type": "boolean"
-              },
-              "registration_allowed_pinned": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "registration_cost_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "slug": {
-                "type": "string"
-              },
-              "spot_price_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average."
-              },
-              "subnet_mechanism": {
-                "anyOf": [
-                  {
-                    "maximum": 9007199254740991,
-                    "minimum": 0,
-                    "type": "integer"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ],
-                "description": "SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom."
-              },
-              "subnet_volume_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "subtoken_enabled": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "tao_in_emission_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "tao_in_pool_tao": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "total_stake_alpha": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "validator_count": {
-                "maximum": 9007199254740991,
-                "minimum": 0,
-                "type": "integer"
-              }
-            },
-            "required": [
-              "alpha_fdv_tao",
-              "alpha_in_pool",
-              "alpha_market_cap_tao",
-              "alpha_out_pool",
-              "alpha_price_tao",
-              "emission_share",
-              "max_stake_alpha",
-              "max_uids",
-              "max_validators",
-              "miner_count",
-              "name",
-              "netuid",
-              "owner_coldkey",
-              "owner_hotkey",
-              "registration_allowed",
-              "registration_cost_tao",
-              "slug",
-              "subnet_volume_tao",
-              "tao_in_pool_tao",
-              "total_stake_alpha",
-              "validator_count"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/SubnetEconomics"
           },
           "endpoints": {
             "items": {
@@ -44462,6 +44061,423 @@
           "gaps",
           "subnet",
           "surfaces"
+        ],
+        "type": "object"
+      },
+      "SubnetEconomics": {
+        "additionalProperties": false,
+        "properties": {
+          "alpha_fdv_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_in_emission": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_in_pool": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_market_cap_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_out_emission": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_out_pool": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "alpha_price_change_1d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227)."
+          },
+          "alpha_price_change_1h": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227)."
+          },
+          "alpha_price_change_1m": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227)."
+          },
+          "alpha_price_change_7d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227)."
+          },
+          "alpha_price_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
+          },
+          "block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "emission_share": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "excess_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "first_emission_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_stake_alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "max_uids": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "max_validators": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "miner_burned_fraction": {
+            "anyOf": [
+              {
+                "maximum": 1,
+                "minimum": 0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "miner_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "miner_readiness": {
+            "anyOf": [
+              {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "moving_price_pinned": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "open_slots": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "owner_coldkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "owner_hotkey": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "registered_at_block": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one."
+          },
+          "registration_allowed": {
+            "type": "boolean"
+          },
+          "registration_allowed_pinned": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "registration_cost_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "slug": {
+            "type": "string"
+          },
+          "spot_price_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average."
+          },
+          "subnet_mechanism": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom."
+          },
+          "subnet_volume_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "subtoken_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tao_in_emission_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tao_in_pool_tao": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "total_stake_alpha": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "validator_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "alpha_fdv_tao",
+          "alpha_in_pool",
+          "alpha_market_cap_tao",
+          "alpha_out_pool",
+          "alpha_price_tao",
+          "emission_share",
+          "max_stake_alpha",
+          "max_uids",
+          "max_validators",
+          "miner_count",
+          "name",
+          "netuid",
+          "owner_coldkey",
+          "owner_hotkey",
+          "registration_allowed",
+          "registration_cost_tao",
+          "slug",
+          "subnet_volume_tao",
+          "tao_in_pool_tao",
+          "total_stake_alpha",
+          "validator_count"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6521,6 +6521,48 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** @description One live chain event as the firehose broadcasts it. Only the fields relevant to the event's table are populated. */
+        ChainFirehoseEvent: {
+            /** @description account_events only */
+            amount_tao?: number | null;
+            /** @description blocks only */
+            block_hash?: string | null;
+            block_number: number;
+            /** @description extrinsics only */
+            call_function?: string | null;
+            /** @description extrinsics only */
+            call_module?: string | null;
+            /** @description account_events only */
+            coldkey?: string | null;
+            /** @description blocks only */
+            event_count?: number | null;
+            /** @description chain_events / account_events (event index within the block) */
+            event_index?: number | null;
+            /** @description account_events only -- the curated kind (e.g. Transfer, StakeAdded) */
+            event_kind?: string | null;
+            /** @description blocks only */
+            extrinsic_count?: number | null;
+            /** @description extrinsics only */
+            extrinsic_index?: number | null;
+            /** @description account_events only */
+            hotkey?: string | null;
+            /** @description chain_events only */
+            method?: string | null;
+            /** @description account_events only */
+            netuid?: number | null;
+            observed_at?: string | null;
+            /** @description chain_events only */
+            pallet?: string | null;
+            /** @description extrinsics only */
+            signer?: string | null;
+            /** @description extrinsics only */
+            success?: boolean | null;
+            /**
+             * @description Which source table this event came from.
+             * @enum {string}
+             */
+            table: "blocks" | "extrinsics" | "chain_events" | "account_events";
+        };
         ChainHoldersArtifact: {
             captured_at: string | null;
             /** @description Present ONLY on a decline. An empty subnets list WITHOUT this block is a measurement. */
@@ -7564,57 +7606,7 @@ export interface components {
             notes?: string | string[];
             /** @constant */
             schema_version: 1;
-            subnets: {
-                alpha_fdv_tao: number | null;
-                alpha_in_emission?: number | null;
-                alpha_in_pool: number | null;
-                alpha_market_cap_tao: number | null;
-                alpha_out_emission?: number | null;
-                alpha_out_pool: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
-                alpha_price_change_1d?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
-                alpha_price_change_1h?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
-                alpha_price_change_1m?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
-                alpha_price_change_7d?: number | null;
-                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
-                alpha_price_tao: number | null;
-                block?: number | null;
-                emission_enabled?: boolean | null;
-                emission_share: number | null;
-                excess_tao?: number | null;
-                first_emission_block?: number | null;
-                max_stake_alpha: number | null;
-                max_uids: number;
-                max_validators: number;
-                miner_burned_fraction?: number | null;
-                miner_count: number;
-                miner_readiness?: number | null;
-                moving_price_pinned?: number | null;
-                name: string;
-                netuid: number;
-                open_slots?: number | null;
-                owner_coldkey: string | null;
-                owner_hotkey: string | null;
-                /** @description SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one. */
-                registered_at_block?: number | null;
-                registration_allowed: boolean;
-                registration_allowed_pinned?: boolean | null;
-                registration_cost_tao: number | null;
-                slug: string;
-                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
-                spot_price_tao?: number | null;
-                /** @description SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom. */
-                subnet_mechanism?: number | null;
-                subnet_volume_tao: number | null;
-                subtoken_enabled?: boolean | null;
-                tao_in_emission_tao?: number | null;
-                tao_in_pool_tao: number | null;
-                total_stake_alpha: number | null;
-                validator_count: number;
-            }[];
+            subnets: components["schemas"]["SubnetEconomics"][];
             summary: {
                 registration_open_count: number;
                 subnet_count: number;
@@ -7674,6 +7666,24 @@ export interface components {
             /** Format: date-time */
             observed_at: string;
             predates_capture: boolean;
+        };
+        /** @description One recorded change to the emission gate. Shape varies by kind: a param entry has no netuid, a subnet entry has no numeric value. */
+        EmissionGateChange: {
+            block_number: number | null;
+            enabled?: boolean | null;
+            is_set?: boolean | null;
+            item?: string | null;
+            /** @enum {string} */
+            kind: "param" | "subnet" | "flow";
+            netuid?: number | null;
+            /** Format: date-time */
+            observed_at: string;
+            param?: string | null;
+            predates_capture: boolean;
+            previous_enabled?: boolean | null;
+            previous_value?: number | null;
+            source?: ("governance" | "runtime_recomputed") | null;
+            value?: number | null;
         };
         EmissionGateChangesArtifact: {
             change_count: number;
@@ -8990,6 +9000,17 @@ export interface components {
             })[];
         } & {
             [key: string]: unknown;
+        };
+        /** @description The economic opportunity boards, ranked. The same ranking /api/v1/registry/leaderboards serves, re-keyed to GraphQL field names. */
+        OpportunityBoards: {
+            biggest_alpha_gain_1d: components["schemas"]["SubnetEconomics"][];
+            biggest_alpha_gain_7d: components["schemas"]["SubnetEconomics"][];
+            cheapest_registration: components["schemas"]["SubnetEconomics"][];
+            highest_emission: components["schemas"]["SubnetEconomics"][];
+            observed_at: string | null;
+            open_slots: components["schemas"]["SubnetEconomics"][];
+            validator_headroom: components["schemas"]["SubnetEconomics"][];
+            with_economics_count: number;
         };
         PaginationMeta: {
             collection: string;
@@ -10661,57 +10682,7 @@ export interface components {
             candidate_surfaces: components["schemas"]["CandidateSurface"][];
             candidates?: components["schemas"]["CandidateSurface"][];
             contract_version?: string;
-            economics?: {
-                alpha_fdv_tao: number | null;
-                alpha_in_emission?: number | null;
-                alpha_in_pool: number | null;
-                alpha_market_cap_tao: number | null;
-                alpha_out_emission?: number | null;
-                alpha_out_pool: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
-                alpha_price_change_1d?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
-                alpha_price_change_1h?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
-                alpha_price_change_1m?: number | null;
-                /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
-                alpha_price_change_7d?: number | null;
-                /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
-                alpha_price_tao: number | null;
-                block?: number | null;
-                emission_enabled?: boolean | null;
-                emission_share: number | null;
-                excess_tao?: number | null;
-                first_emission_block?: number | null;
-                max_stake_alpha: number | null;
-                max_uids: number;
-                max_validators: number;
-                miner_burned_fraction?: number | null;
-                miner_count: number;
-                miner_readiness?: number | null;
-                moving_price_pinned?: number | null;
-                name: string;
-                netuid: number;
-                open_slots?: number | null;
-                owner_coldkey: string | null;
-                owner_hotkey: string | null;
-                /** @description SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one. */
-                registered_at_block?: number | null;
-                registration_allowed: boolean;
-                registration_allowed_pinned?: boolean | null;
-                registration_cost_tao: number | null;
-                slug: string;
-                /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
-                spot_price_tao?: number | null;
-                /** @description SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom. */
-                subnet_mechanism?: number | null;
-                subnet_volume_tao: number | null;
-                subtoken_enabled?: boolean | null;
-                tao_in_emission_tao?: number | null;
-                tao_in_pool_tao: number | null;
-                total_stake_alpha: number | null;
-                validator_count: number;
-            };
+            economics?: components["schemas"]["SubnetEconomics"];
             endpoints?: components["schemas"]["EndpointResource"][];
             gaps: components["schemas"]["Gaps"];
             generated_at: string;
@@ -10724,6 +10695,57 @@ export interface components {
             verified_surfaces?: components["schemas"]["Surface"][];
         } & {
             [key: string]: unknown;
+        };
+        SubnetEconomics: {
+            alpha_fdv_tao: number | null;
+            alpha_in_emission?: number | null;
+            alpha_in_pool: number | null;
+            alpha_market_cap_tao: number | null;
+            alpha_out_emission?: number | null;
+            alpha_out_pool: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
+            alpha_price_change_1d?: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~1h. Always null from daily snapshots (#7227). */
+            alpha_price_change_1h?: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~30 days from subnet_snapshots (#7227). */
+            alpha_price_change_1m?: number | null;
+            /** @description Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
+            alpha_price_change_7d?: number | null;
+            /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
+            alpha_price_tao: number | null;
+            block?: number | null;
+            emission_enabled?: boolean | null;
+            emission_share: number | null;
+            excess_tao?: number | null;
+            first_emission_block?: number | null;
+            max_stake_alpha: number | null;
+            max_uids: number;
+            max_validators: number;
+            miner_burned_fraction?: number | null;
+            miner_count: number;
+            miner_readiness?: number | null;
+            moving_price_pinned?: number | null;
+            name: string;
+            netuid: number;
+            open_slots?: number | null;
+            owner_coldkey: string | null;
+            owner_hotkey: string | null;
+            /** @description SubtensorModule.NetworkRegisteredAt -- the SUBNET's registration height, read in this same pinned sweep. Both the immunity clock's start and the deregistration order's tie-break. Not a neuron's registration block, and not the registry index's field of the same name, which is a publish cycle behind this one. */
+            registered_at_block?: number | null;
+            registration_allowed: boolean;
+            registration_allowed_pinned?: boolean | null;
+            registration_cost_tao: number | null;
+            slug: string;
+            /** @description The AMM spot price in TAO per alpha — the pool ratio at rest, derived from tao_in_pool_tao / alpha_in_pool on this row. Root (netuid 0) has no AMM and is 1 by definition. Null when the reserves cannot support a price; an empty pool has no spot, and 0 would read as free. This is the mark to value a position at; alpha_price_tao is the moving average. */
+            spot_price_tao?: number | null;
+            /** @description SubtensorModule.SubnetMechanism -- 0 is Stable, 1 is Dynamic. Not cosmetic: get_moving_alpha_price substitutes a flat 1.0 for a Stable subnet instead of reading its moving price, moving it from the top of a pruning-price order to the bottom. */
+            subnet_mechanism?: number | null;
+            subnet_volume_tao: number | null;
+            subtoken_enabled?: boolean | null;
+            tao_in_emission_tao?: number | null;
+            tao_in_pool_tao: number | null;
+            total_stake_alpha: number | null;
+            validator_count: number;
         };
         SubnetEndpointsArtifact: {
             contract_version?: string;

--- a/schemas-src/graphql/graphql-only.ts
+++ b/schemas-src/graphql/graphql-only.ts
@@ -1,0 +1,219 @@
+// The three shapes only GraphQL publishes (#10409).
+//
+// Every other published type comes from a route's Zod component. These three do
+// not, because no route serves them: `OpportunityBoards` is a re-key of the
+// leaderboards record, `EmissionGateChange` is the flattened form of a union
+// REST serves un-flattened, and `ChainEvent` is a WebSocket payload with no
+// REST equivalent at all. They sat in `RESOLVER_BUILT_TYPES` -- the list of
+// types NO gate reaches -- and an over-promise in any of them (the class that
+// nulled `SelfHealthLane.detail` on every request, #10215) was invisible.
+//
+// WHY THEY LIVE IN THE SHARED REGISTRY, not a GraphQL-only one. A second
+// registry would be a second `$ref` namespace, and these shapes reference the
+// first: `EmissionGateChange` is built FROM the three arms
+// `EmissionGateChangesArtifact` already models, and the leaderboard rows are
+// the ones `/api/v1/registry/leaderboards` serves. Cross-registry refs do not
+// resolve, so the GraphQL-only copies would have to restate the shapes they
+// reference -- which is the duplication this epic exists to delete. The
+// registry is the contract, not the REST contract: it already emits the MCP
+// output schemas and the GraphQL type system from the same nodes.
+// `GenericArtifact` is the standing precedent for a registered component no
+// route serves.
+//
+// NOTHING HERE IS HAND-RESTATED WHERE IT CAN BE DERIVED. `EmissionGateChange`
+// is computed from the three arm schemas, so a field added to any arm appears
+// in the GraphQL type and the parity gate fails until the SDL publishes it.
+import { z } from "zod";
+import {
+  EmissionFlowChangeSchema,
+  EmissionParamChangeSchema,
+  EmissionSubnetChangeSchema,
+} from "../routes/emission-gate-changes.ts";
+import { SubnetDetailArtifactSchema } from "../routes/subnet-detail.ts";
+
+// ── Query.opportunity_boards ─────────────────────────────────────────────────
+
+/** The six economic boards `formatLeaderboards` always materializes. */
+export const OPPORTUNITY_BOARDS = [
+  "open_slots",
+  "cheapest_registration",
+  "highest_emission",
+  "validator_headroom",
+  "biggest_alpha_gain_1d",
+  "biggest_alpha_gain_7d",
+] as const;
+
+/**
+ * One ranked row, which is the subnet's economics card plus the headroom the
+ * ranker derives -- exactly what `OpportunityEntry` is already declared as a
+ * projection of, taken from the same component so the two cannot diverge.
+ */
+const OpportunityEntrySchema =
+  SubnetDetailArtifactSchema.shape.economics.unwrap();
+
+/**
+ * The resolver's re-key of `RegistryLeaderboardsArtifact.boards`.
+ *
+ * The artifact keys its boards by NAME -- "open-slots", "cheapest-registration"
+ * -- which are not valid GraphQL field names, so the record stays JSON on the
+ * REST mirror and the resolver names the six it publishes. The same reshape
+ * `SubnetTrajectoryDelta` needed for its window keys, and the same fix:
+ * register the value so the published type has something to be checked
+ * against.
+ *
+ * Every board is non-optional because `formatLeaderboards` always materializes
+ * every economic key, possibly as `[]` -- the resolver relies on that and says
+ * so (src/graphql.ts, "no `|| []` fallback -- that branch is unreachable").
+ */
+export const OpportunityBoardsSchema = z
+  .object({
+    observed_at: z.string().nullable(),
+    with_economics_count: z.int().min(0),
+    ...Object.fromEntries(
+      OPPORTUNITY_BOARDS.map((board) => [
+        board,
+        z.array(OpportunityEntrySchema),
+      ]),
+    ),
+  })
+  .describe(
+    "The economic opportunity boards, ranked. The same ranking " +
+      "/api/v1/registry/leaderboards serves, re-keyed to GraphQL field names.",
+  );
+
+// ── Query.emission_gate_changes.changes ──────────────────────────────────────
+
+/** The four every arm carries, which stay required. */
+const SHARED_CHANGE_FIELDS: readonly string[] = [
+  "kind",
+  "observed_at",
+  "block_number",
+  "predates_capture",
+];
+
+const EMISSION_ARMS = [
+  EmissionParamChangeSchema,
+  EmissionSubnetChangeSchema,
+  EmissionFlowChangeSchema,
+];
+
+/**
+ * The three arms of the emission-gate change union, flattened into one type.
+ *
+ * REST serves the union un-flattened: a `param` entry has no `netuid`, a
+ * `subnet` entry has no numeric `value`, and each row carries only its own
+ * fields -- absent, not null, because absent says "this kind has no such
+ * thing" where null would say "it has one and we do not know it". GraphQL has
+ * no way to express that in a selection set a client can write once, so the
+ * SDL publishes one type with the arm-specific fields nullable.
+ *
+ * DERIVED from the three, never restated. A field added to any arm shows up
+ * here, and `validate:graphql-component-parity` then fails until the SDL
+ * publishes it -- which is the whole difference between this and the hand
+ * -written type it replaces.
+ */
+export const EmissionGateChangeSchema = z
+  .object({
+    ...Object.fromEntries(
+      SHARED_CHANGE_FIELDS.map((name) => [
+        name,
+        EmissionParamChangeSchema.shape[
+          name as keyof typeof EmissionParamChangeSchema.shape
+        ] as z.ZodType,
+      ]),
+    ),
+    // Every arm-specific field, made OPTIONAL on top of the `.nullable()` it
+    // already carries. That is not a loosening: a row from the `param` arm has
+    // no `netuid` key at all, and the route schema says why -- absent means
+    // "this kind has no such thing" where null would mean "it has one and we
+    // do not know it". GraphQL cannot express the difference, so the published
+    // field is nullable either way; requiring the key here would reject every
+    // real row. `netuid` is on two arms with the same type, so the spread
+    // order does not matter.
+    ...Object.fromEntries(
+      EMISSION_ARMS.flatMap((arm) =>
+        Object.entries(arm.shape)
+          .filter(([name]) => !SHARED_CHANGE_FIELDS.includes(name))
+          .map(([name, field]) => [name, (field as z.ZodType).optional()]),
+      ),
+    ),
+  })
+  .describe(
+    "One recorded change to the emission gate. Shape varies by kind: a param " +
+      "entry has no netuid, a subnet entry has no numeric value.",
+  );
+
+// ── Subscription.chainEvents ─────────────────────────────────────────────────
+
+/**
+ * The #4980 NOTIFY payload the chain firehose broadcasts.
+ *
+ * No REST route serves it -- it exists only on the WebSocket transport -- and
+ * the four source tables carry different columns, so everything past `table`
+ * and `block_number` is nullable AND optional: `enqueue_chain_firehose()`'s
+ * jsonb_build_object emits only the columns of the table an event came from,
+ * so a `blocks` payload has no `extrinsic_index` KEY rather than a null one.
+ * Those two are the only fields the hand-written ingest check requires, and
+ * they are the only two the SDL declares non-null. `workers/chain-firehose-hub.ts` validates
+ * the ingest side with a hand-written check that bounds every field to a
+ * scalar without enumerating them; `tests/graphql-only-schemas.test.ts` holds
+ * the two to the same vocabulary so they cannot drift apart.
+ */
+export const ChainFirehoseEventSchema = z
+  .object({
+    table: z
+      .enum(["blocks", "extrinsics", "chain_events", "account_events"])
+      .describe("Which source table this event came from."),
+    block_number: z.int().min(0),
+    observed_at: z.string().nullable().optional(),
+    block_hash: z.string().nullable().optional().describe("blocks only"),
+    extrinsic_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("blocks only"),
+    event_count: z.int().min(0).nullable().optional().describe("blocks only"),
+    extrinsic_index: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("extrinsics only"),
+    call_module: z.string().nullable().optional().describe("extrinsics only"),
+    call_function: z.string().nullable().optional().describe("extrinsics only"),
+    signer: z.string().nullable().optional().describe("extrinsics only"),
+    success: z.boolean().nullable().optional().describe("extrinsics only"),
+    event_index: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("chain_events / account_events (event index within the block)"),
+    pallet: z.string().nullable().optional().describe("chain_events only"),
+    method: z.string().nullable().optional().describe("chain_events only"),
+    event_kind: z
+      .string()
+      .nullable()
+      .optional()
+      .describe(
+        "account_events only -- the curated kind (e.g. Transfer, StakeAdded)",
+      ),
+    hotkey: z.string().nullable().optional().describe("account_events only"),
+    coldkey: z.string().nullable().optional().describe("account_events only"),
+    netuid: z
+      .int()
+      .min(0)
+      .nullable()
+      .optional()
+      .describe("account_events only"),
+    amount_tao: z
+      .number()
+      .nullable()
+      .optional()
+      .describe("account_events only"),
+  })
+  .describe(
+    "One live chain event as the firehose broadcasts it. Only the fields " +
+      "relevant to the event's table are populated.",
+  );

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -109,6 +109,12 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   AccountPortfolioArtifact: "AccountPortfolio",
   AccountPortfolioArtifactPositions: "AccountPortfolioPosition",
   AccountsListArtifactAccountsSubnets: "AccountSubnet",
+  // The one GraphQL-only component whose published name differs from its
+  // own (#10409): the component is named for the firehose that produces
+  // it, the type for what a subscriber reads. `OpportunityBoards` and
+  // `EmissionGateChange` are published under their component names and so
+  // need no entry.
+  ChainFirehoseEvent: "ChainEvent",
   AccountPositionHistoryArtifact: "AccountPositionHistory",
   AccountPositionHistoryArtifactPoints: "AccountPositionHistoryPoint",
   AccountPositionsArtifact: "AccountPositions",
@@ -251,7 +257,7 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   DomainSummaryArtifactEmissionConcentration: "ConcentrationMetrics",
   DomainsArtifact: "DomainOverview",
   EconomicsArtifact: "EconomicsList",
-  EconomicsArtifactSubnets: "SubnetEconomics",
+  SubnetEconomics: "SubnetEconomics",
   EconomicsArtifactSummary: "EconomicsSummary",
   EconomicsTrendsArtifact: "EconomicsTrends",
   EconomicsTrendsArtifactDays: "EconomicsTrendsDay",
@@ -2014,7 +2020,7 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
   },
   SubnetHealth: { component: "HealthSubnetSummary", added: [] },
   OpportunityEntry: {
-    component: "SubnetDetailArtifactEconomics",
+    component: "SubnetEconomics",
     added: ["validator_headroom"],
     dropped: [
       "alpha_fdv_tao",
@@ -2056,6 +2062,28 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
     dropped: ["ref", "limit", "offset"],
   },
   AccountEntry: { component: "AccountsListArtifactAccounts", added: [] },
+  // ── the three that had NO component until #10409 ─────────────────────────
+  //
+  // Each has one now, in schemas-src/graphql/graphql-only.ts, so each is
+  // checked field by field like every other projection instead of being
+  // taken on trust. `EmissionGateChange` is DERIVED from the three arm
+  // schemas REST already serves, so a field added to any arm fails the
+  // parity gate until the SDL publishes it.
+  OpportunityBoards: {
+    component: "OpportunityBoards",
+    added: [],
+    dropped: [],
+  },
+  EmissionGateChange: {
+    component: "EmissionGateChange",
+    added: [],
+    dropped: [],
+  },
+  ChainEvent: {
+    component: "ChainFirehoseEvent",
+    added: [],
+    dropped: [],
+  },
   // Two producers, one published type, and the ACCOUNTS-LIST one is the whole
   // of it: `AccountsListArtifactAccountsSubnets` emits exactly the four fields
   // `AccountSubnet` declares, so the projection below (which drops seven of
@@ -2404,31 +2432,59 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
 };
 
 /**
- * Types a resolver builds, with no component behind them.
+ * The Subscription root, declared the way `QUERY_BINDINGS` declares the Query
+ * root (#10409).
  *
- * THIS LIST IS THE DEBT, and only it: everything in `PROJECTED_TYPES` gets
- * checked field by field, and everything here is taken on trust. It was 15
- * when #10371 split the two, 8 after the projections were declared, and 4
- * now that the three with a component behind them moved across -- `SubnetList`
- * and `ProviderList` page over `SubnetsArtifact`/`ProvidersArtifact`, and
- * `GlobalHealth` flattens `HealthSummaryArtifact`. Anything that picks its
- * fields from a component belongs there, not here.
+ * A root type is not a component and never will be -- it is assembled from its
+ * fields -- so `Subscription` sat in `RESOLVER_BUILT_TYPES` for the same
+ * reason `Query` is excluded by name rather than listed there: the debt list
+ * was the only place to put it. Declaring its one field the way the 196 Query
+ * fields are declared is what the generator needs and what takes that list to
+ * zero.
  *
- * Why each of the four is still here, and what closing it would take:
- *
- *   OpportunityBoards       six boards of OpportunityEntry, assembled from a
- *                           leaderboard read. No artifact has this shape.
- *   EmissionGateChange      the flattened form of a three-arm union
- *                           (param/subnet/flow), each arm carrying only its
- *                           own fields. GraphQL could express it as a union;
- *                           the SDL chose one type with everything nullable.
- *   Subscription            a root type, not a component.
- *   ChainEvent              the subscription payload -- the #4980 NOTIFY
- *                           shape, which no REST route serves.
+ * `route` is null and always will be: the field is reached over WebSocket only
+ * (Sec-WebSocket-Protocol: graphql-transport-ws at /api/v1/graphql), and
+ * POSTing a subscription operation to the query endpoint returns a standard
+ * GraphQL error. There is no REST route to mirror.
  */
-export const RESOLVER_BUILT_TYPES: readonly string[] = [
-  "OpportunityBoards",
-  "EmissionGateChange",
-  "Subscription",
-  "ChainEvent",
+export const SUBSCRIPTION_BINDINGS: readonly QueryBinding[] = [
+  {
+    field: "chainEvents",
+    route: null,
+    returns: "ChainEvent!",
+    description:
+      "Live chain events as they land (blocks/extrinsics/chain_events/account_events), optionally filtered to one or more tables. Field shape mirrors the #4980 NOTIFY payload -- only the fields relevant to the event's table are populated.",
+  },
 ];
+
+/**
+ * Types a resolver builds with no component behind them -- EMPTY, and the
+ * generator's completeness depends on it staying that way.
+ *
+ * THIS LIST WAS THE DEBT, and only it: everything in `PROJECTED_TYPES` is
+ * checked field by field and everything here was taken on trust, so an
+ * over-promise in any of them (the class that nulled `SelfHealthLane.detail`
+ * on every request, #10215) was invisible. It was 15 when #10371 split the two,
+ * 8 once the projections were declared, 4 once `SubnetList` / `ProviderList` /
+ * `GlobalHealth` named the components they page over and flatten, and 0 at
+ * #10409:
+ *
+ *   OpportunityBoards    now a projection of the registered `OpportunityBoards`
+ *                        component, whose rows are the same `SubnetEconomics`
+ *                        card `OpportunityEntry` already projects.
+ *   EmissionGateChange   now a projection of a component DERIVED from the three
+ *                        arm schemas /api/v1/chain/governance/emission-changes
+ *                        already serves -- add a field to any arm and the parity
+ *                        gate fails until the SDL publishes it.
+ *   ChainEvent           now a projection of `ChainFirehoseEvent`, the #4980
+ *                        NOTIFY payload, modeled in schemas-src/graphql/
+ *                        graphql-only.ts because no REST route serves it.
+ *   Subscription         a ROOT, like Query -- assembled from its fields rather
+ *                        than emitted as a component, and declared as such in
+ *                        `SUBSCRIPTION_BINDINGS` above.
+ *
+ * A new entry here is a type nothing checks. Give it a component and declare
+ * the projection instead; `schemas-src/graphql/graphql-only.ts` is where a
+ * shape only GraphQL publishes goes.
+ */
+export const RESOLVER_BUILT_TYPES: readonly string[] = [];

--- a/schemas-src/openapi-registry.ts
+++ b/schemas-src/openapi-registry.ts
@@ -61,6 +61,7 @@ import {
   PartnershipTierSchema,
   EpochMillisSchema,
   ScoreDistributionSchema,
+  SubnetEconomicsSchema,
   SubnetStatusSchema,
   SubnetTypeSchema,
   ChainStateSchema,
@@ -251,6 +252,11 @@ import {
   SubnetTrajectoryArtifactSchema,
   SubnetTrajectoryDeltaSchema,
 } from "./routes/subnet-trajectory.ts";
+import {
+  ChainFirehoseEventSchema,
+  EmissionGateChangeSchema,
+  OpportunityBoardsSchema,
+} from "./graphql/graphql-only.ts";
 import {
   SubnetLeaseArtifactSchema,
   SubnetLeaseHistoryArtifactSchema,
@@ -668,6 +674,24 @@ register(SubnetTrajectoryArtifactSchema, "SubnetTrajectoryArtifact");
 // `SubnetTrajectoryDelta` type be compared against something instead of
 // sitting in RESOLVER_BUILT_TYPES where nothing checks it.
 register(SubnetTrajectoryDeltaSchema, "SubnetTrajectoryDelta");
+
+// The three shapes only GraphQL publishes (#10409). No route serves them, so
+// nothing else in this file registers them -- and until they were registered,
+// the published `OpportunityBoards` / `EmissionGateChange` / `ChainEvent`
+// types sat in RESOLVER_BUILT_TYPES, which is the list of types NO gate
+// reaches. Registering them is what lets the parity gate compare them, exactly
+// as it does for SubnetTrajectoryDelta above. See schemas-src/graphql/
+// graphql-only.ts for why they live in this registry rather than a second one.
+// The shared per-subnet economics card, registered under the name the SDL
+// already publishes it as. It is ONE Zod node
+// (schemas-src/shared.ts) that /api/v1/economics and /api/v1/subnets/{netuid}
+// both serve, and unregistered it inlined at every use -- so
+// `OpportunityBoards` six board arrays each got their own anonymous copy of
+// the same 41 fields instead of the one published `OpportunityEntry` (#10409).
+register(SubnetEconomicsSchema, "SubnetEconomics");
+register(OpportunityBoardsSchema, "OpportunityBoards");
+register(EmissionGateChangeSchema, "EmissionGateChange");
+register(ChainFirehoseEventSchema, "ChainFirehoseEvent");
 register(SubnetLeaseArtifactSchema, "SubnetLeaseArtifact");
 register(SubnetLeaseHistoryArtifactSchema, "SubnetLeaseHistoryArtifact");
 register(CrowdloansArtifactSchema, "CrowdloansArtifact");

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -121,6 +121,16 @@ export const DECLARED: Record<string, string> = {
     "heterogeneous union, correctly. The SDL flattens the three into one " +
     "`EmissionGateChange` the resolver builds -- a real type over an honest " +
     "JSON, which is the safe direction and more useful than the blob.",
+  "ChainEvent.table":
+    "the SDL publishes the `ChainFirehoseTable` enum and the emitter maps " +
+    "every registered Zod enum to `String`. This is the ONLY output field in " +
+    "the schema typed by an enum -- the SDL declares exactly two, and the " +
+    "other is an argument -- so making the emitter emit GraphQL enums is a " +
+    "decision about all 17 registered enum components and every field that " +
+    "refs one, not about this field. `String` is the widening, so nothing " +
+    "breaks meanwhile: every value the enum admits serializes identically, " +
+    "and the vocabulary is asserted against the producer's own in " +
+    "tests/graphql-only-schemas.test.ts.",
   "SubnetTrajectory.deltas":
     "the resolver reshapes on purpose (src/graphql.ts, `deltas: Object.entries" +
     "(data.deltas ?? {})`): the artifact keys deltas by window ('7d'/'30d'), " +

--- a/scripts/validate-published-names.ts
+++ b/scripts/validate-published-names.ts
@@ -31,6 +31,7 @@ import {
   ALIASED_TYPE_NAMES,
   PUBLISHED_TYPE_NAMES,
   QUERY_BINDINGS,
+  SUBSCRIPTION_BINDINGS,
   PROJECTED_TYPES,
   RESOLVER_BUILT_TYPES,
 } from "../schemas-src/graphql/published-names.ts";
@@ -275,6 +276,18 @@ const sdlBindings = (sdlTypes.get("Query")?.fields ?? []).map((field) => {
   };
 });
 
+/** Subscription's fields, read the same way Query's are. */
+const sdlSubscriptionBindings = (
+  sdlTypes.get("Subscription")?.fields ?? []
+).map((field) => ({
+  field: field.name.value,
+  // Always null, and structurally so: the field is reached over WebSocket
+  // only, and there is no REST route to mirror.
+  route: null,
+  returns: print(field.type),
+  description: field.description?.value ?? "",
+}));
+
 // ── the pairing, computed the way the parity gate computes it ────────────────
 const { computed, paired, reachable } = traverse(
   sdlTypes,
@@ -356,16 +369,26 @@ if (staleAlias.length) {
   );
 }
 
-// ── the Query bindings ───────────────────────────────────────────────────────
-const bindingProblems = compareQueryBindings(sdlBindings, QUERY_BINDINGS);
-if (bindingProblems.length) {
-  errors.push(
-    `${bindingProblems.length} Query binding(s) that no longer describe the SDL:\n` +
-      bindingProblems
-        .sort()
-        .map((line) => `    ${line}`)
-        .join("\n"),
-  );
+// ── the root bindings ────────────────────────────────────────────────────────
+//
+// BOTH roots, on the same comparison. Subscription's one field was checked by
+// nothing until #10409: it was accounted for as a resolver-built type, which
+// means its return type and description lived only in the SDL -- the exact
+// drift `QUERY_BINDINGS` exists to stop, on the one root that had no registry.
+for (const [rootName, sdlRoot, declaredRoot] of [
+  ["Query", sdlBindings, QUERY_BINDINGS],
+  ["Subscription", sdlSubscriptionBindings, SUBSCRIPTION_BINDINGS],
+] as const) {
+  const bindingProblems = compareQueryBindings(sdlRoot, declaredRoot);
+  if (bindingProblems.length) {
+    errors.push(
+      `${bindingProblems.length} ${rootName} binding(s) that no longer describe the SDL:\n` +
+        bindingProblems
+          .sort()
+          .map((line) => `    ${line}`)
+          .join("\n"),
+    );
+  }
 }
 
 // ── the resolver-built list, and the projections ─────────────────────────────
@@ -377,8 +400,14 @@ if (bindingProblems.length) {
 // them matters because only the first is checked: everything in the second is
 // taken on trust, so that list is the debt and should only shrink.
 const projected = new Set(Object.keys(PROJECTED_TYPES));
+// The two ROOTS are excluded by name, not listed as debt. A root is not a
+// component and never will be -- it is assembled from its fields -- and both
+// have their fields declared: `QUERY_BINDINGS` for Query, `SUBSCRIPTION_
+// BINDINGS` for Subscription (#10409). `Subscription` sat in
+// RESOLVER_BUILT_TYPES only because the debt list was the one place to put it.
+const ROOT_TYPES = new Set(["Query", "Subscription"]);
 const unpaired = [...sdlTypes.keys()]
-  .filter((name) => name !== "Query" && !paired.has(name))
+  .filter((name) => !ROOT_TYPES.has(name) && !paired.has(name))
   .sort();
 const declaredResolverBuilt = [...RESOLVER_BUILT_TYPES].sort();
 const missingResolverBuilt = unpaired.filter(
@@ -464,6 +493,7 @@ if (isMain)
     `Published-name validation passed: ${Object.keys(PUBLISHED_TYPE_NAMES).length} component name(s), ` +
       `${new Set(Object.values(PUBLISHED_TYPE_NAMES)).size} published type(s), ` +
       `${QUERY_BINDINGS.length} Query binding(s), ` +
+      `${SUBSCRIPTION_BINDINGS.length} Subscription binding(s), ` +
       `${Object.keys(PROJECTED_TYPES).length} declared projection(s), ` +
       `${RESOLVER_BUILT_TYPES.length} resolver-built type(s), ` +
       `${Object.keys(ALIASED_TYPE_NAMES).length} declared alias(es).`,

--- a/tests/graphql-only-schemas.test.ts
+++ b/tests/graphql-only-schemas.test.ts
@@ -1,0 +1,209 @@
+// The three GraphQL-only components (#10409) describe shapes whose PRODUCER
+// lives in resolver or Worker code, not in a route schema. That is the whole
+// reason they had no component for so long -- and it is also the way they can
+// rot: nothing forces the Zod to keep describing what the producer emits.
+//
+// So every test here compares the schema to the producer's own source of
+// truth, never to another schema. A contract consistent with itself proves
+// nothing.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { CHAIN_FIREHOSE_TABLES } from "../src/chain-firehose-topics.ts";
+import { validateChainFirehoseIngestPayload } from "../workers/chain-firehose-hub.ts";
+import {
+  ChainFirehoseEventSchema,
+  EmissionGateChangeSchema,
+  OPPORTUNITY_BOARDS,
+  OpportunityBoardsSchema,
+} from "../schemas-src/graphql/graphql-only.ts";
+import {
+  EmissionFlowChangeSchema,
+  EmissionParamChangeSchema,
+  EmissionSubnetChangeSchema,
+} from "../schemas-src/routes/emission-gate-changes.ts";
+
+describe("ChainFirehoseEvent", () => {
+  test("its table vocabulary is the firehose's own, not a copy", () => {
+    // `CHAIN_FIREHOSE_TABLES` is what the subscription filter, the SSE topic
+    // parser and the ingest validator all read. A fifth table added there and
+    // not here would publish a `ChainEvent` the schema rejects.
+    assert.deepEqual(
+      [...ChainFirehoseEventSchema.shape.table.options].sort(),
+      [...CHAIN_FIREHOSE_TABLES].sort(),
+    );
+  });
+
+  test("a payload the ingest validator accepts, the schema accepts", () => {
+    // The ingest side is a HAND-WRITTEN check (bounded scalars, a known table,
+    // a non-negative block_number) that deliberately does not enumerate the
+    // per-table columns. This holds the two to the same answer on a real
+    // payload of each table rather than assuming they agree.
+    const payloads = [
+      {
+        table: "blocks",
+        block_number: 8812800,
+        observed_at: "2026-08-10T08:24:54.186Z",
+        block_hash: "0xabc",
+        extrinsic_count: 3,
+        event_count: 12,
+      },
+      {
+        table: "extrinsics",
+        block_number: 8812800,
+        extrinsic_index: 2,
+        call_module: "SubtensorModule",
+        call_function: "add_stake",
+        signer: "5HCFWvRqzSHWRPecN7q8J6c7aKQnrCZTMHstPv39xL1wgDHh",
+        success: true,
+      },
+      {
+        table: "chain_events",
+        block_number: 8812800,
+        event_index: 5,
+        pallet: "Balances",
+        method: "Transfer",
+      },
+      {
+        table: "account_events",
+        block_number: 8812800,
+        event_index: 5,
+        event_kind: "StakeAdded",
+        hotkey: "5HCFWvRqzSHWRPecN7q8J6c7aKQnrCZTMHstPv39xL1wgDHh",
+        coldkey: "5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u",
+        netuid: 1,
+        amount_tao: 12.5,
+      },
+    ];
+    for (const payload of payloads) {
+      const ingest = validateChainFirehoseIngestPayload(
+        JSON.stringify(payload),
+      );
+      assert.equal(ingest.ok, true, `ingest rejected ${payload.table}`);
+      const parsed = ChainFirehoseEventSchema.safeParse(payload);
+      assert.equal(
+        parsed.success,
+        true,
+        `schema rejected ${payload.table}: ${parsed.error?.message}`,
+      );
+    }
+  });
+
+  test("it REJECTS a table the firehose does not broadcast", () => {
+    // The negative half. Without it the test above passes on a schema that
+    // accepts anything.
+    assert.equal(
+      ChainFirehoseEventSchema.safeParse({
+        table: "neuron_daily",
+        block_number: 1,
+      }).success,
+      false,
+    );
+  });
+});
+
+describe("EmissionGateChange", () => {
+  test("it carries every field of all three arms, and nothing else", () => {
+    // DERIVED, not restated: this is what makes a field added to any arm show
+    // up in the published type instead of silently not.
+    const fromArms = new Set(
+      [
+        EmissionParamChangeSchema,
+        EmissionSubnetChangeSchema,
+        EmissionFlowChangeSchema,
+      ].flatMap((arm) => Object.keys(arm.shape)),
+    );
+    assert.deepEqual(
+      Object.keys(EmissionGateChangeSchema.shape).sort(),
+      [...fromArms].sort(),
+    );
+  });
+
+  test("a row from any one arm parses", () => {
+    const shared = {
+      observed_at: "2026-08-10T08:24:54.186Z",
+      block_number: 8812800,
+      predates_capture: false,
+    };
+    const rows = [
+      {
+        ...shared,
+        kind: "param",
+        param: "emission_gate_bar",
+        value: 0.5,
+        previous_value: 0.4,
+        source: "governance",
+      },
+      {
+        ...shared,
+        kind: "subnet",
+        netuid: 1,
+        enabled: true,
+        previous_enabled: false,
+      },
+      { ...shared, kind: "flow", item: "alpha_in", netuid: 1, is_set: true },
+    ];
+    for (const row of rows) {
+      const parsed = EmissionGateChangeSchema.safeParse(row);
+      assert.equal(
+        parsed.success,
+        true,
+        `${row.kind} row rejected: ${parsed.error?.message}`,
+      );
+    }
+  });
+
+  test("the four shared fields stay REQUIRED", () => {
+    // The flattening makes the arm-specific fields optional. If it made the
+    // shared four optional too, the SDL's four non-null promises would be
+    // over-promises the parity gate could no longer see.
+    for (const name of [
+      "kind",
+      "observed_at",
+      "block_number",
+      "predates_capture",
+    ]) {
+      const row: Record<string, unknown> = {
+        kind: "param",
+        observed_at: "2026-08-10T08:24:54.186Z",
+        block_number: 1,
+        predates_capture: false,
+      };
+      delete row[name];
+      assert.equal(
+        EmissionGateChangeSchema.safeParse(row).success,
+        false,
+        `${name} must be required`,
+      );
+    }
+  });
+});
+
+describe("OpportunityBoards", () => {
+  test("it declares exactly the boards the resolver publishes", () => {
+    const boards = Object.keys(OpportunityBoardsSchema.shape).filter(
+      (name) => name !== "observed_at" && name !== "with_economics_count",
+    );
+    assert.deepEqual(boards.sort(), [...OPPORTUNITY_BOARDS].sort());
+  });
+
+  test("every board is required, because the ranker always materializes it", () => {
+    // `formatLeaderboards` always emits every economic key, possibly as [] --
+    // the resolver relies on it and says so. An optional board here would let
+    // the SDL's six non-null promises go unchecked.
+    const complete = {
+      observed_at: null,
+      with_economics_count: 0,
+      ...Object.fromEntries(OPPORTUNITY_BOARDS.map((board) => [board, []])),
+    };
+    assert.equal(OpportunityBoardsSchema.safeParse(complete).success, true);
+    for (const board of OPPORTUNITY_BOARDS) {
+      const missing = { ...complete };
+      delete (missing as Record<string, unknown>)[board];
+      assert.equal(
+        OpportunityBoardsSchema.safeParse(missing).success,
+        false,
+        `${board} must be required`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`RESOLVER_BUILT_TYPES` was the list of published types **no gate reaches**. Every other type in the schema is compared field by field against the component it mirrors or projects; these four were taken on trust, so an over-promise in any of them — the class that nulled `SelfHealthLane.detail` on every request (#10215) — was invisible by construction.

It is now **empty**, and `validate:published-names` prints `0 resolver-built type(s)`.

| type | what it is now |
|---|---|
| `OpportunityBoards` | a projection of a registered `OpportunityBoards` component whose rows are the same `SubnetEconomics` card `OpportunityEntry` already projects |
| `EmissionGateChange` | a projection of a component **derived** from the three arm schemas `/api/v1/chain/governance/emission-changes` already serves |
| `ChainEvent` | a projection of `ChainFirehoseEvent`, the #4980 NOTIFY payload |
| `Subscription` | a **root**, like Query — declared in `SUBSCRIPTION_BINDINGS` and checked by the same comparison `QUERY_BINDINGS` gets |

Result: `42 declared projection(s) (267 fields)`, up from 39 (227).

## The two decisions this was blocked on

**Where GraphQL-only Zod lives: the same registry.** A second registry would be a second `$ref` namespace, and these shapes *reference the first* — `EmissionGateChange` is built from the arms `EmissionGateChangesArtifact` already models, and the board rows are the ones `/api/v1/registry/leaderboards` serves. Cross-registry refs do not resolve, so the GraphQL-only copies would have had to restate the shapes they reference, which is the duplication this epic exists to delete. The registry is *the* contract, not the REST contract: it already emits the MCP output schemas and the GraphQL type system from the same nodes, and `GenericArtifact` is the standing precedent for a registered component no route serves. New file: `schemas-src/graphql/graphql-only.ts`.

**Whether the emitter should emit GraphQL enums: not here.** `ChainEvent.table` publishes `ChainFirehoseTable!` and the emitter maps every registered Zod enum to `String`. This is the **only** output field in the schema typed by an enum — the SDL declares exactly two and the other is an argument — so changing the emitter is a decision about all 17 registered enum components and every field that refs one, not about this field. It is declared in `DECLARED` with that reasoning, on a list that only shrinks, and `String` is the widening: every value the enum admits serializes identically. The vocabulary is held to the producer's own by test rather than by comment.

## Derived, not restated

`EmissionGateChangeSchema` is computed from `EmissionParamChangeSchema` / `EmissionSubnetChangeSchema` / `EmissionFlowChangeSchema` — the four shared fields stay required, every arm-specific field becomes nullable-and-optional. That last part is not a loosening: a `param` row has **no `netuid` key at all**, and the route schema says why — absent means "this kind has no such thing" where null would mean "it has one and we do not know it". GraphQL cannot express the difference, so the published field is nullable either way; requiring the key would reject every real row.

The payoff is that a field added to any arm appears in the GraphQL type and the parity gate fails until the SDL publishes it. A hand-written flattened type would have silently not.

## The registration that made `OpportunityBoards` possible

`SubnetEconomicsSchema` (`schemas-src/shared.ts`) is **one** Zod node that `/api/v1/economics` and `/api/v1/subnets/{netuid}` both serve — and it was unregistered, so `z.toJSONSchema(registry, {reused: "inline"})` inlined it at every use. `OpportunityBoards`' six board arrays each got their own anonymous copy of the same 41 fields (`OpportunityBoardsOpenSlots`, `OpportunityBoardsCheapestRegistration`, …) instead of the one published `OpportunityEntry`.

Registering it under `SubnetEconomics` — the name the SDL already publishes it as — collapses those copies. `registration_cost_tao` goes from 14 occurrences in `openapi.json` to 12, and `EconomicsArtifactSubnets` stops being a derived nested name, so its `PUBLISHED_TYPE_NAMES` entry is replaced by the real component's. `openapi.json` gains four named components (`OpportunityBoards`, `EmissionGateChange`, `ChainFirehoseEvent`, `SubnetEconomics`), 319 → 323.

## Tests compare each schema to its PRODUCER, never to another schema

A contract consistent with itself proves nothing, and these three describe shapes whose producer lives in resolver or Worker code — which is exactly how they can rot.

- `ChainFirehoseEvent`'s table vocabulary is asserted **equal to `CHAIN_FIREHOSE_TABLES`**, the set the subscription filter, the SSE topic parser and the ingest validator all read — a fifth table added there and not here would publish a `ChainEvent` the schema rejects
- a real payload of each of the four tables is run through **both** `validateChainFirehoseIngestPayload` (the hand-written ingest check) and the Zod schema, and both must accept it — plus the negative half, that an unknown table is rejected
- `EmissionGateChange` must carry exactly the union of the three arms' fields, a row from each arm must parse, and the four shared fields must stay required
- `OpportunityBoards` must declare exactly the six boards the resolver publishes, each required — because `formatLeaderboards` always materializes every economic key and the resolver relies on it

`validate-published-names` now runs its binding comparison over **both** roots. Subscription's one field was checked by nothing: its return type and description lived only in the SDL, which is the exact drift `QUERY_BINDINGS` exists to stop, on the one root that had no registry.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `validate:graphql-component-parity` — 329 mirrors / 2544 fields / **42** projections (**267** fields) / 25 pagination views / 194 drops / 51 under-typings, OK
- `validate:published-names` — 361 component names, 322 published types, 196 Query bindings, **1 Subscription binding**, 42 projections, **0 resolver-built types**, 1 alias
- `validate:contract-drift`, `validate:graphql-types-drift`, `validate:graphql-route-parity` (164 pairs / 1190 fields / 0 divergences) — pass
- `report:graphql-sdl-equivalence` — unchanged at 338/338, 196/196, 167 argument lists
- `npx vitest run` — **799 files, 18,459 passed, 11 skipped, 0 failed**. One earlier run of the same tree showed 2 files failing on the `ENOTEMPTY … dist/metagraph-r2/…` write race that also hit before this branch; neither reproduced on a clean re-run.
- rebuilt on `f399ea2ee` after #10421 and #10410 landed — `npm run build` produced **no** further diff, so the committed artifacts are exactly what the new main plus these sources generate

No `src/**` or `workers/**` file changed, so there is no `codecov/patch` surface in this diff.

Closes #10409.
