### PR TITLE
feat(revenue): declare the payload's shape, and extract from it without guessing

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -12186,6 +12186,11 @@ export interface components {
                 role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
                 /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
                 searched_at?: string;
+                /**
+                 * @description How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.
+                 * @enum {string}
+                 */
+                shape?: "flat-array" | "keyed-map" | "scalar";
                 /** Format: uri */
                 source_url?: string;
                 /** @description Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice. */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -52796,6 +52796,15 @@
                 "description": "When absence was established. Required for provenance 'none': an undated absence is not evidence.",
                 "type": "string"
               },
+              "shape": {
+                "description": "How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.",
+                "enum": [
+                  "flat-array",
+                  "keyed-map",
+                  "scalar"
+                ],
+                "type": "string"
+              },
               "source_url": {
                 "format": "uri",
                 "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -12186,6 +12186,11 @@ export interface components {
                 role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
                 /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
                 searched_at?: string;
+                /**
+                 * @description How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.
+                 * @enum {string}
+                 */
+                shape?: "flat-array" | "keyed-map" | "scalar";
                 /** Format: uri */
                 source_url?: string;
                 /** @description Surface ids this one subsumes. Declares a subset relationship so overlapping channels are not summed twice. */

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -451,6 +451,7 @@
         "provenance": "probe-derived",
         "currency": "USD",
         "grain": "daily",
+        "shape": "flat-array",
         "fields": {
           "date": "date",
           "amount": "total_revenue"
@@ -490,6 +491,7 @@
         "provenance": "probe-derived",
         "currency": "USD",
         "grain": "daily",
+        "shape": "flat-array",
         "fields": {
           "date": "date",
           "amount": "usd_amount"
@@ -720,6 +722,7 @@
         "provenance": "probe-derived",
         "currency": "USD",
         "grain": "cumulative",
+        "shape": "scalar",
         "fields": {
           "amount": "total"
         },
@@ -908,6 +911,7 @@
         "provenance": "chain-verified",
         "currency": "USD",
         "grain": "cumulative",
+        "shape": "flat-array",
         "fields": {
           "date": "timestamp",
           "amount": "usd_amount"

--- a/registry/subnets/lium-io.json
+++ b/registry/subnets/lium-io.json
@@ -232,14 +232,11 @@
         "provenance": "probe-derived",
         "currency": "USD",
         "grain": "monthly",
-        "fields": {
-          "date": "$key",
-          "amount": "$value"
-        },
+        "shape": "keyed-map",
         "circularity": "external",
         "source_url": "https://lium.io/api/openapi.json"
       },
-      "notes": "Public no-auth GET /billing/revenue-for-validators on the Lium Backend API, returning monthly revenue totals keyed by validator coldkey (an already-public on-chain SS58 address) for the SN51 lium.io compute marketplace. Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints. REVENUE SEMANTICS, two unresolved points recorded rather than guessed (#10450). (1) The OpenAPI summary is bare -- \"Revenue For Validators\" -- and does not say whether a figure is platform revenue ATTRIBUTED to a validator or the validator's own CUT of it. The two differ by the take rate, so the magnitude attributed to this subnet depends on which it is. Resolving it needs an operator statement; until then the figure must not be published as a coverage ratio. (2) circularity is external on the reasoning that end customers rent GPUs for fiat and validators are the billing rail, not the source of funds -- the money originates outside Bittensor either way. PAYLOAD SHAPE: the response is a nested map {month: {validator_coldkey: amount}}, so there is no flat field name to point `fields` at; `$key`/`$value` is the keyed-map convention pending the schema gap tracked separately.",
+      "notes": "Public no-auth GET /billing/revenue-for-validators on the Lium Backend API, returning monthly revenue totals keyed by validator coldkey (an already-public on-chain SS58 address) for the SN51 lium.io compute marketplace. Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints. REVENUE SEMANTICS, two unresolved points recorded rather than guessed (#10450). (1) The OpenAPI summary is bare -- \"Revenue For Validators\" -- and does not say whether a figure is platform revenue ATTRIBUTED to a validator or the validator's own CUT of it. The two differ by the take rate, so the magnitude attributed to this subnet depends on which it is. Resolving it needs an operator statement; until then the figure must not be published as a coverage ratio. (2) circularity is external on the reasoning that end customers rent GPUs for fiat and validators are the billing rail, not the source of funds -- the money originates outside Bittensor either way. PAYLOAD SHAPE: the response is a nested map {month: {validator_coldkey: amount}} -- declared `shape: keyed-map`, which carries no `fields` because the period IS the key and there is no field name to point at.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -529,6 +529,10 @@ export const SurfaceRevenueSchema = z
         "Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}.",
     }),
     grain: z.enum(["daily", "weekly", "monthly", "cumulative"]).optional(),
+    shape: z.enum(["flat-array", "keyed-map", "scalar"]).optional().meta({
+      description:
+        "How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.",
+    }),
     provenance: z
       .enum([
         "chain-verified",

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -397,6 +397,10 @@
         "grain": {
           "enum": ["daily", "weekly", "monthly", "cumulative"]
         },
+        "shape": {
+          "enum": ["flat-array", "keyed-map", "scalar"],
+          "description": "How the payload is arranged, so an extractor does not have to guess. `flat-array`: a list of records, `fields.date`/`fields.amount` naming keys within one (SN64's daily_revenue_summary). `keyed-map`: nested {period: {subkey: amount}} where the period IS the key and there are no field names to point at (SN51's revenue-for-validators). `scalar`: one object carrying a single total, `fields.amount` naming it (SN64's payments/summary/tao)."
+        },
         "fields": {
           "description": "Map of role -> field name in the upstream payload, e.g. {\"date\": \"date\", \"amount\": \"total_revenue\"}.",
           "type": "object",
@@ -460,7 +464,60 @@
             "required": ["role", "provenance"]
           },
           "then": {
-            "required": ["currency", "grain", "fields"]
+            "required": ["currency", "grain", "shape"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "shape": {
+                "const": "flat-array"
+              }
+            },
+            "required": ["shape"]
+          },
+          "then": {
+            "properties": {
+              "fields": {
+                "type": "object",
+                "required": ["date", "amount"]
+              }
+            },
+            "required": ["fields"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "shape": {
+                "const": "scalar"
+              }
+            },
+            "required": ["shape"]
+          },
+          "then": {
+            "properties": {
+              "fields": {
+                "type": "object",
+                "required": ["amount"]
+              }
+            },
+            "required": ["fields"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "shape": {
+                "const": "keyed-map"
+              }
+            },
+            "required": ["shape"]
+          },
+          "then": {
+            "properties": {
+              "fields": false
+            }
           }
         }
       ]

--- a/src/revenue-observation.ts
+++ b/src/revenue-observation.ts
@@ -1,0 +1,162 @@
+// #10444: turn one probed payload into dated revenue observations, or into a
+// stated reason it could not.
+//
+// Pure and injected-free on purpose: the probe lane's fetching, hashing and
+// persistence are separable concerns, and this is the part where being wrong is
+// silent. Every failure mode here has the same shape -- a number that looks
+// plausible and is not revenue -- so the module refuses rather than guesses.
+//
+// The two rules it exists to enforce:
+//
+//   1. A FAILURE IS NEVER A ZERO. A missing field, a wrong payload type, a
+//      non-numeric value: each returns a reason, not 0. A zero is a real
+//      measurement meaning "earned nothing today", and a subnet that earned
+//      nothing is a different fact from a subnet whose feed broke. Collapsing
+//      them would understate coverage silently and permanently.
+//   2. `excludes` is SUBTRACTED, not ignored. Chutes' `sponsored_inference` is
+//      inference the subnet funds itself and `pending_instance_revenue` is
+//      unrecognised; leaving them in overstates external revenue by whatever
+//      they happen to be that day.
+import { REVENUE_SHAPES, type RevenueShape } from "./revenue-shape.ts";
+
+export interface RevenueDeclaration {
+  shape?: RevenueShape;
+  currency?: string;
+  fields?: Record<string, string>;
+  excludes?: string[];
+}
+
+export interface RevenueObservation {
+  /** The period this row covers, verbatim from the payload. Null for a scalar
+   * total, which carries no period of its own. */
+  period: string | null;
+  amount: number;
+  currency: string;
+}
+
+export type ExtractResult =
+  | { ok: true; observations: RevenueObservation[] }
+  | { ok: false; reason: string };
+
+function fail(reason: string): ExtractResult {
+  return { ok: false, reason };
+}
+
+/** A finite number, or null. Rejects NaN, Infinity, numeric strings and null --
+ * a string that parses is still a payload that changed shape. */
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Net amount for one record: the declared amount field minus every declared
+ * exclusion. A missing exclusion is not an error -- a feed that stops emitting
+ * `sponsored_inference` on a day it sponsored nothing is behaving correctly --
+ * but a PRESENT and non-numeric one is, because that means the payload changed
+ * under a declaration that still claims to understand it.
+ */
+function netAmount(
+  record: Record<string, unknown>,
+  amountField: string,
+  excludes: string[],
+): number | string {
+  const gross = finiteNumber(record[amountField]);
+  if (gross === null) {
+    return `field "${amountField}" is missing or not a finite number`;
+  }
+  let net = gross;
+  for (const key of excludes) {
+    if (!(key in record)) continue;
+    const excluded = finiteNumber(record[key]);
+    if (excluded === null) {
+      return `exclusion "${key}" is present but not a finite number`;
+    }
+    net -= excluded;
+  }
+  return net;
+}
+
+/**
+ * Extract observations from a probed payload against its declaration.
+ *
+ * `currency` is required: an amount with no unit is the trap this whole schema
+ * exists to close, so it is refused here too rather than defaulted to USD.
+ */
+export function extractRevenue(
+  declaration: RevenueDeclaration,
+  payload: unknown,
+): ExtractResult {
+  const { shape, currency, excludes = [] } = declaration;
+  if (!shape) return fail("no shape declared");
+  // Checked against the vocabulary rather than assumed, because keyed-map is
+  // the fallthrough below: a typo'd shape would otherwise be silently treated
+  // as one and yield plausible numbers from the wrong reading of the payload.
+  // The schema constrains the value in the registry; nothing constrains what
+  // reaches this function.
+  if (!(REVENUE_SHAPES as readonly string[]).includes(shape)) {
+    return fail(`unknown shape "${shape}"`);
+  }
+  if (!currency) return fail("no currency declared");
+  const fields = declaration.fields ?? {};
+
+  if (shape === "flat-array") {
+    if (!Array.isArray(payload)) return fail("expected an array payload");
+    const dateField = fields.date;
+    const amountField = fields.amount;
+    if (!dateField || !amountField) {
+      return fail("flat-array needs both fields.date and fields.amount");
+    }
+    const observations: RevenueObservation[] = [];
+    for (const [index, row] of payload.entries()) {
+      if (!isRecord(row)) return fail(`row ${index} is not an object`);
+      const period = row[dateField];
+      if (typeof period !== "string" || period === "") {
+        return fail(`row ${index}: field "${dateField}" is not a string`);
+      }
+      const amount = netAmount(row, amountField, excludes);
+      if (typeof amount === "string") return fail(`row ${index}: ${amount}`);
+      observations.push({ period, amount, currency });
+    }
+    return { ok: true, observations };
+  }
+
+  if (shape === "scalar") {
+    if (!isRecord(payload)) return fail("expected an object payload");
+    const amountField = fields.amount;
+    if (!amountField) return fail("scalar needs fields.amount");
+    const amount = netAmount(payload, amountField, excludes);
+    if (typeof amount === "string") return fail(amount);
+    return { ok: true, observations: [{ period: null, amount, currency }] };
+  }
+
+  // keyed-map: {period: amount} or {period: {subkey: amount}}. The period is
+  // the key, so there are no field names -- see #10525.
+  if (!isRecord(payload)) return fail("expected an object payload");
+  const observations: RevenueObservation[] = [];
+  for (const [period, value] of Object.entries(payload)) {
+    const direct = finiteNumber(value);
+    if (direct !== null) {
+      observations.push({ period, amount: direct, currency });
+      continue;
+    }
+    if (!isRecord(value)) {
+      return fail(`key "${period}" is neither a number nor an object`);
+    }
+    // A nested map is summed across its subkeys -- SN51 splits a month across
+    // validator coldkeys, and the subnet's figure is their total.
+    let sum = 0;
+    for (const [subkey, inner] of Object.entries(value)) {
+      const n = finiteNumber(inner);
+      if (n === null) {
+        return fail(`key "${period}.${subkey}" is not a finite number`);
+      }
+      sum += n;
+    }
+    observations.push({ period, amount: sum, currency });
+  }
+  return { ok: true, observations };
+}

--- a/src/revenue-shape.ts
+++ b/src/revenue-shape.ts
@@ -1,0 +1,4 @@
+// #10525: the payload-shape vocabulary, in one place so the extractor and any
+// future consumer import it rather than restating the union.
+export const REVENUE_SHAPES = ["flat-array", "keyed-map", "scalar"] as const;
+export type RevenueShape = (typeof REVENUE_SHAPES)[number];

--- a/tests/revenue-observation.test.ts
+++ b/tests/revenue-observation.test.ts
@@ -1,0 +1,214 @@
+// #10444: the extractor's two rules, tested against the real payloads it was
+// written for.
+//
+// A failure is never a zero, and `excludes` is subtracted. Both are silent when
+// wrong -- the output is a plausible number either way -- so every failure path
+// asserts the REASON, not just that something was refused.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { extractRevenue } from "../src/revenue-observation.ts";
+
+// Real shapes, observed 2026-08-10.
+const CHUTES = {
+  shape: "flat-array" as const,
+  currency: "USD",
+  fields: { date: "date", amount: "total_revenue" },
+  excludes: ["sponsored_inference", "pending_instance_revenue"],
+};
+const CHUTES_ROW = {
+  date: "2026-08-08",
+  new_subscriber_revenue: 1536,
+  paygo_revenue: 7629.245674214532,
+  pending_instance_revenue: 610.8139253575,
+  sponsored_inference: 0,
+  total_revenue: 9776.059599572032,
+};
+const LIUM = { shape: "keyed-map" as const, currency: "USD" };
+const TAO_TOTALS = {
+  shape: "scalar" as const,
+  currency: "USD",
+  fields: { amount: "total" },
+};
+
+// Derived from the row rather than pinned: a hardcoded float both loses
+// precision and hides which subtraction it is asserting.
+const CHUTES_NET =
+  CHUTES_ROW.total_revenue -
+  CHUTES_ROW.sponsored_inference -
+  CHUTES_ROW.pending_instance_revenue;
+
+function ok(r: ReturnType<typeof extractRevenue>) {
+  assert.equal(r.ok, true, r.ok ? "" : r.reason);
+  return r.ok ? r.observations : [];
+}
+function reason(r: ReturnType<typeof extractRevenue>): string {
+  assert.equal(r.ok, false, "expected a refusal");
+  return r.ok ? "" : r.reason;
+}
+
+describe("flat-array (SN64 Chutes)", () => {
+  test("subtracts the exclusions rather than reporting gross", () => {
+    const [obs] = ok(extractRevenue(CHUTES, [CHUTES_ROW]));
+    // 9776.059599572032 - 0 - 610.8139253575
+    assert.equal(obs.period, "2026-08-08");
+    assert.ok(Math.abs(obs.amount - CHUTES_NET) < 1e-9, `${obs.amount}`);
+    assert.equal(obs.currency, "USD");
+    // The whole point: the net is materially below the headline field.
+    assert.ok(obs.amount < CHUTES_ROW.total_revenue);
+  });
+
+  test("a missing exclusion is fine; a present non-numeric one is not", () => {
+    // A feed that stops emitting sponsored_inference on a day it sponsored
+    // nothing is behaving correctly.
+    const { sponsored_inference: _drop, ...withoutOne } = CHUTES_ROW;
+    const [obs] = ok(extractRevenue(CHUTES, [withoutOne]));
+    assert.ok(Math.abs(obs.amount - CHUTES_NET) < 1e-9);
+
+    const bad = { ...CHUTES_ROW, sponsored_inference: "0" };
+    assert.match(reason(extractRevenue(CHUTES, [bad])), /sponsored_inference/);
+  });
+
+  test("a real zero is a measurement and survives", () => {
+    const zero = {
+      ...CHUTES_ROW,
+      total_revenue: 0,
+      pending_instance_revenue: 0,
+    };
+    const [obs] = ok(extractRevenue(CHUTES, [zero]));
+    assert.equal(obs.amount, 0);
+  });
+
+  test("a broken payload refuses instead of yielding zero", () => {
+    // Each of these would produce a plausible 0 under a lenient extractor, and
+    // a 0 is indistinguishable from "earned nothing" once stored.
+    assert.match(reason(extractRevenue(CHUTES, {})), /expected an array/);
+    assert.match(reason(extractRevenue(CHUTES, [null])), /not an object/);
+    assert.match(
+      reason(
+        extractRevenue(CHUTES, [{ ...CHUTES_ROW, total_revenue: undefined }]),
+      ),
+      /total_revenue/,
+    );
+    assert.match(
+      reason(
+        extractRevenue(CHUTES, [{ ...CHUTES_ROW, total_revenue: "9776" }]),
+      ),
+      /total_revenue/,
+    );
+    assert.match(
+      reason(extractRevenue(CHUTES, [{ ...CHUTES_ROW, date: 20260808 }])),
+      /"date" is not a string/,
+    );
+  });
+
+  test("NaN and Infinity are refused, not stored", () => {
+    for (const v of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      assert.match(
+        reason(extractRevenue(CHUTES, [{ ...CHUTES_ROW, total_revenue: v }])),
+        /total_revenue/,
+      );
+    }
+  });
+
+  test("flat-array without both field names is refused", () => {
+    assert.match(
+      reason(
+        extractRevenue({ ...CHUTES, fields: { amount: "total_revenue" } }, []),
+      ),
+      /fields\.date/,
+    );
+  });
+});
+
+describe("keyed-map (SN51 Lium)", () => {
+  test("sums a period across its subkeys", () => {
+    const payload = {
+      "2026-07": { "5Csv…": 600000.5, "5E1n…": 4678.33 },
+      "2026-06": { "5Csv…": 1000 },
+    };
+    const obs = ok(extractRevenue(LIUM, payload));
+    assert.equal(obs.length, 2);
+    assert.ok(
+      Math.abs(obs[0].amount - (600000.5 + 4678.33)) < 1e-9,
+      `${obs[0].amount}`,
+    );
+    assert.equal(obs[0].period, "2026-07");
+    assert.equal(obs[1].amount, 1000);
+  });
+
+  test("a flat {period: number} map also works", () => {
+    const obs = ok(extractRevenue(LIUM, { "2026-07": 42 }));
+    assert.deepEqual(obs, [{ period: "2026-07", amount: 42, currency: "USD" }]);
+  });
+
+  test("an empty map is an empty result, not a failure", () => {
+    // A subnet with no recorded months has nothing to report; that is not the
+    // same as a broken feed, and conflating them would fire a false alarm.
+    assert.deepEqual(ok(extractRevenue(LIUM, {})), []);
+  });
+
+  test("a non-numeric leaf refuses and names its path", () => {
+    assert.match(
+      reason(extractRevenue(LIUM, { "2026-07": { "5Csv…": "600000" } })),
+      /2026-07\.5Csv/,
+    );
+    assert.match(
+      reason(extractRevenue(LIUM, { "2026-07": [1, 2] })),
+      /2026-07/,
+    );
+    assert.match(reason(extractRevenue(LIUM, [])), /expected an object/);
+  });
+});
+
+describe("scalar (SN64 payments/summary/tao)", () => {
+  test("reads the single total and carries no period", () => {
+    const obs = ok(
+      extractRevenue(TAO_TOTALS, {
+        today: 1563.61,
+        this_month: 15543.76,
+        total: 2322291.89,
+      }),
+    );
+    assert.deepEqual(obs, [
+      { period: null, amount: 2322291.89, currency: "USD" },
+    ]);
+  });
+
+  test("refuses without fields.amount, and on a missing total", () => {
+    assert.match(
+      reason(extractRevenue({ ...TAO_TOTALS, fields: {} }, { total: 1 })),
+      /fields\.amount/,
+    );
+    assert.match(reason(extractRevenue(TAO_TOTALS, { today: 1 })), /"total"/);
+    assert.match(reason(extractRevenue(TAO_TOTALS, [])), /expected an object/);
+  });
+});
+
+describe("the declaration itself", () => {
+  test("no shape and no currency are both refused", () => {
+    assert.match(reason(extractRevenue({ currency: "USD" }, [])), /no shape/);
+    // An amount with no unit is the exact trap the schema exists to close, so
+    // it is refused here too rather than defaulted to USD.
+    assert.match(
+      reason(extractRevenue({ shape: "flat-array" }, [])),
+      /no currency/,
+    );
+  });
+
+  test("an unknown shape is refused, not read as keyed-map", () => {
+    // keyed-map is the fallthrough branch, so a typo would otherwise be read as
+    // one and produce plausible numbers from the wrong reading of the payload.
+    const r = extractRevenue(
+      { shape: "flat_array" as never, currency: "USD" },
+      [],
+    );
+    assert.match(reason(r), /unknown shape "flat_array"/);
+  });
+
+  test("currency is carried through verbatim", () => {
+    const obs = ok(
+      extractRevenue({ ...LIUM, currency: "TAO" }, { "2026-07": 5 }),
+    );
+    assert.equal(obs[0].currency, "TAO");
+  });
+});

--- a/tests/subnet-manifest-revenue-block.test.ts
+++ b/tests/subnet-manifest-revenue-block.test.ts
@@ -45,6 +45,7 @@ const CHUTES_REVENUE: Json = {
   provenance: "probe-derived",
   currency: "USD",
   grain: "daily",
+  shape: "flat-array",
   fields: { date: "date", amount: "total_revenue" },
   excludes: ["sponsored_inference", "pending_instance_revenue"],
   supersedes: ["sn-64-chutes-payments-summary-tao"],
@@ -141,15 +142,69 @@ describe("subnet-manifest revenue block (#10441)", () => {
     );
   });
 
-  test("external-revenue must declare currency, grain and fields", () => {
+  test("external-revenue must declare currency, grain and shape", () => {
     // Without these the amount is a bare number with no unit, no period and no
-    // named source field — exactly the shape that produced the TAO/USD trap.
+    // stated arrangement — exactly the shape that produced the TAO/USD trap.
+    // `fields` is deliberately NOT required here: a keyed-map payload has no
+    // field names to give, so the per-shape rules below own that requirement.
     const bare = { role: "external-revenue", provenance: "probe-derived" };
     assert.equal(validate(manifest(bare)), false);
     const named = errorsFor(manifest(bare)).join(" ");
-    for (const required of ["currency", "grain", "fields"]) {
+    for (const required of ["currency", "grain", "shape"]) {
       assert.ok(named.includes(required), `rejection must name ${required}`);
     }
+  });
+
+  test("each shape demands exactly the fields it can supply (#10525)", () => {
+    const base = {
+      role: "external-revenue",
+      provenance: "probe-derived",
+      currency: "USD",
+      grain: "daily",
+    };
+    // flat-array: a record list, so both keys are nameable and both required.
+    assert.equal(
+      validate(manifest({ ...base, shape: "flat-array" })),
+      false,
+      "flat-array without fields must be rejected",
+    );
+    assert.equal(
+      validate(
+        manifest({
+          ...base,
+          shape: "flat-array",
+          fields: { date: "d", amount: "a" },
+        }),
+      ),
+      true,
+    );
+    // scalar: one total, so only `amount` is nameable.
+    assert.equal(validate(manifest({ ...base, shape: "scalar" })), false);
+    assert.equal(
+      validate(
+        manifest({ ...base, shape: "scalar", fields: { amount: "total" } }),
+      ),
+      true,
+    );
+    // keyed-map: the period IS the key, so there is nothing to name — and
+    // carrying `fields` anyway would be a sentinel like the `$key`/`$value`
+    // stand-in this replaces.
+    assert.equal(
+      validate(manifest({ ...base, shape: "keyed-map", grain: "monthly" })),
+      true,
+    );
+    assert.equal(
+      validate(
+        manifest({
+          ...base,
+          shape: "keyed-map",
+          grain: "monthly",
+          fields: { date: "$key", amount: "$value" },
+        }),
+      ),
+      false,
+      "a keyed-map carrying fields must be rejected — that is the sentinel this replaces",
+    );
   });
 
   test("an UNREADABLE external-revenue surface is not asked to describe its payload", () => {


### PR DESCRIPTION
Two halves of the same problem: declare how a payload is arranged, then extract from it without guessing.

## Part 1 — `shape`, because `fields` did not generalise

#10441 shipped `fields` as a flat map of role → field name. That fits Chutes, whose `daily_revenue_summary` is a list of records. **SN51 proved it does not generalise** — `lium.io` returns `{ "2026-07": { "5Csv…": 604678.83 } }`, where the period **is** the key and there is no field name to point at. #10450 recorded `$key`/`$value` as an interim sentinel with no schema backing.

| shape | payload | names |
|---|---|---|
| `flat-array` | a list of records | `date` and `amount` |
| `scalar` | one object with a single total | `amount` |
| `keyed-map` | nested `{period: {subkey: amount}}` | **nothing** |

The requirement had to move with it: demanding `fields` for every readable `external-revenue` surface **contradicted `keyed-map`**, so SN51 could not be expressed at all. Readable revenue now requires `currency`, `grain`, `shape`; each shape owns its own `fields` rule. A `keyed-map` carrying `fields` is rejected — that is what retires the sentinel.

SN64 and SN51 are migrated in the same diff. No declaration is left on the interim convention.

## Part 2 — the extractor (#10444's core)

Pure and injection-free, so the part where being wrong is *silent* can be tested exhaustively.

**A failure is never a zero.** A missing field, a wrong payload type, a string where a number was declared — each returns a stated reason. A zero is a real measurement meaning *earned nothing today*, and that is a different fact from *the feed broke*. Once stored, the two are indistinguishable, so they are never allowed to merge.

**`excludes` is subtracted.** On the real SN64 row: **9,776.06 gross → 9,165.25 net**. A *missing* exclusion is fine (a feed that sponsored nothing may omit the field); a *present non-numeric* one is refused, because the payload changed under a declaration still claiming to understand it.

**An unknown shape is refused, not read as `keyed-map`.** `keyed-map` is the fallthrough branch, so a typo would otherwise yield plausible numbers from the wrong reading. The schema constrains the registry; nothing constrains what reaches the function. Found because the vocabulary const was showing 0% coverage — the unused export was the symptom of the missing guard.

## Verification

- Tested against the **real** Chutes, Lium and `payments/summary/tao` payloads
- **100% statements, branches, functions and lines** on both new modules
- All drift and parity gates pass; `tsc`, eslint, prettier clean
- Landed across registry schema, published `SurfaceRevenue` component, and regenerated contract + GraphQL types together

Closes #10525
