### PR TITLE
data(dark sweep 8/9): 11 subnets searched, none publishes a figure

### DIFF
--- a/registry/subnets/affine.json
+++ b/registry/subnets/affine.json
@@ -24,6 +24,11 @@
   "slug": "sn-120",
   "source_repo": "https://github.com/AffineFoundation/affine-cortex",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -31,6 +31,12 @@
   },
   "source_repo": "https://github.com/bitrecs/bitrecs-subnet",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:checkout, website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -42,6 +42,12 @@
   },
   "source_repo": "https://github.com/ditto-assistant/dittobench-starter-kit",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (docs:billing, docs:pricing, docs:subscription, website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/glyph.json
+++ b/registry/subnets/glyph.json
@@ -27,6 +27,11 @@
   "slug": "glyph",
   "source_repo": "https://github.com/glyph-research/glyph-subnet",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/hashichain.json
+++ b/registry/subnets/hashichain.json
@@ -26,6 +26,11 @@
   "slug": "sn-115",
   "source_repo": "https://github.com/hashi115/hashichain",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["source-repo"]
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -26,6 +26,11 @@
   "slug": "sn-123",
   "source_repo": "https://github.com/Barbariandev/MANTIS",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -75,7 +80,7 @@
       "id": "sn-123-mantis-price-feed",
       "kind": "data-artifact",
       "name": "MANTIS price & funding data artifact",
-      "notes": "Public no-auth JSON data artifact of asset prices and funding rates published by the SN123 MANTIS validator — the PRICE_DATA_URL declared in the official repo's config.py (line 63). Freshness/uptime are probe-derived and not asserted here.",
+      "notes": "Public no-auth JSON data artifact of asset prices and funding rates published by the SN123 MANTIS validator \u2014 the PRICE_DATA_URL declared in the official repo's config.py (line 63). Freshness/uptime are probe-derived and not asserted here.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -99,7 +104,7 @@
       "id": "sn-123-mantis-datalog-archive",
       "kind": "data-artifact",
       "name": "MANTIS historical datalog archive",
-      "notes": "Public no-auth downloadable SQLite datalog of the SN123 MANTIS validator's full historical multi-asset signal/price time series — the DATALOG_ARCHIVE_URL declared in the official repo's config.py, distinct from and complementary to the latest_prices.json snapshot (this is the complete historical archive, served as a SQLite database file). Verified as a live SQLite artifact (magic bytes 'SQLite format 3'). Freshness/size are probe-derived and not asserted here. Confirmed ~74.3GiB (Content-Length 79805812736) via HEAD; probe intentionally uses HEAD rather than GET to avoid downloading the full archive on every check.",
+      "notes": "Public no-auth downloadable SQLite datalog of the SN123 MANTIS validator's full historical multi-asset signal/price time series \u2014 the DATALOG_ARCHIVE_URL declared in the official repo's config.py, distinct from and complementary to the latest_prices.json snapshot (this is the complete historical archive, served as a SQLite database file). Verified as a live SQLite artifact (magic bytes 'SQLite format 3'). Freshness/size are probe-derived and not asserted here. Confirmed ~74.3GiB (Content-Length 79805812736) via HEAD; probe intentionally uses HEAD rather than GET to avoid downloading the full archive on every check.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -148,7 +153,7 @@
       "id": "sn-123-mantis-website",
       "kind": "website",
       "name": "MANTIS subnet network console",
-      "notes": "Live MANTIS SN123 network console/dashboard at mantis123.com (page title \"MANTIS · Subnet 123 Network Console\"). Previously tracked only as the overlay's website_url field with a gap_note claiming no standalone website was verified; the domain is now confirmed live and self-identifies netuid 123 via its own dashboard API (see sn-123-mantis-dashboard-snap-meta). Served with an X-Robots noindex/nofollow tag, which does not affect public reachability.",
+      "notes": "Live MANTIS SN123 network console/dashboard at mantis123.com (page title \"MANTIS \u00b7 Subnet 123 Network Console\"). Previously tracked only as the overlay's website_url field with a gap_note claiming no standalone website was verified; the domain is now confirmed live and self-identifies netuid 123 via its own dashboard API (see sn-123-mantis-dashboard-snap-meta). Served with an X-Robots noindex/nofollow tag, which does not affect public reachability.",
       "probe": {
         "enabled": true,
         "expect": "html",
@@ -220,7 +225,7 @@
       "id": "sn-123-mantis-dashboard-snap-breakouts",
       "kind": "subnet-api",
       "name": "MANTIS dashboard breakout events",
-      "notes": "Public no-auth GET /dashboard/api/snap/breakouts on mantis123.com returning per-ticker breakout event history (trigger/resolution blocks, direction, labels, predictor counts). Sibling of the already-registered snap/meta surface — same host/pattern, discovered via the console app.js snap(\"breakouts\") call site. Live-verified 2026-07-21: HTTP 200 JSON.",
+      "notes": "Public no-auth GET /dashboard/api/snap/breakouts on mantis123.com returning per-ticker breakout event history (trigger/resolution blocks, direction, labels, predictor counts). Sibling of the already-registered snap/meta surface \u2014 same host/pattern, discovered via the console app.js snap(\"breakouts\") call site. Live-verified 2026-07-21: HTTP 200 JSON.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -245,7 +250,7 @@
       "id": "sn-123-mantis-dashboard-snap-clusters",
       "kind": "subnet-api",
       "name": "MANTIS dashboard miner clusters",
-      "notes": "Public no-auth GET /dashboard/api/snap/clusters on mantis123.com returning per-ticker miner clustering data as public SS58 address groups (no coldkeys or wallet secrets). Sibling of snap/meta — app.js snap(\"clusters\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "notes": "Public no-auth GET /dashboard/api/snap/clusters on mantis123.com returning per-ticker miner clustering data as public SS58 address groups (no coldkeys or wallet secrets). Sibling of snap/meta \u2014 app.js snap(\"clusters\"). Live-verified 2026-07-21: HTTP 200 JSON.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -270,7 +275,7 @@
       "id": "sn-123-mantis-dashboard-snap-metagraph",
       "kind": "subnet-api",
       "name": "MANTIS dashboard metagraph snapshot",
-      "notes": "Public no-auth GET /dashboard/api/snap/metagraph on mantis123.com returning a per-UID metagraph snapshot (hotkey, incentive, emission, stake, trust) at the latest synced block. Same public-hotkey-only shape as history/incentive. Sibling of snap/meta — app.js snap(\"metagraph\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "notes": "Public no-auth GET /dashboard/api/snap/metagraph on mantis123.com returning a per-UID metagraph snapshot (hotkey, incentive, emission, stake, trust) at the latest synced block. Same public-hotkey-only shape as history/incentive. Sibling of snap/meta \u2014 app.js snap(\"metagraph\"). Live-verified 2026-07-21: HTTP 200 JSON.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -295,7 +300,7 @@
       "id": "sn-123-mantis-dashboard-snap-miners",
       "kind": "subnet-api",
       "name": "MANTIS dashboard miner totals",
-      "notes": "Public no-auth GET /dashboard/api/snap/miners on mantis123.com returning per-ticker miner participation totals (ch_totals). Sibling of snap/meta — app.js snap(\"miners\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "notes": "Public no-auth GET /dashboard/api/snap/miners on mantis123.com returning per-ticker miner participation totals (ch_totals). Sibling of snap/meta \u2014 app.js snap(\"miners\"). Live-verified 2026-07-21: HTTP 200 JSON.",
       "probe": {
         "enabled": true,
         "expect": "json",
@@ -320,7 +325,7 @@
       "id": "sn-123-mantis-dashboard-snap-participation",
       "kind": "subnet-api",
       "name": "MANTIS dashboard participation history",
-      "notes": "Public no-auth GET /dashboard/api/snap/participation on mantis123.com returning per-ticker time series of participation counts. Sibling of snap/meta — app.js snap(\"participation\"). Live-verified 2026-07-21: HTTP 200 JSON.",
+      "notes": "Public no-auth GET /dashboard/api/snap/participation on mantis123.com returning per-ticker time series of participation counts. Sibling of snap/meta \u2014 app.js snap(\"participation\"). Live-verified 2026-07-21: HTTP 200 JSON.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/registry/subnets/satori.json
+++ b/registry/subnets/satori.json
@@ -26,6 +26,11 @@
   "slug": "satori",
   "source_repo": null,
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["source-repo"]
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -38,6 +38,12 @@
   },
   "source_repo": "https://github.com/DendriteHQ/SOMA",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["openapi", "website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -29,6 +29,12 @@
   },
   "source_repo": "https://github.com/sundae-bar/bittensor-subnet",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"],
+    "notes": "Commerce is visible but no revenue FIGURE is published: pricing/billing signals found on this subnet's own site or docs (website:pricing). \"No observable external revenue\" means no published amount, not no revenue."
+  },
   "surfaces": [
     {
       "auth_required": false,
@@ -146,7 +152,7 @@
       "id": "sn-121-sundae-bar-products-api",
       "kind": "subnet-api",
       "name": "Sundae Bar products catalog API",
-      "notes": "Public no-auth GET /api/products on www.sundaebar.ai returning the paginated JSON catalog of SN121 sundae_bar listings ({\"data\":[{type,name,description,...}]}) — the source-of-truth listings feed that the site's own llms.txt directs AI agents to query. Verified 200 application/json, distinct in host and path from the api.sundaebar.ai/api/v2/validators coordinator surface already registered.",
+      "notes": "Public no-auth GET /api/products on www.sundaebar.ai returning the paginated JSON catalog of SN121 sundae_bar listings ({\"data\":[{type,name,description,...}]}) \u2014 the source-of-truth listings feed that the site's own llms.txt directs AI agents to query. Verified 200 application/json, distinct in host and path from the api.sundaebar.ai/api/v2/validators coordinator surface already registered.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -29,6 +29,11 @@
   "slug": "taolend",
   "source_repo": null,
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["website"]
+  },
   "surfaces": [
     {
       "auth_required": false,

--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -31,6 +31,11 @@
   },
   "source_repo": "https://github.com/TensorUSD/subnet",
   "status": "active",
+  "revenue_search": {
+    "searched_at": "2026-08-10T00:00:00Z",
+    "outcome": "none-found",
+    "checked": ["docs", "website"]
+  },
   "surfaces": [
     {
       "auth_required": false,


### PR DESCRIPTION
11 subnets searched for external revenue. **None publishes a revenue figure** — and that is not the same as none having revenue.

| subnet | file | checked | commerce signal |
|---|---|---|---|
| SN113 | `tensorusd` | docs, source-repo, website | — |
| SN114 | `soma` | dashboard, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN115 | `hashichain` | source-repo | — |
| SN116 | `taolend` | source-repo, website | — |
| SN117 | `glyph` | source-repo, website | — |
| SN118 | `ditto` | dashboard, docs, openapi, source-repo, website | **pricing/billing on site or docs** |
| SN119 | `satori` | source-repo | — |
| SN120 | `affine` | openapi, source-repo, website | — |
| SN121 | `sundae-bar` | source-repo, website | **pricing/billing on site or docs** |
| SN122 | `bitrecs` | docs, source-repo, website | **pricing/billing on site or docs** |
| SN123 | `mantis` | source-repo, website | — |

## What was actually done

This is a real search, not an assertion of absence:

- **Every subnet's OpenAPI schema was fetched and its paths scanned** for revenue/billing/invoice/subscription/checkout/payment/earning/payout/credit shapes.
- **Every subnet's website and docs were fetched** and scanned for pricing, subscription, checkout, per-month and dollar-amount signals.

`checked` on each record names where the search looked, so anyone can re-run it and get the same answer. That is the difference between dated evidence and an undated silence.

## The distinction that matters

**4 of these 11 show pricing or billing on their own site or docs.** They sell things. They just do not publish what they earn.

Recording them as a flat `none-found` with no note would be technically true and practically misleading — so where a commerce signal exists it is written into the search record. *"No observable external revenue"* means **no published amount**, never *"no revenue"*, and the wording has to carry that everywhere it appears.

## Verification

- `validate:schemas` · `validate:surface` (2,740 surfaces / 129 files) · `validate:revenue-provenance` — pass
- `outcome: none-found` is cross-checked against the surfaces by #10543's validator, so it cannot drift once a revenue surface is added later
- Purely additive diffs

Closes #10473
