### PR TITLE
feat(revenue): the coverage ratio, and the chain inflow behind its Tier-A half

### DIFF
--- a/src/revenue-chain-inflow.ts
+++ b/src/revenue-chain-inflow.ts
@@ -1,0 +1,157 @@
+// #10445: revenue measured from our own transfer index, with no trust in the
+// operator's API.
+//
+// The Tier-A path. #10448 established it is real -- 32/32 Chutes payments for
+// 2026-08-08 matched on-chain Balances.Transfer events with a delta of
+// 0.000000000 TAO -- and also established its limit: the TAO channel was
+// $1,036.50 against $9,776.06 total revenue that day, so this corroborates the
+// operator on ~10% of the figure rather than replacing the feed.
+//
+// Four rules, each of which was a wrong answer before it was a rule:
+//
+//   1. INBOUND ONLY. A sweep OUT of a collector is treasury movement, not
+//      negative revenue. Netting the two would let a subnet reduce its own
+//      reported revenue by moving its money.
+//   2. PROTOCOL ACCOUNTS ARE REFUSED. A subnet's own TAO reserve receives large,
+//      continuous, many-party inbound -- because that is what buying alpha looks
+//      like -- and presents exactly like a payment collector. #10448 nearly
+//      recorded SN64's as one.
+//   3. EACH INFLOW IS PRICED AT ITS OWN INSTANT, not at a window-average rate.
+//      A window average silently backdates today's TAO price onto a payment
+//      made when it was worth something else.
+//   4. ALPHA IS CLASSIFIED, NOT SUMMED. An inflow denominated in the subnet's
+//      own alpha is circular, not external, and adding it to a USD total would
+//      quietly count a subnet paying itself.
+import { protocolSubnetNetuid } from "./subnet-accounts.ts";
+
+export interface ChainTransfer {
+  to: string;
+  from: string;
+  /** TAO, already scaled from rao. */
+  amount_tao: number;
+  block_number: number;
+  observed_at: number;
+  /** Present when the transfer moved a subnet's alpha rather than TAO. */
+  alpha_netuid?: number | null;
+}
+
+export interface InflowInput {
+  /** Addresses declared `payment-collector` for this subnet, from the entity
+   * registry. */
+  collectors: string[];
+  netuid: number;
+  transfers: ChainTransfer[];
+  /** TAO/USD at a given instant. Returning null means the price is unknown for
+   * that moment, which is not the same as zero. */
+  usdAtInstant: (observedAt: number) => number | null;
+}
+
+export interface InflowResult {
+  netuid: number;
+  /** Summed external TAO inflow to the declared collectors. */
+  tao: number;
+  /** Priced at each transfer's own instant. Null when NO transfer could be
+   * priced -- an unpriced total is not a zero total. */
+  usd: number | null;
+  transfer_count: number;
+  /** Inflows deliberately not counted, with the reason. Reported rather than
+   * dropped: a silently-filtered inflow is indistinguishable from one that
+   * never happened. */
+  excluded: Array<{ reason: string; count: number; tao: number }>;
+  /** Collectors refused before any transfer was read. */
+  rejected_collectors: Array<{ ss58: string; reason: string }>;
+}
+
+function bump(
+  map: Map<string, { count: number; tao: number }>,
+  reason: string,
+  tao: number,
+): void {
+  const entry = map.get(reason) ?? { count: 0, tao: 0 };
+  entry.count += 1;
+  entry.tao += tao;
+  map.set(reason, entry);
+}
+
+/**
+ * Aggregate inbound TAO to a subnet's declared payment collectors.
+ *
+ * `transfers` is whatever the caller pulled for the window; filtering to the
+ * collectors happens here so the rules live in one place rather than in each
+ * caller's query.
+ */
+export function aggregateChainInflow(input: InflowInput): InflowResult {
+  const { collectors, netuid, transfers, usdAtInstant } = input;
+
+  const accepted = new Set<string>();
+  const rejected: InflowResult["rejected_collectors"] = [];
+  for (const ss58 of collectors) {
+    const protocolNetuid = protocolSubnetNetuid(ss58);
+    if (protocolNetuid !== null) {
+      rejected.push({
+        ss58,
+        reason:
+          `protocol-derived TAO account for netuid ${protocolNetuid} — its inbound is ` +
+          "users staking to buy alpha, a capital flow, not revenue (#10448)",
+      });
+      continue;
+    }
+    accepted.add(ss58);
+  }
+
+  const excluded = new Map<string, { count: number; tao: number }>();
+  let tao = 0;
+  let usd = 0;
+  let priced = 0;
+  let counted = 0;
+
+  for (const transfer of transfers) {
+    if (!accepted.has(transfer.to)) {
+      // Outbound from a collector is the case worth naming: it is treasury
+      // movement, and netting it would let a subnet reduce its reported
+      // revenue by moving its own money.
+      if (accepted.has(transfer.from)) {
+        bump(excluded, "outbound from a collector", transfer.amount_tao);
+      }
+      continue;
+    }
+    if (
+      typeof transfer.alpha_netuid === "number" &&
+      Number.isFinite(transfer.alpha_netuid)
+    ) {
+      bump(
+        excluded,
+        "alpha-denominated, so circular not external",
+        transfer.amount_tao,
+      );
+      continue;
+    }
+    if (!Number.isFinite(transfer.amount_tao) || transfer.amount_tao <= 0) {
+      bump(excluded, "non-positive or non-finite amount", 0);
+      continue;
+    }
+    counted += 1;
+    tao += transfer.amount_tao;
+    const rate = usdAtInstant(transfer.observed_at);
+    if (rate !== null && Number.isFinite(rate)) {
+      priced += 1;
+      usd += transfer.amount_tao * rate;
+    }
+  }
+
+  return {
+    netuid,
+    tao: Math.round(tao * 1e9) / 1e9,
+    // A total nobody could price is null, not zero. Partial pricing still
+    // reports what it could price, and the caller can see the gap from
+    // transfer_count.
+    usd: priced > 0 ? Math.round(usd * 1e6) / 1e6 : null,
+    transfer_count: counted,
+    excluded: [...excluded.entries()].map(([reason, v]) => ({
+      reason,
+      count: v.count,
+      tao: Math.round(v.tao * 1e9) / 1e9,
+    })),
+    rejected_collectors: rejected,
+  };
+}

--- a/src/revenue-coverage.ts
+++ b/src/revenue-coverage.ts
@@ -69,7 +69,7 @@ export interface CoverageResult {
   };
 }
 
-function round(value: number, places = 9): number {
+function roundTo(value: number, places = 9): number {
   const f = 10 ** places;
   return Math.round(value * f) / f;
 }
@@ -119,8 +119,8 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
     typeof alpha_price_tao === "number" &&
     Number.isFinite(alpha_price_tao)
       ? {
-          tao: round(alpha_out_per_block * blocks * alpha_price_tao),
-          usd: round(
+          tao: roundTo(alpha_out_per_block * blocks * alpha_price_tao),
+          usd: roundTo(
             alpha_out_per_block * blocks * alpha_price_tao * usd_per_tao,
             6,
           ),
@@ -130,8 +130,8 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
   // The owner's 18% of the SAME denominator, so the two are comparable. Priced
   // off tao_total rather than alpha so it does not silently change basis.
   const ownerTake: CoverageBasis = {
-    tao: round(emissionTao * OWNER_CUT),
-    usd: round(emissionTao * OWNER_CUT * usd_per_tao, 6),
+    tao: roundTo(emissionTao * OWNER_CUT),
+    usd: roundTo(emissionTao * OWNER_CUT * usd_per_tao, 6),
   };
 
   // Null propagates. Zero emission also yields null rather than Infinity: a
@@ -139,10 +139,10 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
   // render as the worst possible subsidy rather than as "not applicable".
   const haveRevenue = revenue_usd !== null;
   const coverage =
-    haveRevenue && emissionUsd > 0 ? round(revenue_usd / emissionUsd) : null;
+    haveRevenue && emissionUsd > 0 ? roundTo(revenue_usd / emissionUsd) : null;
   const subsidy =
     haveRevenue && revenue_usd > 0 && emissionUsd > 0
-      ? round(emissionUsd / revenue_usd)
+      ? roundTo(emissionUsd / revenue_usd)
       : null;
 
   const checks: CoverageResult["verification"]["checks"] = [
@@ -155,7 +155,7 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
       detail:
         coverage === null || subsidy === null
           ? "one or both ratios are null, so there is nothing to reconcile"
-          : `coverage x subsidy = ${round(coverage * subsidy, 6)}`,
+          : `coverage x subsidy = ${roundTo(coverage * subsidy, 6)}`,
     },
     {
       name: "absent_revenue_is_null_not_zero",
@@ -167,7 +167,7 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
     {
       name: "emission_is_positive",
       ok: emissionUsd > 0,
-      detail: `emission ${round(emissionTao, 6)} TAO over ${window_days} day(s)`,
+      detail: `emission ${roundTo(emissionTao, 6)} TAO over ${window_days} day(s)`,
     },
   ];
 
@@ -175,11 +175,11 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
     window_days,
     emission: {
       basis: "tao_total",
-      tao: round(emissionTao, 6),
-      usd: round(emissionUsd, 6),
+      tao: roundTo(emissionTao, 6),
+      usd: roundTo(emissionUsd, 6),
       alternates: { alpha_out_priced: alphaPriced, owner_take: ownerTake },
     },
-    revenue_usd: revenue_usd === null ? null : round(revenue_usd, 6),
+    revenue_usd: revenue_usd === null ? null : roundTo(revenue_usd, 6),
     coverage_ratio: coverage,
     subsidy_multiple: subsidy,
     verification: { verified: checks.every((c) => c.ok), checks },

--- a/src/revenue-coverage.ts
+++ b/src/revenue-coverage.ts
@@ -1,0 +1,187 @@
+// #10446: how much of a subnet's emission its external revenue covers.
+//
+// Two numbers, and they are reciprocals:
+//
+//   coverage_ratio   = revenue / emission     "12.5% covered"
+//   subsidy_multiple = emission / revenue     "8:1", the ecosystem's own phrasing
+//
+// Both are published because both get quoted, and a reader given only one
+// reliably invents the other wrong.
+//
+// The denominator is `tao_total` -- SubnetTaoInEmission + SubnetExcessTao, the
+// TAO the network directs into a subnet. Chosen because it is fully MEASURED
+// (get_emission_pipeline reads both from chain storage) and because it
+// reconciles with the "$52M a year" framing the ecosystem already uses. The
+// alternates are computed alongside and never silently substituted: a ratio
+// whose denominator changed without saying so is worse than no ratio.
+//
+// THE RULE THIS MODULE EXISTS TO HOLD: absent revenue is null, never zero. 127
+// of 129 subnets have no readable revenue figure. Rendering them as "0% covered"
+// would be a false claim about every one of them, at scale, and it is the single
+// most likely way this feature does harm.
+
+/** One day of blocks at 12s. Mirrors validator-economics.ts's own constant. */
+export const BLOCKS_PER_DAY = 7200;
+
+/** Share of alpha emission paid to the subnet owner. SubnetOwnerCut is
+ * 11796/65535 -- 18%, not 1/6. The difference is ~6 TAO/day on SN64. */
+export const OWNER_CUT = 11796 / 65535;
+
+export interface CoverageInput {
+  /** `tao_total` for one block: SubnetTaoInEmission + SubnetExcessTao. */
+  tao_total_per_block: number;
+  /** Alpha paid out per block, for the alternate denominator. */
+  alpha_out_per_block?: number;
+  /** TAO-denominated alpha price, for the alternate denominator. */
+  alpha_price_tao?: number;
+  usd_per_tao: number;
+  /** Days the window spans. */
+  window_days: number;
+  /** Summed external revenue over the window, from Tier A + B surfaces only.
+   * NULL means not observed -- which is not the same as zero. */
+  revenue_usd: number | null;
+}
+
+export interface CoverageBasis {
+  tao: number;
+  usd: number;
+}
+
+export interface CoverageResult {
+  window_days: number;
+  emission: {
+    /** The published denominator. */
+    basis: "tao_total";
+    tao: number;
+    usd: number;
+    /** Computed and published, never silently substituted for the basis. */
+    alternates: {
+      alpha_out_priced: CoverageBasis | null;
+      owner_take: CoverageBasis;
+    };
+  };
+  revenue_usd: number | null;
+  coverage_ratio: number | null;
+  subsidy_multiple: number | null;
+  verification: {
+    verified: boolean;
+    checks: Array<{ name: string; ok: boolean; detail: string }>;
+  };
+}
+
+function round(value: number, places = 9): number {
+  const f = 10 ** places;
+  return Math.round(value * f) / f;
+}
+
+/**
+ * Compute one subnet's coverage over a window.
+ *
+ * Throws on a non-finite or negative input rather than propagating NaN: a NaN
+ * ratio serialises as null, which is the SAME output as "revenue not observed",
+ * and those two must never be confusable.
+ */
+export function computeCoverage(input: CoverageInput): CoverageResult {
+  const {
+    tao_total_per_block,
+    alpha_out_per_block,
+    alpha_price_tao,
+    usd_per_tao,
+    window_days,
+    revenue_usd,
+  } = input;
+
+  for (const [name, value] of [
+    ["tao_total_per_block", tao_total_per_block],
+    ["usd_per_tao", usd_per_tao],
+    ["window_days", window_days],
+  ] as const) {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(`${name} must be a finite, non-negative number`);
+    }
+  }
+  if (
+    revenue_usd !== null &&
+    (!Number.isFinite(revenue_usd) || revenue_usd < 0)
+  ) {
+    throw new Error(
+      "revenue_usd must be null or a finite, non-negative number",
+    );
+  }
+
+  const blocks = BLOCKS_PER_DAY * window_days;
+  const emissionTao = tao_total_per_block * blocks;
+  const emissionUsd = emissionTao * usd_per_tao;
+
+  const alphaPriced =
+    typeof alpha_out_per_block === "number" &&
+    Number.isFinite(alpha_out_per_block) &&
+    typeof alpha_price_tao === "number" &&
+    Number.isFinite(alpha_price_tao)
+      ? {
+          tao: round(alpha_out_per_block * blocks * alpha_price_tao),
+          usd: round(
+            alpha_out_per_block * blocks * alpha_price_tao * usd_per_tao,
+            6,
+          ),
+        }
+      : null;
+
+  // The owner's 18% of the SAME denominator, so the two are comparable. Priced
+  // off tao_total rather than alpha so it does not silently change basis.
+  const ownerTake: CoverageBasis = {
+    tao: round(emissionTao * OWNER_CUT),
+    usd: round(emissionTao * OWNER_CUT * usd_per_tao, 6),
+  };
+
+  // Null propagates. Zero emission also yields null rather than Infinity: a
+  // subnet the gate is emitting nothing to has no ratio, and Infinity would
+  // render as the worst possible subsidy rather than as "not applicable".
+  const haveRevenue = revenue_usd !== null;
+  const coverage =
+    haveRevenue && emissionUsd > 0 ? round(revenue_usd / emissionUsd) : null;
+  const subsidy =
+    haveRevenue && revenue_usd > 0 && emissionUsd > 0
+      ? round(emissionUsd / revenue_usd)
+      : null;
+
+  const checks: CoverageResult["verification"]["checks"] = [
+    {
+      name: "ratios_are_reciprocal",
+      ok:
+        coverage === null ||
+        subsidy === null ||
+        Math.abs(coverage * subsidy - 1) < 1e-6,
+      detail:
+        coverage === null || subsidy === null
+          ? "one or both ratios are null, so there is nothing to reconcile"
+          : `coverage x subsidy = ${round(coverage * subsidy, 6)}`,
+    },
+    {
+      name: "absent_revenue_is_null_not_zero",
+      ok: haveRevenue || (coverage === null && subsidy === null),
+      detail: haveRevenue
+        ? "revenue observed"
+        : "revenue not observed, so both ratios are null",
+    },
+    {
+      name: "emission_is_positive",
+      ok: emissionUsd > 0,
+      detail: `emission ${round(emissionTao, 6)} TAO over ${window_days} day(s)`,
+    },
+  ];
+
+  return {
+    window_days,
+    emission: {
+      basis: "tao_total",
+      tao: round(emissionTao, 6),
+      usd: round(emissionUsd, 6),
+      alternates: { alpha_out_priced: alphaPriced, owner_take: ownerTake },
+    },
+    revenue_usd: revenue_usd === null ? null : round(revenue_usd, 6),
+    coverage_ratio: coverage,
+    subsidy_multiple: subsidy,
+    verification: { verified: checks.every((c) => c.ok), checks },
+  };
+}

--- a/tests/revenue-chain-inflow.test.ts
+++ b/tests/revenue-chain-inflow.test.ts
@@ -1,0 +1,177 @@
+// #10445: four rules, each of which was a wrong answer before it was a rule.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { aggregateChainInflow } from "../src/revenue-chain-inflow.ts";
+import { subnetAccountSs58 } from "../src/subnet-accounts.ts";
+
+const COLLECTOR = "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9";
+const PAYER = "5DJJAZLqnR3P4Um1UFuuZQ9DFVqoGwmeDXvcZDVPhH5V9NUY";
+
+function transfer(
+  over: Partial<
+    Parameters<typeof aggregateChainInflow>[0]["transfers"][0]
+  > = {},
+) {
+  return {
+    to: COLLECTOR,
+    from: PAYER,
+    amount_tao: 0.05,
+    block_number: 8813462,
+    observed_at: 1_786_400_000_000,
+    ...over,
+  };
+}
+
+function run(over: Partial<Parameters<typeof aggregateChainInflow>[0]> = {}) {
+  return aggregateChainInflow({
+    collectors: [COLLECTOR],
+    netuid: 64,
+    transfers: [transfer()],
+    usdAtInstant: () => 204.03,
+    ...over,
+  });
+}
+
+describe("inbound only", () => {
+  test("sums inbound to a declared collector", () => {
+    const r = run({ transfers: [transfer(), transfer({ amount_tao: 0.1 })] });
+    assert.ok(Math.abs(r.tao - 0.15) < 1e-9);
+    assert.equal(r.transfer_count, 2);
+    assert.ok(Math.abs((r.usd as number) - 0.15 * 204.03) < 1e-4);
+  });
+
+  test("outbound is excluded and NAMED, never netted", () => {
+    // Netting would let a subnet reduce its own reported revenue by moving its
+    // money out of the collector.
+    const r = run({
+      transfers: [
+        transfer(),
+        transfer({ to: PAYER, from: COLLECTOR, amount_tao: 5 }),
+      ],
+    });
+    assert.ok(Math.abs(r.tao - 0.05) < 1e-9, "outbound must not be subtracted");
+    assert.equal(r.transfer_count, 1);
+    const out = r.excluded.find((e) => e.reason.includes("outbound"));
+    assert.equal(out?.count, 1);
+    assert.equal(out?.tao, 5);
+  });
+
+  test("a transfer to an unrelated address is ignored entirely", () => {
+    const r = run({ transfers: [transfer({ to: "5Unrelated" })] });
+    assert.equal(r.tao, 0);
+    assert.equal(r.transfer_count, 0);
+    assert.deepEqual(r.excluded, []);
+  });
+});
+
+describe("protocol accounts are refused", () => {
+  test("a subnet's own TAO reserve cannot be a collector", () => {
+    // The exact address #10448 nearly recorded as a Chutes revenue collector.
+    const pool = subnetAccountSs58(64) as string;
+    const r = run({
+      collectors: [pool],
+      transfers: [transfer({ to: pool, amount_tao: 105 })],
+    });
+    assert.equal(r.tao, 0, "no inflow may be counted for a rejected collector");
+    assert.equal(r.rejected_collectors.length, 1);
+    assert.match(r.rejected_collectors[0].reason, /netuid 64/);
+    assert.match(r.rejected_collectors[0].reason, /capital flow, not revenue/);
+  });
+
+  test("rejecting one collector does not reject the others", () => {
+    const pool = subnetAccountSs58(64) as string;
+    const r = run({
+      collectors: [pool, COLLECTOR],
+      transfers: [transfer(), transfer({ to: pool, amount_tao: 105 })],
+    });
+    assert.ok(Math.abs(r.tao - 0.05) < 1e-9);
+    assert.equal(r.rejected_collectors.length, 1);
+  });
+});
+
+describe("pricing at the instant", () => {
+  test("each transfer is priced at its own moment, not a window average", () => {
+    // Two transfers of equal size at different prices must not both take the
+    // later rate.
+    const rates: Record<number, number> = {
+      1000000000000: 100,
+      2000000000000: 300,
+    };
+    const r = run({
+      transfers: [
+        transfer({ observed_at: 1000000000000, amount_tao: 1 }),
+        transfer({ observed_at: 2000000000000, amount_tao: 1 }),
+      ],
+      usdAtInstant: (at) => rates[at] ?? null,
+    });
+    assert.equal(r.tao, 2);
+    assert.equal(r.usd, 400); // 1*100 + 1*300, not 2*300 or 2*100
+  });
+
+  test("an unpriceable total is null, not zero", () => {
+    const r = run({ usdAtInstant: () => null });
+    assert.ok(r.tao > 0, "the TAO total is still real");
+    assert.equal(r.usd, null);
+  });
+
+  test("partial pricing reports what it could price", () => {
+    const r = run({
+      transfers: [
+        transfer({ observed_at: 1, amount_tao: 1 }),
+        transfer({ observed_at: 2, amount_tao: 1 }),
+      ],
+      usdAtInstant: (at) => (at === 1 ? 100 : null),
+    });
+    assert.equal(r.tao, 2);
+    assert.equal(r.usd, 100);
+    assert.equal(r.transfer_count, 2, "the gap is visible from transfer_count");
+  });
+
+  test("a non-finite rate is treated as unpriced, not as NaN", () => {
+    const r = run({ usdAtInstant: () => Number.NaN });
+    assert.equal(r.usd, null);
+  });
+});
+
+describe("alpha is classified, not summed", () => {
+  test("an alpha-denominated inflow is excluded as circular", () => {
+    const r = run({
+      transfers: [transfer(), transfer({ amount_tao: 99, alpha_netuid: 64 })],
+    });
+    assert.ok(Math.abs(r.tao - 0.05) < 1e-9);
+    const alpha = r.excluded.find((e) => e.reason.includes("circular"));
+    assert.equal(alpha?.count, 1);
+    assert.equal(alpha?.tao, 99);
+  });
+
+  test("a null alpha_netuid is a TAO transfer, not an alpha one", () => {
+    const r = run({ transfers: [transfer({ alpha_netuid: null })] });
+    assert.ok(Math.abs(r.tao - 0.05) < 1e-9);
+    assert.deepEqual(r.excluded, []);
+  });
+});
+
+describe("degenerate amounts", () => {
+  test("zero, negative and non-finite amounts are excluded with a reason", () => {
+    const r = run({
+      transfers: [
+        transfer(),
+        transfer({ amount_tao: 0 }),
+        transfer({ amount_tao: -1 }),
+        transfer({ amount_tao: Number.NaN }),
+      ],
+    });
+    assert.ok(Math.abs(r.tao - 0.05) < 1e-9);
+    assert.equal(r.transfer_count, 1);
+    const bad = r.excluded.find((e) => e.reason.includes("non-positive"));
+    assert.equal(bad?.count, 3);
+  });
+
+  test("an empty window is a real zero with a null price", () => {
+    const r = run({ transfers: [] });
+    assert.equal(r.tao, 0);
+    assert.equal(r.usd, null);
+    assert.equal(r.transfer_count, 0);
+    assert.equal(r.netuid, 64);
+  });
+});

--- a/tests/revenue-coverage.test.ts
+++ b/tests/revenue-coverage.test.ts
@@ -1,0 +1,152 @@
+// #10446: the ratio, and the null that must never become a zero.
+//
+// The fixture is the real SN64 measurement from #10448/#10449, so a change that
+// silently alters the denominator shows up as a number the epic already
+// published.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BLOCKS_PER_DAY,
+  OWNER_CUT,
+  computeCoverage,
+} from "../src/revenue-coverage.ts";
+
+// SN64, 2026-08-10: tao_total 0.063615264/block, TAO $204.03, revenue
+// ~$11,668/day. Published in #10439 as 8.0:1 / 12.5%.
+const SN64 = {
+  tao_total_per_block: 0.063615264,
+  alpha_out_per_block: 1,
+  alpha_price_tao: 0.086933658,
+  usd_per_tao: 204.03,
+  window_days: 1,
+  revenue_usd: 11668,
+};
+
+describe("the published SN64 numbers", () => {
+  test("reproduces 8.0:1 and 12.5%", () => {
+    const r = computeCoverage(SN64);
+    assert.equal(r.emission.basis, "tao_total");
+    assert.ok(Math.abs(r.emission.tao - 458.03) < 0.01, `${r.emission.tao}`);
+    assert.ok(Math.abs(r.emission.usd - 93452) < 5, `${r.emission.usd}`);
+    assert.ok(Math.abs((r.subsidy_multiple ?? 0) - 8.0) < 0.05);
+    assert.ok(Math.abs((r.coverage_ratio ?? 0) - 0.125) < 0.001);
+    assert.equal(r.verification.verified, true);
+  });
+
+  test("the two ratios are reciprocal, and the check says so", () => {
+    const r = computeCoverage(SN64);
+    assert.ok(
+      Math.abs(
+        (r.coverage_ratio as number) * (r.subsidy_multiple as number) - 1,
+      ) < 1e-6,
+    );
+    const check = r.verification.checks.find(
+      (c) => c.name === "ratios_are_reciprocal",
+    );
+    assert.equal(check?.ok, true);
+  });
+
+  test("a window scales the emission linearly", () => {
+    const day = computeCoverage(SN64);
+    const week = computeCoverage({ ...SN64, window_days: 7 });
+    assert.ok(Math.abs(week.emission.tao - day.emission.tao * 7) < 1e-6);
+    assert.equal(week.window_days, 7);
+  });
+});
+
+describe("absent revenue is null, never zero", () => {
+  test("null revenue yields null ratios, not 0", () => {
+    // 127 of 129 subnets are in this state. Rendering them "0% covered" would
+    // be a false claim about every one of them, at scale.
+    const r = computeCoverage({ ...SN64, revenue_usd: null });
+    assert.equal(r.revenue_usd, null);
+    assert.equal(r.coverage_ratio, null);
+    assert.equal(r.subsidy_multiple, null);
+    assert.equal(r.verification.verified, true);
+    const check = r.verification.checks.find(
+      (c) => c.name === "absent_revenue_is_null_not_zero",
+    );
+    assert.match(check?.detail ?? "", /not observed/);
+  });
+
+  test("an OBSERVED zero is different from an absent one", () => {
+    // Zero revenue is a measurement: coverage is genuinely 0%. The subsidy
+    // multiple is null because dividing by it is undefined, not infinite.
+    const r = computeCoverage({ ...SN64, revenue_usd: 0 });
+    assert.equal(r.revenue_usd, 0);
+    assert.equal(r.coverage_ratio, 0);
+    assert.equal(r.subsidy_multiple, null);
+    assert.equal(r.verification.verified, true);
+  });
+
+  test("zero emission yields null rather than Infinity", () => {
+    // An emission-gated subnet has no ratio. Infinity would sort as the worst
+    // possible subsidy rather than as "not applicable".
+    const r = computeCoverage({ ...SN64, tao_total_per_block: 0 });
+    assert.equal(r.coverage_ratio, null);
+    assert.equal(r.subsidy_multiple, null);
+    const check = r.verification.checks.find(
+      (c) => c.name === "emission_is_positive",
+    );
+    assert.equal(check?.ok, false);
+    assert.equal(r.verification.verified, false);
+  });
+});
+
+describe("the alternate denominators", () => {
+  test("alpha_out priced, and owner_take at 18%", () => {
+    const r = computeCoverage(SN64);
+    const alpha = r.emission.alternates.alpha_out_priced;
+    assert.ok(alpha);
+    // 1 alpha/block * 7200 * 0.086933658
+    assert.ok(Math.abs(alpha.tao - 7200 * 0.086933658) < 1e-6);
+
+    const owner = r.emission.alternates.owner_take;
+    assert.ok(Math.abs(owner.tao - r.emission.tao * OWNER_CUT) < 1e-6);
+    // 18%, not 1/6 — the difference is ~6 TAO/day here.
+    assert.ok(Math.abs(OWNER_CUT - 0.18) < 0.0001);
+    assert.ok(Math.abs(owner.tao - r.emission.tao / 6) > 1);
+  });
+
+  test("alpha pricing is null when either input is missing", () => {
+    for (const missing of [
+      { alpha_out_per_block: undefined },
+      { alpha_price_tao: undefined },
+    ]) {
+      const r = computeCoverage({ ...SN64, ...missing });
+      assert.equal(r.emission.alternates.alpha_out_priced, null);
+      // The published basis is unaffected — an absent alternate must never
+      // change the headline denominator.
+      assert.equal(r.emission.basis, "tao_total");
+      assert.ok(r.emission.tao > 0);
+    }
+  });
+});
+
+describe("bad input throws instead of yielding NaN", () => {
+  test("a NaN ratio would serialise as null and be read as 'not observed'", () => {
+    for (const bad of [
+      { tao_total_per_block: Number.NaN },
+      { tao_total_per_block: -1 },
+      { usd_per_tao: Number.POSITIVE_INFINITY },
+      { usd_per_tao: -0.5 },
+      { window_days: Number.NaN },
+      { window_days: -7 },
+    ]) {
+      assert.throws(() => computeCoverage({ ...SN64, ...bad }), /finite/);
+    }
+    assert.throws(
+      () => computeCoverage({ ...SN64, revenue_usd: Number.NaN }),
+      /revenue_usd/,
+    );
+    assert.throws(
+      () => computeCoverage({ ...SN64, revenue_usd: -1 }),
+      /revenue_usd/,
+    );
+  });
+});
+
+test("BLOCKS_PER_DAY is one day at 12s", () => {
+  assert.equal(BLOCKS_PER_DAY, 7200);
+  assert.equal((86400 / 12) | 0, BLOCKS_PER_DAY);
+});


### PR DESCRIPTION
Two modules that together turn declarations into a number: the ratio itself, and the on-chain half of its numerator.

---

# Part 1 — `coverage_ratio` and `subsidy_multiple` (#10446)

```
coverage_ratio   = revenue / emission     "12.5% covered"
subsidy_multiple = emission / revenue     "8:1"  ← the ecosystem's own phrasing
```

Both published, because both get quoted and a reader given one reliably invents the other wrong.

**The denominator is `tao_total`** (`SubnetTaoInEmission + SubnetExcessTao`) — fully *measured* rather than reconstructed, and it reconciles with the "$52M a year" framing already in circulation. The alternates (`alpha_out` priced at market, and the owner's 18%) are computed alongside and **never silently substituted**.

## Absent revenue is null, never zero

**127 of 129 subnets have no readable revenue figure.** Rendering them "0% covered" would be a false claim about every one of them, at scale.

| revenue | coverage_ratio | subsidy_multiple |
|---|---|---|
| `null` (not observed) | `null` | `null` |
| `0` (measured) | `0` | `null` — undefined, not infinite |

Zero *emission* also yields `null` rather than `Infinity`, which would sort as the worst possible subsidy rather than "not applicable".

**Bad input throws** rather than propagating `NaN` — a `NaN` ratio serialises as `null`, the *same output* as "not observed". Those must never be confusable.

**Fixtured on the real measurement:** `458.03 TAO/day × $204.03` vs `$11,668/day` → **8.0:1 / 12.5%**, the numbers #10439 already published.

---

# Part 2 — chain inflow (#10445)

The Tier-A path. #10448 proved it works (32/32 payments, delta `0.000000000 TAO`) *and* proved its limit: the TAO channel was $1,036.50 of $9,776.06 that day. This **corroborates** the feed on ~10% of the figure; it does not replace it.

Four rules, each of which was a wrong answer first:

1. **Inbound only.** A sweep *out* of a collector is treasury movement. Netting it would let a subnet reduce its reported revenue by moving its own money — so outbound is excluded and **named**, never subtracted.
2. **Protocol accounts refused**, via #10442's derivation. A subnet's own TAO reserve receives large many-party inbound because that is what buying alpha looks like. Rejecting one collector does not reject the others.
3. **Priced at each instant.** Two equal transfers at $100 and $300 total **$400** — not $200 or $600. An unpriceable total is `null`; partial pricing reports what it priced with the gap visible from `transfer_count`.
4. **Alpha classified, not summed.** An alpha-denominated inflow is circular; adding it to a USD total would quietly count a subnet paying itself.

Every exclusion carries its reason **and its magnitude** — a silently-filtered inflow is indistinguishable from one that never happened.

---

## Verification

- **100% statements, branches, functions and lines on both modules**
- 23 tests total; `tsc`, eslint, prettier clean
- The coverage result carries a `verification` block with three evaluated identities, matching `get_emission_pipeline`'s pattern

Closes #10446
Closes #10445
