### PR TITLE
feat(entities): serve the address-label registry, and stop its vocabulary drifting

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -25,6 +25,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/providers.json`: provider/source registry.
 - `/metagraph/providers/{slug}.json`: per-provider detail payload. R2-backed.
 - `/metagraph/providers/{slug}/endpoints.json`: endpoint resources for one provider or operator. R2-backed.
+- `/metagraph/entities.json`: curated address-label registry — one entry per ss58 that has cleared `docs/nametag-evidence-bar.md`, each carrying the `source_urls` that prove the attribution, plus the money-map roles (`treasury`, `burn`, `payment-collector`, `multisig`) and the `netuid` a subnet-scoped label belongs to. There is no `owner` category: subnet ownership is chain-derived from `SubnetOwner` and is never hand-declared. An empty list is the honest state of a curated layer, not a cold store.
 - `/metagraph/api-index.json`: Worker API route map and response-envelope contract.
 - `/metagraph/openapi.json`: OpenAPI 3.1 contract for backend API consumers.
 - `/metagraph/types.d.ts`: generated TypeScript definitions for consumers.

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -4996,7 +4996,7 @@ export interface components {
         /** @description One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
             labels: ({
-                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
+                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig") | null;
                 name?: string | null;
                 notes?: string | null;
                 source_urls?: string[];
@@ -5460,7 +5460,7 @@ export interface components {
             first_block?: number | null;
             first_seen_at?: string | null;
             labels?: ({
-                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
+                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig") | null;
                 name?: string | null;
                 notes?: string | null;
                 source_urls?: string[];
@@ -8092,6 +8092,55 @@ export interface components {
             endpoint_count: number;
             monitored_count: number;
             pool_eligible_count: number;
+        };
+        /** @description The curated address-label registry (#6737/#10483): one entry per ss58 that has cleared docs/nametag-evidence-bar.md, each carrying the source_urls that prove the attribution. Mirrors the built /metagraph/entities.json. */
+        EntitiesArtifact: {
+            contract_version?: string;
+            /** @description Every non-rejected label in registry/entities/, sorted by ss58. An EMPTY array is a real answer, not a cold store: the registry holds only what has cleared the evidence bar, and a curated layer with nothing in it yet is the honest state. */
+            entities: ({
+                /** @enum {string} */
+                category: "exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig";
+                name: string;
+                /** @description The subnet this address belongs to, when the label is subnet-scoped (a treasury, burn address, or payment collector). Omitted for network-wide entities like an exchange. */
+                netuid?: number;
+                notes?: string;
+                /** @description Human-governance axis only, the same shape and meaning as a subnet surface's own `review` block. `rejected` entries are filtered out at build time and never appear here. */
+                review: {
+                    review_notes?: string;
+                    /** @enum {string} */
+                    state: "community-submitted" | "maintainer-reviewed" | "rejected";
+                    submitted_at?: string;
+                    submitted_by?: string;
+                } & {
+                    [key: string]: unknown;
+                };
+                /** @constant */
+                schema_version: 1;
+                /** @description Independent public proof that this address belongs to this entity -- not that the entity exists, not that the address exists, but that the two are the same thing. See docs/nametag-evidence-bar.md for what clears the bar. */
+                source_urls: string[];
+                /** @description The labeled address, checksum-validated against Bittensor's network prefix at build time and identical to its own filename in registry/entities/. */
+                ss58: string;
+                /** @description Why this address cannot spend what it receives. Required for `category: burn`, because a burn is a CLAIM until proven -- "the team says they burn here" is an operator attestation, not a burn. */
+                unspendable_proof?: {
+                    /** @enum {string} */
+                    basis: "known-black-hole" | "provably-keyless" | "documented-recycle-call";
+                    evidence_url: string;
+                    note?: string;
+                } & {
+                    [key: string]: unknown;
+                };
+                /** @description The entity's own canonical homepage, for linking the rendered nametag. Distinct from source_urls: a homepage is not proof of address ownership. */
+                url?: string;
+            } & {
+                [key: string]: unknown;
+            })[];
+            generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
+            notes?: string | string[];
+            /** @constant */
+            schema_version: 1;
+        } & {
+            [key: string]: unknown;
         };
         /** @description An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int. */
         EpochMillis: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -29,6 +29,15 @@
     },
     {
       "contract_version": "2026-07-03.2",
+      "id": "entities",
+      "path": "/metagraph/entities.json",
+      "retirement": null,
+      "schema_ref": "#/components/schemas/EntitiesArtifact",
+      "status": "live",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-07-03.2",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
       "retirement": null,

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -36,6 +36,17 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-07-03.2",
+      "description": "Curated address-label registry (#6737/#10483): one entry per ss58 that has cleared docs/nametag-evidence-bar.md, each carrying the source_urls that prove the attribution, plus the money-map roles (treasury, burn, payment-collector, multisig) and the netuid a subnet-scoped label belongs to. There is deliberately no `owner` category — subnet ownership is chain-derived from SubnetOwner and must never be hand-declared, and a `burn` label additionally requires unspendable_proof because a burn is a claim until proven. Built from registry/entities/ minus rejected entries; an empty list is the honest state of a curated layer, not a cold store.",
+      "id": "entities",
+      "path": "/metagraph/entities.json",
+      "retirement": null,
+      "schema_ref": "#/components/schemas/EntitiesArtifact",
+      "status": "live",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-07-03.2",
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -13674,7 +13674,11 @@
                         "infra",
                         "project",
                         "operator",
-                        "other"
+                        "other",
+                        "payment-collector",
+                        "treasury",
+                        "burn",
+                        "multisig"
                       ],
                       "type": "string"
                     },
@@ -16531,7 +16535,11 @@
                         "infra",
                         "project",
                         "operator",
-                        "other"
+                        "other",
+                        "payment-collector",
+                        "treasury",
+                        "burn",
+                        "multisig"
                       ],
                       "type": "string"
                     },
@@ -30928,6 +30936,162 @@
           "endpoint_count",
           "monitored_count",
           "pool_eligible_count"
+        ],
+        "type": "object"
+      },
+      "EntitiesArtifact": {
+        "additionalProperties": {},
+        "description": "The curated address-label registry (#6737/#10483): one entry per ss58 that has cleared docs/nametag-evidence-bar.md, each carrying the source_urls that prove the attribution. Mirrors the built /metagraph/entities.json.",
+        "properties": {
+          "contract_version": {
+            "type": "string"
+          },
+          "entities": {
+            "description": "Every non-rejected label in registry/entities/, sorted by ss58. An EMPTY array is a real answer, not a cold store: the registry holds only what has cleared the evidence bar, and a curated layer with nothing in it yet is the honest state.",
+            "items": {
+              "additionalProperties": {},
+              "description": "One curated address label. There is deliberately no `owner` category: subnet ownership is chain-derived from SubnetOwner and must never be hand-declared.",
+              "properties": {
+                "category": {
+                  "enum": [
+                    "exchange",
+                    "bridge",
+                    "foundation",
+                    "pool",
+                    "infra",
+                    "project",
+                    "operator",
+                    "other",
+                    "payment-collector",
+                    "treasury",
+                    "burn",
+                    "multisig"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "netuid": {
+                  "description": "The subnet this address belongs to, when the label is subnet-scoped (a treasury, burn address, or payment collector). Omitted for network-wide entities like an exchange.",
+                  "maximum": 65535,
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "notes": {
+                  "type": "string"
+                },
+                "review": {
+                  "additionalProperties": {},
+                  "description": "Human-governance axis only, the same shape and meaning as a subnet surface's own `review` block. `rejected` entries are filtered out at build time and never appear here.",
+                  "properties": {
+                    "review_notes": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "enum": [
+                        "community-submitted",
+                        "maintainer-reviewed",
+                        "rejected"
+                      ],
+                      "type": "string"
+                    },
+                    "submitted_at": {
+                      "type": "string"
+                    },
+                    "submitted_by": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "state"
+                  ],
+                  "type": "object"
+                },
+                "schema_version": {
+                  "const": 1,
+                  "type": "number"
+                },
+                "source_urls": {
+                  "description": "Independent public proof that this address belongs to this entity -- not that the entity exists, not that the address exists, but that the two are the same thing. See docs/nametag-evidence-bar.md for what clears the bar.",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "type": "array"
+                },
+                "ss58": {
+                  "description": "The labeled address, checksum-validated against Bittensor's network prefix at build time and identical to its own filename in registry/entities/.",
+                  "type": "string"
+                },
+                "unspendable_proof": {
+                  "additionalProperties": {},
+                  "description": "Why this address cannot spend what it receives. Required for `category: burn`, because a burn is a CLAIM until proven -- \"the team says they burn here\" is an operator attestation, not a burn.",
+                  "properties": {
+                    "basis": {
+                      "enum": [
+                        "known-black-hole",
+                        "provably-keyless",
+                        "documented-recycle-call"
+                      ],
+                      "type": "string"
+                    },
+                    "evidence_url": {
+                      "type": "string"
+                    },
+                    "note": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "basis",
+                    "evidence_url"
+                  ],
+                  "type": "object"
+                },
+                "url": {
+                  "description": "The entity's own canonical homepage, for linking the rendered nametag. Distinct from source_urls: a homepage is not proof of address ownership.",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "schema_version",
+                "ss58",
+                "name",
+                "category",
+                "source_urls",
+                "review"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "generated_at": {
+            "type": "string"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "schema_version": {
+            "const": 1,
+            "type": "number"
+          }
+        },
+        "required": [
+          "generated_at",
+          "schema_version",
+          "entities"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -4996,7 +4996,7 @@ export interface components {
         /** @description One `coldkey`'s community-contributed entity labels plus its subnet-ownership ties (#6740). Mirrors GET /api/v1/accounts/{ss58}/entities. */
         AccountEntitiesArtifact: {
             labels: ({
-                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
+                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig") | null;
                 name?: string | null;
                 notes?: string | null;
                 source_urls?: string[];
@@ -5460,7 +5460,7 @@ export interface components {
             first_block?: number | null;
             first_seen_at?: string | null;
             labels?: ({
-                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other") | null;
+                category?: ("exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig") | null;
                 name?: string | null;
                 notes?: string | null;
                 source_urls?: string[];
@@ -8092,6 +8092,55 @@ export interface components {
             endpoint_count: number;
             monitored_count: number;
             pool_eligible_count: number;
+        };
+        /** @description The curated address-label registry (#6737/#10483): one entry per ss58 that has cleared docs/nametag-evidence-bar.md, each carrying the source_urls that prove the attribution. Mirrors the built /metagraph/entities.json. */
+        EntitiesArtifact: {
+            contract_version?: string;
+            /** @description Every non-rejected label in registry/entities/, sorted by ss58. An EMPTY array is a real answer, not a cold store: the registry holds only what has cleared the evidence bar, and a curated layer with nothing in it yet is the honest state. */
+            entities: ({
+                /** @enum {string} */
+                category: "exchange" | "bridge" | "foundation" | "pool" | "infra" | "project" | "operator" | "other" | "payment-collector" | "treasury" | "burn" | "multisig";
+                name: string;
+                /** @description The subnet this address belongs to, when the label is subnet-scoped (a treasury, burn address, or payment collector). Omitted for network-wide entities like an exchange. */
+                netuid?: number;
+                notes?: string;
+                /** @description Human-governance axis only, the same shape and meaning as a subnet surface's own `review` block. `rejected` entries are filtered out at build time and never appear here. */
+                review: {
+                    review_notes?: string;
+                    /** @enum {string} */
+                    state: "community-submitted" | "maintainer-reviewed" | "rejected";
+                    submitted_at?: string;
+                    submitted_by?: string;
+                } & {
+                    [key: string]: unknown;
+                };
+                /** @constant */
+                schema_version: 1;
+                /** @description Independent public proof that this address belongs to this entity -- not that the entity exists, not that the address exists, but that the two are the same thing. See docs/nametag-evidence-bar.md for what clears the bar. */
+                source_urls: string[];
+                /** @description The labeled address, checksum-validated against Bittensor's network prefix at build time and identical to its own filename in registry/entities/. */
+                ss58: string;
+                /** @description Why this address cannot spend what it receives. Required for `category: burn`, because a burn is a CLAIM until proven -- "the team says they burn here" is an operator attestation, not a burn. */
+                unspendable_proof?: {
+                    /** @enum {string} */
+                    basis: "known-black-hole" | "provably-keyless" | "documented-recycle-call";
+                    evidence_url: string;
+                    note?: string;
+                } & {
+                    [key: string]: unknown;
+                };
+                /** @description The entity's own canonical homepage, for linking the rendered nametag. Distinct from source_urls: a homepage is not proof of address ownership. */
+                url?: string;
+            } & {
+                [key: string]: unknown;
+            })[];
+            generated_at: string;
+            /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
+            notes?: string | string[];
+            /** @constant */
+            schema_version: 1;
+        } & {
+            [key: string]: unknown;
         };
         /** @description An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int. */
         EpochMillis: number;

--- a/schemas-src/artifacts/entities.ts
+++ b/schemas-src/artifacts/entities.ts
@@ -1,0 +1,114 @@
+// The curated address-label registry, as its own published artifact (#10483).
+//
+//   /metagraph/entities.json -> EntitiesArtifact
+//
+// The build has written this file since #6737 (scripts/build-artifacts.ts's
+// `loadEntities()` passthrough, minus rejected entries) and the Worker has read
+// it since #6740 -- but it was never added to PUBLIC_ARTIFACTS, so
+// `/metagraph/entities.json` answered `not_found: No public artifact contract
+// matched this path` while its sibling `/metagraph/providers.json` served 200.
+// The layer existed at both ends and was unreachable in the middle.
+//
+// WHY THE WHOLE FILE, NOT JUST THE LABEL: `/accounts/{ss58}/entities` answers
+// "what is THIS address" and needs a caller to already hold the address. The
+// money map (#10440) asks the opposite question -- "which addresses are
+// declared treasuries, and for which subnets" -- which is a scan over the
+// registry, not a lookup. Without this artifact every consumer of that question
+// has to enumerate accounts it cannot enumerate.
+//
+// The record here is `schemas/entity.schema.json`, which OWNS the shape: that
+// file is what a registry contribution is validated against. This is the
+// published projection of it, and `validate:schema-vocabularies` now asserts
+// the category vocabularies match rather than trusting a comment.
+import { z } from "zod";
+import { ArtifactBaseSchema } from "../envelope.ts";
+import {
+  EntityCategorySchema,
+  SubmissionReviewStateSchema,
+} from "../shared.ts";
+
+// Why unspendability is established, for `category: "burn"`. Mirrors
+// entity.schema.json's own enum; an address with no observed outbound is NOT a
+// basis, because absence of spending is not inability to spend.
+export const UNSPENDABLE_PROOF_BASIS_VALUES = [
+  "known-black-hole",
+  "provably-keyless",
+  "documented-recycle-call",
+] as const;
+export const UnspendableProofBasisSchema = z.enum(
+  UNSPENDABLE_PROOF_BASIS_VALUES,
+);
+
+const UnspendableProofSchema = z
+  .object({
+    basis: UnspendableProofBasisSchema,
+    evidence_url: z.string(),
+    note: z.string().optional(),
+  })
+  .passthrough()
+  .describe(
+    'Why this address cannot spend what it receives. Required for `category: burn`, because a burn is a CLAIM until proven -- "the team says they burn here" is an operator attestation, not a burn.',
+  );
+
+const EntityReviewSchema = z
+  .object({
+    state: SubmissionReviewStateSchema,
+    submitted_by: z.string().optional(),
+    submitted_at: z.string().optional(),
+    review_notes: z.string().optional(),
+  })
+  .passthrough()
+  .describe(
+    "Human-governance axis only, the same shape and meaning as a subnet surface's own `review` block. `rejected` entries are filtered out at build time and never appear here.",
+  );
+
+export const EntitySchema = z
+  .object({
+    schema_version: z.literal(1),
+    ss58: z
+      .string()
+      .describe(
+        "The labeled address, checksum-validated against Bittensor's network prefix at build time and identical to its own filename in registry/entities/.",
+      ),
+    name: z.string(),
+    category: EntityCategorySchema,
+    netuid: z
+      .int()
+      .min(0)
+      .max(65535)
+      .optional()
+      .describe(
+        "The subnet this address belongs to, when the label is subnet-scoped (a treasury, burn address, or payment collector). Omitted for network-wide entities like an exchange.",
+      ),
+    unspendable_proof: UnspendableProofSchema.optional(),
+    notes: z.string().optional(),
+    url: z
+      .string()
+      .optional()
+      .describe(
+        "The entity's own canonical homepage, for linking the rendered nametag. Distinct from source_urls: a homepage is not proof of address ownership.",
+      ),
+    source_urls: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        "Independent public proof that this address belongs to this entity -- not that the entity exists, not that the address exists, but that the two are the same thing. See docs/nametag-evidence-bar.md for what clears the bar.",
+      ),
+    review: EntityReviewSchema,
+  })
+  .passthrough()
+  .describe(
+    "One curated address label. There is deliberately no `owner` category: subnet ownership is chain-derived from SubnetOwner and must never be hand-declared.",
+  );
+
+export const EntitiesArtifactSchema = ArtifactBaseSchema.extend({
+  entities: z
+    .array(EntitySchema)
+    .describe(
+      "Every non-rejected label in registry/entities/, sorted by ss58. An EMPTY array is a real answer, not a cold store: the registry holds only what has cleared the evidence bar, and a curated layer with nothing in it yet is the honest state.",
+    ),
+}).describe(
+  "The curated address-label registry (#6737/#10483): one entry per ss58 that has cleared docs/nametag-evidence-bar.md, each carrying the source_urls that prove the attribution. Mirrors the built /metagraph/entities.json.",
+);
+
+export type EntitiesArtifact = z.infer<typeof EntitiesArtifactSchema>;

--- a/schemas-src/openapi-registry.ts
+++ b/schemas-src/openapi-registry.ts
@@ -95,6 +95,7 @@ import {
   SchemaDriftSurfaceSchema,
 } from "./artifacts/schema-drift.ts";
 import { SurfaceAliasesArtifactSchema } from "./artifacts/surface-aliases.ts";
+import { EntitiesArtifactSchema } from "./artifacts/entities.ts";
 import {
   SubnetVerificationArtifactSchema,
   VerificationArtifactSchema,
@@ -1036,6 +1037,7 @@ register(EndpointPublicationStateSchema, "EndpointPublicationState");
 // The build-published artifacts with no REST route of their own -- see
 // schemas-src/artifacts/'s file headers.
 register(SurfaceAliasesArtifactSchema, "SurfaceAliasesArtifact");
+register(EntitiesArtifactSchema, "EntitiesArtifact");
 register(ReviewQueueArtifactSchema, "ReviewQueueArtifact");
 register(OperationalSurfacesArtifactSchema, "OperationalSurfacesArtifact");
 register(HealthLatestArtifactSchema, "HealthLatestArtifact");
@@ -1336,6 +1338,7 @@ export const OPENAPI_ZOD_COMPONENT_NAMES = [
   "CandidateState",
   "EndpointPublicationState",
   "SurfaceAliasesArtifact",
+  "EntitiesArtifact",
   "ReviewQueueArtifact",
   "OperationalSurfacesArtifact",
   "HealthLatestArtifact",

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -15,7 +15,11 @@
 // itself (not a shortcut introduced here), matching the issue's own
 // documented-open-map carve-out.
 import { z } from "zod";
-import { HttpUrlSchema, SocialLinksSchema } from "../shared.ts";
+import {
+  HttpUrlSchema,
+  SocialLinksSchema,
+  SubmissionReviewStateSchema,
+} from "../shared.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
 import {
@@ -582,11 +586,11 @@ export const SurfaceSchema = z
       .object({
         confidence: z.enum(CONFIDENCE_LEVEL_VALUES).optional(),
         review_notes: z.string().optional(),
-        state: z.enum([
-          "community-submitted",
-          "maintainer-reviewed",
-          "rejected",
-        ]),
+        // The SUBMISSION axis, not the curation `ReviewStateSchema` declared
+        // above in this same file. Both were spelled inline here; the two are
+        // different vocabularies that share one member, so the local name
+        // would type-check and publish the wrong enum.
+        state: SubmissionReviewStateSchema,
         submitted_at: z.string().optional(),
         submitted_by: z.string().optional(),
       })

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -113,6 +113,16 @@ export type BittensorNetwork = z.infer<typeof BittensorNetworkSchema>;
  * of a vocabulary with no owner. `validate:schema-vocabularies` could not see
  * either: prettier had wrapped both as `z` then `.enum([...])` on the next
  * line, and the gate's matcher was anchored on `z.enum(`.
+ *
+ * THE OWNER IS schemas/entity.schema.json, not this list (#10483). That file
+ * is what a registry contribution is validated against, so a category it
+ * accepts and this enum does not is a label the registry stores and the API
+ * cannot describe. #10442/#10516 added the four money-map categories there and
+ * not here, and nothing noticed: the drift is invisible until the first
+ * treasury entry exists, at which point `/accounts/{ss58}/entities` serves a
+ * category its own published enum calls invalid. `validate:schema-vocabularies`
+ * now asserts the two match, because the consolidation that gave this
+ * vocabulary an owner never gave it a gate against the JSON Schema half.
  */
 export const ENTITY_CATEGORY_VALUES = [
   "exchange",
@@ -123,9 +133,46 @@ export const ENTITY_CATEGORY_VALUES = [
   "project",
   "operator",
   "other",
+  // The money-map roles (#10440). `owner` is deliberately absent: subnet
+  // ownership is chain-derived from SubnetOwner and must never be declarable.
+  "payment-collector",
+  "treasury",
+  "burn",
+  "multisig",
 ] as const;
 export const EntityCategorySchema = z.enum(ENTITY_CATEGORY_VALUES);
 export type EntityCategory = z.infer<typeof EntityCategorySchema>;
+
+/**
+ * The human-governance axis of a registry SUBMISSION (#10483).
+ *
+ * ONE vocabulary across two registries: a subnet surface's `review.state` and
+ * an entity label's are the same three states, meaning the same three things --
+ * a contribution enters as `community-submitted`, and a maintainer promotes it
+ * to `maintainer-reviewed` or marks it `rejected`. Both
+ * `schemas/entity.schema.json` and `schemas/subnet-manifest.schema.json`
+ * declare it, and it was restated inline at each site with no owner.
+ *
+ * NOT `ReviewStateSchema` in routes/subnet-detail.ts, which is registered as the
+ * published `ReviewState` component and is a DIFFERENT five-value vocabulary --
+ * `unreviewed | machine-generated | maintainer-reviewed | needs-review | stale`,
+ * the CURATION state of a subnet profile. The two share one member
+ * (`maintainer-reviewed`) and one obvious name, which is precisely why this one
+ * is named for the submission rather than for the review: importing the wrong
+ * `ReviewStateSchema` type-checks and silently republishes the other component.
+ *
+ * Distinct again from the machine-verification axis, which the build's prober
+ * owns and no contribution may set.
+ */
+export const SUBMISSION_REVIEW_STATE_VALUES = [
+  "community-submitted",
+  "maintainer-reviewed",
+  "rejected",
+] as const;
+export const SubmissionReviewStateSchema = z.enum(
+  SUBMISSION_REVIEW_STATE_VALUES,
+);
+export type SubmissionReviewState = z.infer<typeof SubmissionReviewStateSchema>;
 
 /**
  * How a callable surface authenticates.

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -227,6 +227,76 @@ for (const [name, collection] of Object.entries(MIRRORED_VOCABULARIES)) {
   }
 }
 
+// The JSON Schema half (#10483).
+//
+// The mirrors above are Zod-to-Zod. This one crosses a bigger boundary: a
+// registry document is validated against schemas/*.schema.json, while the API
+// that serves it is typed from schemas-src/. When those two disagree about a
+// value set, the registry accepts a document the contract cannot describe --
+// and it fails in the one direction nothing tests, because the invalid value
+// does not exist until somebody writes the first entry using it.
+//
+// That is exactly what happened here. #10442/#10516 added `payment-collector`,
+// `treasury`, `burn` and `multisig` to entity.schema.json's category enum and
+// not to ENTITY_CATEGORY_VALUES. `registry/entities/` is empty, so no document
+// carried one, so every gate passed for as long as the layer stayed unused.
+//
+// THE JSON SCHEMA OWNS THE VOCABULARY. It is what a contribution is validated
+// against, so the Zod enum is the copy and the fix is always to widen the copy.
+const JSON_SCHEMA_MIRRORS: Array<{
+  schemaFile: string;
+  pointer: string[];
+  zodExport: string;
+}> = [
+  {
+    schemaFile: "schemas/entity.schema.json",
+    pointer: ["properties", "category", "enum"],
+    zodExport: "ENTITY_CATEGORY_VALUES",
+  },
+];
+
+const schemaSrcShared =
+  (await import("../schemas-src/shared.ts")) as unknown as Record<
+    string,
+    readonly string[]
+  >;
+
+for (const { schemaFile, pointer, zodExport } of JSON_SCHEMA_MIRRORS) {
+  const raw = JSON.parse(
+    await fs.readFile(path.join(repoRoot, schemaFile), "utf8"),
+  ) as unknown;
+  let node: unknown = raw;
+  for (const key of pointer) {
+    node = (node as Record<string, unknown> | null)?.[key];
+  }
+  const zodValues = schemaSrcShared[zodExport];
+  if (!Array.isArray(node)) {
+    errors.push(
+      `${schemaFile} no longer has an enum at ${pointer.join(".")} — ` +
+        `update JSON_SCHEMA_MIRRORS, or restore the enum.`,
+    );
+    continue;
+  }
+  if (!Array.isArray(zodValues)) {
+    errors.push(
+      `schemas-src/shared.ts no longer exports ${zodExport}, which mirrors ` +
+        `${schemaFile}#${pointer.join(".")}.`,
+    );
+    continue;
+  }
+  const fromSchema = [...(node as string[])].sort().join(",");
+  const fromZod = [...zodValues].sort().join(",");
+  if (fromSchema !== fromZod) {
+    errors.push(
+      `${zodExport} has drifted from ${schemaFile}#${pointer.join(".")}:\n` +
+        `    schemas-src: ${fromZod || "(empty)"}\n` +
+        `    JSON Schema: ${fromSchema || "(empty)"}\n` +
+        `  The JSON Schema OWNS this vocabulary — it is what a registry ` +
+        `contribution is validated against. Widen the Zod copy, not the source.`,
+    );
+  }
+}
+
 if (errors.length > 0) {
   console.error(
     `Schema-vocabulary validation failed with ${errors.length} issue(s):`,
@@ -238,5 +308,6 @@ if (errors.length > 0) {
 console.log(
   `Schema-vocabulary validation passed: ${byVocabulary.size} distinct vocabularies, ` +
     `${duplicated.length} still restated in more than one file (all per-domain coincidences, not debt — see COINCIDENT_BY_DOMAIN); ` +
-    `${Object.keys(MIRRORED_VOCABULARIES).length} cross-boundary mirrors match the collection that owns them.`,
+    `${Object.keys(MIRRORED_VOCABULARIES).length} cross-boundary mirrors match the collection that owns them; ` +
+    `${JSON_SCHEMA_MIRRORS.length} JSON Schema enum(s) match their schemas-src copy.`,
 );

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -844,6 +844,12 @@ export const PUBLIC_ARTIFACTS = [
     "ProviderArtifact",
   ),
   artifact(
+    "entities",
+    "/metagraph/entities.json",
+    "Curated address-label registry (#6737/#10483): one entry per ss58 that has cleared docs/nametag-evidence-bar.md, each carrying the source_urls that prove the attribution, plus the money-map roles (treasury, burn, payment-collector, multisig) and the netuid a subnet-scoped label belongs to. There is deliberately no `owner` category — subnet ownership is chain-derived from SubnetOwner and must never be hand-declared, and a `burn` label additionally requires unspendable_proof because a burn is a claim until proven. Built from registry/entities/ minus rejected entries; an empty list is the honest state of a curated layer, not a cold store.",
+    "EntitiesArtifact",
+  ),
+  artifact(
     "provider-endpoints",
     "/metagraph/providers/{slug}/endpoints.json",
     "Endpoint resources for one provider or operator.",

--- a/tests/entities-artifact.test.ts
+++ b/tests/entities-artifact.test.ts
@@ -1,0 +1,181 @@
+// #10483: the curated address-label registry, as a served artifact.
+//
+// The layer existed at both ends and was unreachable in the middle -- the build
+// has written entities.json since #6737 and the Worker has read it since #6740,
+// but it was never in PUBLIC_ARTIFACTS, so the public path answered
+// `not_found: No public artifact contract matched this path`.
+//
+// The vocabulary test below is the one that matters most. #10442/#10516 widened
+// entity.schema.json's category enum with the four money-map roles and left
+// ENTITY_CATEGORY_VALUES at eight, and nothing caught it for the same reason
+// nothing caught the dead producer in #10566: registry/entities/ is empty, so no
+// document carried a `treasury` category, so there was nothing for any gate to
+// reject. The drift becomes visible on the first real entry -- i.e. during the
+// 21 attribution issues, at the point where being wrong is most expensive.
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "vitest";
+import { PUBLIC_ARTIFACTS } from "../src/contracts.ts";
+import { ENTITY_CATEGORY_VALUES } from "../schemas-src/shared.ts";
+import {
+  EntitiesArtifactSchema,
+  EntitySchema,
+  UNSPENDABLE_PROOF_BASIS_VALUES,
+} from "../schemas-src/artifacts/entities.ts";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+async function entityJsonSchema(): Promise<Record<string, never>> {
+  return JSON.parse(
+    await fs.readFile(
+      path.join(repoRoot, "schemas/entity.schema.json"),
+      "utf8",
+    ),
+  );
+}
+
+/** A label that clears the evidence bar, shaped as the build passes it through. */
+function validEntity(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: 1,
+    ss58: "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9",
+    name: "Example Treasury",
+    category: "treasury",
+    netuid: 64,
+    source_urls: ["https://example.org/treasury-address"],
+    review: { state: "community-submitted" },
+    ...overrides,
+  };
+}
+
+describe("entities artifact contract", () => {
+  test("the artifact is published, so /metagraph/entities.json resolves", () => {
+    const entry = PUBLIC_ARTIFACTS.find((a) => a.id === "entities");
+    assert.ok(entry, "no PUBLIC_ARTIFACTS entry with id 'entities'");
+    assert.equal(entry.path, "/metagraph/entities.json");
+    // The catalog holds the bare component name; buildContractsArtifact is
+    // what expands it to a $ref.
+    assert.equal(entry.schema_ref, "EntitiesArtifact");
+  });
+
+  test("it sits beside providers.json rather than under a path template", () => {
+    // A templated path ({slug}/{netuid}) is served per-key; this one is a single
+    // whole-registry document, and reading it must not require knowing an
+    // address in advance -- that is the entire reason the money map needs it.
+    const entry = PUBLIC_ARTIFACTS.find((a) => a.id === "entities");
+    assert.ok(entry);
+    assert.ok(
+      !entry.path.includes("{"),
+      "entities.json must not be a templated per-key path",
+    );
+  });
+});
+
+describe("entity category vocabulary", () => {
+  test("the Zod copy matches the JSON Schema that owns it", async () => {
+    const schema = (await entityJsonSchema()) as unknown as {
+      properties: { category: { enum: string[] } };
+    };
+    assert.deepEqual(
+      [...ENTITY_CATEGORY_VALUES].sort(),
+      [...schema.properties.category.enum].sort(),
+      "entity.schema.json OWNS this vocabulary — widen the schemas-src copy, not the source",
+    );
+  });
+
+  test("the money-map roles are actually present", () => {
+    // Guard the guard: the deepEqual above passes vacuously if BOTH sides lose
+    // the money categories, which is exactly how this drifted in the first
+    // place -- one side was simply never updated.
+    for (const role of [
+      "payment-collector",
+      "treasury",
+      "burn",
+      "multisig",
+    ] as const) {
+      assert.ok(
+        (ENTITY_CATEGORY_VALUES as readonly string[]).includes(role),
+        `${role} missing from ENTITY_CATEGORY_VALUES`,
+      );
+    }
+  });
+
+  test("owner is not declarable", () => {
+    // Chain-derived from SubnetOwner. A hand-declared owner is the one
+    // attribution nobody may make, and the enum is where that is enforced.
+    assert.ok(
+      !(ENTITY_CATEGORY_VALUES as readonly string[]).includes("owner"),
+      "owner must never be a declarable category",
+    );
+  });
+});
+
+describe("EntitiesArtifactSchema", () => {
+  test("accepts an empty registry", () => {
+    // An empty curated layer is the honest state, not a cold store: the
+    // registry holds only what has cleared docs/nametag-evidence-bar.md.
+    const parsed = EntitiesArtifactSchema.safeParse({
+      schema_version: 1,
+      generated_at: "2026-08-10T00:00:00.000Z",
+      entities: [],
+    });
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues));
+  });
+
+  test("accepts a subnet-scoped money-map label", () => {
+    const parsed = EntitySchema.safeParse(validEntity());
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues));
+  });
+
+  test("accepts a burn label carrying its unspendability proof", () => {
+    const parsed = EntitySchema.safeParse(
+      validEntity({
+        category: "burn",
+        unspendable_proof: {
+          basis: UNSPENDABLE_PROOF_BASIS_VALUES[0],
+          evidence_url: "https://example.org/burn-address",
+        },
+      }),
+    );
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues));
+  });
+
+  test("rejects a label with no evidence", () => {
+    // source_urls is the whole point of the file. A claim with no proof is a
+    // specific, confident, wrong assertion rendered next to real financial
+    // activity -- worse than no label at all.
+    for (const source_urls of [undefined, []]) {
+      const parsed = EntitySchema.safeParse(validEntity({ source_urls }));
+      assert.equal(
+        parsed.success,
+        false,
+        `source_urls=${JSON.stringify(source_urls)} must not validate`,
+      );
+    }
+  });
+
+  test("rejects a category outside the vocabulary", () => {
+    const parsed = EntitySchema.safeParse(validEntity({ category: "owner" }));
+    assert.equal(parsed.success, false, "owner must not validate");
+  });
+
+  test("rejects an unspendability basis of 'no outbound observed'", () => {
+    // Absence of spending is not inability to spend, and the enum is where
+    // that distinction is held.
+    const parsed = EntitySchema.safeParse(
+      validEntity({
+        category: "burn",
+        unspendable_proof: {
+          basis: "no-outbound-observed",
+          evidence_url: "https://example.org/x",
+        },
+      }),
+    );
+    assert.equal(parsed.success, false);
+  });
+});


### PR DESCRIPTION
## Summary

`/metagraph/entities.json` 404s in production with `No public artifact contract matched this path`, while `/metagraph/providers.json` beside it serves 200. The build has written the file since #6737 and the Worker has read it since #6740 — it was simply never added to `PUBLIC_ARTIFACTS`. The layer existed at both ends and was unreachable in the middle.

The per-account route is not a substitute. `/accounts/{ss58}/entities` answers *"what is THIS address"* and needs a caller to already hold the address; the money map (#10440) asks *"which addresses are declared treasuries, and for which subnets"*, which is a scan over the registry rather than a lookup.

## The vocabulary had drifted, silently

| | |
|---|---|
| `schemas/entity.schema.json` | 12 categories |
| `ENTITY_CATEGORY_VALUES` | **8** |

#10442/#10516 added `payment-collector`, `treasury`, `burn` and `multisig` to the JSON Schema and not to the Zod copy. Nothing caught it for the same reason nothing caught #10566: `registry/entities/` is empty, so no document carries one of those categories, so no gate had anything to reject.

It would have surfaced on the **first real entry** — during the 21 attribution issues, at the point where being wrong is most expensive — as `/accounts/{ss58}/entities` serving a category its own published enum calls invalid.

`validate:schema-vocabularies` covered Zod-to-Zod mirrors only. It now also compares `schemas/*.schema.json` enums against their schemas-src copies. **The JSON Schema owns the vocabulary**, because it is what a contribution is validated against.

## A name collision worth stating

Extracting the submission review-state to a shared owner surfaced this: `routes/subnet-detail.ts` already exports a `ReviewStateSchema`, registered as the published `ReviewState` component — and it is a **different five-value vocabulary** (`unreviewed | machine-generated | maintainer-reviewed | needs-review | stale`, the curation state).

The two share one member and one obvious name, so importing the wrong one type-checks and silently republishes the other component. Caught mid-change when the local name resolved instead of the imported one. The submission axis is named for the submission for that reason, and both published enums are asserted unchanged:

```
Surface.review.state : ['community-submitted', 'maintainer-reviewed', 'rejected']
ReviewState component: ['unreviewed', 'machine-generated', 'maintainer-reviewed', 'needs-review', 'stale']
```

## Seeding is deliberately not here

No address currently clears `docs/nametag-evidence-bar.md`, and #10448 explicitly forbids attributing any SN64 address after the protocol-pool misattribution. The attribution issues (#10489–#10509) each already say *"Register as an entity with `source_urls` (#10483)"* — entries arrive through them, which is the right order: evidence first, then the entry. An empty `entities` array is the honest state of a curated layer, not a cold store, and the schema says so. #10483 stays open for the seeding.

## The new gate can fail

Reintroducing the drift and re-running it:

```
Schema-vocabulary validation failed with 1 issue(s):
- ENTITY_CATEGORY_VALUES has drifted from schemas/entity.schema.json#properties.category.enum:
    schemas-src: bridge,exchange,foundation,infra,operator,other,pool,project
    JSON Schema: bridge,burn,exchange,foundation,infra,multisig,operator,other,payment-collector,pool,project,treasury
  The JSON Schema OWNS this vocabulary — it is what a registry contribution is
  validated against. Widen the Zod copy, not the source.
```

It also caught a duplicate this change itself introduced (the review-state enum restated in a second file), which is what led to the extraction above.

## Verification

- `npm run build` clean; regenerated `openapi.json`, `types.d.ts`, `contracts.json`, `api-index.json`, `packages/contract/index.d.ts` committed. `r2-manifest.json` auto-reverted by the build and not in the diff.
- `npm run validate` **exit 0**
- `typecheck` · `lint` · `format:check` · `git diff --check` all clean
- Focused validators exit 0: `contract-drift` · `schemas` · `api` · `openapi` · `schema-vocabularies` · `graphql-component-parity` · `published-names` · `artifact-budgets`
- **374 tests** pass across `entities-artifact` · `contracts` · `zod-schemas` · `invariants-contracts`; 11 new tests in `tests/entities-artifact.test.ts`
- Patch coverage: `src/contracts.ts` is the only changed file in codecov's scope; diff-intersection against `coverage-final.json` shows **zero uncovered changed lines**
- Rebased onto `2ef7ef75f`, rebuilt, and re-verified — the rebuild produced no diff, so the committed artifacts are fresh against this base

Closes #10571
