### PR TITLE
feat(validate): revenue provenance, and the misattribution evidence cannot catch

### DIFF
--- a/.claude/skills/metagraphed/reference.md
+++ b/.claude/skills/metagraphed/reference.md
@@ -193,6 +193,14 @@ the prober's cold-start seed) · `validate` ·
 description changes what it claims to serve — tier, liveness, provenance — versus the merge base
 while its `docs/backend-artifact-contracts.md` bullet stays byte-identical) ·
 `validate:intake` · `validate:surface` · `validate:workflows` ·
+`validate:revenue-provenance` (relationships the surface schema cannot see: a `revenue.provenance`
+of `probe-derived` on a surface whose `probe.enabled` is not true — or which is `auth_required` —
+did not come from a probe; `operator-attested` must carry a `source_url`; and a
+`payment-collector`/`treasury`/`burn`/`multisig` entity role may **never** sit on a PROTOCOL-DERIVED
+subnet account. That last one is the trap: a subnet's own TAO reserve receives large, continuous,
+many-party inbound because that is what buying alpha looks like, so it presents exactly like a
+team's payment collector and an evidence citation for it would be real while the conclusion stays
+wrong — see metagraphed#10448) ·
 `validate:migrations` (unique, gap-free D1 migration prefixes) ·
 `validate:pg-json-binds` (type-directed: a SQL bind whose static type is an array or a structured
 object is REINTERPRETED by node-postgres — an array becomes a Postgres array literal `{"a","b"}`,

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -608,6 +608,17 @@ jobs:
         if: env.DOCS_ONLY != 'true'
         run: npm run validate:surface
 
+      # #10443/#10516: relationships the JSON Schema cannot see. A
+      # `probe-derived` revenue figure on a surface nothing probes did not come
+      # from a probe, and a revenue/treasury role on a PROTOCOL-DERIVED subnet
+      # account is the misattribution #10448 nearly made — that account
+      # receives large many-party inbound because that is what buying alpha
+      # looks like, so evidence requirements pass it while the conclusion stays
+      # wrong. File-only scan over registry/, no build needed.
+      - name: Validate revenue provenance
+        if: env.DOCS_ONLY != 'true'
+        run: npm run validate:revenue-provenance
+
       # #8658: the cron prober's input list and call_subnet_surface's resolution
       # catalog must be exactly the published registry filtered to
       # probe-enabled + public-safe + callable kinds. When they drift, surfaces

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "subnet:new": "node scripts/subnet-new.ts",
     "enrich:issues": "node scripts/enrichment-issues.ts --write",
     "enrich:issues:dry-run": "node scripts/enrichment-issues.ts --dry-run",
+    "validate:revenue-provenance": "node scripts/validate-revenue-provenance.ts",
     "validate:surface": "node scripts/validate-surface.ts",
     "providers:list": "node scripts/list-providers.ts",
     "r2:manifest": "node scripts/r2-manifest.ts --write",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -133,6 +133,7 @@ function checkCommands(): Step[] {
     step("validate:adapters"),
     step("validate:intake"),
     step("validate:surface"),
+    step("validate:revenue-provenance"),
     // #8658: runs after the build steps above, so the staged surfaces.json
     // exists to compare the callable catalog against.
     step("validate:operational-surface-parity"),
@@ -244,6 +245,7 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("validate:adapters"),
     step("validate:intake"),
     step("validate:surface"),
+    step("validate:revenue-provenance"),
     // #8658: runs after the build steps above, so the staged surfaces.json
     // exists to compare the callable catalog against.
     step("validate:operational-surface-parity"),

--- a/scripts/validate-revenue-provenance.ts
+++ b/scripts/validate-revenue-provenance.ts
@@ -1,0 +1,152 @@
+// #10443/#10516: revenue provenance has to be earned by the surface claiming
+// it, and a protocol account may never be labelled as somebody's money.
+//
+// schemas/subnet-manifest.schema.json already blocks a hand-set revenue AMOUNT
+// -- the `revenue` block is additionalProperties:false over declaration fields
+// only, so `"amount": 4260000` cannot be written at all. That leaves the holes
+// a JSON Schema cannot see, because they are relationships between fields
+// rather than shapes:
+//
+//   A. `provenance: probe-derived` on a surface nothing probes. The claim says
+//      a value was observed on a schedule; if probe.enabled is false, nothing
+//      ever observes it, and the figure can only have come from a human.
+//      Same for an auth-gated surface: the prober has no credential, so a
+//      probe-derived claim over auth_required is unfounded by construction.
+//   B. `operator-attested` with no source_url -- an attestation with nothing
+//      to cite is just an assertion.
+//   C. An entity carrying a revenue or treasury role over a PROTOCOL-DERIVED
+//      subnet account. #10448 nearly recorded SN64's own TAO reserve as a
+//      Chutes revenue collector: it receives large, continuous, many-party
+//      inbound, because that is what buying alpha looks like, so it presents
+//      exactly like a payment collector. Evidence requirements do not catch
+//      this -- the citation would be real and the conclusion still wrong.
+//
+// (C) is the reason this file exists. It is the one failure mode where being
+// careful is not enough, because the wrong answer looks right.
+import path from "node:path";
+import { listJsonFiles, readJson, repoRoot } from "./lib.ts";
+import { protocolSubnetNetuid } from "../src/subnet-accounts.ts";
+
+// Registry documents are read for validation only, never trusted for control
+// flow. Mirrors the readJson precedent in lib.ts.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+/** Roles that assert somebody's money moves through an address. */
+const MONEY_CATEGORIES = new Set([
+  "payment-collector",
+  "treasury",
+  "burn",
+  "multisig",
+]);
+
+export interface ProvenanceViolation {
+  file: string;
+  subject: string;
+  message: string;
+}
+
+/**
+ * Check one subnet manifest's surfaces. Exported for the test, which needs to
+ * drive it over crafted documents rather than only over the live registry --
+ * a gate asserted solely against a clean registry passes on nothing.
+ */
+export function checkSurfaceRevenue(
+  subnet: Row,
+  file = "<memory>",
+): ProvenanceViolation[] {
+  const out: ProvenanceViolation[] = [];
+  for (const surface of Array.isArray(subnet?.surfaces)
+    ? subnet.surfaces
+    : []) {
+    const revenue = surface?.revenue;
+    if (!revenue || typeof revenue !== "object") continue;
+    const id = String(surface?.id ?? "<unnamed surface>");
+    const provenance = revenue.provenance;
+
+    if (provenance === "probe-derived") {
+      if (surface?.probe?.enabled !== true) {
+        out.push({
+          file,
+          subject: id,
+          message:
+            'provenance "probe-derived" but probe.enabled is not true — nothing observes this surface, so the figure cannot have been derived from a probe',
+        });
+      }
+      if (surface?.auth_required === true) {
+        out.push({
+          file,
+          subject: id,
+          message:
+            'provenance "probe-derived" but auth_required is true — the prober holds no credential for this surface, so use "operator-attested"',
+        });
+      }
+    }
+
+    if (provenance === "operator-attested" && !revenue.source_url) {
+      out.push({
+        file,
+        subject: id,
+        message:
+          'provenance "operator-attested" with no source_url — an attestation that cites nothing is an assertion',
+      });
+    }
+  }
+  return out;
+}
+
+/** Check one entity label. Exported for the same reason as above. */
+export function checkEntityRole(
+  entity: Row,
+  file = "<memory>",
+): ProvenanceViolation[] {
+  const category = entity?.category;
+  if (!MONEY_CATEGORIES.has(String(category))) return [];
+  const netuid = protocolSubnetNetuid(entity?.ss58);
+  if (netuid === null) return [];
+  return [
+    {
+      file,
+      subject: String(entity?.ss58 ?? "<no ss58>"),
+      message:
+        `category "${category}" on the protocol-derived TAO account for netuid ${netuid}. ` +
+        "This address is derived by the runtime, not owned by anyone — its inbound is users " +
+        "staking, a capital flow, not revenue. See #10448.",
+    },
+  ];
+}
+
+export async function collectViolations(): Promise<ProvenanceViolation[]> {
+  const violations: ProvenanceViolation[] = [];
+
+  const subnetDir = path.join(repoRoot, "registry/subnets");
+  for (const file of await listJsonFiles(subnetDir)) {
+    const subnet = (await readJson(file)) as Row;
+    violations.push(
+      ...checkSurfaceRevenue(subnet, path.relative(repoRoot, file)),
+    );
+  }
+
+  const entityDir = path.join(repoRoot, "registry/entities");
+  for (const file of await listJsonFiles(entityDir)) {
+    const entity = (await readJson(file)) as Row;
+    violations.push(...checkEntityRole(entity, path.relative(repoRoot, file)));
+  }
+
+  return violations;
+}
+
+// Only run the CLI when invoked directly, so the test can import the checks.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const violations = await collectViolations();
+  if (violations.length > 0) {
+    for (const v of violations) {
+      console.error(`${v.file}: ${v.subject}\n  ${v.message}`);
+    }
+    console.error(
+      `\nRevenue provenance validation FAILED: ${violations.length} violation(s).`,
+    );
+    process.exit(1);
+  }
+  console.log("Revenue provenance validation passed.");
+}

--- a/tests/validate-revenue-provenance.test.ts
+++ b/tests/validate-revenue-provenance.test.ts
@@ -1,0 +1,167 @@
+// #10443/#10516: a gate asserted only against a clean registry passes on
+// nothing. Every check here is driven over a crafted document that MUST be
+// rejected, and the rejection is asserted to name the right reason -- then the
+// live registry is checked separately to confirm it is currently clean.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  checkEntityRole,
+  checkSurfaceRevenue,
+  collectViolations,
+} from "../scripts/validate-revenue-provenance.ts";
+import { subnetAccountSs58 } from "../src/subnet-accounts.ts";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Row = Record<string, any>;
+
+function subnetWith(surface: Row): Row {
+  return {
+    netuid: 64,
+    slug: "sn-64",
+    surfaces: [
+      {
+        id: "sn-64-example",
+        auth_required: false,
+        probe: { enabled: true },
+        ...surface,
+      },
+    ],
+  };
+}
+
+describe("revenue provenance validator (#10443/#10516)", () => {
+  test("a surface with no revenue block is not the validator's business", () => {
+    assert.deepEqual(checkSurfaceRevenue(subnetWith({})), []);
+    assert.deepEqual(checkSurfaceRevenue({}), []);
+    assert.deepEqual(checkSurfaceRevenue({ surfaces: "not-an-array" }), []);
+  });
+
+  test("probe-derived on an unprobed surface is rejected", () => {
+    const v = checkSurfaceRevenue(
+      subnetWith({
+        probe: { enabled: false },
+        revenue: { role: "external-revenue", provenance: "probe-derived" },
+      }),
+    );
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /probe\.enabled/);
+  });
+
+  test("probe-derived with no probe block at all is rejected", () => {
+    // The registry-wide gap tracked in #5932 — a surface can carry no probe
+    // config, which is not the same as probe.enabled being false.
+    const surface: Row = {
+      revenue: { role: "external-revenue", provenance: "probe-derived" },
+    };
+    delete surface.probe;
+    const v = checkSurfaceRevenue({
+      surfaces: [{ id: "x", auth_required: false, ...surface }],
+    });
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /probe\.enabled/);
+  });
+
+  test("probe-derived over an auth-gated surface is rejected", () => {
+    const v = checkSurfaceRevenue(
+      subnetWith({
+        auth_required: true,
+        revenue: { role: "external-revenue", provenance: "probe-derived" },
+      }),
+    );
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /auth_required/);
+  });
+
+  test("operator-attested with no source_url is rejected", () => {
+    const v = checkSurfaceRevenue(
+      subnetWith({
+        revenue: { role: "external-revenue", provenance: "operator-attested" },
+      }),
+    );
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /source_url/);
+  });
+
+  test("operator-attested with a source_url passes", () => {
+    assert.deepEqual(
+      checkSurfaceRevenue(
+        subnetWith({
+          auth_required: true,
+          probe: { enabled: false },
+          revenue: {
+            role: "external-revenue",
+            provenance: "operator-attested",
+            source_url: "https://example.com/revenue",
+          },
+        }),
+      ),
+      [],
+    );
+  });
+
+  test("the real SN64 declaration passes", () => {
+    assert.deepEqual(
+      checkSurfaceRevenue(
+        subnetWith({
+          revenue: {
+            role: "external-revenue",
+            provenance: "probe-derived",
+            currency: "USD",
+            grain: "daily",
+            fields: { date: "date", amount: "total_revenue" },
+          },
+        }),
+      ),
+      [],
+    );
+  });
+
+  test("a protocol subnet account may not carry a money role", () => {
+    // The exact address #10448 nearly recorded as a Chutes revenue collector.
+    const pool = subnetAccountSs58(64) as string;
+    for (const category of [
+      "payment-collector",
+      "treasury",
+      "burn",
+      "multisig",
+    ]) {
+      const v = checkEntityRole({ ss58: pool, category });
+      assert.equal(v.length, 1, `${category} was not rejected`);
+      assert.match(v[0].message, /netuid 64/);
+    }
+  });
+
+  test("a protocol account may still carry a descriptive label", () => {
+    // Naming it "SN64 Subnet Pool" is useful and true; claiming it is a
+    // treasury is not. Only the money roles are refused.
+    for (const category of ["pool", "infra", "other"]) {
+      assert.deepEqual(
+        checkEntityRole({ ss58: subnetAccountSs58(64), category }),
+        [],
+      );
+    }
+  });
+
+  test("an ordinary address may carry a money role", () => {
+    assert.deepEqual(
+      checkEntityRole({
+        ss58: "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9",
+        category: "treasury",
+      }),
+      [],
+    );
+    assert.deepEqual(checkEntityRole({ category: "treasury" }), []);
+    assert.deepEqual(checkEntityRole({}), []);
+  });
+
+  test("the live registry is currently clean", async () => {
+    const violations = await collectViolations();
+    assert.deepEqual(
+      violations,
+      [],
+      violations
+        .map((v) => `${v.file}: ${v.subject} — ${v.message}`)
+        .join("\n"),
+    );
+  });
+});


### PR DESCRIPTION
The surface schema already blocks a hand-set revenue **amount** — the `revenue` block is `additionalProperties: false` over declaration fields, so `"amount": 4260000` cannot be written. What it cannot see are relationships *between* fields, and that is where unfounded claims live.

## Check A — provenance the surface has not earned

`provenance: probe-derived` asserts a value was observed on a schedule.

- On a surface whose `probe.enabled` is not `true`, nothing ever observes it — so the figure can only have come from a human.
- On an `auth_required` surface, the prober holds no credential, so the claim is unfounded by construction and `operator-attested` is the honest label.

`operator-attested` with no `source_url` is an assertion, not an attestation.

These are not hypothetical: they rejected three of my own Phase 2 classifications (SN43's billing endpoints and SN100's signed POST), which is how I found I had labelled hand-probes as probe-derived.

## Check B — the misattribution evidence cannot catch

Every subnet owns a protocol-derived TAO account. It receives large, continuous, many-party inbound — **because that is what buying alpha looks like** — so it presents exactly like a subnet team's payment collector.

#10448 nearly recorded SN64's as one. Its balance (220,486 TAO) tracks the subnet's published `tao_in_pool_tao` (221,394 TAO).

**Evidence requirements do not help here.** A citation for that address would have been real — it *does* receive those payments — and the conclusion still wrong. So a money role on a protocol-derived account is refused outright, using the derivation from #10442 rather than a curated list.

Descriptive labels stay allowed: naming it `pool` or `infra` is useful and true. Only `payment-collector` / `treasury` / `burn` / `multisig` are refused.

## Registered, and proven to fail

Wired into `package.json` and `validate.yml` beside `validate:surface`. A validator that is not in the workflow never runs and passes silently forever.

**Proven, not assumed** — seeded with the exact SN64 pool address under `payment-collector`:

```
registry/entities/tmp-proof.json: 5EYCAe5jLQhn6ofDSw8caRPiDJ7AgBRh4CABSaeQJqM278gq
  category "payment-collector" on the protocol-derived TAO account for netuid 64…

exit code with violation: 1
exit code when clean:    0
```

Every check is also driven over crafted documents in the test rather than only over the live registry — which would pass on nothing. The live registry is asserted clean as a *separate* test.

## Verification

- 11/11 tests · `tsc --noEmit` · eslint · prettier — clean
- `validate:workflows` passes over the edited workflow
- Skill reference updated: a new contributor-facing gate belongs in the validator table

Closes #10443
Closes #10516
