### PR TITLE
data(dark sweep 3/9): 11 subnets searched, none publishes a figure

### DIFF
--- a/registry/subnets/almanac.json
+++ b/registry/subnets/almanac.json
@@ -24,6 +24,11 @@
   "slug": "sn-41",
   "source_repo": "https://github.com/sportstensor/sn41",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -111,7 +116,7 @@
       "id": "sn-41-almanac-wandb",
       "kind": "dashboard",
       "name": "Almanac validator Weights & Biases dashboard",
-      "notes": "Public Weights & Biases project the SN41 Almanac validators log to (wandb.ai/sportstensor/sportstensor-vali-logs) — live validator run logs and sports-prediction scoring metrics. Validators import wandb and start runs under entity 'sportstensor' / project 'sportstensor-vali-logs' in the official sportstensor/sn41 validator.py. Publicly readable via the W&B API. Distinct host from the api.almanac.market API.",
+      "notes": "Public Weights & Biases project the SN41 Almanac validators log to (wandb.ai/sportstensor/sportstensor-vali-logs) \u2014 live validator run logs and sports-prediction scoring metrics. Validators import wandb and start runs under entity 'sportstensor' / project 'sportstensor-vali-logs' in the official sportstensor/sn41 validator.py. Publicly readable via the W&B API. Distinct host from the api.almanac.market API.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/basilica.json
+++ b/registry/subnets/basilica.json
@@ -26,6 +26,12 @@
   "slug": "sn-39",
   "source_repo": "https://github.com/one-covenant/basilica",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -75,7 +81,7 @@
       "id": "sn-39-basilica-examples",
       "kind": "example",
       "name": "Basilica code examples",
-      "notes": "Official Basilica examples — hello-world, storage, and FastAPI quickstarts.",
+      "notes": "Official Basilica examples \u2014 hello-world, storage, and FastAPI quickstarts.",
       "probe": {
         "enabled": false,
         "expect": "any",

--- a/registry/subnets/bitmind.json
+++ b/registry/subnets/bitmind.json
@@ -26,6 +26,12 @@
   "slug": "sn-34",
   "source_repo": "https://github.com/BitMind-AI/bitmind-subnet",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:pricing, website:per month, website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -232,7 +238,7 @@
       "id": "sn-34-bitmind-detect-v1",
       "kind": "subnet-api",
       "name": "BitMind auto-detecting detection front door",
-      "notes": "Auth-gated POST /v1/detect on api.bitmind.ai — OpenAPI operation detect_v1_detect_post. Infers image/video/text/document type and delegates to the matching detector. Documented in sn-34-bitmind-openapi (info.description requires Authorization: Bearer <token> for all non-health endpoints). Live-verified 2026-07-21: anonymous POST {} returned HTTP 401 {\"detail\":\"API key is required\"}. Probe disabled (auth-gated write action; Phase 1 call_subnet_surface cannot supply credentials).",
+      "notes": "Auth-gated POST /v1/detect on api.bitmind.ai \u2014 OpenAPI operation detect_v1_detect_post. Infers image/video/text/document type and delegates to the matching detector. Documented in sn-34-bitmind-openapi (info.description requires Authorization: Bearer <token> for all non-health endpoints). Live-verified 2026-07-21: anonymous POST {} returned HTTP 401 {\"detail\":\"API key is required\"}. Probe disabled (auth-gated write action; Phase 1 call_subnet_surface cannot supply credentials).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -263,7 +269,7 @@
       "id": "sn-34-bitmind-detect-image",
       "kind": "subnet-api",
       "name": "BitMind AI image detection",
-      "notes": "Auth-gated POST /detect-image on api.bitmind.ai — OpenAPI operation detect_image_detect_image_post. Detects AI-generated images. Same auth wrapper as /v1/detect (schema info.description). Live-verified 2026-07-21: anonymous POST {} returned HTTP 401 {\"detail\":\"API key is required\"}. Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /detect-image on api.bitmind.ai \u2014 OpenAPI operation detect_image_detect_image_post. Detects AI-generated images. Same auth wrapper as /v1/detect (schema info.description). Live-verified 2026-07-21: anonymous POST {} returned HTTP 401 {\"detail\":\"API key is required\"}. Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -294,7 +300,7 @@
       "id": "sn-34-bitmind-detect-video",
       "kind": "subnet-api",
       "name": "BitMind AI video detection",
-      "notes": "Auth-gated POST /detect-video on api.bitmind.ai — OpenAPI operation detect_video_detect_video_post. Detects AI-generated videos. Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /detect-video on api.bitmind.ai \u2014 OpenAPI operation detect_video_detect_video_post. Detects AI-generated videos. Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -325,7 +331,7 @@
       "id": "sn-34-bitmind-detect-text",
       "kind": "subnet-api",
       "name": "BitMind AI text detection",
-      "notes": "Auth-gated POST /detect-text on api.bitmind.ai — OpenAPI operation detect_text_detect_text_post. Detects AI-generated text. Live-verified 2026-07-21: anonymous POST {} returned HTTP 401 {\"detail\":\"API key is required\"}. Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /detect-text on api.bitmind.ai \u2014 OpenAPI operation detect_text_detect_text_post. Detects AI-generated text. Live-verified 2026-07-21: anonymous POST {} returned HTTP 401 {\"detail\":\"API key is required\"}. Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -356,7 +362,7 @@
       "id": "sn-34-bitmind-detect-document",
       "kind": "subnet-api",
       "name": "BitMind document forgery detection",
-      "notes": "Auth-gated POST /detect-document on api.bitmind.ai — OpenAPI operation detect_document_detect_document_post. Detects forgery/tampering in a PDF. Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /detect-document on api.bitmind.ai \u2014 OpenAPI operation detect_document_detect_document_post. Detects forgery/tampering in a PDF. Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -387,7 +393,7 @@
       "id": "sn-34-bitmind-liveness-verify",
       "kind": "subnet-api",
       "name": "BitMind liveness verification",
-      "notes": "Auth-gated POST /liveness/verify on api.bitmind.ai — OpenAPI operation liveness_verify_liveness_verify_post. Verifies a face capture is a live human (KYC). Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /liveness/verify on api.bitmind.ai \u2014 OpenAPI operation liveness_verify_liveness_verify_post. Verifies a face capture is a live human (KYC). Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -418,7 +424,7 @@
       "id": "sn-34-bitmind-preprocess-video",
       "kind": "subnet-api",
       "name": "BitMind video preprocessing",
-      "notes": "Auth-gated POST /preprocess-video on api.bitmind.ai — OpenAPI operation preprocess_video_preprocess_video_post. Preprocesses video for browser compatibility (no detection). Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /preprocess-video on api.bitmind.ai \u2014 OpenAPI operation preprocess_video_preprocess_video_post. Preprocesses video for browser compatibility (no detection). Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",
@@ -449,7 +455,7 @@
       "id": "sn-34-bitmind-get-video-upload-url",
       "kind": "subnet-api",
       "name": "BitMind video upload URL",
-      "notes": "Auth-gated POST /get-video-upload-url on api.bitmind.ai — OpenAPI operation get_video_upload_url_get_video_upload_url_post. Returns a presigned URL for large video uploads. Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
+      "notes": "Auth-gated POST /get-video-upload-url on api.bitmind.ai \u2014 OpenAPI operation get_video_upload_url_get_video_upload_url_post. Returns a presigned URL for large video uploads. Auth-gated per schema info.description (same host/wrapper as live-verified /v1/detect 401). Probe disabled (auth-gated write action).",
       "probe": {
         "enabled": false,
         "expect": "json",

--- a/registry/subnets/chronollm.json
+++ b/registry/subnets/chronollm.json
@@ -25,6 +25,12 @@
   "schema_version": 1,
   "slug": "sn-38",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, docs:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/eirel.json
+++ b/registry/subnets/eirel.json
@@ -25,6 +25,11 @@
   },
   "source_repo": "https://github.com/RendixNetwork/eirel-ai",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/gopher.json
+++ b/registry/subnets/gopher.json
@@ -31,6 +31,12 @@
   "slug": "sn-42",
   "source_repo": "https://github.com/gopher-lab/subnet-42",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, website:billing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -28,6 +28,12 @@
   },
   "source_repo": "https://github.com/It-s-AI/llm-detection",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -183,7 +189,7 @@
       "id": "sn-32-itsai-wandb",
       "kind": "dashboard",
       "name": "ItsAI validator W&B dashboard",
-      "notes": "Public Weights & Biases project for SN32 ItsAI (It's AI / LLM-detection) validator runs (entity itsai-dev, project subnet32; 119,000+ logged runs). Declared as the subnet's public W&B dashboard in the official It-s-AI/llm-detection repo — docs/FAQ.md (\"Yes, https://wandb.ai/itsai-dev/subnet32\") and detection/__init__.py (WANDB_ENTITY = 'itsai-dev', WANDB_PROJECT = 'subnet32', netuid default 32). Publicly readable, no auth; on a distinct host (wandb.ai) from the subnet's site and API.",
+      "notes": "Public Weights & Biases project for SN32 ItsAI (It's AI / LLM-detection) validator runs (entity itsai-dev, project subnet32; 119,000+ logged runs). Declared as the subnet's public W&B dashboard in the official It-s-AI/llm-detection repo \u2014 docs/FAQ.md (\"Yes, https://wandb.ai/itsai-dev/subnet32\") and detection/__init__.py (WANDB_ENTITY = 'itsai-dev', WANDB_PROJECT = 'subnet32', netuid default 32). Publicly readable, no auth; on a distinct host (wandb.ai) from the subnet's site and API.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/ralph.json
+++ b/registry/subnets/ralph.json
@@ -28,6 +28,12 @@
   "slug": "ralph",
   "source_repo": "https://github.com/RalphLabsAI/ralph",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, docs:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/readyai.json
+++ b/registry/subnets/readyai.json
@@ -25,6 +25,12 @@
   "slug": "sn-33",
   "source_repo": "https://github.com/afterpartyai/bittensor-conversation-genome-project",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:checkout, docs:pricing, docs:subscription, website:billing, website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/recall.json
+++ b/registry/subnets/recall.json
@@ -34,5 +34,10 @@
       "No verified standalone static data artifact yet."
     ]
   },
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["source-repo"]
+  },
   "surfaces": []
 }

--- a/registry/subnets/score.json
+++ b/registry/subnets/score.json
@@ -29,6 +29,11 @@
   },
   "source_repo": "https://github.com/score-technologies/turbovision",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,


### PR DESCRIPTION
11 subnets searched for external revenue. **None publishes a revenue figure** — and that is not the same as none having revenue.

| subnet | file | checked | commerce signal |
|---|---|---|---|
| SN31 | `recall` | source-repo | — |
| SN32 | `itsai` | dashboard, docs, source-repo, website | **pricing/billing on site or docs** |
| SN33 | `readyai` | docs, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN34 | `bitmind` | dashboard, docs, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN36 | `eirel` | dashboard, docs, openapi, source-repo, website | — |
| SN38 | `chronollm` | docs, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN39 | `basilica` | docs, source-repo, website | **pricing/billing on site or docs** |
| SN40 | `ralph` | dashboard, docs, source-repo, website | **pricing/billing on site or docs** |
| SN41 | `almanac` | dashboard, source-repo, website | — |
| SN42 | `gopher` | docs, source-repo, website | **pricing/billing on site or docs** |
| SN44 | `score` | openapi, source-repo, website | — |

## What was actually done

This is a real search, not an assertion of absence:

- **Every subnet's OpenAPI schema was fetched and its paths scanned** for revenue/billing/invoice/subscription/checkout/payment/earning/payout/credit shapes.
- **Every subnet's website and docs were fetched** and scanned for pricing, subscription, checkout, per-month and dollar-amount signals.

`checked` on each record names where the search looked, so anyone can re-run it and get the same answer. That is the difference between dated evidence and an undated silence.

## The distinction that matters

**7 of these 11 show pricing or billing on their own site or docs.** They sell things. They just do not publish what they earn.

Recording them as a flat `none-found` with no note would be technically true and practically misleading — so where a commerce signal exists it is written into the search record. *"No observable external revenue"* means **no published amount**, never *"no revenue"*, and the wording has to carry that everywhere it appears.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` — pass
- `outcome: none-found` is cross-checked against the surfaces by #10543's validator, so it cannot drift once a revenue surface is added later
- Purely additive diffs

Closes #10468
