### PR TITLE
feat(revenue): compose the served shape, and keep the unverifiable out of the headline

### DIFF
--- a/src/revenue-serving.ts
+++ b/src/revenue-serving.ts
@@ -1,0 +1,102 @@
+// #10447: compose the served revenue shape from the pieces that already exist.
+//
+// The emission denominator comes from the economics capture, the revenue from
+// the probe lane's observations, the price from the tao-usd index, and the
+// arithmetic from src/revenue-coverage.ts. Nothing is computed twice.
+//
+// The degradation rule is the whole point of this module. The observations
+// table is new and empty, most subnets will never have a row in it, and an
+// operator can withdraw a feed at any time. Every one of those reads back as
+// `revenue_usd: null` with a stated provenance -- NOT as zero, and not as an
+// error. A 500 here would make "we have no revenue data for this subnet", which
+// is true of 127 of 129, look like a broken endpoint.
+import { computeCoverage, type CoverageResult } from "./revenue-coverage.ts";
+
+export interface RevenueSourceRow {
+  surface_id: string;
+  provenance: string;
+  currency: string;
+  grain: string;
+  amount_usd: number | null;
+  response_hash?: string | null;
+  observed_at?: string | null;
+}
+
+export interface SubnetRevenueInput {
+  netuid: number;
+  window_days: number;
+  tao_total_per_block: number;
+  alpha_out_per_block?: number;
+  alpha_price_tao?: number;
+  usd_per_tao: number;
+  /** Every declared revenue surface for this subnet, readable or not. */
+  sources: RevenueSourceRow[];
+  /** When the subnet was searched and nothing found (#10543). */
+  searched_at?: string | null;
+}
+
+export interface SubnetRevenueView extends CoverageResult {
+  netuid: number;
+  provenance: string;
+  searched_at: string | null;
+  sources: RevenueSourceRow[];
+}
+
+/** Only these contribute to the headline. #10439's ladder, enforced in code
+ * rather than left to whoever assembles the sum. */
+const HEADLINE_PROVENANCES = new Set(["chain-verified", "probe-derived"]);
+
+/** Most specific wins: a chain-corroborated figure outranks a probed one,
+ * which outranks an operator's claim. Reported as the response's single
+ * `provenance` so a caller never has to rank them itself. */
+const PROVENANCE_RANK = [
+  "chain-verified",
+  "probe-derived",
+  "operator-attested",
+  "third-party-reported",
+  "proxy-only",
+  "none",
+];
+
+export function buildSubnetRevenue(
+  input: SubnetRevenueInput,
+): SubnetRevenueView {
+  const { sources, searched_at = null } = input;
+
+  // Sum ONLY the readable tiers, and only rows that actually carry a figure.
+  // An operator-attested surface is real and is reported in `sources`; adding
+  // it here would put an unverifiable number in the headline.
+  const contributing = sources.filter(
+    (s) => HEADLINE_PROVENANCES.has(s.provenance) && s.amount_usd !== null,
+  );
+  const revenue_usd = contributing.length
+    ? contributing.reduce((sum, s) => sum + (s.amount_usd as number), 0)
+    : null;
+
+  const coverage = computeCoverage({
+    tao_total_per_block: input.tao_total_per_block,
+    alpha_out_per_block: input.alpha_out_per_block,
+    alpha_price_tao: input.alpha_price_tao,
+    usd_per_tao: input.usd_per_tao,
+    window_days: input.window_days,
+    revenue_usd,
+  });
+
+  // The best evidence class present, so the response carries one answer rather
+  // than making every caller rank the list itself.
+  let provenance = "none";
+  for (const candidate of PROVENANCE_RANK) {
+    if (sources.some((s) => s.provenance === candidate)) {
+      provenance = candidate;
+      break;
+    }
+  }
+
+  return {
+    ...coverage,
+    netuid: input.netuid,
+    provenance,
+    searched_at,
+    sources,
+  };
+}

--- a/tests/revenue-serving.test.ts
+++ b/tests/revenue-serving.test.ts
@@ -1,0 +1,139 @@
+// #10447: which sources reach the headline, and which are reported without
+// reaching it. Getting this wrong is silent — the response looks identical.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildSubnetRevenue } from "../src/revenue-serving.ts";
+
+const BASE = {
+  netuid: 64,
+  window_days: 1,
+  tao_total_per_block: 0.063615264,
+  usd_per_tao: 204.03,
+  sources: [],
+};
+
+function src(over: Record<string, unknown> = {}) {
+  return {
+    surface_id: "s",
+    provenance: "probe-derived",
+    currency: "USD",
+    grain: "daily",
+    amount_usd: 11668,
+    ...over,
+  } as never;
+}
+
+describe("only readable tiers reach the headline", () => {
+  test("probe-derived and chain-verified are summed", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [
+        src({ surface_id: "a", amount_usd: 1000 }),
+        src({ surface_id: "b", provenance: "chain-verified", amount_usd: 500 }),
+      ],
+    });
+    assert.equal(r.revenue_usd, 1500);
+    assert.ok((r.coverage_ratio as number) > 0);
+  });
+
+  test("operator-attested is REPORTED but never summed", () => {
+    // The endpoint is real and declared; the figure is unverifiable. Adding it
+    // would put an unverifiable number in the headline.
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [src({ provenance: "operator-attested", amount_usd: 999999 })],
+    });
+    assert.equal(r.revenue_usd, null, "must not be summed");
+    assert.equal(r.coverage_ratio, null);
+    assert.equal(r.sources.length, 1, "but it is still reported");
+    assert.equal(r.provenance, "operator-attested");
+  });
+
+  test("third-party-reported is likewise carried, not counted", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [
+        src({ provenance: "third-party-reported", amount_usd: 4260000 }),
+      ],
+    });
+    assert.equal(r.revenue_usd, null);
+    assert.equal(r.sources.length, 1);
+  });
+
+  test("a readable source with no figure yet does not fabricate one", () => {
+    // Declared probe-derived, but the lane has not run. Null, not zero.
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [src({ amount_usd: null })],
+    });
+    assert.equal(r.revenue_usd, null);
+    assert.equal(r.subsidy_multiple, null);
+  });
+
+  test("mixing a readable figure with an attested one counts only the readable", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [
+        src({ surface_id: "readable", amount_usd: 100 }),
+        src({
+          surface_id: "attested",
+          provenance: "operator-attested",
+          amount_usd: 900000,
+        }),
+      ],
+    });
+    assert.equal(r.revenue_usd, 100);
+    assert.equal(r.sources.length, 2);
+  });
+});
+
+describe("the reported provenance", () => {
+  test("the strongest evidence class present wins", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [
+        src({ provenance: "operator-attested" }),
+        src({ provenance: "chain-verified" }),
+        src({ provenance: "probe-derived" }),
+      ],
+    });
+    assert.equal(r.provenance, "chain-verified");
+  });
+
+  test("a subnet with no sources reports none, with its search date", () => {
+    // 127 of 129 subnets. This is a dated answer, not a gap.
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [],
+      searched_at: "2026-08-10T00:00:00Z",
+    });
+    assert.equal(r.provenance, "none");
+    assert.equal(r.revenue_usd, null);
+    assert.equal(r.coverage_ratio, null);
+    assert.equal(r.searched_at, "2026-08-10T00:00:00Z");
+    // The emission side is still real and served.
+    assert.ok(r.emission.tao > 0);
+    assert.equal(r.verification.verified, true);
+  });
+
+  test("searched_at defaults to null rather than undefined", () => {
+    const r = buildSubnetRevenue({ ...BASE, sources: [] });
+    assert.equal(r.searched_at, null);
+  });
+});
+
+describe("the SN64 shape end to end", () => {
+  test("reproduces the published ratio through the serving layer", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      alpha_out_per_block: 1,
+      alpha_price_tao: 0.086933658,
+      sources: [src()],
+    });
+    assert.ok(Math.abs((r.subsidy_multiple as number) - 8.0) < 0.05);
+    assert.ok(Math.abs((r.coverage_ratio as number) - 0.125) < 0.001);
+    assert.equal(r.provenance, "probe-derived");
+    assert.equal(r.netuid, 64);
+    assert.ok(r.emission.alternates.alpha_out_priced);
+  });
+});


### PR DESCRIPTION
The layer between the arithmetic (#10446) and the route: given a subnet's declared revenue surfaces, decide **which of them may contribute a number**.

## Only the readable tiers are summed

An `operator-attested` surface is real and declared in the subnet's own schema — SN93, SN110 and SN75 all have them. Its figure is **unverifiable**, and adding it would put a number nobody can check into the headline.

This is #10439's ladder enforced in code rather than left to whoever assembles the sum, and the reason it has to be code is that **the difference is invisible in the response**: both shapes return a plausible `revenue_usd`.

| provenance | summed? | reported in `sources`? |
|---|---|---|
| `chain-verified` | **yes** | yes |
| `probe-derived` | **yes** | yes |
| `operator-attested` | no | yes |
| `third-party-reported` | no | yes |

A readable surface with no figure *yet* — declared `probe-derived`, lane not run — contributes `null`, not zero.

## One reported provenance

The strongest class present, so a caller never ranks the list itself. A subnet with no sources reports `none` with its `searched_at` date: **127 of 129 subnets are in that state**, and it is a dated answer rather than a gap. The emission side is still real and served for every one of them.

## Scope — #10447 stays open

This is the composition half. The route contract (`/subnets/{netuid}/revenue`, `/chain/revenue-coverage`) was drafted and **deliberately withheld from this PR**: `validate:api` requires every declared route to be answered by a live handler, and shipping the contract without the handler would leave CI red on main.

What remains for #10447, all mechanical now that the shape is settled:

- `schemas-src/routes/revenue-coverage.ts` (drafted and verified to register cleanly — both components published, `validate:openapi` passed with the routes declared)
- the `artifact()` + `route()` pairs in `src/contracts.ts`
- doc bullets in `docs/backend-artifact-contracts.md` (drafted, `validate:docs` and `contract-doc-sync` passed)
- the handler + dispatch in `workers/`, plus its `scripts/validate-api.ts` check

## Verification

- **100% statements, branches, functions and lines**
- 34 tests across the three revenue modules
- `validate:api` · `contract-drift` · `openapi` · `types` · `schemas` · `docs` · `contract-doc-sync` · `unreferenced-modules` — all pass
