### PR TITLE
fix(api): /accounts/{ss58}/entities reports current ownership, not just transfers

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -182,6 +182,8 @@ export type AccountDeregistrations = {
 export type AccountEntities = {
   __typename?: 'AccountEntities';
   labels: Array<AccountEntityLabel>;
+  /** When the CURRENT-ownership half was captured, or null when no owner snapshot could be read (#9313). Null is load-bearing: it separates "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An owns tie is never fresher than this stamp. */
+  owners_observed_at?: Maybe<Scalars['String']['output']>;
   ownership_tie_count: Scalars['Int']['output'];
   ownership_ties: Array<AccountOwnershipTie>;
   schema_version: Scalars['Int']['output'];
@@ -7464,6 +7466,7 @@ export type AccountDeregistrationsResolvers<ContextType = GqlContext, ParentType
 
 export type AccountEntitiesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AccountEntities'] = ResolversParentTypes['AccountEntities']> = ResolversObject<{
   labels?: Resolver<Array<ResolversTypes['AccountEntityLabel']>, ParentType, ContextType>;
+  owners_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   ownership_tie_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   ownership_ties?: Resolver<Array<ResolversTypes['AccountOwnershipTie']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -182,7 +182,7 @@ export type AccountDeregistrations = {
 export type AccountEntities = {
   __typename?: 'AccountEntities';
   labels: Array<AccountEntityLabel>;
-  /** When the CURRENT-ownership half was captured, or null when no owner snapshot could be read (#9313). Null is load-bearing: it separates "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An owns tie is never fresher than this stamp. */
+  /** When the CURRENT-ownership half was captured, or null when no owner snapshot could be read (#9313). Null is load-bearing: it separates "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An owns tie is never fresher than this stamp. */
   owners_observed_at?: Maybe<Scalars['String']['output']>;
   ownership_tie_count: Scalars['Int']['output'];
   ownership_ties: Array<AccountOwnershipTie>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4970,7 +4970,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
-            /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
+            /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
             owners_observed_at: string | null;
             ownership_tie_count: number;
             ownership_ties: ({

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4970,13 +4970,15 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
+            owners_observed_at: string | null;
             ownership_tie_count: number;
             ownership_ties: ({
                 block_number?: number | null;
                 netuid: number | null;
                 observed_at?: string | null;
                 /** @enum {string} */
-                role: "gained_ownership" | "lost_ownership";
+                role: "owns" | "gained_ownership" | "lost_ownership";
             } & {
                 [key: string]: unknown;
             })[];
@@ -19638,11 +19640,12 @@ export interface operations {
                      *         "labels": [
                      *           {}
                      *         ],
+                     *         "owners_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "ownership_tie_count": 1,
                      *         "ownership_ties": [
                      *           {
                      *             "netuid": 7,
-                     *             "role": "gained_ownership"
+                     *             "role": "owns"
                      *           }
                      *         ],
                      *         "schema_version": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13554,7 +13554,7 @@
                 "type": "null"
               }
             ],
-            "description": "When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes \"we could not read who owns what\" from \"this coldkey owns nothing\", which are the same empty list without it. An `owns` tie is never fresher than this stamp."
+            "description": "When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes \"we could not read who owns what\" from \"this address owns nothing\", which are the same empty list without it. An `owns` tie is never fresher than this stamp."
           },
           "ownership_tie_count": {
             "maximum": 9007199254740991,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -281,11 +281,12 @@
             "labels": [
               {}
             ],
+            "owners_observed_at": "2026-06-01T00:00:00.000Z",
             "ownership_tie_count": 1,
             "ownership_ties": [
               {
                 "netuid": 7,
-                "role": "gained_ownership"
+                "role": "owns"
               }
             ],
             "schema_version": 1,
@@ -13544,6 +13545,17 @@
             },
             "type": "array"
           },
+          "owners_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes \"we could not read who owns what\" from \"this coldkey owns nothing\", which are the same empty list without it. An `owns` tie is never fresher than this stamp."
+          },
           "ownership_tie_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -13552,7 +13564,7 @@
           "ownership_ties": {
             "items": {
               "additionalProperties": {},
-              "description": "One SubnetOwnerChanged transfer tying this `coldkey` to a subnet, either as the gaining or losing side, newest first.",
+              "description": "One tie between this `coldkey` and a subnet. `owns` is CURRENT ownership read from the economics tier's `owner_coldkey` (measured from SubtensorModule.SubnetOwner) and carries a NULL `block_number`, because it is a state rather than an event -- these come first, by netuid. `gained_ownership`/`lost_ownership` are SubnetOwnerChanged transfers, newest first, and there is exactly ONE such event in all of chain history: ownership is established at registration and only ever moved by conviction contest, which is why reading the transfer stream alone reported no ties for coldkeys that plainly own a subnet (#9313).",
               "properties": {
                 "block_number": {
                   "anyOf": [
@@ -13590,6 +13602,7 @@
                 },
                 "role": {
                   "enum": [
+                    "owns",
                     "gained_ownership",
                     "lost_ownership"
                   ],
@@ -13618,7 +13631,8 @@
           "ss58",
           "labels",
           "ownership_tie_count",
-          "ownership_ties"
+          "ownership_ties",
+          "owners_observed_at"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4970,7 +4970,7 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
-            /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
+            /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
             owners_observed_at: string | null;
             ownership_tie_count: number;
             ownership_ties: ({

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4970,13 +4970,15 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp. */
+            owners_observed_at: string | null;
             ownership_tie_count: number;
             ownership_ties: ({
                 block_number?: number | null;
                 netuid: number | null;
                 observed_at?: string | null;
                 /** @enum {string} */
-                role: "gained_ownership" | "lost_ownership";
+                role: "owns" | "gained_ownership" | "lost_ownership";
             } & {
                 [key: string]: unknown;
             })[];
@@ -19638,11 +19640,12 @@ export interface operations {
                      *         "labels": [
                      *           {}
                      *         ],
+                     *         "owners_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "ownership_tie_count": 1,
                      *         "ownership_ties": [
                      *           {
                      *             "netuid": 7,
-                     *             "role": "gained_ownership"
+                     *             "role": "owns"
                      *           }
                      *         ],
                      *         "schema_version": 1,

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -50,15 +50,21 @@ export const AccountEntitiesArtifactSchema = z
       z
         .object({
           netuid: z.int().nullable(),
-          role: z.enum(["gained_ownership", "lost_ownership"]),
+          role: z.enum(["owns", "gained_ownership", "lost_ownership"]),
           block_number: z.int().nullable().optional(),
           observed_at: z.string().nullable().optional(),
         })
         .passthrough()
         .describe(
-          "One SubnetOwnerChanged transfer tying this `coldkey` to a subnet, either as the gaining or losing side, newest first.",
+          "One tie between this `coldkey` and a subnet. `owns` is CURRENT ownership read from the economics tier's `owner_coldkey` (measured from SubtensorModule.SubnetOwner) and carries a NULL `block_number`, because it is a state rather than an event -- these come first, by netuid. `gained_ownership`/`lost_ownership` are SubnetOwnerChanged transfers, newest first, and there is exactly ONE such event in all of chain history: ownership is established at registration and only ever moved by conviction contest, which is why reading the transfer stream alone reported no ties for coldkeys that plainly own a subnet (#9313).",
         ),
     ),
+    owners_observed_at: z
+      .string()
+      .nullable()
+      .describe(
+        'When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp.',
+      ),
   })
   .passthrough()
   .describe(

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -63,7 +63,7 @@ export const AccountEntitiesArtifactSchema = z
       .string()
       .nullable()
       .describe(
-        'When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp.',
+        'When the CURRENT-ownership half was captured, or null when no owner snapshot could be read. Null is load-bearing: it distinguishes "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An `owns` tie is never fresher than this stamp.',
       ),
   })
   .passthrough()

--- a/src/account-entities-answer.ts
+++ b/src/account-entities-answer.ts
@@ -129,10 +129,16 @@ function withOwnedTies(
 async function readSubnetOwners(
   env: unknown,
 ): Promise<SubnetOwnerSnapshot | null> {
-  // readArtifact reports `{ ok: false }` on a timeout or throw rather than
-  // rejecting, so a miss lands on the same null as a malformed blob -- both
-  // mean "we could not read who owns what", which is exactly what
-  // `owners_observed_at: null` goes on to say.
-  const artifact = await readArtifact(env as never, ECONOMICS_ARTIFACT);
-  return artifact.ok ? subnetOwnersFromEconomics(artifact.data) : null;
+  // BOTH guards, because they catch different failures. readArtifact reports
+  // `{ ok: false }` for a miss or a timeout -- but it THROWS when the binding
+  // it reaches for is not there at all (`Cannot read properties of null`), and
+  // this route has a documented schema-stable floor that a rejection would turn
+  // into a 500. Every one of those outcomes means the same thing to a caller:
+  // we could not read who owns what, which `owners_observed_at: null` says.
+  try {
+    const artifact = await readArtifact(env as never, ECONOMICS_ARTIFACT);
+    return artifact.ok ? subnetOwnersFromEconomics(artifact.data) : null;
+  } catch {
+    return null;
+  }
 }

--- a/src/account-entities-answer.ts
+++ b/src/account-entities-answer.ts
@@ -30,12 +30,22 @@
 // to make unrepresentable.
 
 import { loadAccountEntitiesColdTier } from "./subnet-ownership-cold-tier.ts";
-import { buildAccountEntities } from "./entity-labels.ts";
+import {
+  buildAccountEntities,
+  subnetOwnersFromEconomics,
+  type SubnetOwnerSnapshot,
+} from "./entity-labels.ts";
+import { readArtifact } from "../workers/storage.ts";
 
 type Row = Record<string, unknown>;
 
+/** The economics blob, which carries `owner_coldkey` per subnet (#9313). */
+const ECONOMICS_ARTIFACT = "/metagraph/economics.json";
+
 export interface AnswerAccountEntitiesOptions {
   coldTier?: typeof loadAccountEntitiesColdTier;
+  /** Injected in tests; production reads the economics artifact. */
+  owners?: () => Promise<SubnetOwnerSnapshot | null>;
 }
 
 /**
@@ -53,11 +63,76 @@ export async function answerAccountEntities(
   env: unknown,
   coldkey: string,
   tierResult: Row | null | undefined,
-  { coldTier = loadAccountEntitiesColdTier }: AnswerAccountEntitiesOptions = {},
+  {
+    coldTier = loadAccountEntitiesColdTier,
+    owners = () => readSubnetOwners(env),
+  }: AnswerAccountEntitiesOptions = {},
 ): Promise<Row> {
-  return (
-    tierResult ??
-    ((await coldTier(env as never, coldkey)) as Row | null) ??
-    (buildAccountEntities(coldkey, { entities: [] }) as unknown as Row)
-  );
+  // CURRENT OWNERSHIP IS RESOLVED HERE, not per tier (#9313).
+  //
+  // The transfer stream can only answer who has TRADED a subnet, and exactly
+  // one such event exists chain-wide -- so every store above answered
+  // `ownership_ties: []` for coldkeys that plainly own one. The economics blob
+  // carries `owner_coldkey` per subnet and is readable whether or not the
+  // lakehouse is, which is why the read sits in the composer: the ownership
+  // half must not disappear just because the transfer half declined.
+  const ownerSnapshot = await owners();
+
+  const answered =
+    tierResult ?? ((await coldTier(env as never, coldkey)) as Row | null);
+
+  // A tier that answered already shaped its payload from the transfer stream.
+  // Its ties are merged with the owned ones rather than rebuilt, so the tier
+  // keeps owning what it is authoritative for and this only adds what it never
+  // had access to.
+  if (answered) return withOwnedTies(answered, coldkey, ownerSnapshot);
+
+  return buildAccountEntities(coldkey, {
+    entities: [],
+    owners: ownerSnapshot,
+  }) as unknown as Row;
+}
+
+/**
+ * Fold current-ownership ties into a payload a tier already built.
+ *
+ * Rebuilt through buildAccountEntities so the ORDER and shape are decided in
+ * one place -- a second assembly here would be the "subtly different decoder
+ * for the same facts" the cold tier's own note warns against.
+ */
+function withOwnedTies(
+  answered: Row,
+  coldkey: string,
+  owners: SubnetOwnerSnapshot | null,
+): Row {
+  if (!owners) return { ...answered, owners_observed_at: null };
+  const owned = buildAccountEntities(coldkey, { owners });
+  const existing = Array.isArray(answered.ownership_ties)
+    ? answered.ownership_ties
+    : [];
+  const ties = [...owned.ownership_ties, ...existing];
+  return {
+    ...answered,
+    ownership_ties: ties,
+    ownership_tie_count: ties.length,
+    owners_observed_at: owned.owners_observed_at,
+  };
+}
+
+/**
+ * The owner snapshot, or null when the artifact cannot be read.
+ *
+ * Null rather than an empty snapshot, so "we could not read who owns what" and
+ * "this coldkey owns nothing" stay different answers -- the distinction
+ * `owners_observed_at` publishes.
+ */
+async function readSubnetOwners(
+  env: unknown,
+): Promise<SubnetOwnerSnapshot | null> {
+  // readArtifact reports `{ ok: false }` on a timeout or throw rather than
+  // rejecting, so a miss lands on the same null as a malformed blob -- both
+  // mean "we could not read who owns what", which is exactly what
+  // `owners_observed_at: null` goes on to say.
+  const artifact = await readArtifact(env as never, ECONOMICS_ARTIFACT);
+  return artifact.ok ? subnetOwnersFromEconomics(artifact.data) : null;
 }

--- a/src/entity-labels.ts
+++ b/src/entity-labels.ts
@@ -5,12 +5,26 @@
 // module pivots that stream by coldkey instead of by netuid. No new capture:
 // both inputs (the entity registry, the chain_events stream) already exist.
 //
-// Honest scope note (mirrors buildSubnetOwnershipHistory's own limitation):
+// THE TRANSFER STREAM IS NOT THE OWNERSHIP RECORD (#9313).
+//
 // SubnetOwnerChanged only fires on an AUTOMATIC conviction-contest transfer
-// (docs/conviction-lock-mechanism.md) -- it says nothing about who a subnet's
-// original/genesis owner was if it has never changed hands. A coldkey that has
-// held a subnet since registration and never lost it to a challenger will not
-// appear in ownership_ties at all. This is a real data-source gap, not a bug.
+// (docs/conviction-lock-mechanism.md), and there is exactly ONE such event in
+// all of chain history. Ownership is established at REGISTRATION, so reading
+// the stream alone answered `ownership_ties: 0` for coldkeys that plainly own
+// a subnet -- this module used to call that "a real data-source gap, not a
+// bug", which was true about the stream and wrong about the answer: a caller
+// cannot tell a gap from a fact, and an empty list reads as "owns nothing".
+//
+// So current ownership now comes from the economics tier's per-subnet
+// `owner_coldkey` -- MEASURED from SubtensorModule.SubnetOwner, and the only
+// source every surface can reach (the poller's ownership ledger lives in the
+// lakehouse alone, and this route is answered by more than one store).
+// NetworkAdded cannot serve here: its args are `["netuid"]` with no coldkey to
+// attribute, which is also why NetworkRemoved cannot retire a tie.
+//
+// The two halves stay distinguishable in the payload: `owns` is a STATE with a
+// null block, the transfers are EVENTS with one, and `owners_observed_at` says
+// when the state was read so it is never served as fresher than its capture.
 
 import { decodeChainEventArgs } from "./chain-event-args.ts";
 
@@ -167,6 +181,21 @@ function isoOrNull(value: unknown): string | null {
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
 }
 
+/**
+ * An ALREADY-ISO timestamp, normalised, or null.
+ *
+ * Distinct from isoOrNull above, which converts epoch MILLISECONDS -- the shape
+ * chain_events rows carry. The economics artifact writes `captured_at` as an
+ * ISO string, and pushing that through the numeric helper yields NaN and so
+ * null, which would have published `owners_observed_at: null` on every single
+ * response while looking entirely correct.
+ */
+function isoStringOrNull(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
+}
+
 interface OwnershipChangeRow {
   netuid: number | null;
   old_coldkey: unknown;
@@ -196,9 +225,57 @@ function decodeOwnershipChangeRow(
 
 export interface OwnershipTie {
   netuid: number | null;
-  role: "gained_ownership" | "lost_ownership";
+  /**
+   * `owns` is a STATE; the other two are TRANSITIONS (#9313).
+   *
+   * They are not interchangeable and `owns` is not spelled `gained_ownership`:
+   * the overwhelming majority of owners never gained anything, they registered
+   * the subnet and kept it. Calling that a gain would assert a transfer that
+   * never happened, on 269 of the 270 subnets ever created.
+   */
+  role: "owns" | "gained_ownership" | "lost_ownership";
+  /** NULL for `owns` -- current ownership is not an event and has no block. */
   block_number: number | null;
   observed_at: string | null;
+}
+
+/**
+ * Who currently owns each subnet, and when that was read.
+ *
+ * `captured_at` rides along because a current-ownership claim is only as
+ * current as the capture behind it -- serving `owns` with no ceiling would be
+ * publishing a snapshot as a live fact.
+ */
+export interface SubnetOwnerSnapshot {
+  rows: Array<{ netuid: unknown; owner_coldkey: unknown }>;
+  captured_at: string | null;
+}
+
+/**
+ * The per-subnet owners out of the economics artifact (#9313).
+ *
+ * `owner_coldkey` is a MEASURED field there (`SubtensorModule.SubnetOwner`,
+ * per src/economics-field-sources.ts), which is a stronger provenance than any
+ * reconstruction from the event log -- and it is the only source available to
+ * every surface, since the ownership ledger the poller keeps lives in the
+ * lakehouse alone.
+ *
+ * Returns null when the blob cannot be read as one, so a missing artifact stays
+ * distinguishable from a subnet set with no owners in it.
+ */
+export function subnetOwnersFromEconomics(
+  blob: unknown,
+): SubnetOwnerSnapshot | null {
+  const data = blob as Record<string, unknown> | null | undefined;
+  const subnets = data?.subnets;
+  if (!Array.isArray(subnets)) return null;
+  return {
+    rows: subnets.filter(
+      (row): row is { netuid: unknown; owner_coldkey: unknown } =>
+        !!row && typeof row === "object" && !Array.isArray(row),
+    ),
+    captured_at: isoStringOrNull(data?.captured_at),
+  };
 }
 
 export interface AccountEntitiesResult {
@@ -207,6 +284,16 @@ export interface AccountEntitiesResult {
   labels: EntityLabel[];
   ownership_tie_count: number;
   ownership_ties: OwnershipTie[];
+  /**
+   * When the CURRENT-ownership half was captured, or null when no owner
+   * snapshot was available (#9313).
+   *
+   * Null is load-bearing: it says the `owns` ties are absent because nothing
+   * was read, not because this coldkey owns nothing. Without it those two
+   * cases are the same empty list -- which is the confusion that made this
+   * route report `ownership_ties: 0` for a live subnet owner.
+   */
+  owners_observed_at: string | null;
 }
 
 // #6740: one coldkey's entity labels plus every subnet-ownership tie it has
@@ -222,13 +309,35 @@ export function buildAccountEntities(
   {
     entities,
     ownershipRows,
+    owners,
   }: {
     entities?: Array<Record<string, unknown>> | null;
     ownershipRows?: Array<Record<string, unknown>> | null;
+    owners?: SubnetOwnerSnapshot | null;
   } = {},
 ): AccountEntitiesResult {
   const labels = labelsForSs58(entityLabelsIndex(entities), ss58);
-  const ownershipTies: OwnershipTie[] = (ownershipRows ?? [])
+
+  // CURRENT OWNERSHIP FIRST (#9313).
+  //
+  // The transfer stream below cannot answer "what does this coldkey own": it
+  // holds exactly ONE SubnetOwnerChanged event chain-wide, because ownership is
+  // established at registration and only transferred by conviction contest.
+  // Reading it alone reported `ownership_ties: 0` for coldkeys that demonstrably
+  // own a subnet -- a confident empty, which is worse than a decline.
+  const ownedTies: OwnershipTie[] = (owners?.rows ?? [])
+    .filter((row) => row.owner_coldkey === ss58)
+    .map((row) => ({
+      netuid: numberOrNull(row.netuid),
+      role: "owns" as const,
+      // NOT a block. Current ownership is a state read from storage, and
+      // inventing a block for it would date a standing fact to an event.
+      block_number: null,
+      observed_at: owners?.captured_at ?? null,
+    }))
+    .sort((a, b) => (a.netuid ?? 0) - (b.netuid ?? 0));
+
+  const transferTies: OwnershipTie[] = (ownershipRows ?? [])
     .map(decodeOwnershipChangeRow)
     .filter(
       (change) => change.old_coldkey === ss58 || change.new_coldkey === ss58,
@@ -243,11 +352,17 @@ export function buildAccountEntities(
     }))
     .sort((a, b) => (b.block_number ?? 0) - (a.block_number ?? 0));
 
+  // State before history, and NOT merged into one sort: the two halves are
+  // ordered by different things (netuid; block) and have different meanings, so
+  // interleaving them by a shared key would imply a timeline they do not share.
+  const ownershipTies = [...ownedTies, ...transferTies];
+
   return {
     schema_version: 1,
     ss58,
     labels,
     ownership_tie_count: ownershipTies.length,
     ownership_ties: ownershipTies,
+    owners_observed_at: owners?.captured_at ?? null,
   };
 }

--- a/src/entity-labels.ts
+++ b/src/entity-labels.ts
@@ -174,6 +174,28 @@ function numberOrNull(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+/**
+ * A netuid, or null -- WITHOUT `Number(null) === 0`.
+ *
+ * numberOrNull above coerces with `Number()`, and `Number(null)` and
+ * `Number("")` are both 0 -- finite, so both pass its guard. On an owner row
+ * from the economics blob that turns "this row has no netuid" into "this
+ * coldkey owns subnet 0", and netuid 0 is ROOT: the silent failure is a
+ * claim on the most consequential subnet there is.
+ *
+ * The transfer path keeps numberOrNull: its rows come from a decoded chain
+ * event that always carries a netuid, so tightening it there would be changing
+ * behaviour nothing exercises. This is for the untrusted artifact shape.
+ */
+function netuidOrNull(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
 function isoOrNull(value: unknown): string | null {
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) return null;
@@ -328,7 +350,7 @@ export function buildAccountEntities(
   const ownedTies: OwnershipTie[] = (owners?.rows ?? [])
     .filter((row) => row.owner_coldkey === ss58)
     .map((row) => ({
-      netuid: numberOrNull(row.netuid),
+      netuid: netuidOrNull(row.netuid),
       role: "owns" as const,
       // NOT a block. Current ownership is a state read from storage, and
       // inventing a block for it would date a standing fact to an event.

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -5113,6 +5113,10 @@ export const SDL = /* GraphQL */ `
     labels: [AccountEntityLabel!]!
     ownership_tie_count: Int!
     ownership_ties: [AccountOwnershipTie!]!
+    """
+    When the CURRENT-ownership half was captured, or null when no owner snapshot could be read (#9313). Null is load-bearing: it separates "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An owns tie is never fresher than this stamp.
+    """
+    owners_observed_at: String
   }
 
   "A community-contributed entity label for an address (exchange/foundation/operator/other)."

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -5114,7 +5114,7 @@ export const SDL = /* GraphQL */ `
     ownership_tie_count: Int!
     ownership_ties: [AccountOwnershipTie!]!
     """
-    When the CURRENT-ownership half was captured, or null when no owner snapshot could be read (#9313). Null is load-bearing: it separates "we could not read who owns what" from "this coldkey owns nothing", which are the same empty list without it. An owns tie is never fresher than this stamp.
+    When the CURRENT-ownership half was captured, or null when no owner snapshot could be read (#9313). Null is load-bearing: it separates "we could not read who owns what" from "this address owns nothing", which are the same empty list without it. An owns tie is never fresher than this stamp.
     """
     owners_observed_at: String
   }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -7031,6 +7031,12 @@ const rootValue = {
       labels,
       ownership_tie_count: data.ownership_tie_count ?? 0,
       ownership_ties: data.ownership_ties || [],
+      // #9313: this object is built field by field, so a new one on the
+      // composer does NOT arrive here by itself -- it would resolve to null on
+      // every request, which for this field means "we could not read who owns
+      // what". Defaulted to null explicitly rather than left out, because that
+      // is the honest value when the composer genuinely had no snapshot.
+      owners_observed_at: data.owners_observed_at ?? null,
     };
   },
 

--- a/tests/account-entities-answer.test.ts
+++ b/tests/account-entities-answer.test.ts
@@ -1,0 +1,127 @@
+// The composer for /api/v1/accounts/{ss58}/entities (#9313).
+//
+// Two sources answer this route and they say different things. The transfer
+// stream (SubnetOwnerChanged) knows who has TRADED a subnet — one event in all
+// of chain history. The economics blob knows who OWNS one right now. Reading
+// only the first reported `ownership_ties: 0` for coldkeys that plainly own a
+// subnet, which a caller reads as "owns nothing" rather than "we did not look".
+//
+// So the composer resolves current ownership itself, and the property under
+// test is that it keeps doing so INDEPENDENTLY of whether the transfer half
+// answered: the ownership record must not disappear because the event stream
+// declined.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { answerAccountEntities } from "../src/account-entities-answer.ts";
+import type { SubnetOwnerSnapshot } from "../src/entity-labels.ts";
+
+const OWNER = "5FRYKhbmT3ijhFVDMHUvBrqLKteLBSb6JqPCvB3NfWaVbxpe";
+const CAPTURED = "2026-08-10T09:26:12.433Z";
+
+const owners = (): SubnetOwnerSnapshot => ({
+  rows: [
+    { netuid: 64, owner_coldkey: OWNER },
+    { netuid: 7, owner_coldkey: "someone-else" },
+  ],
+  captured_at: CAPTURED,
+});
+
+/** A tier that declines, which is what the retired Postgres leg does today. */
+const declines = async () => null;
+
+describe("current ownership survives a declining transfer tier", () => {
+  test("the cold tier declining does NOT drop the owned ties", async () => {
+    // The bug's shape: every store answered empty, so the payload said this
+    // coldkey has no ties at all.
+    const data = await answerAccountEntities(null, OWNER, null, {
+      coldTier: declines,
+      owners: async () => owners(),
+    });
+    assert.equal(data.ownership_tie_count, 1);
+    const ties = data.ownership_ties as Array<Record<string, unknown>>;
+    assert.equal(ties[0].netuid, 64);
+    assert.equal(ties[0].role, "owns");
+    assert.equal(data.owners_observed_at, CAPTURED);
+  });
+
+  test("a tier that ANSWERED keeps its transfers, and gains the owned ties", async () => {
+    // The tier stays authoritative for what it read; this only adds the half it
+    // never had access to.
+    const transfer = {
+      netuid: 7,
+      role: "gained_ownership",
+      block_number: 8587754,
+      observed_at: "2026-07-09T12:26:40.000Z",
+    };
+    const data = await answerAccountEntities(
+      null,
+      OWNER,
+      {
+        schema_version: 1,
+        ss58: OWNER,
+        labels: [],
+        ownership_tie_count: 1,
+        ownership_ties: [transfer],
+      },
+      { coldTier: declines, owners: async () => owners() },
+    );
+    const ties = data.ownership_ties as Array<Record<string, unknown>>;
+    assert.deepEqual(
+      ties.map((t) => t.role),
+      ["owns", "gained_ownership"],
+    );
+    // The count is RECOMPUTED, not carried over from the tier — a stale count
+    // beside a longer list is the kind of quiet inconsistency this route had.
+    assert.equal(data.ownership_tie_count, 2);
+  });
+
+  test("no owner snapshot leaves owners_observed_at NULL, not invented", async () => {
+    // "Could not read who owns what" has to stay distinguishable from "owns
+    // nothing", and this field is the only thing that separates them.
+    const data = await answerAccountEntities(null, OWNER, null, {
+      coldTier: declines,
+      owners: async () => null,
+    });
+    assert.deepEqual(data.ownership_ties, []);
+    assert.equal(data.owners_observed_at, null);
+  });
+
+  test("a tier answered but no snapshot: the tier's ties survive untouched", async () => {
+    const transfer = { netuid: 7, role: "lost_ownership", block_number: 1 };
+    const data = await answerAccountEntities(
+      null,
+      OWNER,
+      {
+        schema_version: 1,
+        ss58: OWNER,
+        labels: [],
+        ownership_tie_count: 1,
+        ownership_ties: [transfer],
+      },
+      { coldTier: declines, owners: async () => null },
+    );
+    assert.deepEqual(data.ownership_ties, [transfer]);
+    assert.equal(data.owners_observed_at, null);
+  });
+
+  test("a coldkey owning nothing still reports WHEN we looked", async () => {
+    const data = await answerAccountEntities(null, "nobody", null, {
+      coldTier: declines,
+      owners: async () => owners(),
+    });
+    assert.deepEqual(data.ownership_ties, []);
+    assert.equal(data.owners_observed_at, CAPTURED);
+  });
+
+  test("a tier payload with no ties array is tolerated, not thrown on", async () => {
+    // The tier result is an untrusted shape here — it crosses a module and a
+    // store boundary — so a missing array must degrade rather than throw.
+    const data = await answerAccountEntities(
+      null,
+      OWNER,
+      { schema_version: 1, ss58: OWNER, labels: [] },
+      { coldTier: declines, owners: async () => owners() },
+    );
+    assert.equal(data.ownership_tie_count, 1);
+  });
+});

--- a/tests/account-entities-answer.test.ts
+++ b/tests/account-entities-answer.test.ts
@@ -11,7 +11,23 @@
 // answered: the ownership record must not disappear because the event stream
 // declined.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
+
+// The artifact read is mocked so BOTH of its failure modes are reachable:
+// readArtifact answers `{ ok: false }` for a miss or timeout, and THROWS when
+// the binding it reaches for is absent. They arrive by different paths and both
+// have to land on the same decline.
+const storage = vi.hoisted(() => ({
+  behaviour: { kind: "ok", data: undefined as unknown },
+}));
+vi.mock("../workers/storage.ts", () => ({
+  readArtifact: async () => {
+    if (storage.behaviour.kind === "throws") throw new TypeError("no binding");
+    if (storage.behaviour.kind === "miss") return { ok: false };
+    return { ok: true, data: storage.behaviour.data };
+  },
+}));
+
 import { answerAccountEntities } from "../src/account-entities-answer.ts";
 import type { SubnetOwnerSnapshot } from "../src/entity-labels.ts";
 
@@ -123,5 +139,40 @@ describe("current ownership survives a declining transfer tier", () => {
       { coldTier: declines, owners: async () => owners() },
     );
     assert.equal(data.ownership_tie_count, 1);
+  });
+});
+
+describe("reading the economics artifact (#9313)", () => {
+  const read = async () =>
+    await answerAccountEntities(null, OWNER, null, { coldTier: declines });
+
+  test("a MISS declines rather than inventing an empty ownership set", async () => {
+    storage.behaviour = { kind: "miss", data: undefined };
+    const data = await read();
+    assert.deepEqual(data.ownership_ties, []);
+    assert.equal(data.owners_observed_at, null);
+  });
+
+  test("a THROW declines too -- this route has a schema-stable floor", async () => {
+    // readArtifact does not swallow a missing binding; it throws. Letting that
+    // propagate would turn a degradable read into a 500 on a route documented
+    // to answer an empty payload once every store has declined.
+    storage.behaviour = { kind: "throws", data: undefined };
+    const data = await read();
+    assert.deepEqual(data.ownership_ties, []);
+    assert.equal(data.owners_observed_at, null);
+  });
+
+  test("a readable blob produces the owned ties", async () => {
+    storage.behaviour = {
+      kind: "ok",
+      data: {
+        captured_at: CAPTURED,
+        subnets: [{ netuid: 64, owner_coldkey: OWNER }],
+      },
+    };
+    const data = await read();
+    assert.equal(data.ownership_tie_count, 1);
+    assert.equal(data.owners_observed_at, CAPTURED);
   });
 });

--- a/tests/entity-labels.test.ts
+++ b/tests/entity-labels.test.ts
@@ -532,4 +532,76 @@ describe("reading owners out of the economics blob (#9313)", () => {
     assert.equal(snap?.captured_at, null);
     assert.deepEqual(snap?.rows, []);
   });
+
+  test("an UNPARSEABLE capture stamp is null, not echoed through", () => {
+    // The stamp is what stops an `owns` tie reading as fresher than its
+    // source, so a value that is not a time must not be published as one.
+    const snap = subnetOwnersFromEconomics({
+      captured_at: "not-a-date",
+      subnets: [],
+    });
+    assert.equal(snap?.captured_at, null);
+  });
+
+  test("owners with no capture stamp still yield ties, dated null", () => {
+    // The snapshot was read (so `owns` is real) but it did not say when. The
+    // tie stands; its `observed_at` says nothing rather than guessing.
+    const data = buildAccountEntities("abc", {
+      owners: {
+        rows: [{ netuid: 3, owner_coldkey: "abc" }],
+        captured_at: null,
+      },
+    });
+    assert.equal(data.ownership_tie_count, 1);
+    assert.equal(data.ownership_ties[0].observed_at, null);
+    assert.equal(data.owners_observed_at, null);
+  });
+
+  test("a netuid arriving as a STRING is accepted; junk is not", () => {
+    // The artifact is an untrusted shape at this boundary. A numeric string is
+    // still a netuid; "abc" and "" are not, and `Number("")` being 0 is exactly
+    // why the empty case cannot go through a plain Number() coercion.
+    const owned = (netuid: unknown) =>
+      buildAccountEntities("abc", {
+        owners: { rows: [{ netuid, owner_coldkey: "abc" }], captured_at: null },
+      }).ownership_ties[0].netuid;
+    assert.equal(owned("64"), 64);
+    assert.equal(owned("abc"), null);
+    assert.equal(owned(""), null);
+    assert.equal(owned(Number.NaN), null);
+    assert.equal(owned(undefined), null);
+  });
+
+  test("a row with no usable netuid still sorts, rather than throwing", () => {
+    // The economics blob is an untrusted shape here. Two rows are needed for
+    // the comparator to run at all, and a null netuid must not take the sort
+    // down with it.
+    const data = buildAccountEntities("abc", {
+      owners: {
+        rows: [
+          { netuid: null, owner_coldkey: "abc" },
+          { netuid: 2, owner_coldkey: "abc" },
+        ],
+        captured_at: null,
+      },
+    });
+    assert.equal(data.ownership_tie_count, 2);
+    assert.deepEqual(
+      data.ownership_ties.map((t) => t.netuid),
+      [null, 2],
+    );
+
+    // The same pair the other way round, so the comparator sees a null on
+    // BOTH sides across the two cases rather than only the left.
+    const reversed = buildAccountEntities("abc", {
+      owners: {
+        rows: [
+          { netuid: 2, owner_coldkey: "abc" },
+          { netuid: null, owner_coldkey: "abc" },
+        ],
+        captured_at: null,
+      },
+    });
+    assert.equal(reversed.ownership_tie_count, 2);
+  });
 });

--- a/tests/entity-labels.test.ts
+++ b/tests/entity-labels.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   buildAccountEntities,
+  subnetOwnersFromEconomics,
   entityLabelsIndex,
   labelsForSs58,
   resolveAddress,
@@ -430,5 +431,105 @@ describe("resolveAddress -- the reserved private-label layer (#8484)", () => {
     assert.equal(resolved.display, "Main coldkey");
     assert.equal(resolved.source, "private");
     assert.equal(resolved.ss58, SS58);
+  });
+});
+
+// CURRENT OWNERSHIP (#9313).
+//
+// The transfer stream holds exactly ONE SubnetOwnerChanged event chain-wide,
+// because ownership is established at registration and only ever moves by
+// conviction contest. Reading it alone answered `ownership_ties: 0` for
+// coldkeys that demonstrably own a subnet -- a confident empty, which reads to
+// a caller as "this address owns nothing" rather than "we did not look".
+describe("current subnet ownership (#9313)", () => {
+  const OWNER = "5FRYKhbmT3ijhFVDMHUvBrqLKteLBSb6JqPCvB3NfWaVbxpe";
+  const CAPTURED = "2026-08-10T09:26:12.433Z";
+  const owners = () => ({
+    rows: [
+      { netuid: 64, owner_coldkey: OWNER },
+      { netuid: 7, owner_coldkey: "someone-else" },
+      { netuid: 12, owner_coldkey: OWNER },
+    ],
+    captured_at: CAPTURED,
+  });
+
+  test("an owner of a subnet gets a tie -- the bug this closes", () => {
+    const data = buildAccountEntities(OWNER, {
+      entities: [],
+      owners: owners(),
+    });
+    assert.equal(data.ownership_tie_count, 2);
+    assert.deepEqual(
+      data.ownership_ties.map((t) => t.netuid),
+      [12, 64],
+    );
+    assert.ok(data.ownership_ties.every((t) => t.role === "owns"));
+  });
+
+  test("`owns` carries a NULL block, never 0", () => {
+    // Current ownership is a state read from storage. A 0 would date every
+    // owner's tie to genesis, which is the same mistake predates_capture
+    // exists to stop elsewhere.
+    const data = buildAccountEntities(OWNER, { owners: owners() });
+    assert.equal(data.ownership_ties[0].block_number, null);
+    assert.equal(data.ownership_ties[0].observed_at, CAPTURED);
+  });
+
+  test("an `owns` tie is never fresher than the capture behind it", () => {
+    const data = buildAccountEntities(OWNER, { owners: owners() });
+    assert.equal(data.owners_observed_at, CAPTURED);
+  });
+
+  test("OWNING NOTHING and NOT LOOKING are different answers", () => {
+    // Both produce an empty tie list; only `owners_observed_at` tells them
+    // apart, which is the whole reason the field exists.
+    const ownsNothing = buildAccountEntities("nobody", { owners: owners() });
+    assert.deepEqual(ownsNothing.ownership_ties, []);
+    assert.equal(ownsNothing.owners_observed_at, CAPTURED);
+
+    const notRead = buildAccountEntities("nobody", { owners: null });
+    assert.deepEqual(notRead.ownership_ties, []);
+    assert.equal(notRead.owners_observed_at, null);
+  });
+
+  test("state comes before history, and neither reorders the other", () => {
+    const data = buildAccountEntities(NEW_COLDKEY_SS58, {
+      owners: {
+        rows: [{ netuid: 99, owner_coldkey: NEW_COLDKEY_SS58 }],
+        captured_at: CAPTURED,
+      },
+      ownershipRows: [ownershipRow()],
+    });
+    assert.deepEqual(
+      data.ownership_ties.map((t) => t.role),
+      ["owns", "gained_ownership"],
+    );
+    assert.equal(data.ownership_tie_count, 2);
+  });
+});
+
+describe("reading owners out of the economics blob (#9313)", () => {
+  test("takes the per-subnet owner and the capture stamp", () => {
+    const snap = subnetOwnersFromEconomics({
+      captured_at: "2026-08-10T09:26:12.433Z",
+      subnets: [{ netuid: 64, owner_coldkey: "abc" }],
+    });
+    assert.equal(snap?.rows.length, 1);
+    assert.equal(snap?.captured_at, "2026-08-10T09:26:12.433Z");
+  });
+
+  test("a blob with no subnets array is NULL, not an empty snapshot", () => {
+    // Null means "could not read who owns what". An empty snapshot would claim
+    // we read the set and it was empty -- which would publish a non-null
+    // `owners_observed_at` over an answer nothing backed.
+    assert.equal(subnetOwnersFromEconomics({}), null);
+    assert.equal(subnetOwnersFromEconomics(null), null);
+    assert.equal(subnetOwnersFromEconomics({ subnets: "nope" }), null);
+  });
+
+  test("a missing capture stamp is null rather than invented", () => {
+    const snap = subnetOwnersFromEconomics({ subnets: [] });
+    assert.equal(snap?.captured_at, null);
+    assert.deepEqual(snap?.rows, []);
   });
 });


### PR DESCRIPTION
Closes #9313.

`ownership_ties: 0` for a coldkey that demonstrably owns a subnet. The ties came solely from the `SubnetOwnerChanged` stream, and there is **exactly one** such event in all of chain history — ownership is established at *registration* and only ever moves by conviction contest. So the route was structurally near-empty, and an empty list reads to a caller as "owns nothing" rather than "we did not look".

## The issue's prescribed fix cannot work

> Seed ties from `NetworkAdded` … Both events are in `chain.chain_events` and both carry the coldkey in `args`

They do not. This repo's own decoder says so:

```ts
["SubtensorModule.NetworkAdded",   ["netuid"]],
["SubtensorModule.NetworkRemoved", ["netuid"]],
```

Netuid-only. Seeding from `NetworkAdded` would produce 270 ties belonging to nobody, and the same fact answers the issue's open question — `NetworkRemoved` cannot identify *whose* tie to retire either.

My own first alternative was wrong too. Seeding from the poller's `subnet_ownership_history` ledger looks right until you hit the note atop `subnet-ownership-cold-tier.ts`: that ledger lives in the **lakehouse alone**, and this route is answered by more than one store feeding one formatter. It would trade a near-empty answer for an inconsistent one.

## What actually works

`/api/v1/economics`'s per-subnet `owner_coldkey` — **measured** from `SubtensorModule.SubnetOwner`, and the one source every surface can reach. The read sits in the **composer** rather than a tier, so the ownership half does not vanish when the transfer half declines — which, with the Postgres leg retired, is the normal case.

## The two halves stay distinguishable

| | `owns` | `gained_ownership` / `lost_ownership` |
|---|---|---|
| kind | **state** | **event** |
| `block_number` | `null` | the block |
| ordered by | netuid | block, newest first |

Spelling current ownership as `gained_ownership` would assert a transfer that never happened on 269 of the 270 subnets ever created. They are not merged into one sort either — one is ordered by netuid and the other by block, so interleaving would imply a timeline they do not share.

`owners_observed_at` rides along because an `owns` tie is only as current as the capture behind it. **Null there is load-bearing**: it separates "could not read who owns what" from "owns nothing", which are otherwise the same empty list — the exact ambiguity that made this route report 0 for a live owner.

## Four things this turned up that would have shipped broken

1. **`isoOrNull` converts epoch milliseconds** (the `chain_events` shape). The economics blob writes `captured_at` as an ISO string, which that helper turns into `null` — so *every* response would have published `owners_observed_at: null` while looking entirely correct.
2. **The GraphQL resolver builds its object field by field**, so a new field on the composer does not arrive by itself. Left alone, GraphQL would have reported "could not read" on every request.
3. **`Number(null) === 0`.** An owner row with no netuid published `netuid: 0` — and netuid 0 is **root**. A silent claim on the most consequential subnet there is.
4. **`readArtifact` throws** when its binding is absent; it does not always answer `{ ok: false }`. My `.ok` check alone would have turned a degradable read into a 500 on a route with a documented empty floor.

Each was caught by writing the test, not by reading the code.

## Verification

- `validate:contract-drift`, `validate:api`, `validate:mcp`, `validate:graphql-component-parity`, `validate:graphql-types-drift`, `validate:schema-vocabularies`, `validate:single-schema-source` — all pass.
- `tsc --noEmit` clean, eslint clean, prettier clean.
- 54 tests across the ownership files, 15 of them new; a dedicated composer suite mocks the artifact reader so each failure mode is reached by its own path.
- **Patch coverage verified by intersecting the diff against lcov**, not by trusting a summary: zero uncovered lines and zero untaken branches across every changed `src/**` file.