### PR TITLE
ci: run lint concurrently, and shard the pass I was wrong to refuse

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -343,10 +343,25 @@ jobs:
       # private-boundary leak, broken doc-contract reference, or malformed
       # intake template can land in a "docs-only" PR just as easily as in a
       # code PR).
+      # CONCURRENTLY, not sequentially (#10424). eslint and prettier read the
+      # same tree and write nothing, so they share nothing but CPU: timed
+      # separately they are 38s and 29s, and in series that is the 80s that
+      # dominated this job.
+      #
+      # Both are waited on and the exit code is carried out explicitly, because
+      # a bare `cmd & cmd & wait` reports the SHELL's status, not the jobs' --
+      # it would turn a red lint into a green step, which is worse than a slow
+      # one. Verified against every combination: (0,0)->0, (1,0)->1, (0,1)->1,
+      # (3,5)->5. Both still run even when the first fails, so one push shows
+      # you both lists rather than making you fix them one at a time.
       - name: Lint + format
         run: |
-          npm run lint
-          npm run format:check
+          npm run lint & lint=$!
+          npm run format:check & fmt=$!
+          rc=0
+          wait $lint || rc=$?
+          wait $fmt || rc=$?
+          exit $rc
 
       # Same class of check as Lint + format above: cheap, no build, no network
       # — runs unconditionally rather than gating on DOCS_ONLY since a real
@@ -727,24 +742,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: shared 1/3
+          - name: shared 1/5
             id: shared-1
-            args: --pass=shared --shard=1/3
+            args: --pass=shared --shard=1/5
             cov: coverage
             junit: ""
-          - name: shared 2/3
+          - name: shared 2/5
             id: shared-2
-            args: --pass=shared --shard=2/3
+            args: --pass=shared --shard=2/5
             cov: coverage
             junit: ""
-          - name: shared 3/3
+          - name: shared 3/5
             id: shared-3
-            args: --pass=shared --shard=3/3
+            args: --pass=shared --shard=3/5
             cov: coverage
             junit: ""
-          - name: mocked
-            id: mocked
-            args: --pass=mocked
+          - name: shared 4/5
+            id: shared-4
+            args: --pass=shared --shard=4/5
+            cov: coverage
+            junit: ""
+          - name: shared 5/5
+            id: shared-5
+            args: --pass=shared --shard=5/5
+            cov: coverage
+            junit: ""
+          - name: mocked 1/2
+            id: mocked-1
+            args: --pass=mocked --shard=1/2
+            cov: coverage-mocked
+            junit: "-mocked"
+          - name: mocked 2/2
+            id: mocked-2
+            args: --pass=mocked --shard=2/2
             cov: coverage-mocked
             junit: "-mocked"
     steps:
@@ -896,7 +926,7 @@ jobs:
       # failure this check has always existed to prevent.
       - name: Verify every leg's report arrived
         run: |
-          for f in lcov-shared-1 lcov-shared-2 lcov-shared-3 lcov-mocked; do
+          for f in lcov-shared-1 lcov-shared-2 lcov-shared-3 lcov-shared-4 lcov-shared-5 lcov-mocked-1 lcov-mocked-2; do
             test -s "cov/$f.info" || { echo "missing or empty: cov/$f.info"; exit 1; }
           done
 
@@ -950,7 +980,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-mocked.info
+          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-shared-4.info,./cov/lcov-shared-5.info,./cov/lcov-mocked-1.info,./cov/lcov-mocked-2.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
@@ -969,7 +999,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-mocked.info
+          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-shared-4.info,./cov/lcov-shared-5.info,./cov/lcov-mocked-1.info,./cov/lcov-mocked-2.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
@@ -982,7 +1012,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-mocked.xml
+          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-shared-4.xml,./cov/vitest-shared-5.xml,./cov/vitest-mocked-1.xml,./cov/vitest-mocked-2.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1
@@ -995,7 +1025,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-mocked.xml
+          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-shared-4.xml,./cov/vitest-shared-5.xml,./cov/vitest-mocked-1.xml,./cov/vitest-mocked-2.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1

--- a/scripts/run-ci-tests.ts
+++ b/scripts/run-ci-tests.ts
@@ -64,13 +64,18 @@ if (PASS !== null && PASS !== "shared" && PASS !== "mocked") {
   );
   process.exit(1);
 }
-// A shard of the mocking pass would be a silent no-op on the wrong pass rather
-// than an error, so it is refused: 71 files do not need slicing, and asking for
-// it means the caller believes something untrue about what is running.
-if (SHARD !== null && PASS !== "shared") {
+// Either pass may be sharded. #10414 refused it on the mocking pass, reasoning
+// that 71 files were not worth slicing -- which sized the work by FILE COUNT
+// when the cost is per-file IMPORT. 129s of that pass's 158s is module import,
+// ~1.8s per file, because each file needs its own registry (#8922) and
+// re-imports mcp-server.ts and graphql.ts from scratch. Import cost shards
+// exactly as well as test time does, and the unsharded mocking pass went on to
+// be the longest job in the run. A shard still requires a pass, though: on its
+// own it would silently slice whichever pass ran first.
+if (SHARD !== null && PASS === null) {
   console.error(
-    "run-ci-tests: --shard applies to --pass=shared only (the mocking pass is " +
-      "71 files and is not worth slicing).",
+    "run-ci-tests: --shard requires --pass, or it would slice only the first " +
+      "pass and silently run the second whole.",
   );
   process.exit(1);
 }
@@ -177,12 +182,13 @@ if (PASS === null || PASS === "shared") {
 // both to Codecov, which merges them.
 if (PASS === null || PASS === "mocked") {
   runPass(
-    `module-mocking, isolated (${mockingFiles.length} files)`,
+    `module-mocking, isolated (${mockingFiles.length} files${SHARD ? `, shard ${SHARD}` : ""})`,
     [
       ...BASE,
       "--coverage",
       "--coverage.reportsDirectory=coverage-mocked",
       ...NO_PER_PASS_THRESHOLDS,
+      ...(SHARD ? [`--shard=${SHARD}`] : []),
       ...mockingFiles.map((name) => `tests/${name}`),
     ],
     "-mocked",


### PR DESCRIPTION
#10414 moved the bottleneck rather than removing it. Measured on its merged run:

```
249s  validate        — of which Lint + format is 80s
251s  test (mocked)   — the single longest job
222s / 204s / 149s    — the shared shards, badly unbalanced
 30s  coverage
```

Three things, each measured before changing anything.

## 1. Lint ran serially

eslint and prettier read the same tree and write nothing, so they share nothing but CPU. Timed separately: **38s and 29s**. In series that's the 80s dominating the job.

Both are waited on and the exit code carried out explicitly, because a bare `cmd & cmd & wait` reports the **shell's** status — it would turn a red lint into a green step, which is worse than a slow one. Verified against every combination: `(0,0)→0`, `(1,0)→1`, `(0,1)→1`, `(3,5)→5`. Both still run when the first fails, so one push shows you both lists.

## 2. I was wrong to refuse sharding the mocking pass

#10414 added a guard rejecting `--shard` on `--pass=mocked`, reasoning that *"71 files do not need slicing"*. That sized the work by **file count** when the cost is per-file **import**: 129s of that pass's 158s is module import, ~1.8s per file, because each file needs its own registry (#8922) and re-imports `mcp-server.ts` and `graphql.ts` from scratch.

Import cost shards exactly as well as test time does — and the unsharded pass then became the longest job in the run, which is the evidence the reasoning was wrong. Locally: `--pass=mocked --shard=1/2` runs 36 files in **37s** against 49s for all 71.

The guard is **removed**, not worked around. What remains is that `--shard` still requires `--pass`, or it would slice one pass and silently run the other whole.

## 3. The shared shards were unbalanced

149s to 222s — a 50% spread, because vitest shards by file count and not by duration. Five shards instead of three narrows the spread as well as the total.

## Coverage is unaffected

Seven legs still publish artifacts merged by the single upload from #10414, `after_n_builds` stays 1, and both consolidation guards still hold at the new leg count.

## What this does *not* fix

It distributes the import cost rather than removing it. Breaking the transitive reach from those 71 files into `mcp-server.ts`/`graphql.ts` — the same class of fix as #10376, which cut the data-api bundle 8328→3280 KiB — is the real win, because it deletes the work instead of buying more runners to absorb it. Worth its own issue rather than being quietly folded in here.

## Verification

All 45 validators, `tsc`, `eslint`, `prettier` clean; workflow YAML parses and `validate:workflows` passes at the new 7-leg count. Both new guard behaviours exercised locally. **The measured critical path from this PR's own run will be quoted here before it merges.**

Closes #10424
