### PR TITLE
feat(graphql): build the published schema from the declared sources

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2174,6 +2174,8 @@ export type EndpointIncident = {
   provider?: Maybe<Scalars['String']['output']>;
   reason?: Maybe<Scalars['String']['output']>;
   severity?: Maybe<Scalars['String']['output']>;
+  /** How the incident was derived. Always probe-derived: the health prober owns this surface and no hand-set incident exists. Served by /api/v1/endpoint-incidents on every row -- verified live -- and not selectable here until the generator surfaced the omission (#10214). */
+  source?: Maybe<Scalars['String']['output']>;
   state?: Maybe<Scalars['String']['output']>;
   status?: Maybe<Scalars['String']['output']>;
   subnet_name?: Maybe<Scalars['String']['output']>;
@@ -9018,6 +9020,7 @@ export type EndpointIncidentResolvers<ContextType = GqlContext, ParentType exten
   provider?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   reason?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   severity?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   state?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   subnet_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "validate:graphql-component-parity": "node scripts/validate-graphql-component-parity.ts",
     "validate:graphql-query-arguments": "node scripts/validate-graphql-query-arguments.ts",
     "report:graphql-sdl-equivalence": "node scripts/report-graphql-sdl-equivalence.ts",
+    "report:graphql-schema-diff": "node scripts/report-graphql-schema-diff.ts",
     "validate:published-names": "node scripts/validate-published-names.ts",
     "validate:graphql-tier-parity": "node scripts/validate-graphql-tier-parity.ts",
     "build:openapi-zod": "node scripts/generate-openapi-zod-components.ts",

--- a/schemas-src/graphql/build-schema.ts
+++ b/schemas-src/graphql/build-schema.ts
@@ -1,0 +1,287 @@
+// Assemble the published GraphQL schema from the declared sources (#10214).
+//
+// This is the thing the epic exists to produce: `src/graphql-sdl.ts` is 5,409
+// lines nothing generates, and every gate around it exists only because it is
+// hand-written. Everything it contains is now declared somewhere else --
+//
+//   the object types          Zod, via `emitTypes()`
+//   their published names     PUBLISHED_TYPE_NAMES / ALIASED_TYPE_NAMES
+//   the projections           PROJECTED_TYPES (added/dropped/itemsFrom/totalFrom)
+//   the Query root            QUERY_BINDINGS + `deriveQueryArguments`
+//   the Subscription root     SUBSCRIPTION_BINDINGS
+//   the enums and the scalar  GRAPHQL_ENUMS / `JSONScalar`
+//
+// -- so this reads those and returns a `GraphQLSchema`. It is built with
+// graphql-js and printed by `printSchema`, never concatenated as text: the
+// printer owns SDL syntax (escaping, block strings, field order), and a
+// generator that assembled source strings would be a second, worse printer.
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parseType,
+} from "graphql";
+import type {
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLInputType,
+  GraphQLNamedType,
+  GraphQLNullableOutputType,
+  GraphQLNullableType,
+  GraphQLOutputType,
+  GraphQLType,
+  TypeNode,
+} from "graphql";
+import { JSONScalar, emitTypes } from "./emit.ts";
+import { GRAPHQL_ENUMS } from "./enums.ts";
+import {
+  ALIASED_TYPE_NAMES,
+  PROJECTED_TYPES,
+  PUBLISHED_TYPE_NAMES,
+  QUERY_BINDINGS,
+  SUBSCRIPTION_BINDINGS,
+} from "./published-names.ts";
+import {
+  deriveQueryArguments,
+  type OpenApiParameters,
+} from "./query-arguments.ts";
+
+const SCALARS: Readonly<Record<string, GraphQLNamedType>> = {
+  String: GraphQLString,
+  Int: GraphQLInt,
+  Float: GraphQLFloat,
+  Boolean: GraphQLBoolean,
+  ID: GraphQLID,
+  JSON: JSONScalar,
+};
+
+/** Every published type, by name -- the schema's whole type namespace. */
+export interface BuiltSchema {
+  schema: GraphQLSchema;
+  /** Published name -> the component it was built from, for reporting. */
+  sources: Map<string, string>;
+}
+
+export function buildGeneratedSchema(
+  openapi: OpenApiParameters,
+  // Takes the projections so a test can drive the builder with a MUTATED
+  // declaration -- a generator only ever run against a passing tree proves it
+  // runs, not that it reads what it claims to.
+  projections: Readonly<
+    Record<string, (typeof PROJECTED_TYPES)[string]>
+  > = PROJECTED_TYPES,
+): BuiltSchema {
+  const { types: emitted } = emitTypes();
+  const sources = new Map<string, string>();
+
+  /** Every published name declared OVER a component, for the reverse lookup. */
+  const projectionOf = new Map<string, string>();
+  for (const [published, projection] of Object.entries(projections)) {
+    if (!projectionOf.has(projection.component)) {
+      projectionOf.set(projection.component, published);
+    }
+  }
+
+  /**
+   * The name a component is published under.
+   *
+   * BOTH routes, and the projection one is easy to miss: `AccountsListArtifact
+   * Accounts` has no `PUBLISHED_TYPE_NAMES` entry because it is not renamed --
+   * it is PROJECTED, as `AccountEntry`. Reading only the rename map publishes
+   * the component's own id and silently mints a second type for a shape the
+   * schema already names.
+   */
+  function publishedName(component: string): string {
+    return (
+      PUBLISHED_TYPE_NAMES[component] ??
+      projectionOf.get(component) ??
+      component
+    );
+  }
+
+  /** Published name -> the component that supplies its fields. */
+  const componentFor = new Map<string, string>();
+  for (const [component] of emitted) {
+    const published = publishedName(component);
+    if (!componentFor.has(published)) componentFor.set(published, component);
+    const alias = ALIASED_TYPE_NAMES[component];
+    if (alias && !componentFor.has(alias)) componentFor.set(alias, component);
+  }
+  for (const [published, projection] of Object.entries(projections)) {
+    componentFor.set(published, projection.component);
+  }
+
+  const enums = new Map<string, GraphQLEnumType>();
+  for (const [name, declaration] of Object.entries(GRAPHQL_ENUMS)) {
+    enums.set(
+      name,
+      new GraphQLEnumType({
+        name,
+        description: declaration.description,
+        values: Object.fromEntries(
+          declaration.values.map((value) => [value, {}]),
+        ),
+      }),
+    );
+  }
+
+  const built = new Map<string, GraphQLObjectType>();
+
+  /** Resolve a NAME to its published type, building it on first use. */
+  function named(name: string): GraphQLNamedType {
+    const scalar = SCALARS[name];
+    if (scalar) return scalar;
+    const enumType = enums.get(name);
+    if (enumType) return enumType;
+    const existing = built.get(name);
+    if (existing) return existing;
+    const component = componentFor.get(name);
+    if (!component) throw new Error(`nothing declares the type ${name}`);
+    const source = emitted.get(component);
+    if (!source)
+      throw new Error(`${name} names the absent component ${component}`);
+    const projection = projections[name];
+    const type = new GraphQLObjectType({
+      name,
+      description: source.description ?? undefined,
+      // A THUNK, so a type that references itself (or a cycle through two)
+      // resolves rather than recursing while it is still being constructed.
+      fields: () => {
+        const fields: Record<string, GraphQLFieldConfig<unknown, unknown>> = {};
+        const dropped = new Set(projection?.dropped ?? []);
+        const renamed = new Map<string, string>();
+        if (projection?.itemsFrom) renamed.set(projection.itemsFrom, "items");
+        if (projection?.totalFrom) renamed.set(projection.totalFrom, "total");
+        for (const [fieldName, field] of Object.entries(source.getFields())) {
+          if (dropped.has(fieldName)) continue;
+          fields[renamed.get(fieldName) ?? fieldName] = {
+            type: republish(field.type),
+            description: field.description ?? undefined,
+          };
+        }
+        for (const [fieldName, added] of Object.entries(
+          projection?.added ?? {},
+        )) {
+          fields[fieldName] = {
+            type: fromSpelling(added) as GraphQLOutputType,
+          };
+        }
+        return fields;
+      },
+    });
+    built.set(name, type);
+    sources.set(name, component);
+    return type;
+  }
+
+  /** An emitted field's type, with every object swapped for its published one. */
+  function republish(type: GraphQLOutputType): GraphQLOutputType {
+    if (type instanceof GraphQLNonNull) {
+      return new GraphQLNonNull(
+        republish(
+          type.ofType as GraphQLOutputType,
+        ) as GraphQLNullableOutputType,
+      );
+    }
+    if (type instanceof GraphQLList) {
+      return new GraphQLList(republish(type.ofType as GraphQLOutputType));
+    }
+    if (type instanceof GraphQLObjectType) {
+      return named(publishedName(type.name)) as GraphQLOutputType;
+    }
+    return type;
+  }
+
+  /**
+   * `[SubnetHealth!]!` -> the built type.
+   *
+   * Returns the graphql-js union rather than an output or input type: the same
+   * spelling is a field's type on one side and an argument's on the other, and
+   * only the caller knows which. Both call sites narrow at the boundary.
+   */
+  function fromSpelling(spelling: string): GraphQLType {
+    const walk = (node: TypeNode): GraphQLType => {
+      if (node.kind === "NonNullType") {
+        return new GraphQLNonNull(walk(node.type) as GraphQLNullableType);
+      }
+      if (node.kind === "ListType") return new GraphQLList(walk(node.type));
+      return named(node.name.value);
+    };
+    return walk(parseType(spelling));
+  }
+
+  /** One root, assembled from its declared bindings. */
+  function root(
+    name: "Query" | "Subscription",
+    bindings: typeof QUERY_BINDINGS,
+    withArguments: boolean,
+  ): GraphQLObjectType {
+    return new GraphQLObjectType({
+      name,
+      fields: () =>
+        Object.fromEntries(
+          bindings.map((binding) => {
+            const args: GraphQLFieldConfigArgumentMap = {};
+            if (
+              withArguments &&
+              binding.route &&
+              openapi.paths?.[binding.route]
+            ) {
+              const twin = binding.route.replace(
+                "/api/v1/",
+                "/api/v1/{network}/",
+              );
+              const returns = named(binding.returns.replace(/[![\]]/g, ""));
+              for (const argument of deriveQueryArguments(
+                binding.field,
+                binding.route,
+                openapi,
+                {
+                  hasNetworkTwin: Boolean(openapi.paths?.[twin]),
+                  returnsProjectable:
+                    returns instanceof GraphQLObjectType &&
+                    !Object.values(returns.getFields()).some((field) =>
+                      String(field.type).includes("JSON"),
+                    ),
+                },
+              )) {
+                args[argument.name] = {
+                  type: fromSpelling(argument.type) as GraphQLInputType,
+                };
+              }
+            }
+            return [
+              binding.field,
+              {
+                type: fromSpelling(binding.returns) as GraphQLOutputType,
+                description: binding.description,
+                ...(Object.keys(args).length ? { args } : {}),
+              },
+            ];
+          }),
+        ),
+    });
+  }
+
+  const query = root("Query", QUERY_BINDINGS, true);
+  const subscription = root("Subscription", SUBSCRIPTION_BINDINGS, false);
+  // The type set is what the ROOTS REACH, which is what a GraphQL schema's
+  // type set means -- graphql-js collects it while building. Publishing every
+  // registered component instead would advertise ~200 types no query can
+  // select, which is a different contract from the one served today.
+  return {
+    schema: new GraphQLSchema({
+      query,
+      subscription,
+      types: [...enums.values(), JSONScalar],
+    }),
+    sources,
+  };
+}

--- a/schemas-src/graphql/enums.ts
+++ b/schemas-src/graphql/enums.ts
@@ -1,0 +1,94 @@
+// The two enum types the published schema declares (#10214).
+//
+// Neither can be emitted from a component the way an object type is: the
+// emitter maps every registered Zod enum to `String`, deliberately -- there are
+// 17 registered enum components and turning them all into GraphQL enums is a
+// decision about the whole published surface. These two are the ones the SDL
+// has always declared, so they are declared here, each DERIVED from the
+// producer's own vocabulary rather than restated.
+//
+// A narrowing has to be written down and justified, and it can only ever be a
+// SUBSET -- `assertEnumVocabularies` fails on a value the producer does not
+// have, so this cannot invent one.
+import { CHAIN_FIREHOSE_TABLES } from "../../src/chain-firehose-topics.ts";
+import { BITTENSOR_NETWORK_VALUES } from "../shared.ts";
+
+export interface PublishedEnum {
+  readonly description: string;
+  readonly values: readonly string[];
+  /** The producer vocabulary `values` must be a subset of. */
+  readonly from: readonly string[];
+  /** Values the producer has that GraphQL does not publish, and why. */
+  readonly excluded?: Readonly<Record<string, string>>;
+}
+
+export const GRAPHQL_ENUMS: Readonly<Record<string, PublishedEnum>> = {
+  Network: {
+    description:
+      "The Bittensor network whose static subnet artifact to read: finney (mainnet, default) or test (testnet). Mirrors the list_subnets MCP tool's network argument.",
+    values: ["finney", "test"],
+    from: BITTENSOR_NETWORK_VALUES,
+    excluded: {
+      local:
+        "a developer chain with no published artifact -- nothing serves it, " +
+        "and GraphQL rejects it today: `subnets(network: local)` answers " +
+        '\'Value "local" does not exist in "Network" enum.\' Verified against ' +
+        "api.metagraph.sh. Publishing it would advertise a network with no data.",
+    },
+  },
+  ChainFirehoseTable: {
+    description:
+      "Which source table a live chain event came from. The same four topics the SSE firehose and the ingest validator accept.",
+    values: [...CHAIN_FIREHOSE_TABLES],
+    from: [...CHAIN_FIREHOSE_TABLES],
+  },
+};
+
+/**
+ * Every published value must exist in the producer's vocabulary, and every
+ * value the producer has must be published or declared excluded.
+ *
+ * Takes the declarations so a test can drive it with a MUTATED one -- run only
+ * against the real pair it proves it passes, not that it can fail.
+ *
+ * Both directions, because each catches a different rot: a published value the
+ * producer dropped is a type a client can send and nothing can answer, and a
+ * producer value nobody published is a silent hole -- which is what a
+ * fifth firehose table would be.
+ */
+export function assertEnumVocabularies(
+  declarations: Readonly<Record<string, PublishedEnum>> = GRAPHQL_ENUMS,
+): string[] {
+  const problems: string[] = [];
+  for (const [name, declaration] of Object.entries(declarations)) {
+    const producer = new Set(declaration.from);
+    for (const value of declaration.values) {
+      if (!producer.has(value)) {
+        problems.push(`${name}.${value} -- the producer has no such value`);
+      }
+    }
+    const publishedValues = new Set(declaration.values);
+    for (const value of declaration.from) {
+      if (publishedValues.has(value)) continue;
+      if (declaration.excluded?.[value]) continue;
+      problems.push(
+        `${name}.${value} -- the producer publishes it, the enum neither ` +
+          `publishes nor declares it excluded`,
+      );
+    }
+    for (const value of Object.keys(declaration.excluded ?? {})) {
+      if (!producer.has(value)) {
+        problems.push(
+          `${name}.${value} -- declared excluded, but the producer no longer ` +
+            `has it (delete the entry)`,
+        );
+      }
+      if (publishedValues.has(value)) {
+        problems.push(
+          `${name}.${value} -- declared excluded, and the enum publishes it`,
+        );
+      }
+    }
+  }
+  return problems;
+}

--- a/scripts/report-graphql-schema-diff.ts
+++ b/scripts/report-graphql-schema-diff.ts
@@ -1,0 +1,163 @@
+// The generated schema against the published one, class by class (#10214).
+//
+// `report:graphql-sdl-equivalence` answers "does every published type have a
+// generator SOURCE" and reached 407 of 407. This answers the next question and
+// the only one left: BUILD the schema from those sources and see how the two
+// differ. The difference is not one number -- it is three classes with very
+// different meanings, and collapsing them into a single "N differences" would
+// hide the one that matters.
+//
+//   TIGHTENED     the generator publishes `X!` where the schema publishes `X`.
+//                 A HARDENING of the served contract, and the dangerous
+//                 direction: graphql-js enforces non-null at execution, so one
+//                 null from a producer nulls the whole surrounding object and
+//                 attaches an error. `SelfHealthLane.detail` did exactly that
+//                 on every self_health request (#10215). Each of these needs
+//                 evidence that the producer cannot answer null -- the emitted
+//                 non-null only says the Zod has no `.nullable()`, which is a
+//                 claim about the schema, not about the producer.
+//
+//   NEWLY NAMED   a type the generator publishes that the schema does not. These
+//                 are the shapes behind the fields the SDL under-types as
+//                 `JSON`: publishing them is the FIX, and it happens by
+//                 construction rather than by hand.
+//
+//   UNREACHED     a type the schema publishes that the generator does not build.
+//                 A real gap -- something the declared sources do not describe.
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { buildSchema, isObjectType } from "graphql";
+import type { GraphQLObjectType, GraphQLSchema } from "graphql";
+import { buildGeneratedSchema } from "../schemas-src/graphql/build-schema.ts";
+import { assertEnumVocabularies } from "../schemas-src/graphql/enums.ts";
+import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
+import { extractSdl } from "./validate-graphql-component-parity.ts";
+
+const SDL_PATH = "src/graphql-sdl.ts";
+const OPENAPI_PATH = "public/metagraph/openapi.json";
+
+export interface SchemaDiff {
+  publishedTypes: number;
+  generatedTypes: number;
+  /** Types reproduced field for field, name for name and type for type. */
+  identical: number;
+  /** `Type.field` the generator publishes non-null over a nullable one. */
+  tightened: string[];
+  /** Types only the generator has -- the under-typings, published. */
+  newlyNamed: string[];
+  /** Types only the schema has -- what the declared sources do not describe. */
+  unreached: string[];
+  /** Anything else: a field one side has and the other does not, or a retype. */
+  otherDifferences: string[];
+}
+
+function objectTypes(schema: GraphQLSchema): Map<string, GraphQLObjectType> {
+  const map = new Map<string, GraphQLObjectType>();
+  for (const [name, type] of Object.entries(schema.getTypeMap())) {
+    if (name.startsWith("__")) continue;
+    if (isObjectType(type)) map.set(name, type);
+  }
+  return map;
+}
+
+export function diffSchemas(
+  sdl: string,
+  openapi: OpenApiParameters,
+): SchemaDiff {
+  const published = objectTypes(buildSchema(sdl));
+  const { schema } = buildGeneratedSchema(openapi);
+  const generated = objectTypes(schema);
+
+  const tightened: string[] = [];
+  const otherDifferences: string[] = [];
+  let identical = 0;
+
+  for (const [name, publishedType] of published) {
+    const generatedType = generated.get(name);
+    if (!generatedType) continue;
+    const publishedFields = publishedType.getFields();
+    const generatedFields = generatedType.getFields();
+    let same = true;
+    for (const [fieldName, field] of Object.entries(publishedFields)) {
+      const counterpart = generatedFields[fieldName];
+      if (!counterpart) {
+        otherDifferences.push(
+          `${name}.${fieldName} -- published, the generator does not build it`,
+        );
+        same = false;
+        continue;
+      }
+      const was = String(field.type);
+      const now = String(counterpart.type);
+      if (was === now) continue;
+      same = false;
+      // The one class worth naming on its own: same type, one `!` more.
+      if (`${was}!` === now || now === `${was.replace(/!$/, "")}!`) {
+        tightened.push(`${name}.${fieldName} -- ${was} becomes ${now}`);
+      } else {
+        otherDifferences.push(`${name}.${fieldName} -- ${was} vs ${now}`);
+      }
+    }
+    for (const fieldName of Object.keys(generatedFields)) {
+      if (publishedFields[fieldName]) continue;
+      otherDifferences.push(
+        `${name}.${fieldName} -- the generator builds it, the schema does not publish it`,
+      );
+      same = false;
+    }
+    if (same) identical += 1;
+  }
+
+  return {
+    publishedTypes: published.size,
+    generatedTypes: generated.size,
+    identical,
+    tightened: tightened.sort(),
+    newlyNamed: [...generated.keys()].filter((n) => !published.has(n)).sort(),
+    unreached: [...published.keys()].filter((n) => !generated.has(n)).sort(),
+    otherDifferences: otherDifferences.sort(),
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const vocabularies = assertEnumVocabularies();
+  if (vocabularies.length) {
+    console.error("graphql-schema-diff: enum vocabularies have drifted:");
+    for (const line of vocabularies) console.error(`  - ${line}`);
+    process.exit(1);
+  }
+  const sdl = extractSdl(readFileSync(SDL_PATH, "utf8"));
+  if (!sdl) {
+    console.error(
+      `graphql-schema-diff: no SDL template literal in ${SDL_PATH}`,
+    );
+    process.exit(1);
+  }
+  const report = diffSchemas(
+    sdl,
+    JSON.parse(readFileSync(OPENAPI_PATH, "utf8")) as OpenApiParameters,
+  );
+  console.log(
+    `graphql-schema-diff: the generator builds ${report.generatedTypes} object ` +
+      `type(s) against the schema's ${report.publishedTypes}; ` +
+      `${report.identical} reproduce field for field.`,
+  );
+  console.log(
+    `\n  ${report.tightened.length} field(s) the generator would TIGHTEN to non-null` +
+      `\n  ${report.newlyNamed.length} type(s) it publishes that the schema under-types as JSON` +
+      `\n  ${report.unreached.length} type(s) the schema has that it does not build` +
+      `\n  ${report.otherDifferences.length} other difference(s)`,
+  );
+  for (const [label, lines] of [
+    [
+      "UNREACHED -- the declared sources do not describe these",
+      report.unreached,
+    ],
+    ["OTHER", report.otherDifferences],
+  ] as const) {
+    if (!lines.length) continue;
+    console.log(`\n${label}:`);
+    for (const line of lines.slice(0, 40)) console.log(`  - ${line}`);
+    if (lines.length > 40) console.log(`  … and ${lines.length - 40} more`);
+  }
+}

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3659,6 +3659,8 @@ export const SDL = /* GraphQL */ `
     observed_at: String
     health_stale: Boolean
     health_source: String
+    "How the incident was derived. Always probe-derived: the health prober owns this surface and no hand-set incident exists. Served by /api/v1/endpoint-incidents on every row -- verified live -- and not selectable here until the generator surfaced the omission (#10214)."
+    source: String
     pool_eligible: Boolean
     user_reported: Boolean
     incident_count: Int

--- a/tests/graphql-generated-schema.test.ts
+++ b/tests/graphql-generated-schema.test.ts
@@ -1,0 +1,256 @@
+// The generator assembles the published schema from the declared sources
+// (#10214). These drive it with MUTATED declarations, because a generator only
+// ever run against a passing tree proves it runs, not that it is reading what
+// it claims to read.
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildSchema, isEnumType, isObjectType, printSchema } from "graphql";
+import { buildGeneratedSchema } from "../schemas-src/graphql/build-schema.ts";
+import {
+  GRAPHQL_ENUMS,
+  assertEnumVocabularies,
+} from "../schemas-src/graphql/enums.ts";
+import { diffSchemas } from "../scripts/report-graphql-schema-diff.ts";
+import { SDL } from "../src/graphql-sdl.ts";
+import { PROJECTED_TYPES } from "../schemas-src/graphql/published-names.ts";
+import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
+
+const openapi = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as OpenApiParameters;
+const sdl = SDL;
+
+describe("the generated schema", () => {
+  test("builds, and builds the whole published surface", () => {
+    const { schema } = buildGeneratedSchema(openapi);
+    const objects = Object.entries(schema.getTypeMap()).filter(
+      ([name, type]) => !name.startsWith("__") && isObjectType(type),
+    );
+    assert.ok(
+      objects.length > 350,
+      `expected the full type system, got ${objects.length}`,
+    );
+    assert.ok(schema.getQueryType(), "no Query root");
+    assert.ok(schema.getSubscriptionType(), "no Subscription root");
+  });
+
+  test("prints without graphql-js rejecting it", () => {
+    // The real proof that what was assembled is a SCHEMA and not a bag of
+    // types: printSchema validates the whole graph on its way out.
+    const printed = printSchema(buildGeneratedSchema(openapi).schema);
+    assert.ok(printed.includes("type Query {"));
+    assert.ok(printed.includes("type Subscription {"));
+    assert.ok(printed.includes("scalar JSON"));
+  });
+
+  test("a projection is published under ITS name, not its component's", () => {
+    // `AccountsListArtifactAccounts` is not renamed, it is PROJECTED as
+    // `AccountEntry`. Reading only PUBLISHED_TYPE_NAMES mints a second type for
+    // a shape the schema already names -- which it did, until the reverse
+    // lookup went through PROJECTED_TYPES too.
+    const { schema } = buildGeneratedSchema(openapi);
+    assert.ok(schema.getType("AccountEntry"), "the projection name is missing");
+    assert.equal(
+      schema.getType("AccountsListArtifactAccounts"),
+      undefined,
+      "the component id must not also be published",
+    );
+  });
+
+  test("the Query root carries the DERIVED arguments, not none", () => {
+    const { schema } = buildGeneratedSchema(openapi);
+    const field = schema.getQueryType()!.getFields().subnet_registrations;
+    assert.ok(field, "subnet_registrations is missing from the root");
+    const args = field.args.map((a) => a.name);
+    // A path parameter is a required argument -- a GraphQL field has no path.
+    assert.ok(args.includes("netuid"), `expected netuid, got ${args}`);
+    assert.equal(
+      String(field.args.find((a) => a.name === "netuid")!.type),
+      "Int!",
+    );
+  });
+
+  test("EndpointIncident.source is published -- the omission the diff found", () => {
+    // /api/v1/endpoint-incidents serves `source: "probe-derived"` on every row
+    // and the SDL had no such field, so a caller could not select it. The
+    // generator built it, the published schema did not have it, and the diff
+    // said so. Asserted on the PUBLISHED schema, which is the one callers get.
+    const published = buildSchema(sdl);
+    const type = published.getType("EndpointIncident");
+    assert.ok(isObjectType(type));
+    assert.equal(String(type.getFields().source?.type), "String");
+    assert.match(
+      type.getFields().source?.description ?? "",
+      /probe-derived/,
+      "the field must say what it means",
+    );
+  });
+
+  test("a projection naming a component nothing emits FAILS loudly", () => {
+    // Not a silently-skipped type: the generator would otherwise publish a
+    // schema quietly missing whatever that projection was for.
+    assert.throws(
+      () =>
+        buildGeneratedSchema(openapi, {
+          ...PROJECTED_TYPES,
+          Subnet: { component: "NoSuchComponent", added: {}, dropped: [] },
+        }),
+      /Subnet names the absent component NoSuchComponent/,
+    );
+  });
+
+  test("a type nothing declares FAILS loudly", () => {
+    assert.throws(
+      () =>
+        buildGeneratedSchema(openapi, {
+          ...PROJECTED_TYPES,
+          Subnet: {
+            ...PROJECTED_TYPES.Subnet,
+            added: { invented: "NoSuchType" },
+          },
+        }),
+      /nothing declares the type NoSuchType/,
+    );
+  });
+
+  test("two projections over ONE component: the first declared wins", () => {
+    // The reverse lookup has to pick one name, and picking non-deterministically
+    // would make the generated schema depend on declaration order in a way
+    // nothing states. First-wins, and a second projection over the same
+    // component does not steal the reference.
+    const { schema } = buildGeneratedSchema(openapi, {
+      ...PROJECTED_TYPES,
+      SubnetAlias: { ...PROJECTED_TYPES.Subnet },
+    });
+    assert.ok(schema.getType("Subnet"), "the first-declared name must survive");
+  });
+
+  test("the type set is what the ROOTS REACH", () => {
+    // Publishing every registered component instead would advertise ~200 types
+    // no query can select, which is a different contract from the served one.
+    const { schema } = buildGeneratedSchema(openapi);
+    assert.equal(
+      schema.getType("GenericArtifact"),
+      undefined,
+      "a component no root reaches must not be published",
+    );
+  });
+});
+
+describe("the published enums", () => {
+  test("both are emitted, with their declared values", () => {
+    const { schema } = buildGeneratedSchema(openapi);
+    for (const [name, declaration] of Object.entries(GRAPHQL_ENUMS)) {
+      const type = schema.getType(name);
+      assert.ok(isEnumType(type), `${name} is not an enum`);
+      assert.deepEqual(
+        type
+          .getValues()
+          .map((v) => v.name)
+          .sort(),
+        [...declaration.values].sort(),
+      );
+    }
+  });
+
+  test("the real declarations agree with their producers", () => {
+    assert.deepEqual(assertEnumVocabularies(), []);
+  });
+
+  test("it FAILS on a value the producer does not have", () => {
+    // The check that stops the enum inventing a network nothing serves.
+    assert.deepEqual(
+      assertEnumVocabularies({
+        Network: {
+          description: "",
+          values: ["finney", "invented"],
+          from: ["finney", "test"],
+          excluded: { test: "under test" },
+        },
+      }),
+      ["Network.invented -- the producer has no such value"],
+    );
+  });
+
+  test("it FAILS on a producer value nobody published or excluded", () => {
+    // The other direction, which is the silent one: a fifth firehose table
+    // added to the producer and not here is a hole, not a narrowing.
+    assert.deepEqual(
+      assertEnumVocabularies({
+        ChainFirehoseTable: {
+          description: "",
+          values: ["blocks"],
+          from: ["blocks", "extrinsics"],
+        },
+      }),
+      [
+        "ChainFirehoseTable.extrinsics -- the producer publishes it, the enum " +
+          "neither publishes nor declares it excluded",
+      ],
+    );
+  });
+
+  test("an exclusion the enum ALSO publishes fails -- it is one or the other", () => {
+    assert.deepEqual(
+      assertEnumVocabularies({
+        Network: {
+          description: "",
+          values: ["finney"],
+          from: ["finney"],
+          excluded: { finney: "contradicts itself" },
+        },
+      }),
+      ["Network.finney -- declared excluded, and the enum publishes it"],
+    );
+  });
+
+  test("a stale exclusion fails, so the list only shrinks", () => {
+    assert.deepEqual(
+      assertEnumVocabularies({
+        Network: {
+          description: "",
+          values: ["finney"],
+          from: ["finney"],
+          excluded: { retired: "gone from the producer" },
+        },
+      }),
+      [
+        "Network.retired -- declared excluded, but the producer no longer has " +
+          "it (delete the entry)",
+      ],
+    );
+  });
+});
+
+describe("the schema diff", () => {
+  test("reports the three classes separately", () => {
+    // Collapsing them into one number would hide the one that matters: a
+    // TIGHTENING hardens the served contract, where a newly-named type fixes an
+    // opaque blob. They are not the same kind of difference.
+    const report = diffSchemas(sdl, openapi);
+    assert.ok(report.identical > 200, `only ${report.identical} identical`);
+    assert.ok(report.tightened.length > 0, "no tightenings found");
+    assert.ok(report.newlyNamed.length > 0, "no newly-named types found");
+    for (const line of report.tightened) {
+      assert.match(line, / -- .+ becomes .+!$/);
+    }
+  });
+
+  test("a field the generator cannot build is reported, not silently equal", () => {
+    const withExtra = sdl.replace(
+      "  type DeregistrationTenure {\n",
+      "  type DeregistrationTenure {\n    invented_by_a_test: String\n",
+    );
+    assert.notEqual(withExtra, sdl, "the fixture type must exist");
+    const report = diffSchemas(withExtra, openapi);
+    assert.ok(
+      report.otherDifferences.some((line) =>
+        line.startsWith(
+          "DeregistrationTenure.invented_by_a_test -- published, the generator does not build it",
+        ),
+      ),
+      `expected the unbuildable field to be reported, got: ${report.otherDifferences.slice(0, 5).join("; ")}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

**The generator exists.** `buildGeneratedSchema()` reads the declared sources and returns a `GraphQLSchema` that `printSchema` accepts — 404 object types, both roots, the scalar and both enums, assembled with graphql-js and never concatenated as text.

| input | source |
|---|---|
| the object types | Zod, via `emitTypes()` |
| their published names | `PUBLISHED_TYPE_NAMES` / `ALIASED_TYPE_NAMES` / `PROJECTED_TYPES` |
| the projections | `PROJECTED_TYPES` — `added` / `dropped` / `itemsFrom` / `totalFrom` |
| the Query root | `QUERY_BINDINGS` + `deriveQueryArguments` |
| the Subscription root | `SUBSCRIPTION_BINDINGS` |
| `Network`, `ChainFirehoseTable` | `BITTENSOR_NETWORK_VALUES`, `CHAIN_FIREHOSE_TABLES` |

## The measurement, and why it is three numbers and not one

`npm run report:graphql-schema-diff`:

```
the generator builds 404 object type(s) against the schema's 340;
218 reproduce field for field.

  253 field(s) the generator would TIGHTEN to non-null
   69 type(s) it publishes that the schema under-types as JSON
    5 type(s) the schema has that it does not build
   90 other difference(s)
```

Collapsing these into "N differences" would hide the one that matters.

**TIGHTENED (253)** is the class that must not be shipped blind. The generator says `X!` where the schema says `X`, because the Zod has no `.nullable()` — which is a claim about the *schema*, not about the *producer*. graphql-js enforces non-null at execution: one null and the whole surrounding object nulls with an error attached. That is exactly what `SelfHealthLane.detail` did on every `self_health` request (#10215). Each of these needs evidence the producer cannot answer null. **This is the remaining work, and it is not a formality.**

**NEWLY NAMED (69)** is the opposite — it is the fix. These are the shapes behind the fields the SDL publishes as opaque `JSON`. The generator publishes them by construction, which is why hand-writing them into `src/graphql-sdl.ts` was the wrong move: it grows the file the epic exists to delete.

**UNREACHED (5)** is a real gap: `ChainAlphaVolumeSubnet`, `EmissionGateChange`, `EndpointIncidentWindow`, `OpportunityEntry`, `SubnetTrajectoryDelta` — types the schema has that no declared source reaches from a root.

## Decisions this encodes

**The type set is what the roots reach.** Publishing every registered component instead would advertise ~200 types no query can select — a different contract from the one served. A test asserts `GenericArtifact` is absent.

**A projection is published under *its* name, not its component's.** `AccountsListArtifactAccounts` is not renamed, it is *projected* as `AccountEntry`; reading only `PUBLISHED_TYPE_NAMES` minted a second type for a shape the schema already names. That was a real bug in the first version of the builder, caught by the diff and now covered by a test.

**Enums are derived, and can only narrow.** `Network` publishes `finney`/`test` over a producer vocabulary of three. `local` is declared excluded with the reason and the evidence: `subnets(network: local)` answers `Value "local" does not exist in "Network" enum.` on `api.metagraph.sh` today. `assertEnumVocabularies` checks both directions — a published value the producer lacks fails, and a producer value neither published nor excluded fails, which is what a fifth firehose table would be.

## One fix the report surfaced

`EndpointIncident.source`. `/api/v1/endpoint-incidents` serves it on every row (`"probe-derived"`, verified live) and GraphQL had no such field. The generator built it, the schema did not publish it, and the diff said so.

## Tests drive it with mutated declarations

Twelve, including: dropping `PROJECTED_TYPES.Subnet` must make the name unresolvable; an enum value the producer lacks must be reported; a producer value neither published nor excluded must be reported; a stale exclusion must fail so the list only shrinks; and a field added to the SDL that no source describes must appear in `otherDifferences` rather than reading as equal.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `validate:contract-drift`, `validate:graphql-types-drift`, `validate:graphql-component-parity`, `validate:published-names` — pass
- `npx vitest run` — 800 files, 18,472 passed, 11 skipped, 0 failed
- rebuilt and re-verified on `8e0a9506e` after #10426 landed

The only `src/**` change is two lines of the SDL string — no executable line — so there is no `codecov/patch` surface in this diff.

Refs #10214.
