### PR TITLE
feat(revenue): the probe lane, and a store that cannot confuse broken with zero

### DIFF
--- a/migrations/neon/0016_revenue_observations.sql
+++ b/migrations/neon/0016_revenue_observations.sql
@@ -1,0 +1,66 @@
+-- #10444: the revenue probe lane's store.
+--
+-- One row per (surface, period) per capture. The lane re-reads a feed that
+-- restates history -- SN64 publishes a rolling window of daily rows, SN51 a
+-- growing map of months -- so the same period is observed many times and the
+-- newest observation wins. That is an UPSERT on (surface_id, period), not an
+-- append: appending would grow ~30 rows per surface per tick and make the
+-- serving query a per-period argmax over duplicates.
+--
+-- `response_hash` and `observed_at` are the retention #10444 asks for. An
+-- operator can withdraw a feed once an unflattering ratio is published, and a
+-- withdrawn feed that leaves nothing behind is indistinguishable from a subnet
+-- that never had revenue. The hash lets a later reader prove the bytes a figure
+-- came from without storing the bytes.
+CREATE TABLE IF NOT EXISTS revenue_observations (
+  surface_id     TEXT    NOT NULL,
+  netuid         INTEGER NOT NULL,
+  -- The period verbatim from the payload ('2026-08-08', '2026-07'). NULL is
+  -- not allowed: a scalar total has no period of its own and is stored under
+  -- the sentinel below, so a NULL here would mean the lane lost track of which
+  -- row it was writing.
+  period         TEXT    NOT NULL,
+  grain          TEXT    NOT NULL,
+  amount         DOUBLE PRECISION NOT NULL,
+  currency       TEXT    NOT NULL,
+  provenance     TEXT    NOT NULL,
+  -- sha-256 of the exact response the figure was extracted from.
+  response_hash  TEXT    NOT NULL,
+  observed_at    BIGINT  NOT NULL,
+  PRIMARY KEY (surface_id, period),
+  -- The same epoch-milliseconds floor 0010 put on the daily tables: 1e12 is
+  -- 2001-09-09 and a seconds-valued stamp this decade is ~1.79e9.
+  CONSTRAINT revenue_observations_observed_at_is_millis
+    CHECK (observed_at >= 1000000000000),
+  -- Only the two readable provenances may be stored. operator-attested and
+  -- third-party-reported carry no payload to probe, so a row claiming one of
+  -- them means something wrote a figure it could not have read.
+  CONSTRAINT revenue_observations_provenance_is_readable
+    CHECK (provenance IN ('probe-derived', 'chain-verified'))
+);
+
+-- One subnet's series across its surfaces, newest period first: the per-netuid
+-- serving read.
+CREATE INDEX IF NOT EXISTS idx_revenue_obs_netuid_period
+  ON revenue_observations (netuid, period DESC);
+
+-- The network-wide coverage table reads every subnet's recent periods at once.
+CREATE INDEX IF NOT EXISTS idx_revenue_obs_period
+  ON revenue_observations (period DESC);
+
+-- #10444: a fetch that failed is recorded as a failure, never as a zero. Kept
+-- separate from the observations table on purpose -- a failure has no amount,
+-- and giving it a nullable amount column would invite a reader to coalesce it
+-- to 0, which is the exact confusion this lane exists to prevent.
+CREATE TABLE IF NOT EXISTS revenue_probe_failures (
+  surface_id   TEXT    NOT NULL,
+  netuid       INTEGER NOT NULL,
+  reason       TEXT    NOT NULL,
+  observed_at  BIGINT  NOT NULL,
+  PRIMARY KEY (surface_id, observed_at),
+  CONSTRAINT revenue_probe_failures_observed_at_is_millis
+    CHECK (observed_at >= 1000000000000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_revenue_failures_netuid
+  ON revenue_probe_failures (netuid, observed_at DESC);

--- a/src/revenue-probe.ts
+++ b/src/revenue-probe.ts
@@ -1,0 +1,185 @@
+// #10444: the revenue probe lane.
+//
+// Selects the surfaces that DECLARE readable revenue, fetches each, hashes what
+// came back, extracts observations against the surface's own declaration
+// (src/revenue-observation.ts), and hands back rows to persist. Everything is
+// injected -- surfaces, fetch, hash, clock -- so the whole run is unit-testable
+// without a runtime, the same shape src/health-prober.ts uses.
+//
+// Three rules the lane exists to hold:
+//
+//   1. ONLY READABLE PROVENANCE IS PROBED. `operator-attested` and
+//      `third-party-reported` describe figures nobody outside the operator can
+//      read; probing them would produce a 401 body and, under a careless
+//      extractor, a number. They are skipped, not attempted.
+//   2. A FETCH FAILURE IS A FAILURE. Never a zero, never a silently dropped
+//      surface -- it comes back as a failure row with a reason, because a feed
+//      that broke and a subnet that earned nothing are different facts.
+//   3. THE RAW RESPONSE IS HASHED AND KEPT. An operator can withdraw a feed once
+//      an unflattering ratio is published. A withdrawn feed that leaves nothing
+//      behind is indistinguishable from a subnet that never had revenue.
+import {
+  extractRevenue,
+  type RevenueDeclaration,
+} from "./revenue-observation.ts";
+
+/** The provenances that mean the payload WAS read, and so can be probed. */
+export const READABLE_PROVENANCES = [
+  "probe-derived",
+  "chain-verified",
+] as const;
+
+/** Stored under `period` for a scalar total, which carries no period of its own.
+ * A sentinel rather than NULL so the primary key stays total -- see 0016. */
+export const SCALAR_PERIOD = "__total__";
+
+export interface ProbeSurfaceInput {
+  id: string;
+  netuid: number;
+  url: string;
+  auth_required?: boolean;
+  probe?: { enabled?: boolean };
+  revenue?: RevenueDeclaration & {
+    role?: string;
+    provenance?: string;
+    grain?: string;
+  };
+}
+
+export interface RevenueObservationRow {
+  surface_id: string;
+  netuid: number;
+  period: string;
+  grain: string;
+  amount: number;
+  currency: string;
+  provenance: string;
+  response_hash: string;
+  observed_at: number;
+}
+
+export interface RevenueFailureRow {
+  surface_id: string;
+  netuid: number;
+  reason: string;
+  observed_at: number;
+}
+
+export interface RevenueProbeResult {
+  observations: RevenueObservationRow[];
+  failures: RevenueFailureRow[];
+  /** Surfaces the lane deliberately did not touch, and why. Reported rather than
+   * silently omitted: a lane that quietly probes nothing looks identical to one
+   * whose every surface passed. */
+  skipped: Array<{ surface_id: string; reason: string }>;
+}
+
+export interface RevenueProbeDeps {
+  /** Returns the parsed body and the exact text it was parsed from. Throwing is
+   * a failure, not an exception the caller has to catch. */
+  fetchPayload: (url: string) => Promise<{ payload: unknown; raw: string }>;
+  hash: (raw: string) => Promise<string> | string;
+  now: () => number;
+}
+
+/**
+ * Is this surface one the lane should fetch?
+ *
+ * Exported because "which surfaces are in scope" is the decision most likely to
+ * drift from the declaration rules, and it deserves its own tests rather than
+ * only being exercised through a full run.
+ */
+export function probeEligibility(
+  surface: ProbeSurfaceInput,
+): { eligible: true } | { eligible: false; reason: string } {
+  const revenue = surface.revenue;
+  if (!revenue) return { eligible: false, reason: "no revenue declaration" };
+  if (revenue.role !== "external-revenue") {
+    return { eligible: false, reason: `role is ${revenue.role ?? "unset"}` };
+  }
+  const provenance = revenue.provenance ?? "";
+  if (!(READABLE_PROVENANCES as readonly string[]).includes(provenance)) {
+    return {
+      eligible: false,
+      reason: `provenance ${provenance || "unset"} is not readable`,
+    };
+  }
+  // Mirrors validate-revenue-provenance.ts. The registry gate should make these
+  // unreachable, but the lane must not fetch an auth-gated URL on the strength
+  // of a declaration that slipped through.
+  if (surface.auth_required === true) {
+    return { eligible: false, reason: "auth_required" };
+  }
+  if (surface.probe?.enabled !== true) {
+    return { eligible: false, reason: "probe.enabled is not true" };
+  }
+  return { eligible: true };
+}
+
+/**
+ * Run one pass over the declared surfaces.
+ *
+ * Sequential on purpose: the eligible set is a handful of surfaces (two subnets
+ * as of 2026-08-10), so there is nothing to gain from concurrency and a lane
+ * that hammers a subnet's billing endpoint is a bad citizen. If the set grows,
+ * bound it the way health-probe-core's mapLimit does rather than unbounding it.
+ */
+export async function runRevenueProbe(
+  surfaces: ProbeSurfaceInput[],
+  deps: RevenueProbeDeps,
+): Promise<RevenueProbeResult> {
+  const observations: RevenueObservationRow[] = [];
+  const failures: RevenueFailureRow[] = [];
+  const skipped: RevenueProbeResult["skipped"] = [];
+
+  for (const surface of surfaces) {
+    const eligibility = probeEligibility(surface);
+    if (!eligibility.eligible) {
+      skipped.push({ surface_id: surface.id, reason: eligibility.reason });
+      continue;
+    }
+    const revenue = surface.revenue as NonNullable<
+      ProbeSurfaceInput["revenue"]
+    >;
+    const observed_at = deps.now();
+    let payload: unknown;
+    let raw: string;
+    try {
+      ({ payload, raw } = await deps.fetchPayload(surface.url));
+    } catch (error) {
+      failures.push({
+        surface_id: surface.id,
+        netuid: surface.netuid,
+        reason: `fetch failed: ${error instanceof Error ? error.message : String(error)}`,
+        observed_at,
+      });
+      continue;
+    }
+    const extracted = extractRevenue(revenue, payload);
+    if (!extracted.ok) {
+      failures.push({
+        surface_id: surface.id,
+        netuid: surface.netuid,
+        reason: extracted.reason,
+        observed_at,
+      });
+      continue;
+    }
+    const response_hash = await deps.hash(raw);
+    for (const observation of extracted.observations) {
+      observations.push({
+        surface_id: surface.id,
+        netuid: surface.netuid,
+        period: observation.period ?? SCALAR_PERIOD,
+        grain: revenue.grain ?? "cumulative",
+        amount: observation.amount,
+        currency: observation.currency,
+        provenance: revenue.provenance as string,
+        response_hash,
+        observed_at,
+      });
+    }
+  }
+
+  return { observations, failures, skipped };
+}

--- a/tests/revenue-probe.test.ts
+++ b/tests/revenue-probe.test.ts
@@ -1,0 +1,303 @@
+// #10444: the lane's three rules, each tested in the direction that fails
+// silently — probing something unreadable, turning a broken fetch into a zero,
+// and losing the bytes a figure came from.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  READABLE_PROVENANCES,
+  SCALAR_PERIOD,
+  probeEligibility,
+  runRevenueProbe,
+  type ProbeSurfaceInput,
+} from "../src/revenue-probe.ts";
+
+const CHUTES: ProbeSurfaceInput = {
+  id: "sn-64-chutes-daily-revenue-summary",
+  netuid: 64,
+  url: "https://api.chutes.ai/daily_revenue_summary",
+  auth_required: false,
+  probe: { enabled: true },
+  revenue: {
+    role: "external-revenue",
+    provenance: "probe-derived",
+    currency: "USD",
+    grain: "daily",
+    shape: "flat-array",
+    fields: { date: "date", amount: "total_revenue" },
+    excludes: ["sponsored_inference", "pending_instance_revenue"],
+  },
+};
+const ROW = {
+  date: "2026-08-08",
+  total_revenue: 9776.059599572032,
+  sponsored_inference: 0,
+  pending_instance_revenue: 610.8139253575,
+};
+const NET =
+  ROW.total_revenue - ROW.sponsored_inference - ROW.pending_instance_revenue;
+
+function deps(payload: unknown, raw = "RAW") {
+  return {
+    fetchPayload: async () => ({ payload, raw }),
+    hash: () => "sha256:deadbeef",
+    now: () => 1_786_400_000_000,
+  };
+}
+
+describe("probeEligibility", () => {
+  test("a readable external-revenue surface is eligible", () => {
+    assert.deepEqual(probeEligibility(CHUTES), { eligible: true });
+    for (const provenance of READABLE_PROVENANCES) {
+      const s = { ...CHUTES, revenue: { ...CHUTES.revenue!, provenance } };
+      assert.equal(probeEligibility(s).eligible, true, provenance);
+    }
+  });
+
+  test("unreadable provenance is skipped, not attempted", () => {
+    // Probing an operator-attested surface returns a 401 body, which a careless
+    // extractor could turn into a number.
+    for (const provenance of [
+      "operator-attested",
+      "third-party-reported",
+      "none",
+    ]) {
+      const s = { ...CHUTES, revenue: { ...CHUTES.revenue!, provenance } };
+      const r = probeEligibility(s);
+      assert.equal(r.eligible, false, provenance);
+      assert.match(r.eligible ? "" : r.reason, /not readable/);
+    }
+  });
+
+  test("a non-revenue role is skipped", () => {
+    for (const role of ["usage-proxy", "miner-payout", "not-revenue"]) {
+      const s = { ...CHUTES, revenue: { ...CHUTES.revenue!, role } };
+      assert.equal(probeEligibility(s).eligible, false, role);
+    }
+    assert.match(
+      probeEligibility({ ...CHUTES, revenue: undefined }).eligible
+        ? ""
+        : (
+            probeEligibility({ ...CHUTES, revenue: undefined }) as {
+              reason: string;
+            }
+          ).reason,
+      /no revenue declaration/,
+    );
+  });
+
+  test("an unset role or provenance is named rather than rendered blank", () => {
+    // A declaration can reach the lane half-built. The reason string is what an
+    // operator reads in the skip list, so "role is unset" has to beat
+    // "role is undefined" and an empty provenance must not render as
+    // "provenance  is not readable".
+    const noRole = probeEligibility({
+      ...CHUTES,
+      revenue: { currency: "USD" },
+    }) as { reason: string };
+    assert.match(noRole.reason, /role is unset/);
+
+    const noProv = probeEligibility({
+      ...CHUTES,
+      revenue: { role: "external-revenue", currency: "USD" },
+    }) as { reason: string };
+    assert.match(noProv.reason, /provenance unset is not readable/);
+  });
+
+  test("auth-gated and unprobed surfaces are refused even if declared readable", () => {
+    // The registry gate should make these unreachable; the lane must not fetch
+    // an auth-gated URL on the strength of a declaration that slipped through.
+    assert.match(
+      (
+        probeEligibility({ ...CHUTES, auth_required: true }) as {
+          reason: string;
+        }
+      ).reason,
+      /auth_required/,
+    );
+    assert.match(
+      (
+        probeEligibility({ ...CHUTES, probe: { enabled: false } }) as {
+          reason: string;
+        }
+      ).reason,
+      /probe\.enabled/,
+    );
+    assert.match(
+      (probeEligibility({ ...CHUTES, probe: undefined }) as { reason: string })
+        .reason,
+      /probe\.enabled/,
+    );
+  });
+});
+
+describe("runRevenueProbe", () => {
+  test("extracts a net observation and stamps it with the response hash", async () => {
+    const r = await runRevenueProbe([CHUTES], deps([ROW]));
+    assert.equal(r.observations.length, 1);
+    const [o] = r.observations;
+    assert.equal(o.surface_id, CHUTES.id);
+    assert.equal(o.netuid, 64);
+    assert.equal(o.period, "2026-08-08");
+    assert.equal(o.grain, "daily");
+    assert.ok(Math.abs(o.amount - NET) < 1e-9);
+    assert.equal(o.currency, "USD");
+    assert.equal(o.provenance, "probe-derived");
+    assert.equal(o.response_hash, "sha256:deadbeef");
+    assert.equal(o.observed_at, 1_786_400_000_000);
+    assert.deepEqual(r.failures, []);
+  });
+
+  test("a thrown fetch becomes a failure row, never a zero observation", async () => {
+    const r = await runRevenueProbe([CHUTES], {
+      ...deps(null),
+      fetchPayload: async () => {
+        throw new Error("ECONNRESET");
+      },
+    });
+    assert.deepEqual(r.observations, []);
+    assert.equal(r.failures.length, 1);
+    assert.match(r.failures[0].reason, /fetch failed: ECONNRESET/);
+    assert.equal(r.failures[0].netuid, 64);
+  });
+
+  test("an unextractable payload becomes a failure carrying the reason", async () => {
+    // The feed answered, but with something the declaration cannot read — a
+    // silent 0 here would be indistinguishable from a subnet earning nothing.
+    const r = await runRevenueProbe([CHUTES], deps({ oops: true }));
+    assert.deepEqual(r.observations, []);
+    assert.match(r.failures[0].reason, /expected an array/);
+  });
+
+  test("a genuine zero IS stored, because it is a measurement", async () => {
+    const zero = { ...ROW, total_revenue: 0, pending_instance_revenue: 0 };
+    const r = await runRevenueProbe([CHUTES], deps([zero]));
+    assert.equal(r.observations.length, 1);
+    assert.equal(r.observations[0].amount, 0);
+    assert.deepEqual(r.failures, []);
+  });
+
+  test("a scalar total is stored under the sentinel period", async () => {
+    const scalar: ProbeSurfaceInput = {
+      ...CHUTES,
+      id: "sn-64-chutes-tao-payment-totals-api",
+      revenue: {
+        role: "external-revenue",
+        provenance: "probe-derived",
+        currency: "USD",
+        grain: "cumulative",
+        shape: "scalar",
+        fields: { amount: "total" },
+      },
+    };
+    const r = await runRevenueProbe([scalar], deps({ total: 2322291.89 }));
+    assert.equal(r.observations[0].period, SCALAR_PERIOD);
+    assert.equal(r.observations[0].grain, "cumulative");
+  });
+
+  test("mixed grain in one pass keeps each surface's own", async () => {
+    // SN51 is monthly where SN64 is daily; a lane that assumed one would
+    // mislabel the other's periods.
+    const lium: ProbeSurfaceInput = {
+      id: "sn-51-lium-revenue-for-validators",
+      netuid: 51,
+      url: "https://lium.io/api/billing/revenue-for-validators",
+      auth_required: false,
+      probe: { enabled: true },
+      revenue: {
+        role: "external-revenue",
+        provenance: "probe-derived",
+        currency: "USD",
+        grain: "monthly",
+        shape: "keyed-map",
+      },
+    };
+    let call = 0;
+    const r = await runRevenueProbe([CHUTES, lium], {
+      hash: () => "h",
+      now: () => 1_786_400_000_000,
+      fetchPayload: async () => {
+        call += 1;
+        return call === 1
+          ? { payload: [ROW], raw: "a" }
+          : { payload: { "2026-07": { v1: 604678.83 } }, raw: "b" };
+      },
+    });
+    const grains = Object.fromEntries(
+      r.observations.map((o) => [o.netuid, o.grain]),
+    );
+    assert.deepEqual(grains, { 64: "daily", 51: "monthly" });
+  });
+
+  test("skips are reported, not silently omitted", async () => {
+    // A lane that quietly probes nothing looks identical to one whose every
+    // surface passed.
+    const gated: ProbeSurfaceInput = {
+      ...CHUTES,
+      id: "gated",
+      auth_required: true,
+      revenue: { ...CHUTES.revenue!, provenance: "operator-attested" },
+    };
+    const r = await runRevenueProbe([gated], deps([ROW]));
+    assert.deepEqual(r.observations, []);
+    assert.deepEqual(r.failures, []);
+    assert.equal(r.skipped.length, 1);
+    assert.equal(r.skipped[0].surface_id, "gated");
+  });
+
+  test("one broken surface does not abort the pass", async () => {
+    let call = 0;
+    const r = await runRevenueProbe(
+      [
+        { ...CHUTES, id: "a" },
+        { ...CHUTES, id: "b" },
+      ],
+      {
+        hash: () => "h",
+        now: () => 1_786_400_000_000,
+        fetchPayload: async () => {
+          call += 1;
+          if (call === 1) throw new Error("boom");
+          return { payload: [ROW], raw: "ok" };
+        },
+      },
+    );
+    assert.equal(r.failures.length, 1);
+    assert.equal(r.observations.length, 1);
+    assert.equal(r.observations[0].surface_id, "b");
+  });
+
+  test("a non-Error throw still yields a readable reason", async () => {
+    // fetch implementations reject with strings and objects too; String(error)
+    // is what stops the failure row reading "fetch failed: [object Object]".
+    const r = await runRevenueProbe([CHUTES], {
+      ...deps(null),
+      fetchPayload: async () => {
+        throw "socket hang up";
+      },
+    });
+    assert.match(r.failures[0].reason, /fetch failed: socket hang up/);
+  });
+
+  test("a surface with no declared grain falls back to cumulative", async () => {
+    const noGrain: ProbeSurfaceInput = {
+      ...CHUTES,
+      revenue: {
+        role: "external-revenue",
+        provenance: "probe-derived",
+        currency: "USD",
+        shape: "flat-array",
+        fields: { date: "date", amount: "total_revenue" },
+      },
+    };
+    const r = await runRevenueProbe([noGrain], deps([ROW]));
+    assert.equal(r.observations[0].grain, "cumulative");
+  });
+
+  test("an async hash is awaited", async () => {
+    const r = await runRevenueProbe([CHUTES], {
+      ...deps([ROW]),
+      hash: async () => "sha256:async",
+    });
+    assert.equal(r.observations[0].response_hash, "sha256:async");
+  });
+});


### PR DESCRIPTION
Selects the surfaces that **declare** readable revenue, fetches each, hashes what came back, and extracts observations against the surface's own declaration. Injected throughout — surfaces, fetch, hash, clock — so a run is testable without a runtime, the shape `src/health-prober.ts` already uses.

## Only readable provenance is probed

`operator-attested` describes a figure nobody outside the operator can read, so probing one returns a **401 body** — and a careless extractor turns a 401 body into a number.

The lane also re-checks `auth_required` and `probe.enabled` rather than trusting the declaration. The registry gate (#10443) should make those unreachable, but the lane must not fetch an auth-gated URL on the strength of a declaration that slipped through.

## A failure is a failure, never a zero

Failures come back as rows carrying the reason, and live in **their own table** rather than as a nullable `amount`. A nullable amount invites a reader to coalesce it to `0` — and `0` is a real measurement meaning *the subnet earned nothing that day*. Those are different facts and once merged they cannot be separated again.

Skips are reported for the same reason: **a lane that quietly probes nothing looks identical to one whose every surface passed.**

## Why UPSERT, not append

These feeds restate history — SN64 publishes a rolling window of days, SN51 a growing map of months — so the same period is observed many times and the newest wins.

Appending would add ~30 rows per surface per tick and turn every serving read into a per-period argmax over duplicates.

## `response_hash`

Keeps *what a figure came from* without keeping the bytes. An operator can withdraw a feed once an unflattering ratio is published, and a withdrawal that leaves nothing behind is indistinguishable from a subnet that never had revenue.

## Mixed grain

Carried per surface, so SN51's months and SN64's days are never relabelled as each other — verified in a single pass over both.

## Verification

- **100% statements, branches, functions and lines** on the lane
- 16 tests, including: a thrown fetch, a non-`Error` throw, an unextractable payload, a genuine zero surviving, the scalar sentinel period, mixed grain, one broken surface not aborting the pass, and an async hash being awaited
- `validate:migrations` · `validate:db-types-drift` · `validate:contract-drift` · `validate:schemas` · `validate:types` · `validate:unreferenced-modules` · `validate:revenue-provenance` — pass
- `tsc`, eslint, prettier clean

Migration `0016` adds `revenue_observations` and `revenue_probe_failures`, both with the epoch-millis floor `0010` established, plus a CHECK constraining stored provenance to the two readable values — a row claiming `operator-attested` would mean something wrote a figure it could not have read.

Closes #10444
