### PR TITLE
data(sn62): the price is denominated in the subnet's own alpha

### DIFF
--- a/registry/subnets/ridges.json
+++ b/registry/subnets/ridges.json
@@ -52,7 +52,7 @@
       "authority": "community",
       "id": "sn-62-ridges-subnet-api",
       "kind": "subnet-api",
-      "name": "Ridges API — top agents leaderboard (retrieval)",
+      "name": "Ridges API \u2014 top agents leaderboard (retrieval)",
       "notes": "Public, unauthenticated read endpoint on the Ridges backend API: the live leaderboard of top-scored SWE agents (miner_hotkey, name, version_num, final_score). agent-upload.ridges.ai is the DEFAULT_API_BASE_URL the official CLI uses (ridgesai/ridges miners/cli/commands/upload.py) and serves the platform's read routes; /retrieval/top-agents is defined in api/endpoints/retrieval.py (no auth) and mounted at /retrieval in api/src/main.py. OpenAPI 3.1.0 spec at /openapi.json.",
       "probe": {
         "enabled": true,
@@ -109,7 +109,11 @@
       "id": "sn-62-ridges-eval-pricing",
       "kind": "subnet-api",
       "name": "Ridges eval pricing",
-      "notes": "Public no-auth GET returning the current evaluation submission price (amount_rao, send_address). Documented in the subnet's own OpenAPI schema.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "probe-derived"
+      },
+      "notes": "Public no-auth GET returning the current evaluation submission price (amount_rao, send_address). Documented in the subnet's own OpenAPI schema. REVENUE ROLE (#10457): not-revenue. {amount_alpha_rao, payment_netuid} is the PRICE of submitting an evaluation, not a total earned. Worth noting for later: the price is denominated in the subnet's own alpha, so any revenue eventually derived from this rail is circularity: alpha-denominated, not external. REVENUE ROLE (#10457): not-revenue. {amount_alpha_rao, payment_netuid} is the PRICE of submitting an evaluation, not a total earned. Worth noting for later: the price is denominated in the subnet's own alpha, so any revenue eventually derived from this rail is circularity: alpha-denominated, not external.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
`/upload/eval-pricing` returns `{amount_alpha_rao: 2237548967, payment_netuid: 62}` — the **price** of submitting an evaluation, not a total earned. `not-revenue`.

Worth recording for later: the price is denominated in **the subnet's own alpha**. Any revenue eventually derived from this rail is `circularity: alpha-denominated`, not external — users buy SN62 alpha to pay SN62, which is a closed loop rather than money entering the ecosystem. That distinction is why `circularity` exists and why it defaults to `unknown` rather than `external`.

## Why a negative verdict is the deliverable

Classifying a surface `not-revenue` or `miner-payout` is a **successful** outcome under #10439 — it retires a false positive permanently instead of leaving it to be re-investigated every sweep.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) — pass
- Every `probe-derived` claim sits on a surface with `probe.enabled: true` and `auth_required: false`; unprobed and auth-gated surfaces are `operator-attested` with a `source_url`
- Purely additive diff

Closes #10457
