### PR TITLE
data(sn50): a data product behind an API key is not a revenue report

### DIFF
--- a/registry/subnets/synth.json
+++ b/registry/subnets/synth.json
@@ -68,7 +68,7 @@
       "id": "sn-50-synth-openapi",
       "kind": "openapi",
       "name": "Synth API OpenAPI spec",
-      "notes": "Public Swagger 2.0 spec for the Synth API (48 unauthenticated GET endpoints — probabilistic price forecasts, market insights, leaderboards). The official synth-subnet README documents the API docs at api.synthdata.co/docs.",
+      "notes": "Public Swagger 2.0 spec for the Synth API (48 unauthenticated GET endpoints \u2014 probabilistic price forecasts, market insights, leaderboards). The official synth-subnet README documents the API docs at api.synthdata.co/docs.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -162,7 +162,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -170,7 +170,7 @@
       "id": "sn-50-synth-insights-limitless-15min",
       "kind": "subnet-api",
       "name": "Synth GET insights limitless 15min",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/limitless/15min on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/limitless/15min on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -191,7 +191,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -199,7 +199,7 @@
       "id": "sn-50-synth-insights-limitless-daily",
       "kind": "subnet-api",
       "name": "Synth GET insights limitless daily",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/limitless/daily on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/limitless/daily on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -220,7 +220,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -228,7 +228,7 @@
       "id": "sn-50-synth-insights-limitless-hourly",
       "kind": "subnet-api",
       "name": "Synth GET insights limitless hourly",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/limitless/hourly on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/limitless/hourly on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -249,7 +249,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -257,7 +257,7 @@
       "id": "sn-50-synth-insights-liquidation",
       "kind": "subnet-api",
       "name": "Synth GET insights liquidation",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/liquidation on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/liquidation on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -278,7 +278,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -307,7 +307,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -315,7 +315,7 @@
       "id": "sn-50-synth-insights-lp-probabilities",
       "kind": "subnet-api",
       "name": "Synth GET insights lp probabilities",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/lp-probabilities on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/lp-probabilities on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -336,7 +336,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -344,7 +344,12 @@
       "id": "sn-50-synth-insights-option-pricing",
       "kind": "subnet-api",
       "name": "Synth GET insights option pricing",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/option-pricing on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "operator-attested",
+        "source_url": "https://api.synthdata.co/swagger.json"
+      },
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/option-pricing on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today. REVENUE ROLE (#10456): not-revenue. This is a data PRODUCT (option pricing insights) behind an API key, not a report of what the subnet earns. No public surface carries an external-revenue figure as of 2026-08-10. REVENUE ROLE (#10456): not-revenue. This is a data PRODUCT (option pricing insights) behind an API key, not a report of what the subnet earns. No public surface carries an external-revenue figure as of 2026-08-10.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -365,7 +370,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -373,7 +378,7 @@
       "id": "sn-50-synth-insights-polymarket-above-daily",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket above daily",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/above/daily on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/above/daily on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -394,7 +399,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -402,7 +407,7 @@
       "id": "sn-50-synth-insights-polymarket-hit-daily",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket hit daily",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/hit/daily on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/hit/daily on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -423,7 +428,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -431,7 +436,7 @@
       "id": "sn-50-synth-insights-polymarket-range",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket range",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/range on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/range on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -452,7 +457,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -460,7 +465,7 @@
       "id": "sn-50-synth-insights-polymarket-range-daily",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket range daily",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/range/daily on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/range/daily on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -481,7 +486,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -489,7 +494,7 @@
       "id": "sn-50-synth-insights-polymarket-up-down-15min",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket up down 15min",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/15min on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/15min on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -510,7 +515,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -518,7 +523,7 @@
       "id": "sn-50-synth-insights-polymarket-up-down-5min",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket up down 5min",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/5min on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/5min on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -539,7 +544,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -547,7 +552,7 @@
       "id": "sn-50-synth-insights-polymarket-up-down-daily",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket up down daily",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/daily on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/daily on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -568,7 +573,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -576,7 +581,7 @@
       "id": "sn-50-synth-insights-polymarket-up-down-hourly",
       "kind": "subnet-api",
       "name": "Synth GET insights polymarket up down hourly",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/hourly on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/polymarket/up-down/hourly on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -597,7 +602,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -605,7 +610,7 @@
       "id": "sn-50-synth-insights-prediction-percentiles",
       "kind": "subnet-api",
       "name": "Synth GET insights prediction percentiles",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/prediction-percentiles on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /insights/prediction-percentiles on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -626,7 +631,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\".",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\".",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -656,7 +661,7 @@
       "id": "sn-50-synth-rewards-scores",
       "kind": "subnet-api",
       "name": "Synth GET rewards scores",
-      "notes": "GET /rewards/scores on api.synthdata.co — public, no auth. Required query params: from, to. Live-verified 2026-07-21 with a real, valid parameter set. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /rewards/scores on api.synthdata.co \u2014 public, no auth. Required query params: from, to. Live-verified 2026-07-21 with a real, valid parameter set. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -678,7 +683,7 @@
       "id": "sn-50-synth-v2-leaderboard-historical",
       "kind": "subnet-api",
       "name": "Synth GET v2 leaderboard historical",
-      "notes": "GET /v2/leaderboard/historical on api.synthdata.co — public, no auth. Required query params: start_time, end_time. Live-verified 2026-07-21 with a real, valid parameter set. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /v2/leaderboard/historical on api.synthdata.co \u2014 public, no auth. Required query params: start_time, end_time. Live-verified 2026-07-21 with a real, valid parameter set. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -700,7 +705,7 @@
       "id": "sn-50-synth-v2-meta-leaderboard-historical",
       "kind": "subnet-api",
       "name": "Synth GET v2 meta leaderboard historical",
-      "notes": "GET /v2/meta-leaderboard/historical on api.synthdata.co — public, no auth. Required query params: start_time. Not individually curled — no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /v2/meta-leaderboard/historical on api.synthdata.co \u2014 public, no auth. Required query params: start_time. Not individually curled \u2014 no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -721,7 +726,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: asset, time_increment, time_length.",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: asset, time_increment, time_length.",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -750,7 +755,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: miner, asset, start_time, time_increment, time_length.",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: miner, asset, start_time, time_increment, time_length.",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -758,7 +763,7 @@
       "id": "sn-50-synth-v2-prediction-historical",
       "kind": "subnet-api",
       "name": "Synth GET v2 prediction historical",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /v2/prediction/historical on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /v2/prediction/historical on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -779,7 +784,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: miner, asset, time_increment, time_length.",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: miner, asset, time_increment, time_length.",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -808,7 +813,7 @@
         "location": "header",
         "name": "Authorization",
         "scheme": "api-key",
-        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block — Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: asset.",
+        "scopes_note": "Derived from the subnet's own Swagger 2.0 schema: a required `Authorization` header parameter (not a formal OpenAPI `security` block \u2014 Synth's own convention), example value \"Apikey MY_API_KEY\". Also requires query params: asset.",
         "value_format": "Apikey <key>"
       },
       "auth_required": true,
@@ -816,7 +821,7 @@
       "id": "sn-50-synth-v2-prediction-metamodel-historical",
       "kind": "subnet-api",
       "name": "Synth GET v2 prediction metamodel historical",
-      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /v2/prediction/metamodel/historical on api.synthdata.co. Not individually curled — same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "notes": "Auth-gated (API key via required Authorization header, Phase 3 credential passthrough, not built yet) GET /v2/prediction/metamodel/historical on api.synthdata.co. Not individually curled \u2014 same required `Authorization` header as the verified `sn-50-synth-insights-volatility` (400 \"missing key in request header\"), declared identically in the schema. Path/shape from the subnet's own Swagger schema; registered per the registry's full-API-parity policy (metagraphed#7063) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -838,7 +843,7 @@
       "id": "sn-50-synth-validation-miner",
       "kind": "subnet-api",
       "name": "Synth GET validation miner",
-      "notes": "GET /validation/miner on api.synthdata.co — public, no auth. Required query params: uid. Live-verified 2026-07-21 with a real, valid parameter set. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /validation/miner on api.synthdata.co \u2014 public, no auth. Required query params: uid. Live-verified 2026-07-21 with a real, valid parameter set. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -860,7 +865,7 @@
       "id": "sn-50-synth-validation-prompts",
       "kind": "subnet-api",
       "name": "Synth GET validation prompts",
-      "notes": "GET /validation/prompts on api.synthdata.co — public, no auth. Required query params: from, to, time_increment, time_length. Not individually curled — no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /validation/prompts on api.synthdata.co \u2014 public, no auth. Required query params: from, to, time_increment, time_length. Not individually curled \u2014 no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -882,7 +887,7 @@
       "id": "sn-50-synth-validation-realized-path",
       "kind": "subnet-api",
       "name": "Synth GET validation realized path",
-      "notes": "GET /validation/realized-path on api.synthdata.co — public, no auth. Required query params: start_time, time_increment, time_length. Not individually curled — no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /validation/realized-path on api.synthdata.co \u2014 public, no auth. Required query params: start_time, time_increment, time_length. Not individually curled \u2014 no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -904,7 +909,7 @@
       "id": "sn-50-synth-validation-scores-historical",
       "kind": "subnet-api",
       "name": "Synth GET validation scores historical",
-      "notes": "GET /validation/scores/historical on api.synthdata.co — public, no auth. Required query params: from, to. Not individually curled — no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) — already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
+      "notes": "GET /validation/scores/historical on api.synthdata.co \u2014 public, no auth. Required query params: from, to. Not individually curled \u2014 no auth declared in the schema, same as the verified public query-param endpoints above. Registered with the fixed base url (no query string baked in) per the registry's full-API-parity policy (metagraphed#7063) \u2014 already callable today via call_subnet_surface's own query argument. probe.enabled:false is the safer default here: an auto-probe with no query params would just 400.",
       "probe": {
         "enabled": false,
         "expect": "json",


### PR DESCRIPTION
SN50's only revenue-shaped surface is `/insights/option-pricing`, which answers `400 missing key in request header`.

It is a **data product** the subnet sells — option-pricing insights — not a report of what the subnet earns from selling it. Those are opposite sides of the same transaction, and only one of them is revenue.

**No public surface on SN50 carries an external-revenue figure as of 2026-08-10.**

## Why a negative verdict is the deliverable

Classifying a surface `not-revenue` or `miner-payout` is a **successful** outcome under #10439 — it retires a false positive permanently instead of leaving it to be re-investigated every sweep.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) — pass
- Every `probe-derived` claim sits on a surface with `probe.enabled: true` and `auth_required: false`; unprobed and auth-gated surfaces are `operator-attested` with a `source_url`
- Purely additive diff

Closes #10456
