### PR TITLE
test: use an owner address that actually resolves

### DIFF
--- a/tests/account-entities-answer.test.ts
+++ b/tests/account-entities-answer.test.ts
@@ -31,7 +31,12 @@ vi.mock("../workers/storage.ts", () => ({
 import { answerAccountEntities } from "../src/account-entities-answer.ts";
 import type { SubnetOwnerSnapshot } from "../src/entity-labels.ts";
 
-const OWNER = "5FRYKhbmT3ijhFVDMHUvBrqLKteLBSb6JqPCvB3NfWaVbxpe";
+// Chutes' REAL owner coldkey, and it resolves: the address #9313 quoted
+// (5FRYKhbmT3ij…, same eight-char prefix) fails SS58 checksum validation,
+// so the endpoint answers invalid_ss58 for it rather than any tie count.
+// A fixture that cannot exist invites a test that validates addresses to
+// pass for the wrong reason.
+const OWNER = "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9";
 const CAPTURED = "2026-08-10T09:26:12.433Z";
 
 const owners = (): SubnetOwnerSnapshot => ({

--- a/tests/entity-labels.test.ts
+++ b/tests/entity-labels.test.ts
@@ -442,7 +442,12 @@ describe("resolveAddress -- the reserved private-label layer (#8484)", () => {
 // coldkeys that demonstrably own a subnet -- a confident empty, which reads to
 // a caller as "this address owns nothing" rather than "we did not look".
 describe("current subnet ownership (#9313)", () => {
-  const OWNER = "5FRYKhbmT3ijhFVDMHUvBrqLKteLBSb6JqPCvB3NfWaVbxpe";
+  // Chutes' REAL owner coldkey, and it resolves: the address #9313 quoted
+  // (5FRYKhbmT3ij…, same eight-char prefix) fails SS58 checksum validation,
+  // so the endpoint answers invalid_ss58 for it rather than any tie count.
+  // A fixture that cannot exist invites a test that validates addresses to
+  // pass for the wrong reason.
+  const OWNER = "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9";
   const CAPTURED = "2026-08-10T09:26:12.433Z";
   const owners = () => ({
     rows: [


### PR DESCRIPTION
Follow-up to #10539 / #9313.

Both new test files used the coldkey #9313 quoted, and **that address does not exist**:

```
$ curl -s '…/accounts/5FRYKhbmT3ijhFVDMHUvBrqLKteLBSb6JqPCvB3NfWaVbxpe/entities'
{"code":"invalid_ss58","message":"ss58 address must be a valid finney SS58 account address."}
```

It shares an eight-character prefix with the real owner (`5FRYKhbmfXPD…`) and diverges after it — a transcription slip in the original report, not a different account.

Harmless in these tests, which operate on plain strings, and exactly the kind of fixture that stops being harmless later: the first test that validates an address would pass for the wrong reason, and anyone re-running the issue's own repro reads `invalid_ss58` as a regression rather than a typo.

Swapped for Chutes' real owner coldkey — verified live, it returns `ownership_tie_count: 1`, `role: "owns"` — with a note saying why the obvious-looking one is wrong.

Also worth recording: the original `ownership_ties: 0` was reproduced against an address the API cannot resolve at all, so that number was never evidence of the bug. The bug was real anyway — it was structural, and the diagnosis stood on its own.

51 tests pass, eslint clean, `scan:public-safety` clean.