### PR TITLE
feat(schema): record that a subnet was searched for revenue, and found none

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10669,6 +10669,18 @@ export interface components {
                 [key: string]: unknown;
             };
             registered_at_block?: number;
+            revenue_search?: {
+                /** @description Where the search actually looked. Without it, "we searched" is unfalsifiable and nobody else can re-run it. */
+                checked: ("website" | "docs" | "openapi" | "dashboard" | "source-repo" | "blog" | "explorer")[];
+                notes?: string;
+                /**
+                 * @description Cross-checked against the surfaces themselves, so the summary cannot drift from the data it summarises.
+                 * @enum {string}
+                 */
+                outcome: "none-found" | "surfaces-declared";
+                /** @description An absence with no date is not evidence. */
+                searched_at: string;
+            };
             slug: string;
             social?: components["schemas"]["SocialLinks"] | null;
             source_repo?: string | null;
@@ -18120,6 +18132,13 @@ export interface operations {
                      *           "probed_surface_count": 1,
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
+                     *           "revenue_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "slug": "example-subnet",
                      *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
@@ -38846,6 +38865,13 @@ export interface operations {
                      *           "probed_surface_count": 1,
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
+                     *           "revenue_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "slug": "example-subnet",
                      *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
@@ -44087,6 +44113,13 @@ export interface operations {
                      *           "probed_surface_count": 1,
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
+                     *           "revenue_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "slug": "example-subnet",
                      *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9151,6 +9151,13 @@
               "probed_surface_count": 1,
               "provenance": {},
               "registered_at_block": 5000000,
+              "revenue_search": {
+                "checked": [
+                  "website"
+                ],
+                "outcome": "none-found",
+                "searched_at": "2026-06-01T00:00:00.000Z"
+              },
               "slug": "example-subnet",
               "social": {},
               "source_repo": "https://api.metagraph.sh/example",
@@ -10911,6 +10918,13 @@
               "probed_surface_count": 1,
               "provenance": {},
               "registered_at_block": 5000000,
+              "revenue_search": {
+                "checked": [
+                  "website"
+                ],
+                "outcome": "none-found",
+                "searched_at": "2026-06-01T00:00:00.000Z"
+              },
               "slug": "example-subnet",
               "social": {},
               "source_repo": "https://api.metagraph.sh/example",
@@ -43941,6 +43955,49 @@
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "revenue_search": {
+            "additionalProperties": false,
+            "properties": {
+              "checked": {
+                "description": "Where the search actually looked. Without it, \"we searched\" is unfalsifiable and nobody else can re-run it.",
+                "items": {
+                  "enum": [
+                    "website",
+                    "docs",
+                    "openapi",
+                    "dashboard",
+                    "source-repo",
+                    "blog",
+                    "explorer"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "outcome": {
+                "description": "Cross-checked against the surfaces themselves, so the summary cannot drift from the data it summarises.",
+                "enum": [
+                  "none-found",
+                  "surfaces-declared"
+                ],
+                "type": "string"
+              },
+              "searched_at": {
+                "description": "An absence with no date is not evidence.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "checked",
+              "outcome",
+              "searched_at"
+            ],
+            "type": "object"
           },
           "slug": {
             "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10669,6 +10669,18 @@ export interface components {
                 [key: string]: unknown;
             };
             registered_at_block?: number;
+            revenue_search?: {
+                /** @description Where the search actually looked. Without it, "we searched" is unfalsifiable and nobody else can re-run it. */
+                checked: ("website" | "docs" | "openapi" | "dashboard" | "source-repo" | "blog" | "explorer")[];
+                notes?: string;
+                /**
+                 * @description Cross-checked against the surfaces themselves, so the summary cannot drift from the data it summarises.
+                 * @enum {string}
+                 */
+                outcome: "none-found" | "surfaces-declared";
+                /** @description An absence with no date is not evidence. */
+                searched_at: string;
+            };
             slug: string;
             social?: components["schemas"]["SocialLinks"] | null;
             source_repo?: string | null;
@@ -18120,6 +18132,13 @@ export interface operations {
                      *           "probed_surface_count": 1,
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
+                     *           "revenue_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "slug": "example-subnet",
                      *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
@@ -38846,6 +38865,13 @@ export interface operations {
                      *           "probed_surface_count": 1,
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
+                     *           "revenue_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "slug": "example-subnet",
                      *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
@@ -44087,6 +44113,13 @@ export interface operations {
                      *           "probed_surface_count": 1,
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
+                     *           "revenue_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "slug": "example-subnet",
                      *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -339,6 +339,42 @@ export const CurationMetadataSchema = z
   .strict();
 export type CurationMetadata = z.infer<typeof CurationMetadataSchema>;
 
+// #10543: whether this subnet has been searched for external revenue, and
+// when. `revenue` lives on a SURFACE, so a subnet with no revenue-shaped
+// surface has nowhere to put one -- and that is exactly the population the
+// dark sweep covers. Without this, an undated silence is indistinguishable
+// from nobody having looked, and "N% of the network has no observable
+// external revenue" is not a defensible claim.
+export const RevenueSearchSchema = z
+  .object({
+    checked: z
+      .array(
+        z.enum([
+          "website",
+          "docs",
+          "openapi",
+          "dashboard",
+          "source-repo",
+          "blog",
+          "explorer",
+        ]),
+      )
+      .min(1)
+      .meta({
+        description:
+          'Where the search actually looked. Without it, "we searched" is unfalsifiable and nobody else can re-run it.',
+      }),
+    notes: z.string().optional(),
+    outcome: z.enum(["none-found", "surfaces-declared"]).meta({
+      description:
+        "Cross-checked against the surfaces themselves, so the summary cannot drift from the data it summarises.",
+    }),
+    searched_at: z.string().meta({
+      description: "An absence with no date is not evidence.",
+    }),
+  })
+  .strict();
+
 export const SubnetDetailSchema = z
   .object({
     block: z.int().min(0).optional(),
@@ -413,6 +449,7 @@ export const SubnetDetailSchema = z
     native_slug: z.string().nullable().optional(),
     netuid: z.int().min(0),
     notes: z.string().nullable().optional(),
+    revenue_search: RevenueSearchSchema.optional(),
     participant_count: z.int().min(0).optional(),
     partnership: z.union([PartnershipMetadataSchema, z.null()]).optional(),
     previously_known_as: z.array(z.string()).optional(),

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -62,6 +62,9 @@
     "notes": {
       "type": "string"
     },
+    "revenue_search": {
+      "$ref": "#/$defs/revenue_search"
+    },
     "curation": {
       "$ref": "#/$defs/curation"
     },
@@ -76,19 +79,19 @@
     },
     "exchange_listings": {
       "type": "array",
-      "description": "Centralized-exchange listings where this subnet's token trades (Taostats-parity metadata, #6274). Display-only registry metadata like `social` — not a live-verified surface, so it carries no probe/verification machinery.",
+      "description": "Centralized-exchange listings where this subnet's token trades (Taostats-parity metadata, #6274). Display-only registry metadata like `social` \u2014 not a live-verified surface, so it carries no probe/verification machinery.",
       "items": {
         "$ref": "#/$defs/exchange_listing"
       }
     },
     "contact": {
       "type": "string",
-      "description": "Curated operator support contact (email or public URL, harvested from SubnetIdentitiesV3 subnet_contact) — sanitized at build via subnetContact. Display-only; never feeds completeness."
+      "description": "Curated operator support contact (email or public URL, harvested from SubnetIdentitiesV3 subnet_contact) \u2014 sanitized at build via subnetContact. Display-only; never feeds completeness."
     },
     "social": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Curated social links — wins over on-chain extraction (#745). Display-only; never feeds completeness.",
+      "description": "Curated social links \u2014 wins over on-chain extraction (#745). Display-only; never feeds completeness.",
       "properties": {
         "x": {
           "type": "string",
@@ -226,7 +229,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["state"],
-          "description": "Per-surface HUMAN review/governance state for the single-file contribution model: a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". Human-governance axis ONLY — machine verification + freshness (live or stale) is the separate probe-derived `verification` overlay (health, last_verified_at, incidents); subnet-level curation has its own `curation.review_state`.",
+          "description": "Per-surface HUMAN review/governance state for the single-file contribution model: a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". Human-governance axis ONLY \u2014 machine verification + freshness (live or stale) is the separate probe-derived `verification` overlay (health, last_verified_at, incidents); subnet-level curation has its own `curation.review_state`.",
           "properties": {
             "state": {
               "enum": ["community-submitted", "maintainer-reviewed", "rejected"]
@@ -256,7 +259,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["requests", "window"],
-          "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+          "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only \u2014 metagraphed does not enforce it and it never feeds completeness.",
           "properties": {
             "requests": {
               "type": "integer",
@@ -287,7 +290,7 @@
           "type": ["object", "null"],
           "additionalProperties": false,
           "required": ["scheme"],
-          "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+          "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only \u2014 never a real secret; integration-only, never feeds completeness.",
           "properties": {
             "scheme": {
               "enum": [
@@ -311,7 +314,9 @@
             },
             "names": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "minItems": 1,
               "description": "For scheme:signature only: every header/query-param/body-field name the caller must supply as a complete bundle, e.g. [\"X-Hotkey\", \"X-Timestamp\", \"X-Signature\"]. Mutually exclusive with `name`."
             },
@@ -395,17 +400,23 @@
         "fields": {
           "description": "Map of role -> field name in the upstream payload, e.g. {\"date\": \"date\", \"amount\": \"total_revenue\"}.",
           "type": "object",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "excludes": {
           "description": "Fields present in the payload that are NOT external revenue and must be subtracted, e.g. subnet-funded or unrecognised components.",
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "supersedes": {
           "description": "Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice.",
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "circularity": {
           "description": "Whether the money originates outside Bittensor. Absent means unknown, never external.",
@@ -425,20 +436,32 @@
       "allOf": [
         {
           "if": {
-            "properties": { "provenance": { "const": "none" } },
+            "properties": {
+              "provenance": {
+                "const": "none"
+              }
+            },
             "required": ["provenance"]
           },
-          "then": { "required": ["searched_at"] }
+          "then": {
+            "required": ["searched_at"]
+          }
         },
         {
           "if": {
             "properties": {
-              "role": { "const": "external-revenue" },
-              "provenance": { "enum": ["chain-verified", "probe-derived"] }
+              "role": {
+                "const": "external-revenue"
+              },
+              "provenance": {
+                "enum": ["chain-verified", "probe-derived"]
+              }
             },
             "required": ["role", "provenance"]
           },
-          "then": { "required": ["currency", "grain", "fields"] }
+          "then": {
+            "required": ["currency", "grain", "fields"]
+          }
         }
       ]
     },
@@ -509,7 +532,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": ["tier", "since"],
-      "description": "Display/placement metadata — e.g. a featured-pilot slot on the homepage. Distinct from `authority` and `curation.level`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md).",
+      "description": "Display/placement metadata \u2014 e.g. a featured-pilot slot on the homepage. Distinct from `authority` and `curation.level`, which are trust signals only and never drive placement (docs/adr/0008-subnet-data-model.md).",
       "properties": {
         "tier": {
           "enum": ["pilot"]
@@ -603,6 +626,43 @@
         "redirect_target": {
           "type": ["string", "null"],
           "format": "uri"
+        }
+      }
+    },
+    "revenue_search": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["searched_at", "outcome", "checked"],
+      "description": "Whether this subnet has been searched for external revenue, and when. A subnet with no revenue-shaped surface has nowhere to put a per-surface `revenue` block, so an undated silence is indistinguishable from nobody having looked. This is the subnet-level record that makes an absence evidence.",
+      "properties": {
+        "searched_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the search was run. An absence with no date is not evidence."
+        },
+        "outcome": {
+          "enum": ["none-found", "surfaces-declared"],
+          "description": "`none-found` asserts no external-revenue surface exists; `surfaces-declared` says at least one does. Cross-checked against the surfaces themselves, so the summary cannot drift from the data."
+        },
+        "checked": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "website",
+              "docs",
+              "openapi",
+              "dashboard",
+              "source-repo",
+              "blog",
+              "explorer"
+            ]
+          },
+          "description": "Where the search actually looked. Without this, \"we searched\" is unfalsifiable and nobody else can re-run it."
+        },
+        "notes": {
+          "type": "string"
         }
       }
     }

--- a/scripts/validate-revenue-provenance.ts
+++ b/scripts/validate-revenue-provenance.ts
@@ -95,6 +95,53 @@ export function checkSurfaceRevenue(
   return out;
 }
 
+/**
+ * #10543: the subnet-level search record must agree with the surfaces.
+ *
+ * `revenue_search` summarises a search; the surfaces are its result. Nothing
+ * links them, so without this the summary quietly rots: a subnet recorded
+ * `none-found` in March keeps asserting it after a revenue surface is added in
+ * August, and the "N% of the network has no observable external revenue" claim
+ * silently overcounts. A summary that cannot disagree with its data is a
+ * comment, not a record.
+ */
+export function checkRevenueSearch(
+  subnet: Row,
+  file = "<memory>",
+): ProvenanceViolation[] {
+  const search = subnet?.revenue_search;
+  if (!search || typeof search !== "object") return [];
+  const declared = (
+    Array.isArray(subnet?.surfaces) ? subnet.surfaces : []
+  ).filter((s: Row) => s?.revenue?.role === "external-revenue");
+  const subject = `netuid ${subnet?.netuid ?? "?"}`;
+  if (search.outcome === "none-found" && declared.length > 0) {
+    return [
+      {
+        file,
+        subject,
+        message:
+          `revenue_search says "none-found" but ${declared.length} surface(s) declare ` +
+          `role "external-revenue" (${declared.map((s: Row) => s.id).join(", ")}). ` +
+          "The search record has gone stale against its own data.",
+      },
+    ];
+  }
+  if (search.outcome === "surfaces-declared" && declared.length === 0) {
+    return [
+      {
+        file,
+        subject,
+        message:
+          'revenue_search says "surfaces-declared" but no surface declares role ' +
+          '"external-revenue". Either the declaration was removed and the summary was not ' +
+          'updated, or the outcome should be "none-found".',
+      },
+    ];
+  }
+  return [];
+}
+
 /** Check one entity label. Exported for the same reason as above. */
 export function checkEntityRole(
   entity: Row,
@@ -122,9 +169,9 @@ export async function collectViolations(): Promise<ProvenanceViolation[]> {
   const subnetDir = path.join(repoRoot, "registry/subnets");
   for (const file of await listJsonFiles(subnetDir)) {
     const subnet = (await readJson(file)) as Row;
-    violations.push(
-      ...checkSurfaceRevenue(subnet, path.relative(repoRoot, file)),
-    );
+    const rel = path.relative(repoRoot, file);
+    violations.push(...checkSurfaceRevenue(subnet, rel));
+    violations.push(...checkRevenueSearch(subnet, rel));
   }
 
   const entityDir = path.join(repoRoot, "registry/entities");

--- a/tests/subnet-manifest-revenue-block.test.ts
+++ b/tests/subnet-manifest-revenue-block.test.ts
@@ -208,3 +208,75 @@ describe("subnet-manifest revenue block (#10441)", () => {
     assert.ok(!def.enum.includes("external-assumed"));
   });
 });
+
+describe("subnet-level revenue_search (#10543)", () => {
+  function manifestWith(search?: Json): Json {
+    const doc = manifest() as Record<string, unknown>;
+    if (search !== undefined) doc.revenue_search = search;
+    return doc as Json;
+  }
+  const GOOD: Json = {
+    searched_at: "2026-08-10T00:00:00Z",
+    outcome: "none-found",
+    checked: ["website", "docs", "source-repo"],
+  };
+
+  test("accepts a complete search record", () => {
+    assert.equal(
+      validate(manifestWith(GOOD)),
+      true,
+      errorsFor(manifestWith(GOOD)).join("; "),
+    );
+  });
+
+  test("stays optional", () => {
+    assert.equal(validate(manifestWith()), true);
+  });
+
+  test("all three of searched_at, outcome and checked are required", () => {
+    for (const key of ["searched_at", "outcome", "checked"]) {
+      const partial = { ...(GOOD as Record<string, unknown>) };
+      delete partial[key];
+      assert.equal(
+        validate(manifestWith(partial as Json)),
+        false,
+        `accepted a record missing ${key}`,
+      );
+    }
+  });
+
+  test("`checked` may not be empty", () => {
+    // An empty list would let a subnet claim it was searched while naming
+    // nowhere it looked — unfalsifiable, and the exact thing this field is for.
+    assert.equal(
+      validate(
+        manifestWith({
+          ...(GOOD as Record<string, unknown>),
+          checked: [],
+        } as Json),
+      ),
+      false,
+    );
+  });
+
+  test("rejects an outcome or source outside the vocabulary", () => {
+    assert.equal(
+      validate(
+        manifestWith({
+          ...(GOOD as Record<string, unknown>),
+          outcome: "maybe",
+        } as Json),
+      ),
+      false,
+    );
+    assert.equal(
+      validate(
+        manifestWith({
+          ...(GOOD as Record<string, unknown>),
+          checked: ["vibes"],
+        } as Json),
+      ),
+      false,
+    );
+  });
+});

--- a/tests/validate-revenue-provenance.test.ts
+++ b/tests/validate-revenue-provenance.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   checkEntityRole,
+  checkRevenueSearch,
   checkSurfaceRevenue,
   collectViolations,
 } from "../scripts/validate-revenue-provenance.ts";
@@ -162,6 +163,67 @@ describe("revenue provenance validator (#10443/#10516)", () => {
       violations
         .map((v) => `${v.file}: ${v.subject} — ${v.message}`)
         .join("\n"),
+    );
+  });
+});
+
+describe("revenue_search cross-check (#10543)", () => {
+  function withSearch(outcome: string, revenueRole?: string): Row {
+    const surface: Row = { id: "sn-64-x", auth_required: false };
+    if (revenueRole) {
+      surface.revenue = { role: revenueRole, provenance: "probe-derived" };
+      surface.probe = { enabled: true };
+    }
+    return {
+      netuid: 64,
+      surfaces: [surface],
+      revenue_search: {
+        searched_at: "2026-08-10T00:00:00Z",
+        outcome,
+        checked: ["website", "docs"],
+      },
+    };
+  }
+
+  test("a subnet with no search record is not the validator's business", () => {
+    assert.deepEqual(checkRevenueSearch({ netuid: 1, surfaces: [] }), []);
+    assert.deepEqual(checkRevenueSearch({}), []);
+  });
+
+  test("none-found agrees with a subnet declaring no revenue", () => {
+    assert.deepEqual(checkRevenueSearch(withSearch("none-found")), []);
+    // A usage-proxy or miner-payout surface is not external revenue, so it
+    // does not contradict none-found — that distinction is the whole point of
+    // the role vocabulary.
+    assert.deepEqual(
+      checkRevenueSearch(withSearch("none-found", "miner-payout")),
+      [],
+    );
+    assert.deepEqual(
+      checkRevenueSearch(withSearch("none-found", "usage-proxy")),
+      [],
+    );
+  });
+
+  test("none-found is REJECTED once a surface declares external revenue", () => {
+    // The stale-summary case: searched in March, revenue surface added in
+    // August, and the subnet keeps asserting it has none.
+    const v = checkRevenueSearch(withSearch("none-found", "external-revenue"));
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /none-found/);
+    assert.match(v[0].message, /sn-64-x/);
+  });
+
+  test("surfaces-declared is REJECTED when nothing declares external revenue", () => {
+    const v = checkRevenueSearch(withSearch("surfaces-declared"));
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /surfaces-declared/);
+  });
+
+  test("surfaces-declared agrees with a real declaration", () => {
+    assert.deepEqual(
+      checkRevenueSearch(withSearch("surfaces-declared", "external-revenue")),
+      [],
     );
   });
 });


### PR DESCRIPTION
`revenue` lives on a **surface**. A subnet with no revenue-shaped surface has nowhere to put one — and that is exactly the 93-subnet population the dark sweep (#10466–#10474) covers.

Checked across a sample of dark subnets: every one has surfaces (`website`, `source-repo`, `subnet-api`, `docs`) and **none of them is a revenue surface**. Hanging *"we looked and found nothing"* off a subnet's website surface would assert something different and wrong — that the website was evaluated as a revenue source.

## The block

```json
"revenue_search": {
  "searched_at": "2026-08-10T00:00:00Z",
  "outcome": "none-found",
  "checked": ["website", "docs", "source-repo"]
}
```

- **`searched_at`** — an absence with no date is indistinguishable from nobody having looked.
- **`checked`**, `minItems: 1` — without naming where the search looked, *"we searched"* is unfalsifiable and nobody else can re-run it. An empty list is rejected.

Together these are what make *"N% of the network has no observable external revenue"* a claim rather than an assertion.

## `outcome` is cross-checked, not trusted

A summary that cannot disagree with its data is a comment. Without a link, a subnet recorded `none-found` in March keeps asserting it after a revenue surface lands in August, and the network figure silently overcounts.

The validator rejects:

- `none-found` alongside a surface declaring `role: external-revenue` — *the stale-summary case*
- `surfaces-declared` when nothing declares one

And deliberately leaves `usage-proxy` / `miner-payout` surfaces alone: neither contradicts `none-found`, which is the whole reason the role vocabulary distinguishes them.

## All three surfaces this time

#10441 shipped the registry schema alone and passed CI vacuously — the published component only failed once a real file used the field, which #10526 had to clean up. This lands together:

| | |
|---|---|
| `schemas/subnet-manifest.schema.json` | the registry-file schema |
| `SubnetDetailSchema` in `schemas-src` | `additionalProperties: false`, so the field would have been rejected in artifacts the moment a subnet used it |
| regenerated `openapi.json` / `types.d.ts` / `packages/contract/index.d.ts` / GraphQL types | committed together |

## Verification

- **All 19 drift and parity gates pass** — contract, db-types, lakehouse-types, graphql-types, ui-docs, component-parity, route-parity, published-names, tier-parity, query-arguments, schemas, openapi, types, surface, schema-enums, docs, contract-doc-sync, revenue-provenance, single-schema-source
- 32 tests across the two suites; every rejection asserted to name the right reason
- `tsc --noEmit` clean

Unblocks #10466–#10474.

Closes #10543
