### PR TITLE
feat(api): /network/tao-usd states its staleness instead of implying it

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6204,6 +6204,8 @@ export type SurfaceList = {
 
 export type TaoUsd = {
   __typename?: 'TaoUsd';
+  /** How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
+  age_ms?: Maybe<Scalars['Float']['output']>;
   change_pct?: Maybe<Scalars['Float']['output']>;
   change_usd?: Maybe<Scalars['Float']['output']>;
   latest?: Maybe<TaoUsdLatest>;
@@ -6214,6 +6216,10 @@ export type TaoUsd = {
   /** How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
   priced_point_count: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
+  /** True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh. */
+  stale: Scalars['Boolean']['output'];
+  /** The bound that stale is measured against -- the same one the API refuses to derive USD figures from. */
+  stale_after_ms: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -10932,6 +10938,7 @@ export type SurfaceListResolvers<ContextType = GqlContext, ParentType extends Re
 }>;
 
 export type TaoUsdResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['TaoUsd'] = ResolversParentTypes['TaoUsd']> = ResolversObject<{
+  age_ms?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   change_pct?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   change_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   latest?: Resolver<Maybe<ResolversTypes['TaoUsdLatest']>, ParentType, ContextType>;
@@ -10940,6 +10947,8 @@ export type TaoUsdResolvers<ContextType = GqlContext, ParentType extends Resolve
   points?: Resolver<Array<ResolversTypes['TaoUsdPoint']>, ParentType, ContextType>;
   priced_point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stale?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  stale_after_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12294,6 +12294,8 @@ export interface components {
             [key: string]: unknown;
         };
         TaoUsdArtifact: {
+            /** @description How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
+            age_ms: number | null;
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
@@ -12304,6 +12306,10 @@ export interface components {
             /** @description How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
             priced_point_count: number;
             schema_version: number;
+            /** @description True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh. */
+            stale: boolean;
+            /** @description The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift. */
+            stale_after_ms: number;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -34348,6 +34354,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "age_ms": 1,
                      *         "change_pct": 0.5,
                      *         "change_usd": 0.5,
                      *         "latest": {
@@ -34372,6 +34379,8 @@ export interface operations {
                      *         ],
                      *         "priced_point_count": 1,
                      *         "schema_version": 1,
+                     *         "stale": false,
+                     *         "stale_after_ms": 1,
                      *         "window": "30d"
                      *       },
                      *       "meta": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12229,6 +12229,7 @@
       "TaoUsdArtifactResponse": {
         "value": {
           "data": {
+            "age_ms": 1,
             "change_pct": 0.5,
             "change_usd": 0.5,
             "latest": {
@@ -12253,6 +12254,8 @@
             ],
             "priced_point_count": 1,
             "schema_version": 1,
+            "stale": false,
+            "stale_after_ms": 1,
             "window": "30d"
           },
           "meta": {
@@ -53395,6 +53398,19 @@
       "TaoUsdArtifact": {
         "additionalProperties": {},
         "properties": {
+          "age_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading."
+          },
           "change_pct": {
             "anyOf": [
               {
@@ -53460,6 +53476,16 @@
             "minimum": -9007199254740991,
             "type": "integer"
           },
+          "stale": {
+            "description": "True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh.",
+            "type": "boolean"
+          },
+          "stale_after_ms": {
+            "description": "The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift.",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "window": {
             "anyOf": [
               {
@@ -53475,6 +53501,9 @@
           "schema_version",
           "window",
           "point_count",
+          "stale",
+          "stale_after_ms",
+          "age_ms",
           "priced_point_count",
           "latest",
           "oldest_observed_at",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12294,6 +12294,8 @@ export interface components {
             [key: string]: unknown;
         };
         TaoUsdArtifact: {
+            /** @description How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
+            age_ms: number | null;
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
@@ -12304,6 +12306,10 @@ export interface components {
             /** @description How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
             priced_point_count: number;
             schema_version: number;
+            /** @description True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh. */
+            stale: boolean;
+            /** @description The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift. */
+            stale_after_ms: number;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -34348,6 +34354,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "age_ms": 1,
                      *         "change_pct": 0.5,
                      *         "change_usd": 0.5,
                      *         "latest": {
@@ -34372,6 +34379,8 @@ export interface operations {
                      *         ],
                      *         "priced_point_count": 1,
                      *         "schema_version": 1,
+                     *         "stale": false,
+                     *         "stale_after_ms": 1,
                      *         "window": "30d"
                      *       },
                      *       "meta": {

--- a/schemas-src/routes/tao-usd.ts
+++ b/schemas-src/routes/tao-usd.ts
@@ -56,6 +56,27 @@ export const TaoUsdArtifactSchema = z
     schema_version: z.int(),
     window: z.string().nullable(),
     point_count: z.int().min(0),
+    // STALENESS IS STATED, NOT INFERRED (#8601 requirement 3). A consumer that
+    // has to parse observed_at, know the bound, and compare correctly has three
+    // chances to get it wrong -- and one that skips the check reads a frozen
+    // rate as a current one.
+    stale: z
+      .boolean()
+      .describe(
+        "True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh.",
+      ),
+    stale_after_ms: z
+      .int()
+      .min(0)
+      .describe(
+        "The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift.",
+      ),
+    age_ms: z
+      .int()
+      .nullable()
+      .describe(
+        "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading.",
+      ),
     /** How many points carried a price. A gap from point_count is how a window
      * with unpriceable blocks announces itself. */
     priced_point_count: z

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2928,6 +2928,12 @@ export const SDL = /* GraphQL */ `
     schema_version: Int!
     window: String
     point_count: Int!
+    "True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh."
+    stale: Boolean!
+    "The bound that stale is measured against -- the same one the API refuses to derive USD figures from."
+    stale_after_ms: Int!
+    "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading."
+    age_ms: Float
     "How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself."
     priced_point_count: Int!
     latest: TaoUsdLatest

--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -33,7 +33,41 @@
 // young series read as a complete one is how a four-day chart becomes a claim
 // about the month.
 
+import { TAO_USD_MAX_AGE_MS } from "./alpha-usd.ts";
+
 type Row = Record<string, unknown>;
+
+/**
+ * Age of a stored reading in ms, or null when it cannot say when it was taken.
+ *
+ * NOT `Number(row.observed_at)`. `Number(null)` and `Number("")` are both 0,
+ * which is FINITE -- a missing stamp would come out as "aged since the epoch",
+ * a 56-year-old reading reported as a number rather than as unknown. Only a
+ * real number, or a string that says one, is accepted.
+ */
+function readingAgeMs(row: Row, nowMs: number): number | null {
+  const raw = row?.observed_at;
+  const observed =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && raw.trim() !== ""
+        ? Number(raw)
+        : Number.NaN;
+  if (!Number.isFinite(observed)) return null;
+  return nowMs - observed;
+}
+
+/**
+ * Whether the newest reading is too old to price against.
+ *
+ * A reading that cannot say WHEN it was taken counts as STALE, never fresh --
+ * defaulting the unknown direction to "current" is exactly how a frozen rate
+ * survives a staleness check, and src/alpha-usd.ts makes the same call.
+ */
+function isStale(row: Row, nowMs: number): boolean {
+  const age = readingAgeMs(row, nowMs);
+  return age === null ? true : age > TAO_USD_MAX_AGE_MS;
+}
 
 /** The minimal D1 surface used here, so tests can inject a plain object. */
 export interface TaoUsdSeriesDb {
@@ -111,7 +145,8 @@ export function buildTaoUsdSeries(
   {
     window,
     includePoints = true,
-  }: { window?: unknown; includePoints?: boolean } = {},
+    now = Date.now,
+  }: { window?: unknown; includePoints?: boolean; now?: () => number } = {},
 ): Row {
   const points = (Array.isArray(rows) ? rows : [])
     .map((r) => ({
@@ -151,6 +186,23 @@ export function buildTaoUsdSeries(
     oldest_observed_at: points.length
       ? points[points.length - 1].observed_at
       : null,
+    // STALENESS IS STATED, NOT INFERRED (#8601 requirement 3).
+    //
+    // `latest.observed_at` was always there, but making every consumer parse
+    // it, know TAO_USD_MAX_AGE_MS, and compare correctly is three chances to
+    // get it wrong -- and a consumer that skips the check reads a frozen rate
+    // as a current one, which is #9704's shape: a value with no live writer
+    // behind it, served at 200 OK.
+    //
+    // The bound is the one src/alpha-usd.ts already refuses to multiply by, so
+    // "this response says stale" and "no USD figure anywhere on the API" are
+    // the same condition rather than two thresholds that can drift apart.
+    stale: newestRow ? isStale(newestRow, now()) : true,
+    stale_after_ms: TAO_USD_MAX_AGE_MS,
+    // How old the newest reading actually is, so a caller can show "3 minutes
+    // ago" without re-deriving it -- and so a stale response says HOW stale
+    // rather than only that it is.
+    age_ms: newestRow ? readingAgeMs(newestRow, now()) : null,
     change_usd: changeUsd,
     // Undefined from a zero base: a rise from 0 is not "infinitely more
     // expensive", it is a change with no meaningful ratio.

--- a/tests/tao-usd-series.test.ts
+++ b/tests/tao-usd-series.test.ts
@@ -42,6 +42,7 @@ import { handleRequest } from "../workers/api.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
+import { TAO_USD_MAX_AGE_MS } from "../src/alpha-usd.ts";
 
 // The real DDL, so the CHECK constraint that pairs a null price with
 // `insufficient_pools` is enforced in the fixtures too — a test that could
@@ -653,5 +654,62 @@ describe("tao_usd over GraphQL and MCP", () => {
     assert.equal(card.point_count, 1);
     // A model must not substitute 0 for an unpriceable block.
     assert.match(tool.description, /never as a zero price/);
+  });
+});
+
+describe("staleness is STATED, not left to the caller (#8601)", () => {
+  const NOW = Date.parse("2026-08-10T06:00:00.000Z");
+  const row = (msAgo: number) => ({
+    observed_at: NOW - msAgo,
+    block_number: 25_719_199,
+    usd_per_tao: 204.125,
+    price_basis: "wrapped_onchain_median",
+    eth_usd: 1917,
+    pool_count: 2,
+    pools: "[]",
+  });
+
+  test("a fresh reading is not stale, and says how old it is", () => {
+    const out = buildTaoUsdSeries([row(60_000)], { now: () => NOW });
+    assert.equal(out.stale, false);
+    assert.equal(out.age_ms, 60_000);
+  });
+
+  test("past the bound it says so, rather than making the caller compare", () => {
+    // The failure this closes: a consumer that skips the comparison reads a
+    // frozen rate as a current one -- a value with no live writer behind it,
+    // served at 200 OK.
+    const out = buildTaoUsdSeries([row(TAO_USD_MAX_AGE_MS + 1)], {
+      now: () => NOW,
+    });
+    assert.equal(out.stale, true);
+    assert.ok((out.age_ms as number) > (out.stale_after_ms as number));
+  });
+
+  test("the bound IS the one the API refuses to price against", () => {
+    // Compared against the DECLARATION, not a literal. If these drift, the API
+    // says "fresh" while every USD figure on it is refusing to derive -- two
+    // answers to one question.
+    const out = buildTaoUsdSeries([row(1000)], { now: () => NOW });
+    assert.equal(out.stale_after_ms, TAO_USD_MAX_AGE_MS);
+  });
+
+  test("a reading that cannot say WHEN is STALE, never fresh", () => {
+    // Defaulting the unknown direction to "current" is exactly how a frozen
+    // rate survives a staleness check.
+    for (const bad of [null, "", "not-a-date"]) {
+      const out = buildTaoUsdSeries([{ ...row(0), observed_at: bad }], {
+        now: () => NOW,
+      });
+      assert.equal(out.stale, true, String(bad));
+      assert.equal(out.age_ms, null);
+    }
+  });
+
+  test("an empty window is stale, not silently fresh", () => {
+    // No reading at all is the strongest form of "do not price against this".
+    const out = buildTaoUsdSeries([], { now: () => NOW });
+    assert.equal(out.stale, true);
+    assert.equal(out.age_ms, null);
   });
 });


### PR DESCRIPTION
#8601 requirement 3 asks for staleness to be **explicit in the payload**, not inferred by the caller from a timestamp. The route published `observed_at` and stopped there.

That leaves every consumer to parse it, know the bound, and compare correctly — three chances to get it wrong — and a consumer that simply skips the check reads a frozen rate as a current one. That's #9704's shape: a value with no live writer behind it, served at 200 OK.

```
stale           true when the newest reading is past the bound
stale_after_ms  the bound itself, so the check is reproducible
age_ms          how old it actually is, so "3 minutes ago" needs no re-derivation
```

## The bound is imported, not restated

It's `TAO_USD_MAX_AGE_MS` — the **same** one `src/alpha-usd.ts` refuses to multiply by. So *"this response says stale"* and *"no USD figure anywhere on the API"* are one condition rather than two thresholds that drift apart and give an operator two answers to the same question. The test compares against the declaration, not a literal.

## A reading that cannot say WHEN is stale, never fresh

Defaulting the unknown direction to "current" is exactly how a frozen rate survives a staleness check. An empty window is stale for the same reason — no reading at all is the strongest form of "do not price against this".

## Caught while writing the test

`Number(null)` and `Number("")` are both `0`, and 0 is **finite** — so a missing stamp came out as *"aged since the epoch"*: a 56-year age reported as a number rather than as unknown. That's the third time this coercion has bitten in this area (also in `alpha-usd-history.ts` and `price-at-tx.ts`), so the helper now accepts only a real number or a string that says one.

## Verification

39 tests in `tao-usd-series.test.ts`; schema and SDL both carry the fields; all 45 validators, `tsc`, `eslint`, `prettier` clean; 2,879 tests green across the affected suites.

Closes #8601
