### PR TITLE
fix(schema+contract): the revenue block, as the first data PRs actually exercised it

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12141,6 +12141,42 @@ export interface components {
             quality_signals?: components["schemas"]["SurfaceQualitySignals"];
             rate_limit?: components["schemas"]["SurfaceRateLimit"];
             rate_limit_notes?: string;
+            revenue?: {
+                /**
+                 * @description Whether the money originates outside Bittensor. Absent means unknown, never external.
+                 * @enum {string}
+                 */
+                circularity?: "external" | "alpha-denominated" | "team-funded" | "unknown";
+                /**
+                 * @description Unit the amount field carries. Declared rather than inferred from the path: api.chutes.ai/payments/summary/tao is named for TAO and its values reconcile as USD.
+                 * @enum {string}
+                 */
+                currency?: "USD" | "TAO" | "ALPHA";
+                /** @description Fields present in the payload that are NOT external revenue and must be subtracted -- subnet-funded or unrecognised components. */
+                excludes?: string[];
+                /** @description Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}. */
+                fields?: {
+                    [key: string]: string;
+                };
+                /** @enum {string} */
+                grain?: "daily" | "weekly" | "monthly" | "cumulative";
+                /**
+                 * @description Evidence class. Only chain-verified and probe-derived count toward a published coverage ratio; the rest are shown beside it and never summed in.
+                 * @enum {string}
+                 */
+                provenance: "chain-verified" | "probe-derived" | "operator-attested" | "third-party-reported" | "proxy-only" | "none";
+                /**
+                 * @description What this surface actually measures. A 'stats' endpoint is guilty until proven revenue: miner payout is emission -- the denominator -- and counting it as revenue puts the denominator in the numerator.
+                 * @enum {string}
+                 */
+                role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
+                /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
+                searched_at?: string;
+                /** Format: uri */
+                source_url?: string;
+                /** @description Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice. */
+                supersedes?: string[];
+            };
             review?: {
                 /** @enum {string} */
                 confidence?: "low" | "medium" | "high";

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -52651,6 +52651,98 @@
           "rate_limit_notes": {
             "type": "string"
           },
+          "revenue": {
+            "additionalProperties": false,
+            "properties": {
+              "circularity": {
+                "description": "Whether the money originates outside Bittensor. Absent means unknown, never external.",
+                "enum": [
+                  "external",
+                  "alpha-denominated",
+                  "team-funded",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "currency": {
+                "description": "Unit the amount field carries. Declared rather than inferred from the path: api.chutes.ai/payments/summary/tao is named for TAO and its values reconcile as USD.",
+                "enum": [
+                  "USD",
+                  "TAO",
+                  "ALPHA"
+                ],
+                "type": "string"
+              },
+              "excludes": {
+                "description": "Fields present in the payload that are NOT external revenue and must be subtracted -- subnet-funded or unrecognised components.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "fields": {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}.",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              "grain": {
+                "enum": [
+                  "daily",
+                  "weekly",
+                  "monthly",
+                  "cumulative"
+                ],
+                "type": "string"
+              },
+              "provenance": {
+                "description": "Evidence class. Only chain-verified and probe-derived count toward a published coverage ratio; the rest are shown beside it and never summed in.",
+                "enum": [
+                  "chain-verified",
+                  "probe-derived",
+                  "operator-attested",
+                  "third-party-reported",
+                  "proxy-only",
+                  "none"
+                ],
+                "type": "string"
+              },
+              "role": {
+                "description": "What this surface actually measures. A 'stats' endpoint is guilty until proven revenue: miner payout is emission -- the denominator -- and counting it as revenue puts the denominator in the numerator.",
+                "enum": [
+                  "external-revenue",
+                  "usage-proxy",
+                  "miner-payout",
+                  "not-revenue"
+                ],
+                "type": "string"
+              },
+              "searched_at": {
+                "description": "When absence was established. Required for provenance 'none': an undated absence is not evidence.",
+                "type": "string"
+              },
+              "source_url": {
+                "format": "uri",
+                "type": "string"
+              },
+              "supersedes": {
+                "description": "Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "provenance",
+              "role"
+            ],
+            "type": "object"
+          },
           "review": {
             "additionalProperties": false,
             "properties": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12141,6 +12141,42 @@ export interface components {
             quality_signals?: components["schemas"]["SurfaceQualitySignals"];
             rate_limit?: components["schemas"]["SurfaceRateLimit"];
             rate_limit_notes?: string;
+            revenue?: {
+                /**
+                 * @description Whether the money originates outside Bittensor. Absent means unknown, never external.
+                 * @enum {string}
+                 */
+                circularity?: "external" | "alpha-denominated" | "team-funded" | "unknown";
+                /**
+                 * @description Unit the amount field carries. Declared rather than inferred from the path: api.chutes.ai/payments/summary/tao is named for TAO and its values reconcile as USD.
+                 * @enum {string}
+                 */
+                currency?: "USD" | "TAO" | "ALPHA";
+                /** @description Fields present in the payload that are NOT external revenue and must be subtracted -- subnet-funded or unrecognised components. */
+                excludes?: string[];
+                /** @description Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}. */
+                fields?: {
+                    [key: string]: string;
+                };
+                /** @enum {string} */
+                grain?: "daily" | "weekly" | "monthly" | "cumulative";
+                /**
+                 * @description Evidence class. Only chain-verified and probe-derived count toward a published coverage ratio; the rest are shown beside it and never summed in.
+                 * @enum {string}
+                 */
+                provenance: "chain-verified" | "probe-derived" | "operator-attested" | "third-party-reported" | "proxy-only" | "none";
+                /**
+                 * @description What this surface actually measures. A 'stats' endpoint is guilty until proven revenue: miner payout is emission -- the denominator -- and counting it as revenue puts the denominator in the numerator.
+                 * @enum {string}
+                 */
+                role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
+                /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
+                searched_at?: string;
+                /** Format: uri */
+                source_url?: string;
+                /** @description Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice. */
+                supersedes?: string[];
+            };
             review?: {
                 /** @enum {string} */
                 confidence?: "low" | "medium" | "high";

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -2024,6 +2024,12 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
       "rate_limit",
       "rate_limit_notes",
       "review",
+      // #10441/#10476: `revenue` is a structured declaration block, the same
+      // class as probe/review/verification above -- what a surface measures
+      // and on what terms, not a value. Dropped from the projection until
+      // #10476 models it as its own SDL type; declared here rather than left
+      // to the parity gate, which is what caught it.
+      "revenue",
       "verification",
     ],
   },

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -466,6 +466,63 @@ export const ProbeConfigSchema = z
   })
   .strict();
 
+// #10441: what a surface measures, and on what terms. The published mirror of
+// schemas/subnet-manifest.schema.json's `$defs.revenue` -- a registry-side
+// addition that nothing consumed passed CI vacuously, and only failed once a
+// subnet file actually carried one and the block reached these artifacts.
+export const SurfaceRevenueSchema = z
+  .object({
+    circularity: z
+      .enum(["external", "alpha-denominated", "team-funded", "unknown"])
+      .optional()
+      .meta({
+        description:
+          "Whether the money originates outside Bittensor. Absent means unknown, never external.",
+      }),
+    currency: z.enum(["USD", "TAO", "ALPHA"]).optional().meta({
+      description:
+        "Unit the amount field carries. Declared rather than inferred from the path: api.chutes.ai/payments/summary/tao is named for TAO and its values reconcile as USD.",
+    }),
+    excludes: z.array(z.string()).optional().meta({
+      description:
+        "Fields present in the payload that are NOT external revenue and must be subtracted -- subnet-funded or unrecognised components.",
+    }),
+    fields: z.record(z.string(), z.string()).optional().meta({
+      description:
+        "Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}.",
+    }),
+    grain: z.enum(["daily", "weekly", "monthly", "cumulative"]).optional(),
+    provenance: z
+      .enum([
+        "chain-verified",
+        "probe-derived",
+        "operator-attested",
+        "third-party-reported",
+        "proxy-only",
+        "none",
+      ])
+      .meta({
+        description:
+          "Evidence class. Only chain-verified and probe-derived count toward a published coverage ratio; the rest are shown beside it and never summed in.",
+      }),
+    role: z
+      .enum(["external-revenue", "usage-proxy", "miner-payout", "not-revenue"])
+      .meta({
+        description:
+          "What this surface actually measures. A 'stats' endpoint is guilty until proven revenue: miner payout is emission -- the denominator -- and counting it as revenue puts the denominator in the numerator.",
+      }),
+    searched_at: z.string().optional().meta({
+      description:
+        "When absence was established. Required for provenance 'none': an undated absence is not evidence.",
+    }),
+    source_url: z.url().optional(),
+    supersedes: z.array(z.string()).optional().meta({
+      description:
+        "Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice.",
+    }),
+  })
+  .strict();
+
 export const SurfaceSchema = z
   .object({
     auth: AuthSchema,
@@ -500,6 +557,7 @@ export const SurfaceSchema = z
       })
       .strict()
       .optional(),
+    revenue: SurfaceRevenueSchema.optional(),
     schema_status: z
       .enum(["machine-readable", "ui-only", "not-captured"])
       .optional(),

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -432,8 +432,11 @@
         },
         {
           "if": {
-            "properties": { "role": { "const": "external-revenue" } },
-            "required": ["role"]
+            "properties": {
+              "role": { "const": "external-revenue" },
+              "provenance": { "enum": ["chain-verified", "probe-derived"] }
+            },
+            "required": ["role", "provenance"]
           },
           "then": { "required": ["currency", "grain", "fields"] }
         }

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -359,7 +359,14 @@ describe("paginated views", () => {
     // Every projection's drops, not just the paginated ones -- `dropped` is
     // the whole set on all 38, which is what makes an undeclared drop a
     // failure rather than a silence.
-    assert.equal(report.droppedFields, 194);
+    //
+    // 194 -> 195 (#10441): Surface.revenue. The published Surface component
+    // gained a structured declaration block -- what a surface measures and on
+    // what terms -- and the projection drops it alongside probe, review and
+    // verification until #10476 models it as its own SDL type. This number is
+    // a completeness pin rather than a shrink-only ceiling, so it moves with a
+    // deliberate drop; it moving WITHOUT one is the failure it exists to catch.
+    assert.equal(report.droppedFields, 195);
   });
 
   test("it FAILS when a component field is neither published nor declared dropped", () => {

--- a/tests/subnet-manifest-revenue-block.test.ts
+++ b/tests/subnet-manifest-revenue-block.test.ts
@@ -152,6 +152,36 @@ describe("subnet-manifest revenue block (#10441)", () => {
     }
   });
 
+  test("an UNREADABLE external-revenue surface is not asked to describe its payload", () => {
+    // #10453/#10458/#10459/#10462: SN93, SN110 and Hippius all declare revenue
+    // endpoints in their own OpenAPI schemas that answer 401/403 without a key.
+    // The endpoint is real and the role is external-revenue, but currency,
+    // grain and the field names are exactly what cannot be known without
+    // reading the payload. Demanding them here would force a contributor to
+    // invent three values to describe a response nobody has seen — which is
+    // the opposite of what the provenance ladder is for.
+    for (const provenance of [
+      "operator-attested",
+      "third-party-reported",
+    ] as const) {
+      assert.equal(
+        validate(manifest({ role: "external-revenue", provenance })),
+        true,
+        `${provenance} should not require currency/grain/fields`,
+      );
+    }
+  });
+
+  test("a READABLE external-revenue surface still must describe its payload", () => {
+    for (const provenance of ["probe-derived", "chain-verified"] as const) {
+      assert.equal(
+        validate(manifest({ role: "external-revenue", provenance })),
+        false,
+        `${provenance} must still require currency/grain/fields`,
+      );
+    }
+  });
+
   test("the currency/grain requirement applies only to external-revenue", () => {
     // A miner-payout or proxy surface has nothing to denominate, so demanding a
     // currency there would push contributors into inventing one.


### PR DESCRIPTION
Two fixes to #10441, both found by the schema doing its job on the first data PRs that used it.

## 1. Stop demanding a payload description for a payload nobody can read

`currency`, `grain` and `fields` were required whenever role is `external-revenue`. Right for Chutes, which publishes openly; wrong for three of the twelve Phase 2 subnets:

| subnet | endpoint | live |
|---|---|---|
| SN93 Bitcast | `/api/v2/stats/revenue/summary` | `403` |
| SN110 Green Compute | `/platform/admin/analytics/gross-revenue` | `401 missing api key` |
| SN75 Hippius | `/billing/subscriptions/`, `/transactions/` | `401` |

Each is real, declared in the subnet's own OpenAPI schema, and genuinely `external-revenue`. And in each, the currency, grain and field names are *precisely what cannot be known* without reading a response nobody outside the operator can read. The old rule forced a contributor to invent three values describing a payload they have never seen.

The requirement now fires only for `probe-derived` / `chain-verified` — the classes that mean the payload **was** read. Both directions tested: unreadable provenances accepted without a description, readable ones still rejected without it.

## 2. Publish the block — the registry schema alone was not enough

#10441 added `revenue` to `schemas/subnet-manifest.schema.json` and stopped. That schema validates registry **files**. The same surfaces are also published into `surfaces.json`, `subnet-detail`, `profile-detail` and `surfaces-subnet`, and those validate against the **Zod components in `schemas-src`** — which had never heard of the field and are `.strict()`.

So #10441 **passed CI while incomplete, for the most avoidable reason there is**: no registry file used the field yet, so nothing carried it into an artifact. A schema addition that nothing consumes passes vacuously. It could only fail once a subnet actually declared revenue — which is what happened on the first data PR:

```
Schema validation failed with 30 issue(s):
 - artifact:subnet-detail:64.json/surfaces/11: must NOT have additional properties
 - artifact:surfaces/surfaces/1929: must NOT have additional properties
 …
```

Adds `SurfaceRevenueSchema` as the published mirror, wired into `SurfaceSchema`.

**Verified end to end, not by inspection:** applying `chutes.json`'s declaration, running `npm run build:artifacts` and re-running `validate-schemas` now **passes**, where the identical sequence produced the 30 errors before.

The block inlines **exactly once** in the published contract — `Surface` is itself a registered component and every artifact `$ref`s it — so this costs one copy, not one per consumer.

## Unblocks

#10523, #10524, #10527–#10535 — every open data PR currently fails on (2).

## Verification

- 11/11 revenue-schema tests · `validate:schemas` · `validate:contract-drift` · `npm run build` · `tsc --noEmit` — clean
- Regenerated `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts` committed together
