### PR TITLE
ci: hold the line on unrendered routes — a ceiling that only falls

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -419,6 +419,11 @@ jobs:
           # `ui` job because that job is gated on a path filter that matches
           # neither schemas-src/ nor public/metagraph/openapi.json.
           npm run validate:ui-docs-drift
+          # #10300: published routes the UI renders nowhere. A RATCHET -- the
+          # count may only fall, so a new route either gets rendered or fails
+          # here rather than drifting up one PR at a time, which is how the
+          # gap went 30 -> 35 with nothing watching.
+          npm run validate:ui-route-coverage
           npm run validate:readme-catalog
 
       # Stage artifacts for BOTH halves: the suite's reader tests serve R2-only artifacts with NO

--- a/package.json
+++ b/package.json
@@ -163,7 +163,8 @@
     "curation:brief": "node scripts/curation-brief.ts",
     "curation:stale-notes": "node scripts/stale-gap-notes.ts",
     "curation:identity-divergence": "node scripts/identity-field-divergence.ts",
-    "endpoint:brief": "node scripts/endpoint-ops-brief.ts"
+    "endpoint:brief": "node scripts/endpoint-ops-brief.ts",
+    "validate:ui-route-coverage": "node scripts/validate-ui-route-coverage.ts"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.3",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -117,6 +117,12 @@ function checkCommands(): Step[] {
     // check lived in the separately path-gated `ui` CI job. Checked here so
     // the PR that causes the drift can see it locally.
     step("validate:ui-docs-drift"),
+    // The unrendered-route ceiling (#10300). Sibling of validate:ui-docs-drift
+    // and here for the same reason: a route lands in a BACKEND PR that never
+    // touches apps/ui, so the gap it opens is invisible to the change that
+    // caused it. Reads API_ROUTES against apps/ui sources -- no network, no
+    // build artifacts.
+    step("validate:ui-route-coverage"),
     // Same shape, and it was in neither the pipeline nor CI until #10251: the
     // registry README's catalog section is generated, so a registry change
     // invalidates it without touching the README.
@@ -222,6 +228,12 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     // check lived in the separately path-gated `ui` CI job. Checked here so
     // the PR that causes the drift can see it locally.
     step("validate:ui-docs-drift"),
+    // The unrendered-route ceiling (#10300). Sibling of validate:ui-docs-drift
+    // and here for the same reason: a route lands in a BACKEND PR that never
+    // touches apps/ui, so the gap it opens is invisible to the change that
+    // caused it. Reads API_ROUTES against apps/ui sources -- no network, no
+    // build artifacts.
+    step("validate:ui-route-coverage"),
     // Same shape, and it was in neither the pipeline nor CI until #10251: the
     // registry README's catalog section is generated, so a registry change
     // invalidates it without touching the README.

--- a/scripts/validate-ui-route-coverage.ts
+++ b/scripts/validate-ui-route-coverage.ts
@@ -1,0 +1,161 @@
+// Published routes the UI renders nowhere — a ceiling that only falls (#10300).
+//
+// #10300 measured 30 of 205 GET routes unreferenced by apps/ui. Re-measured
+// while working the issue: 35 of 229. The gap did not stay still and nobody
+// noticed, because nothing was watching — new routes ship, the UI does not
+// grow to meet them, and the number drifts up one PR at a time.
+//
+// So this is a RATCHET, not a pass/fail on zero. Zero is not reachable today
+// and pretending otherwise would mean an allowlist, which is worse: an
+// exemption list stops being read the moment it is longer than a screen, and
+// it hides exactly the thing it names. A ceiling that can only fall states the
+// current number in one place, fails when it grows, and asks to be lowered
+// whenever anyone renders one.
+//
+// ## What counts as "referenced"
+//
+// A route is referenced when its path appears in apps/ui source, with each
+// `{token}` matching ONE path segment however it is constructed -- a literal,
+// a `${expr}`, anything without a slash. That is the UI's actual idiom
+// (`/api/v1/subnets/${netuid}/profile`), so a template literal counts.
+//
+// TWO THINGS THIS GETS WRONG IF DONE CASUALLY, both learned the hard way:
+//
+//   1. Literal segments must be REGEX-ESCAPED. A route containing a `.` --
+//      every feed does, `/api/v1/feeds/gaps.atom` -- otherwise matches any
+//      character there, and `gaps_atom` would clear it.
+//   2. The generated docs tree mentions every route by construction. Left in,
+//      the sweep reports 100% coverage and measures nothing at all.
+//
+// ## What is deliberately NOT counted as a gap
+//
+// The FEEDS. `/api/v1/feeds/*.atom|.rss|.json` are consumed by feed readers,
+// not rendered by our own UI, so counting them measures the wrong thing --
+// their consumer is external by design. Excluded by prefix rather than by
+// name, so a new feed does not silently raise the ceiling.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { repoRoot } from "./lib.ts";
+
+/**
+ * The most unrendered routes allowed. THE CEILING ONLY FALLS.
+ *
+ * Measured 2026-08-10 against 219 non-feed mainnet GET routes -- by running
+ * this check, not by subtracting feeds from a total by hand, which is how the
+ * first value here came out one too low. Lower it when
+ * you render one -- that is the whole point, and a PR that renders a surface
+ * without lowering it fails here rather than leaving the number stale.
+ */
+export const MAX_UNRENDERED_ROUTES = 25;
+
+/** Feed routes: consumed by feed readers, not by our UI. */
+const FEED_PREFIX = "/api/v1/feeds/";
+
+/** Network-prefixed testnet variants mirror their mainnet twin's rendering. */
+const NETWORK_PREFIX = "/api/v1/{network}/";
+
+const escapeLiteral = (segment: string): string =>
+  segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** A path with `{token}` segments turned into a one-segment matcher. */
+export function routePattern(route: string): RegExp {
+  return new RegExp(
+    route
+      .split("/")
+      .map((segment) =>
+        /^\{.+\}$/.test(segment) ? "[^/`'\"\\s]+" : escapeLiteral(segment),
+      )
+      .join("/"),
+  );
+}
+
+/** Every published mainnet GET route that is not a feed. */
+export function publishedRoutes(openapi: {
+  paths: Record<string, Record<string, unknown>>;
+}): string[] {
+  return Object.entries(openapi.paths ?? {})
+    .filter(([, methods]) => Boolean(methods?.get))
+    .map(([route]) => route)
+    .filter(
+      (route) =>
+        !route.startsWith(NETWORK_PREFIX) && !route.startsWith(FEED_PREFIX),
+    )
+    .sort();
+}
+
+/** Which of `routes` never appear in `source`. */
+export function unrenderedRoutes(
+  routes: readonly string[],
+  source: string,
+): string[] {
+  return routes.filter((route) => !routePattern(route).test(source));
+}
+
+function uiSource(): string {
+  const files: string[] = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir)) {
+      const full = path.join(dir, name);
+      if (statSync(full).isDirectory()) {
+        // The generated reference tree names every route by construction.
+        if (!full.includes("api-reference")) walk(full);
+      } else if (/\.(ts|tsx|mdx|json)$/.test(name)) files.push(full);
+    }
+  };
+  for (const root of ["apps/ui/src", "apps/ui/content"]) {
+    try {
+      walk(path.join(repoRoot, root));
+    } catch {
+      // A checkout without apps/ui is not this check's problem to report.
+    }
+  }
+  return files.map((file) => readFileSync(file, "utf8")).join("\n");
+}
+
+// The check runs only when this file is EXECUTED, never when it is imported.
+// Its matchers are unit-tested, and a module that calls process.exit(1) at
+// import time would take the whole test run down with it the moment the
+// ceiling was actually breached -- turning one legible failure into a
+// confusing one, in exactly the situation where legibility matters most.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) main();
+
+function main(): void {
+  const openapi = JSON.parse(
+    readFileSync(path.join(repoRoot, "public/metagraph/openapi.json"), "utf8"),
+  ) as { paths: Record<string, Record<string, unknown>> };
+
+  const routes = publishedRoutes(openapi);
+  const unrendered = unrenderedRoutes(routes, uiSource());
+
+  if (unrendered.length > MAX_UNRENDERED_ROUTES) {
+    console.error(
+      `UI route coverage regressed: ${unrendered.length} published route(s) are rendered nowhere, ` +
+        `ceiling is ${MAX_UNRENDERED_ROUTES}.\n` +
+        `New routes must either be rendered or the gap grows silently, which is how ` +
+        `#10300 went from 30 to 35 with nothing watching.\n` +
+        unrendered.map((route) => `  - ${route}`).join("\n"),
+    );
+    process.exit(1);
+  }
+
+  if (unrendered.length < MAX_UNRENDERED_ROUTES) {
+    console.error(
+      `UI route coverage improved: ${unrendered.length} unrendered, ceiling is ` +
+        `${MAX_UNRENDERED_ROUTES}. Lower MAX_UNRENDERED_ROUTES in ` +
+        `scripts/validate-ui-route-coverage.ts to ${unrendered.length} so the ` +
+        `gain is locked in -- a ceiling nobody lowers stops being a ratchet.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `UI route coverage: ${routes.length - unrendered.length}/${routes.length} published route(s) rendered, ` +
+      `${unrendered.length} not (at the ceiling; feeds excluded, their consumer is external).`,
+  );
+}

--- a/tests/validate-ui-route-coverage.test.ts
+++ b/tests/validate-ui-route-coverage.test.ts
@@ -1,0 +1,112 @@
+// The UI route-coverage ratchet (#10300).
+//
+// The matcher is the whole check, and it is easy to write in a way that quietly
+// reports success. Both failure modes below actually happened while building
+// it: a mangled character class cleared eleven routes that were genuinely
+// unrendered-adjacent, and an unescaped `.` would clear every feed route by
+// matching any character. So the tests are about the matcher being WRONG in
+// the specific ways that look right.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  MAX_UNRENDERED_ROUTES,
+  publishedRoutes,
+  routePattern,
+  unrenderedRoutes,
+} from "../scripts/validate-ui-route-coverage.ts";
+
+describe("matching a route against UI source", () => {
+  test("a {token} matches a template-literal segment, the UI's actual idiom", () => {
+    const src = "const u = `/api/v1/subnets/${netuid}/profile`;";
+    assert.ok(routePattern("/api/v1/subnets/{netuid}/profile").test(src));
+  });
+
+  test("and a function call inside the segment", () => {
+    // `/api/v1/accounts/${ss58PathSegment(ss58)}/balance` is real code in
+    // queries.ts. A character class that excluded parentheses reported this
+    // route unrendered while it was referenced twice.
+    const src =
+      "await apiFetch(`/api/v1/accounts/${ss58PathSegment(ss58)}/balance`)";
+    assert.ok(routePattern("/api/v1/accounts/{ss58}/balance").test(src));
+  });
+
+  test("a {token} does NOT match across a slash", () => {
+    // Otherwise `/api/v1/chain/holders` would be cleared by any longer path
+    // that happens to contain it, and the check would measure nothing.
+    assert.ok(
+      !routePattern("/api/v1/accounts/{ss58}/balance").test(
+        "/api/v1/accounts/a/b/balance",
+      ),
+    );
+  });
+
+  test("a literal dot is ESCAPED, so it cannot match any character", () => {
+    // Every feed route has one. Unescaped, `gaps_atom` would clear
+    // `/api/v1/feeds/gaps.atom` and the exclusion would be doing nothing.
+    const p = routePattern("/api/v1/feeds/gaps.atom");
+    assert.ok(p.test("/api/v1/feeds/gaps.atom"));
+    assert.ok(!p.test("/api/v1/feeds/gapsXatom"));
+  });
+
+  test("the network-wide route is not cleared by its per-subnet twin", () => {
+    // The near-miss #10300 documents, and the one my own first spot-check fell
+    // for: six hits for `concentration/history`, all of them per-subnet.
+    const src = "`/api/v1/subnets/${netuid}/concentration/history`";
+    assert.ok(!routePattern("/api/v1/chain/concentration/history").test(src));
+    assert.ok(
+      routePattern("/api/v1/subnets/{netuid}/concentration/history").test(src),
+    );
+  });
+});
+
+describe("which routes are counted", () => {
+  const oas = {
+    paths: {
+      "/api/v1/subnets": { get: {} },
+      "/api/v1/feeds/gaps.atom": { get: {} },
+      "/api/v1/{network}/subnets": { get: {} },
+      "/api/v1/webhooks": { post: {} },
+    },
+  };
+
+  test("feeds are excluded -- their consumer is external by design", () => {
+    // Counting them measures the wrong thing: a feed reader renders them, not
+    // our UI. Excluded by PREFIX so a new feed cannot silently raise the gap.
+    assert.ok(!publishedRoutes(oas).includes("/api/v1/feeds/gaps.atom"));
+  });
+
+  test("network-prefixed testnet variants are excluded", () => {
+    assert.ok(!publishedRoutes(oas).includes("/api/v1/{network}/subnets"));
+  });
+
+  test("non-GET routes are excluded", () => {
+    assert.ok(!publishedRoutes(oas).includes("/api/v1/webhooks"));
+  });
+
+  test("what remains is the mainnet GET surface", () => {
+    assert.deepEqual(publishedRoutes(oas), ["/api/v1/subnets"]);
+  });
+});
+
+describe("the ratchet", () => {
+  test("unrendered is the set with no reference anywhere", () => {
+    const routes = ["/api/v1/a", "/api/v1/b"];
+    assert.deepEqual(unrenderedRoutes(routes, "fetch('/api/v1/a')"), [
+      "/api/v1/b",
+    ]);
+  });
+
+  test("the ceiling is a number someone measured, not a round one", () => {
+    // 25 came from running the check. The first value here was 24, arrived at
+    // by subtracting feeds from a total by hand, and it was wrong -- the check
+    // caught its own author.
+    assert.equal(MAX_UNRENDERED_ROUTES, 25);
+  });
+
+  test("an empty source means every route is unrendered, not zero", () => {
+    // The direction that matters: a sweep that silently reads nothing must
+    // report everything missing, not report success over an empty set.
+    const routes = ["/api/v1/a", "/api/v1/b"];
+    assert.deepEqual(unrenderedRoutes(routes, ""), routes);
+  });
+});


### PR DESCRIPTION
#10300 measured **30 of 205** published GET routes rendered nowhere. Re-measured while working the issue: **35 of 229**. The gap moved and nobody noticed, because nothing was watching — new routes ship, the UI doesn't grow to meet them, and the number drifts up one PR at a time.

## A ratchet, not a pass/fail on zero

Zero isn't reachable today, and pretending otherwise would mean an allowlist — which is worse: an exemption list stops being read the moment it's longer than a screen, and it hides exactly what it names.

A ceiling states the number in one place, fails when it grows, and **fails when it shrinks too**: render a surface without lowering it and the check tells you to, so a gain can't be left unlocked.

**Feeds are excluded, by prefix rather than by name.** A feed reader renders `/api/v1/feeds/*.atom|rss|json`, not our UI — counting them measures the wrong thing. By prefix, so a new feed can't silently raise the ceiling.

## Three ways this goes wrong if written casually — all of which happened

1. **The first sweep lived in a shell heredoc** and its `{token}` character class got mangled by escaping, reporting 11 account routes unrendered while `/api/v1/accounts/{ss58}/balance` was referenced **twice**. I posted that bad number on the issue before catching it. The matcher is unit-tested against the UI's real idioms now, including a function call inside the segment.
2. **A literal `.` must be escaped.** Every feed route has one; unescaped it matches any character, and `gaps_atom` would clear `gaps.atom` — the exclusion would be doing nothing.
3. **The network-wide route must not be cleared by its per-subnet twin.** `concentration/history` returns six hits and every one is per-subnet. That's the near-miss #10300's body documents — and the one my own first spot-check fell for.

## The ceiling came from running the check

It's **25**. The first value I committed was 24, arrived at by subtracting feeds from a total by hand, and it was wrong — the check caught its own author on the first run. There's a test pinning it as a measured number rather than a round one.

## One design note

The executable half is guarded behind a direct-invocation test, so importing the matchers can't `process.exit` the test run. A module that exits at import time would turn one legible failure into a confusing one — in exactly the situation where legibility matters most.

## Verification

12 tests; registered in `package.json` **and** the workflow (an unregistered validator never runs); all 47 validators, `tsc`, `eslint`, `prettier` clean. Proven to fail in both directions — lowering the ceiling to 24 reports a regression, and the shrink branch asks for the gain to be locked in.

Refs #10300
