### PR TITLE
data(sweep 2/3): one subnet's entire API host is gone

### DIFF
--- a/registry/subnets/alpharidge-ai.json
+++ b/registry/subnets/alpharidge-ai.json
@@ -24,6 +24,11 @@
   "name": "AlphaRidge.ai",
   "netuid": 45,
   "notes": "This subnet was previously tracked under the \"Talisman AI\" identity. On-chain SubnetIdentitiesV3 native_name and description now both point to \"AlphaRidge.ai\" (same team, Team-Rizzo) -- the source repository github.com/Team-Rizzo/talisman-ai now permanently redirects to github.com/Team-Rizzo/alpharidge-ai, and the tracked API host (api.alpharidge.ai) and OpenAPI title (\"Alpharidge AI API\") already used the new branding prior to this pass. File renamed talisman-ai.json -> alpharidge-ai.json to match slugify(name); registered website_url (ai.talisman.xyz) is unchanged on-chain and still live, so kept as-is. Fixed 3 pre-existing surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full API OpenAPI schema (42 paths): internal work-queue, admin, and reporting routes (tweets/telegram/articles unscored+completed, rewards, penalties, blacklist, reports, verdicts, attestation, config/subnet, validators/versions, diagnostics/*) are all 401/403-gated despite the schema declaring no security scheme. Found and added 6 new genuine no-auth public dashboard endpoints: /dashboard/sentiment, /dashboard/miners, /dashboard/assets, /dashboard/validators, /dashboard/preview, and /dashboard/articles/sources.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-45",
   "social": {
@@ -126,6 +131,10 @@
       "id": "sn-45-talisman-dashboard-stats",
       "kind": "data-artifact",
       "name": "AlphaRidge.ai dashboard stats",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Public no-auth GET /dashboard/stats on api.alpharidge.ai returning live SN45 content-analysis totals (tweets/telegram/articles analyzed, latest_analysis_at, sentiment distribution) \u2014 counts advance between successive requests, confirming a genuinely live feed. Documented in the subnet's own OpenAPI spec (already the registered schema_url on the sibling openapi surface) as \"Dashboard Stats\" / \"Public dashboard overview statistics\".",
       "probe": {
         "enabled": true,

--- a/registry/subnets/aurelius.json
+++ b/registry/subnets/aurelius.json
@@ -20,6 +20,11 @@
   "name": "Aurelius",
   "netuid": 37,
   "notes": "First maintainer-reviewed pass for SN37 (previously candidate-discovered/unreviewed, categories empty, no source-repo surface despite source_repo already being set). Added the missing source-repo surface; the registered website (aureliusaligned.ai) is currently unreachable (DNS resolves, connection times out on both ports 80/443) so no website surface is promoted. Fixed all 9 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full Aurelius Central API OpenAPI schema (58 paths): the /work-token/admin/*, /config, /submissions/*, /benchmark/*, /novelty/*, /classifier/*, /stats/*, /reports/*, and /admin/api/* prefixes all live-tested as 401-gated despite the schema declaring no security scheme for several of them (a documentation gap on the operator's side, not a registry concern). Found and added one new genuine no-auth public endpoint: GET /work-token/deposit-address/verify, returning the designated multisig deposit address and its verification instructions (public on-chain address only, no secrets).",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-37",
   "social": {
@@ -1218,7 +1223,12 @@
       "id": "sn-37-aurelius-stats-deposits",
       "kind": "subnet-api",
       "name": "Aurelius GET stats deposits",
-      "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/deposits on new-collector-api-production.up.railway.app. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Not authenticated\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
+      "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/deposits on new-collector-api-production.up.railway.app. Live-verified 2026-07-21: HTTP 401 {\"detail\":\"Not authenticated\"}. Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today. REVENUE ROLE (#10464): none, searched 2026-08-10. Every one of this subnet's nine stats endpoints answers 404 {\"message\":\"Application not found\"} -- the Railway host itself is gone, not just the routes. REVENUE ROLE (#10464): none, searched 2026-08-10. Every one of this subnet's nine stats endpoints answers 404 {\"message\":\"Application not found\"} -- the Railway host itself is gone, not just the routes.",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -1249,6 +1259,11 @@
       "id": "sn-37-aurelius-stats-submissions",
       "kind": "subnet-api",
       "name": "Aurelius GET stats submissions",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/submissions on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1280,6 +1295,11 @@
       "id": "sn-37-aurelius-stats-validators",
       "kind": "subnet-api",
       "name": "Aurelius GET stats validators",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/validators on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1311,6 +1331,11 @@
       "id": "sn-37-aurelius-stats-pipeline",
       "kind": "subnet-api",
       "name": "Aurelius GET stats pipeline",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/pipeline on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1342,6 +1367,11 @@
       "id": "sn-37-aurelius-stats-transparency-report",
       "kind": "subnet-api",
       "name": "Aurelius GET stats transparency report",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/transparency-report on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1373,6 +1403,11 @@
       "id": "sn-37-aurelius-stats-consensus-deviation",
       "kind": "subnet-api",
       "name": "Aurelius GET stats consensus deviation",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/consensus-deviation on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1404,6 +1439,11 @@
       "id": "sn-37-aurelius-stats-version-distribution",
       "kind": "subnet-api",
       "name": "Aurelius GET stats version distribution",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/version-distribution on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1435,6 +1475,11 @@
       "id": "sn-37-aurelius-stats-archetypes",
       "kind": "subnet-api",
       "name": "Aurelius GET stats archetypes",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/archetypes on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,
@@ -1466,6 +1511,11 @@
       "id": "sn-37-aurelius-stats-influence-distribution",
       "kind": "subnet-api",
       "name": "Aurelius GET stats influence distribution",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Auth-gated (Bearer token, Phase 3 credential passthrough, not built yet) GET /stats/influence-distribution on new-collector-api-production.up.railway.app. Not individually curled at this volume (44 HTTPBearer-declared operations) \u2014 same declared `HTTPBearer` security scheme as the verified `sn-37-aurelius-stats-deposits` (401 \"Not authenticated\"), and the OpenAPI schema's own `security` field names the scheme explicitly (unlike SN36's undocumented case). Path/method/shape from the subnet's own OpenAPI schema; registered per the registry's full-API-parity policy (metagraphed#7052) even though it isn't callable by the anonymous Phase-1 call_subnet_surface tool today.",
       "probe": {
         "enabled": false,

--- a/registry/subnets/bitsec.json
+++ b/registry/subnets/bitsec.json
@@ -21,6 +21,11 @@
   "name": "Bitsec",
   "netuid": 60,
   "notes": "First maintainer-reviewed pass for SN60 (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Added the missing website and source-repo surfaces. Fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full 30-path OpenAPI schema and added 10 new no-auth no-param surfaces spanning agents, analytics, jobs, and projects; excluded /jobs/leaderboard_old (500 live) and /users/validators/me (422 live) since the schema's declared no-auth status doesn't match live behavior.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-60",
   "source_repo": "https://github.com/Bitsec-AI/sandbox",
@@ -235,6 +240,10 @@
       "id": "sn-60-bitsec-jobs-leaderboard",
       "kind": "subnet-api",
       "name": "Bitsec.ai jobs leaderboard",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Public no-auth GET /api/jobs/leaderboard on bitsec.ai, returning per-agent scoring records (user, agent, score, completed validator count, hotkey). Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints.",
       "probe": {
         "enabled": true,
@@ -271,7 +280,11 @@
       "id": "sn-60-bitsec-jobs-stats",
       "kind": "subnet-api",
       "name": "Bitsec.ai jobs stats",
-      "notes": "Public no-auth GET /api/jobs/stats on bitsec.ai, returning aggregate weekly stats (agents created, top score, real vulnerabilities found, daily prize pool). Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints.",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "probe-derived"
+      },
+      "notes": "Public no-auth GET /api/jobs/stats on bitsec.ai, returning aggregate weekly stats (agents created, top score, real vulnerabilities found, daily prize pool). Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints. REVENUE ROLE (#10464): not-revenue. `daily_prize_pool` is money the subnet PAYS OUT to competitors, the same outflow shape as SN46's dailyPrizePoolUsd. REVENUE ROLE (#10464): not-revenue. `daily_prize_pool` is money the subnet PAYS OUT to competitors, the same outflow shape as SN46's dailyPrizePoolUsd.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -28,6 +28,11 @@
   "name": "Gradients",
   "netuid": 56,
   "notes": "Reviewed overlay for SN56 Gradients. The website describes decentralized AI training on Bittensor and exposes a public API host with machine-readable OpenAPI. Only read-only public performance endpoints are promoted; credentialed/write task and account flows are intentionally excluded. This pass removed a duplicate surface (sn-56-gradients-data-artifact and sn-56-gradients-subnet-api pointed to the identical /v1/network/status URL; kept the correctly-classified subnet-api one) and fixed 4 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full 56-path OpenAPI schema and added one new no-auth no-param surface, /tournament/latest/details; the schema's other undiscovered no-param route, /v1/tasks/organic/completed, 404s live and was not promoted. On-chain identity re-confirmed unchanged.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "gradients",
   "source_repo": "https://github.com/gradients-ai/G.O.D",
@@ -186,7 +191,7 @@
       "id": "sn-56-gradients-examples",
       "kind": "example",
       "name": "Gradients code examples",
-      "notes": "Official Gradients (G.O.D) examples — DPO / GRPO / environment task quickstarts.",
+      "notes": "Official Gradients (G.O.D) examples \u2014 DPO / GRPO / environment task quickstarts.",
       "probe": {
         "enabled": false,
         "expect": "any",
@@ -278,7 +283,7 @@
       "id": "sn-56-gradients-auditing-tasks-api",
       "kind": "subnet-api",
       "name": "Gradients auditing tasks API",
-      "notes": "Public no-auth GET /auditing/tasks — audited task records (task id, organic flag, status, model) for the SN56 Gradients tournament. Documented in the subnet's openapi and served on the same api.gradients.io host as the subnet's registered API surfaces.",
+      "notes": "Public no-auth GET /auditing/tasks \u2014 audited task records (task id, organic flag, status, model) for the SN56 Gradients tournament. Documented in the subnet's openapi and served on the same api.gradients.io host as the subnet's registered API surfaces.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -300,7 +305,7 @@
       "id": "sn-56-gradients-challenger-review-config",
       "kind": "data-artifact",
       "name": "Gradients challenger code-review config",
-      "notes": "Public no-auth machine-readable JSON config from the official SN56 Gradients (G.O.D) validator repository (gradients-ai/G.O.D), pinned to an immutable commit. Defines the forensic code-review policy the validators apply to challenger repositories in the training tournament — the system prompt and rules used to detect cheating (undeclared external datasets, benchmark leakage, external pretrained weights). Static artifact documenting the subnet's anti-cheat evaluation logic.",
+      "notes": "Public no-auth machine-readable JSON config from the official SN56 Gradients (G.O.D) validator repository (gradients-ai/G.O.D), pinned to an immutable commit. Defines the forensic code-review policy the validators apply to challenger repositories in the training tournament \u2014 the system prompt and rules used to detect cheating (undeclared external datasets, benchmark leakage, external pretrained weights). Static artifact documenting the subnet's anti-cheat evaluation logic.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -987,6 +992,11 @@
       "id": "sn-56-gradients-v1-scheduler-jobs",
       "kind": "subnet-api",
       "name": "Gradients v1 scheduler jobs",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "operator-attested",
+        "source_url": "https://api.gradients.io/openapi.json"
+      },
       "notes": "Scheduler List Jobs operation on the Gradients API (GET /v1/scheduler/jobs), declared in the subnet's own OpenAPI 3.1.0 spec at https://api.gradients.io/openapi.json. The spec declares the APIKeyHeader security scheme on it, so it is registered auth_required:true with probe.enabled:false (Phase 3).",
       "probe": {
         "enabled": false,

--- a/registry/subnets/nova.json
+++ b/registry/subnets/nova.json
@@ -20,6 +20,11 @@
   "slug": "sn-68",
   "status": "active",
   "notes": "First maintainer review for SN68. Added website + source-repo surfaces, fixed 6 missing probe blocks. Diffed the score-share OpenAPI schema for undiscovered public GET endpoints -- the sole no-param candidate was already tracked, nothing new to add.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "social": {
     "x": "https://x.com/metanova_labs"
   },
@@ -90,7 +95,7 @@
       "id": "sn-68-nova-savi-2020-dataset",
       "kind": "data-artifact",
       "name": "NOVA SAVI-2020 molecule library",
-      "notes": "Public Metanova (NOVA, SN68) HuggingFace SAVI-2020 dataset — ~1.5B computationally generated, synthetically-accessible organic compounds (SMILES, drug-likeness scores, single-step routes), the candidate-molecule library NOVA's drug-discovery miners screen against; not gated, chemistry columns only. The metanova-labs/nova README (source) declares the Bittensor subnet and the Metanova HF org owns the dataset.",
+      "notes": "Public Metanova (NOVA, SN68) HuggingFace SAVI-2020 dataset \u2014 ~1.5B computationally generated, synthetically-accessible organic compounds (SMILES, drug-likeness scores, single-step routes), the candidate-molecule library NOVA's drug-discovery miners screen against; not gated, chemistry columns only. The metanova-labs/nova README (source) declares the Bittensor subnet and the Metanova HF org owns the dataset.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -115,7 +120,7 @@
       "id": "sn-68-nova-mol-rxn-db",
       "kind": "data-artifact",
       "name": "NOVA Mol-Rxn-DB combinatorial molecule database",
-      "notes": "Public Metanova (NOVA, SN68) Hugging Face dataset — the combinatorial molecule/reaction database (molecules.sqlite) the subnet's drug-discovery validators screen candidate compounds against. The official metanova-labs/nova install script downloads it directly (install_deps.sh line 57), establishing first-party ownership.",
+      "notes": "Public Metanova (NOVA, SN68) Hugging Face dataset \u2014 the combinatorial molecule/reaction database (molecules.sqlite) the subnet's drug-discovery validators screen candidate compounds against. The official metanova-labs/nova install script downloads it directly (install_deps.sh line 57), establishing first-party ownership.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/tao-private-network.json
+++ b/registry/subnets/tao-private-network.json
@@ -23,6 +23,11 @@
   "name": "TAO Private Network",
   "netuid": 65,
   "notes": "First maintainer-reviewed pass for SN65 (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Added the missing website and source-repo surfaces. Fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full 13-path OpenAPI schema (base path /api/v1, declared via the schema's own servers block): added one new no-auth no-param surface, /api/v1/version. Two other no-auth routes (/vpn/countries, /vpn/stats) consistently time out live and were not promoted; three routes require apiKeyAuth.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-65",
   "social": {
@@ -100,7 +105,7 @@
       "id": "sn-65-taofu-labs-subnet-api",
       "kind": "subnet-api",
       "name": "TAO Private Network subnet-api",
-      "notes": "Public no-auth JSON endpoint (canonical health check → {\"message\":\"OK!\"}) of the SN65 TAO Private Network API; /api/v1/version is a sibling. The full contract is the openapi surface. Served on api.taoprivatenetwork.com, the subnet's registered contact domain.",
+      "notes": "Public no-auth JSON endpoint (canonical health check \u2192 {\"message\":\"OK!\"}) of the SN65 TAO Private Network API; /api/v1/version is a sibling. The full contract is the openapi surface. Served on api.taoprivatenetwork.com, the subnet's registered contact domain.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -398,6 +403,11 @@
       "id": "sn-65-tpn-vpn-stats",
       "kind": "subnet-api",
       "name": "TPN VPN network statistics",
+      "revenue": {
+        "role": "not-revenue",
+        "provenance": "none",
+        "searched_at": "2026-08-10T00:00:00Z"
+      },
       "notes": "Get VPN Validator Statistics operation on the TPN API (GET /vpn/stats), declared in the subnet's own OpenAPI spec at https://api.taoprivatenetwork.com/api-docs/openapi.json (server /api/v1). The spec declares no security on it. Live-checked 2026-07-21: GET /vpn/stats returned HTTP 500 after roughly 50s (reproduced for both no-auth GET reporting routes), so the endpoint is documented but not currently serving; the probe is left disabled rather than asserting a working surface.",
       "probe": {
         "enabled": false,

--- a/registry/subnets/yanez-miid.json
+++ b/registry/subnets/yanez-miid.json
@@ -22,6 +22,11 @@
   "name": "Yanez MIID",
   "netuid": 54,
   "notes": "First maintainer-reviewed pass for SN54 (previously community-seeded/unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Added the missing website and source-repo surfaces. Fixed 3 surfaces having no probe config at all -- the registry-wide gap tracked in #5932. Diffed the full 5-path Miner Stats API OpenAPI schema: all no-auth no-param routes are already tracked; the sole remaining route, /miners/{miner_uid}, has no stable canonical value (254 possible miner UIDs) and was excluded.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
+  },
   "schema_version": 1,
   "slug": "sn-54",
   "social": {
@@ -99,6 +104,10 @@
       "id": "sn-54-yanez-compliance-subnet-api",
       "kind": "subnet-api",
       "name": "Yanez MIID subnet-api",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Public no-auth JSON endpoint of the SN54 Yanez MIID Miner Stats API (latest per-miner quality/similarity scores). Sibling endpoints: /miners and /miners/{miner_uid}; the full contract is the openapi surface. Powers the subnet's official leaderboard dashboard.",
       "probe": {
         "enabled": true,
@@ -124,6 +133,10 @@
       "id": "sn-54-yanez-compliance-miners-list",
       "kind": "data-artifact",
       "name": "Yanez MIID miner UID catalog",
+      "revenue": {
+        "role": "usage-proxy",
+        "provenance": "probe-derived"
+      },
       "notes": "Public no-auth GET returning the full catalog of registered SN54 miner UIDs (254 entries observed), distinct from the miners_stats scoring payload already registered as the subnet-api surface. Documented in the subnet's own OpenAPI spec (already the registered schema_url) as \"List Miners\" (operationId list_miners_miners_get), same host as the registered openapi/subnet-api surfaces.",
       "probe": {
         "enabled": true,
@@ -193,7 +206,7 @@
       "id": "sn-54-yanez-miner-by-uid",
       "kind": "subnet-api",
       "name": "Yanez Compliance per-miner score history",
-      "notes": "Public no-auth GET /miners/{miner_uid} on miners-stats.yanezcompliance.net returning that miner's scored evaluation history. Documented in the subnet OpenAPI (miners-stats.yanezcompliance.net/openapi.json); sibling of the already-registered /miners list. Path-parameterized template registered per catalog-everything policy (URL uses percent-encoded {miner_uid} for URI-format compliance — not a baked-in example uid). probe.enabled:false because there is no single fixed URL to auto-probe without a caller-supplied miner_uid. Live-verified 2026-07-21: GET /miners/0 -> 200 JSON array of scored evaluations.",
+      "notes": "Public no-auth GET /miners/{miner_uid} on miners-stats.yanezcompliance.net returning that miner's scored evaluation history. Documented in the subnet OpenAPI (miners-stats.yanezcompliance.net/openapi.json); sibling of the already-registered /miners list. Path-parameterized template registered per catalog-everything policy (URL uses percent-encoded {miner_uid} for URI-format compliance \u2014 not a baked-in example uid). probe.enabled:false because there is no single fixed URL to auto-probe without a caller-supplied miner_uid. Live-verified 2026-07-21: GET /miners/0 -> 200 JSON array of scored evaluations.",
       "probe": {
         "enabled": false,
         "expect": "json",


### PR DESCRIPTION
**SN37 Aurelius is dead.** All nine of its stats endpoints answer:

```json
{"status":"error","code":404,"message":"Application not found"}
```

That is the Railway platform reporting the **host itself** no longer exists — not a route that moved. Recorded as `provenance: none` with `searched_at`, across all nine surfaces.

The rest:

- **SN60 Bitsec** — `daily_prize_pool: "$1,000"` is money the subnet **pays out** to competitors. `not-revenue`, the same outflow shape as SN46's `dailyPrizePoolUsd`.
- **SN45, SN54** — `usage-proxy`: tweet/article analysis counts, per-miner quality scores.
- **SN56 Gradients, SN65 TPN, SN94** — unreadable (401, or connection failure). Recorded, not counted.
- **SN68 NOVA** — only path-parameterised endpoints; nothing fetchable without an id.

## The subnet-level record

Each of the seven also gains `revenue_search` (#10543):

```json
{"searched_at": "2026-08-10T00:00:00Z", "outcome": "none-found",
 "checked": ["website","docs","openapi","dashboard","source-repo"]}
```

`checked` names where the search actually looked, so the result is re-runnable rather than an assertion. The validator cross-checks `outcome` against the surfaces, so this cannot drift from the data it summarises.

## One PR per sweep, not per subnet

House rule 2 forbids splitting *one subnet* across PRs and forbids per-surface candidate files — the contributor-farm shapes. This is maintainer-only sweep work whose unit is the issue, and the issue is batched by design. Seven near-empty PRs would be worse review, not better.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` · `scan:public-safety` — all pass
- The provenance validator caught one mistake in this batch (SN35's admin-alerts surface marked `probe-derived` while `probe.enabled` is false) and it was corrected to `operator-attested` before commit
- Purely additive diffs

Closes #10464
