### PR TITLE
feat(graphql): 20 Query fields can reach testnet, and the gate can see when one cannot

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3416,6 +3416,7 @@ export type QueryAgent_CatalogArgs = {
 
 
 export type QueryBlockArgs = {
+  network?: InputMaybe<Network>;
   ref: Scalars['String']['input'];
 };
 
@@ -3428,6 +3429,7 @@ export type QueryBlock_Chain_EventsArgs = {
 
 export type QueryBlock_EventsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   ref: Scalars['String']['input'];
 };
@@ -3435,6 +3437,7 @@ export type QueryBlock_EventsArgs = {
 
 export type QueryBlock_ExtrinsicsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   ref: Scalars['String']['input'];
 };
@@ -3449,9 +3452,15 @@ export type QueryBlocksArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   min_events?: InputMaybe<Scalars['Int']['input']>;
   min_extrinsics?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   spec_version?: InputMaybe<Scalars['Int']['input']>;
   to?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryBlocks_SummaryArgs = {
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3471,12 +3480,14 @@ export type QueryCandidatesArgs = {
 
 
 export type QueryChain_ActivityArgs = {
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
 
 export type QueryChain_Alpha_VolumeArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3495,6 +3506,7 @@ export type QueryChain_CallsArgs = {
   call_module?: InputMaybe<Scalars['String']['input']>;
   group_by?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3506,6 +3518,7 @@ export type QueryChain_Concentration_HistoryArgs = {
 
 export type QueryChain_DeregistrationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3531,6 +3544,7 @@ export type QueryChain_Events_StatsArgs = {
 export type QueryChain_FeesArgs = {
   call_module?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3554,6 +3568,7 @@ export type QueryChain_PrometheusArgs = {
 
 export type QueryChain_RegistrationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3567,6 +3582,7 @@ export type QueryChain_ServingArgs = {
 export type QueryChain_SignersArgs = {
   call_module?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   sort?: InputMaybe<Scalars['String']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3574,18 +3590,21 @@ export type QueryChain_SignersArgs = {
 
 export type QueryChain_Stake_FlowArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
 
 export type QueryChain_Stake_MovesArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
 
 export type QueryChain_Stake_TransfersArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3598,6 +3617,7 @@ export type QueryChain_Subnet_LifecycleArgs = {
 
 export type QueryChain_Transfer_PairsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   sort?: InputMaybe<Scalars['String']['input']>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
@@ -3605,6 +3625,7 @@ export type QueryChain_Transfer_PairsArgs = {
 
 export type QueryChain_TransfersArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -3636,6 +3657,11 @@ export type QueryCompareArgs = {
 export type QueryCompare_ValidatorsArgs = {
   hotkeys: Array<Scalars['String']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+};
+
+
+export type QueryCoverageArgs = {
+  network?: InputMaybe<Network>;
 };
 
 
@@ -3674,6 +3700,7 @@ export type QueryEconomicsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   order?: InputMaybe<Scalars['String']['input']>;
   q?: InputMaybe<Scalars['String']['input']>;
   registration_allowed?: InputMaybe<Scalars['Boolean']['input']>;
@@ -3788,6 +3815,7 @@ export type QueryExtrinsicsArgs = {
   cursor?: InputMaybe<Scalars['String']['input']>;
   from?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
+  network?: InputMaybe<Network>;
   offset?: InputMaybe<Scalars['Int']['input']>;
   signer?: InputMaybe<Scalars['String']['input']>;
   success?: InputMaybe<Scalars['Boolean']['input']>;
@@ -9605,7 +9633,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   block_events?: Resolver<ResolversTypes['BlockEvents'], ParentType, ContextType, RequireFields<QueryBlock_EventsArgs, 'ref'>>;
   block_extrinsics?: Resolver<ResolversTypes['BlockExtrinsics'], ParentType, ContextType, RequireFields<QueryBlock_ExtrinsicsArgs, 'ref'>>;
   blocks?: Resolver<ResolversTypes['BlockList'], ParentType, ContextType, Partial<QueryBlocksArgs>>;
-  blocks_summary?: Resolver<ResolversTypes['BlocksSummary'], ParentType, ContextType>;
+  blocks_summary?: Resolver<ResolversTypes['BlocksSummary'], ParentType, ContextType, Partial<QueryBlocks_SummaryArgs>>;
   build?: Resolver<ResolversTypes['BuildSummary'], ParentType, ContextType>;
   candidates?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryCandidatesArgs>>;
   chain_activity?: Resolver<ResolversTypes['ChainActivity'], ParentType, ContextType, Partial<QueryChain_ActivityArgs>>;
@@ -9641,7 +9669,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   compare?: Resolver<ResolversTypes['Compare'], ParentType, ContextType, RequireFields<QueryCompareArgs, 'netuids'>>;
   compare_validators?: Resolver<ResolversTypes['ValidatorComparison'], ParentType, ContextType, RequireFields<QueryCompare_ValidatorsArgs, 'hotkeys'>>;
   contracts?: Resolver<Maybe<ResolversTypes['Contracts']>, ParentType, ContextType>;
-  coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryCoverageArgs>>;
   coverage_depth?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryCoverage_DepthArgs>>;
   curation?: Resolver<ResolversTypes['CurationList'], ParentType, ContextType, Partial<QueryCurationArgs>>;
   domain_summary?: Resolver<ResolversTypes['DomainSummary'], ParentType, ContextType, RequireFields<QueryDomain_SummaryArgs, 'tag'>>;

--- a/scripts/validate-graphql-query-arguments.ts
+++ b/scripts/validate-graphql-query-arguments.ts
@@ -38,30 +38,13 @@ const OPENAPI_PATH = "public/metagraph/openapi.json";
  * argument. Closing one means adding the argument AND network-scoping the
  * resolver's tier read, which is #10394's work, not the generator's.
  *
- * THE LIST ONLY SHRINKS -- an entry whose field now takes `network` fails.
+ * THE LIST ONLY SHRINKS -- an entry whose field now takes `network` fails --
+ * and it is EMPTY as of #10394: all twenty forward the argument to their tier
+ * read AND to the cold-tier fallback below it, so the ladder cannot answer
+ * mainnet under a testnet label. A new entry here is a field that mirrors a
+ * route with a `/{network}/` twin and cannot reach it.
  */
-export const DECLARED_MISSING_NETWORK: readonly string[] = [
-  "block",
-  "block_events",
-  "block_extrinsics",
-  "blocks",
-  "blocks_summary",
-  "chain_activity",
-  "chain_alpha_volume",
-  "chain_calls",
-  "chain_deregistrations",
-  "chain_fees",
-  "chain_registrations",
-  "chain_signers",
-  "chain_stake_flow",
-  "chain_stake_moves",
-  "chain_stake_transfers",
-  "chain_transfer_pairs",
-  "chain_transfers",
-  "coverage",
-  "economics",
-  "extrinsics",
-];
+export const DECLARED_MISSING_NETWORK: readonly string[] = [];
 
 export interface ArgumentReport {
   /** Fields whose argument list the routes reproduce exactly. */

--- a/scripts/validate-graphql-route-parity.ts
+++ b/scripts/validate-graphql-route-parity.ts
@@ -22,7 +22,11 @@ import { DECLARED_ARGUMENTS } from "../schemas-src/graphql/argument-divergences.
 
 type Json = Record<string, unknown>;
 
-const SDL_PATH = "src/graphql-sdl.ts";
+// Overridable so a test can run the whole gate against a MUTATED schema and
+// watch it reject. A gate only ever run against a passing tree proves it runs,
+// not that it can fail -- and the failure mode of a schema comparison is
+// silence, which is exactly what this file's header warns about.
+const SDL_PATH = process.env.GRAPHQL_SDL_PATH || "src/graphql-sdl.ts";
 const OPENAPI_PATH = "public/metagraph/openapi.json";
 
 /**
@@ -459,6 +463,26 @@ for (const field of queryType.fields) {
       key,
       detail: `SDL types ${arg.name} as ${arg.type} but ${route} publishes ${jsonTypes.join("|")}`,
     });
+  }
+
+  // The `network` twin, in the direction the loop below structurally cannot
+  // see. On the twin path `network` is `in: "path"`, and on the base path it
+  // does not appear at all, so "the route has a twin and the field takes no
+  // network argument" was unrepresentable -- the forward rule above exempts a
+  // `network` argument BECAUSE the twin is how it is spelled, and the reverse
+  // check needed the same knowledge and did not have it. Twenty fields sat in
+  // that blind spot: testnet was reachable over REST and unreachable over
+  // GraphQL, and the gate reported zero divergences (#10394).
+  if (hasNetworkTwin(route) && !declaredArguments.has("network")) {
+    const key = `${field.name}.network`;
+    if (key in DECLARED_MISSING_ARGUMENTS) {
+      suppressedArguments.add(key);
+    } else {
+      argumentFindings.push({
+        key,
+        detail: `${route} has a /{network}/ twin and the SDL takes no network argument, so testnet is unreachable here`,
+      });
+    }
   }
 
   for (const [name, parameter] of published) {

--- a/src/chain-network.ts
+++ b/src/chain-network.ts
@@ -141,6 +141,13 @@ export function chainNetworkId(id: string | undefined): ChainNetworkId {
  * translation, never the gate. Silently defaulting an unvalidated string would
  * reintroduce #8804, where an unrecognised value took the testnet branch.
  */
+/** The path segment each network is spelled with -- the inverse of
+ * `chainNetworkFromChainName`, kept beside it so the two cannot drift. */
+export const CHAIN_NAME_BY_NETWORK: Readonly<Record<ChainNetworkId, string>> = {
+  mainnet: "finney",
+  testnet: "test",
+};
+
 export function chainNetworkFromChainName(
   chain: string | null | undefined,
 ): ChainNetworkId {
@@ -163,6 +170,31 @@ export function chainNetworkFromChainName(
  * at the front of the key, so the projections stay one prefix in the bucket
  * and a listing still groups them.
  */
+/**
+ * The `/api/v1/{network}/…` twin of a route path, for a network-scoped read.
+ *
+ * MAINNET KEEPS THE BASE PATH, the same asymmetry `networkKvKey`,
+ * `projectionKey` and `chainTable` use: a mainnet request reaches exactly the
+ * path it reached before, and testnet gets the twin the router already serves.
+ *
+ * Twenty GraphQL fields mirrored a route with such a twin and took no `network`
+ * argument at all, so testnet was reachable over REST and unreachable over
+ * GraphQL (#10394). This is the one place that spelling lives, so a resolver
+ * cannot get it subtly wrong -- and the cold-tier loaders each already take a
+ * `ChainNetworkId`, so the fallback follows the same network as the tier rather
+ * than silently answering mainnet.
+ */
+export function networkScopedRoute(
+  routePath: string,
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
+): string {
+  if (network === DEFAULT_CHAIN_NETWORK) return routePath;
+  const prefix = "/api/v1/";
+  return routePath.startsWith(prefix)
+    ? `${prefix}${CHAIN_NAME_BY_NETWORK[network]}/${routePath.slice(prefix.length)}`
+    : routePath;
+}
+
 export function projectionKey(
   artifactKey: string,
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -179,7 +179,7 @@ export const SDL = /* GraphQL */ `
     "Several validators side by side for a stake/delegate decision: each hotkey's take, estimated APY, nominator count, identity, and cross-subnet stake/emission/trust aggregates. hotkeys takes 1-16 distinct SS58 addresses (a real GraphQL list, like the sibling compare field's netuids, rather than REST's comma-separated string); the optional netuid adds each validator's membership row in that subnet. The validator equivalent of the compare field. Mirrors GET /api/v1/compare/validators."
     compare_validators(hotkeys: [String!]!, netuid: Int): ValidatorComparison!
     "The registry coverage summary: surface/subnet counts, domain coverage, and overall completeness across the whole Bittensor application layer. Null when the coverage artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_coverage MCP/REST shape. Mirrors GET /api/v1/coverage."
-    coverage: JSON
+    coverage(network: Network): JSON
     "The machine-usable coverage-depth scorecard and ranked enrichment queue: per-subnet tier/score/priority rows plus the ranked queue of enrichment targets. Null when the coverage-depth artifact has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the /api/v1/coverage-depth REST shape. Mirrors GET /api/v1/coverage-depth."
     coverage_depth(
       netuid: Int
@@ -402,6 +402,7 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
+      network: Network
     ): EconomicsList!
     "Curated public interface surfaces with full REST filter parity: optionally scope to one subnet (netuid) and filter by kind/provider/id, sort with sort/order, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/surfaces."
     surfaces(
@@ -728,6 +729,7 @@ export const SDL = /* GraphQL */ `
       block_end: Int
       from: String
       to: String
+      network: Network
     ): ExtrinsicList!
     "Paginated all-events feed (newest first) from the chain_events lakehouse table: each event's block, event index, pallet, method, decoded args, phase, and emitting extrinsic index. Filter by pallet/method/block/extrinsic; page with limit (1-200, default 50) and the opaque keyset cursor (or legacy before=block_number). An invalid filter combo is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty feed, never a GraphQL error. Reads the raw all-events tier -- distinct from account_events/subnet_events (the curated account-attributed streams, a different data source) and from Subscription.chainEvents (live WebSocket firehose). Pass network to read testnet's decoded history instead of mainnet's. Mirrors GET /api/v1/chain-events."
     chain_events(
@@ -770,17 +772,28 @@ export const SDL = /* GraphQL */ `
       to: String
       min_extrinsics: Int
       min_events: Int
+      network: Network
     ): BlockList!
     "One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}."
-    block(ref: String!): BlockDetail
+    block(ref: String!, network: Network): BlockDetail
     "The extrinsics in one block by ref (numeric block_number or 0x hash), in natural read order (extrinsic_index ASC), paginated with limit (1-100, default 50)/offset. Returns block_number:null + extrinsics:[] for an unknown ref or cold store, never a GraphQL error. Mirrors GET /api/v1/blocks/{ref}/extrinsics."
-    block_extrinsics(ref: String!, limit: Int, offset: Int): BlockExtrinsics!
+    block_extrinsics(
+      ref: String!
+      limit: Int
+      offset: Int
+      network: Network
+    ): BlockExtrinsics!
     "The decoded, account-attributed chain events in one block by ref, in read order (event_index ASC), paginated with limit (1-1000, default 100)/offset. Returns block_number:null + events:[] for an unknown ref or cold store, never a GraphQL error. Mirrors GET /api/v1/blocks/{ref}/events."
-    block_events(ref: String!, limit: Int, offset: Int): BlockEvents!
+    block_events(
+      ref: String!
+      limit: Int
+      offset: Int
+      network: Network
+    ): BlockEvents!
     "Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{block_number}/chain-events."
     block_chain_events(block_number: Int!, network: Network): BlockChainEvents!
     "Block-production summary over the recent-block window -- counts, inter-block timing, throughput, and author-concentration. Every aggregate is null (never a GraphQL error) when the retired-D1 store is cold. Mirrors GET /api/v1/blocks/summary."
-    blocks_summary: BlocksSummary!
+    blocks_summary(network: Network): BlocksSummary!
     "Site-wide runtime spec-version transition timeline: the earliest known block at each distinct spec_version observed (ascending), the current spec_version, and where coverage starts. The empty shape (transition_count 0, current_spec_version null) is schema-stable, never a GraphQL error, when the store has no reading yet. Mirrors GET /api/v1/runtime."
     runtime: RuntimeVersionHistory!
     "Network-wide validator/operator leaderboard, grouped by hotkey across every subnet it operates in. Paginate with limit/cursor like providers. Mirrors GET /api/v1/validators."
@@ -927,17 +940,31 @@ export const SDL = /* GraphQL */ `
       group_by: String
       limit: Int
       call_module: String
+      network: Network
     ): ChainCalls!
     "Network-wide Prometheus telemetry-endpoint announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by PrometheusServed announcements with each's distinct-exporter count and announcements-per-exporter re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The telemetry-endpoint companion to chain_serving's axon endpoints -- which subnets run observability infrastructure. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/prometheus."
     chain_prometheus(window: String, limit: Int): ChainPrometheus!
     "Network-wide neuron-deregistration leaderboard over a 7d/30d window (default 7d): subnets ranked by deregistration events with each's distinct-hotkey count and deregistrations-per-hotkey churn intensity, plus a network rollup and the per-subnet intensity spread, DERIVED from UID reuse in the NeuronRegistered stream by a scheduled projection -- NeuronDeregistered has never been emitted by the runtime (#9307). The network-wide, exit-side counterpart of subnet_deregistrations -- where neurons are being pushed out. limit caps the leaderboard (default 20, max 100). A window nothing derived carries a degraded block rather than a confident zero. Mirrors GET /api/v1/chain/deregistrations."
-    chain_deregistrations(window: String, limit: Int): ChainDeregistrations!
+    chain_deregistrations(
+      window: String
+      limit: Int
+      network: Network
+    ): ChainDeregistrations!
     "Network-wide neuron-registration leaderboard over a 7d/30d window (default 7d): subnets ranked by NeuronRegistered events with each's distinct-hotkey count and registrations-per-registrant re-registration intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide, entry-side counterpart of subnet_registrations -- where neurons are joining. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/registrations."
-    chain_registrations(window: String, limit: Int): ChainRegistrations!
+    chain_registrations(
+      window: String
+      limit: Int
+      network: Network
+    ): ChainRegistrations!
     "Per-UTC-day network fee/tip series over a 7d/30d window (default 7d): each day's extrinsic count and total/avg/median fee + tip in TAO, plus the top fee-paying signers (limit default 25, max 100), optionally scoped to a single call_module. Computed live from the extrinsics tier; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/fees."
-    chain_fees(window: String, limit: Int, call_module: String): ChainFees!
+    chain_fees(
+      window: String
+      limit: Int
+      call_module: String
+      network: Network
+    ): ChainFees!
     "Per-UTC-day network activity series over a 7d/30d window (default 7d): each UTC day's block count, extrinsic count (with its successful-extrinsic count and success rate), on-chain event count, and distinct signer count, newest day first. Computed live from the extrinsics/blocks tiers; a cold store yields a schema-stable empty series, never a GraphQL error. Mirrors GET /api/v1/chain/activity."
-    chain_activity(window: String): ChainActivity!
+    chain_activity(window: String, network: Network): ChainActivity!
     "Network-wide axon-removal (teardown) leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonInfoRemoved events with each's distinct-remover count and removals-per-remover teardown intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The teardown counterpart of chain_serving's announcements -- where neurons are tearing endpoints down. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/axon-removals."
     chain_axon_removals(window: String, limit: Int): ChainAxonRemovals!
     "Network-wide weight-setter leaderboard over a 7d/30d window (default 7d): the individual validators driving consensus network-wide, each with its total WeightsSet count, share of the network total, and first/last set times, ranked by activity. The setter-level drill-in behind chain_weights. Mirrors GET /api/v1/chain/weights/setters."
@@ -948,6 +975,7 @@ export const SDL = /* GraphQL */ `
       limit: Int
       sort: String
       call_module: String
+      network: Network
     ): ChainSigners!
     "Compact all-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history (probed every ~15 minutes); a cold store still returns both windows, schema-stable and zeroed, never a GraphQL error. Mirrors GET /api/v1/health/trends."
     health_trends(window: String, limit: Int, offset: Int): HealthTrends!
@@ -960,23 +988,40 @@ export const SDL = /* GraphQL */ `
     "Network-wide stake & emission decentralization across every subnet's neurons at once: the raw stake/emission distribution, the same two lenses collapsed per controlling entity (an operator running hotkeys in ten subnets counts once, not ten times), and the permitted-validator stake distribution -- each as gini/HHI/Nakamoto/top-share/entropy. uids_per_entity is the network consolidation signal (1.0 = every UID a distinct owner). Current snapshot only (no window/params). Every metric block is null (never a GraphQL error) on a cold store. The network analog of subnet concentration. Mirrors GET /api/v1/chain/concentration."
     chain_concentration: ChainConcentration!
     "Network-wide rolling 24h buy/sell alpha-volume leaderboard: every subnet with StakeAdded (buy) or StakeRemoved (sell) volume in the last 24h ranked by total_volume_tao, each carrying its full buy/sell/total volume + sentiment scorecard (vol_mcap_ratio always null here -- no per-subnet market-cap input at the network level), plus a network rollup with its own net/gross sentiment reading and the per-subnet total-volume spread, summed live from the account_events stream. Fixed 24h window (no window arg); limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/alpha-volume."
-    chain_alpha_volume(limit: Int): ChainAlphaVolume!
+    chain_alpha_volume(limit: Int, network: Network): ChainAlphaVolume!
     "Network-wide idle-stake rollup: every subnet's stake delegated to a currently-zero-dividends hotkey, ranked by idle_stake_alpha, plus the network total. Current snapshot only (no window/params). A cold store yields a schema-stable empty ranking, never a GraphQL error. Mirrors GET /api/v1/chain/idle-stake."
     chain_idle_stake: ChainIdleStake!
     "Network-wide cross-subnet capital-flow leaderboard over a 7d/30d window (default 7d): subnets ranked by net StakeAdded minus StakeRemoved TAO with staked/unstaked/gross totals and an inflow/outflow/balanced direction label, plus a network rollup and the per-subnet net-flow spread, summed live from the account_events stream. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/stake-flow."
-    chain_stake_flow(window: String, limit: Int): ChainStakeFlow!
+    chain_stake_flow(
+      window: String
+      limit: Int
+      network: Network
+    ): ChainStakeFlow!
     "Network-wide stake-movement (re-delegation) leaderboard over a 7d/30d window (default 7d): subnets ranked by StakeMoved events with each's distinct-mover count and movements-per-mover intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. StakeMoved relocates stake between hotkeys/subnets without unstaking -- re-delegation churn, not net capital flow. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/stake-moves."
-    chain_stake_moves(window: String, limit: Int): ChainStakeMoves!
+    chain_stake_moves(
+      window: String
+      limit: Int
+      network: Network
+    ): ChainStakeMoves!
     "Network-wide stake-transfer (between-coldkeys) leaderboard over a 7d/30d window (default 7d): subnets ranked by StakeTransferred events with each's distinct-sender count and transfers-per-sender intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. StakeTransferred relocates ownership on the same hotkey -- not net capital or re-delegation churn. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/stake-transfers."
-    chain_stake_transfers(window: String, limit: Int): ChainStakeTransfers!
+    chain_stake_transfers(
+      window: String
+      limit: Int
+      network: Network
+    ): ChainStakeTransfers!
     "Network-wide directed native-TAO transfer-corridor leaderboard over a 7d/30d window (default 7d): top sender->receiver pairs ranked by volume (default) or transfer count, each with volume, count, and last block/time, plus a network rollup (total volume, transfer count, unique corridors, top-corridor share). Self-transfers and malformed rows are excluded. limit caps the corridors (default 25, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/transfer-pairs."
     chain_transfer_pairs(
       window: String
       sort: String
       limit: Int
+      network: Network
     ): ChainTransferPairs!
     "Network-wide native-TAO transfer analytics over a 7d/30d window (default 7d): total Balances.Transfer volume and count, distinct senders/receivers, top senders and receivers ranked by volume, and the top senders' share of total volume. limit caps each leaderboard (default 25, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/transfers."
-    chain_transfers(window: String, limit: Int): ChainTransfers!
+    chain_transfers(
+      window: String
+      limit: Int
+      network: Network
+    ): ChainTransfers!
     "Live cumulative TAO recycled for registration on one subnet, read directly from chain via RPC (not the Postgres tier). recycled_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/recycled."
     subnet_recycled(netuid: Int!, network: Network): SubnetRecycled
     "Live current registration/burn cost for one subnet -- the dynamic price between the static min_burn_tao/max_burn_tao bounds, read directly from chain via RPC (not the Postgres tier). burn_tao is null on RPC failure, schema-stable, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/burn."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -424,7 +424,12 @@ import {
   buildSubnetBurnHistory,
   loadSubnetBurnHistory,
 } from "./subnet-burn-history.ts";
-import { chainNetworkFromChainName } from "./chain-network.ts";
+import {
+  DEFAULT_CHAIN_NETWORK,
+  chainNetworkFromChainName,
+  networkScopedRoute,
+  type ChainNetworkId,
+} from "./chain-network.ts";
 import { loadSubnetLease } from "./subnet-lease.ts";
 import { loadAccountBalance, isFinneySs58Address } from "./account-balance.ts";
 import { loadAccountRootClaim } from "./account-root-claim.ts";
@@ -765,6 +770,8 @@ import type {
   QueryAgent_CatalogArgs,
   QueryBlockArgs,
   QueryBlocksArgs,
+  QueryCoverageArgs,
+  QueryBlocks_SummaryArgs,
   QueryBlock_Chain_EventsArgs,
   QueryBlock_EventsArgs,
   QueryBlock_ExtrinsicsArgs,
@@ -1685,18 +1692,34 @@ function loadLiveHealth(context: GqlContext) {
 // Economics blob, preferring the fresh KV tier over the committed R2 artifact —
 // the same source REST (/api/v1/economics, registry leaderboards) serves, so the
 // GraphQL rows and opportunity boards never lag it. Null when both are cold.
-function loadEconomics(context: GqlContext) {
-  return once(context, LIVE_ECONOMICS_KEY, async () => {
-    const live = await resolveLiveEconomics({
-      readHealthKv,
-      env: context.env,
-      contractVersion: contractVersion(context.env),
-    });
-    // Spot on every row (#9408 completion), on whichever tier answered.
-    if (Array.isArray(live?.data?.subnets)) {
-      return withSpotPricedEconomics(live.data as Row);
+function loadEconomics(
+  context: GqlContext,
+  // #10394: which chain's card. The memo key carries it too -- sharing one
+  // entry between the two networks would serve whichever asked first.
+  network?: "finney" | "test",
+) {
+  const testnet = network === "test";
+  const key = testnet ? `${LIVE_ECONOMICS_KEY}:test` : LIVE_ECONOMICS_KEY;
+  return once(context, key, async () => {
+    // The live economics KV is written by the mainnet cron and carries no
+    // network column, so off mainnet there is no live tier to prefer -- the
+    // network's own artifact is the whole answer. Same asymmetry
+    // `answerBlockDetail` applies to the D1 hot tier.
+    if (!testnet) {
+      const live = await resolveLiveEconomics({
+        readHealthKv,
+        env: context.env,
+        contractVersion: contractVersion(context.env),
+      });
+      // Spot on every row (#9408 completion), on whichever tier answered.
+      if (Array.isArray(live?.data?.subnets)) {
+        return withSpotPricedEconomics(live.data as Row);
+      }
     }
-    const res = await readArtifact(context.env, ARTIFACT.economics);
+    const res = await readArtifact(
+      context.env,
+      networkArtifactPath(ARTIFACT.economics, network),
+    );
     return res.ok ? withSpotPricedEconomics(res.data as Row) : null;
   });
 }
@@ -1731,9 +1754,13 @@ function postgresTierRequest(
   context: GqlContext,
   pathname: string,
   params?: Row,
+  // #10394: which chain's rows to read. Mainnet keeps the base path, so every
+  // existing caller is unchanged; testnet reaches the `/api/v1/{network}/…`
+  // twin the router already serves and REST callers already use.
+  network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ) {
   const pgUrl = new URL((context.request as Request).url);
-  pgUrl.pathname = pathname;
+  pgUrl.pathname = networkScopedRoute(pathname, network);
   pgUrl.search = params ? params.toString() : "";
   return new Request(pgUrl);
 }
@@ -4095,7 +4122,10 @@ const rootValue = {
     // it. An invalid filter/sort is a GraphQL BAD_USER_INPUT error, not a silently
     // substituted default. The cursor is REST's positional offset, like every other
     // applyQueryFilters-backed list field.
-    const data = await loadEconomics(context);
+    const data = await loadEconomics(
+      context,
+      (args.network ?? undefined) as "finney" | "test" | undefined,
+    );
     const queryUrl = new URL("https://graphql.internal/economics");
     for (const [name, value] of [
       ["netuid", args?.netuid],
@@ -4674,10 +4704,19 @@ const rootValue = {
     return loadCurationList(mcpCtx(context), args, { readArtifact });
   },
 
-  async coverage(_args: unknown, context: GqlContext) {
+  async coverage({ network }: QueryCoverageArgs, context: GqlContext) {
     // Same baked artifact the REST /api/v1/coverage route + get_coverage MCP
     // tool read; GraphQL degrades to null when cold, like agent_resources.
-    return loadArtifact(context, "/metagraph/coverage.json");
+    // Network-scoped the way `subnets` and every MCP artifact read are: the
+    // testnet card lives in its own keyspace, so a `network: test` query cannot
+    // be answered from mainnet's (#10394).
+    return loadArtifact(
+      context,
+      networkArtifactPath(
+        "/metagraph/coverage.json",
+        (network ?? undefined) as "finney" | "test" | undefined,
+      ),
+    );
   },
 
   schemas(_args: unknown, context: GqlContext) {
@@ -5332,6 +5371,7 @@ const rootValue = {
 
   async extrinsics(
     {
+      network,
       limit,
       offset,
       cursor,
@@ -5376,7 +5416,12 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/extrinsics", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/extrinsics",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
       // The extrinsics cold tier REST and MCP both read (#9540).
@@ -5386,20 +5431,24 @@ const rootValue = {
       // the filter and serving unfiltered rows under a filtered label -- the
       // same gate REST's handleExtrinsics and MCP's list_extrinsics apply.
       ((callHash == null
-        ? await loadExtrinsicFeedColdTier(context.env, {
-            limit: safeLimit,
-            offset: safeOffset,
-            cursor,
-            signer,
-            module: callModule,
-            callFunction,
-            success,
-            block,
-            blockStart,
-            blockEnd,
-            from,
-            to,
-          })
+        ? await loadExtrinsicFeedColdTier(
+            context.env,
+            {
+              limit: safeLimit,
+              offset: safeOffset,
+              cursor,
+              signer,
+              module: callModule,
+              callFunction,
+              success,
+              block,
+              blockStart,
+              blockEnd,
+              from,
+              to,
+            },
+            chainNetworkFromChainName(network),
+          )
         : null) as Row | null) ??
       buildExtrinsicFeed([], {
         limit: safeLimit,
@@ -5718,6 +5767,7 @@ const rootValue = {
 
   async blocks(
     {
+      network,
       limit,
       offset,
       cursor,
@@ -5758,26 +5808,35 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/blocks", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/blocks",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_BLOCKS_SOURCE",
       )) as Row | null) ??
       // The blocks cold tier REST and MCP both read (#9540). Every filter is
       // forwarded, so the tier does the filtering -- the empty builder below
       // ignores them, which is why reaching it silently dropped a filtered
       // query's meaning as well as its rows.
-      ((await loadBlockFeedColdTier(context.env, {
-        limit: safeLimit,
-        offset: safeOffset,
-        cursor,
-        author,
-        specVersion,
-        blockStart,
-        blockEnd,
-        from,
-        to,
-        minExtrinsics,
-        minEvents,
-      } as never)) as Row | null) ??
+      ((await loadBlockFeedColdTier(
+        context.env,
+        {
+          limit: safeLimit,
+          offset: safeOffset,
+          cursor,
+          author,
+          specVersion,
+          blockStart,
+          blockEnd,
+          from,
+          to,
+          minExtrinsics,
+          minEvents,
+        } as never,
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildBlockFeed([], {
         limit: safeLimit,
         offset: safeOffset,
@@ -5790,7 +5849,10 @@ const rootValue = {
     };
   },
 
-  async blocks_summary(_args: unknown, context: GqlContext) {
+  async blocks_summary(
+    { network }: QueryBlocks_SummaryArgs,
+    context: GqlContext,
+  ) {
     // #5664: same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildBlocksSummary([])
     // fallback contract handleBlocksSummary uses. blocks' D1 write path is retired
     // (#4909) so a cold Postgres tier is the steady state -- the empty builder
@@ -5799,11 +5861,21 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/blocks/summary"),
+        postgresTierRequest(
+          context,
+          "/api/v1/blocks/summary",
+          undefined,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_BLOCKS_SOURCE",
       )) as Row | null) ??
-      // #9146: same blocks-summary projection REST and MCP read.
-      ((await loadBlocksSummaryFromArtifact(context.env)) as Row | null) ??
+      // #9146: same blocks-summary projection REST and MCP read -- on the SAME
+      // chain as the tier above, because a fallback that changed network would
+      // answer mainnet under a testnet label (#10394).
+      ((await loadBlocksSummaryFromArtifact(
+        context.env,
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildBlocksSummary([]);
     return {
       schema_version: data.schema_version ?? 1,
@@ -5854,18 +5926,22 @@ const rootValue = {
     };
   },
 
-  async block({ ref }: QueryBlockArgs, context: GqlContext) {
+  async block({ ref, network }: QueryBlockArgs, context: GqlContext) {
+    const chain = chainNetworkFromChainName(network);
     const data =
       ((await tryPostgresTier(
         context.env,
         postgresTierRequest(
           context,
           `/api/v1/blocks/${encodeURIComponent(ref)}`,
+          undefined,
+          chain,
         ),
         "METAGRAPH_BLOCKS_SOURCE",
       )) as Row | null) ??
-      // The block cold tier REST and MCP both read (#9540).
-      ((await loadBlockColdTier(context.env, ref)) as Row | null) ??
+      // The block cold tier REST and MCP both read (#9540), on the SAME chain
+      // as the tier above (#10394).
+      ((await loadBlockColdTier(context.env, ref, chain)) as Row | null) ??
       buildBlock(undefined, ref);
     return {
       schema_version: data.schema_version ?? null,
@@ -5881,7 +5957,7 @@ const rootValue = {
   // /blocks/:ref/{extrinsics,events} routes wrap their body in `{ data }` (unlike
   // the flat /blocks/:ref route), so the tier result is destructured accordingly.
   async block_extrinsics(
-    { ref, limit, offset }: QueryBlock_ExtrinsicsArgs,
+    { ref, limit, offset, network }: QueryBlock_ExtrinsicsArgs,
     context: GqlContext,
   ) {
     const safeLimit =
@@ -5901,6 +5977,7 @@ const rootValue = {
         context,
         `/api/v1/blocks/${encodeURIComponent(ref)}/extrinsics`,
         params,
+        chainNetworkFromChainName(network),
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as Row | null) ?? {
@@ -5911,19 +5988,29 @@ const rootValue = {
       // there would state "this block has no extrinsics", which is the confident
       // zero this whole change exists to remove.
       data: gapAwareBlockDetail(
-        await answerBlockDetail(context.env, ref, {
-          hot: (height) =>
-            loadBlockExtrinsicsHotTier(context.env, ref, height, {
-              limit: safeLimit,
-              offset: safeOffset,
-            }),
-          cold: () =>
-            loadBlockExtrinsicsColdTier(context.env, ref, {
-              limit: safeLimit,
-              offset: safeOffset,
-            }),
-          isEmpty: isEmptyExtrinsicPayload,
-        }),
+        await answerBlockDetail(
+          context.env,
+          ref,
+          {
+            hot: (height) =>
+              loadBlockExtrinsicsHotTier(context.env, ref, height, {
+                limit: safeLimit,
+                offset: safeOffset,
+              }),
+            cold: () =>
+              loadBlockExtrinsicsColdTier(context.env, ref, {
+                limit: safeLimit,
+                offset: safeOffset,
+              }),
+            isEmpty: isEmptyExtrinsicPayload,
+          },
+          // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
+          // blocks_head and the whole hot path are written by the mainnet
+          // firehose poller and carry no network column -- so a testnet ref
+          // resolves from that chain's lakehouse instead of being looked up in
+          // mainnet's D1 (#10394).
+          chainNetworkFromChainName(network),
+        ),
         () =>
           buildBlockExtrinsics([], ref, null, {
             limit: safeLimit,
@@ -5935,7 +6022,7 @@ const rootValue = {
   },
 
   async block_events(
-    { ref, limit, offset }: QueryBlock_EventsArgs,
+    { ref, limit, offset, network }: QueryBlock_EventsArgs,
     context: GqlContext,
   ) {
     const safeLimit =
@@ -5955,6 +6042,7 @@ const rootValue = {
         context,
         `/api/v1/blocks/${encodeURIComponent(ref)}/events`,
         params,
+        chainNetworkFromChainName(network),
       ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     )) as Row | null) ?? {
@@ -5965,19 +6053,29 @@ const rootValue = {
       // there would state "this block has no events", which is the confident
       // zero this whole change exists to remove.
       data: gapAwareBlockDetail(
-        await answerBlockDetail(context.env, ref, {
-          hot: (height) =>
-            loadBlockEventsHotTier(context.env, ref, height, {
-              limit: safeLimit,
-              offset: safeOffset,
-            }),
-          cold: () =>
-            loadBlockEventsColdTier(context.env, ref, {
-              limit: safeLimit,
-              offset: safeOffset,
-            }),
-          isEmpty: isEmptyEventPayload,
-        }),
+        await answerBlockDetail(
+          context.env,
+          ref,
+          {
+            hot: (height) =>
+              loadBlockEventsHotTier(context.env, ref, height, {
+                limit: safeLimit,
+                offset: safeOffset,
+              }),
+            cold: () =>
+              loadBlockEventsColdTier(context.env, ref, {
+                limit: safeLimit,
+                offset: safeOffset,
+              }),
+            isEmpty: isEmptyEventPayload,
+          },
+          // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
+          // blocks_head and the whole hot path are written by the mainnet
+          // firehose poller and carry no network column -- so a testnet ref
+          // resolves from that chain's lakehouse instead of being looked up in
+          // mainnet's D1 (#10394).
+          chainNetworkFromChainName(network),
+        ),
         () =>
           buildBlockEvents([], ref, null, {
             limit: safeLimit,
@@ -7809,7 +7907,7 @@ const rootValue = {
   },
 
   async chain_activity(
-    { window }: QueryChain_ActivityArgs,
+    { network, window }: QueryChain_ActivityArgs,
     context: GqlContext,
   ) {
     // Checked against the window enum the ROUTE publishes, not against
@@ -7833,7 +7931,12 @@ const rootValue = {
     const data = trimChainActivityToWindow(
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/activity", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/activity",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as ReturnType<typeof buildChainActivity> | null) ??
         // The projection tier REST reads (#9540). Window-based like REST's
@@ -7841,9 +7944,13 @@ const rootValue = {
         // get_chain_activity uses -- that tool takes a block count and answers a
         // different question, so borrowing its loader would change this
         // resolver's contract rather than fill it.
-        ((await loadChainActivityFromArtifact(context.env, {
-          window: label,
-        })) as ReturnType<typeof buildChainActivity> | null) ??
+        ((await loadChainActivityFromArtifact(
+          context.env,
+          {
+            window: label,
+          },
+          chainNetworkFromChainName(network),
+        )) as ReturnType<typeof buildChainActivity> | null) ??
         buildChainActivity({ window: label }),
       days,
     );
@@ -7866,6 +7973,7 @@ const rootValue = {
 
   async chain_calls(
     {
+      network,
       window,
       group_by: groupBy,
       limit,
@@ -7907,7 +8015,12 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/calls", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/calls",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as Row | null) ??
       // The projection tier REST and MCP both read (#9540). callModule is
@@ -7915,12 +8028,16 @@ const rootValue = {
       // by contract (its value space is not precomputed), so passing it keeps
       // GraphQL's answer identical to REST's instead of quietly serving the
       // unfiltered mix under a filtered label.
-      ((await loadChainCallsFromArtifact(context.env, {
-        window: label,
-        groupBy: requestedGroupBy,
-        limit: safeLimit,
-        callModule,
-      })) as Row | null) ??
+      ((await loadChainCallsFromArtifact(
+        context.env,
+        {
+          window: label,
+          groupBy: requestedGroupBy,
+          limit: safeLimit,
+          callModule,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainCalls({ window: label, groupBy: requestedGroupBy });
     return {
       schema_version: data.schema_version ?? 1,
@@ -7939,7 +8056,7 @@ const rootValue = {
   },
 
   async chain_fees(
-    { window, limit, call_module: callModule }: QueryChain_FeesArgs,
+    { network, window, limit, call_module: callModule }: QueryChain_FeesArgs,
     context: GqlContext,
   ) {
     // Checked against the window enum the ROUTE publishes, not against
@@ -7969,16 +8086,25 @@ const rootValue = {
     const data = trimChainFeesToWindow(
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/fees", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/fees",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_EXTRINSICS_SOURCE",
       )) as ReturnType<typeof buildChainFees> | null) ??
         // The projection tier REST and MCP both read (#9540); same
         // declines-a-scoped-call contract as chain_calls above.
-        ((await loadChainFeesFromArtifact(context.env, {
-          window: label,
-          limit: safeLimit,
-          callModule,
-        })) as ReturnType<typeof buildChainFees> | null) ??
+        ((await loadChainFeesFromArtifact(
+          context.env,
+          {
+            window: label,
+            limit: safeLimit,
+            callModule,
+          },
+          chainNetworkFromChainName(network),
+        )) as ReturnType<typeof buildChainFees> | null) ??
         buildChainFees({ window: label }),
       days,
     );
@@ -8168,7 +8294,7 @@ const rootValue = {
   },
 
   async chain_deregistrations(
-    { window, limit }: QueryChain_DeregistrationsArgs,
+    { network, window, limit }: QueryChain_DeregistrationsArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW;
@@ -8196,15 +8322,24 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/deregistrations", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/deregistrations",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // #9307: same UID-reuse derivation REST's handleChainDeregistrations
       // reads, then the same MARKED empty when nothing derived it.
-      ((await loadChainDeregistrationsFromArtifact(context.env, {
-        window: requestedWindow,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainDeregistrationsFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       (markDeregistrationsNotDerived(
         buildChainDeregistrations([], {
           window: requestedWindow,
@@ -8229,7 +8364,7 @@ const rootValue = {
   },
 
   async chain_registrations(
-    { window, limit }: QueryChain_RegistrationsArgs,
+    { network, window, limit }: QueryChain_RegistrationsArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_REGISTRATIONS_WINDOW;
@@ -8254,15 +8389,24 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/registrations", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/registrations",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // #9146: same chain-registrations projection REST reads, so the two
       // surfaces cannot report different registration activity.
-      ((await loadChainRegistrationsFromArtifact(context.env, {
-        window: requestedWindow,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainRegistrationsFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainRegistrations([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -8340,7 +8484,13 @@ const rootValue = {
   },
 
   async chain_signers(
-    { window, limit, sort, call_module: callModule }: QueryChain_SignersArgs,
+    {
+      network,
+      window,
+      limit,
+      sort,
+      call_module: callModule,
+    }: QueryChain_SignersArgs,
     context: GqlContext,
   ) {
     // Checked against the window enum the ROUTE publishes, not against
@@ -8381,7 +8531,12 @@ const rootValue = {
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
     const tier = await tryPostgresTier(
       context.env,
-      postgresTierRequest(context, "/api/v1/chain/signers", params),
+      postgresTierRequest(
+        context,
+        "/api/v1/chain/signers",
+        params,
+        chainNetworkFromChainName(network),
+      ),
       "METAGRAPH_EXTRINSICS_SOURCE",
     );
     const data =
@@ -8390,12 +8545,16 @@ const rootValue = {
       // loader declines a pallet-scoped call itself (serving the unfiltered
       // leaderboard under a filtered label would be a wrong answer), so
       // call_module is passed through rather than gated here.
-      ((await loadChainSignersFromArtifact(context.env, {
-        window: label,
-        sort,
-        limit: safeLimit,
-        callModule,
-      })) as Row | null) ??
+      ((await loadChainSignersFromArtifact(
+        context.env,
+        {
+          window: label,
+          sort,
+          limit: safeLimit,
+          callModule,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainSigners({
         window: label,
         sort: sort ?? undefined,
@@ -8470,7 +8629,7 @@ const rootValue = {
   },
 
   async chain_alpha_volume(
-    { limit }: QueryChain_Alpha_VolumeArgs,
+    { network, limit }: QueryChain_Alpha_VolumeArgs,
     context: GqlContext,
   ) {
     const safeLimit = clampLimit(limit, {
@@ -8488,16 +8647,25 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/alpha-volume", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/alpha-volume",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // The projection tier REST and MCP both read (#9540); without it this
       // resolver's whole answer was the empty card below. The market-cap index
       // rides along so vol_mcap_ratio is not null on GraphQL alone (#9526).
-      ((await loadChainAlphaVolumeFromArtifact(context.env, {
-        limit: safeLimit,
-        marketCapByNetuid: await resolveMarketCapIndex(context.env),
-      })) as Row | null) ??
+      ((await loadChainAlphaVolumeFromArtifact(
+        context.env,
+        {
+          limit: safeLimit,
+          marketCapByNetuid: await resolveMarketCapIndex(context.env),
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainAlphaVolume([], { limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8543,7 +8711,7 @@ const rootValue = {
   },
 
   async chain_stake_flow(
-    { window, limit }: QueryChain_Stake_FlowArgs,
+    { network, window, limit }: QueryChain_Stake_FlowArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_FLOW_WINDOW;
@@ -8566,16 +8734,25 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/stake-flow", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/stake-flow",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // The projection tier REST and MCP both read (#9540). Without this rung
       // the ladder below is the whole answer, and the retired flag above
       // guarantees we reach it -- a confident zero, with no error to say so.
-      ((await loadChainStakeFlowFromArtifact(context.env, {
-        window: requestedWindow,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainStakeFlowFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainStakeFlow([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -8602,7 +8779,7 @@ const rootValue = {
   },
 
   async chain_stake_moves(
-    { window, limit }: QueryChain_Stake_MovesArgs,
+    { network, window, limit }: QueryChain_Stake_MovesArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_MOVES_WINDOW;
@@ -8625,16 +8802,25 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/stake-moves", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/stake-moves",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // The projection tier REST and MCP both read (#9540). Without this rung
       // the ladder below is the whole answer, and the retired flag above
       // guarantees we reach it -- a confident zero, with no error to say so.
-      ((await loadChainStakeMovesFromArtifact(context.env, {
-        window: requestedWindow,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainStakeMovesFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainStakeMoves([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -8655,7 +8841,7 @@ const rootValue = {
   },
 
   async chain_stake_transfers(
-    { window, limit }: QueryChain_Stake_TransfersArgs,
+    { network, window, limit }: QueryChain_Stake_TransfersArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW;
@@ -8681,16 +8867,25 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/stake-transfers", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/stake-transfers",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // The projection tier REST and MCP both read (#9540). Without this rung
       // the ladder below is the whole answer, and the retired flag above
       // guarantees we reach it -- a confident zero, with no error to say so.
-      ((await loadChainStakeTransfersFromArtifact(context.env, {
-        window: requestedWindow,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainStakeTransfersFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainStakeTransfers([], {
         window: requestedWindow,
         limit: safeLimit,
@@ -8711,7 +8906,7 @@ const rootValue = {
   },
 
   async chain_transfer_pairs(
-    { window, sort, limit }: QueryChain_Transfer_PairsArgs,
+    { network, window, sort, limit }: QueryChain_Transfer_PairsArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW;
@@ -8743,15 +8938,24 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/transfer-pairs", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/transfer-pairs",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // The projection tier (#9146) REST reads and this field skipped.
-      ((await loadChainTransferPairsFromArtifact(context.env, {
-        window: requestedWindow,
-        sort,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainTransferPairsFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          sort,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainTransferPairs({
         window: requestedWindow,
         sort,
@@ -8774,7 +8978,7 @@ const rootValue = {
   },
 
   async chain_transfers(
-    { window, limit }: QueryChain_TransfersArgs,
+    { network, window, limit }: QueryChain_TransfersArgs,
     context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_TRANSFER_WINDOW;
@@ -8798,7 +9002,12 @@ const rootValue = {
     const data =
       ((await tryPostgresTier(
         context.env,
-        postgresTierRequest(context, "/api/v1/chain/transfers", params),
+        postgresTierRequest(
+          context,
+          "/api/v1/chain/transfers",
+          params,
+          chainNetworkFromChainName(network),
+        ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
       // The projection tier (#9146): a cron recomputes this window's scorecard
@@ -8808,10 +9017,14 @@ const rootValue = {
       // same window in the same second, and without a degraded marker to say
       // so. The three fields left off when #9146 landed are exactly the three
       // that disagreed: this, chain_transfer_pairs and chain_signers.
-      ((await loadChainTransfersFromArtifact(context.env, {
-        window: requestedWindow,
-        limit: safeLimit,
-      })) as Row | null) ??
+      ((await loadChainTransfersFromArtifact(
+        context.env,
+        {
+          window: requestedWindow,
+          limit: safeLimit,
+        },
+        chainNetworkFromChainName(network),
+      )) as Row | null) ??
       buildChainTransfers({
         window: requestedWindow,
         observedAt: await loadObservedAt(context),

--- a/tests/chain-detail-serving.test.ts
+++ b/tests/chain-detail-serving.test.ts
@@ -1,4 +1,4 @@
-// What a CALLER sees once the hot tier exists (#9208) -- REST and MCP.
+// What a CALLER sees once the hot tier exists (#9208) -- REST, MCP, GraphQL.
 //
 // The measurement that opened the issue: against head 8,762,608, block
 // 8,759,000 answered 29 extrinsics and block 8,762,600 answered 0. This file
@@ -22,6 +22,7 @@ vi.mock("pg", () => pg.module);
 
 import { handleRequest } from "../workers/api.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
+import { handleGraphQLRequest } from "../src/graphql.ts";
 import { DEFAULT_BLOCKS_SEAM } from "../src/blocks-cold-tier.ts";
 import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
 import { jsonBody } from "./row-type.ts";
@@ -381,5 +382,73 @@ describe("the MCP tools decline the same gap", () => {
         return true;
       },
     );
+  });
+});
+
+describe("GraphQL runs the same cascade", () => {
+  // The third caller of `answerBlockDetail`, and the one #10394 changed: its
+  // resolvers now pass the network through, and the network is what decides
+  // whether the hot leg is consulted at all. REST and MCP pin the cascade
+  // above; the GraphQL half of it was reached by no test, so the hot callbacks
+  // its resolvers hand in could have been wired to the wrong loader and every
+  // suite would still have passed on the cold answer underneath.
+  async function gql(text: string, env: unknown) {
+    const res = await handleGraphQLRequest(
+      new Request("https://api.metagraph.sh/api/v1/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: text }),
+      }),
+      env as never,
+      {},
+    );
+    return jsonBody(res);
+  }
+
+  test("a covered recent block serves the hot rows", async () => {
+    // The two rows publish differently: `events` is `[AccountEvent!]!` and
+    // selects into subfields, `extrinsics` is still a bare `[JSON!]!` where the
+    // row itself is the leaf. Each query below is written against what its
+    // field actually publishes, so this reads as the asymmetry it is.
+    const body = await gql(
+      `{ block_extrinsics(ref: "${RECENT}") ` +
+        `{ block_number extrinsic_count extrinsics } }`,
+      envWith({ covered: [RECENT] }),
+    );
+    assert.equal(body.errors, undefined);
+    const detail = body.data.block_extrinsics;
+    assert.equal(detail.block_number, RECENT);
+    assert.equal(detail.extrinsic_count, 2);
+    assert.equal(detail.extrinsics[0].call_function, "set_weights");
+
+    const events = await gql(
+      `{ block_events(ref: "${RECENT}") ` +
+        `{ block_number event_count events { event_kind } } }`,
+      envWith({ covered: [RECENT] }),
+    );
+    assert.equal(events.errors, undefined);
+    assert.equal(events.data.block_events.event_count, 1);
+    assert.equal(events.data.block_events.events[0].event_kind, "StakeAdded");
+  });
+
+  test("a GAP is an error with a typed code, not an empty block", async () => {
+    // Same argument as the REST 503 and the MCP throw: `extrinsics: []` and "a
+    // block that genuinely had none" are the same bytes to a client.
+    for (const field of ["block_extrinsics", "block_events"]) {
+      const body = await gql(
+        `{ ${field}(ref: "${RECENT}") { block_number } }`,
+        envWith({
+          covered: [],
+          window: { floor: RECENT + 500, head: RECENT + 900 },
+        }),
+      );
+      assert.ok(body.errors, `${field} answered instead of declining`);
+      assert.equal(
+        body.errors[0].extensions.code,
+        "BLOCK_DETAIL_UNAVAILABLE",
+        `${field} declined with the wrong code`,
+      );
+      assert.equal(body.errors[0].extensions.block_number, RECENT);
+    }
   });
 });

--- a/tests/graphql-network-scoping.test.ts
+++ b/tests/graphql-network-scoping.test.ts
@@ -1,0 +1,202 @@
+// Does `network: test` actually reach testnet? (#10394)
+//
+// Twenty Query fields published the argument and the resolvers forward it to
+// BOTH legs of their read -- the Postgres tier's path and the cold-tier
+// fallback under it. A test that only checked the argument was accepted would
+// pass on a resolver that ignored it, which is strictly worse than not
+// publishing the argument: the caller asks for testnet and is told mainnet.
+//
+// So these assert the PATH the tier is asked for, by capturing the Request the
+// DATA_API binding receives.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleGraphQLRequest } from "../src/graphql.ts";
+import {
+  DEFAULT_CHAIN_NETWORK,
+  networkScopedRoute,
+} from "../src/chain-network.ts";
+import type { Row } from "./row-type.ts";
+
+/** A DATA_API double that records every path it is asked for. */
+function recordingDataApi(payload: Row) {
+  const paths: string[] = [];
+  return {
+    paths,
+    binding: {
+      fetch: async (request: Request) => {
+        paths.push(new URL(request.url).pathname);
+        return Response.json(payload);
+      },
+    },
+  };
+}
+
+async function query(text: string, env: Row) {
+  const res = await handleGraphQLRequest(
+    new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: text }),
+    }),
+    env as never,
+    {},
+  );
+  return { status: res.status, body: (await res.json()) as Row };
+}
+
+describe("networkScopedRoute", () => {
+  test("mainnet keeps the base path", () => {
+    // The asymmetry every sibling helper uses: an existing caller reaches
+    // exactly what it reached before, so this cannot regress mainnet.
+    assert.equal(
+      networkScopedRoute("/api/v1/blocks", DEFAULT_CHAIN_NETWORK),
+      "/api/v1/blocks",
+    );
+    assert.equal(networkScopedRoute("/api/v1/blocks"), "/api/v1/blocks");
+  });
+
+  test("testnet gets the twin the router already serves", () => {
+    assert.equal(
+      networkScopedRoute("/api/v1/blocks", "testnet"),
+      "/api/v1/test/blocks",
+    );
+    assert.equal(
+      networkScopedRoute("/api/v1/chain/stake-flow", "testnet"),
+      "/api/v1/test/chain/stake-flow",
+    );
+  });
+
+  test("a path that is not an /api/v1 route is returned unchanged", () => {
+    // Nothing should be rewritten on a guess -- a caller passing something
+    // else gets it back rather than a plausible-looking twin.
+    assert.equal(
+      networkScopedRoute("/metagraph/blocks.json", "testnet"),
+      "/metagraph/blocks.json",
+    );
+  });
+});
+
+describe("the resolvers ask the twin path", () => {
+  test("blocks(network: test) reads /api/v1/test/blocks", async () => {
+    const api = recordingDataApi({ blocks: [], block_count: 0 });
+    const { status } = await query(
+      "{ blocks(limit: 1, network: test) { total } }",
+      { METAGRAPH_BLOCKS_SOURCE: "postgres", DATA_API: api.binding },
+    );
+    assert.equal(status, 200);
+    assert.deepEqual(api.paths, ["/api/v1/test/blocks"]);
+  });
+
+  test("blocks() with no network still reads the base path", async () => {
+    const api = recordingDataApi({ blocks: [], block_count: 0 });
+    await query("{ blocks(limit: 1) { total } }", {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: api.binding,
+    });
+    assert.deepEqual(api.paths, ["/api/v1/blocks"]);
+  });
+
+  test("a chain rollup forwards it too", async () => {
+    const api = recordingDataApi({ schema_version: 1, transfers: [] });
+    await query('{ chain_transfers(window: "7d", network: test) { window } }', {
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      DATA_API: api.binding,
+    });
+    assert.deepEqual(api.paths, ["/api/v1/test/chain/transfers"]);
+  });
+
+  test("a per-block read forwards it", async () => {
+    const api = recordingDataApi({ schema_version: 1, ref: "9", block: null });
+    await query('{ block(ref: "9", network: test) { ref } }', {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: api.binding,
+    });
+    assert.deepEqual(api.paths, ["/api/v1/test/blocks/9"]);
+  });
+
+  test("a block-detail cascade forwards it to the hot/cold decision", async () => {
+    // `answerBlockDetail` is where the network decides whether the D1 hot tier
+    // is consulted at all -- off mainnet it is not, because blocks_head is
+    // written by the mainnet firehose poller and carries no network column.
+    const extrinsics = recordingDataApi({
+      data: { block_number: 9, extrinsic_count: 0, extrinsics: [] },
+    });
+    await query(
+      '{ block_extrinsics(ref: "9", network: test) { block_number } }',
+      {
+        METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+        DATA_API: extrinsics.binding,
+      },
+    );
+    assert.deepEqual(extrinsics.paths, ["/api/v1/test/blocks/9/extrinsics"]);
+
+    const events = recordingDataApi({
+      data: { block_number: 9, event_count: 0, events: [] },
+    });
+    await query('{ block_events(ref: "9", network: test) { block_number } }', {
+      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
+      DATA_API: events.binding,
+    });
+    assert.deepEqual(events.paths, ["/api/v1/test/blocks/9/events"]);
+  });
+
+  test("economics(network: test) skips the mainnet-only live KV", async () => {
+    // The live economics KV is written by the mainnet cron and carries no
+    // network column. Preferring it off mainnet would answer mainnet rows
+    // under a testnet label -- and the memo is keyed by network so one entry
+    // cannot serve both.
+    let liveReads = 0;
+    const env = {
+      METAGRAPH_HEALTH_KV: {
+        get: async () => {
+          liveReads += 1;
+          return null;
+        },
+      },
+    };
+    const { status } = await query(
+      "{ economics(network: test, limit: 1) { total } }",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(liveReads, 0, "the live KV must not be consulted off mainnet");
+  });
+
+  test("on MAINNET the same cascade consults the hot tier", async () => {
+    // The other side of the branch the network decides. `answerBlockDetail`
+    // routes to the hot leg only on mainnet AND only for a ref above the seam
+    // -- off mainnet the seam is 0 and every block comes from the lakehouse,
+    // which is why a testnet query can never run the hot callback.
+    //
+    // Reaching it needs the store the deployment actually uses: Hyperdrive in
+    // front of Neon, plus the four chain_detail tables declared Neon's.
+    // `readStore` refuses a table it was not told the store owns, so binding
+    // Hyperdrive alone still answers undefined.
+    const env = {
+      ICEBERG_BLOCKS_MAX: "1",
+      HYPERDRIVE: { connectionString: "postgresql://mock/db" },
+      NEON_SOLE_STORE_TABLES:
+        "chain_detail_blocks,chain_detail_extrinsics," +
+        "chain_detail_chain_events,chain_detail_account_events",
+    };
+    const extrinsics = await query(
+      '{ block_extrinsics(ref: "9") { block_number extrinsic_count } }',
+      env,
+    );
+    assert.equal(extrinsics.status, 200);
+    const events = await query(
+      '{ block_events(ref: "9") { block_number event_count } }',
+      env,
+    );
+    assert.equal(events.status, 200);
+  });
+
+  test("blocks_summary forwards it", async () => {
+    const api = recordingDataApi({ schema_version: 1, block_count: 0 });
+    await query("{ blocks_summary(network: test) { block_count } }", {
+      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      DATA_API: api.binding,
+    });
+    assert.deepEqual(api.paths, ["/api/v1/test/blocks/summary"]);
+  });
+});

--- a/tests/graphql-route-parity.test.ts
+++ b/tests/graphql-route-parity.test.ts
@@ -10,7 +10,9 @@
 // resolve, and it prints a clean bill of health forever.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, test } from "vitest";
 
 const SCRIPT = "scripts/validate-graphql-route-parity.ts";
@@ -133,5 +135,46 @@ describe("graphql route parity gate", () => {
     const sdl = readFileSync("src/graphql-sdl.ts", "utf8");
     const annotations = [...sdl.matchAll(/Mirrors GET \/api\/v1\//g)].length;
     assert.ok(annotations > 200, `only ${annotations} route annotations left`);
+  });
+});
+
+// ── the network twin, in the reverse direction (#10394) ──────────────────────
+//
+// The forward rule exempts a `network` ARGUMENT because the twin path is how
+// that parameter is spelled. The reverse loop could not represent the opposite
+// -- a route with a twin whose Query field takes no `network` -- because on the
+// twin `network` is `in: "path"` and on the base path it does not appear at
+// all. Twenty fields sat in that blind spot: testnet reachable over REST,
+// unreachable over GraphQL, and the gate reporting zero divergences.
+describe("the network twin's reverse check", () => {
+  test("FAILS when a field drops the network argument its route twins", () => {
+    const sdl = readFileSync("src/graphql-sdl.ts", "utf8");
+    // `blocks` mirrors /api/v1/blocks, which has a /api/v1/{network}/blocks
+    // twin. Removing its argument must be reported, not passed over.
+    const broken = sdl.replace(
+      "\n      network: Network\n    ): BlockList!",
+      "\n    ): BlockList!",
+    );
+    assert.notEqual(broken, sdl, "the fixture argument must exist to remove");
+    const path = join(mkdtempSync(join(tmpdir(), "sdl-")), "graphql-sdl.ts");
+    writeFileSync(path, broken);
+    assert.throws(
+      () =>
+        execFileSync("node", [SCRIPT], {
+          encoding: "utf8",
+          env: { ...process.env, GRAPHQL_SDL_PATH: path },
+        }),
+      (err: unknown) => {
+        const e = err as { stdout?: string; stderr?: string };
+        const output = `${e.stdout ?? ""}\n${e.stderr ?? ""}`;
+        assert.match(output, /blocks\.network/);
+        assert.match(output, /has a \/\{network\}\/ twin/);
+        return true;
+      },
+    );
+  });
+
+  test("the real SDL passes it -- all twenty forward the argument", () => {
+    assert.match(run(), /0 divergence\(s\)/);
   });
 });


### PR DESCRIPTION
## Summary

Twenty Query fields mirrored a route that publishes a `/api/v1/{network}/…` twin and took **no `network` argument**, so testnet was reachable over REST and unreachable over GraphQL:

```
GET /api/v1/test/blocks?limit=1  -> 200, first block 7749726  (testnet)
GET /api/v1/blocks?limit=1       -> 200, first block 8812074  (mainnet)

{ blocks(limit:1, network: test){ items { block_number } } }
  -> Unknown argument "network" on field "Query.blocks".
```

Fifteen other fields whose route has a twin already took one, so this was twenty fields out of step with a convention the schema already keeps — not a capability GraphQL had decided against.

## Both legs of every read, always

The part worth reading. Each of the twenty reads a Postgres tier and falls back to an artifact or cold tier underneath it. Scoping only the tier would leave the fallback answering **mainnet under a testnet label** — a wrong answer wearing a right one's clothes, and strictly worse than having no argument at all.

So every ladder carries the same chain end to end:

- the tier path goes through a new `networkScopedRoute` in `chain-network.ts`, beside `networkKvKey` / `projectionKey` / `chainTable` and keeping their asymmetry: **mainnet keeps the base path**, so every existing caller reaches exactly what it reached before
- the cold leg takes the same `ChainNetworkId`. All fourteen of those loaders already accepted one (#9412) — the resolvers simply never passed it
- `answerBlockDetail` already skips the D1 hot tier off mainnet (`blocks_head` is written by the mainnet firehose poller and carries no network column), so `block_extrinsics` / `block_events` just hand it the network
- `loadEconomics` skips the mainnet-only live KV off mainnet **and keys its memo by network** — one shared entry would have served whichever network asked first
- `coverage` and `economics` read through `networkArtifactPath`, the same helper `subnets` and every MCP artifact read already use

## Why the gate reported zero divergences

`validate-graphql-route-parity` checks arguments in both directions, and its `network` rule was one-directional **by construction**:

```ts
// forward: an SDL argument with no published parameter
if (arg.name === "network" && hasNetworkTwin(route)) continue;
…
// reverse: a published parameter with no SDL argument
for (const [name, parameter] of published) {
  if (parameter.in !== "query") continue;   // <- `network` is a PATH segment
```

On the twin `network` is `in: "path"`; on the base path it does not appear at all. So "the route has a twin and the SDL takes no `network`" was **unrepresentable** — the forward exemption exists precisely because the twin is how the parameter is spelled, and the reverse check needed the same knowledge and did not have it. Same class as the one-directional parity problem #9889 set out to close.

The reverse check is added, and `DECLARED_MISSING_NETWORK` — which held all twenty — is now **empty**, its shrink-only rule having failed every entry the moment the SDL grew the argument.

## Proving the new check fails

`GRAPHQL_SDL_PATH` makes the gate's schema overridable, so a test runs the **whole gate** against a mutated SDL with `blocks.network` removed and asserts it rejects:

```
blocks.network -- /api/v1/blocks has a /{network}/ twin and the SDL takes no
network argument, so testnet is unreachable here
```

Without that, a schema-comparison gate's failure mode is silence — the exact thing this file's own header warns about.

## Validation

- `npm run typecheck`, `npm run lint`, `npm run format:check` — clean
- `validate:graphql-route-parity` — 164 pairs, 1193 fields, 659 argument pairs, **0 divergences**
- `validate:graphql-query-arguments` — 187 exact, 9 skipped, **0 missing `network`** (was 20)
- `validate:graphql-component-parity`, `validate:published-names`, `validate:contract-drift`, `validate:graphql-types-drift` — pass
- `npx vitest run` — **804 files, 18,539 passed, 11 skipped, 0 failed**

`generated/graphql/types.ts` is regenerated and committed, so the resolvers' argument types carry `network`.

Closes #10394.
