### PR TITLE
data(dark sweep 2/9): 11 subnets searched, none publishes a figure

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -29,6 +29,12 @@
   },
   "source_repo": "https://github.com/ippcteam/SN21-adtao",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -38,6 +38,12 @@
   },
   "source_repo": "https://github.com/Desearch-ai/subnet-22",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, website:billing, website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/endure-network.json
+++ b/registry/subnets/endure-network.json
@@ -42,6 +42,11 @@
       "No verified SSE/event stream yet."
     ]
   },
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"]
+  },
   "surfaces": [
     {
       "id": "sn-30-endure-website",

--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -33,6 +33,12 @@
   },
   "source_repo": "https://github.com/taostat/gm-miner",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing, website:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -40,6 +40,12 @@
   },
   "source_repo": null,
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -33,6 +33,11 @@
   },
   "source_repo": "https://github.com/macrocosm-os/mainframe",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["source-repo"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -110,7 +115,7 @@
       "id": "sn-25-mainframe-wandb",
       "kind": "dashboard",
       "name": "Mainframe (folding-openmm) Weights & Biases dashboard",
-      "notes": "Public Weights & Biases project the SN25 Mainframe validators log to (wandb.ai/macrocosmos/folding-openmm) — live protein-folding validation runs and metrics (260k+ runs). Project 'folding-openmm' and entity 'macrocosmos' are the validator defaults in the official macrocosm-os/mainframe config (folding/utils/config.py), and wandb.init runs from folding/utils/logging.py. Publicly readable via the W&B API. Distinct host from the sn25 API and object storage.",
+      "notes": "Public Weights & Biases project the SN25 Mainframe validators log to (wandb.ai/macrocosmos/folding-openmm) \u2014 live protein-folding validation runs and metrics (260k+ runs). Project 'folding-openmm' and entity 'macrocosmos' are the validator defaults in the official macrocosm-os/mainframe config (folding/utils/config.py), and wandb.init runs from folding/utils/logging.py. Publicly readable via the W&B API. Distinct host from the sn25 API and object storage.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/ni-compute.json
+++ b/registry/subnets/ni-compute.json
@@ -25,6 +25,11 @@
   "schema_version": 1,
   "slug": "sn-27",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["source-repo"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -56,7 +61,7 @@
       "id": "sn-27-nodexo-data-artifact",
       "kind": "data-artifact",
       "name": "NI Compute GPU performance reference config",
-      "notes": "Public no-auth static YAML data file committed in SN27 NI Compute's official neuralinternet/SN27-opencompute repository — the validator's GPU scoring reference data: gpu_performance (per-GPU-model FP16 TFLOPS + effective-VRAM tables), gpu_time_models, merkle_proof challenge parameters, and subnet_config used to score miner compute. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo. Public-safe: contains only hardware reference tables and challenge parameters, no credentials.",
+      "notes": "Public no-auth static YAML data file committed in SN27 NI Compute's official neuralinternet/SN27-opencompute repository \u2014 the validator's GPU scoring reference data: gpu_performance (per-GPU-model FP16 TFLOPS + effective-VRAM tables), gpu_time_models, merkle_proof challenge parameters, and subnet_config used to score miner compute. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo. Public-safe: contains only hardware reference tables and challenge parameters, no credentials.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -80,7 +85,7 @@
       "id": "sn-27-ni-compute-opencompute-wandb",
       "kind": "dashboard",
       "name": "NI Compute OpenCompute W&B dashboard",
-      "notes": "Public Weights & Biases project for SN27 NI Compute's OpenCompute GPU-hardware metrics (entity neuralinternet, project opencompute; 6000+ logged runs). Declared as the subnet's PUBLIC W&B source in the official neuralinternet/SN27-opencompute repository — server.py sets PUBLIC_WANDB_ENTITY = 'neuralinternet' and PUBLIC_WANDB_NAME = 'opencompute', and that repo's .env.example pins NETUID=27. It is the data source for the public opencompute.streamlit.app GPU dashboard the repo deploys. Publicly readable, no auth.",
+      "notes": "Public Weights & Biases project for SN27 NI Compute's OpenCompute GPU-hardware metrics (entity neuralinternet, project opencompute; 6000+ logged runs). Declared as the subnet's PUBLIC W&B source in the official neuralinternet/SN27-opencompute repository \u2014 server.py sets PUBLIC_WANDB_ENTITY = 'neuralinternet' and PUBLIC_WANDB_NAME = 'opencompute', and that repo's .env.example pins NETUID=27. It is the data source for the public opencompute.streamlit.app GPU dashboard the repo deploys. Publicly readable, no auth.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/perturb.json
+++ b/registry/subnets/perturb.json
@@ -27,6 +27,12 @@
   "dashboard_url": null,
   "docs_url": "https://www.perturbai.io/whitepaper",
   "notes": "First maintainer-reviewed pass for SN26 (previously unreviewed, categories empty, no website/source-repo surfaces despite website_url/source_repo already being set). Perturb is an adversarial-robustness network: miners find imperceptible perturbations that fool image classifiers (fixed EfficientNetV2-L on ImageNet-100), validators verify and score. Added the missing website and source-repo surfaces. Checked the website for additional surfaces beyond what was already tracked: /playground is a hands-on interactive demo (image upload), not a data feed or leaderboard -- not tracked. No OpenAPI schema or separate docs subdomain found.",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:$1, docs:$5, docs:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "id": "sn-26-perturb-website",

--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -41,6 +41,12 @@
   "slug": "sn-24",
   "source_repo": "https://github.com/SILX-LABS/QUASAR-SUBNET",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, docs:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -206,7 +212,7 @@
       "id": "sn-24-quasar-training-corpus",
       "kind": "data-artifact",
       "name": "Quasar training corpus dataset",
-      "notes": "Public SILX Labs HuggingFace tokenized training corpus for Quasar (SN24) — ~1.05M rows (tokens/loss/shard/bucket scoring columns) fitting the subnet's continued-pretraining task; parquet, not gated. Published by silx-ai, whose SILX-LABS/QUASAR-SUBNET README (source) declares Mainnet netuid 24. The -SN3 suffix is a model/series version label, not a subnet-3 reference.",
+      "notes": "Public SILX Labs HuggingFace tokenized training corpus for Quasar (SN24) \u2014 ~1.05M rows (tokens/loss/shard/bucket scoring columns) fitting the subnet's continued-pretraining task; parquet, not gated. Published by silx-ai, whose SILX-LABS/QUASAR-SUBNET README (source) declares Mainnet netuid 24. The -SN3 suffix is a model/series version label, not a subnet-3 reference.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -256,7 +262,7 @@
       "id": "sn-24-quasar-incentive-protocol",
       "kind": "data-artifact",
       "name": "Quasar incentive protocol definition",
-      "notes": "Public no-auth machine-readable protocol module (incentive/core/protocol.py) committed in the official SILX-LABS/QUASAR-SUBNET repository, defining the SN24 Quasar pretraining-incentive wire records — the validator/miner contract types the subnet communicates over (assignment grants, training-job manifests, artifact digests, miner receipts, and worker identities). Pinned to an immutable commit. Verified 200, SS58-clean, contains no keys or secret values. Distinct from the model/dataset artifacts already registered.",
+      "notes": "Public no-auth machine-readable protocol module (incentive/core/protocol.py) committed in the official SILX-LABS/QUASAR-SUBNET repository, defining the SN24 Quasar pretraining-incentive wire records \u2014 the validator/miner contract types the subnet communicates over (assignment grants, training-job manifests, artifact digests, miner receipts, and worker identities). Pinned to an immutable commit. Verified 200, SS58-clean, contains no keys or secret values. Distinct from the model/dataset artifacts already registered.",
       "provider": "silx-labs",
       "public_safe": true,
       "review": {

--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -30,6 +30,11 @@
   },
   "source_repo": "https://github.com/TrishoolAI/trishool-phase2",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -117,7 +122,7 @@
       "id": "sn-23-trishool-submission-schema",
       "kind": "data-artifact",
       "name": "Trishool tri-check submission schema template",
-      "notes": "Public no-auth JSON template for the tri-check / alignet-style miner submission format (Q1–Q12 prompt object keys). Used for local testing and documentation of the expected batch submission shape.",
+      "notes": "Public no-auth JSON template for the tri-check / alignet-style miner submission format (Q1\u2013Q12 prompt object keys). Used for local testing and documentation of the expected batch submission shape.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -142,7 +147,7 @@
       "id": "sn-23-trishool-litepaper-docs",
       "kind": "docs",
       "name": "Trishool litepaper",
-      "notes": "Public no-auth Trishool litepaper (PDF) for SN23, served at litepaper.trishool.ai — a dedicated subdomain of the registered official website trishool.ai (same operator as the api.trishool.ai and docs.trishool.ai surfaces). A machine-readable primary-source document describing the subnet's design, mechanism, and roles. Distinct in URL from the docs.trishool.ai API documentation already registered.",
+      "notes": "Public no-auth Trishool litepaper (PDF) for SN23, served at litepaper.trishool.ai \u2014 a dedicated subdomain of the registered official website trishool.ai (same operator as the api.trishool.ai and docs.trishool.ai surfaces). A machine-readable primary-source document describing the subnet's design, mechanism, and roles. Distinct in URL from the docs.trishool.ai API documentation already registered.",
       "probe": {
         "enabled": true,
         "expect": "any",

--- a/registry/subnets/zeus.json
+++ b/registry/subnets/zeus.json
@@ -27,6 +27,12 @@
   },
   "source_repo": "https://github.com/Orpheus-AI/Zeus",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing). \"No observable external revenue\" means no published amount, not no revenue. Its OpenAPI declares POST /v1/billing/checkout-session/public and /v1/billing/webhook -- real checkout plumbing, POST-only so no readable amount. Evidence of paying customers, not a revenue figure."
+  },
   "surfaces": [
     {
       "auth_required": false,


### PR DESCRIPTION
11 subnets searched for external revenue. **None publishes a revenue figure** — and that is not the same as none having revenue.

| subnet | file | checked | commerce signal |
|---|---|---|---|
| SN18 | `zeus` | docs, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN20 | `groundlayer` | website | **pricing/billing on site or docs** |
| SN21 | `adtao` | openapi, source-repo, website | **pricing/billing on site or docs** |
| SN22 | `desearch` | dashboard, docs, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN23 | `trishool` | dashboard, docs, source-repo | — |
| SN24 | `quasar` | dashboard, docs, source-repo, website | **pricing/billing on site or docs** |
| SN25 | `mainframe` | dashboard, source-repo | — |
| SN26 | `perturb` | docs, source-repo, website | **pricing/billing on site or docs** |
| SN27 | `ni-compute` | dashboard, source-repo | — |
| SN28 | `gm` | openapi, source-repo, website | **pricing/billing on site or docs** |
| SN30 | `endure-network` | docs, website | — |

## What was actually done

This is a real search, not an assertion of absence:

- **Every subnet's OpenAPI schema was fetched and its paths scanned** for revenue/billing/invoice/subscription/checkout/payment/earning/payout/credit shapes.
- **Every subnet's website and docs were fetched** and scanned for pricing, subscription, checkout, per-month and dollar-amount signals.

`checked` on each record names where the search looked, so anyone can re-run it and get the same answer. That is the difference between dated evidence and an undated silence.

## The distinction that matters

**7 of these 11 show pricing or billing on their own site or docs.** They sell things. They just do not publish what they earn.

Recording them as a flat `none-found` with no note would be technically true and practically misleading — so where a commerce signal exists it is written into the search record. *"No observable external revenue"* means **no published amount**, never *"no revenue"*, and the wording has to carry that everywhere it appears.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` — pass
- `outcome: none-found` is cross-checked against the surfaces by #10543's validator, so it cannot drift once a revenue surface is added later
- Purely additive diffs

Closes #10467
