### PR TITLE
data(sn103): the surface is gone, and it was payout anyway

### DIFF
--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -299,7 +299,7 @@
       "id": "sn-103-djinn-odds",
       "kind": "subnet-api",
       "name": "Djinn odds by sport",
-      "notes": "Public no-auth GET /api/odds on www.djinn.gg returning live odds for one sport. Requires query param `sport` (allowed keys listed in the 400 body when omitted). Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without sport returns HTTP 400. Live-verified 2026-07-21: no sport → 400; ?sport=basketball_nba → 200 JSON.",
+      "notes": "Public no-auth GET /api/odds on www.djinn.gg returning live odds for one sport. Requires query param `sport` (allowed keys listed in the 400 body when omitted). Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without sport returns HTTP 400. Live-verified 2026-07-21: no sport \u2192 400; ?sport=basketball_nba \u2192 200 JSON.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -324,7 +324,7 @@
       "id": "sn-103-djinn-genius-signals",
       "kind": "subnet-api",
       "name": "Djinn genius signals by address",
-      "notes": "Public no-auth GET /api/genius/signals on www.djinn.gg returning Genius-track signals for one Ethereum address. Requires query param `address`. Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without address returns HTTP 400. Live-verified 2026-07-21: no address → 400 {\"error\":\"invalid_address\",...}.",
+      "notes": "Public no-auth GET /api/genius/signals on www.djinn.gg returning Genius-track signals for one Ethereum address. Requires query param `address`. Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without address returns HTTP 400. Live-verified 2026-07-21: no address \u2192 400 {\"error\":\"invalid_address\",...}.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -349,7 +349,12 @@
       "id": "sn-103-djinn-genius-earnings",
       "kind": "subnet-api",
       "name": "Djinn genius earnings by address",
-      "notes": "Public no-auth GET /api/genius/earnings on www.djinn.gg returning Genius-track earnings for one Ethereum address. Requires query param `address`. Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without address returns HTTP 400. Live-verified 2026-07-21: no address → 400 {\"error\":\"invalid_address\",...}.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
+      "notes": "Public no-auth GET /api/genius/earnings on www.djinn.gg returning Genius-track earnings for one Ethereum address. Requires query param `address`. Callable via call_subnet_surface's `query` argument. probe.enabled:false because bare GET without address returns HTTP 400. Live-verified 2026-07-21: no address \u2192 400 {\"error\":\"invalid_address\",...}. REVENUE ROLE (#10461): none, searched 2026-08-10. www.djinn.gg 301-redirects to djinn.gg and the target returns the site's SPA HTML shell, not JSON -- the path is swallowed by the frontend router, so there is no earnings API here to read. 'earnings' would in any case be miner payout, not platform revenue. REVENUE ROLE (#10461): none, searched 2026-08-10. www.djinn.gg 301-redirects to djinn.gg and the target returns the site's SPA HTML shell, not JSON -- the path is swallowed by the frontend router, so there is no earnings API here to read. 'earnings' would in any case be miner payout, not platform revenue.",
       "probe": {
         "enabled": false,
         "expect": "json",


### PR DESCRIPTION
`www.djinn.gg/api/genius/earnings` 301-redirects to `djinn.gg/api/genius/earnings`, and the target returns the site's **SPA HTML shell**, not JSON — the path is swallowed by the frontend router. There is no earnings API there to read.

Recorded as `provenance: none` with `searched_at: 2026-08-10`. An undated absence is not evidence; a dated one is.

Separately, *earnings* on this subnet would be **miner payout** rather than platform revenue even if the endpoint were live — so this surface could not have contributed a coverage numerator either way.

## Why a negative verdict is the deliverable

Classifying a surface `not-revenue` or `miner-payout` is a **successful** outcome under #10439 — it retires a false positive permanently instead of leaving it to be re-investigated every sweep.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) — pass
- Every `probe-derived` claim sits on a surface with `probe.enabled: true` and `auth_required: false`; unprobed and auth-gated surfaces are `operator-attested` with a `source_url`
- Purely additive diff

Closes #10461
