### PR TITLE
data(sweep 1/3): a money figure is not automatically a revenue figure

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -35,6 +35,11 @@
   "name": "Allways",
   "netuid": 7,
   "notes": "Pilot manifest. Registry observations are external status data, not Allways protocol authority.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "partnership": {
     "since": "2026-07-04",
     "tier": "pilot"
@@ -352,6 +357,10 @@
       "id": "allways-network-stats",
       "kind": "subnet-api",
       "name": "Allways network stats",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Public no-auth GET returning aggregate totals: total swap count, total volume (SOL), active miner count, active swap count. Documented in the subnet's own OpenAPI (api.all-ways.io/swagger-json, path /stats); same host as existing subnet-api surfaces.",
       "probe": {
         "enabled": true,

--- a/registry/subnets/coldint.json
+++ b/registry/subnets/coldint.json
@@ -25,6 +25,11 @@
   "name": "Coldint",
   "netuid": 29,
   "notes": "Reviewed overlay for SN29 using the official Coldint website, validator repository, dynamic configuration repository, README documentation, and referenced training dataset. This pass fixed the min-compute data-artifact surface (added by a recent contributor PR) having no probe config at all -- the registry-wide gap tracked in #5932 -- and removed an incorrect social.x value (https://x.com/cacheon_ai, a copy-paste of SN14 Cacheon's own handle, unrelated to this subnet); no official Coldint social account was found on the website or in the README to replace it with. On-chain SubnetIdentitiesV3 native_name is a stylized \"hotfloat\" rather than \"Coldint\", but the on-chain website_url field matches coldint.io exactly, positively confirming the same operator -- not treated as a rename.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-29",
   "source_repo": "https://github.com/coldint/coldint_validator",
@@ -135,6 +140,10 @@
       "id": "sn-29-coldint-taostats-dashboard",
       "kind": "dashboard",
       "name": "Coldint TaoStats dashboard",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "probe-derived"
+      },
       "notes": "TaoStats subnet dashboard linked by the Coldint README.",
       "probe": {
         "enabled": true,

--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -25,6 +25,11 @@
   "name": "DSperse",
   "netuid": 2,
   "notes": "Reviewed overlay for SN2 DSperse / Inference Labs. Official website, docs, and source repository are verified live. The main sn2-api.inferencelabs.com host has no machine-readable schema (its /stats endpoint is tracked directly), but the circuit-repository host (repository.inferencelabs.com) publishes a full OpenAPI 3.1 schema with circuit/component/model list endpoints, all tracked. No verified SSE/event stream yet.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "dsperse",
   "social": {
@@ -167,6 +172,10 @@
       "id": "sn-2-inference-labs-subnet-api",
       "kind": "subnet-api",
       "name": "DSperse network stats API",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Public no-auth GET /stats on sn2-api.inferencelabs.com returning JSON network counters (observed: total_proofs, unique_miners, unique_validators). The official subnet-2 validator client sets DEFAULT_API_URL to https://sn2-api.inferencelabs.com on the same host. Live-verified 2026-07-21: GET https://sn2-api.inferencelabs.com/stats -> HTTP 200 application/json (total_proofs, unique_miners, unique_validators).",
       "probe": {
         "enabled": true,

--- a/registry/subnets/numinous.json
+++ b/registry/subnets/numinous.json
@@ -25,6 +25,11 @@
   "name": "Numinous",
   "netuid": 6,
   "notes": "Reviewed overlay for SN6 Numinous. The public API exposes Swagger UI, a machine-readable OpenAPI 3.1 schema, and a read-only health endpoint. The OpenAPI schema documents 20 total paths; 3 are tracked here (health, leaderboard, benchmarks/baseline). Of the remaining 17: 3 explicitly require an API key (forecasters/predictions, internal/liveuamap/events, internal/liveuamap/regions) and are correctly gated; the other 14 are per-miner (miner_uid + miner_hotkey, sometimes also event_id/version_id/run_id) or per-query (free-text \"question\") lookups with no stable canonical parameter value to probe against -- unlike this file's leaderboard/benchmarks endpoints, which need none. Not tracked as surfaces: a hardcoded miner_uid would silently go stale the moment that specific miner deregisters, misrepresenting an API problem that doesn't exist.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "numinous",
   "social": {
@@ -192,7 +197,7 @@
       "id": "sn-6-numinous-api-v1-aggregated-scores",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 aggregated scores",
-      "notes": "GET /api/v1/aggregated-scores on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: miner_uid, miner_hotkey. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/aggregated-scores on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Required query: miner_uid, miner_hotkey. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in \u2014 already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -214,7 +219,7 @@
       "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey predictions active",
-      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/predictions/active on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/predictions/active on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -236,7 +241,7 @@
       "id": "sn-6-numinous-api-v1-agents-versionid-code",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 agents by version_id code",
-      "notes": "GET /api/v1/agents/{version_id}/code on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/agents/{version_id}/code on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -258,7 +263,7 @@
       "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-agents",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey agents",
-      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/agents on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/agents on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Not individually curled \u2014 same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -280,7 +285,7 @@
       "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-agents-versionid-code",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey agents by version_id code",
-      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/agents/{version_id}/code on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/agents/{version_id}/code on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Not individually curled \u2014 same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -302,7 +307,7 @@
       "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-historical-ranking",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey historical ranking",
-      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/historical-ranking on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/historical-ranking on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Not individually curled \u2014 same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -324,7 +329,7 @@
       "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-runs-eventid",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey runs by event_id",
-      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/runs/{event_id} on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/runs/{event_id} on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Not individually curled \u2014 same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -346,7 +351,7 @@
       "id": "sn-6-numinous-api-v1-miners-mineruid-minerhotkey-runs-runid-logs",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miners by miner_uid by miner_hotkey runs by run_id logs",
-      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/runs/{run_id}/logs on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Not individually curled — same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miners/{miner_uid}/{miner_hotkey}/runs/{run_id}/logs on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Not individually curled \u2014 same no-auth shape as the verified `sn-6-numinous-api-v1-miners-mineruid-minerhotkey-predictions-active` sibling. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -368,7 +373,7 @@
       "id": "sn-6-numinous-api-v1-miner-reasonings",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 miner reasonings",
-      "notes": "GET /api/v1/miner-reasonings on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: miner_uid, miner_hotkey, event_id. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/miner-reasonings on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Required query: miner_uid, miner_hotkey, event_id. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in \u2014 already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -416,7 +421,7 @@
       "id": "sn-6-numinous-api-v1-forecasters-prediction-jobs-predictionid",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 forecasters prediction jobs by prediction_id",
-      "notes": "GET /api/v1/forecasters/prediction-jobs/{prediction_id} on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) — the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/forecasters/prediction-jobs/{prediction_id} on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Live-verified 2026-07-21 with a placeholder value: HTTP 200 or a clean validation error (e.g. UUID-parsing 422), confirming the route is real, not an auth gate. Path-param endpoint (needs Phase 2 schema-aware execution, not built yet) \u2014 the URL's %7B...%7D segment is the URI-encoded form of a literal {param} template (raw unescaped braces fail this repo's url format:\"uri\" schema check). Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -490,7 +495,7 @@
       "id": "sn-6-numinous-api-v1-causal-drivers",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 causal drivers",
-      "notes": "GET /api/v1/causal-drivers/ on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: question. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/causal-drivers/ on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Required query: question. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in \u2014 already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -512,7 +517,7 @@
       "id": "sn-6-numinous-api-v1-deep-research",
       "kind": "subnet-api",
       "name": "Numinous GET api v1 deep research",
-      "notes": "GET /api/v1/deep-research/ on api.numinouslabs.io — public, no auth declared in the OpenAPI schema. Required query: question. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in — already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
+      "notes": "GET /api/v1/deep-research/ on api.numinouslabs.io \u2014 public, no auth declared in the OpenAPI schema. Required query: question. Live-verified 2026-07-21: an unparameterized request returns HTTP 422 listing the exact required query fields, not an auth error. probe.enabled:false is the safer default here: an auto-probe with no query params would just 422. Registered with the fixed base url, no query string baked in \u2014 already callable today via call_subnet_surface's own query argument. Registered per the registry's full-API-parity policy (metagraphed#7022).",
       "probe": {
         "enabled": false,
         "expect": "json",

--- a/registry/subnets/oxmarkets.json
+++ b/registry/subnets/oxmarkets.json
@@ -19,6 +19,11 @@
   "name": "OxMarkets",
   "netuid": 35,
   "notes": "First maintainer-reviewed pass for SN35 (previously candidate-discovered/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). OxMarkets/Cartha is a liquidity-as-a-service subnet powering a permissionless perp DEX (FX, crypto, commodities). Added the missing website and source-repo surfaces. Fixed 7 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full Cartha Verifier OpenAPI schema (58 paths): most are 401/403-gated in practice despite the schema declaring no security scheme (a documentation gap on the operator's side, not a registry concern), and the remaining unauthenticated GETs are either already tracked or require query parameters with no stable canonical value (e.g. /v1/metagraph/compare, /v1/miner/status). One new genuine no-auth public endpoint found and added: GET /pools, returning the registered liquidity-pool/vault list.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-35",
   "social": {
@@ -93,7 +98,7 @@
       "id": "sn-35-oxmarkets-cartha-cli",
       "kind": "sdk",
       "name": "Cartha CLI (PyPI)",
-      "notes": "Published PyPI package `cartha-cli` — the official CLI for Cartha subnet (SN35) miners; built from the team's General-Tao-Ventures/cartha-cli repo.",
+      "notes": "Published PyPI package `cartha-cli` \u2014 the official CLI for Cartha subnet (SN35) miners; built from the team's General-Tao-Ventures/cartha-cli repo.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -213,7 +218,11 @@
       "id": "sn-35-oxmarkets-lp-stats",
       "kind": "data-artifact",
       "name": "Cartha liquidity-providing metrics",
-      "notes": "Public no-auth GET /v1/lp-stats on api.cartha.finance returning aggregated liquidity-providing metrics for the 0xMarkets landing page (observed top-level fields: apy_tiers, max_apy, tvl, weekly_rewards, emissions, prices, epoch, extras, last_updated). Documented as GET /v1/lp-stats in the subnet OpenAPI spec (api.cartha.finance/openapi.json, already cited for the existing health and OpenAPI surfaces); same api.cartha.finance host as the Cartha Verifier API.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "probe-derived"
+      },
+      "notes": "Public no-auth GET /v1/lp-stats on api.cartha.finance returning aggregated liquidity-providing metrics for the 0xMarkets landing page (observed top-level fields: apy_tiers, max_apy, tvl, weekly_rewards, emissions, prices, epoch, extras, last_updated). Documented as GET /v1/lp-stats in the subnet OpenAPI spec (api.cartha.finance/openapi.json, already cited for the existing health and OpenAPI surfaces); same api.cartha.finance host as the Cartha Verifier API. REVENUE ROLE (#10463): not-revenue. `apy_tiers` is yield CONFIGURATION (lock periods, boosts, advertised APY), not an amount anybody earned. REVENUE ROLE (#10463): not-revenue. `apy_tiers` is yield CONFIGURATION (lock periods, boosts, advertised APY), not an amount anybody earned.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -1067,6 +1076,11 @@
       "id": "sn-35-oxmarkets-v1-admin-system-alerts-stats",
       "kind": "subnet-api",
       "name": "OxMarkets v1 admin system alerts stats",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "operator-attested",
+        "source_url": "https://api.cartha.finance/openapi.json"
+      },
       "notes": "Get System Alerts Stats operation on the OxMarkets/Cartha API (GET /v1/admin/system-alerts/stats), declared in the subnet's own OpenAPI spec at https://api.cartha.finance/openapi.json. The spec declares no security on it; registered with the probe disabled (not individually verified beyond the sampled routes above).",
       "probe": {
         "enabled": false,

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -25,6 +25,11 @@
   "name": "Targon",
   "netuid": 4,
   "notes": "Reviewed overlay for SN4 using the official Targon website, docs, Intel whitepaper, and source repository. The docs site's own sitemap lists 10 API categories (compute, health, heim, inventory, ssh-keys, templates, user, version, volumes, workloads); all but inventory and version are personal compute-rental account actions requiring a Bearer API key (create/manage workloads, templates, ssh keys, volumes), not eligible for public surface tracking. The documented no-auth health endpoints (/tha/v2/healthz, /tha/v2/readyz) currently 500 in production despite the docs describing them as working liveness/readiness checks -- not tracked as a surface since it would only generate false-unhealthy noise. No OpenAPI/Swagger schema, SSE stream, or standalone data artifact is verified yet.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-4",
   "social": {
@@ -178,6 +183,10 @@
       "id": "sn-4-targon-stats-dashboard",
       "kind": "dashboard",
       "name": "Targon Stats dashboard",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Official Targon Stats dashboard (page title \"Targon Stats\"). Its first-party ownership is proven by the official manifold-inc/targon CLI source, which names https://stats.targon.com as a default endpoint host.",
       "probe": {
         "enabled": true,
@@ -202,7 +211,11 @@
       "id": "sn-4-targon-miner-stats-api",
       "kind": "subnet-api",
       "name": "Targon miner stats API",
-      "notes": "Public no-auth JSON endpoint returning live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), documented as 'Get All Miners' in the official Targon Stats HTTP API docs.",
+      "revenue": {
+        "role": "miner-payout",
+        "provenance": "probe-derived"
+      },
+      "notes": "Public no-auth JSON endpoint returning live SN4 per-miner stats (uid, payout, GPU card count, confidential-compute type), documented as 'Get All Miners' in the official Targon Stats HTTP API docs. REVENUE ROLE (#10463): miner-payout. The `payout` field is EMISSION paid to miners, not customer revenue -- the single most-quoted number on this subnet and the denominator of a coverage ratio, not its numerator. REVENUE ROLE (#10463): miner-payout. The `payout` field is EMISSION paid to miners, not customer revenue -- the single most-quoted number on this subnet and the denominator of a coverage ratio, not its numerator.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -39,6 +39,11 @@
   "name": "TrajectoryRL",
   "netuid": 11,
   "notes": "Reviewed overlay for SN11 TrajectoryRL using the official website, docs, leaderboard, live, winners, benchmark pages, and source repository. Common API/OpenAPI/Swagger paths currently return 404 and are not promoted as operational API surfaces. Two community-submitted surfaces (api-docs, subnet-api) had no probe config at all -- not disabled, just absent, meaning they were silently excluded from operational-surfaces.json / live health tracking despite being valid public endpoints (see #5932 for the registry-wide scope of this class of gap). Both confirmed live and given probe configs matching their sibling surfaces' conventions.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-11",
   "social": {
@@ -207,7 +212,11 @@
       "id": "sn-11-trajectoryrl-subnet-api",
       "kind": "subnet-api",
       "name": "TrajectoryRL network stats API",
-      "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "probe-derived"
+      },
+      "notes": "Public read-only REST JSON endpoint reporting SN11 network totals (reports, LLM calls, tokens, cost); no auth. Documented in the official trajrl API client. REVENUE ROLE (#10463): not-revenue. `totalCostUsd` is what the subnet SPENDS on LLM calls -- an expense, the opposite sign from revenue. A money figure is not automatically a revenue figure. REVENUE ROLE (#10463): not-revenue. `totalCostUsd` is what the subnet SPENDS on LLM calls -- an expense, the opposite sign from revenue. A money figure is not automatically a revenue figure.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -231,7 +240,7 @@
       "id": "sn-11-trajectoryrl-miners",
       "kind": "data-artifact",
       "name": "TrajectoryRL miner directory",
-      "notes": "Public no-auth GET returning the TrajectoryRL (SN11) miner directory as JSON — aggregate counters (total / active / qualified miner counts, validator count) plus a per-miner array of 256 rows carrying uid, name, incentive, score, rank, activity flags, and latest-model fields. Served on trajrl.com, the subnet's own registered domain (same host as the existing website and /api/stats subnet-api), and distinct from that aggregate-only stats surface.",
+      "notes": "Public no-auth GET returning the TrajectoryRL (SN11) miner directory as JSON \u2014 aggregate counters (total / active / qualified miner counts, validator count) plus a per-miner array of 256 rows carrying uid, name, incentive, score, rank, activity flags, and latest-model fields. Served on trajrl.com, the subnet's own registered domain (same host as the existing website and /api/stats subnet-api), and distinct from that aggregate-only stats surface.",
       "probe": {
         "enabled": true,
         "expect": "json",


### PR DESCRIPTION
Seven subnets classified. **None carries external revenue** — but three carry money, pointing the wrong way.

| subnet | surface | live payload | verdict |
|---|---|---|---|
| **SN4 Targon** | `/api/miners` | `payout: 16, 33.68` | **`miner-payout`** — this is *emission* paid to miners, the denominator of a coverage ratio. It is the most-quoted number on this subnet. |
| **SN11 TrajectoryRL** | `/api/stats` | `totalCostUsd: 373.48` | **`not-revenue`** — what the subnet **spends** on LLM calls. An expense, the opposite sign from revenue. |
| **SN35 OxMarkets** | `/v1/lp-stats` | `apy_tiers[]` | **`not-revenue`** — yield *configuration* (lock periods, boosts, advertised APY), not an amount anybody earned. |

The rest are counts: SN2 `total_proofs`, SN7 `totalSwaps` / `totalVolumeSol`, SN29's third-party taostats dashboard.

**SN7 is worth a note.** `totalVolumeSol` is swap *volume routed through* the subnet, not fees earned from it. Volume is a usage measure and the take rate is not published, so it is `usage-proxy` — reading volume as revenue would overstate SN7 by whatever the spread is.

## The subnet-level record

Each of the seven also gains `revenue_search` (#10543):

```json
{"searched_at": "2026-08-10T00:00:00Z", "outcome": "none-found",
 "checked": ["website","docs","openapi","dashboard","source-repo"]}
```

`checked` names where the search actually looked, so the result is re-runnable rather than an assertion. The validator cross-checks `outcome` against the surfaces, so this cannot drift from the data it summarises.

## One PR per sweep, not per subnet

House rule 2 forbids splitting *one subnet* across PRs and forbids per-surface candidate files — the contributor-farm shapes. This is maintainer-only sweep work whose unit is the issue, and the issue is batched by design. Seven near-empty PRs would be worse review, not better.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` · `scan:public-safety` — all pass
- The provenance validator caught one mistake in this batch (SN35's admin-alerts surface marked `probe-derived` while `probe.enabled` is false) and it was corrected to `operator-attested` before commit
- Purely additive diffs

Closes #10463
