### PR TITLE
fix(ci): a sweep's verdict must survive its own logging

### DIFF
--- a/.github/workflows/check-adversarial-surface.yml
+++ b/.github/workflows/check-adversarial-surface.yml
@@ -58,6 +58,7 @@ jobs:
         run: npm ci
 
       - name: Probe the surface
+        shell: bash
         run: |
           node scripts/check-adversarial-surface.ts | tee adversarial.log
           {

--- a/.github/workflows/check-cross-surface-values.yml
+++ b/.github/workflows/check-cross-surface-values.yml
@@ -54,6 +54,7 @@ jobs:
         run: npm ci
 
       - name: Compare the three surfaces
+        shell: bash
         run: |
           node scripts/check-cross-surface-values.ts | tee cross-surface.log
           {

--- a/.github/workflows/check-graphql-conformance.yml
+++ b/.github/workflows/check-graphql-conformance.yml
@@ -59,6 +59,7 @@ jobs:
         run: npm ci
 
       - name: Execute every Query field against production
+        shell: bash
         run: |
           node scripts/check-graphql-conformance.ts | tee graphql-conformance.log
           {

--- a/.github/workflows/check-graphql-int-range.yml
+++ b/.github/workflows/check-graphql-int-range.yml
@@ -59,6 +59,7 @@ jobs:
         run: npm ci
 
       - name: Measure every published value against GraphQL's Int
+        shell: bash
         run: |
           node scripts/check-graphql-int-range.ts | tee int-range.log
           {

--- a/.github/workflows/check-graphql-nullability.yml
+++ b/.github/workflows/check-graphql-nullability.yml
@@ -64,6 +64,7 @@ jobs:
         run: npm ci
 
       - name: Probe every generated non-null against production
+        shell: bash
         run: |
           node scripts/check-graphql-nullability.ts | tee nullability.log
           {

--- a/.github/workflows/check-mcp-conformance.yml
+++ b/.github/workflows/check-mcp-conformance.yml
@@ -67,6 +67,7 @@ jobs:
       # publish, and both halves have to come from production for the answer
       # to mean anything.
       - name: Validate live MCP responses against their published outputSchemas
+        shell: bash
         run: |
           node scripts/check-mcp-conformance.ts | tee mcp-conformance.log
           {

--- a/.github/workflows/check-operation-latency.yml
+++ b/.github/workflows/check-operation-latency.yml
@@ -56,6 +56,7 @@ jobs:
         run: npm ci
 
       - name: Time every operation
+        shell: bash
         run: |
           node scripts/check-operation-latency.ts | tee latency.log
           {

--- a/.github/workflows/check-response-conformance.yml
+++ b/.github/workflows/check-response-conformance.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Validate live responses against the published spec
         env:
           LIVE_ALERT_WEBHOOK_URL: ${{ secrets.LIVE_ALERT_WEBHOOK_URL }}
+        shell: bash
         run: |
           node scripts/check-response-conformance.ts | tee conformance.log
           {

--- a/.github/workflows/discover-testnet-surfaces.yml
+++ b/.github/workflows/discover-testnet-surfaces.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Probe testnet subnet surfaces
         env:
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
+        shell: bash
         run: |
           node scripts/discover-testnet-surfaces.ts --out testnet-discovery.json | tee discovery.log
           {

--- a/.github/workflows/enrichment-issues.yml
+++ b/.github/workflows/enrichment-issues.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Generate enrichment issues
         env:
           GH_TOKEN: ${{ github.token }}
+        shell: bash
         run: node scripts/enrichment-issues.ts --write | tee enrichment-run.log
 
       - name: Job summary

--- a/scripts/validate-workflows.ts
+++ b/scripts/validate-workflows.ts
@@ -1,6 +1,8 @@
 import { promises as fs, readFileSync } from "node:fs";
 import path from "node:path";
+import { parse as parseYaml } from "yaml";
 import { repoRoot } from "./lib.ts";
+import { pipedLogSteps } from "./workflow-pipe-status.ts";
 import {
   OBSERVABILITY_TOKEN_ENV,
   buildStepScripts,
@@ -59,6 +61,9 @@ check(
   "scripts/build.ts's productionSteps() no longer declares any instrumented script as a nodeStep() -- either the step list moved (so the publish build is no longer checked) or the instrumentation was dropped",
 );
 
+/** How many steps piped a report into `tee` -- see the rule in the loop. */
+let pipedLogStepCount = 0;
+
 for (const workflow of workflows) {
   const content = await fs.readFile(path.join(workflowRoot, workflow), "utf8");
   check(
@@ -76,6 +81,17 @@ for (const workflow of workflows) {
     workflow,
     "must not mask failures with continue-on-error",
   );
+  // The sibling of the rule above: the other way a workflow keeps running a
+  // check while discarding its verdict. See scripts/workflow-pipe-status.ts
+  // for what it cost (#10564) and why `shell: bash` is the fix.
+  for (const step of pipedLogSteps(parseYaml(content))) {
+    pipedLogStepCount += 1;
+    check(
+      step.preservesStatus,
+      workflow,
+      `step "${step.name}" pipes into \`tee\`, so the script's exit status is discarded -- declare \`shell: bash\` (Actions' opt-in to \`-eo pipefail\`) or \`set -o pipefail\` in the run block`,
+    );
+  }
   check(
     !/\$\{\{\s*github\.event\.(issue|comment|pull_request)\.(body|title)/.test(
       content,
@@ -390,6 +406,18 @@ for (const workflow of workflows) {
   }
 }
 
+// The same vacuous-pass guard the observability rule carries. `pipedLogSteps`
+// reads a PARSED workflow, so a YAML shape change (a step list that stops being
+// a sequence, a `run:` that becomes a mapping) would silently yield nothing and
+// every workflow would satisfy the pipe rule by finding no pipes at all. The
+// sweeps are the population it exists for, so if they ever stop being visible
+// the rule has to fail rather than pass.
+check(
+  pipedLogStepCount > 0,
+  "scripts/validate-workflows.ts",
+  "found no run steps piping into `tee` -- the scan is broken, so the exit-status rule above proves nothing",
+);
+
 if (errors.length > 0) {
   console.error(`Workflow validation failed with ${errors.length} issue(s):`);
   for (const error of errors) {
@@ -398,7 +426,9 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`Validated ${workflows.length} workflow file(s).`);
+console.log(
+  `Validated ${workflows.length} workflow file(s); ${pipedLogStepCount} step(s) pipe a report into \`tee\` and preserve its exit status.`,
+);
 
 function check(condition: unknown, workflow: string, message: string): void {
   if (!condition) {

--- a/scripts/workflow-pipe-status.ts
+++ b/scripts/workflow-pipe-status.ts
@@ -1,0 +1,90 @@
+// Keeps a scheduled sweep's verdict from being thrown away by its own logging.
+//
+// The sweeps pipe their report into `tee` so the text survives for the job
+// summary. That hands the STEP's exit status to `tee`, which always succeeds,
+// because Actions' default shell on Linux is `bash -e {0}` -- `-e` without
+// `-o pipefail`. Ten steps do this and eight of them signal failure by exit
+// code, so eight scheduled sweeps ran green for months while reporting real
+// findings (#10564):
+//
+//   check-operation-latency    printed "12 over the 5000ms budget"
+//                              and "3 stale DECLARED entr(y/ies)"  -> green
+//   check-cross-surface-values printed "6 divergence(s)"           -> green
+//
+// Both scripts exit 1 on exactly those conditions. Nothing was wrong with the
+// checks; the verdict never left the pipe.
+//
+// `shell: bash` is Actions' documented opt-in to
+// `bash --noprofile --norc -eo pipefail {0}`, so declaring it restores the
+// status without changing a byte of what the step prints.
+//
+// This module is the derivation, kept separate from the validator so it can be
+// unit-tested against synthetic documents -- the same split
+// scripts/workflow-observability.ts uses, and for the same reason: the
+// validator self-executes on import, so a test cannot reach a helper declared
+// inside it.
+
+/** The subset of a workflow document this rule reads. */
+interface WorkflowRunDefaults {
+  defaults?: { run?: { shell?: unknown } };
+}
+interface WorkflowStep extends WorkflowRunDefaults {
+  name?: unknown;
+  run?: unknown;
+  shell?: unknown;
+}
+interface WorkflowJob extends WorkflowRunDefaults {
+  steps?: unknown;
+}
+interface WorkflowDocument extends WorkflowRunDefaults {
+  jobs?: unknown;
+}
+
+export interface PipedLogStep {
+  /** The step's `name`, or `(unnamed)` -- only ever used in the message. */
+  name: string;
+  /** Whether the pipeline's exit status survives `tee`. */
+  preservesStatus: boolean;
+}
+
+/**
+ * Every step whose `run` pipes into `tee`, with whether its exit status
+ * survives.
+ *
+ * Matched on `tee` specifically rather than on any pipe. `tee` is THIS repo's
+ * idiom for "keep the output for the job summary and still fail on it", so a
+ * `tee` pipe is exactly the case where the status is meant to matter. A rule
+ * over every pipe would flag `grep`/`head` filters where a non-zero status is
+ * ordinary and expected, and a gate that fails on correct code teaches people
+ * to exempt it.
+ *
+ * `shell` may be declared on the step, on the job's defaults, or on the
+ * workflow's; the innermost wins, which is Actions' own precedence.
+ *
+ * Reads a PARSED document rather than the file text, so a reformatting -- a
+ * folded scalar, a quoted key, a different indent -- cannot make the rule stop
+ * seeing a step it was written to see.
+ */
+export function pipedLogSteps(document: unknown): PipedLogStep[] {
+  const doc = (document ?? {}) as WorkflowDocument;
+  const found: PipedLogStep[] = [];
+  const jobs = doc.jobs;
+  if (typeof jobs !== "object" || jobs === null) return found;
+  for (const job of Object.values(jobs as Record<string, WorkflowJob>)) {
+    if (!Array.isArray(job?.steps)) continue;
+    for (const step of job.steps as WorkflowStep[]) {
+      const run = step?.run;
+      if (typeof run !== "string" || !/\|\s*tee\b/.test(run)) continue;
+      const shell =
+        step?.shell ?? job?.defaults?.run?.shell ?? doc.defaults?.run?.shell;
+      found.push({
+        name: typeof step?.name === "string" ? step.name : "(unnamed)",
+        // `set -o pipefail` and `set -euo pipefail` are both in use in this
+        // repo, so match any `set` line that turns it on rather than one form.
+        preservesStatus:
+          shell === "bash" || /\bset\b[^\n]*\bpipefail\b/.test(run),
+      });
+    }
+  }
+  return found;
+}

--- a/tests/validate-workflows-pipe-status.test.ts
+++ b/tests/validate-workflows-pipe-status.test.ts
@@ -1,0 +1,154 @@
+// Tests for scripts/workflow-pipe-status.ts -- the rule that stopped eight
+// scheduled sweeps from reporting findings into a green run (#10564).
+//
+// The live workflows only exercise the PASSING side once they are fixed, which
+// is the shape of check that quietly stops meaning anything. These cover the
+// failing side, the three places `shell` can be declared, and the malformed
+// documents that would otherwise make the scan return nothing and pass
+// vacuously.
+
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { pipedLogSteps } from "../scripts/workflow-pipe-status.ts";
+
+const workflow = (steps: string): unknown =>
+  parse(`
+jobs:
+  sweep:
+    steps:
+${steps}
+`);
+
+describe("a step that pipes into tee", () => {
+  it("is reported as losing its status under the default shell", () => {
+    const found = pipedLogSteps(
+      workflow(`      - name: Time every operation
+        run: node scripts/check-operation-latency.ts | tee latency.log`),
+    );
+    expect(found).toEqual([
+      { name: "Time every operation", preservesStatus: false },
+    ]);
+  });
+
+  it("preserves its status with shell: bash on the step", () => {
+    const found = pipedLogSteps(
+      workflow(`      - name: Sweep
+        shell: bash
+        run: node scripts/sweep.ts | tee sweep.log`),
+    );
+    expect(found[0]?.preservesStatus).toBe(true);
+  });
+
+  it("preserves its status with an explicit set -o pipefail", () => {
+    const found = pipedLogSteps(
+      workflow(`      - name: Sweep
+        run: |
+          set -o pipefail
+          node scripts/sweep.ts | tee sweep.log`),
+    );
+    expect(found[0]?.preservesStatus).toBe(true);
+  });
+
+  // `set -euo pipefail` is the form actually used by the publish workflows, and
+  // a regex written for `set -o pipefail` alone silently misses it.
+  it("accepts the combined set -euo pipefail form", () => {
+    const found = pipedLogSteps(
+      workflow(`      - name: Sweep
+        run: |
+          set -euo pipefail
+          node scripts/sweep.ts | tee sweep.log`),
+    );
+    expect(found[0]?.preservesStatus).toBe(true);
+  });
+
+  it("reads shell from the job's defaults", () => {
+    const found = pipedLogSteps(
+      parse(`
+jobs:
+  sweep:
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Sweep
+        run: node scripts/sweep.ts | tee sweep.log
+`),
+    );
+    expect(found[0]?.preservesStatus).toBe(true);
+  });
+
+  it("reads shell from the workflow's defaults", () => {
+    const found = pipedLogSteps(
+      parse(`
+defaults:
+  run:
+    shell: bash
+jobs:
+  sweep:
+    steps:
+      - name: Sweep
+        run: node scripts/sweep.ts | tee sweep.log
+`),
+    );
+    expect(found[0]?.preservesStatus).toBe(true);
+  });
+
+  // The step's own declaration wins over the job's, which is Actions' own
+  // precedence -- so a job-wide bash default does NOT excuse a step that opts
+  // back out.
+  it("lets the step's shell override the job's default", () => {
+    const found = pipedLogSteps(
+      parse(`
+jobs:
+  sweep:
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Sweep
+        shell: sh
+        run: node scripts/sweep.ts | tee sweep.log
+`),
+    );
+    expect(found[0]?.preservesStatus).toBe(false);
+  });
+});
+
+describe("what the rule deliberately ignores", () => {
+  it("ignores a pipe that is not into tee", () => {
+    expect(
+      pipedLogSteps(
+        workflow(`      - name: Filter
+        run: node scripts/sweep.ts | grep -c warning`),
+      ),
+    ).toEqual([]);
+  });
+
+  it("ignores a step with no run block", () => {
+    expect(
+      pipedLogSteps(
+        workflow(`      - name: Checkout
+        uses: actions/checkout@v7`),
+      ),
+    ).toEqual([]);
+  });
+});
+
+// Each of these would make the scan return nothing. The validator's own
+// vacuous-pass guard fails when the total is zero across the whole tree, but
+// these pin the reason it could go to zero.
+describe("malformed documents yield nothing rather than throwing", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a scalar", "not a workflow"],
+    ["no jobs key", parse("name: Sweep\n")],
+    ["jobs that is not a mapping", parse("jobs: []\n")],
+    [
+      "a job whose steps is not a sequence",
+      parse("jobs:\n  a:\n    steps: {}\n"),
+    ],
+  ])("%s", (_label, document) => {
+    expect(pipedLogSteps(document)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Ten workflow steps pipe a report into `tee`; eight of them run a script that signals failure by
  exit code, so eight scheduled sweeps have been reporting real findings into green runs.
- `shell: bash` on those ten steps restores the status without changing what any of them prints.
- A rule in `scripts/validate-workflows.ts` makes the pattern unrepresentable, proven to fail three
  ways before being trusted.

## What Changed

**The defect.** Actions' default shell on Linux is `bash -e {0}` — `-e` **without** `-o pipefail` —
so a `node scripts/<sweep>.ts | tee <name>.log` step exits with `tee`'s status, which is always 0.
Every one of these scripts signals by `process.exit(1)` or `process.exitCode = 1`, which is exactly
what the pipe discards.

Two live proofs, both runs concluded `success`:

| sweep | printed | exits 1 on it? |
|---|---|---|
| `check-operation-latency` | `12 over the 5000ms budget`, `3 stale DECLARED entr(y/ies)` | yes |
| `check-cross-surface-values` | `6 divergence(s)` | yes — `scripts/check-cross-surface-values.ts:376` |

`check-adversarial-surface` — the answer to "no endpoint on any surface has ever been
security-tested" (#10216) — is among the eight. It is weekly and has no completed run yet, so it
would have reported into a green run on its first Sunday.

**The fix.** `shell: bash` is Actions' documented opt-in to
`bash --noprofile --norc -eo pipefail {0}`. The two steps that do not signal by exit code today
(`discover-testnet-surfaces`, `enrichment-issues`) are fixed too — nothing makes the masking correct
for them, and a script that gains an exit code later should not have to remember to fix its workflow
as well.

**The gate.** The rule lands beside `validate-workflows.ts`'s existing
`must not mask failures with continue-on-error` check — the same defect wearing a different hat. It:

- reads a **parsed** workflow, not the file text, so a reformat cannot make it stop seeing a step;
- matches `tee` specifically rather than any pipe, because `tee` is this repo's idiom for "keep the
  output and still fail on it", while a `grep`/`head` filter has an ordinary non-zero status — a gate
  that fails on correct code teaches people to exempt it;
- consults `shell` on the step, the job's defaults and the workflow's, innermost first, which is
  Actions' own precedence;
- carries the same vacuous-pass guard the observability rule has: if the scan ever finds zero piped
  steps, it fails rather than passes.

The derivation sits in its own module (`scripts/workflow-pipe-status.ts`) so it can be unit-tested —
`validate-workflows.ts` self-executes on import, so a test cannot reach a helper declared inside it.
That mirrors `scripts/workflow-observability.ts`.

**Proven to fail** before being trusted:

1. with `shell: bash` stripped from the latency sweep → `step "Time every operation" pipes into
   \`tee\`, so the script's exit status is discarded`;
2. via the vacuous-pass guard, with the scan made to match nothing → `found no run steps piping into
   \`tee\` -- the scan is broken`;
3. across the malformed documents and the shell-precedence cases in the unit test (15 tests).

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — this PR touches no
      schema, route, or artifact.)*

## Validation

Run on a clean `npm ci` + `npm run build` in this worktree:

- [x] `npm run lint` — exit 0
- [x] `npm run format:check` (touched files) — exit 0
- [x] `npm run typecheck` — exit 0
- [x] `npm run validate` — exit 0
- [x] `npm run validate:workflows` — exit 0, `31 workflow file(s); 10 step(s) pipe a report into \`tee\` and preserve its exit status`
- [x] `npx vitest run tests/validate-workflows-pipe-status.test.ts tests/validate-workflows-env-readers.test.ts` — 18 passed
- [x] `npm run scan:public-safety` — exit 0
- [x] `git diff --check` — exit 0
- [ ] `npm run check` — **fails on `main` for an unrelated pre-existing reason**: `pipeline:check`
      runs `schemas:bundle:check`, which is not a script in `package.json`. Filed as #10567. Every
      other leg of `check` (`lint`, `format:check`, `typecheck`) is ticked above individually.
- [ ] `npm run test:coverage` — not run; this PR adds no `src/**` or `workers/**` code, so
      `codecov/patch` has no changed runtime lines to measure.

## Template Used

- `backend-code.md`

Closes #10564
