### PR TITLE
feat(ui): render every published route — 30 unrendered surfaces down to 0

### DIFF
--- a/apps/ui/src/components/metagraphed/account-root-claim.tsx
+++ b/apps/ui/src/components/metagraphed/account-root-claim.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import { accountRootClaimQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatRelative } from "@/lib/metagraphed/format";
+
+/**
+ * `/api/v1/accounts/{ss58}/root-claim` (#10300), published and rendered
+ * nowhere.
+ *
+ * What this account's root stake would do in a swap, and which hotkeys it
+ * reaches. The panel exists because of one thing the payload says about
+ * itself:
+ *
+ * `field_sources` MARKS THE HOTKEY LIST AS RECONSTRUCTED, not measured. The
+ * claim type is read from chain storage; the hotkey list is inferred. Rendering
+ * them the same way would present an inference with the authority of a reading,
+ * which is the whole failure mode `field_sources` exists to prevent -- so the
+ * provenance is shown next to the thing it qualifies, not buried in a footer.
+ */
+export function AccountRootClaim({ ss58 }: { ss58: string }) {
+  const { data, isLoading, isError, error, refetch } = useQuery(accountRootClaimQuery(ss58));
+
+  if (isLoading) return <Skeleton className="h-[90px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const c = data?.data;
+  // No root claim is a real answer for most accounts, not a gap — rendered as
+  // a plain statement rather than an error or an empty-state alarm.
+  if (!c || !c.claim_kind) {
+    return (
+      <Panel as="section" dense>
+        <p className="mg-type-data-sm text-ink-muted">
+          This account has no root-claim state recorded.
+        </p>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel as="section" dense>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+        <div>
+          <div className="mg-type-label text-ink-muted">claim type</div>
+          <div className="mg-type-data text-ink" title="Read from SubtensorModule.RootClaimType.">
+            {c.claim_kind}
+          </div>
+        </div>
+        <div>
+          <div className="mg-type-label text-ink-muted">hotkeys reached</div>
+          <div className="mg-type-data tabular-nums text-ink">{formatNumber(c.hotkeys.length)}</div>
+        </div>
+      </div>
+
+      {/* The provenance sits beside the figure it qualifies. A reconstructed
+          list is inferred from other state, not read from it. */}
+      {c.hotkeys_source && c.hotkeys_source !== "measured" ? (
+        <p className="mt-3 mg-type-label text-ink-muted">
+          The hotkey list is <strong>{c.hotkeys_source}</strong> — inferred from other state rather
+          than read from chain storage, unlike the claim type above.
+        </p>
+      ) : null}
+
+      {c.queried_at ? (
+        <p className="mt-2 mg-type-label text-ink-muted">Read {formatRelative(c.queried_at)}.</p>
+      ) : null}
+    </Panel>
+  );
+}

--- a/apps/ui/src/components/metagraphed/alert-trigger-lookup.tsx
+++ b/apps/ui/src/components/metagraphed/alert-trigger-lookup.tsx
@@ -1,0 +1,134 @@
+import { useState, type FormEvent } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/metagraphed/client";
+import { Panel } from "@/components/metagraphed/primitives";
+import { formatNumber, formatRelative } from "@/lib/metagraphed/format";
+
+/** Mirrors src/alert-triggers.ts. */
+const OWNER_TOKEN_HEADER = "x-alert-trigger-owner-token";
+
+interface TriggerView {
+  id: string;
+  channel: string;
+  destination: string;
+  active: boolean;
+  netuid: number | null;
+  event_kind: string | null;
+  last_matched_at: string | null;
+  match_count: number;
+}
+
+/**
+ * `/api/v1/alerts/triggers/{id}` (#10300), published and rendered nowhere.
+ *
+ * The UI has always been able to CREATE a trigger — that is what the watch
+ * forms do — and never to read one back. So a caller who created an alert had
+ * no way to answer "is it still active, and has it ever fired", which is the
+ * only question you have after setting one up.
+ *
+ * It needs the `owner_token` issued once at creation, and the route returns the
+ * SAME 404 for a wrong token and a nonexistent id so it cannot be used to
+ * enumerate other callers' triggers. The panel says that rather than guessing
+ * which of the two happened — reporting "no such trigger" for a mistyped token
+ * would send someone hunting for a trigger that exists.
+ *
+ * `last_matched_at` being null is DISTINCT from `match_count` of 0: one means
+ * it has never fired, the other is the count. They agree today, and the panel
+ * shows the count with its own "never fired" wording rather than deriving one
+ * from the other.
+ */
+export function AlertTriggerLookup() {
+  const [id, setId] = useState("");
+  const [token, setToken] = useState("");
+
+  const lookup = useMutation({
+    mutationFn: async (vars: { id: string; token: string }): Promise<TriggerView> => {
+      const res = await apiFetch<TriggerView>(
+        `/api/v1/alerts/triggers/${encodeURIComponent(vars.id)}`,
+        { init: { headers: { [OWNER_TOKEN_HEADER]: vars.token } } },
+      );
+      return res.data;
+    },
+  });
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    lookup.mutate({ id: id.trim(), token: token.trim() });
+  }
+
+  const t = lookup.data;
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-1 mg-type-label text-ink-muted">Look up a trigger</h3>
+      <p className="mb-3 max-w-2xl mg-type-caption-lg text-ink-muted">
+        Check whether an alert you created is still active and whether it has ever fired. Needs the
+        owner token issued when it was created — it is shown once and never echoed back.
+      </p>
+
+      <form onSubmit={onSubmit} className="flex flex-wrap gap-2">
+        <input
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+          placeholder="trigger id"
+          aria-label="Trigger id"
+          className="min-w-0 flex-1 rounded border border-border bg-surface px-2 py-1 mg-type-data-sm text-ink"
+        />
+        <input
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          type="password"
+          placeholder="owner token"
+          aria-label="Owner token"
+          className="min-w-0 flex-1 rounded border border-border bg-surface px-2 py-1 mg-type-data-sm text-ink"
+        />
+        <button
+          type="submit"
+          disabled={lookup.isPending || !id.trim() || !token.trim()}
+          className="rounded border border-border bg-card px-3 py-1 mg-type-caption font-medium text-ink-strong hover:border-accent/40 disabled:opacity-50"
+        >
+          {lookup.isPending ? "Looking up…" : "Look up"}
+        </button>
+      </form>
+
+      {/* The route returns the SAME 404 either way, deliberately, so the panel
+          must not pick one. Claiming "no such trigger" for a mistyped token
+          would send someone hunting for a trigger that exists. */}
+      {lookup.isError ? (
+        <p className="mt-3 mg-type-data-sm text-ink-muted">
+          No trigger matched — either the id does not exist or the token is wrong. The API returns
+          the same answer for both on purpose, so that this cannot be used to discover other
+          callers&rsquo; triggers.
+        </p>
+      ) : null}
+
+      {t ? (
+        <dl className="mt-3 grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-4">
+          <Detail label="state" value={t.active ? "active" : "paused"} />
+          <Detail label="channel" value={`${t.channel}`} />
+          <Detail
+            label="watching"
+            value={t.netuid == null ? (t.event_kind ?? "everything") : `SN${t.netuid}`}
+          />
+          <Detail
+            label="fired"
+            value={
+              t.last_matched_at
+                ? `${formatNumber(t.match_count)} · last ${formatRelative(t.last_matched_at)}`
+                : "never"
+            }
+          />
+        </dl>
+      ) : null}
+    </Panel>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="mg-type-label text-ink-muted">{label}</dt>
+      <dd className="mg-type-data-sm text-ink">{value}</dd>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/capture-currency-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/capture-currency-panel.test.ts
@@ -30,10 +30,7 @@ describe("ranking the failure classifications", () => {
   it("ranks by share OF THE FAILURES, not of all checks", () => {
     // `dns` is a bigger slice of all traffic but a smaller slice of the
     // failures. "Why do probes fail" asks the second question.
-    const out = rankedFailures([
-      reason("dns", true, 0.2, 0.9),
-      reason("timeout", true, 0.8, 0.05),
-    ]);
+    const out = rankedFailures([reason("dns", true, 0.2, 0.9), reason("timeout", true, 0.8, 0.05)]);
     expect(out[0].classification).toBe("timeout");
   });
 

--- a/apps/ui/src/components/metagraphed/capture-currency-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/capture-currency-panel.test.ts
@@ -1,0 +1,56 @@
+// Probe failure classifications (#10300).
+//
+// `is_failure` marks classifications that are NOT failures, and `share` and
+// `failure_share` have different denominators. Reading any of the three as the
+// others is how a working probe reads as a broken one, or how a classification
+// that is 2% of traffic reads as 2% of the problem.
+import { describe, expect, it } from "vitest";
+import { rankedFailures } from "./capture-currency-panel";
+import type { FailureReason } from "@/lib/metagraphed/types";
+
+const reason = (
+  classification: string,
+  is_failure: boolean,
+  failure_share: number | null,
+  share: number | null = 0.1,
+): FailureReason => ({ classification, is_failure, checks: 100, share, failure_share });
+
+describe("ranking the failure classifications", () => {
+  it("EXCLUDES the classifications that are not failures", () => {
+    // The route marks non-failure outcomes explicitly. Listing an `ok` among
+    // the failures would report a working probe as a broken one.
+    const out = rankedFailures([
+      reason("ok", false, null),
+      reason("timeout", true, 0.6),
+      reason("dns", true, 0.4),
+    ]);
+    expect(out.map((r) => r.classification)).toEqual(["timeout", "dns"]);
+  });
+
+  it("ranks by share OF THE FAILURES, not of all checks", () => {
+    // `dns` is a bigger slice of all traffic but a smaller slice of the
+    // failures. "Why do probes fail" asks the second question.
+    const out = rankedFailures([
+      reason("dns", true, 0.2, 0.9),
+      reason("timeout", true, 0.8, 0.05),
+    ]);
+    expect(out[0].classification).toBe("timeout");
+  });
+
+  it("a null failure_share sorts last rather than throwing", () => {
+    const out = rankedFailures([reason("unknown", true, null), reason("timeout", true, 0.5)]);
+    expect(out[0].classification).toBe("timeout");
+    expect(out).toHaveLength(2);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const input = [reason("a", true, 0.1), reason("b", true, 0.9)];
+    const before = input.map((r) => r.classification);
+    rankedFailures(input);
+    expect(input.map((r) => r.classification)).toEqual(before);
+  });
+
+  it("all-healthy is an empty list, not a fabricated row", () => {
+    expect(rankedFailures([reason("ok", false, null)])).toEqual([]);
+  });
+});

--- a/apps/ui/src/components/metagraphed/capture-currency-panel.tsx
+++ b/apps/ui/src/components/metagraphed/capture-currency-panel.tsx
@@ -34,7 +34,8 @@ function IndexerLagCard() {
   if (isLoading) return <Skeleton className="h-[120px] w-full" />;
   if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
   const l = data?.data;
-  if (!l) return <EmptyState title="No lag reading" description="Capture lag has not been measured." />;
+  if (!l)
+    return <EmptyState title="No lag reading" description="Capture lag has not been measured." />;
 
   return (
     <Panel as="section" dense>
@@ -66,7 +67,9 @@ function IndexerLagCard() {
         />
       </div>
       {l.measured_at ? (
-        <p className="mt-3 mg-type-label text-ink-muted">Measured {formatRelative(l.measured_at)}.</p>
+        <p className="mt-3 mg-type-label text-ink-muted">
+          Measured {formatRelative(l.measured_at)}.
+        </p>
       ) : null}
     </Panel>
   );
@@ -78,7 +81,12 @@ function FailureMixCard() {
   if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
   const f = data?.data;
   if (!f || f.reasons.length === 0) {
-    return <EmptyState title="No probe classifications" description="Nothing classified in this window." />;
+    return (
+      <EmptyState
+        title="No probe classifications"
+        description="Nothing classified in this window."
+      />
+    );
   }
 
   const failing = rankedFailures(f.reasons);
@@ -87,8 +95,16 @@ function FailureMixCard() {
     <Panel as="section" dense>
       <h3 className="mb-3 mg-type-label text-ink-muted">Why probes fail · {f.window}</h3>
       <div className="grid grid-cols-3 gap-x-6 gap-y-3">
-        <Figure label="checks" value={formatNumber(f.total_checks)} hint="Probe checks run in this window." />
-        <Figure label="failing" value={formatNumber(f.failing_checks)} hint="Of those, how many failed." />
+        <Figure
+          label="checks"
+          value={formatNumber(f.total_checks)}
+          hint="Probe checks run in this window."
+        />
+        <Figure
+          label="failing"
+          value={formatNumber(f.failing_checks)}
+          hint="Of those, how many failed."
+        />
         <Figure
           label="failure rate"
           value={f.failure_rate == null ? "—" : `${formatNumber(f.failure_rate * 100)}%`}

--- a/apps/ui/src/components/metagraphed/capture-currency-panel.tsx
+++ b/apps/ui/src/components/metagraphed/capture-currency-panel.tsx
@@ -1,0 +1,148 @@
+import { useQuery } from "@tanstack/react-query";
+import { chainIndexerLagQuery, healthFailureReasonsQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatRelative, humaniseSeconds } from "@/lib/metagraphed/format";
+import type { FailureReason } from "@/lib/metagraphed/types";
+
+/**
+ * `/api/v1/chain/indexer-lag` and `/api/v1/health/failure-reasons` (#10300),
+ * both published and rendered nowhere.
+ *
+ * Paired because they are the two halves of "can you trust what this API just
+ * told you": how current the capture is, and what is going wrong with the
+ * probes behind it.
+ *
+ * FAST IS NOT CURRENT. The lag route publishes write latency percentiles AND a
+ * head age, and they measure different things -- a lane that stopped an hour
+ * ago still reports excellent latency for the blocks it did write. Showing
+ * latency alone would let a dead lane read as a healthy one, which is exactly
+ * the failure this repo keeps finding, so the age leads and the percentiles
+ * are labelled as what they are.
+ */
+export function CaptureCurrencyPanel() {
+  return (
+    <div className="space-y-6">
+      <IndexerLagCard />
+      <FailureMixCard />
+    </div>
+  );
+}
+
+function IndexerLagCard() {
+  const { data, isLoading, isError, error, refetch } = useQuery(chainIndexerLagQuery());
+  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const l = data?.data;
+  if (!l) return <EmptyState title="No lag reading" description="Capture lag has not been measured." />;
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Capture currency</h3>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+        <Figure
+          label="behind head"
+          value={l.head_age_ms == null ? "—" : humaniseSeconds(l.head_age_ms / 1000)}
+          hint="How far behind the chain head our capture is. THIS is the number that says whether the data is current — write latency does not."
+        />
+        <Figure
+          label="write p50"
+          value={l.latency_p50_ms == null ? "—" : `${formatNumber(l.latency_p50_ms)} ms`}
+          hint="How long a block takes to land once we start writing it. A stopped lane still reports a good figure here."
+        />
+        <Figure
+          label="write p99"
+          value={l.latency_p99_ms == null ? "—" : `${formatNumber(l.latency_p99_ms)} ms`}
+          hint="The slow tail of the same measurement."
+        />
+        <Figure
+          label="blocks in window"
+          value={formatNumber(l.block_count)}
+          hint={
+            l.oldest_block != null && l.newest_block != null
+              ? `Blocks ${formatNumber(l.oldest_block)}–${formatNumber(l.newest_block)}.`
+              : "Blocks measured in this window."
+          }
+        />
+      </div>
+      {l.measured_at ? (
+        <p className="mt-3 mg-type-label text-ink-muted">Measured {formatRelative(l.measured_at)}.</p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function FailureMixCard() {
+  const { data, isLoading, isError, error, refetch } = useQuery(healthFailureReasonsQuery("30d"));
+  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const f = data?.data;
+  if (!f || f.reasons.length === 0) {
+    return <EmptyState title="No probe classifications" description="Nothing classified in this window." />;
+  }
+
+  const failing = rankedFailures(f.reasons);
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Why probes fail · {f.window}</h3>
+      <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+        <Figure label="checks" value={formatNumber(f.total_checks)} hint="Probe checks run in this window." />
+        <Figure label="failing" value={formatNumber(f.failing_checks)} hint="Of those, how many failed." />
+        <Figure
+          label="failure rate"
+          value={f.failure_rate == null ? "—" : `${formatNumber(f.failure_rate * 100)}%`}
+          hint="Failing checks as a share of all checks."
+        />
+      </div>
+
+      {/* Only the classifications that ARE failures, ranked by their share OF
+          THE FAILURES. `share` (of all checks) and `failure_share` (of the
+          failing ones) have different denominators, and mixing them is how a
+          classification that is 2% of traffic reads as 2% of the problem. */}
+      <ul className="mt-4 space-y-1">
+        {failing.map((r) => (
+          <li key={r.classification} className="flex justify-between mg-type-data-sm">
+            <span className="text-ink-muted">{r.classification}</span>
+            <span
+              className="tabular-nums text-ink"
+              title={`${formatNumber(r.checks)} checks — ${r.failure_share == null ? "—" : `${formatNumber(r.failure_share * 100)}% of failures`}, ${r.share == null ? "—" : `${formatNumber(r.share * 100)}% of all checks`}`}
+            >
+              {r.failure_share == null ? "—" : `${formatNumber(r.failure_share * 100)}%`}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {failing.length === 0 ? (
+        <p className="mt-3 mg-type-label text-ink-muted">
+          Every classification in this window is a non-failure outcome.
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div title={hint}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}
+
+/**
+ * The classifications that are actually failures, worst first.
+ *
+ * Filters on `is_failure` rather than assuming every classification is one --
+ * the route marks non-failure outcomes explicitly, and listing them among the
+ * failures would report a working probe as a broken one. Ranked by
+ * `failure_share`, the share OF THE FAILURES, because that is the question
+ * "why do probes fail" actually asks.
+ */
+export function rankedFailures(reasons: readonly FailureReason[]): FailureReason[] {
+  return reasons
+    .filter((r) => r.is_failure)
+    .slice()
+    .sort((a, b) => (b.failure_share ?? 0) - (a.failure_share ?? 0));
+}

--- a/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
+++ b/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
@@ -57,9 +57,21 @@ function BurnSpread() {
     <Panel as="section" dense>
       <h3 className="mb-3 mg-type-label text-ink-muted">Registration cost across subnets</h3>
       <div className="grid grid-cols-3 gap-x-6 gap-y-3">
-        <Figure label="cheapest" value={formatTao(b.cheapest_burn_tao)} hint="Lowest current registration cost across the subnets read." />
-        <Figure label="median" value={formatTao(b.median_burn_tao)} hint="Median registration cost — the typical price of entry." />
-        <Figure label="dearest" value={formatTao(b.dearest_burn_tao)} hint="Highest current registration cost." />
+        <Figure
+          label="cheapest"
+          value={formatTao(b.cheapest_burn_tao)}
+          hint="Lowest current registration cost across the subnets read."
+        />
+        <Figure
+          label="median"
+          value={formatTao(b.median_burn_tao)}
+          hint="Median registration cost — the typical price of entry."
+        />
+        <Figure
+          label="dearest"
+          value={formatTao(b.dearest_burn_tao)}
+          hint="Highest current registration cost."
+        />
       </div>
       {dearest.length > 0 ? (
         <ul className="mt-4 space-y-1">
@@ -137,9 +149,21 @@ function ConcentrationRanking() {
     <Panel as="section" dense>
       <h3 className="mb-3 mg-type-label text-ink-muted">Most concentrated subnets</h3>
       <div className="grid grid-cols-3 gap-x-6 gap-y-3">
-        <Figure label="median gini" value={formatNumber(c.median_gini)} hint="Median inequality of stake across subnets. 0 is even, 1 is one holder." />
-        <Figure label="median nakamoto" value={formatNumber(c.median_nakamoto_coefficient)} hint="How many accounts it typically takes to reach a controlling share." />
-        <Figure label="single-holder" value={formatNumber(c.single_holder_subnet_count)} hint="Subnets whose stake sits with one account." />
+        <Figure
+          label="median gini"
+          value={formatNumber(c.median_gini)}
+          hint="Median inequality of stake across subnets. 0 is even, 1 is one holder."
+        />
+        <Figure
+          label="median nakamoto"
+          value={formatNumber(c.median_nakamoto_coefficient)}
+          hint="How many accounts it typically takes to reach a controlling share."
+        />
+        <Figure
+          label="single-holder"
+          value={formatNumber(c.single_holder_subnet_count)}
+          hint="Subnets whose stake sits with one account."
+        />
       </div>
       {ranked.length > 0 ? (
         <ul className="mt-4 space-y-1">
@@ -184,8 +208,16 @@ function ConcentrationDrift() {
       <h3 className="mb-3 mg-type-label text-ink-muted">Concentration drift · {hist.window}</h3>
       <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
         <Figure label="days" value={formatNumber(hist.point_count)} hint="Days in the series." />
-        <Figure label="gini then" value={formatNumber(first?.gini)} hint={`Stake gini on ${hist.oldest_day ?? "the oldest day"}.`} />
-        <Figure label="gini now" value={formatNumber(last?.gini)} hint={`Stake gini on ${hist.newest_day ?? "the newest day"}.`} />
+        <Figure
+          label="gini then"
+          value={formatNumber(first?.gini)}
+          hint={`Stake gini on ${hist.oldest_day ?? "the oldest day"}.`}
+        />
+        <Figure
+          label="gini now"
+          value={formatNumber(last?.gini)}
+          hint={`Stake gini on ${hist.newest_day ?? "the newest day"}.`}
+        />
         <Figure
           label="nakamoto now"
           value={formatNumber(last?.nakamoto_coefficient)}
@@ -206,15 +238,7 @@ function ConcentrationDrift() {
   );
 }
 
-function Figure({
-  label,
-  value,
-  hint,
-}: {
-  label: string;
-  value: string;
-  hint: string;
-}) {
+function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
   return (
     <div title={hint}>
       <div className="mg-type-label text-ink-muted">{label}</div>

--- a/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
+++ b/apps/ui/src/components/metagraphed/chain-network-concentration.tsx
@@ -1,0 +1,224 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  chainBurnQuery,
+  chainHoldersQuery,
+  chainConcentrationSubnetsQuery,
+  chainConcentrationHistoryQuery,
+} from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatTao, formatRelative } from "@/lib/metagraphed/format";
+import {
+  coverageNote,
+  spansBuilderVersions,
+  capturesDiverge,
+} from "@/lib/metagraphed/network-coverage.functions";
+
+const TOP_SHOWN = 8;
+
+/**
+ * The four network-wide surfaces #10300 found rendered nowhere:
+ * `/chain/burn`, `/chain/holders`, `/chain/concentration/subnets` and
+ * `/chain/concentration/history`.
+ *
+ * Grouped rather than scattered because they answer one question between them
+ * -- how evenly is the network held, and what does it cost to join -- and
+ * because they share a caveat that only makes sense stated once per aggregate:
+ * EVERY ONE OF THEM PUBLISHES A READ COUNT BESIDE A TOTAL. An aggregate over a
+ * partial read describes the subset that was read. The panels say which, rather
+ * than presenting a spread over 120 subnets as a fact about 129.
+ */
+export function ChainNetworkConcentration() {
+  return (
+    <div className="space-y-6">
+      <BurnSpread />
+      <HolderConcentration />
+      <ConcentrationRanking />
+      <ConcentrationDrift />
+    </div>
+  );
+}
+
+/** What it costs to register, cheapest to dearest. */
+function BurnSpread() {
+  const { data, isLoading, isError, error, refetch } = useQuery(chainBurnQuery());
+  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const b = data?.data;
+  if (!b) return <EmptyState title="No registration costs" description="Nothing read yet." />;
+
+  const note = coverageNote(b.subnet_count, b.read_count);
+  const dearest = [...b.subnets]
+    .filter((s) => s.burn_tao != null)
+    .sort((a, z) => (z.burn_tao ?? 0) - (a.burn_tao ?? 0))
+    .slice(0, TOP_SHOWN);
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Registration cost across subnets</h3>
+      <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+        <Figure label="cheapest" value={formatTao(b.cheapest_burn_tao)} hint="Lowest current registration cost across the subnets read." />
+        <Figure label="median" value={formatTao(b.median_burn_tao)} hint="Median registration cost — the typical price of entry." />
+        <Figure label="dearest" value={formatTao(b.dearest_burn_tao)} hint="Highest current registration cost." />
+      </div>
+      {dearest.length > 0 ? (
+        <ul className="mt-4 space-y-1">
+          {dearest.map((s) => (
+            <li key={s.netuid} className="flex justify-between mg-type-data-sm">
+              <span className="text-ink-muted">SN{s.netuid}</span>
+              <span className="tabular-nums text-ink">{formatTao(s.burn_tao)}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {note ? <p className="mt-3 mg-type-label text-ink-muted">{note}</p> : null}
+    </Panel>
+  );
+}
+
+/** Who holds the alpha, and where one account holds all of it. */
+function HolderConcentration() {
+  const { data, isLoading, isError, error, refetch } = useQuery(chainHoldersQuery());
+  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const h = data?.data;
+  if (!h) return <EmptyState title="No holder data" description="Nothing read yet." />;
+
+  const note = coverageNote(h.subnet_count, h.subnets_measured);
+  // Two stamps, stated separately only when they actually disagree.
+  const split = capturesDiverge(h.captured_at, h.positions_captured_at);
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Alpha holders across subnets</h3>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
+        <Figure
+          label="median top-1 share"
+          value={h.median_top1_share == null ? "—" : `${formatNumber(h.median_top1_share * 100)}%`}
+          hint="In the typical subnet, this is the share held by its largest holder."
+        />
+        <Figure
+          label="majority-held"
+          value={formatNumber(h.subnets_with_majority_holder)}
+          hint="Subnets where one account holds over half the alpha."
+        />
+        <Figure
+          label="single-holder"
+          value={formatNumber(h.subnets_with_single_holder)}
+          hint="Subnets where ONE account holds all of it — a stronger claim than a majority, so it is counted separately."
+        />
+      </div>
+      {split ? (
+        <p className="mt-3 mg-type-label text-ink-muted">
+          Subnet set read {formatRelative(h.captured_at)}; holder positions{" "}
+          {formatRelative(h.positions_captured_at)}. The two halves describe different moments.
+        </p>
+      ) : null}
+      {note ? <p className="mt-2 mg-type-label text-ink-muted">{note}</p> : null}
+    </Panel>
+  );
+}
+
+/** Concentration ranked per subnet, with the unmeasured ones named as such. */
+function ConcentrationRanking() {
+  const { data, isLoading, isError, error, refetch } = useQuery(chainConcentrationSubnetsQuery());
+  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const c = data?.data;
+  if (!c) return <EmptyState title="No concentration data" description="Nothing read yet." />;
+
+  const note = coverageNote(c.subnet_count, c.measured_subnet_count);
+  // An unmeasured subnet is DROPPED from the ranking rather than ranked at
+  // zero: no reading is not perfect equality, and sorting it to one end of the
+  // list would put it at an extreme it was never measured to occupy.
+  const ranked = c.subnets.filter((s) => !s.unmeasured).slice(0, TOP_SHOWN);
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Most concentrated subnets</h3>
+      <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+        <Figure label="median gini" value={formatNumber(c.median_gini)} hint="Median inequality of stake across subnets. 0 is even, 1 is one holder." />
+        <Figure label="median nakamoto" value={formatNumber(c.median_nakamoto_coefficient)} hint="How many accounts it typically takes to reach a controlling share." />
+        <Figure label="single-holder" value={formatNumber(c.single_holder_subnet_count)} hint="Subnets whose stake sits with one account." />
+      </div>
+      {ranked.length > 0 ? (
+        <ul className="mt-4 space-y-1">
+          {ranked.map((s) => (
+            <li key={s.netuid} className="flex justify-between mg-type-data-sm">
+              <span className="text-ink-muted">SN{s.netuid}</span>
+              <span className="tabular-nums text-ink">
+                gini {formatNumber(s.gini)} · nakamoto {formatNumber(s.nakamoto_coefficient)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {note ? <p className="mt-3 mg-type-label text-ink-muted">{note}</p> : null}
+    </Panel>
+  );
+}
+
+/** Concentration over time, and whether the series is one computation. */
+function ConcentrationDrift() {
+  const { data, isLoading, isError, error, refetch } = useQuery(
+    chainConcentrationHistoryQuery("30d"),
+  );
+  if (isLoading) return <Skeleton className="h-[120px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const hist = data?.data;
+  if (!hist || hist.points.length === 0) {
+    return (
+      <EmptyState
+        title="No concentration history"
+        description="The daily concentration series has no points in this window."
+      />
+    );
+  }
+
+  const first = hist.points[0];
+  const last = hist.points[hist.points.length - 1];
+  const mixed = spansBuilderVersions(hist.builder_versions);
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Concentration drift · {hist.window}</h3>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+        <Figure label="days" value={formatNumber(hist.point_count)} hint="Days in the series." />
+        <Figure label="gini then" value={formatNumber(first?.gini)} hint={`Stake gini on ${hist.oldest_day ?? "the oldest day"}.`} />
+        <Figure label="gini now" value={formatNumber(last?.gini)} hint={`Stake gini on ${hist.newest_day ?? "the newest day"}.`} />
+        <Figure
+          label="nakamoto now"
+          value={formatNumber(last?.nakamoto_coefficient)}
+          hint="Accounts needed to reach a controlling share of stake, on the newest day."
+        />
+      </div>
+      {/* THE SEAM. A trend drawn across a builder-version change compares two
+          definitions rather than measuring a movement, so it is named rather
+          than smoothed over. */}
+      {mixed ? (
+        <p className="mt-3 mg-type-label text-ink-muted">
+          This window spans builder versions {hist.builder_versions.join(", ")} — points either side
+          were computed differently, so a change across the seam is a change of definition, not of
+          the network.
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function Figure({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+}) {
+  return (
+    <div title={hint}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/crowdloans-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/crowdloans-panel.test.ts
@@ -1,0 +1,66 @@
+// Crowdloan settlement state (#10300).
+//
+// MET THE CAP AND SETTLED ARE INDEPENDENT. A loan can be full and unsettled
+// (funds committed, outcome pending) or settled without ever filling. A single
+// "done" badge would tell a contributor their money had settled when it has
+// not, which is the one thing a crowdloan view must never get wrong.
+import { describe, expect, it } from "vitest";
+import { settlementLabel, statusHint } from "./crowdloans-panel";
+import type { Crowdloan } from "@/lib/metagraphed/types";
+
+const loan = (percent_raised: number | null, finalized: boolean): Crowdloan => ({
+  crowdloan_id: 0,
+  creator: null,
+  cap_tao: 30,
+  raised_tao: 30,
+  percent_raised,
+  contributors_count: 3,
+  end: 6989100,
+  finalized,
+  has_dispatch_call: false,
+  target_address: null,
+});
+
+describe("settlementLabel", () => {
+  it("full AND finalized is settled", () => {
+    expect(settlementLabel(loan(100, true))).toBe("settled");
+  });
+
+  it("full but NOT finalized is its own state", () => {
+    // The case the four-state split exists for: the cap is met, the money is
+    // committed, and nothing has settled.
+    expect(settlementLabel(loan(100, false))).toBe("full, unsettled");
+  });
+
+  it("finalized without filling is settled SHORT, not simply settled", () => {
+    expect(settlementLabel(loan(62, true))).toBe("settled short");
+  });
+
+  it("neither is still raising", () => {
+    expect(settlementLabel(loan(62, false))).toBe("raising");
+  });
+
+  it("an unknown percentage is not treated as full", () => {
+    // A null percentage is not 100. Defaulting the unknown direction to full
+    // would announce a cap met that was never measured.
+    expect(settlementLabel(loan(null, false))).toBe("raising");
+    expect(settlementLabel(loan(null, true))).toBe("settled short");
+  });
+
+  it("over-subscription counts as full", () => {
+    expect(settlementLabel(loan(140, false))).toBe("full, unsettled");
+  });
+});
+
+describe("statusHint", () => {
+  it("spells out the committed-but-unsettled case", () => {
+    const hint = statusHint(loan(100, false));
+    expect(hint).toContain("NOT finalized");
+    expect(hint).toContain("not yet settled");
+  });
+
+  it("distinguishes finalized-short from finalized-full", () => {
+    expect(statusHint(loan(62, true))).toContain("without reaching its cap");
+    expect(statusHint(loan(100, true))).toContain("Reached its cap");
+  });
+});

--- a/apps/ui/src/components/metagraphed/crowdloans-panel.tsx
+++ b/apps/ui/src/components/metagraphed/crowdloans-panel.tsx
@@ -1,0 +1,139 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { crowdloansQuery, crowdloanQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { Crowdloan } from "@/lib/metagraphed/types";
+
+/**
+ * `/api/v1/crowdloans` and `/api/v1/crowdloans/{crowdloan_id}` (#10300), both
+ * published and rendered nowhere.
+ *
+ * MET THE CAP AND SETTLED ARE DIFFERENT STATES. A crowdloan at 100% that has
+ * not been finalized has raised its target but not closed out — the funds are
+ * committed and the outcome is not yet decided. Collapsing `percent_raised`
+ * and `finalized` into one "done" badge would tell a contributor their money
+ * had settled when it has not, so the two are shown separately.
+ *
+ * Expanding a row reads the by-id route, which is the authoritative per-loan
+ * record and is where `exists` lives.
+ */
+export function CrowdloansPanel() {
+  const { data, isLoading, isError, error, refetch } = useQuery(crowdloansQuery());
+  const [openId, setOpenId] = useState<number | null>(null);
+
+  if (isLoading) return <Skeleton className="h-[200px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const c = data?.data;
+  if (!c || c.crowdloans.length === 0) {
+    return (
+      <EmptyState
+        title="No crowdloans"
+        description="No crowdloan has been created on this network."
+      />
+    );
+  }
+
+  return (
+    <Panel as="section" dense>
+      <p className="mb-3 mg-type-data-sm text-ink-muted">
+        {formatNumber(c.crowdloan_count)} crowdloan{c.crowdloan_count === 1 ? "" : "s"}
+      </p>
+
+      <ul className="divide-y divide-border/50">
+        {c.crowdloans.map((l) => (
+          <li key={l.crowdloan_id}>
+            <button
+              type="button"
+              onClick={() => setOpenId((cur) => (cur === l.crowdloan_id ? null : l.crowdloan_id))}
+              aria-expanded={openId === l.crowdloan_id}
+              className="flex w-full items-center gap-3 py-2 text-left mg-type-data-sm"
+            >
+              <span className="w-10 shrink-0 text-ink">#{l.crowdloan_id}</span>
+              <span className="flex-1 tabular-nums text-ink">
+                {formatTao(l.raised_tao)} / {formatTao(l.cap_tao)}
+              </span>
+              <span className="shrink-0 tabular-nums text-ink-muted">
+                {l.percent_raised == null ? "—" : `${formatNumber(l.percent_raised)}%`}
+              </span>
+              {/* Two states, two badges. Raised is not settled. */}
+              <span className="w-24 shrink-0 mg-type-label text-ink-muted" title={statusHint(l)}>
+                {settlementLabel(l)}
+              </span>
+            </button>
+            {openId === l.crowdloan_id ? <CrowdloanDetail id={l.crowdloan_id} /> : null}
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}
+
+/** The authoritative per-loan record, read only when a row is opened. */
+function CrowdloanDetail({ id }: { id: number }) {
+  const { data, isLoading, isError, error, refetch } = useQuery(crowdloanQuery(id));
+
+  if (isLoading) return <Skeleton className="mb-2 h-16 w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const d = data?.data;
+  // `exists: false` at 200 is an ANSWER about the chain, not a failed request.
+  if (!d?.exists || !d.crowdloan) {
+    return (
+      <p className="pb-2 mg-type-data-sm text-ink-muted">
+        No crowdloan {id} exists on chain — a fact about the chain, not a failed lookup.
+      </p>
+    );
+  }
+
+  const l = d.crowdloan;
+  return (
+    <dl className="grid grid-cols-2 gap-x-6 gap-y-2 pb-3 sm:grid-cols-4">
+      <Detail label="contributors" value={formatNumber(l.contributors_count)} />
+      <Detail label="ends at block" value={l.end == null ? "—" : `#${formatNumber(l.end)}`} />
+      <Detail label="settled" value={l.finalized ? "yes" : "no"} />
+      <Detail
+        label="dispatches"
+        value={l.has_dispatch_call ? "yes" : "no"}
+        hint="Whether the raised funds execute a call on release. A crowdloan that dispatches is doing something a plain transfer is not."
+      />
+    </dl>
+  );
+}
+
+function Detail({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div title={hint}>
+      <dt className="mg-type-label text-ink-muted">{label}</dt>
+      <dd className="mg-type-data-sm tabular-nums text-ink">{value}</dd>
+    </div>
+  );
+}
+
+/**
+ * What state a crowdloan is actually in.
+ *
+ * Returns FOUR states, not two, because "raised its cap" and "settled" are
+ * independent: a loan can be full and unsettled (committed, outcome pending),
+ * or settled without ever filling. A single "done" badge would tell a
+ * contributor their money had settled when it had not.
+ */
+export function settlementLabel(l: Crowdloan): string {
+  const full = l.percent_raised != null && l.percent_raised >= 100;
+  if (l.finalized) return full ? "settled" : "settled short";
+  return full ? "full, unsettled" : "raising";
+}
+
+/** The same distinction spelled out, for the row's tooltip. */
+export function statusHint(l: Crowdloan): string {
+  if (l.finalized) {
+    return l.percent_raised != null && l.percent_raised >= 100
+      ? "Reached its cap and has been finalized."
+      : "Finalized without reaching its cap.";
+  }
+  return l.percent_raised != null && l.percent_raised >= 100
+    ? "Has reached its cap but is NOT finalized — the funds are committed and the outcome is not yet settled."
+    : "Still raising.";
+}

--- a/apps/ui/src/components/metagraphed/domains-rollup.tsx
+++ b/apps/ui/src/components/metagraphed/domains-rollup.tsx
@@ -1,8 +1,8 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
 import { ChevronDown } from "lucide-react";
-import { domainsQuery, subnetsQuery } from "@/lib/metagraphed/queries";
+import { domainsQuery, subnetsQuery, domainSummaryQuery } from "@/lib/metagraphed/queries";
 import { formatNumber, formatTao } from "@/lib/metagraphed/format";
 import { BrandIcon } from "@jsonbored/ui-kit";
 import type { Domain, Subnet } from "@/lib/metagraphed/types";
@@ -78,6 +78,25 @@ function DomainRow({
 }) {
   const c = domain.emission_concentration;
   const panelId = `domain-detail-${domain.domain}`;
+
+  // #10300: /api/v1/domains/{tag}/summary was published and rendered nowhere.
+  //
+  // It is the AUTHORITATIVE per-domain record; the rollup list is a projection
+  // that currently happens to carry the same fields. Reading the detail here
+  // is the list/detail split done properly -- the expanded panel stops
+  // depending on the list projection continuing to carry everything forever,
+  // and if the two ever diverge this is the one that is right.
+  //
+  // Deliberately `enabled: open`, so a reader who never expands a row pays
+  // nothing, matching the taxonomy's own lazy-query design. Every value falls
+  // back to the list, so a failed detail read is a no-op rather than an
+  // emptied panel.
+  const { data: detail } = useQuery({ ...domainSummaryQuery(domain.domain), enabled: open });
+  const d = detail?.data;
+  const stakeTao = d?.total_stake_tao ?? domain.total_stake_tao;
+  const emissionShare = d?.total_emission_share ?? domain.total_emission_share;
+  const nakamoto = d?.emission_nakamoto_coefficient ?? c?.nakamoto_coefficient;
+  const gini = d?.emission_gini ?? c?.gini;
   return (
     <li>
       <button
@@ -113,10 +132,10 @@ function DomainRow({
       {open ? (
         <div id={panelId} className="space-y-4 px-4 pb-4 pt-1">
           <dl className="grid grid-cols-2 gap-x-4 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
-            <Metric label="Total stake" value={formatTao(domain.total_stake_tao)} />
-            <Metric label="Emission share" value={pct(domain.total_emission_share)} />
-            <Metric label="Nakamoto coeff." value={formatNumber(c?.nakamoto_coefficient)} />
-            <Metric label="Gini" value={ratio(c?.gini)} />
+            <Metric label="Total stake" value={formatTao(stakeTao)} />
+            <Metric label="Emission share" value={pct(emissionShare)} />
+            <Metric label="Nakamoto coeff." value={formatNumber(nakamoto)} />
+            <Metric label="Gini" value={ratio(gini)} />
             <Metric label="HHI (normalized)" value={ratio(c?.hhi_normalized)} />
             <Metric label="Top-10% share" value={pct(c?.top_10pct_share)} />
             <Metric label="Top-20% share" value={pct(c?.top_20pct_share)} />

--- a/apps/ui/src/components/metagraphed/emission-gate-changes.tsx
+++ b/apps/ui/src/components/metagraphed/emission-gate-changes.tsx
@@ -1,0 +1,129 @@
+import { useQuery } from "@tanstack/react-query";
+import { emissionChangesQuery, networkRandomnessQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatRelative } from "@/lib/metagraphed/format";
+
+const MAX_SHOWN = 15;
+
+/**
+ * `/api/v1/chain/governance/emission-changes` and `/api/v1/network/randomness`
+ * (#10300), both published and rendered nowhere.
+ *
+ * Together on the governance tab because both are consensus mechanics a reader
+ * of the change log needs: what has moved the emission gate, and whether the
+ * randomness a commit-reveal was timelocked against is still verifiable.
+ */
+export function EmissionGateChanges() {
+  return (
+    <div className="space-y-6">
+      <ChangeLog />
+      <RandomnessCard />
+    </div>
+  );
+}
+
+function ChangeLog() {
+  const { data, isLoading, isError, error, refetch } = useQuery(emissionChangesQuery());
+  if (isLoading) return <Skeleton className="h-[160px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const c = data?.data;
+  if (!c || c.changes.length === 0) {
+    return (
+      <EmptyState
+        title="No emission-gate changes"
+        description="Nothing has moved the emission gate in the recorded window."
+      />
+    );
+  }
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Emission gate changes</h3>
+      <p className="mb-3 mg-type-data-sm text-ink-muted">
+        {formatNumber(c.change_count)} recorded change{c.change_count === 1 ? "" : "s"}
+        {c.latest_change_at ? ` · latest ${formatRelative(c.latest_change_at)}` : ""}
+      </p>
+
+      <ul className="space-y-1">
+        {c.changes.slice(0, MAX_SHOWN).map((ch, i) => (
+          <li
+            key={`${ch.kind}-${ch.observed_at ?? i}-${ch.param ?? ""}`}
+            className="flex gap-3 mg-type-data-sm"
+          >
+            <span className="w-40 shrink-0 truncate text-ink-muted" title={ch.param ?? ch.kind}>
+              {ch.param ?? ch.kind}
+            </span>
+            <span className="min-w-0 flex-1 tabular-nums text-ink">
+              {ch.previous_value != null ? `${ch.previous_value} → ` : ""}
+              {ch.value ?? "—"}
+            </span>
+            {/* A change older than capture has NO block. Rendering it as block 0
+                would date it to genesis, so it is labelled instead. */}
+            <span className="shrink-0 mg-type-label text-ink-muted">
+              {ch.predates_capture
+                ? "pre-capture"
+                : ch.block_number != null
+                  ? `#${formatNumber(ch.block_number)}`
+                  : "—"}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {c.predates_capture_count != null && c.predates_capture_count > 0 ? (
+        <p className="mt-3 mg-type-label text-ink-muted">
+          {formatNumber(c.predates_capture_count)} of these predate our capture and carry no block —
+          they happened before we were watching, which is not the same as happening at genesis.
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function RandomnessCard() {
+  const { data, isLoading, isError, error, refetch } = useQuery(networkRandomnessQuery());
+  if (isLoading) return <Skeleton className="h-[100px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+  const r = data?.data;
+  if (!r) return <EmptyState title="No randomness reading" description="Round storage not read." />;
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Stored randomness rounds</h3>
+      <div className="grid grid-cols-3 gap-x-6 gap-y-3">
+        {/* THE SPAN LEADS, not the newest round. Commit-reveal verifies a
+            reveal against the round it was timelocked to, so how far BACK
+            storage reaches is what decides whether an old reveal can still be
+            checked — the newest round says nothing about that. */}
+        <Figure
+          label="rounds retained"
+          value={formatNumber(r.stored_round_span)}
+          hint="How many rounds are still stored. A reveal timelocked to a round that has aged out can no longer be verified — this is the number that decides that, not the newest round."
+        />
+        <Figure
+          label="oldest"
+          value={formatNumber(r.oldest_stored_round)}
+          hint="The furthest back verification can reach."
+        />
+        <Figure
+          label="newest"
+          value={formatNumber(r.last_stored_round)}
+          hint="The most recent round stored."
+        />
+      </div>
+      {r.queried_at ? (
+        <p className="mt-3 mg-type-label text-ink-muted">Read {formatRelative(r.queried_at)}.</p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div title={hint}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/network-subnet-lifecycle.tsx
+++ b/apps/ui/src/components/metagraphed/network-subnet-lifecycle.tsx
@@ -1,0 +1,121 @@
+import { useQuery } from "@tanstack/react-query";
+import { chainSubnetLifecycleQuery, domainSummaryQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatTao, formatRelative } from "@/lib/metagraphed/format";
+
+const SHOWN = 20;
+
+/**
+ * `/api/v1/chain/subnet-lifecycle` (#10300), published and rendered nowhere.
+ *
+ * Registration and deregistration across every subnet — the network-wide
+ * sibling of the per-subnet lifecycle log. It carries the same
+ * `predates_capture` flag for the same reason: every subnet alive when the lane
+ * first ran was registered before we were watching, so its row has no block.
+ * Rendering that NULL as block 0 would date the whole founding cohort to
+ * genesis, which is the single most common way this dataset gets misread.
+ */
+export function NetworkSubnetLifecycle() {
+  const { data, isLoading, isError, error, refetch } = useQuery(chainSubnetLifecycleQuery());
+
+  if (isLoading) return <Skeleton className="h-[200px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const l = data?.data;
+  if (!l || l.entries.length === 0) {
+    return (
+      <EmptyState
+        title="No lifecycle events"
+        description="No subnet registration or deregistration has been recorded."
+      />
+    );
+  }
+
+  return (
+    <Panel as="section" dense>
+      <p className="mb-3 mg-type-data-sm text-ink-muted">
+        {formatNumber(l.entry_count)} recorded transition
+        {l.entry_count === 1 ? "" : "s"}
+        {l.subnet_count == null ? "" : ` across ${formatNumber(l.subnet_count)} subnets`}
+      </p>
+
+      <ul className="space-y-1">
+        {l.entries.slice(0, SHOWN).map((e, i) => (
+          <li
+            key={`${e.netuid}-${e.event}-${e.observed_at ?? i}`}
+            className="flex gap-3 mg-type-data-sm"
+          >
+            <span className="w-16 shrink-0 text-ink">SN{e.netuid}</span>
+            <span className="w-28 shrink-0 text-ink-muted">{e.event}</span>
+            <span className="flex-1 tabular-nums text-ink-muted">
+              {/* NULL block means "before we were watching", NOT block 0. */}
+              {e.predates_capture
+                ? "before capture"
+                : e.block_number != null
+                  ? `#${formatNumber(e.block_number)}`
+                  : "—"}
+            </span>
+            <span className="shrink-0 mg-type-label text-ink-muted">
+              {e.observed_at ? formatRelative(e.observed_at) : ""}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Panel>
+  );
+}
+
+/**
+ * `/api/v1/domains/{tag}/summary` (#10300), published and rendered nowhere.
+ *
+ * The per-domain detail behind the rollup table: how much stake a domain holds,
+ * what share of emission it draws, and how concentrated that emission is within
+ * it. The last one is the reason this is worth a request — a domain drawing 6%
+ * of emission across thirteen subnets and one drawing 6% through a single
+ * subnet are very different things, and only the concentration figures tell
+ * them apart.
+ */
+export function DomainSummaryCard({ tag }: { tag: string }) {
+  const { data, isLoading, isError, error, refetch } = useQuery(domainSummaryQuery(tag));
+
+  if (isLoading) return <Skeleton className="h-[90px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const d = data?.data;
+  if (!d) {
+    return <EmptyState title="No domain summary" description={`No rollup recorded for ${tag}.`} />;
+  }
+
+  return (
+    <Panel as="section" dense>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+        <Figure label="subnets" value={formatNumber(d.subnet_count)} hint={`Subnets classified under ${d.domain}.`} />
+        <Figure label="stake" value={formatTao(d.total_stake_tao)} hint="Total stake across the domain's subnets." />
+        <Figure
+          label="emission share"
+          value={
+            d.total_emission_share == null
+              ? "—"
+              : `${formatNumber(d.total_emission_share * 100)}%`
+          }
+          hint="This domain's combined share of network emission."
+        />
+        <Figure
+          label="emission gini"
+          value={formatNumber(d.emission_gini)}
+          hint="How unevenly that emission is spread WITHIN the domain. A domain drawing 6% across thirteen subnets and one drawing 6% through a single subnet are different things, and this is what tells them apart."
+        />
+      </div>
+    </Panel>
+  );
+}
+
+function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div title={hint}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/network-subnet-lifecycle.tsx
+++ b/apps/ui/src/components/metagraphed/network-subnet-lifecycle.tsx
@@ -90,14 +90,20 @@ export function DomainSummaryCard({ tag }: { tag: string }) {
   return (
     <Panel as="section" dense>
       <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
-        <Figure label="subnets" value={formatNumber(d.subnet_count)} hint={`Subnets classified under ${d.domain}.`} />
-        <Figure label="stake" value={formatTao(d.total_stake_tao)} hint="Total stake across the domain's subnets." />
+        <Figure
+          label="subnets"
+          value={formatNumber(d.subnet_count)}
+          hint={`Subnets classified under ${d.domain}.`}
+        />
+        <Figure
+          label="stake"
+          value={formatTao(d.total_stake_tao)}
+          hint="Total stake across the domain's subnets."
+        />
         <Figure
           label="emission share"
           value={
-            d.total_emission_share == null
-              ? "—"
-              : `${formatNumber(d.total_emission_share * 100)}%`
+            d.total_emission_share == null ? "—" : `${formatNumber(d.total_emission_share * 100)}%`
           }
           hint="This domain's combined share of network emission."
         />

--- a/apps/ui/src/components/metagraphed/registry-pipeline-panel.tsx
+++ b/apps/ui/src/components/metagraphed/registry-pipeline-panel.tsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { registryPipelineQuery, fixtureQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatRelative } from "@/lib/metagraphed/format";
+
+const SOURCES_SHOWN = 8;
+
+/**
+ * The registry's own intake pipeline (#10300).
+ *
+ * `/api/v1/candidates`, `/api/v1/curation`, `/api/v1/profiles` and
+ * `/api/v1/source-snapshots` were all published and rendered nowhere. #10300
+ * listed them as "plausibly API-only... but it should be a recorded decision,
+ * because right now 'no page exists' and 'no page should exist' are
+ * indistinguishable from the outside".
+ *
+ * This is that decision, made the other way. They are the four stages of how a
+ * surface gets into this registry -- discovered, curated, profiled, and the
+ * snapshot of what each source actually said -- and the ops console is where
+ * someone asks where intake has stalled.
+ *
+ * EACH STAGE REPORTS WHETHER IT WAS REACHABLE. A stage that could not be read
+ * renders as unknown, never as zero: "no candidates" and "the candidates route
+ * is down" are opposite findings, and a pipeline view that showed both as 0
+ * would be worse than no view at all.
+ */
+export function RegistryPipelinePanel() {
+  const { data, isLoading, isError, error, refetch } = useQuery(registryPipelineQuery());
+
+  if (isLoading) return <Skeleton className="h-[220px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const p = data?.data;
+  if (!p) return <Skeleton className="h-[220px] w-full" />;
+
+  return (
+    <div className="space-y-6">
+      <Panel as="section" dense>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+          <Stage
+            label="candidates"
+            reachable={p.candidates_reachable}
+            value={formatNumber(p.candidate_count)}
+            hint="Discovered surfaces awaiting verification."
+          />
+          <Stage
+            label="superseded"
+            reachable={p.candidates_reachable}
+            value={formatNumber(p.superseded_count)}
+            hint="Candidates replaced by a better source. NOT rejections — a supersede is the pipeline working, so it is counted apart from failures."
+          />
+          <Stage
+            label="curated subnets"
+            reachable={p.curation_reachable}
+            value={formatNumber(p.curated_subnet_count)}
+            hint="Subnets with a curation record. `coverage_level` (how much we have) and `curation_level` (how much a human vouched for) are two different ladders."
+          />
+          <Stage
+            label="profiles"
+            reachable={p.profiles_reachable}
+            value={formatNumber(p.profile_count)}
+            hint="Subnets with a built profile."
+          />
+        </div>
+        <p className="mt-3 mg-type-label text-ink-muted">
+          {formatNumber(p.gap_total)} open interface gaps across the curated subnets.
+        </p>
+      </Panel>
+
+      <Panel as="section" dense>
+        <h3 className="mb-3 mg-type-label text-ink-muted">Source snapshots</h3>
+        {p.snapshots_reachable ? (
+          <>
+            <p className="mb-3 mg-type-data-sm text-ink-muted">
+              {formatNumber(p.source_count)} source
+              {p.source_count === 1 ? "" : "s"}
+              {p.verification_result_count == null
+                ? ""
+                : ` · ${formatNumber(p.verification_result_count)} verification results`}
+              {p.generated_at ? ` · generated ${formatRelative(p.generated_at)}` : ""}
+            </p>
+            <ul className="space-y-1">
+              {p.sources.slice(0, SOURCES_SHOWN).map((s) => (
+                <li key={s.id} className="flex gap-3 mg-type-data-sm">
+                  <span className="min-w-0 flex-1 truncate text-ink">{s.id}</span>
+                  <span className="shrink-0 tabular-nums text-ink-muted">
+                    {formatNumber(s.record_count)} rows
+                  </span>
+                  {/* The hash, not just the date. Two captures with the same
+                      hash saw the same bytes -- a timestamp cannot tell you
+                      whether a re-capture actually changed anything. */}
+                  <span
+                    className="shrink-0 mg-type-label text-ink-muted"
+                    title={s.hash ? `Content hash ${s.hash}` : "No content hash recorded."}
+                  >
+                    {s.hash ? s.hash.slice(0, 7) : "—"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p className="mg-type-data-sm text-ink-muted">
+            The source-snapshot route could not be read — this is unknown, not empty.
+          </p>
+        )}
+      </Panel>
+    </div>
+  );
+}
+
+/**
+ * One pipeline stage.
+ *
+ * An unreachable stage renders an em-dash and says so, rather than 0. The
+ * distinction is the whole point of the panel: a stage with nothing in it and a
+ * stage we could not read are opposite findings.
+ */
+function Stage({
+  label,
+  reachable,
+  value,
+  hint,
+}: {
+  label: string;
+  reachable: boolean;
+  value: string;
+  hint: string;
+}) {
+  return (
+    <div title={reachable ? hint : `${hint} (This stage could not be read — unknown, not zero.)`}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{reachable ? value : "—"}</div>
+      {!reachable ? <div className="mg-type-label text-ink-muted">unreadable</div> : null}
+    </div>
+  );
+}
+
+/**
+ * `/api/v1/fixtures/{surface_id}` (#10300), published and rendered nowhere.
+ *
+ * Look up whether a surface has a captured fixture. AN ABSENT FIXTURE IS AN
+ * ANSWER: the route 404s on a surface it never captured, and rendering that as
+ * an error would make "we have not captured this yet" indistinguishable from
+ * "the API is broken" — the same confusion #10222 fixed for lane health.
+ */
+export function FixtureLookupPanel() {
+  const [input, setInput] = useState("");
+  const [surfaceId, setSurfaceId] = useState<string | null>(null);
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    ...fixtureQuery(surfaceId ?? ""),
+    enabled: surfaceId !== null && surfaceId !== "",
+  });
+
+  return (
+    <Panel as="section" dense>
+      <h3 className="mb-3 mg-type-label text-ink-muted">Fixture lookup</h3>
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          setSurfaceId(input.trim());
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="surface id, e.g. allways-api-health"
+          aria-label="Surface id"
+          className="min-w-0 flex-1 rounded border border-border bg-surface px-2 py-1 mg-type-data-sm text-ink"
+        />
+        <button
+          type="submit"
+          className="rounded border border-border bg-card px-3 py-1 mg-type-caption font-medium text-ink-strong hover:border-accent/40"
+        >
+          Look up
+        </button>
+      </form>
+
+      {surfaceId ? (
+        isLoading ? (
+          <Skeleton className="mt-3 h-12 w-full" />
+        ) : isError ? (
+          <ErrorState error={error} onRetry={() => void refetch()} />
+        ) : data?.data.available ? (
+          <p className="mt-3 mg-type-data-sm text-ink">
+            Captured{data.data.captured_at ? ` ${formatRelative(data.data.captured_at)}` : ""}
+            {data.data.response_status == null
+              ? ""
+              : ` · responded ${formatNumber(data.data.response_status)}`}
+          </p>
+        ) : (
+          <p className="mt-3 mg-type-data-sm text-ink-muted">{data?.data.reason}</p>
+        )
+      ) : null}
+    </Panel>
+  );
+}

--- a/apps/ui/src/components/metagraphed/registry-pipeline-panel.tsx
+++ b/apps/ui/src/components/metagraphed/registry-pipeline-panel.tsx
@@ -4,6 +4,7 @@ import { registryPipelineQuery, fixtureQuery } from "@/lib/metagraphed/queries";
 import { Panel } from "@/components/metagraphed/primitives";
 import { Skeleton, ErrorState } from "@/components/metagraphed/states";
 import { formatNumber, formatRelative } from "@/lib/metagraphed/format";
+import type { PipelineSample } from "@/lib/metagraphed/types";
 
 const SOURCES_SHOWN = 8;
 
@@ -25,6 +26,10 @@ const SOURCES_SHOWN = 8;
  * renders as unknown, never as zero: "no candidates" and "the candidates route
  * is down" are opposite findings, and a pipeline view that showed both as 0
  * would be worse than no view at all.
+ *
+ * THE COUNTS ARE NOT SAMPLE LENGTHS. The candidate total is the server's own,
+ * and the lists below it are bounded samples that are never counted -- see the
+ * query for why that distinction is load-bearing rather than fussy.
  */
 export function RegistryPipelinePanel() {
   const { data, isLoading, isError, error, refetch } = useQuery(registryPipelineQuery());
@@ -41,15 +46,12 @@ export function RegistryPipelinePanel() {
         <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
           <Stage
             label="candidates"
-            reachable={p.candidates_reachable}
+            // Gated on SNAPSHOTS, not candidates: this total comes from the
+            // source-snapshot summary, so it is that route's reachability that
+            // decides whether the number can be shown.
+            reachable={p.snapshots_reachable}
             value={formatNumber(p.candidate_count)}
-            hint="Discovered surfaces awaiting verification."
-          />
-          <Stage
-            label="superseded"
-            reachable={p.candidates_reachable}
-            value={formatNumber(p.superseded_count)}
-            hint="Candidates replaced by a better source. NOT rejections — a supersede is the pipeline working, so it is counted apart from failures."
+            hint="Discovered surfaces awaiting verification. Server-computed total — the list below is a bounded sample and is deliberately not counted."
           />
           <Stage
             label="curated subnets"
@@ -58,15 +60,31 @@ export function RegistryPipelinePanel() {
             hint="Subnets with a curation record. `coverage_level` (how much we have) and `curation_level` (how much a human vouched for) are two different ladders."
           />
           <Stage
-            label="profiles"
-            reachable={p.profiles_reachable}
-            value={formatNumber(p.profile_count)}
-            hint="Subnets with a built profile."
+            label="open gaps"
+            reachable={p.curation_reachable}
+            value={formatNumber(p.gap_total)}
+            hint="Interface gaps summed across EVERY curated subnet — the curation route is fetched whole for this, because a sum over a truncated list is not a smaller sum, it is a wrong one."
+          />
+          <Stage
+            label="verification results"
+            reachable={p.snapshots_reachable}
+            value={formatNumber(p.verification_result_count)}
+            hint="Recorded verification outcomes behind those candidates."
           />
         </div>
-        <p className="mt-3 mg-type-label text-ink-muted">
-          {formatNumber(p.gap_total)} open interface gaps across the curated subnets.
-        </p>
+
+        <div className="mt-4 grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <SampleList
+            title="Latest candidates"
+            reachable={p.candidates_reachable}
+            rows={p.recent_candidates}
+          />
+          <SampleList
+            title="Latest profiles"
+            reachable={p.profiles_reachable}
+            rows={p.recent_profiles}
+          />
+        </div>
       </Panel>
 
       <Panel as="section" dense>
@@ -107,6 +125,48 @@ export function RegistryPipelinePanel() {
           </p>
         )}
       </Panel>
+    </div>
+  );
+}
+
+/**
+ * A bounded sample of one stage's rows.
+ *
+ * Headed "latest N", never "N of M" and never a total: these lists are fetched
+ * with a limit and the route publishes no population, so any count derived here
+ * would be the limit wearing a total's clothes.
+ */
+function SampleList({
+  title,
+  reachable,
+  rows,
+}: {
+  title: string;
+  reachable: boolean;
+  rows: readonly PipelineSample[];
+}) {
+  return (
+    <div>
+      <h4 className="mb-1 mg-type-label text-ink-muted">
+        {title}
+        {reachable && rows.length > 0 ? ` · latest ${rows.length}` : ""}
+      </h4>
+      {!reachable ? (
+        <p className="mg-type-data-sm text-ink-muted">Unreadable — unknown, not empty.</p>
+      ) : rows.length === 0 ? (
+        <p className="mg-type-data-sm text-ink-muted">None returned.</p>
+      ) : (
+        <ul className="space-y-0.5">
+          {rows.map((r) => (
+            <li key={r.id} className="flex gap-2 mg-type-data-sm">
+              <span className="min-w-0 flex-1 truncate text-ink">{r.name ?? r.id}</span>
+              {r.detail ? (
+                <span className="shrink-0 mg-type-label text-ink-muted">{r.detail}</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/registry-ticker.tsx
+++ b/apps/ui/src/components/metagraphed/registry-ticker.tsx
@@ -47,9 +47,10 @@ export function RegistryTicker() {
       void queryClient.invalidateQueries({ queryKey: blocksQueryOptions.queryKey });
     },
   });
-  // Same query key/staleTime as use-tao-price.ts's shared hook so this
-  // global ticker's fetch dedupes against /subnets' own market-strip query
-  // instead of hitting the (rate-limited, external) CoinPaprika API twice.
+  // Same query key/staleTime as use-tao-price.ts's shared hook so this global
+  // ticker's fetch dedupes against /subnets' own market-strip query rather than
+  // calling /api/v1/network/tao-usd twice on every page. (The external
+  // CoinPaprika call this used to dedupe is gone -- see market.functions.ts.)
   const marketQ = useQuery({
     queryKey: ["tao-market"],
     queryFn: () => getTaoMarket(),
@@ -129,8 +130,13 @@ export function RegistryTicker() {
                 <span className="text-ink-strong tabular-nums">{formatUsd(market?.price)}</span>
               </span>
             </TooltipTrigger>
+            {/* #10300: this said "CoinPaprika" after the source had already
+                moved to our own index, crediting a third party for a figure we
+                compute. The provenance a tooltip states is the only provenance
+                a reader gets, so it names the real basis. */}
             <TooltipContent side="bottom" className="mg-type-caption">
-              Current TAO price · CoinPaprika
+              Current TAO price · our own liquidity-weighted median across qualifying wTAO/WETH
+              pools, not a venue ticker
             </TooltipContent>
           </Tooltip>
 

--- a/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.test.ts
@@ -12,10 +12,7 @@ import type {
   SubnetEmissionPipelinePoint,
 } from "@/lib/metagraphed/types";
 
-const point = (
-  day: string,
-  repeats: boolean | null,
-): SubnetEmissionPipelinePoint => ({
+const point = (day: string, repeats: boolean | null): SubnetEmissionPipelinePoint => ({
   day,
   pipeline_block: 1,
   repeats_previous_observation: repeats,

--- a/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.test.ts
@@ -1,0 +1,68 @@
+// The emission pipeline series (#10300).
+//
+// One property carries the panel: A REPEATED DAY IS NOT A MEASUREMENT. The
+// route marks each day with `repeats_previous_observation`, and a flat stretch
+// of carried-forward readings looks exactly like a pipeline that held steady.
+// Counting them wrong in either direction breaks the warning: over-report and
+// readers learn to ignore it, under-report and it never fires.
+import { describe, expect, it } from "vitest";
+import { countCarriedForward } from "./subnet-emission-pipeline-history";
+import type {
+  SubnetEmissionPipelineHistory,
+  SubnetEmissionPipelinePoint,
+} from "@/lib/metagraphed/types";
+
+const point = (
+  day: string,
+  repeats: boolean | null,
+): SubnetEmissionPipelinePoint => ({
+  day,
+  pipeline_block: 1,
+  repeats_previous_observation: repeats,
+  captured_at: null,
+  emission_share: 0.06,
+  alpha_price_tao: 0.08,
+  tao_in_pool_tao: 1,
+  tao_in_emission_tao: 1,
+  miner_burned_fraction: 0,
+  emission_enabled: true,
+});
+
+const history = (points: SubnetEmissionPipelinePoint[]): SubnetEmissionPipelineHistory => ({
+  netuid: 64,
+  window: "30d",
+  point_count: points.length,
+  distinct_observations: null,
+  oldest_day: points[0]?.day ?? null,
+  newest_day: points[points.length - 1]?.day ?? null,
+  first_captured_day: null,
+  points,
+});
+
+describe("counting carried-forward days", () => {
+  it("counts the days that say they repeat", () => {
+    const h = history([
+      point("2026-08-01", false),
+      point("2026-08-02", true),
+      point("2026-08-03", true),
+    ]);
+    expect(countCarriedForward(h)).toBe(2);
+  });
+
+  it("a NULL flag is not counted as a repeat", () => {
+    // The API declining to say is not the same as saying no. Counting unknowns
+    // as repeats would inflate the warning, and a warning that over-reports is
+    // one readers learn to ignore — which loses the case it exists for.
+    const h = history([point("2026-08-01", null), point("2026-08-02", null)]);
+    expect(countCarriedForward(h)).toBe(0);
+  });
+
+  it("a fully measured window warns about nothing", () => {
+    const h = history([point("2026-08-01", false), point("2026-08-02", false)]);
+    expect(countCarriedForward(h)).toBe(0);
+  });
+
+  it("an empty series is zero, not a crash", () => {
+    expect(countCarriedForward(history([]))).toBe(0);
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.tsx
@@ -1,0 +1,110 @@
+import { useQuery } from "@tanstack/react-query";
+import { subnetEmissionPipelineHistoryQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber } from "@/lib/metagraphed/format";
+import type { SubnetEmissionPipelineHistory } from "@/lib/metagraphed/types";
+
+/**
+ * The emission pipeline over time (#10300).
+ *
+ * `/api/v1/subnets/{netuid}/emission-pipeline/history` was published and
+ * rendered nowhere. The card exists for one reason the current snapshot cannot
+ * give: WHETHER THE SERIES IS MEASUREMENT OR REPETITION.
+ *
+ * The route publishes `point_count` and `distinct_observations` separately, and
+ * marks each day with `repeats_previous_observation`. A day that repeats
+ * carried the previous reading forward rather than taking a new one -- so a
+ * flat stretch means either "the pipeline did not move" or "the lane did not
+ * run", and those look identical on a chart that treats every point as a
+ * measurement. This panel states the gap rather than smoothing it, because the
+ * second reading is a data-collection failure being displayed as stability.
+ */
+export function SubnetEmissionPipelineHistoryPanel({ netuid }: { netuid: number }) {
+  const { data, isLoading, isError, error, refetch } = useQuery(
+    subnetEmissionPipelineHistoryQuery(netuid, "30d"),
+  );
+
+  if (isLoading) return <Skeleton className="h-[160px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const h = data?.data ?? null;
+  if (!h || h.points.length === 0) {
+    return (
+      <EmptyState
+        title="No pipeline history yet"
+        description="The emission pipeline has not been captured for this subnet over the selected window."
+      />
+    );
+  }
+
+  const carried = countCarriedForward(h);
+  const latest = h.points[h.points.length - 1];
+
+  return (
+    <Panel as="section" dense>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+        <Figure label="days" value={formatNumber(h.point_count)} hint="Days in the window." />
+        <Figure
+          label="distinct readings"
+          value={h.distinct_observations == null ? "—" : formatNumber(h.distinct_observations)}
+          hint="How many of those days were independently observed. Fewer than the day count means some days repeat the previous reading."
+        />
+        <Figure
+          label="emission share"
+          value={
+            latest?.emission_share == null
+              ? "—"
+              : `${formatNumber(latest.emission_share * 100)}%`
+          }
+          hint="This subnet's share of network emission on the newest day."
+        />
+        <Figure
+          label="gate"
+          value={latest?.emission_enabled == null ? "—" : latest.emission_enabled ? "open" : "shut"}
+          hint="Whether emission was enabled for this subnet on the newest day."
+        />
+      </div>
+
+      {/* THE CARRIED-FORWARD WARNING. Said in words rather than drawn, because
+          a chart cannot distinguish a flat line that was measured from one that
+          was copied -- and this is the difference between "stable" and "we
+          stopped looking". */}
+      {carried > 0 ? (
+        <p className="mt-4 mg-type-data-sm text-ink-muted">
+          {carried} of {h.point_count} day{h.point_count === 1 ? "" : "s"} repeat the previous
+          reading rather than a fresh observation — a flat stretch here is not evidence the pipeline
+          held steady.
+        </p>
+      ) : null}
+
+      {h.first_captured_day ? (
+        <p className="mt-2 mg-type-data-sm text-ink-muted">
+          Capture begins {h.first_captured_day}. Anything earlier is unwatched, not empty.
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div title={hint}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}
+
+/**
+ * How many days carried the previous reading forward.
+ *
+ * Counts only days that SAY they repeat. A null flag is not counted as a
+ * repeat: the API declining to say is not the same as saying no, and inflating
+ * the warning count with unknowns would make the warning untrustworthy in the
+ * direction that matters -- a reader who learns it over-reports stops reading
+ * it.
+ */
+export function countCarriedForward(history: SubnetEmissionPipelineHistory): number {
+  return history.points.filter((p) => p.repeats_previous_observation === true).length;
+}

--- a/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-emission-pipeline-history.tsx
@@ -53,9 +53,7 @@ export function SubnetEmissionPipelineHistoryPanel({ netuid }: { netuid: number 
         <Figure
           label="emission share"
           value={
-            latest?.emission_share == null
-              ? "—"
-              : `${formatNumber(latest.emission_share * 100)}%`
+            latest?.emission_share == null ? "—" : `${formatNumber(latest.emission_share * 100)}%`
           }
           hint="This subnet's share of network emission on the newest day."
         />

--- a/apps/ui/src/components/metagraphed/subnet-surface-history.test.ts
+++ b/apps/ui/src/components/metagraphed/subnet-surface-history.test.ts
@@ -1,0 +1,34 @@
+// The surface audit trail (#10300).
+//
+// "12 changes" and "12 surfaces changed" are DIFFERENT claims, and the route
+// publishes both counts precisely so a reader is not left to assume they are
+// the same. One surface edited twelve times must never read as twelve surfaces.
+import { describe, expect, it } from "vitest";
+import { distinctSurfaces } from "./subnet-surface-history";
+import type { SubnetSurfaceChange } from "@/lib/metagraphed/types";
+
+const change = (surfaceId: string, action = "update"): SubnetSurfaceChange => ({
+  surface_id: surfaceId,
+  action,
+  kind: "example",
+  url: null,
+  name: null,
+  source_commit: "c7d264b4fa93d414ff9dfc54c9989af816736cd1",
+  recorded_at: "2026-08-02T03:53:22.000Z",
+});
+
+describe("distinct surfaces in a change list", () => {
+  it("one surface changed repeatedly is ONE surface", () => {
+    const changes = [change("sn-64-a"), change("sn-64-a", "create"), change("sn-64-a", "remove")];
+    expect(changes.length).toBe(3);
+    expect(distinctSurfaces(changes)).toBe(1);
+  });
+
+  it("counts each distinct surface once", () => {
+    expect(distinctSurfaces([change("sn-64-a"), change("sn-64-b"), change("sn-64-a")])).toBe(2);
+  });
+
+  it("an empty trail is zero", () => {
+    expect(distinctSurfaces([])).toBe(0);
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-surface-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-surface-history.tsx
@@ -43,7 +43,9 @@ export function SubnetSurfaceHistoryPanel({ netuid }: { netuid: number }) {
       <p className="mb-3 mg-type-data-sm text-ink-muted">
         {formatNumber(h.change_count)} recorded change
         {h.change_count === 1 ? "" : "s"}
-        {h.surface_count == null ? "" : ` across ${formatNumber(h.surface_count)} surface${h.surface_count === 1 ? "" : "s"}`}
+        {h.surface_count == null
+          ? ""
+          : ` across ${formatNumber(h.surface_count)} surface${h.surface_count === 1 ? "" : "s"}`}
         {h.latest_change_at ? ` · latest ${formatRelative(h.latest_change_at)}` : ""}
       </p>
 

--- a/apps/ui/src/components/metagraphed/subnet-surface-history.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-surface-history.tsx
@@ -1,0 +1,93 @@
+import { useQuery } from "@tanstack/react-query";
+import { subnetSurfaceHistoryQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatRelative } from "@/lib/metagraphed/format";
+import type { SubnetSurfaceChange } from "@/lib/metagraphed/types";
+
+const MAX_SHOWN = 12;
+
+/**
+ * A subnet's surface audit trail (#10300).
+ *
+ * `/api/v1/subnets/{netuid}/surface-history` was published and rendered
+ * nowhere, which is the odd one out in this repo: the whole registry rests on
+ * the claim that a surface was added because someone could prove the subnet
+ * publishes it, and this is the only route that shows the record of those
+ * decisions. An audit trail no one can read is not an audit trail.
+ *
+ * `change_count` and `surface_count` are shown as two numbers because one
+ * surface can change many times. Collapsing them would let a single surface
+ * edited twelve times read as twelve surfaces.
+ */
+export function SubnetSurfaceHistoryPanel({ netuid }: { netuid: number }) {
+  const { data, isLoading, isError, error, refetch } = useQuery(subnetSurfaceHistoryQuery(netuid));
+
+  if (isLoading) return <Skeleton className="h-[160px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const h = data?.data ?? null;
+  if (!h || h.changes.length === 0) {
+    return (
+      <EmptyState
+        title="No recorded surface changes"
+        description="Nothing has been added, updated or removed for this subnet since the audit trail began."
+      />
+    );
+  }
+
+  const shown = h.changes.slice(0, MAX_SHOWN);
+
+  return (
+    <Panel as="section" dense>
+      <p className="mb-3 mg-type-data-sm text-ink-muted">
+        {formatNumber(h.change_count)} recorded change
+        {h.change_count === 1 ? "" : "s"}
+        {h.surface_count == null ? "" : ` across ${formatNumber(h.surface_count)} surface${h.surface_count === 1 ? "" : "s"}`}
+        {h.latest_change_at ? ` · latest ${formatRelative(h.latest_change_at)}` : ""}
+      </p>
+
+      <ul className="space-y-2">
+        {shown.map((c) => (
+          <li key={`${c.surface_id}-${c.recorded_at ?? ""}-${c.action}`} className="flex gap-3">
+            <span className="mg-type-label w-16 shrink-0 text-ink-muted">{c.action}</span>
+            <span className="min-w-0 flex-1">
+              <span className="mg-type-data-sm text-ink">{c.name ?? c.surface_id}</span>
+              {c.kind ? <span className="ml-2 mg-type-label text-ink-muted">{c.kind}</span> : null}
+              {/* The commit is what makes this auditable rather than anecdotal:
+                  a claim about a surface traces to the change that made it. */}
+              {c.source_commit ? (
+                <span
+                  className="ml-2 mg-type-label text-ink-muted"
+                  title={`Recorded by commit ${c.source_commit}`}
+                >
+                  {c.source_commit.slice(0, 7)}
+                </span>
+              ) : null}
+            </span>
+            <span className="mg-type-label shrink-0 text-ink-muted">
+              {c.recorded_at ? formatRelative(c.recorded_at) : "—"}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {h.changes.length > MAX_SHOWN ? (
+        <p className="mt-3 mg-type-label text-ink-muted">
+          Showing the {MAX_SHOWN} most recent of {formatNumber(h.changes.length)} returned.
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+/**
+ * How many DISTINCT surfaces a change list touches.
+ *
+ * Exported for the panel's own copy and unit-tested, because "12 changes" and
+ * "12 surfaces changed" are different claims and the API publishes both counts
+ * precisely so a reader is not left to assume they are the same.
+ */
+export function distinctSurfaces(changes: readonly SubnetSurfaceChange[]): number {
+  return new Set(changes.map((c) => c.surface_id)).size;
+}

--- a/apps/ui/src/components/metagraphed/subnet-validator-economics-panel.test.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validator-economics-panel.test.tsx
@@ -1,0 +1,43 @@
+// The validator-economics card (#10300).
+//
+// The card's value is that it refuses to flatten three distinctions the API
+// went to the trouble of publishing separately. The trend word is unit-tested
+// because "rose" on an unchanged pair is a claim about movement that did not
+// happen -- the exact class of confident-but-wrong statement this whole surface
+// exists to avoid.
+import { describe, expect, it } from "vitest";
+import { trendWord } from "./subnet-validator-economics-panel";
+
+describe("describing which way a threshold moved", () => {
+  it("says rose or fell only when it actually did", () => {
+    expect(trendWord(10, 5)).toBe("rose");
+    expect(trendWord(5, 10)).toBe("fell");
+  });
+
+  it("says UNCHANGED rather than picking a direction", () => {
+    // A `>` comparison alone would report "fell" on an identical pair, which
+    // invents movement over a flat window.
+    expect(trendWord(7, 7)).toBe("unchanged");
+    expect(trendWord(0, 0)).toBe("unchanged");
+  });
+
+  it("distinguishes 'no comparison exists' from 'no change'", () => {
+    // A missing end is not a flat line. Reporting it as unchanged would claim
+    // stability we never observed.
+    for (const [a, b] of [
+      [null, 5],
+      [5, null],
+      [undefined, 5],
+      [null, null],
+    ] as const) {
+      expect(trendWord(a, b)).toBe("not comparable");
+    }
+  });
+
+  it("treats zero as a real value, not as missing", () => {
+    // `!latest` would send a genuine 0 down the not-comparable path -- a floor
+    // that fell to zero is the most interesting movement there is.
+    expect(trendWord(0, 5)).toBe("fell");
+    expect(trendWord(5, 0)).toBe("rose");
+  });
+});

--- a/apps/ui/src/components/metagraphed/subnet-validator-economics-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-validator-economics-panel.tsx
@@ -1,0 +1,161 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  subnetValidatorEconomicsQuery,
+  subnetValidatorEconomicsHistoryQuery,
+} from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber } from "@/lib/metagraphed/format";
+
+/**
+ * What it costs to validate on this subnet (#10300).
+ *
+ * `/api/v1/subnets/{netuid}/validator-economics` and its `/history` were
+ * published and rendered nowhere. The card exists because the three numbers a
+ * would-be validator actually needs are not interchangeable, and a single
+ * "cost to validate" figure would flatten them:
+ *
+ * PERMIT AND EARNING ARE DIFFERENT THRESHOLDS. Holding a validator permit does
+ * not mean earning from it -- the earning floor sits above the permit floor,
+ * and `permit_to_earning_multiple` is how far above. Publishing only one would
+ * tell a reader they can validate for a price that does not get them paid.
+ *
+ * PERMITTED, ACTIVE AND EARNING ARE THREE DIFFERENT SETS. The API publishes
+ * them separately rather than collapsed because "how many validators does this
+ * subnet have" has three defensible answers, and which one matters depends on
+ * the question being asked.
+ *
+ * `cap_binding` changes what a reader should do with `validator_slots_open`:
+ * open slots are meaningless when the cap, not the stake floor, is what holds
+ * entry back. So the slot count is only shown as actionable when it is.
+ */
+export function SubnetValidatorEconomicsPanel({ netuid }: { netuid: number }) {
+  const {
+    data: current,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery(subnetValidatorEconomicsQuery(netuid));
+  const { data: history } = useQuery(subnetValidatorEconomicsHistoryQuery(netuid, "30d"));
+
+  if (isLoading) return <Skeleton className="h-[180px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const e = current?.data ?? null;
+  if (!e) {
+    return (
+      <EmptyState
+        title="No validator economics yet"
+        description="This subnet has not reported the stake thresholds a validator permit and earning require."
+      />
+    );
+  }
+
+  const points = history?.data ?? [];
+  const tao = (v: number | null) => (v == null ? "—" : `${formatNumber(v)} τ`);
+
+  return (
+    <Panel as="section" dense>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+        <Figure
+          label="permit floor"
+          value={tao(e.permit_floor_cost_tao)}
+          hint="Stake needed to hold a validator permit. Holding one does not mean earning from it."
+        />
+        <Figure
+          label="earning floor"
+          value={tao(e.earning_floor_cost_tao)}
+          hint="Stake needed to actually earn. This is the number that matters if you intend to be paid."
+        />
+        <Figure
+          label="earning / permit"
+          value={
+            e.permit_to_earning_multiple == null
+              ? "—"
+              : `${formatNumber(e.permit_to_earning_multiple)}×`
+          }
+          hint="How far above the permit floor the earning floor sits. A permit bought at the lower number earns nothing."
+        />
+        <Figure
+          label="median take"
+          value={e.median_take == null ? "—" : `${formatNumber(e.median_take * 100)}%`}
+          hint="Median commission across permit-holders on this subnet."
+        />
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+        {/* Three DIFFERENT sets, shown as three numbers. Collapsing them would
+            answer a question the reader did not ask. */}
+        <Figure
+          label="permitted"
+          value={formatNumber(e.permitted ?? 0)}
+          hint="Hold a validator permit."
+        />
+        <Figure
+          label="active"
+          value={formatNumber(e.active ?? 0)}
+          hint="Permitted AND currently serving."
+        />
+        <Figure
+          label="earning"
+          value={formatNumber(e.earning ?? 0)}
+          hint="Active AND above the earning floor."
+        />
+        <Figure
+          label="slots"
+          value={
+            e.max_validators == null
+              ? "—"
+              : `${formatNumber(e.validator_slots_open ?? 0)} / ${formatNumber(e.max_validators)}`
+          }
+          hint={
+            e.cap_binding
+              ? "The validator CAP is what holds entry back here, not the stake floor — open slots are not the constraint."
+              : "Open slots against the cap. The stake floor is the binding constraint, not the cap."
+          }
+        />
+      </div>
+
+      {/* The trend, only when there is more than one point to compare. A
+          single day is not a direction, and rendering it as one would invent
+          movement that has not been observed. */}
+      {points.length > 1 ? (
+        <p className="mt-4 mg-type-data-sm text-ink-muted">
+          {points.length} days of history · earning floor{" "}
+          {trendWord(
+            points[points.length - 1]?.earning_floor_alpha,
+            points[0]?.earning_floor_alpha,
+          )}{" "}
+          over the window
+        </p>
+      ) : null}
+    </Panel>
+  );
+}
+
+function Figure({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div title={hint}>
+      <div className="mg-type-label text-ink-muted">{label}</div>
+      <div className="mg-type-data tabular-nums text-ink">{value}</div>
+    </div>
+  );
+}
+
+/**
+ * Which way a figure moved, or that it did not move at all.
+ *
+ * Returns "unchanged" rather than a direction when the two ends are equal --
+ * "rose" on an identical pair would be a claim about movement that did not
+ * happen. Null at either end means no comparison exists, which is not the same
+ * as no change.
+ */
+export function trendWord(
+  latest: number | null | undefined,
+  oldest: number | null | undefined,
+): string {
+  if (latest == null || oldest == null) return "not comparable";
+  if (latest === oldest) return "unchanged";
+  return latest > oldest ? "rose" : "fell";
+}

--- a/apps/ui/src/components/metagraphed/top-holders-panel.test.ts
+++ b/apps/ui/src/components/metagraphed/top-holders-panel.test.ts
@@ -1,0 +1,71 @@
+// The network-wide holder leaderboard (#10300).
+//
+// The route publishes 7d, 30d and 90d net flows because they can disagree: an
+// account can be growing over the week and shrinking over the quarter. Showing
+// one window as "the" direction is how a short bounce reads as a trend, so the
+// panel marks the accounts whose windows do not agree — and that marker has to
+// be right in both directions to be worth anything.
+import { describe, expect, it } from "vitest";
+import { flowsDisagree, flowTooltip } from "./top-holders-panel";
+import type { TopHolder } from "@/lib/metagraphed/types";
+
+const holder = (
+  net_flow_7d: number | null,
+  net_flow_30d: number | null,
+  net_flow_90d: number | null,
+): TopHolder => ({
+  ss58: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+  free_tao: 100,
+  delegated_tao: 900,
+  total_tao: 1000,
+  net_flow_7d,
+  net_flow_30d,
+  net_flow_90d,
+});
+
+describe("flowsDisagree", () => {
+  it("all three rising is agreement", () => {
+    expect(flowsDisagree(holder(10, 20, 30))).toBe(false);
+  });
+
+  it("all three falling is agreement", () => {
+    expect(flowsDisagree(holder(-10, -20, -30))).toBe(false);
+  });
+
+  it("growing on the week, shrinking on the quarter IS a disagreement", () => {
+    // The case the marker exists for.
+    expect(flowsDisagree(holder(10, 5, -40))).toBe(true);
+  });
+
+  it("a MISSING window is not a disagreement", () => {
+    // Otherwise every account with a gap in its history gets a caveat marker,
+    // and a marker that fires on missing data stops meaning "these disagree".
+    expect(flowsDisagree(holder(null, 20, 30))).toBe(false);
+    expect(flowsDisagree(holder(null, null, null))).toBe(false);
+  });
+
+  it("zero is its own direction, not folded into up", () => {
+    // No movement genuinely differs from movement. Treating 0 as positive
+    // would hide a real split between a flat week and a falling quarter.
+    expect(flowsDisagree(holder(0, 0, 0))).toBe(false);
+    expect(flowsDisagree(holder(0, -5, -5))).toBe(true);
+  });
+
+  it("a non-finite flow is treated as missing, not as a direction", () => {
+    expect(flowsDisagree(holder(Number.NaN, 20, 30))).toBe(false);
+  });
+});
+
+describe("flowTooltip", () => {
+  it("names all three windows, so one number is never read as the direction", () => {
+    const tip = flowTooltip(holder(10, -5, -40));
+    expect(tip).toContain("7d");
+    expect(tip).toContain("30d");
+    expect(tip).toContain("90d");
+  });
+
+  it("an absent window renders as absent, not as zero", () => {
+    // A missing flow is not a flat one — 0 would be a claim about movement.
+    expect(flowTooltip(holder(null, 20, 30))).toContain("7d: —");
+  });
+});

--- a/apps/ui/src/components/metagraphed/top-holders-panel.tsx
+++ b/apps/ui/src/components/metagraphed/top-holders-panel.tsx
@@ -81,10 +81,7 @@ export function TopHoldersPanel() {
                   {formatTao(a.delegated_tao)}
                 </td>
                 <td className="py-1 text-right tabular-nums text-ink">{formatTao(a.total_tao)}</td>
-                <td
-                  className="py-1 text-right tabular-nums text-ink"
-                  title={flowTooltip(a)}
-                >
+                <td className="py-1 text-right tabular-nums text-ink" title={flowTooltip(a)}>
                   {formatTao(a.net_flow_30d)}
                   {flowsDisagree(a) ? (
                     <span className="ml-1 text-ink-muted" aria-label="flow windows disagree">
@@ -109,11 +106,9 @@ export function TopHoldersPanel() {
 /** All three windows, so one number is never mistaken for the direction. */
 export function flowTooltip(a: TopHolder): string {
   const part = (label: string, v: number | null) => `${label}: ${v == null ? "—" : formatTao(v)}`;
-  return [
-    part("7d", a.net_flow_7d),
-    part("30d", a.net_flow_30d),
-    part("90d", a.net_flow_90d),
-  ].join(" · ");
+  return [part("7d", a.net_flow_7d), part("30d", a.net_flow_30d), part("90d", a.net_flow_90d)].join(
+    " · ",
+  );
 }
 
 /**

--- a/apps/ui/src/components/metagraphed/top-holders-panel.tsx
+++ b/apps/ui/src/components/metagraphed/top-holders-panel.tsx
@@ -1,0 +1,133 @@
+import { useQuery } from "@tanstack/react-query";
+import { topHoldersQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatTao, formatRelative } from "@/lib/metagraphed/format";
+import { AddressDisplay } from "@/components/metagraphed/address-display";
+import type { TopHolder } from "@/lib/metagraphed/types";
+
+const SHOWN = 15;
+
+/**
+ * `/api/v1/accounts/top-holders` (#10300), published and rendered nowhere.
+ *
+ * The network-wide holder leaderboard. Two things it refuses to collapse:
+ *
+ * FREE AND DELEGATED ARE DIFFERENT POSITIONS. Delegated TAO is committed to a
+ * validator and earning; free TAO is not. An account holding 10k free and one
+ * holding 10k delegated have the same total and are doing opposite things, so
+ * the split is shown rather than the total alone.
+ *
+ * THE FLOW WINDOWS CAN DISAGREE. The route publishes 7d, 30d and 90d because a
+ * holder can be growing over the week and shrinking over the quarter. Showing
+ * one window lets a short bounce read as a trend, so the panel names which
+ * window it is showing and flags the holders whose direction is not consistent
+ * across them.
+ */
+export function TopHoldersPanel() {
+  const { data, isLoading, isError, error, refetch } = useQuery(topHoldersQuery());
+
+  if (isLoading) return <Skeleton className="h-[240px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const h = data?.data;
+  if (!h || h.accounts.length === 0) {
+    return (
+      <EmptyState
+        title="No holder ranking"
+        description="The network-wide holder leaderboard has not been captured."
+      />
+    );
+  }
+
+  return (
+    <Panel as="section" dense>
+      <p className="mb-3 mg-type-data-sm text-ink-muted">
+        Largest TAO holders network-wide
+        {h.captured_at ? ` · captured ${formatRelative(h.captured_at)}` : ""}
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full mg-type-data-sm">
+          <thead>
+            <tr className="mg-type-label text-ink-muted">
+              <th className="py-1 text-left font-normal">account</th>
+              <th className="py-1 text-right font-normal" title="Not committed to a validator.">
+                free
+              </th>
+              <th
+                className="py-1 text-right font-normal"
+                title="Committed to a validator and earning — a different position from free TAO, not a subtotal of it."
+              >
+                delegated
+              </th>
+              <th className="py-1 text-right font-normal">total</th>
+              <th
+                className="py-1 text-right font-normal"
+                title="Net flow over 30 days. The 7d and 90d windows can point the other way — hover a value to see all three."
+              >
+                30d flow
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {h.accounts.slice(0, SHOWN).map((a) => (
+              <tr key={a.ss58} className="border-t border-border/50">
+                <td className="max-w-0 py-1">
+                  <AddressDisplay ss58={a.ss58} fallback={a.ss58} />
+                </td>
+                <td className="py-1 text-right tabular-nums text-ink">{formatTao(a.free_tao)}</td>
+                <td className="py-1 text-right tabular-nums text-ink">
+                  {formatTao(a.delegated_tao)}
+                </td>
+                <td className="py-1 text-right tabular-nums text-ink">{formatTao(a.total_tao)}</td>
+                <td
+                  className="py-1 text-right tabular-nums text-ink"
+                  title={flowTooltip(a)}
+                >
+                  {formatTao(a.net_flow_30d)}
+                  {flowsDisagree(a) ? (
+                    <span className="ml-1 text-ink-muted" aria-label="flow windows disagree">
+                      *
+                    </span>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-3 mg-type-label text-ink-muted">
+        * the 7d, 30d and 90d flows do not all point the same way — a move in one window is not a
+        trend in the others.
+      </p>
+    </Panel>
+  );
+}
+
+/** All three windows, so one number is never mistaken for the direction. */
+export function flowTooltip(a: TopHolder): string {
+  const part = (label: string, v: number | null) => `${label}: ${v == null ? "—" : formatTao(v)}`;
+  return [
+    part("7d", a.net_flow_7d),
+    part("30d", a.net_flow_30d),
+    part("90d", a.net_flow_90d),
+  ].join(" · ");
+}
+
+/**
+ * Whether the flow windows point in different directions.
+ *
+ * Only compares the windows that HAVE a value -- a missing window is not a
+ * disagreement, and treating it as one would put a caveat marker on every
+ * account with a gap in its history. Zero is treated as its own direction
+ * rather than folded into positive or negative: no movement genuinely differs
+ * from movement, and calling it "up" would invent a direction.
+ */
+export function flowsDisagree(a: TopHolder): boolean {
+  const signs = [a.net_flow_7d, a.net_flow_30d, a.net_flow_90d]
+    .filter((v): v is number => typeof v === "number" && Number.isFinite(v))
+    .map((v) => Math.sign(v));
+  return new Set(signs).size > 1;
+}

--- a/apps/ui/src/components/metagraphed/top-holders-panel.tsx
+++ b/apps/ui/src/components/metagraphed/top-holders-panel.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { topHoldersQuery } from "@/lib/metagraphed/queries";
 import { Panel } from "@/components/metagraphed/primitives";
 import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
-import { formatTao, formatRelative } from "@/lib/metagraphed/format";
+import { formatNumber, formatTao, formatRelative } from "@/lib/metagraphed/format";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import type { TopHolder } from "@/lib/metagraphed/types";
 
@@ -25,7 +25,7 @@ const SHOWN = 15;
  * across them.
  */
 export function TopHoldersPanel() {
-  const { data, isLoading, isError, error, refetch } = useQuery(topHoldersQuery());
+  const { data, isLoading, isError, error, refetch } = useQuery(topHoldersQuery(SHOWN));
 
   if (isLoading) return <Skeleton className="h-[240px] w-full" />;
   if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
@@ -43,7 +43,8 @@ export function TopHoldersPanel() {
   return (
     <Panel as="section" dense>
       <p className="mb-3 mg-type-data-sm text-ink-muted">
-        Largest TAO holders network-wide
+        Largest {formatNumber(Math.min(SHOWN, h.accounts.length))} TAO holders network-wide
+        {h.account_count == null ? "" : ` of ${formatNumber(h.account_count)} ranked`}
         {h.captured_at ? ` · captured ${formatRelative(h.captured_at)}` : ""}
       </p>
 

--- a/apps/ui/src/components/metagraphed/validator-economics-ranking.test.ts
+++ b/apps/ui/src/components/metagraphed/validator-economics-ranking.test.ts
@@ -1,0 +1,50 @@
+// The cross-subnet validator-economics ranking (#10300).
+//
+// A leaderboard that silently drops the rows it could not rank reports a subset
+// as the whole. The route returns those rows in `excluded` WITH a reason, and
+// the reasons are the information: thirty subnets excluded for one cause is a
+// different story from thirty excluded for thirty causes.
+import { describe, expect, it } from "vitest";
+import { groupExclusions } from "./validator-economics-ranking";
+import type { ExcludedSubnet } from "@/lib/metagraphed/types";
+
+const ex = (netuid: number, reason: string | null): ExcludedSubnet => ({ netuid, reason });
+
+describe("grouping exclusions by reason", () => {
+  it("collects the subnets that share a reason", () => {
+    const out = groupExclusions([
+      ex(1, "no validators"),
+      ex(2, "no validators"),
+      ex(3, "read failed"),
+    ]);
+    expect(out).toEqual([
+      ["no validators", [1, 2]],
+      ["read failed", [3]],
+    ]);
+  });
+
+  it("puts the largest group first", () => {
+    const out = groupExclusions([ex(1, "rare"), ex(2, "common"), ex(3, "common")]);
+    expect(out[0][0]).toBe("common");
+  });
+
+  it("a MISSING reason becomes an explicit bucket rather than being dropped", () => {
+    // Dropping the ones that did not say why would understate the count the
+    // heading already published — the panel would claim N excluded and then
+    // account for fewer than N.
+    const out = groupExclusions([ex(1, null), ex(2, "no validators")]);
+    const total = out.reduce((n, [, list]) => n + list.length, 0);
+    expect(total).toBe(2);
+    expect(out.map(([reason]) => reason)).toContain("reason unstated");
+  });
+
+  it("nothing excluded is an empty list", () => {
+    expect(groupExclusions([])).toEqual([]);
+  });
+
+  it("does not mutate the caller's array", () => {
+    const input = [ex(1, "a"), ex(2, "b")];
+    groupExclusions(input);
+    expect(input).toHaveLength(2);
+  });
+});

--- a/apps/ui/src/components/metagraphed/validator-economics-ranking.tsx
+++ b/apps/ui/src/components/metagraphed/validator-economics-ranking.tsx
@@ -1,0 +1,160 @@
+import { useQuery } from "@tanstack/react-query";
+import { validatorEconomicsQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/states";
+import { formatNumber, formatTao } from "@/lib/metagraphed/format";
+import type { ExcludedSubnet } from "@/lib/metagraphed/types";
+
+const SHOWN = 15;
+
+/**
+ * `/api/v1/validators/economics` (#10300), published and rendered nowhere.
+ *
+ * The cross-subnet answer to "where is it cheapest to start validating". The
+ * per-subnet panel already exists; this is the ranking, and it carries one
+ * thing a ranking must never drop:
+ *
+ * `excluded` IS RENDERED, NOT FILTERED. The route returns the subnets it could
+ * NOT rank, each with a reason, and a leaderboard that silently omits them
+ * reports a subset as the whole. The reasons matter on their own terms too:
+ * "no validators" and "the read failed" are different facts, and only one of
+ * them is about the subnet.
+ */
+export function ValidatorEconomicsRanking() {
+  const { data, isLoading, isError, error, refetch } = useQuery(validatorEconomicsQuery());
+
+  if (isLoading) return <Skeleton className="h-[240px] w-full" />;
+  if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
+
+  const e = data?.data;
+  if (!e || e.rows.length === 0) {
+    return (
+      <EmptyState
+        title="No validator economics"
+        description="No subnet reported the stake thresholds a validator permit and earning require."
+      />
+    );
+  }
+
+  const grouped = groupExclusions(e.excluded);
+
+  return (
+    <Panel as="section" dense>
+      <p className="mb-3 mg-type-data-sm text-ink-muted">
+        What it costs to start validating, by subnet — {formatNumber(e.total)} ranked
+        {e.tao_weight != null ? ` · tao weight ${formatNumber(e.tao_weight)}` : ""}
+      </p>
+
+      <div className="overflow-x-auto">
+        <table className="w-full mg-type-data-sm">
+          <thead>
+            <tr className="mg-type-label text-ink-muted">
+              <th className="py-1 text-left font-normal">subnet</th>
+              <th
+                className="py-1 text-right font-normal"
+                title="Stake needed to hold a validator permit. Holding one does not mean earning from it."
+              >
+                permit floor
+              </th>
+              <th
+                className="py-1 text-right font-normal"
+                title="Stake needed to actually earn. This is the number that matters if you intend to be paid."
+              >
+                earning floor
+              </th>
+              <th className="py-1 text-right font-normal" title="How far above the permit floor the earning floor sits.">
+                ×
+              </th>
+              <th className="py-1 text-right font-normal">slots</th>
+            </tr>
+          </thead>
+          <tbody>
+            {e.rows.slice(0, SHOWN).map((r) => (
+              <tr key={r.netuid} className="border-t border-border/50">
+                <td className="py-1 text-ink">
+                  SN{r.netuid}
+                  {/* A degraded row is still a row, but it is labelled -- a
+                      figure derived under a stated degradation is not the same
+                      claim as one that was not. */}
+                  {r.degraded_reason ? (
+                    <span className="ml-1 mg-type-label text-ink-muted" title={r.degraded_reason}>
+                      degraded
+                    </span>
+                  ) : null}
+                  {r.emission_gate_open === false ? (
+                    <span
+                      className="ml-1 mg-type-label text-ink-muted"
+                      title="The emission gate is shut for this subnet — a permit here earns nothing regardless of stake."
+                    >
+                      gate shut
+                    </span>
+                  ) : null}
+                </td>
+                <td className="py-1 text-right tabular-nums text-ink">
+                  {formatTao(r.permit_floor_cost_tao)}
+                </td>
+                <td className="py-1 text-right tabular-nums text-ink">
+                  {formatTao(r.earning_floor_cost_tao)}
+                </td>
+                <td className="py-1 text-right tabular-nums text-ink">
+                  {r.permit_to_earning_multiple == null
+                    ? "—"
+                    : `${formatNumber(r.permit_to_earning_multiple)}×`}
+                </td>
+                <td
+                  className="py-1 text-right tabular-nums text-ink"
+                  title={
+                    r.cap_binding
+                      ? "The validator cap, not the stake floor, is holding entry back here — open slots are not the constraint."
+                      : "Open validator slots."
+                  }
+                >
+                  {formatNumber(r.validator_slots_open)}
+                  {r.cap_binding ? <span className="ml-1 text-ink-muted">cap</span> : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* The subnets that could not be ranked, grouped by why. Named, because a
+          ranking that hides its exclusions describes a subset as the whole. */}
+      {grouped.length > 0 ? (
+        <div className="mt-4">
+          <p className="mg-type-label text-ink-muted">
+            Not ranked ({e.excluded.length} subnet{e.excluded.length === 1 ? "" : "s"}):
+          </p>
+          <ul className="mt-1 space-y-0.5">
+            {grouped.map(([reason, netuids]) => (
+              <li key={reason} className="mg-type-label text-ink-muted">
+                {reason} — {netuids.map((n) => `SN${n}`).join(", ")}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </Panel>
+  );
+}
+
+/**
+ * Exclusions grouped by reason, largest group first.
+ *
+ * Grouped rather than listed one per line because the reason is the
+ * information: thirty subnets excluded for one cause is a different story from
+ * thirty excluded for thirty causes, and a flat list tells neither. A missing
+ * reason becomes an explicit "unstated" bucket rather than being dropped --
+ * silently discarding the ones that did not say why would understate the count
+ * the heading just published.
+ */
+export function groupExclusions(excluded: readonly ExcludedSubnet[]): Array<[string, number[]]> {
+  const by = new Map<string, number[]>();
+  for (const e of excluded) {
+    const reason = e.reason ?? "reason unstated";
+    const list = by.get(reason);
+    if (list) list.push(e.netuid);
+    else by.set(reason, [e.netuid]);
+  }
+  return [...by.entries()].sort((a, b) => b[1].length - a[1].length);
+}

--- a/apps/ui/src/components/metagraphed/validator-economics-ranking.tsx
+++ b/apps/ui/src/components/metagraphed/validator-economics-ranking.tsx
@@ -62,7 +62,10 @@ export function ValidatorEconomicsRanking() {
               >
                 earning floor
               </th>
-              <th className="py-1 text-right font-normal" title="How far above the permit floor the earning floor sits.">
+              <th
+                className="py-1 text-right font-normal"
+                title="How far above the permit floor the earning floor sits."
+              >
                 ×
               </th>
               <th className="py-1 text-right font-normal">slots</th>

--- a/apps/ui/src/components/metagraphed/validator-economics-ranking.tsx
+++ b/apps/ui/src/components/metagraphed/validator-economics-ranking.tsx
@@ -21,7 +21,7 @@ const SHOWN = 15;
  * them is about the subnet.
  */
 export function ValidatorEconomicsRanking() {
-  const { data, isLoading, isError, error, refetch } = useQuery(validatorEconomicsQuery());
+  const { data, isLoading, isError, error, refetch } = useQuery(validatorEconomicsQuery(SHOWN));
 
   if (isLoading) return <Skeleton className="h-[240px] w-full" />;
   if (isError) return <ErrorState error={error} onRetry={() => void refetch()} />;
@@ -41,7 +41,8 @@ export function ValidatorEconomicsRanking() {
   return (
     <Panel as="section" dense>
       <p className="mb-3 mg-type-data-sm text-ink-muted">
-        What it costs to start validating, by subnet — {formatNumber(e.total)} ranked
+        What it costs to start validating — cheapest {formatNumber(Math.min(SHOWN, e.rows.length))}{" "}
+        of {formatNumber(e.total)} ranked subnets
         {e.tao_weight != null ? ` · tao weight ${formatNumber(e.tao_weight)}` : ""}
       </p>
 

--- a/apps/ui/src/lib/metagraphed/network-coverage.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/network-coverage.functions.test.ts
@@ -1,0 +1,111 @@
+// Coverage arithmetic for the network-wide panels (#10300).
+//
+// The claim under test is one this repo keeps re-learning: an aggregate over a
+// partial read is an answer about a subset. These helpers exist so all four
+// panels say that the same way, and so the unknown direction always resolves to
+// "we cannot claim coverage" rather than to "we covered everything".
+import { describe, expect, it } from "vitest";
+import {
+  unmeasuredCount,
+  coverageNote,
+  spansBuilderVersions,
+  capturesDiverge,
+} from "./network-coverage.functions";
+
+describe("unmeasuredCount", () => {
+  it("is the difference when both counts are known", () => {
+    expect(unmeasuredCount(129, 120)).toBe(9);
+  });
+
+  it("is NULL when either count is missing", () => {
+    // Not 0. A missing count means we do not know the coverage, and 0 would
+    // claim complete coverage — the exact assertion we cannot make.
+    expect(unmeasuredCount(null, 120)).toBeNull();
+    expect(unmeasuredCount(129, null)).toBeNull();
+    expect(unmeasuredCount(undefined, undefined)).toBeNull();
+  });
+
+  it("never goes negative", () => {
+    // A measured count above the total means the two came from different
+    // reads; "-3 unmeasured" is worse than saying nothing.
+    expect(unmeasuredCount(120, 129)).toBe(0);
+  });
+
+  it("treats a non-finite count as unknown", () => {
+    expect(unmeasuredCount(Number.NaN, 10)).toBeNull();
+    expect(unmeasuredCount(10, Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe("coverageNote", () => {
+  it("states the subset when something went unmeasured", () => {
+    const note = coverageNote(129, 120);
+    expect(note).toContain("120 of 129");
+    expect(note).toContain("9 subnets");
+    expect(note).toContain("not the network");
+  });
+
+  it("says NOTHING when coverage is complete", () => {
+    // A caveat printed unconditionally is one readers stop seeing.
+    expect(coverageNote(129, 129)).toBeNull();
+  });
+
+  it("says nothing when coverage is unknown", () => {
+    expect(coverageNote(null, 120)).toBeNull();
+  });
+
+  it("singularises one missing item", () => {
+    expect(coverageNote(10, 9)).toContain("1 subnet had no reading");
+  });
+});
+
+describe("spansBuilderVersions", () => {
+  it("one version is not a span", () => {
+    expect(spansBuilderVersions([1])).toBe(false);
+    expect(spansBuilderVersions([1, 1, 1])).toBe(false);
+  });
+
+  it("two versions in a window IS a span", () => {
+    // Points from different builders are different computations, so a trend
+    // across them compares definitions rather than measuring a movement.
+    expect(spansBuilderVersions([1, 2])).toBe(true);
+  });
+
+  it("an empty list is not a span", () => {
+    expect(spansBuilderVersions([])).toBe(false);
+  });
+});
+
+describe("capturesDiverge", () => {
+  const t = (iso: string) => iso;
+
+  it("minutes apart is noise", () => {
+    expect(
+      capturesDiverge(t("2026-08-10T09:00:00Z"), t("2026-08-10T09:05:00Z")),
+    ).toBe(false);
+  });
+
+  it("past the threshold the two halves describe different moments", () => {
+    expect(
+      capturesDiverge(t("2026-08-10T09:00:00Z"), t("2026-08-10T11:00:00Z")),
+    ).toBe(true);
+  });
+
+  it("is symmetric — order does not decide", () => {
+    const a = t("2026-08-10T11:00:00Z");
+    const b = t("2026-08-10T09:00:00Z");
+    expect(capturesDiverge(a, b)).toBe(capturesDiverge(b, a));
+  });
+
+  it("a missing stamp is not a divergence", () => {
+    expect(capturesDiverge(null, t("2026-08-10T09:00:00Z"))).toBe(false);
+    expect(capturesDiverge(undefined, undefined)).toBe(false);
+  });
+
+  it("an UNPARSEABLE stamp is not a divergence either", () => {
+    // Date.parse returns NaN, and NaN comparisons are false — but relying on
+    // that would have reported "these disagree" for a formatting bug. Unknown
+    // is unknown, not a discrepancy.
+    expect(capturesDiverge("not-a-date", t("2026-08-10T09:00:00Z"))).toBe(false);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/network-coverage.functions.test.ts
+++ b/apps/ui/src/lib/metagraphed/network-coverage.functions.test.ts
@@ -80,15 +80,11 @@ describe("capturesDiverge", () => {
   const t = (iso: string) => iso;
 
   it("minutes apart is noise", () => {
-    expect(
-      capturesDiverge(t("2026-08-10T09:00:00Z"), t("2026-08-10T09:05:00Z")),
-    ).toBe(false);
+    expect(capturesDiverge(t("2026-08-10T09:00:00Z"), t("2026-08-10T09:05:00Z"))).toBe(false);
   });
 
   it("past the threshold the two halves describe different moments", () => {
-    expect(
-      capturesDiverge(t("2026-08-10T09:00:00Z"), t("2026-08-10T11:00:00Z")),
-    ).toBe(true);
+    expect(capturesDiverge(t("2026-08-10T09:00:00Z"), t("2026-08-10T11:00:00Z"))).toBe(true);
   });
 
   it("is symmetric — order does not decide", () => {

--- a/apps/ui/src/lib/metagraphed/network-coverage.functions.ts
+++ b/apps/ui/src/lib/metagraphed/network-coverage.functions.ts
@@ -1,0 +1,73 @@
+// Coverage arithmetic shared by the network-wide panels (#10300).
+//
+// Every one of these surfaces publishes a "how many exist" count beside a "how
+// many were read" count, and the reason is always the same: an aggregate over a
+// partial read is a real answer about a subset, and rendering it as an answer
+// about the network is how a measurement gap becomes a finding.
+//
+// Kept out of the components so the arithmetic is testable without rendering,
+// and so all four panels phrase the same caveat the same way.
+
+/** How many of a set were NOT measured, or null when either count is unknown. */
+export function unmeasuredCount(
+  total: number | null | undefined,
+  measured: number | null | undefined,
+): number | null {
+  if (typeof total !== "number" || typeof measured !== "number") return null;
+  if (!Number.isFinite(total) || !Number.isFinite(measured)) return null;
+  // Never negative. A measured count above the total means the two came from
+  // different reads, and "-3 unmeasured" is worse than declining to say.
+  return Math.max(0, total - measured);
+}
+
+/**
+ * The sentence a panel puts under a network-wide aggregate.
+ *
+ * Returns null when coverage is complete or unknown -- a caveat printed on
+ * every panel regardless is one readers stop seeing, so it appears only when
+ * there is something to caveat.
+ */
+export function coverageNote(
+  total: number | null | undefined,
+  measured: number | null | undefined,
+  noun = "subnet",
+): string | null {
+  const missing = unmeasuredCount(total, measured);
+  if (missing === null || missing === 0) return null;
+  return (
+    `Computed over ${measured} of ${total} ${noun}s — ${missing} ${noun}${missing === 1 ? "" : "s"} ` +
+    `had no reading, so this describes the measured subset, not the network.`
+  );
+}
+
+/**
+ * Whether a series was computed by more than one builder version.
+ *
+ * A trend drawn across a version change compares two definitions rather than
+ * measuring a movement, so the panel says so instead of drawing a line through
+ * the seam.
+ */
+export function spansBuilderVersions(versions: readonly number[]): boolean {
+  return new Set(versions).size > 1;
+}
+
+/**
+ * Are two capture stamps far enough apart to be worth stating separately?
+ *
+ * Both halves of a joined answer carry their own timestamp, and when they were
+ * read minutes apart that is noise. Past a threshold it is not: the older half
+ * is describing a different moment than the newer one.
+ */
+export function capturesDiverge(
+  a: string | null | undefined,
+  b: string | null | undefined,
+  thresholdMs = 60 * 60_000,
+): boolean {
+  if (!a || !b) return false;
+  const ta = Date.parse(a);
+  const tb = Date.parse(b);
+  // An unparseable stamp is not a divergence -- it is an unknown, and reporting
+  // it as "these disagree" would invent a discrepancy out of a formatting bug.
+  if (!Number.isFinite(ta) || !Number.isFinite(tb)) return false;
+  return Math.abs(ta - tb) >= thresholdMs;
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -237,6 +237,7 @@ import type {
   SubnetEmissionPipelinePoint,
   SubnetSurfaceChange,
   RegistryPipeline,
+  PipelineSample,
   SourceSnapshot,
   Crowdloan,
   FixtureLookup,
@@ -5561,7 +5562,23 @@ function normalizeValidatorEconomicsPoint(raw: unknown): SubnetValidatorEconomic
  * the four stages of how a surface gets into this registry, and #10300's point
  * about them is the one that matters: "no page exists" and "no page should
  * exist" are indistinguishable from outside. This is the page.
+ *
+ * ## THE COUNT DOES NOT COME FROM AN ARRAY LENGTH
+ *
+ * `/api/v1/candidates` is 3.6MB unlimited, and it accepts `?limit=` -- but NO
+ * total survives the trim. The response is `{candidates, generated_at, notes,
+ * schema_version}`, so a limited fetch counted by `candidates.length` silently
+ * reports the LIMIT as the total. Fetching it whole just to count it would be
+ * 3.6MB for one number, and adding a limit later would quietly make that number
+ * wrong -- the exact "confident wrong figure" this whole panel is about.
+ *
+ * So the total comes from `source-snapshots`, whose `summary.candidate_count`
+ * is server-computed (2,184, verified equal to the full array on 2026-08-10) in
+ * a 17KB payload, and the list routes are fetched BOUNDED as samples. Nothing
+ * here derives a total from a list it truncated.
  */
+const PIPELINE_SAMPLE = 12;
+
 export const registryPipelineQuery = () =>
   queryOptions({
     queryKey: k("registry-pipeline"),
@@ -5571,9 +5588,11 @@ export const registryPipelineQuery = () =>
       // whole point is showing where things stall would be useless if any
       // stalled stage took the view down with it.
       const [candidates, curation, profiles, snapshots] = await Promise.allSettled([
-        apiFetch<Record<string, unknown>>("/api/v1/candidates", { signal }),
+        apiFetch<Record<string, unknown>>(`/api/v1/candidates?limit=${PIPELINE_SAMPLE}`, {
+          signal,
+        }),
         apiFetch<Record<string, unknown>>("/api/v1/curation", { signal }),
-        apiFetch<Record<string, unknown>>("/api/v1/profiles", { signal }),
+        apiFetch<Record<string, unknown>>(`/api/v1/profiles?limit=${PIPELINE_SAMPLE}`, { signal }),
         apiFetch<Record<string, unknown>>("/api/v1/source-snapshots", { signal }),
       ]);
       const body = (r: PromiseSettledResult<{ data: unknown }>): Record<string, unknown> =>
@@ -5586,20 +5605,28 @@ export const registryPipelineQuery = () =>
       const snap = body(snapshots);
       const snapSummary = isRecord(snap.summary) ? snap.summary : {};
 
-      const candidateRows = Array.isArray(cand.candidates) ? cand.candidates : [];
+      // Curation is fetched WHOLE (158KB) because `gap_total` is a sum over
+      // every curated subnet -- a sum over a truncated list is not a smaller
+      // sum, it is a wrong one.
       const curationRows = Array.isArray(cur.curation) ? cur.curation : [];
 
       return {
         data: {
           candidates_reachable: ok(candidates),
-          candidate_count: candidateRows.length,
-          // A SUPERSEDED candidate is not a rejected one -- it was replaced by
-          // a better source, which is a success of the pipeline rather than a
-          // failure, and folding the two together would make intake look worse
-          // than it is.
-          superseded_count: candidateRows.filter(
-            (c) => isRecord(c) && firstString(c.superseded_by) !== undefined,
-          ).length,
+          // From the SERVER's own total, never from the sample above.
+          candidate_count: firstFiniteNumber(snapSummary.candidate_count) ?? null,
+          recent_candidates: (Array.isArray(cand.candidates) ? cand.candidates : [])
+            .map((raw): PipelineSample | null => {
+              if (!isRecord(raw)) return null;
+              const id = firstString(raw.id);
+              if (!id) return null;
+              return {
+                id,
+                name: firstString(raw.name) ?? firstString(raw.subnet_name) ?? null,
+                detail: firstString(raw.state) ?? null,
+              };
+            })
+            .filter((c): c is PipelineSample => c !== null),
           curation_reachable: ok(curation),
           curated_subnet_count: curationRows.length,
           // TWO LADDERS, not one. `coverage_level` is how much we have;
@@ -5610,7 +5637,24 @@ export const registryPipelineQuery = () =>
             0,
           ),
           profiles_reachable: ok(profiles),
-          profile_count: Array.isArray(prof.profiles) ? prof.profiles.length : 0,
+          recent_profiles: (Array.isArray(prof.profiles) ? prof.profiles : [])
+            .map((raw): PipelineSample | null => {
+              if (!isRecord(raw)) return null;
+              const netuid = firstFiniteNumber(raw.netuid);
+              if (netuid === undefined) return null;
+              const score = firstFiniteNumber(raw.completeness_score);
+              return {
+                id: `sn-${netuid}`,
+                name: firstString(raw.name) ?? `SN${netuid}`,
+                // ALREADY A PERCENTAGE (0-100, measured 25..97 across a live
+                // sample on 2026-08-10), not a 0..1 ratio like every other
+                // share on this API. Multiplying by 100 here rendered
+                // "9000% complete" -- caught by checking a real payload rather
+                // than assuming this field matched its neighbours.
+                detail: score === undefined ? null : `${Math.round(score)}% complete`,
+              };
+            })
+            .filter((p): p is PipelineSample => p !== null),
           snapshots_reachable: ok(snapshots),
           source_count: firstFiniteNumber(snapSummary.source_count) ?? null,
           verification_result_count:

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -233,6 +233,17 @@ import type {
   SubnetLifecycleEntry,
   SubnetValidatorEconomics,
   SubnetValidatorEconomicsPoint,
+  SubnetEmissionPipelineHistory,
+  SubnetEmissionPipelinePoint,
+  SubnetSurfaceChange,
+  ChainBurn,
+  ChainBurnSubnet,
+  ChainHolders,
+  ChainHolderSubnet,
+  NetworkConcentrationSubnets,
+  NetworkConcentrationSubnet,
+  NetworkConcentrationHistory,
+  NetworkConcentrationHistoryPoint,
   DeregistrationStanding,
   SubnetLeaseTerms,
   SubnetLeaseHistory,
@@ -5522,6 +5533,331 @@ function normalizeValidatorEconomicsPoint(raw: unknown): SubnetValidatorEconomic
     validators_permitted: firstFiniteNumber(raw.validators_permitted) ?? null,
     validators_earning: firstFiniteNumber(raw.validators_earning) ?? null,
     emission_gate_open: typeof raw.emission_gate_open === "boolean" ? raw.emission_gate_open : null,
+  };
+}
+
+/**
+ * What it costs to register, across every subnet (#10300).
+ *
+ * `subnet_count` and `read_count` are DIFFERENT numbers: the first is how many
+ * subnets exist, the second how many were actually read for this answer. A
+ * spread computed over a partial read is a real answer about a subset, and
+ * presenting it as "the network" would be the confident-zero mistake in its
+ * cheapest form.
+ */
+export const chainBurnQuery = () =>
+  queryOptions({
+    queryKey: k("chain-burn"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>("/api/v1/chain/burn", { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      const subnets = (Array.isArray(d.subnets) ? d.subnets : [])
+        .map((raw): ChainBurnSubnet | null => {
+          if (!isRecord(raw)) return null;
+          const netuid = firstFiniteNumber(raw.netuid);
+          if (netuid === undefined) return null;
+          return { netuid, burn_tao: firstFiniteNumber(raw.burn_tao) ?? null };
+        })
+        .filter((s): s is ChainBurnSubnet => s !== null);
+      return {
+        data: {
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? null,
+          // NOT defaulted to subnet_count. That default would assert full
+          // coverage, which is the single claim this field exists to check.
+          read_count: firstFiniteNumber(d.read_count) ?? null,
+          cheapest_burn_tao: firstFiniteNumber(d.cheapest_burn_tao) ?? null,
+          dearest_burn_tao: firstFiniteNumber(d.dearest_burn_tao) ?? null,
+          median_burn_tao: firstFiniteNumber(d.median_burn_tao) ?? null,
+          queried_at: firstString(d.queried_at) ?? null,
+          subnets,
+        } satisfies ChainBurn,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * Who holds the alpha, across every subnet (#10300).
+ *
+ * TWO capture stamps, kept apart. `captured_at` is when the subnet set was
+ * read; `positions_captured_at` is when the holder positions were. They can
+ * differ, and showing one as "the" timestamp would date a holder distribution
+ * by when its subnet list was refreshed.
+ */
+export const chainHoldersQuery = (limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-holders", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/chain/holders?limit=${limit}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const net = isRecord(d.network) ? d.network : {};
+      const subnets = (Array.isArray(d.subnets) ? d.subnets : [])
+        .map((raw): ChainHolderSubnet | null => {
+          if (!isRecord(raw)) return null;
+          const netuid = firstFiniteNumber(raw.netuid);
+          if (netuid === undefined) return null;
+          return {
+            netuid,
+            holder_count: firstFiniteNumber(raw.holder_count) ?? null,
+            total_alpha: firstFiniteNumber(raw.total_alpha) ?? null,
+            top_holder: firstString(raw.top_holder) ?? null,
+            top1_share: firstFiniteNumber(raw.top1_share) ?? null,
+            top5_share: firstFiniteNumber(raw.top5_share) ?? null,
+            top10_share: firstFiniteNumber(raw.top10_share) ?? null,
+          };
+        })
+        .filter((s): s is ChainHolderSubnet => s !== null);
+      return {
+        data: {
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? null,
+          subnets_measured: firstFiniteNumber(net.subnets_measured) ?? null,
+          // A subnet whose alpha sits with ONE account. Published separately
+          // from "majority holder" because they are different severities.
+          subnets_with_single_holder: firstFiniteNumber(net.subnets_with_single_holder) ?? null,
+          subnets_with_majority_holder: firstFiniteNumber(net.subnets_with_majority_holder) ?? null,
+          median_top1_share: firstFiniteNumber(net.median_top1_share) ?? null,
+          captured_at: firstString(d.captured_at) ?? null,
+          positions_captured_at: firstString(d.positions_captured_at) ?? null,
+          subnets,
+        } satisfies ChainHolders,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * Concentration ranked per subnet (#10300).
+ *
+ * `unmeasured` rides along per subnet, and `measured_subnet_count` beside
+ * `subnet_count`, because a subnet with no concentration reading is not a
+ * subnet with even distribution -- and a ranking that silently drops the
+ * unmeasured ones reports a leaderboard over a subset as one over the network.
+ */
+export const chainConcentrationSubnetsQuery = (limit = 20) =>
+  queryOptions({
+    queryKey: k("chain-concentration-subnets", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/chain/concentration/subnets?limit=${limit}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const net = isRecord(d.network) ? d.network : {};
+      const subnets = (Array.isArray(d.subnets) ? d.subnets : [])
+        .map((raw): NetworkConcentrationSubnet | null => {
+          if (!isRecord(raw)) return null;
+          const netuid = firstFiniteNumber(raw.netuid);
+          if (netuid === undefined) return null;
+          return {
+            netuid,
+            gini: firstFiniteNumber(raw.gini) ?? null,
+            nakamoto_coefficient: firstFiniteNumber(raw.nakamoto_coefficient) ?? null,
+            top_1pct_share: firstFiniteNumber(raw.top_1pct_share) ?? null,
+            holders: firstFiniteNumber(raw.holders) ?? null,
+            // Unknown counts as UNMEASURED, never as measured. Defaulting the
+            // unknown direction to "we looked" is how a gap becomes a finding.
+            unmeasured: raw.unmeasured === true || raw.unmeasured === undefined,
+          };
+        })
+        .filter((s): s is NetworkConcentrationSubnet => s !== null);
+      return {
+        data: {
+          lens: firstString(d.lens) ?? null,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? null,
+          measured_subnet_count: firstFiniteNumber(d.measured_subnet_count) ?? null,
+          median_gini: firstFiniteNumber(net.median_gini) ?? null,
+          median_nakamoto_coefficient: firstFiniteNumber(net.median_nakamoto_coefficient) ?? null,
+          single_holder_subnet_count: firstFiniteNumber(net.single_holder_subnet_count) ?? null,
+          captured_at: firstString(d.captured_at) ?? null,
+          subnets,
+        } satisfies NetworkConcentrationSubnets,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * Network concentration drift (#10300).
+ *
+ * `builder_versions` is the load-bearing field. Points computed by different
+ * builder versions are different computations, so a trend drawn across a
+ * version change is a comparison between two definitions rather than a movement
+ * in the thing being measured. The route publishes every version present in the
+ * window so a reader can see when that has happened.
+ */
+export const chainConcentrationHistoryQuery = (window: string) =>
+  queryOptions({
+    queryKey: k("chain-concentration-history", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/chain/concentration/history?window=${encodeURIComponent(window)}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const points = (Array.isArray(d.points) ? d.points : [])
+        .map((raw): NetworkConcentrationHistoryPoint | null => {
+          if (!isRecord(raw)) return null;
+          const day = firstString(raw.day);
+          if (!day) return null;
+          const stake = isRecord(raw.stake) ? raw.stake : {};
+          return {
+            day,
+            builder_version: firstFiniteNumber(raw.builder_version) ?? null,
+            neuron_count: firstFiniteNumber(raw.neuron_count) ?? null,
+            subnet_count: firstFiniteNumber(raw.subnet_count) ?? null,
+            gini: firstFiniteNumber(stake.gini) ?? null,
+            nakamoto_coefficient: firstFiniteNumber(stake.nakamoto_coefficient) ?? null,
+            top_1pct_share: firstFiniteNumber(stake.top_1pct_share) ?? null,
+          };
+        })
+        .filter((p): p is NetworkConcentrationHistoryPoint => p !== null);
+      return {
+        data: {
+          window: firstString(d.window) ?? null,
+          point_count: firstFiniteNumber(d.point_count) ?? points.length,
+          oldest_day: firstString(d.oldest_day) ?? null,
+          newest_day: firstString(d.newest_day) ?? null,
+          builder_versions: (Array.isArray(d.builder_versions) ? d.builder_versions : [])
+            .map((v) => firstFiniteNumber(v))
+            .filter((v): v is number => v !== undefined),
+          points,
+        } satisfies NetworkConcentrationHistory,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_LONG,
+  });
+
+/**
+ * The emission pipeline over time (#10300).
+ *
+ * `point_count` and `distinct_observations` are DIFFERENT numbers, and the gap
+ * between them is the whole reason this surface publishes both. A day whose
+ * `repeats_previous_observation` is true carried the previous reading forward
+ * rather than measuring a new one -- so a flat stretch of the series can mean
+ * "the pipeline did not move" or "the lane did not run", and only this flag
+ * tells the two apart. Charting every point as a measurement would render the
+ * second as the first.
+ */
+export const subnetEmissionPipelineHistoryQuery = (netuid: number, window: string) =>
+  queryOptions({
+    queryKey: k("subnet-emission-pipeline-history", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/subnets/${netuid}/emission-pipeline/history?window=${encodeURIComponent(window)}`,
+        { signal },
+      );
+      return {
+        data: normalizeEmissionPipelineHistory(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeEmissionPipelineHistory(raw: unknown): SubnetEmissionPipelineHistory {
+  const d = isRecord(raw) ? raw : {};
+  const points = (Array.isArray(d.points) ? d.points : [])
+    .map(normalizeEmissionPipelinePoint)
+    .filter((p): p is SubnetEmissionPipelinePoint => p !== null);
+  return {
+    netuid: firstFiniteNumber(d.netuid) ?? null,
+    window: firstString(d.window) ?? null,
+    point_count: firstFiniteNumber(d.point_count) ?? points.length,
+    // NOT defaulted to point_count. Falling back to the number of points would
+    // assert every day was independently observed, which is the one claim this
+    // field exists to let a reader check.
+    distinct_observations: firstFiniteNumber(d.distinct_observations) ?? null,
+    oldest_day: firstString(d.oldest_day) ?? null,
+    newest_day: firstString(d.newest_day) ?? null,
+    first_captured_day: firstString(d.first_captured_day) ?? null,
+    points,
+  };
+}
+
+function normalizeEmissionPipelinePoint(raw: unknown): SubnetEmissionPipelinePoint | null {
+  if (!isRecord(raw)) return null;
+  const day = firstString(raw.day);
+  if (!day) return null;
+  return {
+    day,
+    pipeline_block: firstFiniteNumber(raw.pipeline_block) ?? null,
+    // A carried-forward day, not a fresh reading. Defaulting the unknown
+    // direction to `false` would silently promote it to a measurement.
+    repeats_previous_observation:
+      typeof raw.repeats_previous_observation === "boolean"
+        ? raw.repeats_previous_observation
+        : null,
+    captured_at: firstString(raw.captured_at) ?? null,
+    emission_share: firstFiniteNumber(raw.emission_share) ?? null,
+    alpha_price_tao: firstFiniteNumber(raw.alpha_price_tao) ?? null,
+    tao_in_pool_tao: firstFiniteNumber(raw.tao_in_pool_tao) ?? null,
+    tao_in_emission_tao: firstFiniteNumber(raw.tao_in_emission_tao) ?? null,
+    miner_burned_fraction: firstFiniteNumber(raw.miner_burned_fraction) ?? null,
+    emission_enabled: typeof raw.emission_enabled === "boolean" ? raw.emission_enabled : null,
+  };
+}
+
+/**
+ * A subnet's surface audit trail (#10300).
+ *
+ * Newest first. Every row is an `action` on a `surface_id` at a `recorded_at`,
+ * with the `source_commit` that carried it -- which is what makes this an audit
+ * trail rather than a changelog: a claim about a surface can be traced to the
+ * commit that made it.
+ */
+export const subnetSurfaceHistoryQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-surface-history", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/subnets/${netuid}/surface-history`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const changes = (Array.isArray(d.changes) ? d.changes : [])
+        .map(normalizeSurfaceChange)
+        .filter((c): c is SubnetSurfaceChange => c !== null);
+      return {
+        data: {
+          // `change_count` and `surface_count` are different: one surface can
+          // change many times, so collapsing them would overstate breadth.
+          change_count: firstFiniteNumber(d.change_count) ?? changes.length,
+          surface_count: firstFiniteNumber(d.surface_count) ?? null,
+          latest_change_at: firstString(d.latest_change_at) ?? null,
+          changes,
+        },
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_LONG,
+  });
+
+function normalizeSurfaceChange(raw: unknown): SubnetSurfaceChange | null {
+  if (!isRecord(raw)) return null;
+  const surfaceId = firstString(raw.surface_id);
+  const action = firstString(raw.action);
+  if (!surfaceId || !action) return null;
+  return {
+    surface_id: surfaceId,
+    action,
+    kind: firstString(raw.kind) ?? null,
+    url: firstString(raw.url) ?? null,
+    name: firstString(raw.name) ?? null,
+    source_commit: firstString(raw.source_commit) ?? null,
+    recorded_at: firstString(raw.recorded_at) ?? null,
   };
 }
 

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -236,6 +236,13 @@ import type {
   SubnetEmissionPipelineHistory,
   SubnetEmissionPipelinePoint,
   SubnetSurfaceChange,
+  TopHolders,
+  TopHolder,
+  RootClaim,
+  ValidatorEconomics,
+  ValidatorEconomicsRow,
+  ExcludedSubnet,
+  DomainSummary,
   IndexerLag,
   FailureReasons,
   FailureReason,
@@ -5541,6 +5548,217 @@ function normalizeValidatorEconomicsPoint(raw: unknown): SubnetValidatorEconomic
     emission_gate_open: typeof raw.emission_gate_open === "boolean" ? raw.emission_gate_open : null,
   };
 }
+
+/**
+ * The network-wide TAO holder leaderboard (#10300).
+ *
+ * `free_tao`, `delegated_tao` and `total_tao` are three different positions,
+ * and the net flows come in three windows because they can disagree -- an
+ * account can be growing over 7d while shrinking over 90d, and showing one
+ * window would let a short bounce read as a trend.
+ */
+export const topHoldersQuery = (limit = 25) =>
+  queryOptions({
+    queryKey: k("accounts-top-holders", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/accounts/top-holders?limit=${limit}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const accounts = (Array.isArray(d.accounts) ? d.accounts : [])
+        .map((raw): TopHolder | null => {
+          if (!isRecord(raw)) return null;
+          const ss58 = firstString(raw.ss58);
+          if (!ss58) return null;
+          return {
+            ss58,
+            free_tao: firstFiniteNumber(raw.free_tao) ?? null,
+            delegated_tao: firstFiniteNumber(raw.delegated_tao) ?? null,
+            total_tao: firstFiniteNumber(raw.total_tao) ?? null,
+            net_flow_7d: firstFiniteNumber(raw.net_flow_7d) ?? null,
+            net_flow_30d: firstFiniteNumber(raw.net_flow_30d) ?? null,
+            net_flow_90d: firstFiniteNumber(raw.net_flow_90d) ?? null,
+          };
+        })
+        .filter((a): a is TopHolder => a !== null);
+      return {
+        data: {
+          account_count: firstFiniteNumber(d.account_count) ?? null,
+          captured_at: firstString(d.captured_at) ?? null,
+          accounts,
+        } satisfies TopHolders,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * One account's root-claim state (#10300).
+ *
+ * `field_sources` is carried through rather than dropped, because it says the
+ * hotkey list is RECONSTRUCTED while the claim type is MEASURED. Those are
+ * different confidences: one was read from chain storage, the other inferred,
+ * and rendering them identically would present an inference as a reading.
+ */
+export const accountRootClaimQuery = (ss58: string) =>
+  queryOptions({
+    queryKey: k("account-root-claim", ss58),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/accounts/${encodeURIComponent(ss58)}/root-claim`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const claim = isRecord(d.claim_type) ? d.claim_type : {};
+      const sources = isRecord(d.field_sources) ? d.field_sources : {};
+      const hotkeySource = isRecord(sources.hotkeys) ? sources.hotkeys : {};
+      return {
+        data: {
+          ss58: firstString(d.ss58) ?? ss58,
+          claim_kind: firstString(claim.kind) ?? null,
+          hotkeys: (Array.isArray(d.hotkeys) ? d.hotkeys : [])
+            .map((h) => firstString(h))
+            .filter((h): h is string => h !== undefined),
+          // "reconstructed" vs "measured" -- an inference is not a reading.
+          hotkeys_source: firstString(hotkeySource.kind) ?? null,
+          queried_at: firstString(d.queried_at) ?? null,
+        } satisfies RootClaim,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * Validator entry economics ranked across subnets (#10300).
+ *
+ * `excluded` rides along with a reason per subnet. A leaderboard that silently
+ * drops the subnets it could not rank reports a subset as the whole -- and the
+ * reasons are the interesting part, because "excluded because it has no
+ * validators" and "excluded because the read failed" are different facts.
+ */
+export const validatorEconomicsQuery = (limit = 25) =>
+  queryOptions({
+    queryKey: k("validators-economics", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/validators/economics?limit=${limit}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const rows = (Array.isArray(d.rows) ? d.rows : [])
+        .map((raw): ValidatorEconomicsRow | null => {
+          if (!isRecord(raw)) return null;
+          const netuid = firstFiniteNumber(raw.netuid);
+          if (netuid === undefined) return null;
+          return {
+            netuid,
+            permit_floor_cost_tao: firstFiniteNumber(raw.permit_floor_cost_tao) ?? null,
+            earning_floor_cost_tao: firstFiniteNumber(raw.earning_floor_cost_tao) ?? null,
+            permit_to_earning_multiple: firstFiniteNumber(raw.permit_to_earning_multiple) ?? null,
+            validator_slots_open: firstFiniteNumber(raw.validator_slots_open) ?? null,
+            cap_binding: typeof raw.cap_binding === "boolean" ? raw.cap_binding : null,
+            emission_gate_open:
+              typeof raw.emission_gate_open === "boolean" ? raw.emission_gate_open : null,
+            degraded_reason: firstString(raw.degraded_reason) ?? null,
+          };
+        })
+        .filter((r): r is ValidatorEconomicsRow => r !== null);
+      const excluded = (Array.isArray(d.excluded) ? d.excluded : [])
+        .map((raw): ExcludedSubnet | null => {
+          if (!isRecord(raw)) return null;
+          const netuid = firstFiniteNumber(raw.netuid);
+          if (netuid === undefined) return null;
+          return { netuid, reason: firstString(raw.reason) ?? null };
+        })
+        .filter((e): e is ExcludedSubnet => e !== null);
+      return {
+        data: {
+          total: firstFiniteNumber(d.total) ?? rows.length,
+          tao_weight: firstFiniteNumber(d.tao_weight) ?? null,
+          stake_threshold_units: firstFiniteNumber(d.stake_threshold_units) ?? null,
+          rows,
+          excluded,
+        } satisfies ValidatorEconomics,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * Registration and deregistration across every subnet (#10300).
+ *
+ * The network-wide sibling of `/subnets/{netuid}/lifecycle`, and it carries the
+ * same `predates_capture` flag for the same reason: every subnet alive when the
+ * lane first ran was registered before we were watching, so its row has no
+ * block and saying so is the only honest rendering.
+ */
+export const chainSubnetLifecycleQuery = (limit = 30) =>
+  queryOptions({
+    queryKey: k("chain-subnet-lifecycle", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/chain/subnet-lifecycle?limit=${limit}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const entries = (Array.isArray(d.entries) ? d.entries : [])
+        .map(normalizeSubnetLifecycleEntry)
+        .filter((e): e is SubnetLifecycleEntry => e !== null);
+      return {
+        data: {
+          entry_count: firstFiniteNumber(d.entry_count) ?? entries.length,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? null,
+          entries,
+        },
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * One domain's rollup (#10300).
+ *
+ * `/api/v1/domains/{tag}/summary` -- the per-domain detail behind the rollup
+ * table, carrying the emission concentration that the list view has no room
+ * for.
+ */
+export const domainSummaryQuery = (tag: string) =>
+  queryOptions({
+    queryKey: k("domain-summary", tag),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/domains/${encodeURIComponent(tag)}/summary`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const conc = isRecord(d.emission_concentration) ? d.emission_concentration : {};
+      return {
+        data: {
+          domain: firstString(d.domain) ?? tag,
+          subnet_count: firstFiniteNumber(d.subnet_count) ?? null,
+          netuids: (Array.isArray(d.netuids) ? d.netuids : [])
+            .map((n) => firstFiniteNumber(n))
+            .filter((n): n is number => n !== undefined),
+          total_stake_tao: firstFiniteNumber(d.total_stake_tao) ?? null,
+          total_emission_share: firstFiniteNumber(d.total_emission_share) ?? null,
+          emission_gini: firstFiniteNumber(conc.gini) ?? null,
+          emission_nakamoto_coefficient: firstFiniteNumber(conc.nakamoto_coefficient) ?? null,
+        } satisfies DomainSummary,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_LONG,
+  });
 
 /**
  * How current our own capture is (#10300).

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -236,6 +236,12 @@ import type {
   SubnetEmissionPipelineHistory,
   SubnetEmissionPipelinePoint,
   SubnetSurfaceChange,
+  IndexerLag,
+  FailureReasons,
+  FailureReason,
+  EmissionChanges,
+  EmissionChange,
+  RandomnessStatus,
   ChainBurn,
   ChainBurnSubnet,
   ChainHolders,
@@ -5535,6 +5541,174 @@ function normalizeValidatorEconomicsPoint(raw: unknown): SubnetValidatorEconomic
     emission_gate_open: typeof raw.emission_gate_open === "boolean" ? raw.emission_gate_open : null,
   };
 }
+
+/**
+ * How current our own capture is (#10300).
+ *
+ * `head_age_ms` and `write_latency_ms` measure DIFFERENT things and the panel
+ * must not blur them: latency is how long a block takes to land once we start
+ * writing it, age is how far behind the chain head we are. A lane that stopped
+ * an hour ago still reports excellent latency for the blocks it did write --
+ * fast is not the same as current, and only the age says which.
+ */
+export const chainIndexerLagQuery = () =>
+  queryOptions({
+    queryKey: k("chain-indexer-lag"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>("/api/v1/chain/indexer-lag", { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      const w = isRecord(d.window) ? d.window : {};
+      const lat = isRecord(d.write_latency_ms) ? d.write_latency_ms : {};
+      return {
+        data: {
+          block_count: firstFiniteNumber(d.block_count) ?? null,
+          head_age_ms: firstFiniteNumber(d.head_age_ms) ?? null,
+          measured_at: firstString(d.measured_at) ?? null,
+          oldest_block: firstFiniteNumber(w.oldest_block) ?? null,
+          newest_block: firstFiniteNumber(w.newest_block) ?? null,
+          newest_observed_at: firstString(w.newest_observed_at) ?? null,
+          latency_p50_ms: firstFiniteNumber(lat.p50) ?? null,
+          latency_p95_ms: firstFiniteNumber(lat.p95) ?? null,
+          latency_p99_ms: firstFiniteNumber(lat.p99) ?? null,
+          latency_max_ms: firstFiniteNumber(lat.max) ?? null,
+        } satisfies IndexerLag,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_SHORT,
+  });
+
+/**
+ * Why health probes fail, and whether the mix is moving (#10300).
+ *
+ * `share` and `failure_share` have DIFFERENT denominators -- one is the
+ * classification's share of every check, the other its share of the failing
+ * ones -- and `is_failure` marks the classifications that are not failures at
+ * all. Reading any of the three as the others turns a healthy mix into an
+ * alarming one.
+ */
+export const healthFailureReasonsQuery = (window: string) =>
+  queryOptions({
+    queryKey: k("health-failure-reasons", window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/health/failure-reasons?window=${encodeURIComponent(window)}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const reasons = (Array.isArray(d.reasons) ? d.reasons : [])
+        .map((raw): FailureReason | null => {
+          if (!isRecord(raw)) return null;
+          const classification = firstString(raw.classification);
+          if (!classification) return null;
+          return {
+            classification,
+            // Unknown is NOT a failure. Defaulting the unknown direction to
+            // "this is a failure" would inflate the failing mix with rows the
+            // API never claimed were failures.
+            is_failure: raw.is_failure === true,
+            checks: firstFiniteNumber(raw.checks) ?? null,
+            share: firstFiniteNumber(raw.share) ?? null,
+            failure_share: firstFiniteNumber(raw.failure_share) ?? null,
+          };
+        })
+        .filter((r): r is FailureReason => r !== null);
+      return {
+        data: {
+          window: firstString(d.window) ?? null,
+          days_covered: firstFiniteNumber(d.days_covered) ?? null,
+          total_checks: firstFiniteNumber(d.total_checks) ?? null,
+          failing_checks: firstFiniteNumber(d.failing_checks) ?? null,
+          failure_rate: firstFiniteNumber(d.failure_rate) ?? null,
+          reasons,
+        } satisfies FailureReasons,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * The emission-gate change log (#10300).
+ *
+ * `predates_capture_count` is published beside `change_count` because a change
+ * older than capture carries a NULL block. Rendering those as block 0 would
+ * date every pre-capture change to genesis, and dropping them would understate
+ * how often the gate has moved.
+ */
+export const emissionChangesQuery = (limit = 25) =>
+  queryOptions({
+    queryKey: k("emission-changes", limit),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/chain/governance/emission-changes?limit=${limit}`,
+        { signal },
+      );
+      const d = isRecord(res.data) ? res.data : {};
+      const changes = (Array.isArray(d.changes) ? d.changes : [])
+        .map((raw): EmissionChange | null => {
+          if (!isRecord(raw)) return null;
+          const kind = firstString(raw.kind);
+          if (!kind) return null;
+          return {
+            kind,
+            observed_at: firstString(raw.observed_at) ?? null,
+            // NULLABLE ON PURPOSE -- see the note above.
+            block_number: firstFiniteNumber(raw.block_number) ?? null,
+            predates_capture: raw.predates_capture === true,
+            param: firstString(raw.param) ?? null,
+            value: firstString(raw.value) ?? firstFiniteNumber(raw.value)?.toString() ?? null,
+            previous_value:
+              firstString(raw.previous_value) ??
+              firstFiniteNumber(raw.previous_value)?.toString() ??
+              null,
+          };
+        })
+        .filter((c): c is EmissionChange => c !== null);
+      return {
+        data: {
+          change_count: firstFiniteNumber(d.change_count) ?? changes.length,
+          predates_capture_count: firstFiniteNumber(d.predates_capture_count) ?? null,
+          latest_change_at: firstString(d.latest_change_at) ?? null,
+          changes,
+        } satisfies EmissionChanges,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * Which drand rounds the chain still stores (#10300).
+ *
+ * `stored_round_span` is the operative number, not `last_stored_round`.
+ * Commit-reveal verifies a reveal against the round it was timelocked to, and
+ * a round that has aged out of storage can no longer be checked -- so how far
+ * back storage reaches is what decides whether an old reveal is still
+ * verifiable, and the newest round says nothing about that.
+ */
+export const networkRandomnessQuery = () =>
+  queryOptions({
+    queryKey: k("network-randomness"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>("/api/v1/network/randomness", { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          last_stored_round: firstFiniteNumber(d.last_stored_round) ?? null,
+          oldest_stored_round: firstFiniteNumber(d.oldest_stored_round) ?? null,
+          stored_round_span: firstFiniteNumber(d.stored_round_span) ?? null,
+          queried_at: firstString(d.queried_at) ?? null,
+        } satisfies RandomnessStatus,
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
 
 /**
  * What it costs to register, across every subnet (#10300).

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions, infiniteQueryOptions } from "@tanstack/react-query";
-import { apiFetch, type ApiResult, type QueryParams } from "./client";
+import { apiFetch, ApiError, type ApiResult, type QueryParams } from "./client";
 import { getNetwork } from "./config";
 import { blockRefPathSegment } from "./blocks";
 import { extrinsicHashPathSegment } from "./extrinsics";
@@ -236,6 +236,10 @@ import type {
   SubnetEmissionPipelineHistory,
   SubnetEmissionPipelinePoint,
   SubnetSurfaceChange,
+  RegistryPipeline,
+  SourceSnapshot,
+  Crowdloan,
+  FixtureLookup,
   TopHolders,
   TopHolder,
   RootClaim,
@@ -5550,6 +5554,227 @@ function normalizeValidatorEconomicsPoint(raw: unknown): SubnetValidatorEconomic
 }
 
 /**
+ * The registry's own intake pipeline (#10300).
+ *
+ * `/api/v1/candidates`, `/api/v1/curation`, `/api/v1/profiles` and
+ * `/api/v1/source-snapshots` were all published and rendered nowhere. They are
+ * the four stages of how a surface gets into this registry, and #10300's point
+ * about them is the one that matters: "no page exists" and "no page should
+ * exist" are indistinguishable from outside. This is the page.
+ */
+export const registryPipelineQuery = () =>
+  queryOptions({
+    queryKey: k("registry-pipeline"),
+    queryFn: async ({ signal }) => {
+      // Four independent reads. `allSettled`, not `all`: one stage being
+      // unavailable must not blank the other three -- a pipeline view whose
+      // whole point is showing where things stall would be useless if any
+      // stalled stage took the view down with it.
+      const [candidates, curation, profiles, snapshots] = await Promise.allSettled([
+        apiFetch<Record<string, unknown>>("/api/v1/candidates", { signal }),
+        apiFetch<Record<string, unknown>>("/api/v1/curation", { signal }),
+        apiFetch<Record<string, unknown>>("/api/v1/profiles", { signal }),
+        apiFetch<Record<string, unknown>>("/api/v1/source-snapshots", { signal }),
+      ]);
+      const body = (r: PromiseSettledResult<{ data: unknown }>): Record<string, unknown> =>
+        r.status === "fulfilled" && isRecord(r.value.data) ? r.value.data : {};
+      const ok = (r: PromiseSettledResult<unknown>) => r.status === "fulfilled";
+
+      const cand = body(candidates);
+      const cur = body(curation);
+      const prof = body(profiles);
+      const snap = body(snapshots);
+      const snapSummary = isRecord(snap.summary) ? snap.summary : {};
+
+      const candidateRows = Array.isArray(cand.candidates) ? cand.candidates : [];
+      const curationRows = Array.isArray(cur.curation) ? cur.curation : [];
+
+      return {
+        data: {
+          candidates_reachable: ok(candidates),
+          candidate_count: candidateRows.length,
+          // A SUPERSEDED candidate is not a rejected one -- it was replaced by
+          // a better source, which is a success of the pipeline rather than a
+          // failure, and folding the two together would make intake look worse
+          // than it is.
+          superseded_count: candidateRows.filter(
+            (c) => isRecord(c) && firstString(c.superseded_by) !== undefined,
+          ).length,
+          curation_reachable: ok(curation),
+          curated_subnet_count: curationRows.length,
+          // TWO LADDERS, not one. `coverage_level` is how much we have;
+          // `curation_level` is how much of it a human has vouched for. A
+          // subnet can be rich and unvouched, or thin and fully reviewed.
+          gap_total: curationRows.reduce(
+            (n, c) => n + (isRecord(c) ? (firstFiniteNumber(c.gap_count) ?? 0) : 0),
+            0,
+          ),
+          profiles_reachable: ok(profiles),
+          profile_count: Array.isArray(prof.profiles) ? prof.profiles.length : 0,
+          snapshots_reachable: ok(snapshots),
+          source_count: firstFiniteNumber(snapSummary.source_count) ?? null,
+          verification_result_count:
+            firstFiniteNumber(snapSummary.verification_result_count) ?? null,
+          sources: (Array.isArray(snap.sources) ? snap.sources : [])
+            .map((raw): SourceSnapshot | null => {
+              if (!isRecord(raw)) return null;
+              const id = firstString(raw.id);
+              if (!id) return null;
+              return {
+                id,
+                kind: firstString(raw.kind) ?? null,
+                // The hash is what makes a snapshot auditable rather than
+                // merely dated -- two captures with the same hash saw the same
+                // bytes, which a timestamp alone cannot tell you.
+                hash: firstString(raw.hash) ?? null,
+                captured_at: firstString(raw.captured_at) ?? null,
+                record_count: firstFiniteNumber(raw.record_count) ?? null,
+              };
+            })
+            .filter((s): s is SourceSnapshot => s !== null),
+          generated_at: firstString(snap.generated_at) ?? firstString(cand.generated_at) ?? null,
+        } satisfies RegistryPipeline,
+        meta: undefined,
+        url: undefined,
+      };
+    },
+    staleTime: STALE_LONG,
+  });
+
+/**
+ * Every crowdloan on chain (#10300).
+ *
+ * `percent_raised` and `finalized` are separate states and the panel must not
+ * conflate them: a crowdloan at 100% that has not been finalized has met its
+ * cap but not settled, which is a different thing to be looking at than one
+ * that has.
+ */
+export const crowdloansQuery = () =>
+  queryOptions({
+    queryKey: k("crowdloans"),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>("/api/v1/crowdloans", { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      const crowdloans = (Array.isArray(d.crowdloans) ? d.crowdloans : [])
+        .map(normalizeCrowdloan)
+        .filter((c): c is Crowdloan => c !== null);
+      return {
+        data: {
+          crowdloan_count: firstFiniteNumber(d.crowdloan_count) ?? crowdloans.length,
+          crowdloans,
+        },
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/**
+ * One crowdloan by id (#10300).
+ *
+ * `exists` is published in the BODY at 200 rather than signalled as a 404,
+ * because "there is no crowdloan 47" is a fact about the chain, not a failed
+ * request. The panel renders that as an answer instead of an error.
+ */
+export const crowdloanQuery = (id: number) =>
+  queryOptions({
+    queryKey: k("crowdloan", id),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/crowdloans/${id}`, { signal });
+      const d = isRecord(res.data) ? res.data : {};
+      return {
+        data: {
+          crowdloan_id: firstFiniteNumber(d.crowdloan_id) ?? id,
+          exists: d.exists === true,
+          crowdloan: normalizeCrowdloan(d.crowdloan),
+        },
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeCrowdloan(raw: unknown): Crowdloan | null {
+  if (!isRecord(raw)) return null;
+  const id = firstFiniteNumber(raw.crowdloan_id);
+  if (id === undefined) return null;
+  return {
+    crowdloan_id: id,
+    creator: firstString(raw.creator) ?? null,
+    cap_tao: firstFiniteNumber(raw.cap_tao) ?? null,
+    raised_tao: firstFiniteNumber(raw.raised_tao) ?? null,
+    percent_raised: firstFiniteNumber(raw.percent_raised) ?? null,
+    contributors_count: firstFiniteNumber(raw.contributors_count) ?? null,
+    end: firstFiniteNumber(raw.end) ?? null,
+    // Met the cap and SETTLED are different states.
+    finalized: raw.finalized === true,
+    // Whether the raised funds execute a call on release. A crowdloan that
+    // dispatches is doing something a plain transfer is not.
+    has_dispatch_call: raw.has_dispatch_call === true,
+    target_address: firstString(raw.target_address) ?? null,
+  };
+}
+
+/**
+ * One surface's captured fixture (#10300).
+ *
+ * A fixture that is MISSING says why -- the list route publishes a `status` and
+ * a `reason` per surface, and "we never captured this" is a different fact from
+ * "the capture failed with a 500". The lookup returns the artifact when it
+ * exists and the stated absence when it does not, rather than an error either
+ * way.
+ */
+export const fixtureQuery = (surfaceId: string) =>
+  queryOptions({
+    queryKey: k("fixture", surfaceId),
+    queryFn: async ({ signal }) => {
+      try {
+        const res = await apiFetch<Record<string, unknown>>(
+          `/api/v1/fixtures/${encodeURIComponent(surfaceId)}`,
+          { signal },
+        );
+        const d = isRecord(res.data) ? res.data : {};
+        return {
+          data: {
+            surface_id: surfaceId,
+            available: true,
+            captured_at: firstString(d.captured_at) ?? null,
+            response_status: firstFiniteNumber(d.response_status) ?? null,
+            reason: null,
+          } satisfies FixtureLookup,
+          meta: res.meta,
+          url: res.url,
+        };
+      } catch (err) {
+        // An absent fixture is an ANSWER, not a failure. The route 404s on a
+        // surface it never captured, and surfacing that as a thrown error
+        // would make "we have not captured this yet" indistinguishable from
+        // "the API is broken" -- which is the exact confusion #10222 fixed for
+        // lane health.
+        const status = err instanceof ApiError ? err.status : null;
+        if (status === 404) {
+          return {
+            data: {
+              surface_id: surfaceId,
+              available: false,
+              captured_at: null,
+              response_status: null,
+              reason: "No fixture has been captured for this surface.",
+            } satisfies FixtureLookup,
+            meta: undefined,
+            url: undefined,
+          };
+        }
+        throw err;
+      }
+    },
+    staleTime: STALE_LONG,
+    retry: false,
+  });
+
+/**
  * The network-wide TAO holder leaderboard (#10300).
  *
  * `free_tao`, `delegated_tao` and `total_tao` are three different positions,
@@ -5982,10 +6207,9 @@ export const chainHoldersQuery = (limit = 20) =>
   queryOptions({
     queryKey: k("chain-holders", limit),
     queryFn: async ({ signal }) => {
-      const res = await apiFetch<Record<string, unknown>>(
-        `/api/v1/chain/holders?limit=${limit}`,
-        { signal },
-      );
+      const res = await apiFetch<Record<string, unknown>>(`/api/v1/chain/holders?limit=${limit}`, {
+        signal,
+      });
       const d = isRecord(res.data) ? res.data : {};
       const net = isRecord(d.network) ? d.network : {};
       const subnets = (Array.isArray(d.subnets) ? d.subnets : [])

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -231,6 +231,8 @@ import type {
   SubnetOwnershipHistory,
   SubnetLeaseState,
   SubnetLifecycleEntry,
+  SubnetValidatorEconomics,
+  SubnetValidatorEconomicsPoint,
   DeregistrationStanding,
   SubnetLeaseTerms,
   SubnetLeaseHistory,
@@ -5439,6 +5441,87 @@ export function normalizeSubnetLeaseState(netuid: number, raw: unknown): SubnetL
     leased,
     lease: normalizeSubnetLeaseTerms(d.lease),
     queried_at: firstString(d.queried_at) ?? null,
+  };
+}
+
+/**
+ * What it costs to hold a validator permit on this subnet, and to earn (#10300).
+ *
+ * PERMIT AND EARNING ARE DIFFERENT THRESHOLDS and the gap between them is the
+ * point: holding a permit does not mean earning, so the route publishes both
+ * floors and the multiple between them rather than one "validator cost".
+ */
+export const subnetValidatorEconomicsQuery = (netuid: number) =>
+  queryOptions({
+    queryKey: k("subnet-validator-economics", netuid),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<Record<string, unknown>>(
+        `/api/v1/subnets/${netuid}/validator-economics`,
+        { signal },
+      );
+      return {
+        data: normalizeSubnetValidatorEconomics(res.data),
+        meta: res.meta,
+        url: res.url,
+      };
+    },
+    staleTime: STALE_MED,
+  });
+
+/** The same thresholds over time, so a reader sees which way they are moving. */
+export const subnetValidatorEconomicsHistoryQuery = (netuid: number, window: string) =>
+  queryOptions({
+    queryKey: k("subnet-validator-economics-history", netuid, window),
+    queryFn: async ({ signal }) => {
+      const res = await apiFetch<{ points?: unknown }>(
+        `/api/v1/subnets/${netuid}/validator-economics/history?window=${encodeURIComponent(window)}`,
+        { signal },
+      );
+      const raw = isRecord(res.data) ? res.data.points : null;
+      const points = (Array.isArray(raw) ? raw : [])
+        .map(normalizeValidatorEconomicsPoint)
+        .filter((p): p is SubnetValidatorEconomicsPoint => p !== null);
+      return { data: points, meta: res.meta, url: res.url };
+    },
+    staleTime: STALE_MED,
+  });
+
+function normalizeSubnetValidatorEconomics(raw: unknown): SubnetValidatorEconomics | null {
+  if (!isRecord(raw)) return null;
+  const composition = isRecord(raw.composition) ? raw.composition : {};
+  const takes = isRecord(raw.takes) ? raw.takes : {};
+  return {
+    netuid: firstFiniteNumber(raw.netuid) ?? null,
+    permit_floor_cost_tao: firstFiniteNumber(raw.permit_floor_cost_tao) ?? null,
+    earning_floor_cost_tao: firstFiniteNumber(raw.earning_floor_cost_tao) ?? null,
+    permit_to_earning_multiple: firstFiniteNumber(raw.permit_to_earning_multiple) ?? null,
+    max_validators: firstFiniteNumber(raw.max_validators) ?? null,
+    validator_slots_open: firstFiniteNumber(raw.validator_slots_open) ?? null,
+    // Three DIFFERENT sets, never collapsed: permitted, active and earning
+    // answer "how many validators does this subnet have" three defensible ways.
+    permitted: firstFiniteNumber(composition.permitted) ?? null,
+    active: firstFiniteNumber(composition.active) ?? null,
+    earning: firstFiniteNumber(composition.earning) ?? null,
+    median_take: firstFiniteNumber(takes.median) ?? null,
+    // `cap_binding` is the one that changes what a reader should do: slots open
+    // is meaningless when the cap is what is holding entry back.
+    cap_binding: typeof raw.cap_binding === "boolean" ? raw.cap_binding : null,
+  };
+}
+
+function normalizeValidatorEconomicsPoint(raw: unknown): SubnetValidatorEconomicsPoint | null {
+  if (!isRecord(raw)) return null;
+  // A point with no date cannot be placed on a timeline, so it is dropped
+  // rather than rendered at an arbitrary position.
+  const date = firstString(raw.snapshot_date);
+  if (date === null || date === undefined) return null;
+  return {
+    snapshot_date: date,
+    permit_floor_alpha: firstFiniteNumber(raw.permit_floor_alpha) ?? null,
+    earning_floor_alpha: firstFiniteNumber(raw.earning_floor_alpha) ?? null,
+    validators_permitted: firstFiniteNumber(raw.validators_permitted) ?? null,
+    validators_earning: firstFiniteNumber(raw.validators_earning) ?? null,
+    emission_gate_open: typeof raw.emission_gate_open === "boolean" ? raw.emission_gate_open : null,
   };
 }
 

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4189,6 +4189,82 @@ export interface SubnetValidatorEconomics {
   cap_binding: boolean | null;
 }
 
+/**
+ * How current our own capture is (#10300).
+ *
+ * `head_age_ms` and the latency percentiles are different measurements: a lane
+ * that stopped an hour ago still reports excellent latency for the blocks it
+ * did write. Fast is not current.
+ */
+export interface IndexerLag {
+  block_count: number | null;
+  /** How far behind the chain head we are. The one that says "current". */
+  head_age_ms: number | null;
+  measured_at: string | null;
+  oldest_block: number | null;
+  newest_block: number | null;
+  newest_observed_at: string | null;
+  /** How long a block takes to land once written. NOT how current we are. */
+  latency_p50_ms: number | null;
+  latency_p95_ms: number | null;
+  latency_p99_ms: number | null;
+  latency_max_ms: number | null;
+}
+
+/** Why probes fail, and whether the mix is moving (#10300). */
+export interface FailureReasons {
+  window: string | null;
+  days_covered: number | null;
+  total_checks: number | null;
+  failing_checks: number | null;
+  failure_rate: number | null;
+  reasons: FailureReason[];
+}
+
+export interface FailureReason {
+  classification: string;
+  /** Not every classification is a failure. */
+  is_failure: boolean;
+  checks: number | null;
+  /** Share of ALL checks. */
+  share: number | null;
+  /** Share of the FAILING checks. A different denominator. */
+  failure_share: number | null;
+}
+
+/** The emission-gate change log (#10300). */
+export interface EmissionChanges {
+  change_count: number;
+  /** Changes older than capture — they carry a NULL block, not block 0. */
+  predates_capture_count: number | null;
+  latest_change_at: string | null;
+  changes: EmissionChange[];
+}
+
+export interface EmissionChange {
+  kind: string;
+  observed_at: string | null;
+  block_number: number | null;
+  predates_capture: boolean;
+  param: string | null;
+  value: string | null;
+  previous_value: string | null;
+}
+
+/**
+ * Which drand rounds the chain still stores (#10300).
+ *
+ * `stored_round_span` is the operative number: a reveal timelocked to a round
+ * that has aged out of storage can no longer be verified, and the newest round
+ * says nothing about how far back that reach goes.
+ */
+export interface RandomnessStatus {
+  last_stored_round: number | null;
+  oldest_stored_round: number | null;
+  stored_round_span: number | null;
+  queried_at: string | null;
+}
+
 /** Registration cost across the network (#10300). */
 export interface ChainBurn {
   /** How many subnets exist. */

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4170,3 +4170,31 @@ export interface DeregistrationStanding {
   immune_until_block: number | null;
   blocks_until_prunable: number | null;
 }
+
+/** What holding a permit, and earning, cost on one subnet (#10300). */
+export interface SubnetValidatorEconomics {
+  netuid: number | null;
+  permit_floor_cost_tao: number | null;
+  earning_floor_cost_tao: number | null;
+  /** How many times the permit floor the earning floor is. */
+  permit_to_earning_multiple: number | null;
+  max_validators: number | null;
+  validator_slots_open: number | null;
+  /** Permitted, active and earning are THREE DIFFERENT SETS, never collapsed. */
+  permitted: number | null;
+  active: number | null;
+  earning: number | null;
+  median_take: number | null;
+  /** True when the validator cap, not the stake floor, is holding entry back. */
+  cap_binding: boolean | null;
+}
+
+/** One day of the same thresholds. */
+export interface SubnetValidatorEconomicsPoint {
+  snapshot_date: string;
+  permit_floor_alpha: number | null;
+  earning_floor_alpha: number | null;
+  validators_permitted: number | null;
+  validators_earning: number | null;
+  emission_gate_open: boolean | null;
+}

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4189,6 +4189,64 @@ export interface SubnetValidatorEconomics {
   cap_binding: boolean | null;
 }
 
+/**
+ * The registry's own intake pipeline (#10300).
+ *
+ * Each stage carries a `*_reachable` flag so an unavailable stage renders as
+ * unknown rather than as zero — a stage that could not be read is not a stage
+ * with nothing in it.
+ */
+export interface RegistryPipeline {
+  candidates_reachable: boolean;
+  candidate_count: number;
+  /** Replaced by a better source — a pipeline success, not a rejection. */
+  superseded_count: number;
+  curation_reachable: boolean;
+  curated_subnet_count: number;
+  gap_total: number;
+  profiles_reachable: boolean;
+  profile_count: number;
+  snapshots_reachable: boolean;
+  source_count: number | null;
+  verification_result_count: number | null;
+  sources: SourceSnapshot[];
+  generated_at: string | null;
+}
+
+export interface SourceSnapshot {
+  id: string;
+  kind: string | null;
+  /** Two captures with the same hash saw the same bytes. A date cannot say that. */
+  hash: string | null;
+  captured_at: string | null;
+  record_count: number | null;
+}
+
+/** One crowdloan (#10300). */
+export interface Crowdloan {
+  crowdloan_id: number;
+  creator: string | null;
+  cap_tao: number | null;
+  raised_tao: number | null;
+  percent_raised: number | null;
+  contributors_count: number | null;
+  end: number | null;
+  /** Met the cap and SETTLED are different states. */
+  finalized: boolean;
+  /** Whether the raised funds execute a call on release. */
+  has_dispatch_call: boolean;
+  target_address: string | null;
+}
+
+/** One surface's fixture lookup (#10300). An absent fixture is an answer. */
+export interface FixtureLookup {
+  surface_id: string;
+  available: boolean;
+  captured_at: string | null;
+  response_status: number | null;
+  reason: string | null;
+}
+
 /** The network-wide TAO holder leaderboard (#10300). */
 export interface TopHolders {
   account_count: number | null;

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4189,6 +4189,72 @@ export interface SubnetValidatorEconomics {
   cap_binding: boolean | null;
 }
 
+/** The network-wide TAO holder leaderboard (#10300). */
+export interface TopHolders {
+  account_count: number | null;
+  captured_at: string | null;
+  accounts: TopHolder[];
+}
+
+export interface TopHolder {
+  ss58: string;
+  /** Free, delegated and total are three different positions. */
+  free_tao: number | null;
+  delegated_tao: number | null;
+  total_tao: number | null;
+  /** Three windows, because they can disagree. */
+  net_flow_7d: number | null;
+  net_flow_30d: number | null;
+  net_flow_90d: number | null;
+}
+
+/** One account's root-claim state (#10300). */
+export interface RootClaim {
+  ss58: string;
+  claim_kind: string | null;
+  hotkeys: string[];
+  /** "measured" or "reconstructed" — an inference is not a reading. */
+  hotkeys_source: string | null;
+  queried_at: string | null;
+}
+
+/** Validator entry economics ranked across subnets (#10300). */
+export interface ValidatorEconomics {
+  total: number;
+  tao_weight: number | null;
+  stake_threshold_units: number | null;
+  rows: ValidatorEconomicsRow[];
+  /** Subnets that could NOT be ranked, each with why. */
+  excluded: ExcludedSubnet[];
+}
+
+export interface ValidatorEconomicsRow {
+  netuid: number;
+  permit_floor_cost_tao: number | null;
+  earning_floor_cost_tao: number | null;
+  permit_to_earning_multiple: number | null;
+  validator_slots_open: number | null;
+  cap_binding: boolean | null;
+  emission_gate_open: boolean | null;
+  degraded_reason: string | null;
+}
+
+export interface ExcludedSubnet {
+  netuid: number;
+  reason: string | null;
+}
+
+/** One domain's rollup (#10300). */
+export interface DomainSummary {
+  domain: string;
+  subnet_count: number | null;
+  netuids: number[];
+  total_stake_tao: number | null;
+  total_emission_share: number | null;
+  emission_gini: number | null;
+  emission_nakamoto_coefficient: number | null;
+}
+
 /**
  * How current our own capture is (#10300).
  *

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4189,6 +4189,150 @@ export interface SubnetValidatorEconomics {
   cap_binding: boolean | null;
 }
 
+/** Registration cost across the network (#10300). */
+export interface ChainBurn {
+  /** How many subnets exist. */
+  subnet_count: number | null;
+  /** How many were actually read. Below subnet_count, the spread is a subset. */
+  read_count: number | null;
+  cheapest_burn_tao: number | null;
+  dearest_burn_tao: number | null;
+  median_burn_tao: number | null;
+  queried_at: string | null;
+  subnets: ChainBurnSubnet[];
+}
+
+export interface ChainBurnSubnet {
+  netuid: number;
+  burn_tao: number | null;
+}
+
+/** Alpha holders across the network (#10300). */
+export interface ChainHolders {
+  subnet_count: number | null;
+  subnets_measured: number | null;
+  /** One account holds the whole subnet's alpha — distinct from a majority. */
+  subnets_with_single_holder: number | null;
+  subnets_with_majority_holder: number | null;
+  median_top1_share: number | null;
+  /** When the subnet set was read. */
+  captured_at: string | null;
+  /** When the holder positions were. These are allowed to differ. */
+  positions_captured_at: string | null;
+  subnets: ChainHolderSubnet[];
+}
+
+export interface ChainHolderSubnet {
+  netuid: number;
+  holder_count: number | null;
+  total_alpha: number | null;
+  top_holder: string | null;
+  top1_share: number | null;
+  top5_share: number | null;
+  top10_share: number | null;
+}
+
+/** Concentration ranked per subnet (#10300). */
+export interface NetworkConcentrationSubnets {
+  lens: string | null;
+  subnet_count: number | null;
+  measured_subnet_count: number | null;
+  median_gini: number | null;
+  median_nakamoto_coefficient: number | null;
+  single_holder_subnet_count: number | null;
+  captured_at: string | null;
+  subnets: NetworkConcentrationSubnet[];
+}
+
+export interface NetworkConcentrationSubnet {
+  netuid: number;
+  gini: number | null;
+  nakamoto_coefficient: number | null;
+  top_1pct_share: number | null;
+  holders: number | null;
+  /** No reading. NOT the same as evenly distributed. */
+  unmeasured: boolean;
+}
+
+/** Network concentration drift (#10300). */
+export interface NetworkConcentrationHistory {
+  window: string | null;
+  point_count: number;
+  oldest_day: string | null;
+  newest_day: string | null;
+  /**
+   * Every builder version present in the window. More than one means points in
+   * this series were computed by different definitions, so a trend across them
+   * compares the definitions, not the network.
+   */
+  builder_versions: number[];
+  points: NetworkConcentrationHistoryPoint[];
+}
+
+export interface NetworkConcentrationHistoryPoint {
+  day: string;
+  builder_version: number | null;
+  neuron_count: number | null;
+  subnet_count: number | null;
+  gini: number | null;
+  nakamoto_coefficient: number | null;
+  top_1pct_share: number | null;
+}
+
+/**
+ * The emission pipeline over time (#10300).
+ *
+ * `distinct_observations` is nullable and deliberately NOT defaulted to
+ * `point_count`: the gap between the two is how a reader tells a pipeline that
+ * did not move from a lane that did not run.
+ */
+export interface SubnetEmissionPipelineHistory {
+  netuid: number | null;
+  window: string | null;
+  point_count: number;
+  distinct_observations: number | null;
+  oldest_day: string | null;
+  newest_day: string | null;
+  /** The first day capture reached — earlier gaps are unwatched, not empty. */
+  first_captured_day: string | null;
+  points: SubnetEmissionPipelinePoint[];
+}
+
+/** One day of the pipeline. */
+export interface SubnetEmissionPipelinePoint {
+  day: string;
+  pipeline_block: number | null;
+  /** True when this day carried the previous reading forward, not measured. */
+  repeats_previous_observation: boolean | null;
+  captured_at: string | null;
+  emission_share: number | null;
+  alpha_price_tao: number | null;
+  tao_in_pool_tao: number | null;
+  tao_in_emission_tao: number | null;
+  miner_burned_fraction: number | null;
+  emission_enabled: boolean | null;
+}
+
+/** A subnet's surface audit trail (#10300). */
+export interface SubnetSurfaceHistory {
+  /** One surface can change many times, so these two are not the same number. */
+  change_count: number;
+  surface_count: number | null;
+  latest_change_at: string | null;
+  changes: SubnetSurfaceChange[];
+}
+
+/** One recorded change to one surface, traceable to the commit that made it. */
+export interface SubnetSurfaceChange {
+  surface_id: string;
+  action: string;
+  kind: string | null;
+  url: string | null;
+  name: string | null;
+  source_commit: string | null;
+  recorded_at: string | null;
+}
+
 /** One day of the same thresholds. */
 export interface SubnetValidatorEconomicsPoint {
   snapshot_date: string;

--- a/apps/ui/src/lib/metagraphed/types.ts
+++ b/apps/ui/src/lib/metagraphed/types.ts
@@ -4195,22 +4195,38 @@ export interface SubnetValidatorEconomics {
  * Each stage carries a `*_reachable` flag so an unavailable stage renders as
  * unknown rather than as zero — a stage that could not be read is not a stage
  * with nothing in it.
+ *
+ * NO TOTAL HERE IS AN ARRAY LENGTH OF A TRUNCATED LIST. `candidate_count` comes
+ * from source-snapshots' server-computed summary; the sample lists are fetched
+ * bounded and are NOT counted. `/api/v1/candidates` accepts `?limit=` and
+ * publishes no total, so counting a limited fetch would report the limit.
  */
 export interface RegistryPipeline {
   candidates_reachable: boolean;
-  candidate_count: number;
-  /** Replaced by a better source — a pipeline success, not a rejection. */
-  superseded_count: number;
+  /** Server-computed, from source-snapshots. Never a sample's length. */
+  candidate_count: number | null;
+  /** A BOUNDED sample, for display only. Never counted. */
+  recent_candidates: PipelineSample[];
   curation_reachable: boolean;
+  /** Curation is fetched whole, so this length is the real count. */
   curated_subnet_count: number;
+  /** A sum over EVERY curated subnet — a sum over a truncated list is wrong. */
   gap_total: number;
   profiles_reachable: boolean;
-  profile_count: number;
+  /** A BOUNDED sample, for display only. Never counted. */
+  recent_profiles: PipelineSample[];
   snapshots_reachable: boolean;
   source_count: number | null;
   verification_result_count: number | null;
   sources: SourceSnapshot[];
   generated_at: string | null;
+}
+
+/** One row of a bounded sample list. Display only — never a population. */
+export interface PipelineSample {
+  id: string;
+  name: string | null;
+  detail: string | null;
 }
 
 export interface SourceSnapshot {

--- a/apps/ui/src/routes/-accounts-index-page.tsx
+++ b/apps/ui/src/routes/-accounts-index-page.tsx
@@ -10,6 +10,7 @@ import { TOP_ACTIVE_ACCOUNTS_WINDOW_DAYS } from "@/components/metagraphed/top-ac
 import { ActionBar, ShareButton } from "@jsonbored/ui-kit";
 import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { Ss58Inspector } from "@/components/metagraphed/ss58-inspector";
+import { TopHoldersPanel } from "@/components/metagraphed/top-holders-panel";
 import { YourPositionsPanel } from "@/components/metagraphed/your-positions-panel";
 import { WalletConnectButton } from "@/components/metagraphed/wallet-connect";
 import { useWallet } from "@/hooks/use-wallet";
@@ -161,11 +162,22 @@ export function AccountsPage() {
           Decode any SS58 address&apos;s network prefix and public key, and verify its checksum —
           useful for catching a mistyped or wrong-network address before sending to it.
         </p>
+        {/* #10300: the network-wide holder leaderboard was published and
+            rendered nowhere. */}
+        <section className="mt-8">
+          <TopHoldersPanel />
+        </section>
+
         <Ss58Inspector />
       </Panel>
 
       <ApiSourceFooter
-        paths={["/api/v1/accounts/{ss58}", "/api/v1/accounts", "/api/v1/chain/signers"]}
+        paths={[
+          "/api/v1/accounts/{ss58}",
+          "/api/v1/accounts",
+          "/api/v1/chain/signers",
+          "/api/v1/accounts/top-holders",
+        ]}
       />
     </AppShell>
   );

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -31,6 +31,7 @@ import { PriceAtTx } from "@/components/metagraphed/price-at-tx";
 import { AddressLabelEditor } from "@/components/metagraphed/address-label-editor";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { AccountRootClaim } from "@/components/metagraphed/account-root-claim";
 import {
   EmptyState,
   Skeleton,
@@ -402,6 +403,17 @@ function ValidAccountDetail({ ss58 }: { ss58: string }) {
           info="Depth is limited by how far back daily snapshots reach; it grows as the genesis backfill (#8368) lands."
         >
           <AccountHoldingsHistory ss58={ss58} />
+        </SectionAnchor>
+      )}
+
+      {tab === "holdings" && (
+        <SectionAnchor
+          id="root-claim"
+          title="Root claim"
+          subtitle="What this account's root stake would do in a swap, and which hotkeys it reaches."
+          info="GET /api/v1/accounts/{ss58}/root-claim — the payload's own `field_sources` marks the claim type as MEASURED (read from SubtensorModule.RootClaimType) and the hotkey list as RECONSTRUCTED (inferred from other state). The panel shows that provenance beside the figure it qualifies rather than rendering an inference with the authority of a reading."
+        >
+          <AccountRootClaim ss58={ss58} />
         </SectionAnchor>
       )}
 

--- a/apps/ui/src/routes/-chain-analytics-page.tsx
+++ b/apps/ui/src/routes/-chain-analytics-page.tsx
@@ -9,6 +9,7 @@ import { ChainConcentrationSnapshot } from "@/components/metagraphed/chain-conce
 import { ChainIdleStakeSnapshot } from "@/components/metagraphed/chain-idle-stake-snapshot";
 import { ChainEmissionTrend } from "@/components/metagraphed/chain-emission-trend";
 import { ChainRegistrationEconomics } from "@/components/metagraphed/chain-registration-economics";
+import { ChainNetworkConcentration } from "@/components/metagraphed/chain-network-concentration";
 import { classNames } from "@/lib/metagraphed/format";
 import {
   chainStakeFlowQuery,
@@ -133,6 +134,20 @@ export function ChainAnalyticsPage() {
         <AnalyticsBody />
       </AsyncPanel>
 
+      {/* #10300: four network-wide surfaces that were published and rendered
+          nowhere. Deliberately BELOW the suspense boundary above rather than
+          inside it — the body's six-request budget is a documented property of
+          that section, and these four fetch independently so a slow one cannot
+          hold the sankey back. */}
+      <section className="mt-8">
+        <SectionLabel>Network concentration & entry cost</SectionLabel>
+        <p className="mb-4 mt-1 max-w-3xl mg-type-caption-lg text-ink-muted">
+          What it costs to register, who holds the alpha, and how evenly — each computed over the
+          subnets that were actually read, which these panels state rather than assume.
+        </p>
+        <ChainNetworkConcentration />
+      </section>
+
       <ApiSourceFooter
         paths={[
           "/api/v1/chain/stake-flow",
@@ -141,6 +156,10 @@ export function ChainAnalyticsPage() {
           "/api/v1/chain/idle-stake",
           "/api/v1/economics/trends",
           "/api/v1/economics",
+          "/api/v1/chain/burn",
+          "/api/v1/chain/holders",
+          "/api/v1/chain/concentration/subnets",
+          "/api/v1/chain/concentration/history",
         ]}
       />
     </>

--- a/apps/ui/src/routes/-chain-governance-page.tsx
+++ b/apps/ui/src/routes/-chain-governance-page.tsx
@@ -11,6 +11,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { classNames } from "@/lib/metagraphed/format";
 import { ChainTabActions } from "./-chain-hub";
+import { EmissionGateChanges } from "@/components/metagraphed/emission-gate-changes";
 import { SudoKeyCard, SudoTable, sudoQueryParams } from "./-sudo-index-page";
 import {
   AdminChangesTable,
@@ -120,6 +121,12 @@ export function ChainGovernancePage() {
               <AdminChangesTable />
             </AsyncPanel>
           </div>
+          {/* #10300: the emission-gate change log and the stored randomness
+              rounds were both published and rendered nowhere. Own boundary so
+              a slow live read never blocks the artifact-backed table above. */}
+          <div className="mt-6 min-w-0">
+            <EmissionGateChanges />
+          </div>
         </>
       ) : (
         <>
@@ -139,7 +146,12 @@ export function ChainGovernancePage() {
         paths={
           view === "sudo"
             ? ["/api/v1/sudo", "/api/v1/sudo/key"]
-            : ["/api/v1/governance/config-changes", "/api/v1/network/parameters"]
+            : [
+                "/api/v1/governance/config-changes",
+                "/api/v1/network/parameters",
+                "/api/v1/chain/governance/emission-changes",
+                "/api/v1/network/randomness",
+              ]
         }
         artifacts={
           view === "sudo" ? ["/metagraph/sudo.json"] : ["/metagraph/governance/config-changes.json"]

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -3,6 +3,7 @@ import { useQuery, useSuspenseQueries } from "@tanstack/react-query";
 import { useState } from "react";
 import { Activity, Boxes, ChevronDown, Coins, Layers, UserPlus, Zap } from "lucide-react";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { CrowdloansPanel } from "@/components/metagraphed/crowdloans-panel";
 import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/states";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import {
@@ -314,12 +315,25 @@ export function ExplorerPage() {
               </AsyncPanel>
             </TimeRangeProvider>
           </section>
+
+          {/* #10300: /crowdloans and /crowdloans/{id} were published and
+              rendered nowhere. Chain-level state that belongs beside the rest
+              of it. Expanding a row reads the by-id route, which is where the
+              `exists` flag lives. */}
+          <section className="mt-10">
+            <SectionHeading
+              title="Crowdloans"
+              intro="On-chain crowdloans — raised against cap, and whether they have actually settled."
+            />
+            <CrowdloansPanel />
+          </section>
         </>
       )}
 
       <ApiSourceFooter
         paths={[
           "/api/v1/blocks",
+          "/api/v1/crowdloans",
           "/api/v1/chain/activity",
           "/api/v1/chain/fees",
           "/api/v1/chain/calls",

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -315,20 +315,23 @@ export function ExplorerPage() {
               </AsyncPanel>
             </TimeRangeProvider>
           </section>
-
-          {/* #10300: /crowdloans and /crowdloans/{id} were published and
-              rendered nowhere. Chain-level state that belongs beside the rest
-              of it. Expanding a row reads the by-id route, which is where the
-              `exists` flag lives. */}
-          <section className="mt-10">
-            <SectionHeading
-              title="Crowdloans"
-              intro="On-chain crowdloans — raised against cap, and whether they have actually settled."
-            />
-            <CrowdloansPanel />
-          </section>
         </>
       )}
+
+      {/* #10300: /crowdloans and /crowdloans/{id} were published and rendered
+          nowhere. OUTSIDE the `showAnalytics` disclosure on purpose -- that
+          block defaults to closed, so mounting here would have satisfied the
+          route-coverage sweep while leaving the surface effectively unseen,
+          which is the rubber stamp #10300 warned the gate must not become.
+          Crowdloans are chain state, not analytics, so they belong in the
+          always-rendered body. */}
+      <section className="mt-10">
+        <SectionHeading
+          title="Crowdloans"
+          intro="On-chain crowdloans — raised against cap, and whether they have actually settled."
+        />
+        <CrowdloansPanel />
+      </section>
 
       <ApiSourceFooter
         paths={[

--- a/apps/ui/src/routes/-gaps-page.tsx
+++ b/apps/ui/src/routes/-gaps-page.tsx
@@ -3,6 +3,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { useMemo, useEffect, useState } from "react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { RegistryPipelinePanel } from "@/components/metagraphed/registry-pipeline-panel";
 import {
   ExternalLink,
   TableState,
@@ -105,6 +106,22 @@ export function GapsPage() {
         <AsyncPanel height="lg">
           <OpenGapsSection />
         </AsyncPanel>
+
+        {/* #10300: /candidates, /curation, /profiles and /source-snapshots were
+            all published and rendered nowhere. The issue listed them as
+            "plausibly API-only... but it should be a recorded decision, because
+            right now 'no page exists' and 'no page should exist' are
+            indistinguishable from the outside". This is that decision, made the
+            other way -- they are the four stages of registry intake, and this
+            is the console where someone asks where it has stalled. */}
+        <PageSection
+          id="registry-pipeline"
+          eyebrow="Intake"
+          title="Registry pipeline"
+          description="Discovered, curated, profiled — and the snapshot of what each source actually said."
+        >
+          <RegistryPipelinePanel />
+        </PageSection>
 
         <PageSection
           id="profile-completeness"

--- a/apps/ui/src/routes/-health-page.tsx
+++ b/apps/ui/src/routes/-health-page.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import { RefreshCw, Pause, Play, ChevronDown, ChevronRight, ArrowUpRight } from "lucide-react";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { CaptureCurrencyPanel } from "@/components/metagraphed/capture-currency-panel";
 import { StaleBanner } from "@/components/metagraphed/states";
 import { AsyncPanel, PageMasthead, Panel } from "@/components/metagraphed/primitives";
 import { IncidentCard } from "@/components/metagraphed/incident-card";
@@ -176,6 +177,22 @@ export function HealthPage() {
           </AsyncPanel>
         </PageSection>
 
+        {/* #10300: /chain/indexer-lag and /health/failure-reasons were both
+            published and rendered nowhere. The ops console is their home --
+            "how current is our capture, and what is failing behind it" is the
+            question this page exists to answer. */}
+        <PageSection
+          id="capture-currency"
+          eyebrow="Capture"
+          title="Capture currency & failure mix"
+          description="How far behind the chain head our indexing is, and what is actually going wrong with the probes."
+          className={sectionRing("capture-currency")}
+        >
+          <AsyncPanel height="md">
+            <CaptureCurrencyPanel />
+          </AsyncPanel>
+        </PageSection>
+
         <PageSection
           id="incidents"
           eyebrow="Incidents"
@@ -190,7 +207,13 @@ export function HealthPage() {
       </main>
 
       <ApiSourceFooter
-        paths={["/api/v1/health", "/api/v1/freshness", "/api/v1/endpoint-incidents"]}
+        paths={[
+          "/api/v1/health",
+          "/api/v1/freshness",
+          "/api/v1/endpoint-incidents",
+          "/api/v1/chain/indexer-lag",
+          "/api/v1/health/failure-reasons",
+        ]}
       />
     </AppShell>
   );

--- a/apps/ui/src/routes/-settings-page.tsx
+++ b/apps/ui/src/routes/-settings-page.tsx
@@ -4,6 +4,7 @@ import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
 import { WebhookSubscriptionManager } from "@/components/metagraphed/webhook-subscription-manager";
 import { ApiKeysManager } from "@/components/metagraphed/api-keys-manager";
 import { AlertsManager } from "@/components/metagraphed/alerts-manager";
+import { AlertTriggerLookup } from "@/components/metagraphed/alert-trigger-lookup";
 import { WatchlistPortability } from "@/components/metagraphed/watchlist-portability";
 import { AddressLabelPortability } from "@/components/metagraphed/address-label-portability";
 import { InstallAppRow } from "@/components/metagraphed/install-app-row";
@@ -32,6 +33,12 @@ export function SettingsPage() {
       <AddressLabelPortability />
       <ApiKeysManager />
       <AlertsManager />
+      {/* #10300: the UI could always CREATE an alert trigger and never read one
+          back, so "is it still active, and has it ever fired" had no answer.
+          GET /api/v1/alerts/triggers/{id} was published and rendered nowhere. */}
+      <div className="mt-6">
+        <AlertTriggerLookup />
+      </div>
       <WebhookSubscriptionManager />
       <ApiSourceFooter
         paths={["/api/v1/webhooks/subscriptions", "/api/v1/keys", "/api/v1/watch/triggers"]}

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -328,11 +328,7 @@ export function SubnetsPage() {
                 "/api/v1/chain/deregistrations",
                 "/api/v1/economics",
               ]
-            : [
-                "/api/v1/subnets",
-                "/api/v1/domains",
-                "/api/v1/chain/subnet-lifecycle",
-              ]
+            : ["/api/v1/subnets", "/api/v1/domains", "/api/v1/chain/subnet-lifecycle"]
         }
         artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
       />

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/metagraphed/primitives";
 import { AppShell } from "@/components/metagraphed/app-shell";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { NetworkSubnetLifecycle } from "@/components/metagraphed/network-subnet-lifecycle";
 import { EmptyState, Skeleton, StatUnavailable } from "@/components/metagraphed/states";
 import { statPhase } from "@/lib/metagraphed/stat-phase";
 import {
@@ -308,6 +309,14 @@ export function SubnetsPage() {
               it costs nothing to the reader who came for the table, and its
               query doesn't fire until opened. */}
           <SubnetsDomainsTaxonomy />
+          {/* #10300: network-wide registration/deregistration was published
+              and rendered nowhere. It belongs beside the registry table --
+              "which subnets came and went" is the same question the table
+              answers as a snapshot. */}
+          <section className="mt-8">
+            <h2 className="mb-2 mg-type-label text-ink-muted">Registration churn</h2>
+            <NetworkSubnetLifecycle />
+          </section>
         </>
       )}
       <ApiSourceFooter
@@ -319,7 +328,11 @@ export function SubnetsPage() {
                 "/api/v1/chain/deregistrations",
                 "/api/v1/economics",
               ]
-            : ["/api/v1/subnets", "/api/v1/domains"]
+            : [
+                "/api/v1/subnets",
+                "/api/v1/domains",
+                "/api/v1/chain/subnet-lifecycle",
+              ]
         }
         artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
       />

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -69,6 +69,8 @@ import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownershi
 import { SubnetLeasePanel } from "@/components/metagraphed/subnet-lease-panel";
 import { SubnetLifecyclePanel } from "@/components/metagraphed/subnet-lifecycle-panel";
 import { SubnetValidatorEconomicsPanel } from "@/components/metagraphed/subnet-validator-economics-panel";
+import { SubnetEmissionPipelineHistoryPanel } from "@/components/metagraphed/subnet-emission-pipeline-history";
+import { SubnetSurfaceHistoryPanel } from "@/components/metagraphed/subnet-surface-history";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -716,6 +718,28 @@ function GovernancePanel({ netuid }: { netuid: number }) {
           {/* #10300: validator-economics and its history were published and
               rendered nowhere. */}
           <SubnetValidatorEconomicsPanel netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="pipeline-history"
+        title="Emission pipeline over time"
+        subtitle="How this subnet's emission share, price and pool moved — and which days were actually measured."
+        info="GET /api/v1/subnets/{netuid}/emission-pipeline/history — the route publishes `point_count` and `distinct_observations` as SEPARATE numbers, and marks each day with `repeats_previous_observation`. A day that repeats carried the previous reading forward rather than taking a new one, so a flat stretch means either the pipeline held steady or the lane did not run. The panel states that gap instead of charting repeats as measurements."
+      >
+        <QueryErrorBoundary>
+          <SubnetEmissionPipelineHistoryPanel netuid={netuid} />
+        </QueryErrorBoundary>
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="surface-history"
+        title="Surface audit trail"
+        subtitle="Every surface added, updated or removed for this subnet, and the commit that did it."
+        info="GET /api/v1/subnets/{netuid}/surface-history — the record behind every surface this registry claims the subnet publishes. `change_count` and `surface_count` are shown separately because one surface can change many times, so collapsing them would let a single surface edited twelve times read as twelve surfaces."
+      >
+        <QueryErrorBoundary>
+          <SubnetSurfaceHistoryPanel netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -68,6 +68,7 @@ import { SubnetHoldersLeaderboard } from "@/components/metagraphed/subnet-holder
 import { SubnetOwnershipHistory } from "@/components/metagraphed/subnet-ownership-history";
 import { SubnetLeasePanel } from "@/components/metagraphed/subnet-lease-panel";
 import { SubnetLifecyclePanel } from "@/components/metagraphed/subnet-lifecycle-panel";
+import { SubnetValidatorEconomicsPanel } from "@/components/metagraphed/subnet-validator-economics-panel";
 import { MetagraphTableLoader } from "@/components/metagraphed/metagraph-panel";
 import { ValidatorsTableLoader } from "@/components/metagraphed/validators-panel";
 import { DistributionPanel } from "@/components/metagraphed/concentration-panel";
@@ -712,6 +713,9 @@ function GovernancePanel({ netuid }: { netuid: number }) {
       >
         <QueryErrorBoundary>
           <SubnetLifecyclePanel netuid={netuid} />
+          {/* #10300: validator-economics and its history were published and
+              rendered nowhere. */}
+          <SubnetValidatorEconomicsPanel netuid={netuid} />
         </QueryErrorBoundary>
       </SectionAnchor>
 

--- a/apps/ui/src/routes/-surfaces-page.tsx
+++ b/apps/ui/src/routes/-surfaces-page.tsx
@@ -11,6 +11,7 @@ import {
   type FilterChipItem,
 } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { FixtureLookupPanel } from "@/components/metagraphed/registry-pipeline-panel";
 import { StateBlock } from "@/components/metagraphed/states/state-block";
 import { ApisTabActions } from "./-apis-hub";
 import { EvidencePanel } from "@/components/metagraphed/evidence-panel";
@@ -120,8 +121,16 @@ export function SurfacesPage() {
           <SectionHeading title="Evidence & sources" />
           <EvidencePanel />
         </section>
+        {/* #10300: /api/v1/fixtures/{surface_id} was published and rendered
+            nowhere. An absent fixture is an ANSWER, not an error. */}
+        <section className="mt-section">
+          <FixtureLookupPanel />
+        </section>
       </TimeRangeProvider>
-      <ApiSourceFooter paths={["/api/v1/surfaces"]} artifacts={["/metagraph/surfaces.json"]} />
+      <ApiSourceFooter
+        paths={["/api/v1/surfaces", "/api/v1/fixtures/{surface_id}"]}
+        artifacts={["/metagraph/surfaces.json"]}
+      />
     </>
   );
 }

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -20,6 +20,7 @@ import {
   TableSkeleton,
 } from "@/components/metagraphed/primitives";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { ValidatorEconomicsRanking } from "@/components/metagraphed/validator-economics-ranking";
 import { EmptyState, StaleBanner, Skeleton } from "@/components/metagraphed/states";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { validatorsQuery } from "@/lib/metagraphed/queries";
@@ -94,7 +95,12 @@ export function ValidatorsPage() {
       >
         <ValidatorsDirectory density={density} onDensityChange={onDensityChange} />
       </AsyncPanel>
-      <ApiSourceFooter paths={["/api/v1/validators"]} />
+      {/* #10300: the cross-subnet "where is it cheapest to start validating"
+          ranking was published and rendered nowhere. */}
+      <section className="mt-8">
+        <ValidatorEconomicsRanking />
+      </section>
+      <ApiSourceFooter paths={["/api/v1/validators", "/api/v1/validators/economics"]} />
       <ValidatorsCompareDrawer />
     </AppShell>
   );

--- a/scripts/validate-ui-route-coverage.ts
+++ b/scripts/validate-ui-route-coverage.ts
@@ -44,9 +44,15 @@ import { repoRoot } from "./lib.ts";
  *
  * NOW ZERO (#10300). Every published non-feed GET route is referenced by
  * apps/ui, so this has stopped being a ratchet with slack in it and become a
- * flat rule: a new route that nothing renders fails CI. That is the gate
+ * flat rule: a new route that nothing references fails CI. That is the gate
  * #10300 asked for -- "fails when a NEW route lands with no UI reference" --
  * and it is only enforceable because the backlog it was measuring is gone.
+ *
+ * WHAT IT PROVES IS A REFERENCE, NOT A RENDER (#10517). The evidence is a
+ * string match over the apps/ui sources, which cannot tell a fetch from a
+ * comment or see whether the component holding it is ever mounted. That was
+ * fine for a ratchet against a backlog and is a weaker claim than a ceiling of
+ * 0 invites; #10517 tracks narrowing it.
  *
  * Measured by RUNNING this check, never by subtracting feeds from a total by
  * hand, which is how the first value here came out one too low.
@@ -163,11 +169,22 @@ function main(): void {
     process.exit(1);
   }
 
+  // "REFERENCED BY", not "rendered" (#10517).
+  //
+  // This check matches a route path against the apps/ui source blob, so any
+  // occurrence counts -- a comment, an `.mdx` line, or an ApiSourceFooter
+  // `paths` entry, which is a plain string array and the case most likely to
+  // occur by accident. It cannot see whether anything fetches the route or
+  // whether the component holding it is ever mounted.
+  //
+  // At a ceiling of 25 that slack did not matter: the check was a ratchet
+  // against a backlog. At 0 it gets read as a guarantee, so the wording says
+  // what was actually measured. #10517 tracks narrowing the evidence.
   console.log(
     MAX_UNRENDERED_ROUTES === 0
-      ? `UI route coverage: all ${routes.length} published route(s) are rendered ` +
+      ? `UI route coverage: all ${routes.length} published route(s) are referenced by apps/ui ` +
           `(feeds excluded, their consumer is external).`
-      : `UI route coverage: ${routes.length - unrendered.length}/${routes.length} published route(s) rendered, ` +
+      : `UI route coverage: ${routes.length - unrendered.length}/${routes.length} published route(s) referenced, ` +
           `${unrendered.length} not (at the ceiling; feeds excluded, their consumer is external).`,
   );
 }

--- a/scripts/validate-ui-route-coverage.ts
+++ b/scripts/validate-ui-route-coverage.ts
@@ -42,13 +42,22 @@ import { repoRoot } from "./lib.ts";
 /**
  * The most unrendered routes allowed. THE CEILING ONLY FALLS.
  *
- * Measured 2026-08-10 against 219 non-feed mainnet GET routes -- by running
- * this check, not by subtracting feeds from a total by hand, which is how the
- * first value here came out one too low. Lower it when
- * you render one -- that is the whole point, and a PR that renders a surface
- * without lowering it fails here rather than leaving the number stale.
+ * NOW ZERO (#10300). Every published non-feed GET route is referenced by
+ * apps/ui, so this has stopped being a ratchet with slack in it and become a
+ * flat rule: a new route that nothing renders fails CI. That is the gate
+ * #10300 asked for -- "fails when a NEW route lands with no UI reference" --
+ * and it is only enforceable because the backlog it was measuring is gone.
+ *
+ * Measured by RUNNING this check, never by subtracting feeds from a total by
+ * hand, which is how the first value here came out one too low.
+ *
+ * If a route genuinely should not be rendered, this is the wrong place to say
+ * so: raising the ceiling would hide every other gap behind one number. Add it
+ * to a named exemption with a reason instead, so what is exempt stays legible
+ * -- an undifferentiated allowance is exactly the shape that let this reach 35
+ * with nothing watching.
  */
-export const MAX_UNRENDERED_ROUTES = 25;
+export const MAX_UNRENDERED_ROUTES = 0;
 
 /** Feed routes: consumed by feed readers, not by our UI. */
 const FEED_PREFIX = "/api/v1/feeds/";
@@ -155,7 +164,10 @@ function main(): void {
   }
 
   console.log(
-    `UI route coverage: ${routes.length - unrendered.length}/${routes.length} published route(s) rendered, ` +
-      `${unrendered.length} not (at the ceiling; feeds excluded, their consumer is external).`,
+    MAX_UNRENDERED_ROUTES === 0
+      ? `UI route coverage: all ${routes.length} published route(s) are rendered ` +
+          `(feeds excluded, their consumer is external).`
+      : `UI route coverage: ${routes.length - unrendered.length}/${routes.length} published route(s) rendered, ` +
+          `${unrendered.length} not (at the ceiling; feeds excluded, their consumer is external).`,
   );
 }

--- a/tests/validate-ui-route-coverage.test.ts
+++ b/tests/validate-ui-route-coverage.test.ts
@@ -96,11 +96,17 @@ describe("the ratchet", () => {
     ]);
   });
 
-  test("the ceiling is a number someone measured, not a round one", () => {
-    // 25 came from running the check. The first value here was 24, arrived at
-    // by subtracting feeds from a total by hand, and it was wrong -- the check
-    // caught its own author.
-    assert.equal(MAX_UNRENDERED_ROUTES, 25);
+  test("the ceiling is ZERO -- every published route is rendered (#10300)", () => {
+    // It was 25, measured by running the check (the first value was 24,
+    // arrived at by subtracting feeds from a total by hand, and wrong -- the
+    // check caught its own author). #10300 closed the remaining gap, so this
+    // stopped being a ratchet with slack in it and became a flat rule: a new
+    // route that nothing renders fails CI.
+    //
+    // Asserted here as well as in the script so RAISING it is a visible test
+    // change rather than a one-character edit. A ceiling that can drift up
+    // quietly is not a ratchet.
+    assert.equal(MAX_UNRENDERED_ROUTES, 0);
   });
 
   test("an empty source means every route is unrendered, not zero", () => {


### PR DESCRIPTION
Closes #10300.

`/api/v1/network/tao-usd` and 24 other published routes were rendered nowhere. All of them render now, and the ratchet's ceiling drops from 25 to **0**: every published non-feed GET route is referenced by `apps/ui`.

```
UI route coverage: all 205 published route(s) are rendered
```

## The principle

Each panel renders the **distinction its route went to the trouble of publishing**, not just the headline number. That is the whole reason these were worth building rather than stubbing:

| surface | the distinction it would have lost |
|---|---|
| emission-pipeline/history | `point_count` vs `distinct_observations` — a flat stretch is either a steady pipeline or a lane that stopped, and only `repeats_previous_observation` tells them apart |
| chain/burn, holders, concentration ×2 | every one publishes a **read count beside a total**; an aggregate over a partial read describes the subset that was read |
| concentration/history | `builder_versions` — a trend across a version change compares two definitions, not a movement |
| chain/indexer-lag | **fast is not current**: a lane that stopped an hour ago still reports excellent write latency |
| health/failure-reasons | `share` (of all checks) and `failure_share` (of the failures) have different denominators |
| network/randomness | `stored_round_span`, not the newest round — a reveal timelocked to a round that aged out cannot be verified |
| validators/economics | `excluded` is **rendered, not filtered**; a leaderboard that hides its exclusions reports a subset as the whole |
| accounts/top-holders | free vs delegated are different positions; 7d/30d/90d flows can disagree |
| accounts/{ss58}/root-claim | `field_sources` says the claim type is *measured* and the hotkey list *reconstructed* |
| subnet-lifecycle, emission-changes | a NULL block means "before we were watching", never block 0 |
| crowdloans | met the cap and settled are **independent** — four states, not two |
| candidates/curation/profiles/source-snapshots | each stage says whether it was **reachable**; unreadable renders as unknown, never as 0 |
| fixtures/{surface_id} | an absent fixture is an answer, not an error |
| alerts/triggers/{id} | the same 404 for a wrong token and a missing id, on purpose — the panel refuses to guess which |

## Two judgement calls I want visible

**`/domains/{tag}/summary` adds no information today.** The rollup list already carries every field the summary returns. Rather than bolt on a second fetch of identical data to move a number, I wired it as the *authoritative* record behind the expandable row — lazily (`enabled: open`), with the list values as fallback. That is the list/detail split done properly; it is not new data, and the code says so.

**Category C got rendered, not exempted.** #10300 listed six routes as "plausibly API-only... but it should be a recorded decision". Rendering them *is* the decision, and it means the ceiling can be 0 — which is only enforceable because there is no backlog left to hide behind an allowance.

## The ceiling at zero

`MAX_UNRENDERED_ROUTES` 25 → 0 turns the ratchet into the gate #10300 proposed: **a new route with no UI reference fails CI**. The zero is asserted in `tests/validate-ui-route-coverage.test.ts` as well as the script, so raising it is a visible test change rather than a one-character edit. If a route genuinely should not render, the fix is a named exemption with a reason — raising the ceiling would hide every other gap behind one number, which is the shape that let this reach 35 unnoticed.

## Verification

- `validate:ui-route-coverage` — 205/205, exit 0
- `tsc --noEmit` clean at repo root **and** in `apps/ui`
- eslint clean in both workspaces (0 errors; 9 pre-existing `react-refresh` warnings, none in new files)
- prettier clean under each workspace's own config
- `apps/ui` component suite: **53 files, 324 tests passing**
- `tests/validate-ui-route-coverage.test.ts` + `tests/pipeline-validator-parity.test.ts`: 18 passing
- Response shapes taken from **live production**, not inferred from the spec

New unit tests cover the reasoning that is easy to get wrong: a null flow window is not a disagreement, zero is its own direction, an unmeasured subnet is dropped rather than ranked, an exclusion with no stated reason still gets counted, and an unknown coverage count resolves to "cannot claim coverage" rather than "covered everything".

Screenshots waived per the maintainer convention on this repo.

---

## Changes since this was opened

Self-review after opening found four defects, three of them in my own new code. Recorded here rather than left in scattered comments.

**1. The candidate total was the exact bug this PR argues against.** `/api/v1/candidates` is 3.6 MB unlimited, and the panel fetched it whole to count an array. It accepts `?limit=` and **no total survives the trim** — so the obvious later optimisation would have silently turned the total into the limit. The total now comes from `source-snapshots`'s server-computed `summary.candidate_count`; list routes are fetched bounded as display samples that are never counted. Curation stays a whole fetch because `gap_total` sums across every curated subnet, and a sum over a truncated list is wrong, not smaller. **4,413,759 → 254,999 bytes (-94%).**

**2. `completeness_score` is 0–100, not a 0..1 ratio** like every neighbouring share on this API (measured 25..97 live). The panel multiplied by 100 and would have shipped "9000% complete".

**3. Crowdloans were mounted inside `{showAnalytics && …}`, which defaults to closed.** The sweep counts a source reference, so this would have passed the gate at 0 unrendered while the surface stayed effectively unseen — the rubber stamp #10300 warned against. Moved to the always-rendered body. I audited every other mount added here: the rest are unconditional or on a default view. The emission-gate log stays under `?view=admin` deliberately, because that is a real linkable tab beside the config-change table it belongs with, not a disclosure that starts closed.

**4. The header ticker credited CoinPaprika for a price we compute.** This is #10300's *second half*. The fetch had already moved to `/api/v1/network/tao-usd`, but the tooltip still read "Current TAO price · CoinPaprika", attributing our own liquidity-weighted median across qualifying wTAO/WETH pools to a venue that no longer supplies it. A tooltip is the only provenance a reader gets for that number. Fixed; the remaining `coinpaprika` mentions in `market.functions.ts` are the historical note explaining why the swap happened and how `market_cap`/`volume_24h` are now different quantities — those are correct and stay.

Both leaderboards also now say **"cheapest 15 of 123"** and **"largest 15 of 3,843"** rather than quoting a server total beside a silently truncated list. Every total quoted that way was checked against production at `limit=2/15/25/200` first — `total`, `excluded` and `account_count` are all server-computed and limit-independent.

## One caveat on this gate, recorded as #10517

`validate:ui-route-coverage` proves a route is **mentioned** in `apps/ui`, not rendered. Verified against the real exported function: a bare comment, an `.mdx` line, and an `ApiSourceFooter` `paths` string all count as rendered. That last one is a plain string array someone will reasonably add while touching a page.

Nothing is gamed today and all 205 routes genuinely render — but at a ceiling of 0 a green tick invites a reading the evidence cannot support, so I corrected **the check's own success message** here ("are referenced by apps/ui", not "are rendered"). Narrowing the evidence itself is left to #10517 for a decision.

Re-verified after all of the above: `tsc` clean in both workspaces, eslint clean in both, **198 test files / 1,517 tests passing**, sweep 205/205.
