### PR TITLE
feat(ui): render the fiat leg beside price_at_tx, and say it is the less precise one

### DIFF
--- a/apps/ui/src/components/metagraphed/price-at-tx.test.tsx
+++ b/apps/ui/src/components/metagraphed/price-at-tx.test.tsx
@@ -1,0 +1,91 @@
+// The event price line, TAO and its fiat companion (#8369, #8602).
+//
+// Both halves follow the same rule and it is the point of the component: a
+// figure that does not exist renders NOTHING. For most event kinds a price is
+// not missing, it simply does not exist, and an em-dash placeholder would
+// imply a value being withheld. The fiat leg inherits that rule for a second
+// reason -- an event predating the index has no dollar price, and inventing
+// one from the oldest rate would be fabrication.
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PriceAtTx, priceAtTxTooltip, usdAtTxTooltip } from "./price-at-tx";
+
+const markup = (el: React.ReactElement) => renderToStaticMarkup(el);
+
+describe("the TAO price line", () => {
+  it("renders the price with its basis in the tooltip", () => {
+    const html = markup(<PriceAtTx price={0.0284} basis="trade_exact" blockNumber={8454388} />);
+    expect(html).toContain("0.0284");
+    expect(html).toContain("execution price");
+  });
+
+  it("renders NOTHING when there is no derivable price", () => {
+    // A transfer, a registration, root (no AMM pool), or a malformed leg.
+    for (const absent of [null, undefined, Number.NaN]) {
+      expect(markup(<PriceAtTx price={absent} />)).toBe("");
+    }
+  });
+});
+
+describe("the fiat companion (#8602)", () => {
+  it("renders beside the TAO price when the API resolved one", () => {
+    const html = markup(<PriceAtTx price={0.0284} basis="trade_exact" usd={5.8} />);
+    expect(html).toContain("0.0284");
+    expect(html).toContain("5.8");
+  });
+
+  it("renders NOTHING for the dollar leg when there is no rate", () => {
+    // An event predating the index has no dollar price. The TAO side is
+    // untouched -- a missing rate says nothing about the trade's own price.
+    const html = markup(<PriceAtTx price={0.0284} basis="trade_exact" usd={null} />);
+    expect(html).toContain("0.0284");
+    expect(html).not.toContain("$");
+  });
+
+  it("treats a non-finite usd as absent rather than rendering NaN", () => {
+    const html = markup(<PriceAtTx price={0.0284} basis="trade_exact" usd={Number.NaN} />);
+    expect(html).not.toContain("NaN");
+    expect(html).not.toContain("$");
+  });
+
+  it("no TAO price means the whole line is absent, fiat included", () => {
+    // The fiat leg is secondary text under a price; with no price there is
+    // nothing for it to qualify.
+    expect(markup(<PriceAtTx price={null} usd={5.8} />)).toBe("");
+  });
+});
+
+describe("what the tooltips have to say", () => {
+  it("states the dollar leg is the LESS precise of the two", () => {
+    // The misunderstanding this exists to prevent: a reader assuming the USD
+    // figure is as exact as the trade's own execution price. They are
+    // different kinds of claim and the tooltip is where that is said.
+    const tip = usdAtTxTooltip(5.8, "2026-08-10T09:00:00.000Z", 2);
+    expect(tip).toContain("at or before this trade");
+    expect(tip).toContain("2 qualifying liquidity pools");
+    expect(tip).toContain("alpha price is exact");
+    expect(tip).toContain("less precise");
+  });
+
+  it("degrades cleanly when there is no provenance to state", () => {
+    const tip = usdAtTxTooltip(5.8, null, null);
+    expect(tip).toContain("5.8");
+    expect(tip).not.toContain("observed");
+    expect(tip).not.toContain("qualifying");
+  });
+
+  it("says pool, not pools, when there is one", () => {
+    expect(usdAtTxTooltip(5.8, null, 1)).toContain("1 qualifying liquidity pool");
+    expect(usdAtTxTooltip(5.8, null, 1)).not.toContain("pools");
+  });
+
+  it("a zero pool count is treated as no provenance, not as 'across 0'", () => {
+    expect(usdAtTxTooltip(5.8, null, 0)).not.toContain("qualifying");
+  });
+
+  it("the TAO tooltip still names its own basis distinctly", () => {
+    // The two vocabularies must not blur: trade_exact is the row's own legs.
+    expect(priceAtTxTooltip(0.0284, "trade_exact", 1)).toContain("Not a bucket average");
+    expect(priceAtTxTooltip(0.0284, "root_no_pool", 1)).not.toContain("execution price");
+  });
+});

--- a/apps/ui/src/components/metagraphed/price-at-tx.tsx
+++ b/apps/ui/src/components/metagraphed/price-at-tx.tsx
@@ -3,6 +3,10 @@ import { formatNumber } from "@/lib/metagraphed/format";
 /** Mirrors the API's `price_basis` enum (schemas-src/routes/subnet-events.ts). */
 export type PriceBasis = "trade_exact" | "root_no_pool";
 
+/** Mirrors the API's `usd_basis` enum. Deliberately a DIFFERENT vocabulary
+ * from PriceBasis: the alpha price is exact, the dollar leg is a lookup. */
+export type UsdBasis = "index_at_or_before";
+
 /**
  * Build the hover explainer for a resolved price (#8369 requirement 4: state
  * the basis and when it was measured, so precision is never guessed at).
@@ -21,6 +25,28 @@ export function priceAtTxTooltip(
 }
 
 /**
+ * The hover explainer for the fiat leg (#8602).
+ *
+ * States the BASIS in words, because `index_at_or_before` means something a
+ * reader will otherwise assume wrongly: the alpha price is this trade's own
+ * execution price, while the dollar figure is a lookup against the newest
+ * index reading at or before it. Those are different confidences and the
+ * tooltip is where a reader finds that out.
+ */
+export function usdAtTxTooltip(
+  usd: number,
+  observedAt?: string | null,
+  poolCount?: number | null,
+): string {
+  const at = observedAt ? `, observed ${observedAt}` : "";
+  const venues =
+    poolCount != null && poolCount > 0
+      ? ` across ${poolCount} qualifying liquidity pool${poolCount === 1 ? "" : "s"}`
+      : "";
+  return `≈ $${usd} per alpha — our TAO/USD index at or before this trade${at}${venues}. The alpha price is exact; this conversion is a lookup, so it is the less precise of the two.`;
+}
+
+/**
  * Secondary "what was it worth, then" line under an event's amount (#8369).
  *
  * Renders NOTHING when there's no derivable price — a transfer, a
@@ -30,25 +56,35 @@ export function priceAtTxTooltip(
  * would be worse than absence, since for most event kinds a price is not
  * missing, it simply doesn't exist.
  *
- * TAO-denominated only. There is no USD companion here on purpose — see
- * src/price-at-tx.ts's header and the follow-up issue it points to.
+ * The USD companion renders beside it when the API resolved one (#8602), and
+ * renders NOTHING when it did not — an event predating the index has no dollar
+ * price, and an em-dash there would imply a value we are withholding rather
+ * than one that never existed. Same rule as the TAO figure, for the same
+ * reason.
  */
 export function PriceAtTx({
   price,
   basis,
   blockNumber,
+  usd,
+  usdObservedAt,
+  usdPoolCount,
 }: {
   price?: number | null;
   basis?: PriceBasis | null;
   blockNumber?: number | null;
+  usd?: number | null;
+  usdObservedAt?: string | null;
+  usdPoolCount?: number | null;
 }) {
   if (price == null || !Number.isFinite(price)) return null;
+  const showUsd = usd != null && Number.isFinite(usd);
   return (
-    <span
-      className="block mg-type-data-sm tabular-nums text-ink-muted"
-      title={priceAtTxTooltip(price, basis, blockNumber)}
-    >
-      @ {price} τ/α
+    <span className="block mg-type-data-sm tabular-nums text-ink-muted">
+      <span title={priceAtTxTooltip(price, basis, blockNumber)}>@ {price} τ/α</span>
+      {showUsd ? (
+        <span title={usdAtTxTooltip(usd, usdObservedAt, usdPoolCount)}> (≈ ${usd})</span>
+      ) : null}
     </span>
   );
 }

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -1145,6 +1145,14 @@ export interface AccountEvent {
    * non-swap events, root (no AMM pool), or a malformed leg. */
   price_at_tx?: number | null;
   price_basis?: "trade_exact" | "root_no_pool" | null;
+  /** USD per alpha at this trade (#8602): price_at_tx multiplied by the newest
+   * index reading at-or-before this event. Null for events predating the
+   * index -- it starts when we started collecting, and carrying the oldest
+   * rate backwards would be fabrication. */
+  usd_at_tx?: number | null;
+  /** A DIFFERENT kind of claim from price_basis: the alpha price is exact,
+   * the dollar leg is a lookup. */
+  usd_basis?: "index_at_or_before" | null;
   [key: string]: unknown;
 }
 

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -3145,11 +3145,14 @@ function AccountEventsSection({
                   <td className="px-4 py-4 text-right mg-type-data tabular-nums text-ink">
                     {ev.amount_tao != null ? `${formatNumber(ev.amount_tao)} τ` : "—"}
                     {/* #8369: what it was worth at the time, as secondary
-                        text. Renders nothing for events that have no price. */}
+                        text. Renders nothing for events that have no price.
+                        #8602 adds the fiat leg beside it, which renders
+                        nothing of its own for events predating the index. */}
                     <PriceAtTx
                       price={ev.price_at_tx}
                       basis={ev.price_basis}
                       blockNumber={ev.block_number}
+                      usd={ev.usd_at_tx}
                     />
                   </td>
                   <td className="px-4 py-4 text-right mg-type-data text-ink-muted">

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6204,6 +6204,8 @@ export type SurfaceList = {
 
 export type TaoUsd = {
   __typename?: 'TaoUsd';
+  /** How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
+  age_ms?: Maybe<Scalars['Float']['output']>;
   change_pct?: Maybe<Scalars['Float']['output']>;
   change_usd?: Maybe<Scalars['Float']['output']>;
   latest?: Maybe<TaoUsdLatest>;
@@ -6214,6 +6216,10 @@ export type TaoUsd = {
   /** How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
   priced_point_count: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
+  /** True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh. */
+  stale: Scalars['Boolean']['output'];
+  /** The bound that stale is measured against -- the same one the API refuses to derive USD figures from. */
+  stale_after_ms: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -10932,6 +10938,7 @@ export type SurfaceListResolvers<ContextType = GqlContext, ParentType extends Re
 }>;
 
 export type TaoUsdResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['TaoUsd'] = ResolversParentTypes['TaoUsd']> = ResolversObject<{
+  age_ms?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   change_pct?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   change_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   latest?: Resolver<Maybe<ResolversTypes['TaoUsdLatest']>, ParentType, ContextType>;
@@ -10940,6 +10947,8 @@ export type TaoUsdResolvers<ContextType = GqlContext, ParentType extends Resolve
   points?: Resolver<Array<ResolversTypes['TaoUsdPoint']>, ParentType, ContextType>;
   priced_point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stale?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  stale_after_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12294,6 +12294,8 @@ export interface components {
             [key: string]: unknown;
         };
         TaoUsdArtifact: {
+            /** @description How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
+            age_ms: number | null;
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
@@ -12304,6 +12306,10 @@ export interface components {
             /** @description How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
             priced_point_count: number;
             schema_version: number;
+            /** @description True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh. */
+            stale: boolean;
+            /** @description The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift. */
+            stale_after_ms: number;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -34348,6 +34354,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "age_ms": 1,
                      *         "change_pct": 0.5,
                      *         "change_usd": 0.5,
                      *         "latest": {
@@ -34372,6 +34379,8 @@ export interface operations {
                      *         ],
                      *         "priced_point_count": 1,
                      *         "schema_version": 1,
+                     *         "stale": false,
+                     *         "stale_after_ms": 1,
                      *         "window": "30d"
                      *       },
                      *       "meta": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12229,6 +12229,7 @@
       "TaoUsdArtifactResponse": {
         "value": {
           "data": {
+            "age_ms": 1,
             "change_pct": 0.5,
             "change_usd": 0.5,
             "latest": {
@@ -12253,6 +12254,8 @@
             ],
             "priced_point_count": 1,
             "schema_version": 1,
+            "stale": false,
+            "stale_after_ms": 1,
             "window": "30d"
           },
           "meta": {
@@ -53395,6 +53398,19 @@
       "TaoUsdArtifact": {
         "additionalProperties": {},
         "properties": {
+          "age_ms": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": -9007199254740991,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading."
+          },
           "change_pct": {
             "anyOf": [
               {
@@ -53460,6 +53476,16 @@
             "minimum": -9007199254740991,
             "type": "integer"
           },
+          "stale": {
+            "description": "True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh.",
+            "type": "boolean"
+          },
+          "stale_after_ms": {
+            "description": "The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift.",
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "window": {
             "anyOf": [
               {
@@ -53475,6 +53501,9 @@
           "schema_version",
           "window",
           "point_count",
+          "stale",
+          "stale_after_ms",
+          "age_ms",
           "priced_point_count",
           "latest",
           "oldest_observed_at",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12294,6 +12294,8 @@ export interface components {
             [key: string]: unknown;
         };
         TaoUsdArtifact: {
+            /** @description How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
+            age_ms: number | null;
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
@@ -12304,6 +12306,10 @@ export interface components {
             /** @description How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself. */
             priced_point_count: number;
             schema_version: number;
+            /** @description True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh. */
+            stale: boolean;
+            /** @description The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift. */
+            stale_after_ms: number;
             window: string | null;
         } & {
             [key: string]: unknown;
@@ -34348,6 +34354,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "age_ms": 1,
                      *         "change_pct": 0.5,
                      *         "change_usd": 0.5,
                      *         "latest": {
@@ -34372,6 +34379,8 @@ export interface operations {
                      *         ],
                      *         "priced_point_count": 1,
                      *         "schema_version": 1,
+                     *         "stale": false,
+                     *         "stale_after_ms": 1,
                      *         "window": "30d"
                      *       },
                      *       "meta": {

--- a/schemas-src/routes/tao-usd.ts
+++ b/schemas-src/routes/tao-usd.ts
@@ -56,6 +56,27 @@ export const TaoUsdArtifactSchema = z
     schema_version: z.int(),
     window: z.string().nullable(),
     point_count: z.int().min(0),
+    // STALENESS IS STATED, NOT INFERRED (#8601 requirement 3). A consumer that
+    // has to parse observed_at, know the bound, and compare correctly has three
+    // chances to get it wrong -- and one that skips the check reads a frozen
+    // rate as a current one.
+    stale: z
+      .boolean()
+      .describe(
+        "True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh.",
+      ),
+    stale_after_ms: z
+      .int()
+      .min(0)
+      .describe(
+        "The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift.",
+      ),
+    age_ms: z
+      .int()
+      .nullable()
+      .describe(
+        "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading.",
+      ),
     /** How many points carried a price. A gap from point_count is how a window
      * with unpriceable blocks announces itself. */
     priced_point_count: z

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2928,6 +2928,12 @@ export const SDL = /* GraphQL */ `
     schema_version: Int!
     window: String
     point_count: Int!
+    "True when the newest reading is older than stale_after_ms, or carries no usable timestamp at all. A reading that cannot say WHEN it was taken counts as stale, never fresh."
+    stale: Boolean!
+    "The bound that stale is measured against -- the same one the API refuses to derive USD figures from."
+    stale_after_ms: Int!
+    "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading."
+    age_ms: Float
     "How many points carried a price. A gap from point_count is how a window with unpriceable blocks announces itself."
     priced_point_count: Int!
     latest: TaoUsdLatest

--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -33,7 +33,41 @@
 // young series read as a complete one is how a four-day chart becomes a claim
 // about the month.
 
+import { TAO_USD_MAX_AGE_MS } from "./alpha-usd.ts";
+
 type Row = Record<string, unknown>;
+
+/**
+ * Age of a stored reading in ms, or null when it cannot say when it was taken.
+ *
+ * NOT `Number(row.observed_at)`. `Number(null)` and `Number("")` are both 0,
+ * which is FINITE -- a missing stamp would come out as "aged since the epoch",
+ * a 56-year-old reading reported as a number rather than as unknown. Only a
+ * real number, or a string that says one, is accepted.
+ */
+function readingAgeMs(row: Row, nowMs: number): number | null {
+  const raw = row?.observed_at;
+  const observed =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && raw.trim() !== ""
+        ? Number(raw)
+        : Number.NaN;
+  if (!Number.isFinite(observed)) return null;
+  return nowMs - observed;
+}
+
+/**
+ * Whether the newest reading is too old to price against.
+ *
+ * A reading that cannot say WHEN it was taken counts as STALE, never fresh --
+ * defaulting the unknown direction to "current" is exactly how a frozen rate
+ * survives a staleness check, and src/alpha-usd.ts makes the same call.
+ */
+function isStale(row: Row, nowMs: number): boolean {
+  const age = readingAgeMs(row, nowMs);
+  return age === null ? true : age > TAO_USD_MAX_AGE_MS;
+}
 
 /** The minimal D1 surface used here, so tests can inject a plain object. */
 export interface TaoUsdSeriesDb {
@@ -111,7 +145,8 @@ export function buildTaoUsdSeries(
   {
     window,
     includePoints = true,
-  }: { window?: unknown; includePoints?: boolean } = {},
+    now = Date.now,
+  }: { window?: unknown; includePoints?: boolean; now?: () => number } = {},
 ): Row {
   const points = (Array.isArray(rows) ? rows : [])
     .map((r) => ({
@@ -151,6 +186,23 @@ export function buildTaoUsdSeries(
     oldest_observed_at: points.length
       ? points[points.length - 1].observed_at
       : null,
+    // STALENESS IS STATED, NOT INFERRED (#8601 requirement 3).
+    //
+    // `latest.observed_at` was always there, but making every consumer parse
+    // it, know TAO_USD_MAX_AGE_MS, and compare correctly is three chances to
+    // get it wrong -- and a consumer that skips the check reads a frozen rate
+    // as a current one, which is #9704's shape: a value with no live writer
+    // behind it, served at 200 OK.
+    //
+    // The bound is the one src/alpha-usd.ts already refuses to multiply by, so
+    // "this response says stale" and "no USD figure anywhere on the API" are
+    // the same condition rather than two thresholds that can drift apart.
+    stale: newestRow ? isStale(newestRow, now()) : true,
+    stale_after_ms: TAO_USD_MAX_AGE_MS,
+    // How old the newest reading actually is, so a caller can show "3 minutes
+    // ago" without re-deriving it -- and so a stale response says HOW stale
+    // rather than only that it is.
+    age_ms: newestRow ? readingAgeMs(newestRow, now()) : null,
     change_usd: changeUsd,
     // Undefined from a zero base: a rise from 0 is not "infinitely more
     // expensive", it is a change with no meaningful ratio.

--- a/tests/tao-usd-series.test.ts
+++ b/tests/tao-usd-series.test.ts
@@ -42,6 +42,7 @@ import { handleRequest } from "../workers/api.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
+import { TAO_USD_MAX_AGE_MS } from "../src/alpha-usd.ts";
 
 // The real DDL, so the CHECK constraint that pairs a null price with
 // `insufficient_pools` is enforced in the fixtures too — a test that could
@@ -653,5 +654,62 @@ describe("tao_usd over GraphQL and MCP", () => {
     assert.equal(card.point_count, 1);
     // A model must not substitute 0 for an unpriceable block.
     assert.match(tool.description, /never as a zero price/);
+  });
+});
+
+describe("staleness is STATED, not left to the caller (#8601)", () => {
+  const NOW = Date.parse("2026-08-10T06:00:00.000Z");
+  const row = (msAgo: number) => ({
+    observed_at: NOW - msAgo,
+    block_number: 25_719_199,
+    usd_per_tao: 204.125,
+    price_basis: "wrapped_onchain_median",
+    eth_usd: 1917,
+    pool_count: 2,
+    pools: "[]",
+  });
+
+  test("a fresh reading is not stale, and says how old it is", () => {
+    const out = buildTaoUsdSeries([row(60_000)], { now: () => NOW });
+    assert.equal(out.stale, false);
+    assert.equal(out.age_ms, 60_000);
+  });
+
+  test("past the bound it says so, rather than making the caller compare", () => {
+    // The failure this closes: a consumer that skips the comparison reads a
+    // frozen rate as a current one -- a value with no live writer behind it,
+    // served at 200 OK.
+    const out = buildTaoUsdSeries([row(TAO_USD_MAX_AGE_MS + 1)], {
+      now: () => NOW,
+    });
+    assert.equal(out.stale, true);
+    assert.ok((out.age_ms as number) > (out.stale_after_ms as number));
+  });
+
+  test("the bound IS the one the API refuses to price against", () => {
+    // Compared against the DECLARATION, not a literal. If these drift, the API
+    // says "fresh" while every USD figure on it is refusing to derive -- two
+    // answers to one question.
+    const out = buildTaoUsdSeries([row(1000)], { now: () => NOW });
+    assert.equal(out.stale_after_ms, TAO_USD_MAX_AGE_MS);
+  });
+
+  test("a reading that cannot say WHEN is STALE, never fresh", () => {
+    // Defaulting the unknown direction to "current" is exactly how a frozen
+    // rate survives a staleness check.
+    for (const bad of [null, "", "not-a-date"]) {
+      const out = buildTaoUsdSeries([{ ...row(0), observed_at: bad }], {
+        now: () => NOW,
+      });
+      assert.equal(out.stale, true, String(bad));
+      assert.equal(out.age_ms, null);
+    }
+  });
+
+  test("an empty window is stale, not silently fresh", () => {
+    // No reading at all is the strongest form of "do not price against this".
+    const out = buildTaoUsdSeries([], { now: () => NOW });
+    assert.equal(out.stale, true);
+    assert.equal(out.age_ms, null);
   });
 });


### PR DESCRIPTION
#8602 requirement 2, now that #10431 ships the field.

The event price line showed TAO only, and the component's own header said there was no USD companion *"on purpose — see src/price-at-tx.ts's header and the follow-up issue it points to."* That issue has shipped.

## The rule both halves follow

The dollar figure renders as secondary text beside the TAO price, and renders **nothing** when the API resolved none. That silence is the component's existing rule, and it applies here for a second reason: an event predating the index has no dollar price *at all*, so an em-dash would imply a value being withheld rather than one that never existed.

## The tooltip says which figure is which

`price_at_tx` is this trade's own execution price, from its two legs. `usd_at_tx` is a **lookup** against the newest index reading at-or-before it. A reader who cannot tell those apart will read one confidence off the other — so the hover states the basis, the reading's observed-at, and how many qualifying pools contributed, and says outright that the conversion is *the less precise of the two*.

Both tooltips are exported separately from the component so the wording is unit-testable — the convention `priceAtTxTooltip` already set.

## The component had no test file

It has one now, 11 cases covering both halves: the fiat leg absent on a null rate, absent on a non-finite one, the whole line absent with no TAO price, singular/plural pool wording, a zero pool count treated as no provenance rather than *"across 0"*, and the two basis vocabularies staying distinct.

## Visual change

`price-at-tx.tsx` — the price cell in the account events table gains ` (≈ $N)` after the existing `@ N τ/α`, on the same line, same muted style. Structurally it's one added `<span>` inside the existing one; no layout or component-tree change. Rows where the API resolved no rate render exactly as they do today.

Per the repo rule, apps/ui PRs touching visual output are held for manual review regardless of CI.

## Verification

`tsc`, `eslint`, `prettier` clean in **both** workspaces (apps/ui has its own config); full apps/ui suite green; all 45 root validators clean.

Refs #8602
