### PR TITLE
data(sn51): Lium revenue provenance, and the two things the endpoint does not say

### DIFF
--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -170,6 +170,11 @@
       "id": "sn-51-lium-executor-stats",
       "kind": "data-artifact",
       "name": "Lium executor GPU utilization statistics",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived",
+        "source_url": "https://lium.io/api/openapi.json"
+      },
       "notes": "Public no-auth GET /api/executors/stats on lium.io returning a JSON dataset of live GPU-rental statistics aggregated per GPU type across the SN51 lium.io compute marketplace (gpu_type, rented_count, all_count, utilization percentage). Documented as a security-free public endpoint in the official Lium Backend API OpenAPI spec. Verified 200 application/json.",
       "probe": {
         "enabled": true,
@@ -222,7 +227,19 @@
       "id": "sn-51-lium-revenue-for-validators",
       "kind": "data-artifact",
       "name": "Lium per-validator revenue history",
-      "notes": "Public no-auth GET /billing/revenue-for-validators on the Lium Backend API, returning monthly revenue totals keyed by validator coldkey (an already-public on-chain SS58 address) for the SN51 lium.io compute marketplace. Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints.",
+      "revenue": {
+        "role": "external-revenue",
+        "provenance": "probe-derived",
+        "currency": "USD",
+        "grain": "monthly",
+        "fields": {
+          "date": "$key",
+          "amount": "$value"
+        },
+        "circularity": "external",
+        "source_url": "https://lium.io/api/openapi.json"
+      },
+      "notes": "Public no-auth GET /billing/revenue-for-validators on the Lium Backend API, returning monthly revenue totals keyed by validator coldkey (an already-public on-chain SS58 address) for the SN51 lium.io compute marketplace. Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints. REVENUE SEMANTICS, two unresolved points recorded rather than guessed (#10450). (1) The OpenAPI summary is bare -- \"Revenue For Validators\" -- and does not say whether a figure is platform revenue ATTRIBUTED to a validator or the validator's own CUT of it. The two differ by the take rate, so the magnitude attributed to this subnet depends on which it is. Resolving it needs an operator statement; until then the figure must not be published as a coverage ratio. (2) circularity is external on the reasoning that end customers rent GPUs for fiat and validators are the billing rail, not the source of funds -- the money originates outside Bittensor either way. PAYLOAD SHAPE: the response is a nested map {month: {validator_coldkey: amount}}, so there is no flat field name to point `fields` at; `$key`/`$value` is the keyed-map convention pending the schema gap tracked separately.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
`/billing/revenue-for-validators` is public, probed, and carries **20 months** of monthly USD totals back to `2025-01`. Declared `external-revenue` / `probe-derived` / monthly.

## circularity: external — with the reasoning recorded

End customers rent GPUs for fiat, and validators are the billing rail rather than the source of funds. The money originates outside Bittensor on either reading of who ultimately holds it. #10450 asked for the reasoning rather than just the verdict, so it is in the surface notes.

## Two things the endpoint does not say

Both written into the notes instead of guessed:

**1. Whose revenue is it?** The OpenAPI summary is bare — `"Revenue For Validators"` — and never distinguishes platform revenue *attributed to* a validator from the validator's own *cut* of it. Those differ by the take rate, so which one it is changes the magnitude attributed to this subnet. Resolving it needs an operator statement, and **until then the figure must not be published as a coverage ratio.**

**2. The payload is not flat.** The response is a nested map `{month: {validator_coldkey: amount}}`, so there is no flat field name for `fields` to point at. `$key`/`$value` records the keyed-map convention. The schema gap it exposes is filed separately — #10441 shipped assuming a flat record, and Lium is the first surface to prove otherwise.

## For context, not for publication

At 2026-07's $604,678.83/month against SN51's 383.7 TAO/day, the ratio would be roughly **25% coverage / 3.9:1** — notably better than SN64's 8:1. That number is *not* being declared anywhere in this PR, because point (1) above is unresolved and the take rate could move it substantially.

`/executors/stats` is `usage-proxy`: GPU rental counts and utilisation, no money.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) — pass
- prettier clean; 18 insertions, 1 removal (the removal is the notes line being extended)

Closes #10450
