### PR TITLE
data(sn19): a rate card is not revenue

### DIFF
--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -187,7 +187,7 @@
       "id": "sn-19-blockmachine-epochs-catalog",
       "kind": "data-artifact",
       "name": "BlockMachine epochs catalog",
-      "notes": "Public no-auth BlockMachine epochs listing — every epoch's id/number, participating gateway_ids, and per-gateway manifest (request log files + finalized CU-allocation objects). The full-history catalog behind the already-registered latest-finalized/current single-epoch endpoints; declared as GET /epochs (\"List Epochs\") in the operator's OpenAPI (source).",
+      "notes": "Public no-auth BlockMachine epochs listing \u2014 every epoch's id/number, participating gateway_ids, and per-gateway manifest (request log files + finalized CU-allocation objects). The full-history catalog behind the already-registered latest-finalized/current single-epoch endpoints; declared as GET /epochs (\"List Epochs\") in the operator's OpenAPI (source).",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -721,7 +721,12 @@
       "id": "sn-19-blockmachine-pricing-rules",
       "kind": "subnet-api",
       "name": "BlockMachine pricing rules",
-      "notes": "Delete Pricing Rule operation on the BlockMachine API (DELETE, GET, POST /pricing/rules), declared in the subnet's own OpenAPI spec at https://api.blockmachine.io/openapi.json. The spec declares the HTTPBearer security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET returns HTTP 401 {\"detail\":\"Not authenticated\"}, confirming the gate.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "operator-attested",
+        "source_url": "https://api.blockmachine.io/openapi.json"
+      },
+      "notes": "Delete Pricing Rule operation on the BlockMachine API (DELETE, GET, POST /pricing/rules), declared in the subnet's own OpenAPI spec at https://api.blockmachine.io/openapi.json. The spec declares the HTTPBearer security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3). Live-verified 2026-07-21: an unauthenticated GET returns HTTP 401 {\"detail\":\"Not authenticated\"}, confirming the gate. REVENUE ROLE (#10452): not-revenue. /pricing/rules is a rate card, not a revenue figure, and it answers 401 unauthenticated. No public surface on this subnet carries an external-revenue number as of 2026-08-10. REVENUE ROLE (#10452): not-revenue. /pricing/rules is a rate card, not a revenue figure, and it answers 401 unauthenticated. No public surface on this subnet carries an external-revenue number as of 2026-08-10.",
       "probe": {
         "enabled": false,
         "expect": "json",


### PR DESCRIPTION
SN19's only revenue-shaped surface is `/pricing/rules`, which answers `401 Not authenticated`.

A rate card is what a customer *would* pay, not what the subnet *did* earn — those are different numbers even when both are real. Recorded as `not-revenue` / `operator-attested` against the subnet's own OpenAPI schema.

**No public surface on SN19 carries an external-revenue figure as of 2026-08-10.**

## Why a negative verdict is the deliverable

Classifying a surface `not-revenue` or `miner-payout` is a **successful** outcome under #10439 — it retires a false positive permanently instead of leaving it to be re-investigated every sweep.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) — pass
- Every `probe-derived` claim sits on a surface with `probe.enabled: true` and `auth_required: false`; unprobed and auth-gated surfaces are `operator-attested` with a `source_url`
- Purely additive diff

Closes #10452
