### PR TITLE
feat(schema): declare what a revenue surface measures, and on what terms

### DIFF
--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -352,10 +352,92 @@
         "probe": {
           "$ref": "#/$defs/probe"
         },
+        "revenue": {
+          "$ref": "#/$defs/revenue"
+        },
         "notes": {
           "type": "string"
         }
       }
+    },
+    "revenue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "provenance"],
+      "properties": {
+        "role": {
+          "description": "What this surface actually measures. A \"stats\" endpoint is guilty until proven revenue: miner payout is emission (the denominator), and counting it as revenue puts the denominator in the numerator. `not-revenue` and `miner-payout` are successful verdicts, recorded so a false positive is retired rather than re-investigated.",
+          "enum": [
+            "external-revenue",
+            "usage-proxy",
+            "miner-payout",
+            "not-revenue"
+          ]
+        },
+        "provenance": {
+          "description": "Evidence class. Only chain-verified and probe-derived count toward a published coverage ratio; the rest are shown beside it and never summed in.",
+          "enum": [
+            "chain-verified",
+            "probe-derived",
+            "operator-attested",
+            "third-party-reported",
+            "proxy-only",
+            "none"
+          ]
+        },
+        "currency": {
+          "description": "Unit the amount field carries. Declared rather than inferred from the path: api.chutes.ai/payments/summary/tao is named for TAO and reconciles as USD.",
+          "enum": ["USD", "TAO", "ALPHA"]
+        },
+        "grain": {
+          "enum": ["daily", "weekly", "monthly", "cumulative"]
+        },
+        "fields": {
+          "description": "Map of role -> field name in the upstream payload, e.g. {\"date\": \"date\", \"amount\": \"total_revenue\"}.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "excludes": {
+          "description": "Fields present in the payload that are NOT external revenue and must be subtracted, e.g. subnet-funded or unrecognised components.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "supersedes": {
+          "description": "Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "circularity": {
+          "description": "Whether the money originates outside Bittensor. Absent means unknown, never external.",
+          "enum": ["external", "alpha-denominated", "team-funded", "unknown"],
+          "default": "unknown"
+        },
+        "source_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "searched_at": {
+          "description": "When absence was established. Required for provenance \"none\": an undated absence is not evidence.",
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "provenance": { "const": "none" } },
+            "required": ["provenance"]
+          },
+          "then": { "required": ["searched_at"] }
+        },
+        {
+          "if": {
+            "properties": { "role": { "const": "external-revenue" } },
+            "required": ["role"]
+          },
+          "then": { "required": ["currency", "grain", "fields"] }
+        }
+      ]
     },
     "probe": {
       "type": "object",

--- a/tests/subnet-manifest-revenue-block.test.ts
+++ b/tests/subnet-manifest-revenue-block.test.ts
@@ -1,0 +1,180 @@
+// #10441: the `revenue` block on a subnet surface declares what that surface
+// measures and on what terms. Every field encodes a trap found by probing a
+// real subnet, not a hypothetical:
+//
+//   role        — Targon's stats.targon.com/api/miners exposes `payout`, which
+//                 is EMISSION payout to miners. Without an explicit role the
+//                 denominator ends up in the numerator.
+//   currency    — api.chutes.ai/payments/summary/tao is named for TAO and its
+//                 values reconcile as USD.
+//   excludes    — Chutes' `sponsored_inference` is subnet-funded and
+//                 `pending_instance_revenue` is unrecognised; neither is
+//                 external revenue.
+//   supersedes  — Chutes exposes /payments (TAO channel) AND
+//                 daily_revenue_summary (all channels). The first is a subset;
+//                 summing both inflates ~10%.
+//   searched_at — an undated absence is not evidence, so provenance "none"
+//                 without a date is rejected rather than accepted as a claim.
+//
+// The two conditionals are the load-bearing part: a schema that only ever
+// accepts proves nothing, so every `then` branch here is asserted to REJECT.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormatsPlugin from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.ts";
+
+const addFormats = addFormatsPlugin as unknown as (instance: Ajv2020) => void;
+const ajv = new Ajv2020({
+  strict: false,
+  validateFormats: true,
+  allErrors: true,
+});
+addFormats(ajv);
+const manifestSchema = await readJson(
+  path.join(repoRoot, "schemas/subnet-manifest.schema.json"),
+);
+const validate = ajv.compile(manifestSchema);
+
+type Json = Record<string, unknown>;
+
+// The SN64 surface this block was designed against, verified live 2026-08-10.
+const CHUTES_REVENUE: Json = {
+  role: "external-revenue",
+  provenance: "probe-derived",
+  currency: "USD",
+  grain: "daily",
+  fields: { date: "date", amount: "total_revenue" },
+  excludes: ["sponsored_inference", "pending_instance_revenue"],
+  supersedes: ["sn-64-chutes-payments-summary-tao"],
+  circularity: "external",
+  source_url: "https://api.chutes.ai/openapi.json",
+};
+
+function manifest(revenue?: Json): Json {
+  const surface: Json = {
+    id: "sn-64-chutes-daily-revenue-summary",
+    name: "Chutes daily revenue summary",
+    kind: "data-artifact",
+    url: "https://api.chutes.ai/daily_revenue_summary",
+    provider: "chutes",
+    auth_required: false,
+    authority: "community",
+    public_safe: true,
+  };
+  if (revenue !== undefined) surface.revenue = revenue;
+  return {
+    schema_version: 1,
+    netuid: 64,
+    name: "Chutes",
+    slug: "sn-64",
+    status: "active",
+    categories: ["inference"],
+    surfaces: [surface],
+  };
+}
+
+function errorsFor(doc: Json): string[] {
+  validate(doc);
+  return (validate.errors ?? []).map(
+    (e) => `${e.instancePath} ${e.keyword} ${JSON.stringify(e.params)}`,
+  );
+}
+
+describe("subnet-manifest revenue block (#10441)", () => {
+  test("accepts the real SN64 declaration", () => {
+    assert.equal(
+      validate(manifest(CHUTES_REVENUE)),
+      true,
+      errorsFor(manifest(CHUTES_REVENUE)).join("; "),
+    );
+  });
+
+  test("the block stays optional — surfaces without revenue still validate", () => {
+    assert.equal(validate(manifest()), true);
+  });
+
+  test("role and provenance are both required when the block is present", () => {
+    for (const partial of [
+      {},
+      { role: "external-revenue" },
+      { provenance: "probe-derived" },
+    ]) {
+      assert.equal(
+        validate(manifest(partial as Json)),
+        false,
+        `expected rejection for ${JSON.stringify(partial)}`,
+      );
+    }
+  });
+
+  test("rejects a role or provenance outside the vocabulary", () => {
+    // "revenue" is the kind of plausible-looking value a contributor reaches
+    // for; it is not a role, and accepting it would erase the payout/proxy
+    // distinction the enum exists to draw.
+    assert.equal(
+      validate(manifest({ role: "revenue", provenance: "probe-derived" })),
+      false,
+    );
+    assert.equal(
+      validate(
+        manifest({ role: "external-revenue", provenance: "self-reported" }),
+      ),
+      false,
+    );
+  });
+
+  test('provenance "none" without searched_at is rejected', () => {
+    const undated = { role: "not-revenue", provenance: "none" };
+    assert.equal(validate(manifest(undated)), false);
+    assert.ok(
+      errorsFor(manifest(undated)).some((e) => e.includes("searched_at")),
+      "rejection must name searched_at, not fail for an unrelated reason",
+    );
+
+    const dated = { ...undated, searched_at: "2026-08-10T00:00:00Z" };
+    assert.equal(
+      validate(manifest(dated)),
+      true,
+      errorsFor(manifest(dated)).join("; "),
+    );
+  });
+
+  test("external-revenue must declare currency, grain and fields", () => {
+    // Without these the amount is a bare number with no unit, no period and no
+    // named source field — exactly the shape that produced the TAO/USD trap.
+    const bare = { role: "external-revenue", provenance: "probe-derived" };
+    assert.equal(validate(manifest(bare)), false);
+    const named = errorsFor(manifest(bare)).join(" ");
+    for (const required of ["currency", "grain", "fields"]) {
+      assert.ok(named.includes(required), `rejection must name ${required}`);
+    }
+  });
+
+  test("the currency/grain requirement applies only to external-revenue", () => {
+    // A miner-payout or proxy surface has nothing to denominate, so demanding a
+    // currency there would push contributors into inventing one.
+    for (const role of ["usage-proxy", "miner-payout", "not-revenue"]) {
+      assert.equal(
+        validate(manifest({ role, provenance: "operator-attested" })),
+        true,
+        `${role} should not require currency/grain/fields`,
+      );
+    }
+  });
+
+  test("rejects unknown keys inside the block", () => {
+    assert.equal(
+      validate(manifest({ ...CHUTES_REVENUE, estimated_arr: 4260000 })),
+      false,
+      "an estimate has no place in a block whose whole point is observed provenance",
+    );
+  });
+
+  test("circularity documents unknown as its default rather than external", () => {
+    const def = manifestSchema.$defs.revenue.properties.circularity;
+    assert.equal(def.default, "unknown");
+    assert.ok(!def.enum.includes("external-assumed"));
+  });
+});


### PR DESCRIPTION
A surface that reports a number tells you nothing about whether that number is revenue.

Probing the registry's own surfaces turned up three that read as "stats" endpoints and are not revenue at all: Targon's public `/api/miners` exposes `payout`, which is **emission paid to miners** — counted as revenue it puts the denominator in the numerator; SN43's `/stats/subnet` returns `total_alpha_stake`; SN96's `/network/stats` returns miner health.

This adds a `revenue` block to the surface definition so a surface says what it is.

## What it declares

| field | why it exists |
|---|---|
| `role` | separates `external-revenue` from `usage-proxy`, `miner-payout`, `not-revenue`. The last two are **verdicts worth recording**, so a false positive is retired rather than re-investigated every quarter. |
| `provenance` | the evidence class, so a probed figure is distinguishable from an operator's claim |
| `currency` | `api.chutes.ai/payments/summary/tao` is named for TAO and its values reconcile as USD. The unit is declared, never inferred from the path. |
| `grain` | daily / weekly / monthly / cumulative — SN51 is monthly where SN64 is daily |
| `fields` | which key in the upstream payload is the amount |
| `excludes` | Chutes' `sponsored_inference` is subnet-funded and `pending_instance_revenue` is unrecognised; neither is external revenue |
| `supersedes` | `/payments` is a subset of `daily_revenue_summary`; summing both inflates ~10% |
| `circularity` | defaults to `unknown`, never `external` |
| `searched_at` | when absence was established |

## The enforcing part

Two conditionals, and they are the reason this is a schema change rather than a convention:

- **`external-revenue` must declare `currency`, `grain` and `fields`** — otherwise an amount is a bare number with no unit, no period, and no named source field, which is exactly the shape that produced the TAO/USD trap.
- **`provenance: none` must carry `searched_at`** — an undated absence is not evidence.

Both are asserted to **reject**, not merely to accept, and the rejection is asserted to *name the missing field* so the test cannot pass on an unrelated validation error. Removing the `allOf` fails exactly those two tests and no others — verified.

## Scope

Registry-file schema only (`schemas/subnet-manifest.schema.json` validates `registry/subnets/*.json`). It is not a published contract component — the single-source gate scopes to `schemas/components`, and `npm run build` produced no `openapi.json` change. `validate:contract-drift` passes.

No registry file is edited here; SN64's own declaration is #10449.

## Verification

- `validate-schemas` · `validate-surface` (2,740 surfaces / 129 files) · `validate-schema-enums` · `validate:contract-drift` — all pass
- `tsc --noEmit` clean, eslint clean, prettier clean
- 9/9 new tests pass; conditionals proven load-bearing by removal

Closes #10441
