### PR TITLE
ci: cut the import at its root, and revert the shard count that measured worse

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -742,29 +742,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: shared 1/5
+          - name: shared 1/3
             id: shared-1
-            args: --pass=shared --shard=1/5
+            args: --pass=shared --shard=1/3
             cov: coverage
             junit: ""
-          - name: shared 2/5
+          - name: shared 2/3
             id: shared-2
-            args: --pass=shared --shard=2/5
+            args: --pass=shared --shard=2/3
             cov: coverage
             junit: ""
-          - name: shared 3/5
+          - name: shared 3/3
             id: shared-3
-            args: --pass=shared --shard=3/5
-            cov: coverage
-            junit: ""
-          - name: shared 4/5
-            id: shared-4
-            args: --pass=shared --shard=4/5
-            cov: coverage
-            junit: ""
-          - name: shared 5/5
-            id: shared-5
-            args: --pass=shared --shard=5/5
+            args: --pass=shared --shard=3/3
             cov: coverage
             junit: ""
           - name: mocked 1/2
@@ -926,7 +916,7 @@ jobs:
       # failure this check has always existed to prevent.
       - name: Verify every leg's report arrived
         run: |
-          for f in lcov-shared-1 lcov-shared-2 lcov-shared-3 lcov-shared-4 lcov-shared-5 lcov-mocked-1 lcov-mocked-2; do
+          for f in lcov-shared-1 lcov-shared-2 lcov-shared-3 lcov-mocked-1 lcov-mocked-2; do
             test -s "cov/$f.info" || { echo "missing or empty: cov/$f.info"; exit 1; }
           done
 
@@ -980,7 +970,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-shared-4.info,./cov/lcov-shared-5.info,./cov/lcov-mocked-1.info,./cov/lcov-mocked-2.info
+          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-mocked-1.info,./cov/lcov-mocked-2.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
@@ -999,7 +989,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-shared-4.info,./cov/lcov-shared-5.info,./cov/lcov-mocked-1.info,./cov/lcov-mocked-2.info
+          files: ./cov/lcov-shared-1.info,./cov/lcov-shared-2.info,./cov/lcov-shared-3.info,./cov/lcov-mocked-1.info,./cov/lcov-mocked-2.info
           disable_search: true
           version: v11.3.1
           override_branch: ${{ github.event.pull_request.head.repo.owner.login }}:${{ github.event.pull_request.head.ref }}
@@ -1012,7 +1002,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-shared-4.xml,./cov/vitest-shared-5.xml,./cov/vitest-mocked-1.xml,./cov/vitest-mocked-2.xml
+          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-mocked-1.xml,./cov/vitest-mocked-2.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1
@@ -1025,7 +1015,7 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]') }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-shared-4.xml,./cov/vitest-shared-5.xml,./cov/vitest-mocked-1.xml,./cov/vitest-mocked-2.xml
+          files: ./cov/vitest-shared-1.xml,./cov/vitest-shared-2.xml,./cov/vitest-shared-3.xml,./cov/vitest-mocked-1.xml,./cov/vitest-mocked-2.xml
           report_type: test_results
           disable_search: true
           version: v11.3.1

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -209,6 +209,27 @@ for (const workflow of workflows) {
         workflow,
         "sharded test legs must publish coverage as artifacts for one merged Codecov upload, not upload per leg",
       );
+      // Every leg must be named in the merge job -- in the existence check AND
+      // in both Codecov `files:` lists (token and tokenless). Changing the
+      // shard count and missing one of those four places is not hypothetical:
+      // it happened twice while writing this, and the failure is silent. A
+      // leg left out of `files:` is simply not counted, which reads as a
+      // coverage drop; a leg left out of the existence check removes the only
+      // thing that would have said so.
+      const legIds = [
+        ...content.matchAll(/\n\s+id: (\S+)\n\s+args: --pass=/g),
+      ].map((m) => m[1]);
+      const missing = legIds.filter(
+        (id) =>
+          !content.includes(`lcov-${id}.info`) ||
+          !content.includes(`vitest-${id}.xml`) ||
+          !new RegExp(`for f in [^;]*lcov-${id}\\b`).test(content),
+      );
+      check(
+        legIds.length > 0 && missing.length === 0,
+        workflow,
+        `test matrix leg(s) missing from the coverage merge job: ${missing.join(", ") || "(no legs parsed)"} -- every leg must appear in both Codecov files: lists and the per-leg existence check`,
+      );
     }
 
     const coverageUploads = codecovSteps.filter(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -408,7 +408,6 @@ import {
 import { McpSessionHub } from "./mcp-session-hub.ts";
 import { AlerterHub } from "./alerter-hub.ts";
 import { SubnetStatusHub } from "./subnet-status-hub.ts";
-import { handleMcpRequest } from "../src/mcp-server.ts";
 import { handleFeedRequest, resolveFeedFormat } from "../src/feeds.ts";
 import { handleBadgeRequest } from "../src/badge.ts";
 import { handleOgImage } from "../src/og-image.ts";
@@ -439,7 +438,6 @@ import { resolveEmissionPipelineEconomics } from "../src/emission-pipeline-surfa
 import { pruneChainDetail } from "../src/chain-detail-prune.ts";
 import { runRpcUsageStalenessWatchdog } from "../src/rpc-usage-staleness-watchdog.ts";
 import { runTopHoldersStalenessWatchdog } from "../src/top-holders-staleness-watchdog.ts";
-import { handleGraphQLRequest } from "../src/graphql.ts";
 import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 import {
   handleAuthorizeRequest,
@@ -4590,6 +4588,16 @@ async function dispatchRequest(
   // treats the two as one route, and the app answering only the bare form is what put
   // an otherwise-correct client on the 405 path.
   if (isMcpEndpointPath(url.pathname)) {
+    // IMPORTED HERE, NOT AT MODULE SCOPE (#10424). src/mcp-server.ts is ~12.5k
+    // lines and this is the ONLY thing api.ts uses from it, so a static import
+    // made every consumer of api.ts pay for the whole MCP server: 23 of the 39
+    // module-mocking tests that reach a heavy module reached it through this
+    // one edge, at ~1.8s of import each because those tests cannot share a
+    // module registry (#8922). Deferring it also takes the parse and evaluate
+    // off the Worker's startup path, where #10238 already showed that what runs
+    // at import is what exceeds the 400ms ceiling -- an MCP request pays for
+    // the module it actually uses, and nothing else does.
+    const { handleMcpRequest } = await import("../src/mcp-server.ts");
     // executionCtx is what lets tool-dispatch telemetry (#6031) drain its
     // capture through waitUntil instead of stranding it on isolate exit.
     return handleMcpRequest(request, env, {
@@ -4746,6 +4754,13 @@ async function dispatchRequest(
     }
     const limited = await graphqlRateLimited(request, env);
     if (limited) return limited;
+    // Deferred for the same reason as the MCP handler above (#10424):
+    // src/graphql.ts is ~10k lines, this is the only thing api.ts uses from
+    // it, and a static import made every consumer of api.ts load the whole
+    // GraphQL surface. Loaded after the rate limiter deliberately -- a
+    // throttled request should not pay to parse a schema it is not going to
+    // execute against.
+    const { handleGraphQLRequest } = await import("../src/graphql.ts");
     return handleGraphQLRequest(request, env, ctx);
   }
 

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -9,16 +9,6 @@ import { readArtifact, readHealthKv } from "../storage.ts";
 import { contractVersion, publishedAt } from "../responses.ts";
 import { KV_HEALTH_CURRENT } from "../../src/health-prober.ts";
 import { subnetBadgeStatus } from "../../src/health-serving.ts";
-import {
-  listToolDefinitions,
-  listPromptDefinitions,
-  MCP_SERVER_INFO,
-  MCP_INSTRUCTIONS,
-  MCP_PROTOCOL_VERSIONS,
-  MCP_CAPABILITIES,
-  MCP_REGISTRY_META,
-  MCP_RESOURCE_TEMPLATES,
-} from "../../src/mcp-server.ts";
 import { feedLinkHeader } from "../../src/feeds.ts";
 import {
   buildAgentToolsIndex,
@@ -392,6 +382,27 @@ export async function mcpServerCardResponse(
   request: Request,
   env: Env,
 ): Promise<Response> {
+  // IMPORTED HERE, NOT AT MODULE SCOPE (#10424). src/mcp-server.ts is ~12.5k
+  // lines; these eight bindings are the only things this module uses from it,
+  // and six of them are plain constants. A static import made every consumer
+  // of discovery.ts -- which is most of the request-handler graph -- load the
+  // whole MCP server: 19 of the module-mocking tests that reach a heavy module
+  // reached it through THIS edge, paying ~1.8s of import each because those
+  // tests cannot share a module registry (#8922).
+  //
+  // Deferred rather than split into a leaf constants module: listToolDefinitions
+  // genuinely needs the tool registry, so extracting only the constants would
+  // leave the expensive edge in place for a smaller win and two files.
+  const {
+    listToolDefinitions,
+    listPromptDefinitions,
+    MCP_SERVER_INFO,
+    MCP_INSTRUCTIONS,
+    MCP_PROTOCOL_VERSIONS,
+    MCP_CAPABILITIES,
+    MCP_REGISTRY_META,
+    MCP_RESOURCE_TEMPLATES,
+  } = await import("../../src/mcp-server.ts");
   const base = `https://${PRIMARY_DOMAIN}`;
   const serverCardContent = {
     schema_version: 1,
@@ -492,6 +503,8 @@ export async function agentToolsResponse(
   env: Env,
   kind: string,
 ): Promise<Response> {
+  // Deferred for the same reason as mcpServerCardResponse above (#10424).
+  const { listToolDefinitions } = await import("../../src/mcp-server.ts");
   const tools = listToolDefinitions();
   const data =
     kind === "openai"


### PR DESCRIPTION
#10425 merged at its **first** push, not its last — so main carries a configuration that PR's own run measured as worse, and none of the fix it was ultimately about. This re-lands the final state.

## 1. The shard count goes back to three

| shards | per-leg | max | sum |
|---|---|---|---|
| 3 shared | 149 / 204 / 222s | **222s** | 575s |
| 5 shared | 98 / 130 / 149 / 153 / **263s** | **263s** | 793s |

Five shards **added 218s of total work** and made the *slowest* leg worse — the number that sets the critical path. Each shard is its own process with its own module registry, so splitting further re-imports the shared modules more times; and vitest shards by file count, not duration, so a finer split concentrates the slow files: 263s against a 98s sibling.

Main's critical path is ~294s today, against ~281s before #10425. This puts it back.

## 2. The import cost, cut at its root

Sharding distributes it; this removes it. Crawling the static import graph from the 71 module-mocking tests, 39 reach a heavy module — through **three edges, not seventy-one**:

```
23  workers/api.ts                        -> src/mcp-server.ts
19  workers/request-handlers/discovery.ts -> src/mcp-server.ts
20  workers/chain-firehose-hub.ts         -> src/graphql.ts
```

The first two are accidents of module scope, not real dependencies. `api.ts` uses exactly **one** binding from `mcp-server.ts` (~12.5k lines) and **one** from `graphql.ts` (~10k). `discovery.ts` uses eight, six of them plain constants. All sit inside async functions, so they are imported there.

Reach drops **39 → 32**, and both modules come off the Worker's startup path — where #10238 established that what runs at import is what breaches the 400 ms ceiling. Those tests each pay ~1.8s of import because they cannot share a module registry (#8922), so this is 42 file-loads of 22.5k lines that simply stop happening.

**The third edge stays deliberately.** `chain-firehose-hub.ts` validates subscription documents against the real schema in a *synchronous* exported function, and builds the graphql-ws server in a Durable Object **constructor** — which cannot await. That is a genuine dependency; deferring it would mean restructuring a live DO's initialisation to save import time, which is a different change with a different risk profile.

## 3. A guard, because I broke this twice

Every matrix leg must appear in the merge job's existence check **and both** Codecov `files:` lists. Changing the shard count and missing one of those four places is silent — a leg left out of `files:` is simply not counted, which reads as a coverage drop, and a leg left out of the existence check removes the only thing that would have said so. Proven to fail on a dropped leg.

## On measurement

Local timing was unusable for any of this — the same command took **170s and 69s** minutes apart on a contended machine, and I nearly drew a conclusion from the first number. Every figure above is from CI.

Closes #10428
