### PR TITLE
data(sn110): the bonus schedule proves the revenue is external

### DIFF
--- a/registry/subnets/green-compute.json
+++ b/registry/subnets/green-compute.json
@@ -218,7 +218,11 @@
       "id": "sn-110-green-compute-billing-bonus-rates-api",
       "kind": "subnet-api",
       "name": "Green Compute billing bonus rates API",
-      "notes": "Public no-auth GET returning platform billing bonus rates by payment method (stripe, usdt, usdc, tao, alpha). Documented in the subnet's own OpenAPI (api.green-compute.com/openapi.json, path /platform/billing/bonus-rates); same host as the existing healthz and openapi surfaces.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "probe-derived"
+      },
+      "notes": "Public no-auth GET returning platform billing bonus rates by payment method (stripe, usdt, usdc, tao, alpha). Documented in the subnet's own OpenAPI (api.green-compute.com/openapi.json, path /platform/billing/bonus-rates); same host as the existing healthz and openapi surfaces. REVENUE ROLE (#10462): not-revenue, but load-bearing evidence. The live payload {stripe, usdt, usdc, tao, alpha} is a payment-method bonus schedule, which establishes Green Compute takes fiat and stablecoin -- so its revenue is external rather than alpha-denominated -- while carrying no amount itself. Note alpha is +10%, i.e. paying in the subnet's own token is incentivised.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -758,7 +762,12 @@
       "id": "sn-110-green-compute-get-platform-admin-analytics-gross-revenue",
       "kind": "subnet-api",
       "name": "Green Compute Analytics Gross Revenue",
-      "notes": "Auth-gated GET /platform/admin/analytics/gross-revenue on api.green-compute.com from the GreenCompute Gateway OpenAPI schema (sn-110-green-compute-openapi). Schema declares no security scheme, but live anonymous calls return 401 missing api key on representative routes (#7121). auth_required:true, probe.enabled:false.",
+      "revenue": {
+        "role": "external-revenue",
+        "provenance": "operator-attested",
+        "source_url": "https://api.green-compute.com/openapi.json"
+      },
+      "notes": "Auth-gated GET /platform/admin/analytics/gross-revenue on api.green-compute.com from the GreenCompute Gateway OpenAPI schema (sn-110-green-compute-openapi). Schema declares no security scheme, but live anonymous calls return 401 missing api key on representative routes (#7121). auth_required:true, probe.enabled:false. REVENUE ROLE (#10462): external-revenue, operator-attested. Declared by the subnet's own OpenAPI schema but answers 401 'missing api key' unauthenticated (the schema declares no security scheme -- the mismatch tracked in #7121). Declared and unreadable: recorded, never counted.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -789,6 +798,11 @@
       "id": "sn-110-green-compute-get-platform-admin-analytics-revenue-by-miner",
       "kind": "subnet-api",
       "name": "Green Compute Analytics Revenue By Miner",
+      "revenue": {
+        "role": "miner-payout",
+        "provenance": "operator-attested",
+        "source_url": "https://api.green-compute.com/openapi.json"
+      },
       "notes": "Auth-gated GET /platform/admin/analytics/revenue-by-miner on api.green-compute.com from the GreenCompute Gateway OpenAPI schema (sn-110-green-compute-openapi). Schema declares no security scheme, but live anonymous calls return 401 missing api key on representative routes (#7121). auth_required:true, probe.enabled:false.",
       "probe": {
         "enabled": false,
@@ -1068,7 +1082,12 @@
       "id": "sn-110-green-compute-get-platform-billing-admin-miner-revenue",
       "kind": "subnet-api",
       "name": "Green Compute Billing Admin Miner Revenue",
-      "notes": "Auth-gated GET /platform/billing/admin/miner-revenue on api.green-compute.com from the GreenCompute Gateway OpenAPI schema (sn-110-green-compute-openapi). Schema declares no security scheme, but live anonymous calls return 401 missing api key on representative routes (#7121). auth_required:true, probe.enabled:false.",
+      "revenue": {
+        "role": "miner-payout",
+        "provenance": "operator-attested",
+        "source_url": "https://api.green-compute.com/openapi.json"
+      },
+      "notes": "Auth-gated GET /platform/billing/admin/miner-revenue on api.green-compute.com from the GreenCompute Gateway OpenAPI schema (sn-110-green-compute-openapi). Schema declares no security scheme, but live anonymous calls return 401 missing api key on representative routes (#7121). auth_required:true, probe.enabled:false. REVENUE ROLE (#10462): miner-payout, not platform revenue -- 'revenue-by-miner' and 'miner-revenue' name what miners EARN from the platform, the outbound side. Naming alone does not settle it, so this is recorded as payout and excluded from any coverage numerator.",
       "probe": {
         "enabled": false,
         "expect": "json",


### PR DESCRIPTION
`/platform/billing/bonus-rates` is public and returns:

```json
{"stripe":"+0%","usdt":"+0%","usdc":"+0%","tao":"+0%","alpha":"+10%"}
```

It carries **no amount**, so it is `not-revenue` — but it is load-bearing evidence. A payment-method bonus schedule listing Stripe, USDT and USDC establishes that Green Compute takes **fiat and stablecoin**, which settles `circularity` for this subnet: its revenue originates outside Bittensor rather than being alpha-denominated. Note `alpha` is `+10%`, i.e. paying in the subnet's own token is actively incentivised — worth watching, because that is the mechanism by which external revenue turns circular.

**`/platform/admin/analytics/gross-revenue`** — `external-revenue`, `operator-attested`. Answers `401 missing api key`, while the schema declares no security scheme at all (the mismatch tracked in #7121). Declared and unreadable.

**`/analytics/revenue-by-miner` and `/billing/admin/miner-revenue`** — `miner-payout`. Both are named for what miners **earn from** the platform, the outbound side. Naming alone does not settle that, which is why it is recorded as payout explicitly and excluded from any coverage numerator rather than left ambiguous.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` — all pass
- Every `operator-attested` surface carries a `source_url` pointing at the subnet's own OpenAPI schema; no `probe-derived` claim sits on an auth-gated or unprobed surface
- Purely additive diff

Closes #10462
