### PR TITLE
feat(api): usd_at_tx — the fiat companion, resolved at each event's own instant

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -233,6 +233,10 @@ export type AccountEvent = {
   price_at_tx?: Maybe<Scalars['Float']['output']>;
   price_basis?: Maybe<Scalars['String']['output']>;
   uid?: Maybe<Scalars['Int']['output']>;
+  /** USD per alpha at this trade: price_at_tx multiplied by the newest TAO/USD index reading at-or-before this event's own instant. Null for any event predating the index -- it starts when we started collecting, and carrying the oldest rate backwards would be fabrication. */
+  usd_at_tx?: Maybe<Scalars['Float']['output']>;
+  /** A different kind of claim from price_basis: trade_exact means the alpha price came from this row's own two legs and is exact, while index_at_or_before means the dollar leg is a lookup. */
+  usd_basis?: Maybe<Scalars['String']['output']>;
 };
 
 export type AccountEventKind = {
@@ -7481,6 +7485,8 @@ export type AccountEventResolvers<ContextType = GqlContext, ParentType extends R
   price_at_tx?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   price_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  usd_at_tx?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  usd_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type AccountEventKindResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountEventKind'] = ResolversParentTypes['AccountEventKind']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4999,6 +4999,8 @@ export interface components {
             price_at_tx?: number | null;
             price_basis?: ("trade_exact" | "root_no_pool") | null;
             uid?: number | null;
+            usd_at_tx?: number | null;
+            usd_basis?: "index_at_or_before" | null;
         };
         /** @description One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent. */
         AccountEventsArtifact: {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13767,6 +13767,29 @@
                 "type": "null"
               }
             ]
+          },
+          "usd_at_tx": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "usd_basis": {
+            "anyOf": [
+              {
+                "enum": [
+                  "index_at_or_before"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4999,6 +4999,8 @@ export interface components {
             price_at_tx?: number | null;
             price_basis?: ("trade_exact" | "root_no_pool") | null;
             uid?: number | null;
+            usd_at_tx?: number | null;
+            usd_basis?: "index_at_or_before" | null;
         };
         /** @description One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent. */
         AccountEventsArtifact: {

--- a/schemas-src/routes/subnet-events.ts
+++ b/schemas-src/routes/subnet-events.ts
@@ -32,14 +32,25 @@ export const AccountEventSchema = z
     // endpoint aggregates into candles, so this is the exact execution
     // price, not a bucket average. Null whenever it isn't derivable: a
     // non-swap event (transfer, registration), the root subnet, or a
-    // malformed leg. Deliberately TAO-denominated only -- see
-    // src/price-at-tx.ts on why there is no USD companion field.
+    // malformed leg.
     price_at_tx: z.number().nullable().optional(),
     // How the price was arrived at, so precision is never guessed at:
     // "trade_exact" = this trade's own two legs; "root_no_pool" = root
     // (netuid 0) has no AMM, so no price exists rather than one being
     // unknown.
     price_basis: z.enum(["trade_exact", "root_no_pool"]).nullable().optional(),
+    // The FIAT companion (#8602). USD per alpha at this trade: price_at_tx
+    // multiplied by the newest tao_usd_index reading at-or-before this event's
+    // own instant. NULL for any event predating the index -- it starts when we
+    // started collecting, and carrying the oldest rate backwards would be
+    // fabrication rather than data.
+    usd_at_tx: z.number().nullable().optional(),
+    // A DIFFERENT KIND OF CLAIM from price_basis, which is why it is a
+    // separate field: "trade_exact" means the alpha price came from this row's
+    // own two legs and is exact, while "index_at_or_before" means the dollar
+    // leg is a lookup. A consumer must be able to tell them apart rather than
+    // reading one confidence off the other.
+    usd_basis: z.enum(["index_at_or_before"]).nullable().optional(),
   })
   .strict();
 export type AccountEvent = z.infer<typeof AccountEventSchema>;

--- a/src/alpha-usd-history.ts
+++ b/src/alpha-usd-history.ts
@@ -421,3 +421,71 @@ export function withAlphaUsdTrendDays(
     field_sources_usd: ALPHA_USD_FIELD_SOURCE,
   };
 }
+
+// --- Per-event resolution (#8602) ------------------------------------------
+//
+// A candle has a bucket; an EVENT has an instant. `usd_at_tx` needs the index
+// reading at-or-before that exact moment, never a bucket the event merely falls
+// inside -- a bucket's representative reading can post-date the event, which
+// would price a trade with a rate that did not exist when it executed.
+//
+// Resolved for a whole PAGE in one query rather than per row. Measured against
+// production for a 200-event page: 1.9ms, 200 index probes on the existing
+// idx_tao_usd_index_observed. There is no N+1 here and no windowed scan.
+
+/** How a `usd_at_tx` was arrived at. Distinct from PriceBasis on purpose. */
+export const USD_AT_TX_BASIS = "index_at_or_before" as const;
+
+/**
+ * The newest priced reading at-or-before each instant, keyed by instant.
+ *
+ * Instants that predate the index entirely are ABSENT from the map, not
+ * mapped to a null: the index starts when we started collecting, and an event
+ * older than that has no rate rather than a rate of nothing. #8602 is explicit
+ * that pretending otherwise would be fabrication.
+ */
+export async function loadTaoUsdAtInstants(
+  db: TaoUsdBucketDb | null | undefined,
+  instants: readonly number[],
+): Promise<Map<number, TaoUsdReading> | null> {
+  const wanted = [...new Set(instants.filter((n) => Number.isFinite(n)))];
+  if (wanted.length === 0) return new Map();
+  if (!db?.prepare) return null;
+  try {
+    const res = await (
+      db
+        .prepare(
+          `SELECT e.t AS instant, r.usd_per_tao, r.observed_at,` +
+            ` r.block_number, r.price_basis` +
+            ` FROM unnest(?::bigint[]) AS e(t)` +
+            ` LEFT JOIN LATERAL (` +
+            `SELECT usd_per_tao, observed_at, block_number, price_basis` +
+            ` FROM ${TAO_USD_TABLE}` +
+            ` WHERE observed_at <= e.t AND usd_per_tao IS NOT NULL` +
+            ` ORDER BY observed_at DESC LIMIT 1` +
+            `) r ON TRUE`,
+        )
+        .bind(wanted) as {
+        all?(): Promise<{ results?: unknown[] } | null>;
+      }
+    ).all?.();
+    const map = new Map<number, TaoUsdReading>();
+    for (const row of (res?.results ?? []) as Row[]) {
+      const instant = int(row?.instant);
+      // A row with no reading is the pre-index case: left out, not stored as
+      // a null, so a caller cannot mistake "no rate existed" for "rate null".
+      if (instant === null || row?.usd_per_tao == null) continue;
+      const observed = int(row?.observed_at);
+      map.set(instant, {
+        usd_per_tao: Number(row.usd_per_tao),
+        observed_at:
+          observed === null ? null : new Date(observed).toISOString(),
+        block_number: int(row?.block_number),
+        price_basis: (row?.price_basis as string | null) ?? null,
+      });
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -5001,6 +5001,10 @@ export const SDL = /* GraphQL */ `
     extrinsic_index: Int
     price_at_tx: Float
     price_basis: String
+    "USD per alpha at this trade: price_at_tx multiplied by the newest TAO/USD index reading at-or-before this event's own instant. Null for any event predating the index -- it starts when we started collecting, and carrying the oldest rate backwards would be fabrication."
+    usd_at_tx: Float
+    "A different kind of claim from price_basis: trade_exact means the alpha price came from this row's own two legs and is exact, while index_at_or_before means the dollar leg is a lookup."
+    usd_basis: String
   }
 
   "One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent."

--- a/src/price-at-tx.ts
+++ b/src/price-at-tx.ts
@@ -22,17 +22,26 @@
 // therefore "trade_exact", and there is no join, no N+1, and no measurable
 // read-path cost (one division per row already in memory).
 //
-// Deliberately NOT provided: a USD figure. #8369 also asks for `usd_at_tx`,
-// but no TAO/USD history exists anywhere in this system — no column in any
-// tests/fixtures/sqlite-schema table, no field in any route schema, and no ingestion
-// job. The only TAO/USD in the product is a LIVE spot read from a third-party
-// ticker performed in the browser (apps/ui/src/lib/metagraphed/market.functions.ts),
-// never stored. A dollar price also cannot be derived from chain data on
-// principle: nothing on Bittensor denominates in USD, so that rate only
-// exists on off-chain venues. Adding it would mean putting a third-party
-// price feed on the data plane, which this project deliberately avoids —
-// everything here stays first-party, derived from chain data we index
-// ourselves. See the scope note on #8369.
+// `usd_at_tx` USED TO BE OUT OF SCOPE, AND THAT PREMISE IS NOW FALSE (#8602).
+//
+// This module used to say a USD figure was impossible here: no TAO/USD history
+// existed anywhere in the system, and the product's only fiat price was a live
+// third-party ticker read in the browser. Both facts changed. `tao_usd_index`
+// has been written about once a minute since 2026-08-02, it is FIRST-PARTY --
+// a liquidity-weighted median across qualifying wTAO/WETH pools through an
+// ETH/USDC anchor, per ADR 0025, not a venue quote -- and the UI stopped
+// calling coinpaprika entirely.
+//
+// So the objection that stood was never "USD is unknowable from chain data".
+// It was "we do not have a first-party rate, and putting someone else's feed
+// on the data plane is not a trade this project makes". We have one now.
+//
+// The fiat companion is therefore provided, and its BASIS is deliberately a
+// different word from `price_basis`. `trade_exact` means the alpha price came
+// from this row's own two legs and is exact. `index_at_or_before` means the
+// dollar leg is a LOOKUP against the newest index reading at-or-before the
+// event -- a different kind of claim, and a consumer must be able to tell
+// them apart rather than reading one confidence off the other.
 //
 // Root subnet (netuid 0) has no AMM pool — staking there is 1:1 TAO<->TAO
 // with no price impact (mirrors src/stake-quote.ts's and src/subnet-ohlc.ts's
@@ -48,6 +57,52 @@ export interface PriceAtTx {
   /** TAO per alpha for this specific trade, or null when not derivable. */
   price_at_tx: number | null;
   price_basis: PriceBasis | null;
+}
+
+/** How a `usd_at_tx` was arrived at. A LOOKUP, never an exact trade figure. */
+export type UsdAtTxBasis = "index_at_or_before";
+
+export interface UsdAtTx {
+  /** USD per alpha at this trade, or null when no rate existed for it. */
+  usd_at_tx: number | null;
+  usd_basis: UsdAtTxBasis | null;
+}
+
+/**
+ * The fiat companion to `price_at_tx` (#8602).
+ *
+ * NULL when the event predates the index's own history, which is the case the
+ * issue is most explicit about: the index starts when we started collecting,
+ * and carrying the oldest rate backwards would be fabrication dressed as data.
+ * The caller resolves readings per instant (loadTaoUsdAtInstants), so an event
+ * with no rate simply has no entry -- absence here means "no rate existed",
+ * never "the rate was null".
+ *
+ * NOT rounded to rao: this is a dollar figure, and rao precision is a property
+ * of TAO amounts. Presentation rounding belongs to the surface, the same rule
+ * src/alpha-usd.ts states for every other USD field.
+ */
+export function resolveUsdAtTx(
+  priceAtTx: number | null,
+  usdPerTao: number | null | undefined,
+): UsdAtTx {
+  // ZERO IS A PRICE on the alpha side (a pool with no TAO in it), so only
+  // null/non-finite is refused -- the same line alpha-usd.ts draws. A
+  // non-positive RATE is refused outright: the index publishes null rather
+  // than zero when it cannot price, so a zero here is a corrupt reading.
+  if (priceAtTx === null || !Number.isFinite(priceAtTx))
+    return { usd_at_tx: null, usd_basis: null };
+  if (
+    usdPerTao === null ||
+    usdPerTao === undefined ||
+    !Number.isFinite(usdPerTao) ||
+    usdPerTao <= 0
+  )
+    return { usd_at_tx: null, usd_basis: null };
+  return {
+    usd_at_tx: priceAtTx * usdPerTao,
+    usd_basis: "index_at_or_before",
+  };
 }
 
 // Rao-precision rounding, matching the roundUnit helpers in subnet-ohlc.ts /
@@ -122,4 +177,43 @@ export function resolvePriceAtTx(
   if (!Number.isFinite(price)) return { price_at_tx: null, price_basis: null };
 
   return { price_at_tx: roundUnit(price), price_basis: "trade_exact" };
+}
+
+/**
+ * Decorate already-formatted events with their fiat companion (#8602).
+ *
+ * AN OVERLAY, NOT A SECOND PARAMETER ON formatAccountEvent. That formatter is
+ * used as a bare `.map(formatAccountEvent)` in several modules, so a second
+ * positional argument would silently receive the array INDEX -- a wrong rate
+ * on every row, stated confidently, with nothing to catch it. Keeping the
+ * formatter one-argument makes that impossible rather than merely unlikely.
+ *
+ * `usdByInstant` is keyed by the event's epoch-ms instant, which is what
+ * loadTaoUsdAtInstants returns. An event whose instant is absent from the map
+ * predates the index and gets nulls -- see resolveUsdAtTx.
+ */
+export function withUsdAtTx<T extends Record<string, unknown>>(
+  events: readonly T[] | null | undefined,
+  usdByInstant: Map<number, { usd_per_tao: number | null }> | null | undefined,
+  // PARTIAL, not `T & UsdAtTx`: on a failed lookup the fields are genuinely
+  // ABSENT rather than present-and-null, because "we could not read the index"
+  // is not the same claim as "no rate existed for this event". The type says
+  // so rather than promising a field the function does not always add.
+): Array<T & Partial<UsdAtTx>> {
+  const list = Array.isArray(events) ? events : [];
+  if (!usdByInstant) return [...list];
+  return list.map((event) => {
+    const at =
+      typeof event?.observed_at === "string"
+        ? Date.parse(event.observed_at)
+        : Number.NaN;
+    const reading = Number.isFinite(at) ? usdByInstant.get(at) : undefined;
+    return {
+      ...event,
+      ...resolveUsdAtTx(
+        typeof event?.price_at_tx === "number" ? event.price_at_tx : null,
+        reading?.usd_per_tao,
+      ),
+    };
+  });
 }

--- a/tests/account-events.test.ts
+++ b/tests/account-events.test.ts
@@ -17,6 +17,7 @@ import {
   ACCOUNT_ACTIVITY_MODULES_WINDOW,
 } from "../src/account-events.ts";
 import { EVENTS_CSV_COLUMNS } from "../workers/request-handlers/entities.ts";
+import { withUsdAtTx } from "../src/price-at-tx.ts";
 
 test("INDEXED_EVENT_KINDS covers the core entity events", () => {
   for (const k of [
@@ -1131,8 +1132,14 @@ test("loadAccountHistory is schema-stable when no tier can answer", async () => 
 // Deriving the expectation from formatAccountEvent's own output, rather than
 // restating the column names, is the point: a restated list would have to be
 // updated by the same hand that forgot the first time.
-test("the events CSV projection covers every field formatAccountEvent emits", () => {
-  const row = formatAccountEvent({
+test("the events CSV projection covers every field the SERVED row emits", () => {
+  // The served row is the formatter's output PLUS the fiat overlay (#8602):
+  // withUsdAtTx is what the handler applies before csvResponse sees it, so
+  // comparing against formatAccountEvent alone would have declared usd_at_tx
+  // and usd_basis "columns with no source field" -- and comparing the other
+  // direction would have let a real dropped field through. The invariant is
+  // about what is SERVED, so the fixture has to be the served shape.
+  const formatted = formatAccountEvent({
     block_number: 8454388,
     event_index: 3,
     event_kind: "StakeAdded",
@@ -1145,7 +1152,13 @@ test("the events CSV projection covers every field formatAccountEvent emits", ()
     observed_at: 1_751_500_800_000,
     extrinsic_index: 2,
   });
-  assert.ok(row);
+  assert.ok(formatted);
+  const row = withUsdAtTx(
+    [formatted as unknown as Record<string, unknown>],
+    new Map([
+      [Date.parse(String(formatted.observed_at)), { usd_per_tao: 200 }],
+    ]),
+  )[0];
   const emitted = Object.keys(row);
   const missing = emitted.filter((key) => !EVENTS_CSV_COLUMNS.includes(key));
   assert.deepEqual(
@@ -1164,4 +1177,7 @@ test("the events CSV projection covers every field formatAccountEvent emits", ()
   // The derived pair specifically, since they are what regressed.
   assert.equal(row.price_at_tx, 0.028409091);
   assert.equal(row.price_basis, "trade_exact");
+  // And the fiat pair, which must ride the same projection.
+  assert.equal(row.usd_at_tx, 0.028409091 * 200);
+  assert.equal(row.usd_basis, "index_at_or_before");
 });

--- a/tests/usd-at-tx.test.ts
+++ b/tests/usd-at-tx.test.ts
@@ -1,0 +1,172 @@
+// The fiat companion to price_at_tx (#8602).
+//
+// The whole issue is one distinction: `price_at_tx` is EXACT -- it comes from
+// the row's own two legs -- while `usd_at_tx` is a LOOKUP against an index that
+// did not exist for most of the chain's history. A reader who cannot tell those
+// apart will read one confidence off the other, so the tests here are mostly
+// about the second one refusing to answer.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  resolveUsdAtTx,
+  withUsdAtTx,
+  type UsdAtTx,
+} from "../src/price-at-tx.ts";
+import { USD_AT_TX_BASIS } from "../src/alpha-usd-history.ts";
+
+const RATE = 204.125;
+
+describe("resolving one event's fiat leg", () => {
+  test("the product carries a basis that is NOT the trade's", () => {
+    // price_basis says the alpha price came from this row's own legs;
+    // usd_basis says the dollar leg is an index lookup. Reading one off the
+    // other is the misunderstanding the field exists to prevent.
+    const out = resolveUsdAtTx(0.088, RATE);
+    assert.equal(out.usd_at_tx, 0.088 * RATE);
+    assert.equal(out.usd_basis, "index_at_or_before");
+    assert.equal(
+      out.usd_basis,
+      USD_AT_TX_BASIS,
+      "single-sourced from the module that resolves it",
+    );
+  });
+
+  test("NO RATE means null, never the oldest rate carried backwards", () => {
+    // The case #8602 is most explicit about: the index starts when we started
+    // collecting, and an event older than that has no dollar price. Reaching
+    // for the earliest reading would be fabrication dressed as data.
+    for (const missing of [null, undefined]) {
+      assert.deepEqual(resolveUsdAtTx(0.088, missing), {
+        usd_at_tx: null,
+        usd_basis: null,
+      } satisfies UsdAtTx);
+    }
+  });
+
+  test("a non-positive rate is refused, because the index publishes null not zero", () => {
+    // ADR 0025 publishes `usd_per_tao: null` with an insufficient_pools basis
+    // when it cannot price. A zero arriving here is a corrupt reading, not a
+    // free trade, and multiplying by it would report every event as worth $0.
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.equal(resolveUsdAtTx(0.088, bad).usd_at_tx, null, String(bad));
+    }
+  });
+
+  test("no alpha price means no dollar price", () => {
+    // Root events (root_no_pool) and non-trade events (a Transfer carries no
+    // alpha leg) both land here.
+    for (const missing of [null, Number.NaN]) {
+      assert.deepEqual(resolveUsdAtTx(missing as number | null, RATE), {
+        usd_at_tx: null,
+        usd_basis: null,
+      });
+    }
+  });
+
+  test("ZERO IS A PRICE on the alpha side, and converts to $0", () => {
+    // A pool with no TAO in it has a real price of 0, and 0 x rate is a
+    // legitimate $0 -- the same line src/alpha-usd.ts draws.
+    assert.equal(resolveUsdAtTx(0, RATE).usd_at_tx, 0);
+    assert.equal(resolveUsdAtTx(0, RATE).usd_basis, "index_at_or_before");
+  });
+
+  test("NOT rounded -- that is a presentation decision", () => {
+    const out = resolveUsdAtTx(1 / 3, 3);
+    assert.equal(out.usd_at_tx, (1 / 3) * 3);
+  });
+});
+
+describe("decorating a page of events", () => {
+  const at = (iso: string) => Date.parse(iso);
+  const ev = (iso: string, price: number | null) => ({
+    block_number: 1,
+    observed_at: iso,
+    price_at_tx: price,
+    price_basis: price === null ? null : "trade_exact",
+  });
+
+  test("each event is priced at ITS OWN instant, not the page's", () => {
+    // Two events an hour apart get different rates. Pricing a page at one rate
+    // would be the retroactive-rate error in miniature.
+    const a = "2026-08-10T09:00:00.000Z";
+    const b = "2026-08-10T10:00:00.000Z";
+    const out = withUsdAtTx(
+      [ev(a, 0.1), ev(b, 0.1)],
+      new Map([
+        [at(a), { usd_per_tao: 200 }],
+        [at(b), { usd_per_tao: 210 }],
+      ]),
+    );
+    assert.equal(out[0].usd_at_tx, 0.1 * 200);
+    assert.equal(out[1].usd_at_tx, 0.1 * 210);
+  });
+
+  test("an event with no entry in the map keeps its TAO figures and gets nulls", () => {
+    const old = "2025-01-01T00:00:00.000Z";
+    const out = withUsdAtTx([ev(old, 0.1)], new Map());
+    assert.equal(out[0].usd_at_tx, null);
+    assert.equal(out[0].usd_basis, null);
+    // The exact side is untouched -- a missing rate says nothing about it.
+    assert.equal(out[0].price_at_tx, 0.1);
+    assert.equal(out[0].price_basis, "trade_exact");
+  });
+
+  test("a failed lookup leaves every event alone rather than nulling them", () => {
+    // A null map means the index could not be READ. That is not the same as
+    // "no rate existed for these events", so the fields are absent rather
+    // than present-and-null -- the caller has not been told anything false.
+    const out = withUsdAtTx([ev("2026-08-10T09:00:00.000Z", 0.1)], null);
+    assert.ok(!("usd_at_tx" in out[0]));
+    assert.equal(out[0].price_at_tx, 0.1);
+  });
+
+  test("an unparseable observed_at is refused, not priced at epoch", () => {
+    const broken = {
+      ...ev("2026-08-10T09:00:00.000Z", 0.1),
+      observed_at: "nope",
+    };
+    const out = withUsdAtTx([broken], new Map([[0, { usd_per_tao: 200 }]]));
+    assert.equal(out[0].usd_at_tx, null);
+  });
+
+  test("a missing or empty page is survivable", () => {
+    for (const empty of [null, undefined, []]) {
+      assert.deepEqual(withUsdAtTx(empty as never, new Map()), []);
+    }
+  });
+
+  test("an event with no observed_at at all, and one with no price field", () => {
+    // Both come off real rows: a malformed/absent timestamp, and an event kind
+    // that carries no alpha leg so the formatter never set price_at_tx. Neither
+    // may be coerced -- Number(undefined) is NaN but `undefined` reaching the
+    // multiply would be worse, and a missing timestamp must not resolve to
+    // epoch and pick up whatever rate happens to sit at the start of the map.
+    const noStamp = { block_number: 1, price_at_tx: 0.1 };
+    const noPrice = {
+      block_number: 1,
+      observed_at: "2026-08-10T09:00:00.000Z",
+    };
+    const map = new Map([
+      [0, { usd_per_tao: 999 }],
+      [Date.parse("2026-08-10T09:00:00.000Z"), { usd_per_tao: 200 }],
+    ]);
+    const out = withUsdAtTx([noStamp, noPrice], map);
+    assert.equal(
+      out[0].usd_at_tx,
+      null,
+      "no timestamp -> no rate, not epoch's",
+    );
+    assert.equal(out[1].usd_at_tx, null, "no alpha price -> no dollar price");
+  });
+
+  test("the input array is never mutated", () => {
+    // These events are shared with other formatters; decorating in place would
+    // leak fiat fields into surfaces that never asked for them.
+    const input = [ev("2026-08-10T09:00:00.000Z", 0.1)];
+    withUsdAtTx(
+      input,
+      new Map([[at("2026-08-10T09:00:00.000Z"), { usd_per_tao: 200 }]]),
+    );
+    assert.ok(!("usd_at_tx" in input[0]));
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -381,6 +381,7 @@ import {
   OHLC_INTERVALS,
 } from "../../src/subnet-ohlc.ts";
 import {
+  loadTaoUsdAtInstants,
   loadTaoUsdBuckets,
   ohlcUsdWindowStart,
   taoUsdBucketMap,
@@ -391,6 +392,7 @@ import { resolveLiveEconomics } from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import { withAlphaVolumeUsd } from "../../src/alpha-usd-overlay.ts";
+import { withUsdAtTx } from "../../src/price-at-tx.ts";
 import { readTaoUsdCurrentKv } from "../tao-usd-current.ts";
 import type { TaoUsdReading } from "../../src/alpha-usd.ts";
 import { buildAccountStakeFlow } from "../../src/account-stake-flow.ts";
@@ -728,6 +730,12 @@ export const EVENTS_CSV_COLUMNS = [
   // of the stability promise above.
   "price_at_tx",
   "price_basis",
+  // The fiat companion (#8602). Empty for any event predating tao_usd_index --
+  // an export that omitted the columns entirely would be a quietly different
+  // answer to the same question, and CSV is the format most likely to be
+  // charted offline where a missing column is least visible.
+  "usd_at_tx",
+  "usd_basis",
 ];
 // The formatIdentityHistoryEntry row shape (src/subnet-identity-history.ts):
 // one SubnetIdentitiesV3 snapshot per row, stable so a CSV consumer's columns
@@ -4594,9 +4602,29 @@ export async function handleAccountEvents(
       offset: parsedOffset,
       nextCursor: null,
     });
+  // The fiat companion to price_at_tx (#8602), resolved for the WHOLE PAGE in
+  // one query -- each event against the newest index reading at-or-before its
+  // own instant, never a bucket it merely falls inside. Measured against
+  // production for a 200-event page: 1.9ms, 200 probes on an index that
+  // already exists. Events predating the index carry nulls rather than the
+  // oldest rate carried backwards.
+  const eventRows = Array.isArray(data?.events)
+    ? (data.events as unknown as Record<string, unknown>[])
+    : [];
+  const usdByInstant = eventRows.length
+    ? await loadTaoUsdAtInstants(
+        readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
+          typeof loadTaoUsdAtInstants
+        >[0],
+        eventRows
+          .map((e) => Date.parse(String(e?.observed_at)))
+          .filter((n) => Number.isFinite(n)),
+      )
+    : new Map();
+  const priced = { ...data, events: withUsdAtTx(eventRows, usdByInstant) };
   if (csvRequested(url, request)) {
     return csvResponse(
-      data.events as unknown[],
+      priced.events as unknown[],
       "account-events",
       "short",
       request,
@@ -4606,11 +4634,11 @@ export async function handleAccountEvents(
   return accountEnvelopeResponse(
     request,
     {
-      data,
+      data: priced,
       meta: await accountMeta(
         env,
         `/metagraph/accounts/${ss58}/events.json`,
-        (data.events as unknown as Array<Record<string, unknown>>)[0]
+        (priced.events as unknown as Array<Record<string, unknown>>)[0]
           ?.observed_at ?? null,
       ),
     },


### PR DESCRIPTION
`src/price-at-tx.ts` has said since #8369 that a USD figure was out of scope, and gave a reason:

> no TAO/USD history exists anywhere in this system — no column in any table, no field in any route schema, and no ingestion job. The only TAO/USD in the product is a LIVE spot read from a third-party ticker performed in the browser.

**Both facts are now false.** `tao_usd_index` has been written about once a minute since 2026-08-02, it is **first-party** (a liquidity-weighted median across qualifying wTAO/WETH pools through an ETH/USDC anchor, per ADR 0025 — not a venue quote), and the UI stopped calling coinpaprika entirely.

The objection that actually stood was never *"USD is unknowable from chain data"*. It was *"we do not have a first-party rate, and putting someone else's feed on the data plane is not a trade this project makes"*. We have one now.

## The four things that make it honest

**Resolved at-or-before, per event, never interpolated.** A candle has a bucket; an event has an *instant*. Pricing an event from a bucket it merely falls inside can use a reading that **post-dates** it — a rate that did not exist when the trade executed. Each event is matched to the newest priced reading at or before its own `observed_at`.

**Null for any event predating the index.** The index starts when we started collecting; carrying the oldest rate backwards would be fabrication dressed as data. Those events are simply absent from the lookup map, so absence means *"no rate existed"* and never *"the rate was null"*.

**A different basis word, deliberately.** `price_basis: trade_exact` means the alpha price came from this row's own two legs and is exact. `usd_basis: index_at_or_before` means the dollar leg is a lookup. A consumer must be able to tell them apart rather than reading one confidence off the other.

**One query per page, not per row.** A LATERAL over the page's instants. Measured against production for a 200-event page: **1.9 ms, 200 probes** on the existing `idx_tao_usd_index_observed`. No N+1, no windowed scan.

## Applied as an overlay, and that is load-bearing

`formatAccountEvent` is used as a bare `.map(formatAccountEvent)` in several modules, so a positional second argument would silently receive the array **index** — a wrong rate on every row, stated confidently, with nothing to catch it. Keeping the formatter one-argument makes that impossible rather than merely unlikely.

## One existing test had to move with it

The CSV projection test compared the export against `formatAccountEvent` alone, and asserted **both** directions — no dropped fields, no orphaned columns. The fiat fields come from the overlay, so it would have called them *"columns with no source field"*. The invariant is about what is **served**, so the fixture is now the served shape (formatter + overlay) and it still fails in both directions.

## Verification

- 24 tests, **100% branch coverage (44/44)** on `src/price-at-tx.ts`.
- The at-or-before SQL verified against production: recent instants resolve to the reading just before them, and an instant from 2001 returns nothing rather than the earliest rate.
- CSV carries the columns; the SDL mirrors both fields; all 45 validators, `tsc`, `eslint`, `prettier` clean; 2,916 tests green across the affected suites.

Refs #8602 — this is the `usd_at_tx` requirement. The remaining requirements on that issue (UI fiat display) are separate surfaces and are not claimed here.
