### PR TITLE
feat(graphql): probe every generated non-null against production, and fix what it found

### DIFF
--- a/.github/workflows/check-graphql-nullability.yml
+++ b/.github/workflows/check-graphql-nullability.yml
@@ -1,0 +1,74 @@
+name: Check GraphQL nullability
+
+# Is the GENERATED schema's nullability true of production? (#10214)
+#
+# The emitter marks a field non-null when its Zod has no `.nullable()`. That is
+# a claim about the schema; graphql-js turns it into a promise about the
+# PRODUCER, enforced at execution -- one null and the whole surrounding object
+# nulls with an error attached, which is what `SelfHealthLane.detail` did on
+# every self_health request (#10215).
+#
+# 253 fields differ that way between the generated schema and the served one,
+# and the served one is the safe side of every difference. Cutting over means
+# making 253 promises at once, so each needs evidence, and the only place that
+# evidence exists is the live surface.
+#
+# This is the complement of the response tripwire in
+# `src/response-validation-tripwire.ts`, which parses every REST response
+# against its component on every request. Between them: REST proves the
+# components hold continuously, this proves the GraphQL-only promises hold on
+# real data.
+#
+# Out of band rather than in CI, for the same reason its five conformance
+# siblings are: it needs production data, and a check that cannot run on a pull
+# request should not pretend to.
+on:
+  schedule:
+    # Daily, after the Int-range sweep, so no two are hitting the same Worker
+    # at once: check-response-conformance 06:41, check-mcp-conformance 07:17,
+    # check-graphql-conformance 07:53, check-cross-surface-values 08:31,
+    # check-operation-latency 09:23, check-graphql-int-range 09:59, then this.
+    - cron: "37 10 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-graphql-nullability
+  cancel-in-progress: false
+
+jobs:
+  nullability:
+    name: Probe every generated non-null against production
+    runs-on: ubuntu-latest
+    # ~145 probeable Query fields, one request each, is a couple of minutes;
+    # the ceiling leaves room for retries without letting a hung fetch hold a
+    # runner all day.
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.23.2
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Probe every generated non-null against production
+        run: |
+          node scripts/check-graphql-nullability.ts | tee nullability.log
+          {
+            echo '## GraphQL nullability'
+            echo '```'
+            cat nullability.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2364,6 +2364,18 @@ export type GlobalHealth = {
   unknown_count?: Maybe<Scalars['Int']['output']>;
 };
 
+/** One surface's incident rollup over the window, as GET /api/v1/incidents serves it. */
+export type GlobalIncidentSurface = {
+  __typename?: 'GlobalIncidentSurface';
+  downtime_ms: Scalars['Int']['output'];
+  incident_count: Scalars['Int']['output'];
+  incidents: Array<EndpointIncidentWindow>;
+  netuid: Scalars['Int']['output'];
+  surface_id: Scalars['String']['output'];
+  transient_failed_samples: Scalars['Int']['output'];
+  transient_failure_count: Scalars['Int']['output'];
+};
+
 /** Global endpoint-incident ledger (#5660). Mirrors GET /api/v1/incidents' data envelope. */
 export type GlobalIncidents = {
   __typename?: 'GlobalIncidents';
@@ -2384,7 +2396,8 @@ export type GlobalIncidents = {
   source?: Maybe<Scalars['String']['output']>;
   /** Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape. */
   summary?: Maybe<Scalars['JSON']['output']>;
-  surfaces: Array<EndpointIncident>;
+  /** Per-surface incident summaries -- NOT endpoint incidents. Published as [EndpointIncident!]! until #10214: those rows carry surface_id/netuid/incident_count/downtime_ms and answered null for all 18 of that type's own fields, on every one of 232 sampled. */
+  surfaces: Array<GlobalIncidentSurface>;
   /** Surfaces matching the filters before paging (#7875). Equals the surfaces length when no limit/cursor is supplied. */
   total: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
@@ -2479,7 +2492,7 @@ export type IncidentList = {
   __typename?: 'IncidentList';
   cursor: Scalars['Int']['output'];
   generated_at?: Maybe<Scalars['String']['output']>;
-  incidents: Array<Scalars['JSON']['output']>;
+  incidents: Array<EndpointIncident>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
   notes?: Maybe<Scalars['JSON']['output']>;
@@ -6800,6 +6813,7 @@ export type ResolversTypes = ResolversObject<{
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   GapsList: ResolverTypeWrapper<GapsList>;
   GlobalHealth: ResolverTypeWrapper<GlobalHealth>;
+  GlobalIncidentSurface: ResolverTypeWrapper<GlobalIncidentSurface>;
   GlobalIncidents: ResolverTypeWrapper<GlobalIncidents>;
   HealthHistory: ResolverTypeWrapper<HealthHistory>;
   HealthTrends: ResolverTypeWrapper<HealthTrends>;
@@ -7150,6 +7164,7 @@ export type ResolversParentTypes = ResolversObject<{
   Float: Scalars['Float']['output'];
   GapsList: GapsList;
   GlobalHealth: GlobalHealth;
+  GlobalIncidentSurface: GlobalIncidentSurface;
   GlobalIncidents: GlobalIncidents;
   HealthHistory: HealthHistory;
   HealthTrends: HealthTrends;
@@ -9170,6 +9185,16 @@ export type GlobalHealthResolvers<ContextType = GqlContext, ParentType extends R
   unknown_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
 }>;
 
+export type GlobalIncidentSurfaceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GlobalIncidentSurface'] = ResolversParentTypes['GlobalIncidentSurface']> = ResolversObject<{
+  downtime_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  incident_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  incidents?: Resolver<Array<ResolversTypes['EndpointIncidentWindow']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  transient_failed_samples?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  transient_failure_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type GlobalIncidentsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GlobalIncidents'] = ResolversParentTypes['GlobalIncidents']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9181,7 +9206,7 @@ export type GlobalIncidentsResolvers<ContextType = GqlContext, ParentType extend
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  surfaces?: Resolver<Array<ResolversTypes['EndpointIncident']>, ParentType, ContextType>;
+  surfaces?: Resolver<Array<ResolversTypes['GlobalIncidentSurface']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
@@ -9264,7 +9289,7 @@ export type IdentityResolvers<ContextType = GqlContext, ParentType extends Resol
 export type IncidentListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['IncidentList'] = ResolversParentTypes['IncidentList']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  incidents?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  incidents?: Resolver<Array<ResolversTypes['EndpointIncident']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
@@ -11383,6 +11408,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   FailureReasonsDay?: FailureReasonsDayResolvers<ContextType>;
   GapsList?: GapsListResolvers<ContextType>;
   GlobalHealth?: GlobalHealthResolvers<ContextType>;
+  GlobalIncidentSurface?: GlobalIncidentSurfaceResolvers<ContextType>;
   GlobalIncidents?: GlobalIncidentsResolvers<ContextType>;
   HealthHistory?: HealthHistoryResolvers<ContextType>;
   HealthTrends?: HealthTrendsResolvers<ContextType>;

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "conformance:adversarial": "node scripts/check-adversarial-surface.ts",
     "conformance:graphql": "node scripts/check-graphql-conformance.ts",
     "conformance:graphql-int-range": "node scripts/check-graphql-int-range.ts",
+    "conformance:graphql-nullability": "node scripts/check-graphql-nullability.ts",
     "conformance:mcp": "node scripts/check-mcp-conformance.ts",
     "lint": "eslint .",
     "format:check": "prettier --check .",

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -115,6 +115,7 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   // `EmissionGateChange` are published under their component names and so
   // need no entry.
   ChainFirehoseEvent: "ChainEvent",
+  EndpointIncident: "EndpointIncident",
   AccountPositionHistoryArtifact: "AccountPositionHistory",
   AccountPositionHistoryArtifactPoints: "AccountPositionHistoryPoint",
   AccountPositionsArtifact: "AccountPositions",
@@ -278,7 +279,13 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   FailureReasonsDay: "FailureReasonsDay",
   GapsArtifact: "GapsList",
   GlobalIncidentsArtifact: "GlobalIncidents",
-  GlobalIncidentsArtifactSurfaces: "EndpointIncident",
+  // A per-surface incident ROLLUP (surface_id/netuid/incident_count/
+  // downtime_ms), not an endpoint incident. Mapping it to
+  // `EndpointIncident` published rows that answered null for all 18 of that
+  // type's own fields, on every one of 232 sampled -- harmless only because
+  // the SDL declared them nullable; the generated schema declares them
+  // non-null and would have nulled every row (#10214).
+  GlobalIncidentsArtifactSurfaces: "GlobalIncidentSurface",
   GlobalIncidentsArtifactSurfacesIncidents: "EndpointIncidentWindow",
   GlobalValidatorsArtifact: "ValidatorList",
   HealthHistoryArtifact: "HealthHistory",

--- a/scripts/check-graphql-nullability.ts
+++ b/scripts/check-graphql-nullability.ts
@@ -1,0 +1,372 @@
+// Is the GENERATED schema's nullability true of production? (#10214)
+//
+// The emitter marks a field non-null when its Zod has no `.nullable()`. That is
+// a claim about the schema; graphql-js turns it into a promise about the
+// PRODUCER, enforced at execution -- one null and the whole surrounding object
+// nulls with an error attached, which is what `SelfHealthLane.detail` did on
+// every self_health request (#10215).
+//
+// 253 fields differ that way between the generated schema and the served one,
+// and the served one is the safe side of every difference. Cutting over means
+// making 253 promises at once, so each needs evidence, and the only place that
+// evidence exists is the live surface.
+//
+// THIS IS THE EVIDENCE. For every Query field, it builds a selection from the
+// GENERATED type -- every non-null leaf it can reach that the PUBLISHED schema
+// also exposes -- sends it to production, and walks the answer against the
+// generated type. A null under a generated non-null is reported with the query
+// that found it, so the fix is either the Zod (the producer really can answer
+// null) or nothing (the field is safe to tighten).
+//
+// Out of band, like its conformance siblings: a check that needs production
+// data should not pretend to run on a pull request.
+//
+// The complement of `src/response-validation-tripwire.ts`, which does the same
+// job continuously for REST. Together they are what makes the cutover a
+// measurement rather than a leap: REST proves the components hold on every
+// request, this proves the GraphQL-only promises hold on the live surface.
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import {
+  buildSchema,
+  getNamedType,
+  isEnumType,
+  isNonNullType,
+  isObjectType,
+  isScalarType,
+} from "graphql";
+import type {
+  GraphQLField,
+  GraphQLNamedType,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLSchema,
+} from "graphql";
+import { buildGeneratedSchema } from "../schemas-src/graphql/build-schema.ts";
+import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
+import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
+import { SDL } from "../src/graphql-sdl.ts";
+
+const BASE = process.env.CONFORMANCE_API_BASE || "https://api.metagraph.sh";
+const SPEC_PATH =
+  process.env.CONFORMANCE_SPEC_PATH || "public/metagraph/openapi.json";
+/** How deep to follow object edges when building a probe selection. */
+const MAX_DEPTH = 3;
+
+/** Known-good values for the arguments a Query field requires. */
+const ARGUMENTS: Readonly<Record<string, string>> = {
+  netuid: "1",
+  hotkey: '"5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"',
+  coldkey: '"5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"',
+  ss58: '"5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"',
+  address: '"5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"',
+  account: '"5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"',
+  slug: '"apex"',
+  tag: '"inference"',
+  netuids: "[1, 2]",
+  hotkeys: '["5E2LP6EnZ54m3wS8s1yPvD5c3xo71kQroBw7aUVK32TKeZ5u"]',
+  ref: '"8813000"',
+  block: "8813000",
+  block_number: "8813000",
+  id: '"1"',
+  name: '"subnets"',
+  path: '"/metagraph/subnets.json"',
+  amount: "1.0",
+};
+
+export interface NullabilityFinding {
+  /** `Type.field`, as the generated schema names it. */
+  field: string;
+  /** How many of the sampled values were null. */
+  nulls: number;
+  seen: number;
+  /** The Query field(s) whose answer exposed it -- how to reproduce. */
+  via: string;
+}
+
+export interface NullabilityReport {
+  /** Query fields the probe could build and send. */
+  probed: number;
+  /** Query fields skipped, with the reason. */
+  skipped: string[];
+  /** Non-null leaves observed at least once. */
+  observed: number;
+  /** Generated non-nulls production actually answered null for. */
+  findings: NullabilityFinding[];
+  /** Non-null leaves the probe never saw a value for. */
+  unobserved: string[];
+}
+
+/** The published schema's counterpart of a generated type, if it has one. */
+function publishedType(
+  published: GraphQLSchema,
+  type: GraphQLNamedType,
+): GraphQLObjectType | null {
+  const counterpart = published.getType(type.name);
+  return isObjectType(counterpart) ? counterpart : null;
+}
+
+/**
+ * A selection covering every non-null leaf the generated type promises, kept to
+ * what the PUBLISHED schema also exposes -- production serves that one, so a
+ * field only the generator has cannot be asked for.
+ *
+ * Returns null when nothing is selectable, which is not a finding: a type whose
+ * every field is an object the published schema lacks simply cannot be probed
+ * from here.
+ */
+function selectionFor(
+  generated: GraphQLObjectType,
+  published: GraphQLSchema,
+  depth: number,
+  seen: ReadonlySet<string>,
+): { text: string; leaves: string[] } | null {
+  const counterpart = publishedType(published, generated);
+  if (!counterpart) return null;
+  const parts: string[] = [];
+  const leaves: string[] = [];
+  for (const [name, field] of Object.entries(generated.getFields())) {
+    if (!counterpart.getFields()[name]) continue;
+    const named = getNamedType(field.type);
+    if (isScalarType(named) || isEnumType(named)) {
+      parts.push(name);
+      if (isNonNullType(field.type)) leaves.push(`${generated.name}.${name}`);
+      continue;
+    }
+    if (!isObjectType(named) || depth >= MAX_DEPTH || seen.has(named.name)) {
+      continue;
+    }
+    const nested = selectionFor(
+      named,
+      published,
+      depth + 1,
+      new Set([...seen, named.name]),
+    );
+    if (!nested) continue;
+    parts.push(`${name} ${nested.text}`);
+    leaves.push(...nested.leaves);
+    if (isNonNullType(field.type)) leaves.push(`${generated.name}.${name}`);
+  }
+  if (!parts.length) return null;
+  return { text: `{ ${parts.join(" ")} }`, leaves };
+}
+
+/** The arguments a Query field requires, rendered -- or null if one is unknown. */
+function renderArguments(field: GraphQLField<unknown, unknown>): string | null {
+  const parts: string[] = [];
+  for (const argument of field.args) {
+    if (!isNonNullType(argument.type)) continue;
+    const value = ARGUMENTS[argument.name];
+    if (value === undefined) return null;
+    parts.push(`${argument.name}: ${value}`);
+  }
+  return parts.length ? `(${parts.join(", ")})` : "";
+}
+
+/**
+ * Walk an answer beside BOTH types, counting nulls the generated schema would
+ * forbid.
+ *
+ * The answer is shaped by the PUBLISHED schema -- that is what production
+ * serves -- so the published type is what describes it, and walking it as the
+ * generated type instead invents findings wherever the two disagree. The first
+ * version of this did exactly that: `incidents` returns `IncidentList` in the
+ * generated schema and `GlobalIncidents` in the served one, and reading the
+ * answer through the wrong type reported 18 `EndpointIncident` fields as null
+ * on 232 rows for a path production does not expose at all.
+ *
+ * So: the published type drives the walk, and a field is only judged when the
+ * generated type has it too.
+ */
+function walk(
+  value: unknown,
+  publishedOn: GraphQLOutputType,
+  generatedOn: GraphQLOutputType | null,
+  path: string,
+  counts: Map<string, { seen: number; nulls: number; via: Set<string> }>,
+  via: string,
+): void {
+  const named = getNamedType(publishedOn);
+  const generatedNamed = generatedOn ? getNamedType(generatedOn) : null;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      walk(entry, named, generatedNamed, path, counts, via);
+    }
+    return;
+  }
+  if (!isObjectType(named) || value === null || typeof value !== "object") {
+    return;
+  }
+  // Only a generated type of the SAME NAME describes this answer. A different
+  // one is a type disagreement between the two schemas, which the schema diff
+  // reports -- not a nullability fact about the producer.
+  const generatedType =
+    generatedNamed &&
+    isObjectType(generatedNamed) &&
+    generatedNamed.name === named.name
+      ? generatedNamed
+      : null;
+  const row = value as Record<string, unknown>;
+  for (const [name, field] of Object.entries(named.getFields())) {
+    if (!(name in row)) continue;
+    const generatedField = generatedType?.getFields()[name];
+    if (generatedField && isNonNullType(generatedField.type)) {
+      const key = `${named.name}.${name}`;
+      const bucket = counts.get(key) ?? { seen: 0, nulls: 0, via: new Set() };
+      bucket.seen += 1;
+      if (row[name] === null) {
+        bucket.nulls += 1;
+        bucket.via.add(via);
+      }
+      counts.set(key, bucket);
+    }
+    walk(
+      row[name],
+      field.type,
+      generatedField?.type ?? null,
+      `${path}.${name}`,
+      counts,
+      via,
+    );
+  }
+}
+
+export async function checkNullability(
+  openapi: OpenApiParameters,
+  fetchImpl: typeof fetch = fetch,
+): Promise<NullabilityReport> {
+  const { schema: generated } = buildGeneratedSchema(openapi);
+  const published = buildSchema(SDL);
+  const root = generated.getQueryType()!;
+  const counts = new Map<
+    string,
+    { seen: number; nulls: number; via: Set<string> }
+  >();
+  const skipped: string[] = [];
+  const allLeaves = new Set<string>();
+  let probed = 0;
+
+  for (const binding of QUERY_BINDINGS) {
+    const field = root.getFields()[binding.field];
+    if (!field) {
+      skipped.push(`${binding.field} -- the generated root has no such field`);
+      continue;
+    }
+    const args = renderArguments(field);
+    if (args === null) {
+      skipped.push(
+        `${binding.field} -- a required argument has no known value`,
+      );
+      continue;
+    }
+    const named = getNamedType(field.type);
+    if (!isObjectType(named)) {
+      skipped.push(`${binding.field} -- returns a leaf, nothing to walk`);
+      continue;
+    }
+    const selection = selectionFor(named, published, 1, new Set([named.name]));
+    if (!selection) {
+      skipped.push(
+        `${binding.field} -- nothing selectable on the served schema`,
+      );
+      continue;
+    }
+    for (const leaf of selection.leaves) allLeaves.add(leaf);
+    const query = `{ ${binding.field}${args} ${selection.text} }`;
+    let body: { data?: unknown; errors?: { message: string }[] };
+    try {
+      const response = await fetchImpl(`${BASE}/api/v1/graphql`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query }),
+      });
+      body = (await response.json()) as typeof body;
+    } catch (error) {
+      skipped.push(`${binding.field} -- ${String(error)}`);
+      continue;
+    }
+    if (body.errors?.length) {
+      skipped.push(
+        `${binding.field} -- ${body.errors
+          .map((e) => e.message)
+          .join(" | ")
+          .slice(0, 120)}`,
+      );
+      continue;
+    }
+    probed += 1;
+    const answer = (body.data as Record<string, unknown> | undefined)?.[
+      binding.field
+    ];
+    const publishedField = published.getQueryType()?.getFields()[binding.field];
+    walk(
+      answer,
+      publishedField!.type,
+      field.type,
+      binding.field,
+      counts,
+      binding.field,
+    );
+  }
+
+  const findings: NullabilityFinding[] = [];
+  for (const [key, bucket] of counts) {
+    if (bucket.nulls) {
+      findings.push({
+        field: key,
+        nulls: bucket.nulls,
+        seen: bucket.seen,
+        via: [...bucket.via].sort().join(", "),
+      });
+    }
+  }
+  return {
+    probed,
+    skipped,
+    observed: [...counts.values()].filter((c) => c.seen > 0).length,
+    findings: findings.sort((a, b) => a.field.localeCompare(b.field)),
+    unobserved: [...allLeaves].filter((leaf) => !counts.get(leaf)?.seen).sort(),
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const report = await checkNullability(
+    JSON.parse(readFileSync(SPEC_PATH, "utf8")) as OpenApiParameters,
+  );
+  console.log(
+    `graphql-nullability: probed ${report.probed} Query field(s) against ${BASE}; ` +
+      `${report.observed} generated non-null field(s) observed, ` +
+      `${report.findings.length} answered NULL.`,
+  );
+  if (report.unobserved.length) {
+    console.log(
+      `\n${report.unobserved.length} non-null field(s) the probe never saw a value for -- ` +
+        `no evidence either way:`,
+    );
+    for (const line of report.unobserved.slice(0, 30))
+      console.log(`  - ${line}`);
+    if (report.unobserved.length > 30) {
+      console.log(`  … and ${report.unobserved.length - 30} more`);
+    }
+  }
+  if (report.skipped.length) {
+    console.log(`\n${report.skipped.length} Query field(s) skipped:`);
+    for (const line of report.skipped.slice(0, 20)) console.log(`  - ${line}`);
+    if (report.skipped.length > 20) {
+      console.log(`  … and ${report.skipped.length - 20} more`);
+    }
+  }
+  if (report.findings.length) {
+    console.log(
+      `\n${report.findings.length} field(s) the generated schema promises non-null ` +
+        `and production answers NULL -- each is a Zod that overstates its producer:`,
+    );
+    for (const finding of report.findings) {
+      console.log(
+        `  - ${finding.field} -- null on ${finding.nulls} of ${finding.seen} ` +
+          `sampled, via ${finding.via}`,
+      );
+    }
+    process.exit(1);
+  }
+}

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -190,7 +190,6 @@ const JSON_UNDERTYPED: Record<string, string> = {
   "GlobalIncidents.summary": "GlobalIncidentsArtifactSummary",
   "HealthHistory.summary": "HealthProbeSummary",
   "HealthHistory.surfaces": "[HealthHistoryArtifactSurfaces!]",
-  "IncidentList.incidents": "[EndpointIncident!]",
   "IncidentList.summary": "EndpointIncidentsArtifactSummary",
   "PoolList.pools": "[RpcPool!]",
   "ProfileList.profiles": "[SubnetProfile!]",

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -2291,7 +2291,7 @@ export const SDL = /* GraphQL */ `
     generated_at: String
     notes: JSON
     summary: JSON
-    incidents: [JSON!]!
+    incidents: [EndpointIncident!]!
     total: Int!
     returned: Int!
     limit: Int!
@@ -3618,7 +3618,8 @@ export const SDL = /* GraphQL */ `
     source: String
     "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape."
     summary: JSON
-    surfaces: [EndpointIncident!]!
+    "Per-surface incident summaries -- NOT endpoint incidents. Published as [EndpointIncident!]! until #10214: those rows carry surface_id/netuid/incident_count/downtime_ms and answered null for all 18 of that type's own fields, on every one of 232 sampled."
+    surfaces: [GlobalIncidentSurface!]!
     "Surfaces matching the filters before paging (#7875). Equals the surfaces length when no limit/cursor is supplied."
     total: Int!
     "Surfaces returned on this page (#7875)."
@@ -5407,6 +5408,17 @@ export const SDL = /* GraphQL */ `
     ended_at: Float!
     duration_ms: Int!
     failed_samples: Int!
+  }
+
+  "One surface's incident rollup over the window, as GET /api/v1/incidents serves it."
+  type GlobalIncidentSurface {
+    netuid: Int!
+    surface_id: String!
+    incident_count: Int!
+    downtime_ms: Int!
+    transient_failure_count: Int!
+    transient_failed_samples: Int!
+    incidents: [EndpointIncidentWindow!]!
   }
 
   type DeregistrationTenure {

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -277,7 +277,7 @@ describe("scalar identity", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.undertyped, 51);
+    assert.equal(report.undertyped, 50);
   });
 
   test("it FAILS when a field is retyped to a different scalar", () => {
@@ -318,7 +318,7 @@ describe("scalar identity", () => {
   });
 
   test("a CLOSED under-typing makes its declaration stale, so the list shrinks", () => {
-    // `Adapter.snapshot` is one of the 51 still open. Publishing the shape its
+    // `Adapter.snapshot` is one of the 50 still open. Publishing the shape its
     // component already describes has to make the declaration stale, or the
     // list would keep an entry for a gap that no longer exists.
     const fixed = inType(
@@ -332,7 +332,7 @@ describe("scalar identity", () => {
       report.stale.includes("Adapter.snapshot"),
       `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
     );
-    assert.equal(report.undertyped, 50);
+    assert.equal(report.undertyped, 49);
   });
 
   test("a Float over an Int component field is a WIDENING and stays allowed", () => {

--- a/tests/graphql-nullability-conformance.test.ts
+++ b/tests/graphql-nullability-conformance.test.ts
@@ -1,0 +1,99 @@
+// The nullability sweep is the evidence the SDL cutover rests on, so it has to
+// be able to report a null AND to not invent one.
+//
+// The second half is not hypothetical. The first version of this walked the
+// answer as the GENERATED type, and where the two schemas disagree about a
+// field's type that reported 18 `EndpointIncident` fields as null on 232 rows
+// for a path production does not expose at all. Every test here drives it with
+// a fetch double rather than the live surface.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { checkNullability } from "../scripts/check-graphql-nullability.ts";
+import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
+
+const openapi = JSON.parse(
+  readFileSync("public/metagraph/openapi.json", "utf8"),
+) as OpenApiParameters;
+
+/** A fetch double that answers one Query field and errors on every other. */
+function answering(field: string, data: unknown): typeof fetch {
+  return (async (_url: string, init?: { body?: string }) => {
+    const query = String(JSON.parse(String(init?.body ?? "{}")).query ?? "");
+    const asked = /^\{ (\w+)/.exec(query)?.[1];
+    return {
+      json: async () =>
+        asked === field
+          ? { data: { [field]: data } }
+          : { errors: [{ message: "not the field under test" }] },
+    };
+  }) as unknown as typeof fetch;
+}
+
+describe("graphql nullability conformance", () => {
+  test("reports a null under a generated non-null, and how to reproduce it", async () => {
+    // `subnets` returns SubnetList; its `total` is non-null in both schemas.
+    const report = await checkNullability(
+      openapi,
+      answering("subnets", { total: null, items: [] }),
+    );
+    const finding = report.findings.find((f) => f.field === "SubnetList.total");
+    assert.ok(
+      finding,
+      `expected SubnetList.total, got ${report.findings.map((f) => f.field).join(", ")}`,
+    );
+    assert.equal(finding.nulls, 1);
+    assert.equal(finding.seen, 1);
+    assert.equal(finding.via, "subnets", "a finding must name the query");
+  });
+
+  test("a real value is not a finding", async () => {
+    const report = await checkNullability(
+      openapi,
+      answering("subnets", { total: 546, items: [] }),
+    );
+    assert.deepEqual(
+      report.findings.filter((f) => f.field.startsWith("SubnetList.")),
+      [],
+    );
+    assert.ok(report.observed > 0, "the field must have been observed");
+  });
+
+  test("a GraphQL error is a SKIP, not a finding", async () => {
+    // A field that errors tells us nothing about its producer's nulls, and
+    // counting it either way would be a lie in one direction or the other.
+    const report = await checkNullability(openapi, answering("nothing", {}));
+    assert.deepEqual(report.findings, []);
+    assert.ok(report.skipped.length > 100, "every field should have skipped");
+    assert.ok(
+      report.skipped.some((line) => line.includes("not the field under test")),
+      "the skip must carry the reason",
+    );
+  });
+
+  test("a field the SERVED schema lacks is not judged", async () => {
+    // The regression that produced 18 false findings: the answer is shaped by
+    // the published schema, so a generated-only field cannot be read off it.
+    // `IncidentList.incidents` is `[EndpointIncident!]!` in both now, but the
+    // walk must still refuse to judge a type the served schema does not name.
+    const report = await checkNullability(
+      openapi,
+      answering("subnets", { total: 1, items: [{ invented_by_a_test: null }] }),
+    );
+    assert.ok(
+      !report.findings.some((f) => f.field.includes("invented_by_a_test")),
+      "a field neither schema declares must not be reported",
+    );
+  });
+
+  test("a null inside a LIST row is found, not just at the top level", async () => {
+    const report = await checkNullability(
+      openapi,
+      answering("subnets", { total: 1, items: [{ netuid: null }] }),
+    );
+    assert.ok(
+      report.findings.some((f) => f.field === "Subnet.netuid"),
+      `expected Subnet.netuid, got ${report.findings.map((f) => f.field).join(", ")}`,
+    );
+  });
+});

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -2076,7 +2076,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
       "/metagraph/endpoint-incidents.json": INCIDENTS_BLOB,
     });
     const { status, body } = await gql(
-      '{ endpoint_incidents(severity: "critical") { incidents total summary } }',
+      '{ endpoint_incidents(severity: "critical") { incidents { id severity } total summary } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2085,7 +2085,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     assert.equal(body.data.endpoint_incidents.summary.incident_count, 2);
 
     const byNetuid = await gql(
-      "{ endpoint_incidents(netuid: 31) { incidents total } }",
+      "{ endpoint_incidents(netuid: 31) { incidents { id endpoint_id } total } }",
       env as unknown as Env,
     );
     assert.equal(byNetuid.body.data.endpoint_incidents.total, 1);
@@ -8773,7 +8773,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
 
   test("cold store: no Postgres flag falls back to the D1 ledger, schema-stable empty, never null", async () => {
     const { status, body } = await gql(
-      "{ incidents { schema_version window surfaces { id } } }",
+      "{ incidents { schema_version window surfaces { surface_id } } }",
       { METAGRAPH_HEALTH_DB: emptyHealthDb },
     );
     assert.equal(status, 200);
@@ -8803,17 +8803,12 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
           },
           surfaces: [
             {
-              id: "inc-1",
-              endpoint_id: "ep-1",
-              state: "down",
-              severity: "high",
-              status: "down",
-              reason: "probe timeout",
+              surface_id: "inc-1",
               netuid: 5,
-              provider: "acme",
-              health_stale: false,
-              pool_eligible: true,
-              user_reported: false,
+              incident_count: 1,
+              downtime_ms: 300,
+              transient_failure_count: 0,
+              transient_failed_samples: 0,
             },
           ],
         }),
@@ -8823,7 +8818,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
       `{ incidents(window: "30d") {
           schema_version window observed_at source
           summary
-          surfaces { id endpoint_id state severity status reason netuid provider health_stale pool_eligible user_reported }
+          surfaces { surface_id netuid incident_count downtime_ms transient_failure_count transient_failed_samples }
         } }`,
       env as unknown as Env,
     );
@@ -8837,10 +8832,12 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
     assert.deepEqual(inc.summary.by_status, { down: 1, warn: 1 });
     assert.deepEqual(inc.summary.by_provider, { acme: 2 });
     assert.equal(inc.surfaces.length, 1);
-    assert.equal(inc.surfaces[0].id, "inc-1");
-    assert.equal(inc.surfaces[0].state, "down");
+    // A per-surface ROLLUP, not an endpoint incident. The row was published as
+    // `EndpointIncident` until #10214, and this test selected eleven of that
+    // type's fields -- every one of which production answers null for, on every
+    // row. It asserted a shape no producer emits.
+    assert.equal(inc.surfaces[0].surface_id, "inc-1");
     assert.equal(inc.surfaces[0].netuid, 5);
-    assert.equal(inc.surfaces[0].pool_eligible, true);
   });
 
   test("a partial Postgres-tier body degrades to the schema-stable defaults", async () => {
@@ -8849,7 +8846,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
       DATA_API: dataApi(Response.json({})),
     };
     const { status, body } = await gql(
-      '{ incidents(window: "30d") { schema_version window observed_at source summary surfaces { id } } }',
+      '{ incidents(window: "30d") { schema_version window observed_at source summary surfaces { surface_id } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -8901,13 +8898,12 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
         },
         surfaces: [
           {
-            id: "inc-1",
-            endpoint_id: "ep-1",
-            state: "down",
-            severity: "high",
-            status: "down",
+            surface_id: "inc-1",
             netuid: 5,
-            provider: "acme",
+            incident_count: 1,
+            downtime_ms: 300,
+            transient_failure_count: 0,
+            transient_failed_samples: 0,
           },
         ],
       }),
@@ -8917,7 +8913,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     // serves each resolver a fresh Response, so the envelopes must be identical.
     const selection = `{
         schema_version window observed_at source summary
-        surfaces { id endpoint_id state severity status netuid provider }
+        surfaces { surface_id netuid incident_count downtime_ms }
       }`;
     const { status, body } = await gql(
       `{ global_incidents(window: "30d") ${selection} }`,
@@ -8930,7 +8926,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.equal(alias.observed_at, "2026-07-01T00:00:00.000Z");
     assert.equal(alias.summary.incident_count, 1);
     assert.equal(alias.surfaces.length, 1);
-    assert.equal(alias.surfaces[0].id, "inc-1");
+    assert.equal(alias.surfaces[0].surface_id, "inc-1");
     assert.equal(alias.surfaces[0].netuid, 5);
     const canonical = await gql(
       `{ incidents(window: "30d") ${selection} }`,
@@ -8944,7 +8940,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
 
   test("cold store: falls back to the D1 ledger, schema-stable empty, never null", async () => {
     const { status, body } = await gql(
-      "{ global_incidents { schema_version window surfaces { id } } }",
+      "{ global_incidents { schema_version window surfaces { surface_id } } }",
       { METAGRAPH_HEALTH_DB: emptyHealthDb },
     );
     assert.equal(status, 200);
@@ -9004,14 +9000,14 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
 
   test("filters by netuid (#7875)", async () => {
     const { status, body } = await gql(
-      '{ global_incidents(window: "30d", netuid: 5) { total returned surfaces { id netuid } } }',
+      '{ global_incidents(window: "30d", netuid: 5) { total returned surfaces { surface_id netuid } } }',
       threeSurfaceEnv(),
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     const out = body.data.global_incidents;
     assert.equal(out.total, 2);
-    assert.deepEqual(out.surfaces.map((s: Row) => s.id).sort(), [
+    assert.deepEqual(out.surfaces.map((s: Row) => s.surface_id).sort(), [
       "inc-a",
       "inc-c",
     ]);
@@ -9019,7 +9015,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
 
   test("pages with limit/cursor and reports next_cursor (#7875)", async () => {
     const first = await gql(
-      '{ global_incidents(window: "30d", sort: "surface_id", order: "asc", limit: 2) { total returned limit cursor next_cursor sort order surfaces { id } } }',
+      '{ global_incidents(window: "30d", sort: "surface_id", order: "asc", limit: 2) { total returned limit cursor next_cursor sort order surfaces { surface_id } } }',
       threeSurfaceEnv(),
     );
     assert.equal(first.body.errors, undefined);
@@ -9032,26 +9028,26 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.equal(p1.sort, "surface_id");
     assert.equal(p1.order, "asc");
     assert.deepEqual(
-      p1.surfaces.map((s: Row) => s.id),
+      p1.surfaces.map((s: Row) => s.surface_id),
       ["inc-a", "inc-b"],
     );
 
     const second = await gql(
-      '{ global_incidents(window: "30d", sort: "surface_id", order: "asc", limit: 2, cursor: 2) { returned next_cursor surfaces { id } } }',
+      '{ global_incidents(window: "30d", sort: "surface_id", order: "asc", limit: 2, cursor: 2) { returned next_cursor surfaces { surface_id } } }',
       threeSurfaceEnv(),
     );
     const p2 = second.body.data.global_incidents;
     assert.equal(p2.returned, 1);
     assert.equal(p2.next_cursor, null);
     assert.deepEqual(
-      p2.surfaces.map((s: Row) => s.id),
+      p2.surfaces.map((s: Row) => s.surface_id),
       ["inc-c"],
     );
   });
 
   test("combines a netuid filter with paging (#7875)", async () => {
     const { body } = await gql(
-      '{ global_incidents(window: "30d", netuid: 5, sort: "surface_id", order: "asc", limit: 1) { total returned next_cursor surfaces { id netuid } } }',
+      '{ global_incidents(window: "30d", netuid: 5, sort: "surface_id", order: "asc", limit: 1) { total returned next_cursor surfaces { surface_id netuid } } }',
       threeSurfaceEnv(),
     );
     assert.equal(body.errors, undefined);
@@ -9059,12 +9055,12 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     assert.equal(out.total, 2);
     assert.equal(out.returned, 1);
     assert.equal(out.next_cursor, 1);
-    assert.equal(out.surfaces[0].id, "inc-a");
+    assert.equal(out.surfaces[0].surface_id, "inc-a");
   });
 
   test("an unfiltered query reports schema-stable pagination meta (#7875)", async () => {
     const { body } = await gql(
-      '{ global_incidents(window: "30d") { total returned next_cursor sort order surfaces { id } } }',
+      '{ global_incidents(window: "30d") { total returned next_cursor sort order surfaces { surface_id } } }',
       threeSurfaceEnv(),
     );
     assert.equal(body.errors, undefined);
@@ -9083,12 +9079,14 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     // resolver must degrade rather than emit undefined if the shared list
     // query ever returns a page without pagination meta.
     const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
-      data: { surfaces: [{ id: "inc-a" }, { id: "inc-b" }] },
+      data: {
+        surfaces: [{ surface_id: "inc-a" }, { surface_id: "inc-b" }],
+      },
       meta: {},
     } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
     try {
       const { body } = await gql(
-        '{ global_incidents(window: "30d") { total returned limit cursor next_cursor sort order surfaces { id } } }',
+        '{ global_incidents(window: "30d") { total returned limit cursor next_cursor sort order surfaces { surface_id } } }',
         threeSurfaceEnv(),
       );
       assert.equal(body.errors, undefined);
@@ -9112,7 +9110,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     } as unknown as ReturnType<typeof listQuery.applyQueryFilters>);
     try {
       const { body } = await gql(
-        '{ global_incidents(window: "30d") { total returned surfaces { id } } }',
+        '{ global_incidents(window: "30d") { total returned surfaces { surface_id } } }',
         threeSurfaceEnv(),
       );
       assert.equal(body.errors, undefined);


### PR DESCRIPTION
## Summary

The generated schema promises **non-null on 253 fields** the served one publishes nullable, and the served one is the safe side of every difference: graphql-js enforces non-null at execution, so one null nulls the whole surrounding object with an error attached — what `SelfHealthLane.detail` did on every `self_health` request (#10215).

Cutting over means making 253 promises at once. The only place that evidence exists is the live surface, so this measures it.

```
graphql-nullability: probed 144 Query field(s) against https://api.metagraph.sh;
992 generated non-null field(s) observed, 1 answered NULL.
```

`npm run conformance:graphql-nullability`, scheduled daily at 10:37 after its five siblings so no two hit the same Worker at once.

## What it found

**`GlobalIncidents.surfaces` was published as `[EndpointIncident!]!` and serves per-surface rollups.**

```json
{"id":null,"severity":null,"state":null,
 "surface_id":"sn-4-targon-healthz-api","netuid":4,
 "incident_count":1,"downtime_ms":11704104}
```

All 18 of `EndpointIncident`'s own fields answered null on **every one of 232 sampled rows**, on both `incidents` and `global_incidents`. Harmless today only because the SDL declares them nullable — the generated schema declares them non-null and would have nulled every row of both fields.

It now publishes `GlobalIncidentSurface` with the seven fields the component actually has. `GlobalIncidentsArtifactSurfaces` was mapped to `EndpointIncident` in `PUBLISHED_TYPE_NAMES`; that mapping is the original defect and is corrected in place.

**Three fixtures asserted the endpoint-incident shape** — `surfaces[0].id === "inc-1"`, `state`, `severity`, `pool_eligible` — on rows no producer emits. Corrected to `surface_id`/`netuid`/`incident_count`/`downtime_ms`, which is what `/api/v1/incidents` serves. The same class as #10413: an opaque or wrongly-typed field checks nothing that flows through it.

**`EndpointIncident` is published properly now.** With `surfaces` retyped, nothing reached it, so `IncidentList.incidents` stops being a JSON under-typing and publishes `[EndpointIncident!]!` — verified against production, which serves real incident rows there (`classification: "dead"`, `detected_at`, `endpoint_id`, …). Under-typings: **50**, down one.

## The walk is driven by the SERVED type, and that is the whole correctness argument

The first version walked the answer as the **generated** type. Where the two schemas disagree about a field's type that invents findings: it reported 18 `EndpointIncident` fields as null on 232 rows for a path production does not expose at all (`GlobalIncidents` has no `incidents` field — the query 400s).

The answer is shaped by the published schema, so the published type describes it, and a field is judged only when the generated type has one of the same name. A test drives exactly that case.

## Tests

Five, every one against a fetch double rather than the live surface:

- a null under a generated non-null is reported, with `via` naming the query that found it — a finding you cannot reproduce is not a finding
- a real value is not a finding, and the field is counted as observed
- a GraphQL error is a **skip**, not a finding: a field that errors says nothing about its producer's nulls, and counting it either way is a lie in one direction
- a field neither schema declares is not judged (the regression above)
- a null inside a **list row** is found, not just at the top level

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `validate:graphql-component-parity` — 330 mirrors / 2574 fields / 42 projections / 25 pagination views / 194 drops / **50** under-typings, OK
- `validate:published-names` — 362 component names, 323 published types, 0 resolver-built
- `validate:contract-drift`, `validate:graphql-types-drift`, `validate:graphql-route-parity` (164 pairs / 1193 fields / 0 divergences), `validate:graphql-hand-written-checks`, `validate:graphql-query-arguments` — pass
- `npx vitest run` — **803 files, 18,513 passed, 11 skipped, 0 failed**
- rebased and re-verified on current main

The only `src/**` change is the SDL string — no executable line — so there is no `codecov/patch` surface in this diff.

Refs #10214.
