### PR TITLE
fix(api): read the clock once per tao-usd response, so stale and age_ms agree

### DIFF
--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -148,6 +148,16 @@ export function buildTaoUsdSeries(
     now = Date.now,
   }: { window?: unknown; includePoints?: boolean; now?: () => number } = {},
 ): Row {
+  // ONE clock reading for the whole response.
+  //
+  // `stale` and `age_ms` are two statements about the SAME reading, and calling
+  // now() once per field lets them describe different instants. A response can
+  // then say `stale: false` beside an `age_ms` above its own `stale_after_ms` --
+  // internally contradictory, and a caller re-deriving staleness from the age
+  // gets a different answer than the one the API stated. Sampling the clock
+  // once makes that disagreement unrepresentable rather than merely unlikely.
+  const nowMs = now();
+
   const points = (Array.isArray(rows) ? rows : [])
     .map((r) => ({
       observed_at: toIsoOrNull(r?.observed_at),
@@ -197,12 +207,12 @@ export function buildTaoUsdSeries(
     // The bound is the one src/alpha-usd.ts already refuses to multiply by, so
     // "this response says stale" and "no USD figure anywhere on the API" are
     // the same condition rather than two thresholds that can drift apart.
-    stale: newestRow ? isStale(newestRow, now()) : true,
+    stale: newestRow ? isStale(newestRow, nowMs) : true,
     stale_after_ms: TAO_USD_MAX_AGE_MS,
     // How old the newest reading actually is, so a caller can show "3 minutes
     // ago" without re-deriving it -- and so a stale response says HOW stale
     // rather than only that it is.
-    age_ms: newestRow ? readingAgeMs(newestRow, now()) : null,
+    age_ms: newestRow ? readingAgeMs(newestRow, nowMs) : null,
     change_usd: changeUsd,
     // Undefined from a zero base: a rise from 0 is not "infinitely more
     // expensive", it is a change with no meaningful ratio.

--- a/tests/tao-usd-series.test.ts
+++ b/tests/tao-usd-series.test.ts
@@ -501,10 +501,17 @@ describe("buildTaoUsdSeries — include_points (#9720)", () => {
   test("NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT", () => {
     // Every summary must be computed over the FULL window either way -- the
     // whole value of the toggle is that dropping the series costs nothing.
-    const withPoints = buildTaoUsdSeries(rows, { window: "24h" });
+    //
+    // Both calls are pinned to ONE instant. `age_ms` is clock-derived, so two
+    // calls on the live clock differ by a millisecond whenever they straddle
+    // one -- which asserts that two Date.now() reads agree, not that the toggle
+    // preserves the measurement. The pin keeps this testing its own claim.
+    const now = () => BASE + 300_000;
+    const withPoints = buildTaoUsdSeries(rows, { window: "24h", now });
     const without = buildTaoUsdSeries(rows, {
       window: "24h",
       includePoints: false,
+      now,
     });
     const { points: _dropped, ...summary } = withPoints as Row;
     assert.deepEqual(without, summary);
@@ -711,5 +718,34 @@ describe("staleness is STATED, not left to the caller (#8601)", () => {
     const out = buildTaoUsdSeries([], { now: () => NOW });
     assert.equal(out.stale, true);
     assert.equal(out.age_ms, null);
+  });
+
+  test("the clock is read ONCE, so `stale` and `age_ms` cannot disagree", () => {
+    // `stale` and `age_ms` are two statements about the same reading. Sampling
+    // the clock per field lets them straddle the bound and contradict each
+    // other -- `stale: false` beside an age ABOVE `stale_after_ms` -- so a
+    // caller re-deriving staleness from the age gets a different answer than
+    // the one the API stated.
+    //
+    // COUNTING THE READS, rather than only asserting the two agree. Agreement
+    // holds whenever both samples land the same side of the bound, which is
+    // almost always -- a consistency-only check passes on the broken code for
+    // any reading that is not within a millisecond of the threshold, which is
+    // precisely how two reads survived here in the first place.
+    let reads = 0;
+    const out = buildTaoUsdSeries([row(TAO_USD_MAX_AGE_MS)], {
+      now: () => {
+        reads++;
+        return NOW;
+      },
+    });
+    assert.equal(reads, 1, `the response sampled the clock ${reads} times`);
+    const age = out.age_ms as number;
+    const bound = out.stale_after_ms as number;
+    assert.equal(
+      out.stale,
+      age > bound,
+      `stale=${String(out.stale)} contradicts age_ms=${age} vs ${bound}`,
+    );
   });
 });


### PR DESCRIPTION
`buildTaoUsdSeries` sampled `now()` once for `stale` and again for `age_ms`. Those are two statements about the **same** reading, so when the two samples straddled `TAO_USD_MAX_AGE_MS` the response contradicted itself:

```json
{ "stale": false, "age_ms": 7200001, "stale_after_ms": 7200000 }
```

An age above its own stated bound, beside `stale: false`. #10432 added `age_ms` precisely so consumers would not have to make that comparison themselves — sampling twice reintroduced the disagreement it was meant to remove.

## The fix

One `const nowMs = now()` for the whole response. The contradiction becomes unrepresentable rather than merely unlikely.

## It was also a live flake

`tests/tao-usd-series.test.ts > NARROWING THE RESPONSE NEVER NARROWS THE MEASUREMENT` builds the card twice and deep-equals the summaries. On the live clock the two calls differ by a millisecond whenever they straddle one:

```
+   age_ms: 298341020,
-   age_ms: 298341019,
```

So the test was asserting that two `Date.now()` reads agree, not that `include_points` preserves the measurement. Both calls are now pinned to one instant, which restores what it claims to test. This was failing on `main` at random.

## The regression test counts the reads

Deliberately **not** an assertion that the two fields agree. Agreement holds whenever both samples land the same side of the bound — which is essentially always, so a consistency-only check passes on the broken code. I confirmed that directly: a straddle-based version of this test passed against the two-read implementation. Counting the clock reads states the invariant itself and fails cleanly:

```
AssertionError: the response sampled the clock 2 times
```

## Verification

- `tests/tao-usd-series.test.ts` — 40 passed with the fix; the new test fails on the unfixed code with the message above.
- `tsc --noEmit` clean, eslint clean (exit 0), prettier clean.

## Scope

`buildTaoUsdSeries` only. `loadTaoUsdSeries` already reads `now()` once for its cutoff, and `runTaoUsdIndexWatchdog` already hoists `const nowMs = now()`.

Closes #10436