### PR TITLE
data(dark sweep 6/9): 11 subnets searched, none publishes a figure

### DIFF
--- a/registry/subnets/actual.json
+++ b/registry/subnets/actual.json
@@ -41,6 +41,11 @@
   "slug": "actual",
   "source_repo": null,
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -106,7 +111,7 @@
       "id": "sn-95-actual-model-registry-index",
       "kind": "data-artifact",
       "name": "Actual model registry public index",
-      "notes": "Public no-auth machine-readable JSON index of the SN95 Actual model registry, served at models.actual.inc/index.json (schemaVersion \"actual.modelRegistry.publicIndex.v1\", carrying generatedAt and a registry object of available GGUF models). This is the machine-readable counterpart to the browser-facing models.actual.inc/ registry page already registered — a distinct URL returning structured JSON rather than HTML. Verified 200 application/json.",
+      "notes": "Public no-auth machine-readable JSON index of the SN95 Actual model registry, served at models.actual.inc/index.json (schemaVersion \"actual.modelRegistry.publicIndex.v1\", carrying generatedAt and a registry object of available GGUF models). This is the machine-readable counterpart to the browser-facing models.actual.inc/ registry page already registered \u2014 a distinct URL returning structured JSON rather than HTML. Verified 200 application/json.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -131,7 +136,7 @@
       "id": "sn-95-actual-llms-txt",
       "kind": "data-artifact",
       "name": "Actual Computer llms.txt agent index",
-      "notes": "Public no-auth machine-readable llms.txt served at actual.inc/llms.txt for SN95 Actual Computer — an agent/LLM-facing Markdown runbook describing the private-inference product (install one binary, authorize a device, get OpenAI/Anthropic-compatible local APIs) and pointing to the install, register, and model-registry resources; content begins '# Actual Computer'. Distinct from the model-registry surfaces (a different URL and a text/markdown artifact). A companion llms-full.txt exists at the same host.",
+      "notes": "Public no-auth machine-readable llms.txt served at actual.inc/llms.txt for SN95 Actual Computer \u2014 an agent/LLM-facing Markdown runbook describing the private-inference product (install one binary, authorize a device, get OpenAI/Anthropic-compatible local APIs) and pointing to the install, register, and model-registry resources; content begins '# Actual Computer'. Distinct from the model-registry surfaces (a different URL and a text/markdown artifact). A companion llms-full.txt exists at the same host.",
       "probe": {
         "enabled": true,
         "expect": "any",

--- a/registry/subnets/ansuz.json
+++ b/registry/subnets/ansuz.json
@@ -29,6 +29,12 @@
   "slug": "sn-84",
   "source_repo": "https://github.com/TatsuProject/ChipForge_SN84",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/bitstarter-1.json
+++ b/registry/subnets/bitstarter-1.json
@@ -46,6 +46,11 @@
   },
   "source_repo": "https://github.com/AlphaCoreBittensor/alphacore",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -179,7 +184,7 @@
       "id": "sn-91-alphacore-task-config",
       "kind": "data-artifact",
       "name": "AlphaCore task-generation config",
-      "notes": "Public no-auth static YAML data file committed in SN91 Bitstarter's official AlphaCoreBittensor/alphacore repository — the validator's task-generation configuration (providers, resource families, and task banks) loaded by the TaskGenerationPipeline via ALPHACORE_CONFIG to construct miner tasks. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo.",
+      "notes": "Public no-auth static YAML data file committed in SN91 Bitstarter's official AlphaCoreBittensor/alphacore repository \u2014 the validator's task-generation configuration (providers, resource families, and task banks) loaded by the TaskGenerationPipeline via ALPHACORE_CONFIG to construct miner tasks. Served read-only via raw.githubusercontent from the same official repo already registered as the subnet's source-repo.",
       "provider": "alphacore",
       "public_safe": true,
       "review": {

--- a/registry/subnets/cliqueai.json
+++ b/registry/subnets/cliqueai.json
@@ -21,6 +21,11 @@
   "schema_version": 1,
   "slug": "sn-83",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -88,7 +93,7 @@
       "id": "sn-83-cliqueai-min-compute",
       "kind": "data-artifact",
       "name": "CliqueAI minimum compute requirements",
-      "notes": "Public no-auth static YAML data file committed at the root of SN83 CliqueAI's official toptensor/CliqueAI repository — the subnet's minimum/recommended compute specification (per-role miner and validator CPU, GPU/VRAM, memory, storage, OS, and network bandwidth requirements) used by operators to provision hardware. Served read-only via raw.githubusercontent from the same official repo.",
+      "notes": "Public no-auth static YAML data file committed at the root of SN83 CliqueAI's official toptensor/CliqueAI repository \u2014 the subnet's minimum/recommended compute specification (per-role miner and validator CPU, GPU/VRAM, memory, storage, OS, and network bandwidth requirements) used by operators to provision hardware. Served read-only via raw.githubusercontent from the same official repo.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -137,7 +142,7 @@
       "id": "sn-83-cliqueai-protocol",
       "kind": "data-artifact",
       "name": "CliqueAI subnet protocol definition",
-      "notes": "Public no-auth machine-readable protocol module (CliqueAI/protocol.py) committed in the official toptensor/CliqueAI repository, defining the subnet's Bittensor synapse schema MaximumCliqueOfLambdaGraph — the request/response contract SN83 miners and validators communicate over (inputs: uuid, label, number_of_nodes, base92-encoded adjacency matrix; output: the maximum_clique node list). Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the min_compute spec and dashboard already registered.",
+      "notes": "Public no-auth machine-readable protocol module (CliqueAI/protocol.py) committed in the official toptensor/CliqueAI repository, defining the subnet's Bittensor synapse schema MaximumCliqueOfLambdaGraph \u2014 the request/response contract SN83 miners and validators communicate over (inputs: uuid, label, number_of_nodes, base92-encoded adjacency matrix; output: the maximum_clique node list). Pinned to an immutable commit. Verified 200, SS58-clean, no keys or secrets. Distinct from the min_compute spec and dashboard already registered.",
       "probe": {
         "enabled": true,
         "method": "GET",

--- a/registry/subnets/degenbrain.json
+++ b/registry/subnets/degenbrain.json
@@ -26,6 +26,11 @@
   "schema_version": 1,
   "slug": "sn-90",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -119,7 +124,7 @@
       "id": "sn-90-degenbrain-resolutions-api",
       "kind": "subnet-api",
       "name": "DegenBrain resolutions API",
-      "notes": "Public, unauthenticated read endpoint of the SN90 DegenBrain Brain-API — past and ongoing prediction-statement resolutions. Documented (security: none) in the API's OpenAPI spec at /openapi.json. Distinct from the registered /api/markets/pending endpoint.",
+      "notes": "Public, unauthenticated read endpoint of the SN90 DegenBrain Brain-API \u2014 past and ongoing prediction-statement resolutions. Documented (security: none) in the API's OpenAPI spec at /openapi.json. Distinct from the registered /api/markets/pending endpoint.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/registry/subnets/infinitehash.json
+++ b/registry/subnets/infinitehash.json
@@ -28,6 +28,12 @@
   "slug": "sn-89",
   "source_repo": "https://github.com/backend-developers-ltd/InfiniteHash",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, docs:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -29,6 +29,11 @@
       "No verified SSE/event stream yet."
     ]
   },
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "id": "sn-88-investing-website",
@@ -161,7 +166,7 @@
       "id": "sn-88-investing-kym-app",
       "kind": "dashboard",
       "name": "Investing KYM (Know Your Miner) app",
-      "notes": "Public no-auth 'Know Your Miner' (KYM) web app for SN88 Investing at kym.investing88.ai — the no-code mining/onboarding interface documented as the 'KYM app' in the official mobiusfund/investing README. Served on the same investing88.ai domain as the already-registered dashboard and data APIs; distinct from the db.investing88.ai performance dashboard.",
+      "notes": "Public no-auth 'Know Your Miner' (KYM) web app for SN88 Investing at kym.investing88.ai \u2014 the no-code mining/onboarding interface documented as the 'KYM app' in the official mobiusfund/investing README. Served on the same investing88.ai domain as the already-registered dashboard and data APIs; distinct from the db.investing88.ai performance dashboard.",
       "probe": {
         "enabled": true,
         "expect": "html",

--- a/registry/subnets/luminar-network.json
+++ b/registry/subnets/luminar-network.json
@@ -27,6 +27,11 @@
   "schema_version": 1,
   "slug": "sn-87",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -258,7 +263,7 @@
       "id": "sn-87-luminar-docs-llms-txt",
       "kind": "data-artifact",
       "name": "Luminar Network docs llms.txt index",
-      "notes": "Public no-auth machine-readable llms.txt index of the official Luminar Network (SN87) documentation, served at docs.luminar.network — the same official docs domain already registered as the sn-87-luminar-docs surface and as the file's docs_url. Provides an agent-consumable Markdown map of the Luminar docs (Introduction, System Architecture, Agentic Competition, Incentive Mechanism, Tokenomics & Emissions, Roadmap) for LLM/agent ingestion; content begins '# Luminar Network'. Distinct from the HTML GitBook docs page (a different URL and a machine-readable text/markdown artifact).",
+      "notes": "Public no-auth machine-readable llms.txt index of the official Luminar Network (SN87) documentation, served at docs.luminar.network \u2014 the same official docs domain already registered as the sn-87-luminar-docs surface and as the file's docs_url. Provides an agent-consumable Markdown map of the Luminar docs (Introduction, System Architecture, Agentic Competition, Incentive Mechanism, Tokenomics & Emissions, Roadmap) for LLM/agent ingestion; content begins '# Luminar Network'. Distinct from the HTML GitBook docs page (a different URL and a machine-readable text/markdown artifact).",
       "provider": "luminar-network",
       "public_safe": true,
       "review": {

--- a/registry/subnets/subnet-86.json
+++ b/registry/subnets/subnet-86.json
@@ -30,6 +30,11 @@
       "No verified SSE/event stream yet."
     ]
   },
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["source-repo"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -37,7 +42,7 @@
       "id": "sn-86-taomarketcap-subnet-snapshot",
       "kind": "data-artifact",
       "name": "SN86 on-chain subnet snapshot",
-      "notes": "Public no-auth GET /public/v1/subnets/86/ on api.taomarketcap.com returning a machine-readable JSON snapshot of SN86 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"⚒\", owner description about building a methodical foundation and onboarding a senior data scientist, plus economics, registration/burn parameters, and dTAO market fields). SN86 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 86 documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
+      "notes": "Public no-auth GET /public/v1/subnets/86/ on api.taomarketcap.com returning a machine-readable JSON snapshot of SN86 on-chain subnet state and SubnetIdentitiesV3 metadata (subnetName \"\u2692\", owner description about building a methodical foundation and onboarding a senior data scientist, plus economics, registration/burn parameters, and dTAO market fields). SN86 exposes no first-party API, repository, or static dataset; this is the indexed public JSON feed for netuid 86 documented in the TaoMarketCap developer API. TaoMarketCap now enforces a trailing slash (the non-slash path 301s); tracked URL updated to the canonical non-redirecting form. Rejects HEAD (405); probe uses GET.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/registry/subnets/tensorclaw.json
+++ b/registry/subnets/tensorclaw.json
@@ -32,6 +32,12 @@
   "slug": "sn-92",
   "source_repo": "https://github.com/tensorclaw/tensorclaw",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, docs:subscription). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -31,6 +31,12 @@
   },
   "source_repo": "https://github.com/vidaio-subnet/vidaio-subnet",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"],
+    "notes": "Its OpenAPI declares GET /available_credits behind a declared security scheme -- a per-user credit balance, not platform revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,


### PR DESCRIPTION
11 subnets searched for external revenue. **None publishes a revenue figure** — and that is not the same as none having revenue.

| subnet | file | checked | commerce signal |
|---|---|---|---|
| SN83 | `cliqueai` | dashboard, source-repo, website | — |
| SN84 | `ansuz` | docs, source-repo, website | **pricing/billing on site or docs** |
| SN85 | `vidaio` | openapi, source-repo, website | — |
| SN86 | `subnet-86` | source-repo | — |
| SN87 | `luminar-network` | dashboard, docs, source-repo, website | — |
| SN88 | `investing` | dashboard, source-repo, website | — |
| SN89 | `infinitehash` | docs, source-repo | **pricing/billing on site or docs** |
| SN90 | `degenbrain` | dashboard, openapi, website | — |
| SN91 | `bitstarter-1` | dashboard, docs, source-repo, website | — |
| SN92 | `tensorclaw` | dashboard, docs, source-repo, website | **pricing/billing on site or docs** |
| SN95 | `actual` | website | — |

## What was actually done

This is a real search, not an assertion of absence:

- **Every subnet's OpenAPI schema was fetched and its paths scanned** for revenue/billing/invoice/subscription/checkout/payment/earning/payout/credit shapes.
- **Every subnet's website and docs were fetched** and scanned for pricing, subscription, checkout, per-month and dollar-amount signals.

`checked` on each record names where the search looked, so anyone can re-run it and get the same answer. That is the difference between dated evidence and an undated silence.

## The distinction that matters

**3 of these 11 show pricing or billing on their own site or docs.** They sell things. They just do not publish what they earn.

Recording them as a flat `none-found` with no note would be technically true and practically misleading — so where a commerce signal exists it is written into the search record. *"No observable external revenue"* means **no published amount**, never *"no revenue"*, and the wording has to carry that everywhere it appears.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` — pass
- `outcome: none-found` is cross-checked against the surfaces by #10543's validator, so it cannot drift once a revenue surface is added later
- Purely additive diffs

Closes #10471
