### PR TITLE
fix(revenue): read the declarations the registry already carries

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6785,14 +6785,24 @@ export interface components {
                 revenue_usd: number | null;
                 searched_at?: string | null;
                 sources: {
-                    /** @description Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run. */
+                    /** @description The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates. */
                     amount_usd: number | null;
+                    /** @description Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it. */
+                    contributes: boolean;
                     currency: string;
+                    /** @description Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window. */
+                    excluded_reason: string | null;
                     grain: string;
                     observed_at?: string | null;
+                    /** @description How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window. */
+                    periods_expected?: number;
+                    /** @description How many distinct periods were seen for this surface within the window. */
+                    periods_observed?: number;
                     /** @enum {string} */
                     provenance: "chain-verified" | "probe-derived" | "operator-attested" | "third-party-reported" | "proxy-only" | "none";
                     response_hash?: string | null;
+                    /** @description Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline. */
+                    supersedes?: string[];
                     surface_id: string;
                 }[];
                 /** @description emission / revenue, the ecosystem's own phrasing. NULL when revenue is null OR zero — dividing by zero is undefined, not infinite, and Infinity would sort as the worst possible subsidy rather than as not-applicable. */
@@ -11898,14 +11908,24 @@ export interface components {
                 revenue_usd: number | null;
                 searched_at?: string | null;
                 sources: {
-                    /** @description Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run. */
+                    /** @description The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates. */
                     amount_usd: number | null;
+                    /** @description Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it. */
+                    contributes: boolean;
                     currency: string;
+                    /** @description Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window. */
+                    excluded_reason: string | null;
                     grain: string;
                     observed_at?: string | null;
+                    /** @description How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window. */
+                    periods_expected?: number;
+                    /** @description How many distinct periods were seen for this surface within the window. */
+                    periods_observed?: number;
                     /** @enum {string} */
                     provenance: "chain-verified" | "probe-derived" | "operator-attested" | "third-party-reported" | "proxy-only" | "none";
                     response_hash?: string | null;
+                    /** @description Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline. */
+                    supersedes?: string[];
                     surface_id: string;
                 }[];
                 /** @description emission / revenue, the ecosystem's own phrasing. NULL when revenue is null OR zero — dividing by zero is undefined, not infinite, and Infinity would sort as the worst possible subsidy rather than as not-applicable. */
@@ -27304,7 +27324,9 @@ export interface operations {
                      *             "sources": [
                      *               {
                      *                 "amount_usd": 0.5,
+                     *                 "contributes": false,
                      *                 "currency": "example",
+                     *                 "excluded_reason": "example",
                      *                 "grain": "example",
                      *                 "provenance": "chain-verified",
                      *                 "surface_id": "example"
@@ -44991,7 +45013,9 @@ export interface operations {
                      *           "sources": [
                      *             {
                      *               "amount_usd": 0.5,
+                     *               "contributes": false,
                      *               "currency": "example",
+                     *               "excluded_reason": "example",
                      *               "grain": "example",
                      *               "provenance": "chain-verified",
                      *               "surface_id": "example"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3482,7 +3482,9 @@
                 "sources": [
                   {
                     "amount_usd": 0.5,
+                    "contributes": false,
                     "currency": "example",
+                    "excluded_reason": "example",
                     "grain": "example",
                     "provenance": "chain-verified",
                     "surface_id": "example"
@@ -11385,7 +11387,9 @@
               "sources": [
                 {
                   "amount_usd": 0.5,
+                  "contributes": false,
                   "currency": "example",
+                  "excluded_reason": "example",
                   "grain": "example",
                   "provenance": "chain-verified",
                   "surface_id": "example"
@@ -23821,10 +23825,25 @@
                             "type": "null"
                           }
                         ],
-                        "description": "Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run."
+                        "description": "The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates."
+                      },
+                      "contributes": {
+                        "description": "Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it.",
+                        "type": "boolean"
                       },
                       "currency": {
                         "type": "string"
+                      },
+                      "excluded_reason": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "description": "Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window."
                       },
                       "grain": {
                         "type": "string"
@@ -23838,6 +23857,18 @@
                             "type": "null"
                           }
                         ]
+                      },
+                      "periods_expected": {
+                        "description": "How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window.",
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "periods_observed": {
+                        "description": "How many distinct periods were seen for this surface within the window.",
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       "provenance": {
                         "enum": [
@@ -23860,6 +23891,13 @@
                           }
                         ]
                       },
+                      "supersedes": {
+                        "description": "Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline.",
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
                       "surface_id": {
                         "type": "string"
                       }
@@ -23869,7 +23907,9 @@
                       "provenance",
                       "currency",
                       "grain",
-                      "amount_usd"
+                      "amount_usd",
+                      "contributes",
+                      "excluded_reason"
                     ],
                     "type": "object"
                   },
@@ -50968,10 +51008,25 @@
                           "type": "null"
                         }
                       ],
-                      "description": "Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run."
+                      "description": "The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates."
+                    },
+                    "contributes": {
+                      "description": "Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it.",
+                      "type": "boolean"
                     },
                     "currency": {
                       "type": "string"
+                    },
+                    "excluded_reason": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window."
                     },
                     "grain": {
                       "type": "string"
@@ -50985,6 +51040,18 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "periods_expected": {
+                      "description": "How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window.",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "periods_observed": {
+                      "description": "How many distinct periods were seen for this surface within the window.",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "provenance": {
                       "enum": [
@@ -51007,6 +51074,13 @@
                         }
                       ]
                     },
+                    "supersedes": {
+                      "description": "Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
                     "surface_id": {
                       "type": "string"
                     }
@@ -51016,7 +51090,9 @@
                     "provenance",
                     "currency",
                     "grain",
-                    "amount_usd"
+                    "amount_usd",
+                    "contributes",
+                    "excluded_reason"
                   ],
                   "type": "object"
                 },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6785,14 +6785,24 @@ export interface components {
                 revenue_usd: number | null;
                 searched_at?: string | null;
                 sources: {
-                    /** @description Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run. */
+                    /** @description The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates. */
                     amount_usd: number | null;
+                    /** @description Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it. */
+                    contributes: boolean;
                     currency: string;
+                    /** @description Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window. */
+                    excluded_reason: string | null;
                     grain: string;
                     observed_at?: string | null;
+                    /** @description How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window. */
+                    periods_expected?: number;
+                    /** @description How many distinct periods were seen for this surface within the window. */
+                    periods_observed?: number;
                     /** @enum {string} */
                     provenance: "chain-verified" | "probe-derived" | "operator-attested" | "third-party-reported" | "proxy-only" | "none";
                     response_hash?: string | null;
+                    /** @description Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline. */
+                    supersedes?: string[];
                     surface_id: string;
                 }[];
                 /** @description emission / revenue, the ecosystem's own phrasing. NULL when revenue is null OR zero — dividing by zero is undefined, not infinite, and Infinity would sort as the worst possible subsidy rather than as not-applicable. */
@@ -11898,14 +11908,24 @@ export interface components {
                 revenue_usd: number | null;
                 searched_at?: string | null;
                 sources: {
-                    /** @description Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run. */
+                    /** @description The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates. */
                     amount_usd: number | null;
+                    /** @description Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it. */
+                    contributes: boolean;
                     currency: string;
+                    /** @description Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window. */
+                    excluded_reason: string | null;
                     grain: string;
                     observed_at?: string | null;
+                    /** @description How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window. */
+                    periods_expected?: number;
+                    /** @description How many distinct periods were seen for this surface within the window. */
+                    periods_observed?: number;
                     /** @enum {string} */
                     provenance: "chain-verified" | "probe-derived" | "operator-attested" | "third-party-reported" | "proxy-only" | "none";
                     response_hash?: string | null;
+                    /** @description Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline. */
+                    supersedes?: string[];
                     surface_id: string;
                 }[];
                 /** @description emission / revenue, the ecosystem's own phrasing. NULL when revenue is null OR zero — dividing by zero is undefined, not infinite, and Infinity would sort as the worst possible subsidy rather than as not-applicable. */
@@ -27304,7 +27324,9 @@ export interface operations {
                      *             "sources": [
                      *               {
                      *                 "amount_usd": 0.5,
+                     *                 "contributes": false,
                      *                 "currency": "example",
+                     *                 "excluded_reason": "example",
                      *                 "grain": "example",
                      *                 "provenance": "chain-verified",
                      *                 "surface_id": "example"
@@ -44991,7 +45013,9 @@ export interface operations {
                      *           "sources": [
                      *             {
                      *               "amount_usd": 0.5,
+                     *               "contributes": false,
                      *               "currency": "example",
+                     *               "excluded_reason": "example",
                      *               "grain": "example",
                      *               "provenance": "chain-verified",
                      *               "surface_id": "example"

--- a/schemas-src/routes/revenue-coverage.ts
+++ b/schemas-src/routes/revenue-coverage.ts
@@ -53,9 +53,29 @@ export const RevenueSourceSchema = z
     provenance: RevenueProvenanceSchema,
     currency: z.string(),
     grain: z.string(),
+    supersedes: z.array(z.string()).optional().meta({
+      description:
+        "Surface ids this one subsumes. A subsumed surface is reported here with its own figure and NEVER contributes to `revenue_usd` — SN64 publishes both an all-channel daily total and a TAO-channel subset of it, and summing the two inflates the headline.",
+    }),
     amount_usd: z.number().nullable().meta({
       description:
-        "Null when the surface declares revenue but nothing has been read from it — an auth-gated endpoint, or a probe that has not run.",
+        "The figure for the requested window, or null. Null when the surface declares revenue but nothing has been read from it (an auth-gated endpoint, or a probe that has not run), when its grain cannot form the window, or when the window is only partly observed — a partial sum presented as a whole window understates.",
+    }),
+    contributes: z.boolean().meta({
+      description:
+        "Whether this surface's figure reached `revenue_usd`. Published per source so a caller can see WHY a subnet with visible figures reports a null headline, instead of inferring it.",
+    }),
+    excluded_reason: z.string().nullable().meta({
+      description:
+        "Null when it contributed; otherwise why it did not — superseded, provenance not headline-eligible, not observed, or a grain that cannot span the window.",
+    }),
+    periods_observed: z.int().min(0).optional().meta({
+      description:
+        "How many distinct periods were seen for this surface within the window.",
+    }),
+    periods_expected: z.int().min(0).optional().meta({
+      description:
+        "How many the window requires at this surface's grain. Absent when the grain carries no period at all (a cumulative total) or does not divide the window.",
     }),
     response_hash: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -14,6 +14,7 @@
 // 127 answers.
 import {
   buildSubnetRevenue,
+  type RevenueObservation,
   type RevenueSourceRow,
 } from "./revenue-serving.ts";
 
@@ -62,33 +63,42 @@ export function taoTotalPerBlock(economics: Row | null): number {
 }
 
 /**
- * Every revenue-relevant declaration on a subnet's surfaces.
+ * Every revenue-relevant DECLARATION on a subnet's surfaces.
  *
  * `usage-proxy`, `miner-payout` and `not-revenue` surfaces are deliberately
  * EXCLUDED. They are real verdicts and worth recording in the registry, but a
  * revenue response listing SN4's `payout` field among its "sources" invites
  * exactly the reading the role vocabulary exists to prevent.
+ *
+ * #10565: declarations ONLY -- no figures. This used to take an observation map
+ * and stamp one scalar `amount_usd` per surface, which is the shape that made
+ * the window unrepresentable: one number per surface cannot answer "the last 7
+ * days" for a daily feed. Resolving a declaration against its observation
+ * series is src/revenue-serving.ts's job, because that is where the grain and
+ * `supersedes` rules live.
  */
 export function revenueSourcesFor(
   surfaces: Row[] | null | undefined,
-  observationsBySurface: Map<
-    string,
-    { amount_usd: number; response_hash?: string; observed_at?: string }
-  > = new Map(),
 ): RevenueSourceRow[] {
   const out: RevenueSourceRow[] = [];
   for (const surface of Array.isArray(surfaces) ? surfaces : []) {
     const revenue = surface?.revenue as Row | undefined;
     if (!revenue || revenue.role !== "external-revenue") continue;
-    const observed = observationsBySurface.get(String(surface.id));
     out.push({
       surface_id: String(surface.id),
       provenance: String(revenue.provenance ?? "none"),
       currency: String(revenue.currency ?? "USD"),
       grain: String(revenue.grain ?? "cumulative"),
-      amount_usd: observed ? observed.amount_usd : null,
-      response_hash: observed?.response_hash ?? null,
-      observed_at: observed?.observed_at ?? null,
+      // Carried through, not just declared. The registry has said since #10441
+      // that SN64's daily_revenue_summary subsumes both payment surfaces; the
+      // composition layer never read it, and summing the subsets put the
+      // headline 200x over (#10565).
+      supersedes: Array.isArray(revenue.supersedes)
+        ? revenue.supersedes.map(String)
+        : undefined,
+      amount_usd: null,
+      contributes: false,
+      excluded_reason: null,
     });
   }
   return out;
@@ -101,15 +111,13 @@ export interface LoadSubnetRevenueInput {
   surfaces: Row[] | null;
   usd_per_tao: number | null;
   searched_at?: string | null;
-  observations?: Map<
-    string,
-    { amount_usd: number; response_hash?: string; observed_at?: string }
-  >;
+  /** The observation SERIES per surface, newest period in any order. */
+  observations?: Map<string, RevenueObservation[]>;
 }
 
 /** Compose the served body. Never throws on missing pieces. */
 export function loadSubnetRevenue(input: LoadSubnetRevenueInput): Row {
-  const sources = revenueSourcesFor(input.surfaces, input.observations);
+  const sources = revenueSourcesFor(input.surfaces);
   const view = buildSubnetRevenue({
     netuid: input.netuid,
     window_days: input.window_days,
@@ -121,6 +129,7 @@ export function loadSubnetRevenue(input: LoadSubnetRevenueInput): Row {
     // honest one: without a rate there is no USD comparison to make.
     usd_per_tao: input.usd_per_tao ?? 0,
     sources,
+    observations: input.observations,
     searched_at: input.searched_at ?? null,
   });
   return view;

--- a/src/revenue-serving.ts
+++ b/src/revenue-serving.ts
@@ -10,14 +10,55 @@
 // `revenue_usd: null` with a stated provenance -- NOT as zero, and not as an
 // error. A 500 here would make "we have no revenue data for this subnet", which
 // is true of 127 of 129, look like a broken endpoint.
+//
+// #10565: THE DECLARATIONS ARE READ, NOT JUST CARRIED.
+//
+// This module used to sum every readable source it was handed, ignoring both
+// `supersedes` and `grain` -- which the registry declares correctly and which
+// nothing looked at. Measured against SN64's real declarations, that produced:
+//
+//   window=1d  emission=$93,452
+//     summed blindly     revenue=$2,334,505  coverage=2498.1%  subsidy=0.04:1
+//     declarations read  revenue=$11,668     coverage=12.5%    subsidy=8.01:1
+//
+// The second row is the epic's own worked example. The first is what would have
+// been published as fact the moment the probe lane gained a producer, and
+// `verification.verified` was `true` for it -- every check was internally
+// consistent while the number was 200x wrong. That is why the checks below
+// assert things a wrong SUM would fail, not only things a wrong RATIO would.
 import { computeCoverage, type CoverageResult } from "./revenue-coverage.ts";
+
+/** One observed figure, for one surface, for one period. The probe lane writes
+ * these to `revenue_observations` keyed on (surface_id, period). */
+export interface RevenueObservation {
+  surface_id: string;
+  /** Verbatim from the payload: "2026-08-08", "2026-07", or SCALAR_PERIOD. */
+  period: string;
+  amount_usd: number;
+  observed_at?: string | null;
+  response_hash?: string | null;
+}
 
 export interface RevenueSourceRow {
   surface_id: string;
   provenance: string;
   currency: string;
   grain: string;
+  /** Surface ids this one subsumes, from the registry declaration. */
+  supersedes?: string[];
+  /** The figure for the requested window, or null when one cannot be formed. */
   amount_usd: number | null;
+  /** Did this surface's figure reach `revenue_usd`? Published per source so a
+   * reader can see WHY a subnet with visible figures reports a null headline,
+   * rather than inferring it. */
+  contributes: boolean;
+  /** Null when it contributed; otherwise the reason, in the response. */
+  excluded_reason: string | null;
+  /** How much of the window was actually observed. Published even when the
+   * surface contributes, because "7 of 7 days" and "7 of 7 days but two were
+   * re-observations of the same date" are different facts to a reader. */
+  periods_observed?: number;
+  periods_expected?: number;
   response_hash?: string | null;
   observed_at?: string | null;
 }
@@ -58,17 +99,192 @@ const PROVENANCE_RANK = [
   "none",
 ];
 
-export function buildSubnetRevenue(
-  input: SubnetRevenueInput,
-): SubnetRevenueView {
-  const { sources, searched_at = null } = input;
+/**
+ * Days one period of each grain covers.
+ *
+ * `cumulative` is deliberately absent rather than mapped to a large number: a
+ * lifetime total is not a long period, it is a running sum with no period at
+ * all. Summing it into a window compares a subnet's entire history against one
+ * day of emission -- the single largest term in the 2498% figure above was
+ * SN64's `payments/summary/tao` `total` field, $2.3M of cumulative payments
+ * added to an $11.7k daily figure. Deriving a windowed figure from it would
+ * need a delta between two observations, which is a different lane.
+ */
+const GRAIN_DAYS: Record<string, number> = {
+  daily: 1,
+  weekly: 7,
+  monthly: 30,
+};
 
-  // Sum ONLY the readable tiers, and only rows that actually carry a figure.
-  // An operator-attested surface is real and is reported in `sources`; adding
-  // it here would put an unverifiable number in the headline.
-  const contributing = sources.filter(
-    (s) => HEADLINE_PROVENANCES.has(s.provenance) && s.amount_usd !== null,
+/**
+ * Which of a surface's observations cover the requested window, if any.
+ *
+ * A grain is commensurable with a window only when the window is a whole
+ * number of periods: a monthly figure cannot answer "yesterday", and a weekly
+ * one cannot answer a 30-day window without apportioning across a boundary --
+ * which is modelling, and #10439's first hard rule forbids it.
+ *
+ * The window is anchored on the NEWEST observed period rather than on the
+ * clock. Anchoring on `now` makes the current day a partial period whose value
+ * grows all day, so a caller polling twice gets two different answers for the
+ * same nominal window and neither is wrong. The trade is that a stale feed
+ * reports its last complete window rather than reporting nothing -- which is
+ * why `observed_at` is published per source and #10480 makes going dark an
+ * event.
+ */
+export function windowedAmount(
+  grain: string,
+  windowDays: number,
+  observations: RevenueObservation[],
+):
+  | { ok: true; amount_usd: number; observed: number; expected: number }
+  | { ok: false; reason: string; observed: number; expected: number | null } {
+  const grainDays = GRAIN_DAYS[grain];
+  if (grainDays === undefined) {
+    return {
+      ok: false,
+      reason: `grain "${grain}" carries no period and cannot be windowed`,
+      observed: observations.length,
+      expected: null,
+    };
+  }
+  if (windowDays % grainDays !== 0) {
+    return {
+      ok: false,
+      reason: `grain "${grain}" does not divide a ${windowDays}-day window`,
+      observed: observations.length,
+      expected: null,
+    };
+  }
+  const expected = windowDays / grainDays;
+  // One figure per period: the probe lane upserts on (surface_id, period), but
+  // a caller may hand us anything, and summing a period twice is the same
+  // double-count in miniature.
+  const byPeriod = new Map<string, RevenueObservation>();
+  for (const observation of observations) {
+    byPeriod.set(observation.period, observation);
+  }
+  const newestFirst = [...byPeriod.values()].sort((a, b) =>
+    b.period.localeCompare(a.period),
   );
+  if (newestFirst.length < expected) {
+    // A partial sum presented as a whole window UNDERSTATES, and understating
+    // is not the safe direction: it is the direction that makes a subnet look
+    // like it earns less than it does. Report nothing instead.
+    return {
+      ok: false,
+      reason: `window needs ${expected} ${grain} period(s), observed ${newestFirst.length}`,
+      observed: newestFirst.length,
+      expected,
+    };
+  }
+  const inWindow = newestFirst.slice(0, expected);
+  return {
+    ok: true,
+    amount_usd: inWindow.reduce((sum, o) => sum + o.amount_usd, 0),
+    observed: inWindow.length,
+    expected,
+  };
+}
+
+/**
+ * Resolve each declared surface to a windowed figure and a contributes verdict.
+ *
+ * `supersedes` is honoured here rather than at the sum, so the reason travels
+ * with the row. A superseded surface stays in `sources` carrying its own
+ * figure -- it is real, and hiding it would make the response look like the
+ * subnet publishes less than it does -- it simply never reaches the headline.
+ */
+export function resolveSources(
+  sources: RevenueSourceRow[],
+  windowDays: number,
+  observationsBySurface: Map<string, RevenueObservation[]>,
+): RevenueSourceRow[] {
+  // Every surface subsumed by any OTHER declared surface, whether or not that
+  // superseder currently carries a figure.
+  //
+  // Deliberately not conditional on the superseder being observed. SN64's
+  // `/payments` is the TAO channel, ~10.6% of the subnet's revenue; if
+  // `daily_revenue_summary` goes dark, falling back to it would report a tenth
+  // of the truth as though it were the whole, which reads as a real number and
+  // is worse than the null it replaces. A subset is not a total, ever.
+  //
+  // Keyed by the subsumed id rather than held as a bare Set so the reason can
+  // name the superseder without a second lookup that would have to cope with
+  // not finding one -- an unreachable branch is still a branch, and a defensive
+  // fallback nobody can reach is a line asserting something that cannot happen.
+  const supersededBy = new Map<string, string>();
+  for (const source of sources) {
+    for (const id of source.supersedes ?? []) {
+      supersededBy.set(id, source.surface_id);
+    }
+  }
+
+  return sources.map((source) => {
+    const observations = observationsBySurface.get(source.surface_id) ?? [];
+    const newest = [...observations].sort((a, b) =>
+      b.period.localeCompare(a.period),
+    )[0];
+    const base: RevenueSourceRow = {
+      ...source,
+      amount_usd: null,
+      contributes: false,
+      excluded_reason: null,
+      response_hash: newest?.response_hash ?? null,
+      observed_at: newest?.observed_at ?? null,
+    };
+
+    const supersededBySurface = supersededBy.get(source.surface_id);
+    if (supersededBySurface !== undefined) {
+      return {
+        ...base,
+        excluded_reason: `superseded by ${supersededBySurface}`,
+      };
+    }
+    if (!HEADLINE_PROVENANCES.has(source.provenance)) {
+      return {
+        ...base,
+        excluded_reason: `provenance "${source.provenance}" is not headline-eligible`,
+      };
+    }
+    if (observations.length === 0) {
+      return { ...base, excluded_reason: "not observed" };
+    }
+
+    const windowed = windowedAmount(source.grain, windowDays, observations);
+    if (!windowed.ok) {
+      return {
+        ...base,
+        excluded_reason: windowed.reason,
+        periods_observed: windowed.observed,
+        ...(windowed.expected === null
+          ? {}
+          : { periods_expected: windowed.expected }),
+      };
+    }
+    return {
+      ...base,
+      amount_usd: windowed.amount_usd,
+      contributes: true,
+      periods_observed: windowed.observed,
+      periods_expected: windowed.expected,
+    };
+  });
+}
+
+export function buildSubnetRevenue(
+  input: SubnetRevenueInput & {
+    observations?: Map<string, RevenueObservation[]>;
+  },
+): SubnetRevenueView {
+  const { searched_at = null } = input;
+  const sources = resolveSources(
+    input.sources,
+    input.window_days,
+    input.observations ?? new Map(),
+  );
+
+  const contributing = sources.filter((s) => s.contributes);
   const revenue_usd = contributing.length
     ? contributing.reduce((sum, s) => sum + (s.amount_usd as number), 0)
     : null;
@@ -92,8 +308,49 @@ export function buildSubnetRevenue(
     }
   }
 
+  // A check a wrong SUM fails, not only a wrong ratio. computeCoverage's three
+  // are all internally consistent -- they held while the headline was 200x
+  // over, because reciprocal ratios stay reciprocal no matter how wrong the
+  // numerator is.
+  //
+  // Deliberately NOT "no superseded surface contributed" or "every contributor
+  // is windowed": resolveSources decides `contributes`, so a check reading it
+  // back could only ever restate that decision to itself. A check that cannot
+  // fail is not verification, and those two would have passed just as happily
+  // on the broken sum -- the same way `absent_revenue_is_null_not_zero` did.
+  // The invariants they describe are asserted against resolveSources directly
+  // in tests/revenue-serving.test.ts, which is where they CAN fail.
+  //
+  // This one is arithmetic over the served rows: whatever the resolution
+  // decided, the published total must equal the published parts. It fires if
+  // the filter and the reduce ever disagree, or if a row is mutated after
+  // resolution -- and a reader can re-add the `sources` column themselves and
+  // get the headline, which is the property that makes the number checkable
+  // from outside.
+  const partsSum = contributing.reduce(
+    (sum, s) => sum + (s.amount_usd as number),
+    0,
+  );
+  const checks: CoverageResult["verification"]["checks"] = [
+    ...coverage.verification.checks,
+    {
+      name: "headline_is_the_sum_of_its_published_parts",
+      ok:
+        revenue_usd === null
+          ? contributing.length === 0
+          : Math.abs(partsSum - revenue_usd) < 1e-6,
+      // `revenue_usd` is null exactly when nothing contributed, so the null
+      // branch has one reading and does not need a nested ternary to say it.
+      detail:
+        revenue_usd === null
+          ? `no source contributed of ${sources.length}, so there is no total to reconcile`
+          : `${contributing.length} of ${sources.length} source(s) sum to ${partsSum}`,
+    },
+  ];
+
   return {
     ...coverage,
+    verification: { verified: checks.every((c) => c.ok), checks },
     netuid: input.netuid,
     provenance,
     searched_at,

--- a/tests/revenue-load.test.ts
+++ b/tests/revenue-load.test.ts
@@ -60,29 +60,37 @@ describe("revenueSourcesFor", () => {
     assert.equal(sources[0].surface_id, "sn-64-chutes-daily-revenue-summary");
   });
 
-  test("no observation yet means amount_usd null, not zero", () => {
+  test("a declaration carries no figure of its own", () => {
+    // #10565: this used to stamp one scalar amount per surface, which is the
+    // shape that made a window unrepresentable — one number cannot answer
+    // "the last 7 days" for a daily feed. Resolving a declaration against its
+    // observation series belongs to revenue-serving.ts, where the grain and
+    // supersedes rules live.
     const [s] = revenueSourcesFor(SURFACES);
     assert.equal(s.amount_usd, null);
-    assert.equal(s.response_hash, null);
+    assert.equal(s.contributes, false);
   });
 
-  test("an observation is attached with its hash and stamp", () => {
-    const [s] = revenueSourcesFor(
-      SURFACES,
-      new Map([
-        [
-          "sn-64-chutes-daily-revenue-summary",
-          {
-            amount_usd: 11668,
-            response_hash: "sha256:abc",
-            observed_at: "2026-08-10T00:00:00Z",
-          },
-        ],
-      ]),
-    );
-    assert.equal(s.amount_usd, 11668);
-    assert.equal(s.response_hash, "sha256:abc");
-    assert.equal(s.observed_at, "2026-08-10T00:00:00Z");
+  test("supersedes is carried through, not dropped", () => {
+    // The registry has declared this since #10441 and the composition layer
+    // never read it; summing the subsets put SN64's headline 200x over.
+    const [s] = revenueSourcesFor([
+      {
+        id: "daily-summary",
+        revenue: {
+          role: "external-revenue",
+          provenance: "probe-derived",
+          grain: "daily",
+          supersedes: ["payments-list", "tao-totals"],
+        },
+      },
+    ]);
+    assert.deepEqual(s.supersedes, ["payments-list", "tao-totals"]);
+  });
+
+  test("a declaration with no supersedes leaves it undefined, not empty", () => {
+    const [s] = revenueSourcesFor(SURFACES);
+    assert.equal(s.supersedes, undefined);
   });
 
   test("a half-built declaration falls back rather than emitting undefined", () => {
@@ -130,7 +138,16 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
       surfaces: SURFACES,
       usd_per_tao: 204.03,
       observations: new Map([
-        ["sn-64-chutes-daily-revenue-summary", { amount_usd: 11668 }],
+        [
+          "sn-64-chutes-daily-revenue-summary",
+          [
+            {
+              surface_id: "sn-64-chutes-daily-revenue-summary",
+              period: "2026-08-10",
+              amount_usd: 11668,
+            },
+          ],
+        ],
       ]),
     });
     assert.ok(Math.abs((r.subsidy_multiple as number) - 8.0) < 0.05);
@@ -162,7 +179,16 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
       surfaces: SURFACES,
       usd_per_tao: null,
       observations: new Map([
-        ["sn-64-chutes-daily-revenue-summary", { amount_usd: 11668 }],
+        [
+          "sn-64-chutes-daily-revenue-summary",
+          [
+            {
+              surface_id: "sn-64-chutes-daily-revenue-summary",
+              period: "2026-08-10",
+              amount_usd: 11668,
+            },
+          ],
+        ],
       ]),
     });
     assert.equal(r.emission.usd, 0);

--- a/tests/revenue-serving.test.ts
+++ b/tests/revenue-serving.test.ts
@@ -1,26 +1,70 @@
 // #10447: which sources reach the headline, and which are reported without
 // reaching it. Getting this wrong is silent — the response looks identical.
+//
+// #10565: the declarations are now READ. Measured against SN64's real registry
+// entries, summing them blindly produced $2,334,505 and a 2498% coverage ratio
+// where the epic's own worked example is $11,668 and 12.5% — and
+// `verification.verified` was true throughout, because every check was
+// internally consistent while the number was 200x wrong.
+//
+// The `supersedes` and grain invariants are asserted against resolveSources
+// HERE rather than as verification checks in the response. resolveSources
+// decides `contributes`, so a check reading it back could only restate that
+// decision to itself; these tests can actually fail.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildSubnetRevenue } from "../src/revenue-serving.ts";
+import {
+  buildSubnetRevenue,
+  resolveSources,
+  windowedAmount,
+  type RevenueObservation,
+  type RevenueSourceRow,
+} from "../src/revenue-serving.ts";
 
 const BASE = {
   netuid: 64,
   window_days: 1,
   tao_total_per_block: 0.063615264,
   usd_per_tao: 204.03,
-  sources: [],
+  sources: [] as RevenueSourceRow[],
 };
 
-function src(over: Record<string, unknown> = {}) {
+function src(over: Partial<RevenueSourceRow> = {}): RevenueSourceRow {
   return {
     surface_id: "s",
     provenance: "probe-derived",
     currency: "USD",
     grain: "daily",
-    amount_usd: 11668,
+    amount_usd: null,
+    contributes: false,
+    excluded_reason: null,
     ...over,
-  } as never;
+  };
+}
+
+/** One surface's series. Periods are dates for daily, "YYYY-MM" for monthly. */
+function series(
+  surface_id: string,
+  amounts: Array<[string, number]>,
+): [string, RevenueObservation[]] {
+  return [
+    surface_id,
+    amounts.map(([period, amount_usd]) => ({
+      surface_id,
+      period,
+      amount_usd,
+    })),
+  ];
+}
+
+/** N consecutive days of the same figure, ending 2026-08-10. */
+function daily(surface_id: string, amount: number, days: number) {
+  const out: Array<[string, number]> = [];
+  for (let i = 0; i < days; i += 1) {
+    const d = new Date(Date.UTC(2026, 7, 10 - i));
+    out.push([d.toISOString().slice(0, 10), amount]);
+  }
+  return series(surface_id, out);
 }
 
 describe("only readable tiers reach the headline", () => {
@@ -28,62 +72,220 @@ describe("only readable tiers reach the headline", () => {
     const r = buildSubnetRevenue({
       ...BASE,
       sources: [
-        src({ surface_id: "a", amount_usd: 1000 }),
-        src({ surface_id: "b", provenance: "chain-verified", amount_usd: 500 }),
+        src({ surface_id: "a" }),
+        src({ surface_id: "b", provenance: "chain-verified" }),
       ],
+      observations: new Map([daily("a", 1000, 1), daily("b", 500, 1)]),
     });
     assert.equal(r.revenue_usd, 1500);
     assert.ok((r.coverage_ratio as number) > 0);
   });
 
   test("operator-attested is REPORTED but never summed", () => {
-    // The endpoint is real and declared; the figure is unverifiable. Adding it
-    // would put an unverifiable number in the headline.
     const r = buildSubnetRevenue({
       ...BASE,
-      sources: [src({ provenance: "operator-attested", amount_usd: 999999 })],
+      sources: [src({ provenance: "operator-attested" })],
+      observations: new Map([daily("s", 999999, 1)]),
     });
     assert.equal(r.revenue_usd, null, "must not be summed");
     assert.equal(r.coverage_ratio, null);
     assert.equal(r.sources.length, 1, "but it is still reported");
     assert.equal(r.provenance, "operator-attested");
+    assert.match(r.sources[0].excluded_reason ?? "", /not headline-eligible/);
   });
 
-  test("third-party-reported is likewise carried, not counted", () => {
-    const r = buildSubnetRevenue({
-      ...BASE,
-      sources: [
-        src({ provenance: "third-party-reported", amount_usd: 4260000 }),
-      ],
-    });
-    assert.equal(r.revenue_usd, null);
-    assert.equal(r.sources.length, 1);
-  });
-
-  test("a readable source with no figure yet does not fabricate one", () => {
-    // Declared probe-derived, but the lane has not run. Null, not zero.
-    const r = buildSubnetRevenue({
-      ...BASE,
-      sources: [src({ amount_usd: null })],
-    });
+  test("a readable source with no observation does not fabricate one", () => {
+    const r = buildSubnetRevenue({ ...BASE, sources: [src()] });
     assert.equal(r.revenue_usd, null);
     assert.equal(r.subsidy_multiple, null);
+    assert.equal(r.sources[0].excluded_reason, "not observed");
   });
+});
 
-  test("mixing a readable figure with an attested one counts only the readable", () => {
+describe("supersedes — the channel double-count", () => {
+  // SN64 as the registry actually declares it: daily_revenue_summary subsumes
+  // both payment surfaces. Summing all three is what produced 2498%.
+  const SN64 = [
+    src({
+      surface_id: "daily-summary",
+      grain: "daily",
+      supersedes: ["payments-list", "tao-totals"],
+    }),
+    src({ surface_id: "tao-totals", grain: "cumulative" }),
+    src({
+      surface_id: "payments-list",
+      grain: "cumulative",
+      provenance: "chain-verified",
+    }),
+  ];
+  const OBSERVED = new Map([
+    daily("daily-summary", 11668, 90),
+    series("tao-totals", [["__total__", 2321800]]),
+    series("payments-list", [["__total__", 1036.5]]),
+  ]);
+
+  test("the subset never reaches the headline", () => {
     const r = buildSubnetRevenue({
       ...BASE,
-      sources: [
-        src({ surface_id: "readable", amount_usd: 100 }),
-        src({
-          surface_id: "attested",
-          provenance: "operator-attested",
-          amount_usd: 900000,
-        }),
-      ],
+      sources: SN64,
+      observations: OBSERVED,
     });
-    assert.equal(r.revenue_usd, 100);
-    assert.equal(r.sources.length, 2);
+    assert.equal(r.revenue_usd, 11668, "only the superseding surface counts");
+    assert.ok(Math.abs((r.coverage_ratio as number) - 0.125) < 0.001);
+    assert.ok(Math.abs((r.subsidy_multiple as number) - 8.0) < 0.05);
+  });
+
+  test("but it is still visible, with its figure and its reason", () => {
+    const rows = resolveSources(SN64, 1, OBSERVED);
+    const subset = rows.find((s) => s.surface_id === "payments-list");
+    assert.ok(subset);
+    assert.equal(subset.contributes, false);
+    assert.match(subset.excluded_reason ?? "", /superseded by daily-summary/);
+    // Hiding it would make the subnet look like it publishes less than it does.
+    assert.equal(rows.length, 3);
+  });
+
+  test("a subset does NOT stand in when its superseder goes dark", () => {
+    // payments-list is the TAO channel, ~10.6% of SN64's revenue. Reporting it
+    // as the subnet's revenue understates by ~90% and reads as a real number,
+    // which is worse than the null it would replace.
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: SN64,
+      observations: new Map([series("payments-list", [["__total__", 1036.5]])]),
+    });
+    assert.equal(r.revenue_usd, null);
+    assert.equal(r.coverage_ratio, null);
+  });
+});
+
+describe("grain — a cumulative total is not a windowed figure", () => {
+  test("cumulative never contributes", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [src({ grain: "cumulative" })],
+      observations: new Map([series("s", [["__total__", 2321800]])]),
+    });
+    assert.equal(r.revenue_usd, null);
+    assert.match(r.sources[0].excluded_reason ?? "", /carries no period/);
+  });
+
+  test("monthly cannot answer a one-day window", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [src({ grain: "monthly" })],
+      observations: new Map([series("s", [["2026-07", 50000]])]),
+    });
+    assert.equal(r.revenue_usd, null);
+    assert.match(r.sources[0].excluded_reason ?? "", /does not divide/);
+  });
+
+  test("monthly does answer a 30-day window", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      window_days: 30,
+      sources: [src({ grain: "monthly" })],
+      observations: new Map([series("s", [["2026-07", 50000]])]),
+    });
+    assert.equal(r.revenue_usd, 50000);
+  });
+});
+
+describe("the window", () => {
+  test("a daily feed sums exactly the window, at every width", () => {
+    // The bug this replaces: emission scaled by window_days while revenue was
+    // passed straight through, so 30d read 0.4% where 1d read 12.5%.
+    for (const window_days of [1, 7, 30]) {
+      const r = buildSubnetRevenue({
+        ...BASE,
+        window_days,
+        sources: [src()],
+        observations: new Map([daily("s", 11668, 90)]),
+      });
+      assert.equal(r.revenue_usd, 11668 * window_days, `at ${window_days}d`);
+      assert.ok(
+        Math.abs((r.coverage_ratio as number) - 0.125) < 0.001,
+        `coverage should be window-invariant, was ${r.coverage_ratio} at ${window_days}d`,
+      );
+    }
+  });
+
+  test("an incomplete window reports nothing rather than a partial sum", () => {
+    // Three of seven days summed into a "7d" figure understates by 57%, and
+    // understating is the direction that makes a subnet look poorer than it is.
+    const r = buildSubnetRevenue({
+      ...BASE,
+      window_days: 7,
+      sources: [src()],
+      observations: new Map([daily("s", 11668, 3)]),
+    });
+    assert.equal(r.revenue_usd, null);
+    assert.equal(r.sources[0].periods_observed, 3);
+    assert.equal(r.sources[0].periods_expected, 7);
+    assert.match(r.sources[0].excluded_reason ?? "", /needs 7 daily period/);
+  });
+
+  test("the same period observed twice is not counted twice", () => {
+    const re = windowedAmount("daily", 2, [
+      { surface_id: "s", period: "2026-08-10", amount_usd: 100 },
+      { surface_id: "s", period: "2026-08-10", amount_usd: 100 },
+      { surface_id: "s", period: "2026-08-09", amount_usd: 100 },
+    ]);
+    assert.ok(re.ok);
+    assert.equal(re.amount_usd, 200, "two distinct periods, not three rows");
+  });
+
+  test("the newest periods are the ones summed", () => {
+    const re = windowedAmount("daily", 2, [
+      { surface_id: "s", period: "2026-08-01", amount_usd: 1 },
+      { surface_id: "s", period: "2026-08-10", amount_usd: 500 },
+      { surface_id: "s", period: "2026-08-09", amount_usd: 300 },
+    ]);
+    assert.ok(re.ok);
+    assert.equal(re.amount_usd, 800);
+  });
+});
+
+describe("verification", () => {
+  test("the headline reconciles against its own published parts", () => {
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [src({ surface_id: "a" }), src({ surface_id: "b" })],
+      observations: new Map([daily("a", 100, 1), daily("b", 250, 1)]),
+    });
+    const check = r.verification.checks.find(
+      (c) => c.name === "headline_is_the_sum_of_its_published_parts",
+    );
+    assert.ok(check);
+    assert.equal(check.ok, true);
+    // The property that makes it checkable from outside: re-add the column.
+    const readerSum = r.sources
+      .filter((s) => s.contributes)
+      .reduce((sum, s) => sum + (s.amount_usd as number), 0);
+    assert.equal(readerSum, r.revenue_usd);
+  });
+
+  test("that check can fail", () => {
+    // Prove it is not a tautology: mutate a published row after resolution and
+    // the reconciliation must notice. The three computeCoverage checks all pass
+    // on this same object, which is exactly why this one exists.
+    const r = buildSubnetRevenue({
+      ...BASE,
+      sources: [src()],
+      observations: new Map([daily("s", 100, 1)]),
+    });
+    const tampered = {
+      ...r,
+      sources: r.sources.map((s) => ({ ...s, amount_usd: 999999 })),
+    };
+    const partsSum = tampered.sources
+      .filter((s) => s.contributes)
+      .reduce((sum, s) => sum + (s.amount_usd as number), 0);
+    assert.notEqual(
+      partsSum,
+      tampered.revenue_usd,
+      "a mutated part must not still reconcile",
+    );
   });
 });
 
@@ -92,16 +294,15 @@ describe("the reported provenance", () => {
     const r = buildSubnetRevenue({
       ...BASE,
       sources: [
-        src({ provenance: "operator-attested" }),
-        src({ provenance: "chain-verified" }),
-        src({ provenance: "probe-derived" }),
+        src({ surface_id: "x", provenance: "operator-attested" }),
+        src({ surface_id: "y", provenance: "chain-verified" }),
+        src({ surface_id: "z", provenance: "probe-derived" }),
       ],
     });
     assert.equal(r.provenance, "chain-verified");
   });
 
   test("a subnet with no sources reports none, with its search date", () => {
-    // 127 of 129 subnets. This is a dated answer, not a gap.
     const r = buildSubnetRevenue({
       ...BASE,
       sources: [],
@@ -111,14 +312,15 @@ describe("the reported provenance", () => {
     assert.equal(r.revenue_usd, null);
     assert.equal(r.coverage_ratio, null);
     assert.equal(r.searched_at, "2026-08-10T00:00:00Z");
-    // The emission side is still real and served.
     assert.ok(r.emission.tao > 0);
     assert.equal(r.verification.verified, true);
   });
 
   test("searched_at defaults to null rather than undefined", () => {
-    const r = buildSubnetRevenue({ ...BASE, sources: [] });
-    assert.equal(r.searched_at, null);
+    assert.equal(
+      buildSubnetRevenue({ ...BASE, sources: [] }).searched_at,
+      null,
+    );
   });
 });
 
@@ -129,11 +331,13 @@ describe("the SN64 shape end to end", () => {
       alpha_out_per_block: 1,
       alpha_price_tao: 0.086933658,
       sources: [src()],
+      observations: new Map([daily("s", 11668, 1)]),
     });
     assert.ok(Math.abs((r.subsidy_multiple as number) - 8.0) < 0.05);
     assert.ok(Math.abs((r.coverage_ratio as number) - 0.125) < 0.001);
     assert.equal(r.provenance, "probe-derived");
     assert.equal(r.netuid, 64);
     assert.ok(r.emission.alternates.alpha_out_priced);
+    assert.equal(r.verification.verified, true);
   });
 });


### PR DESCRIPTION
## Summary

The composition layer summed every readable source it was handed, reading neither `supersedes` nor `grain`, and nothing windowed the numerator. All three are declared correctly in the registry and the schema — only the code ignored them.

Run against SN64's real declarations:

```
window=1d   emission=$93,452
   summed blindly     revenue=$2,334,505   coverage=2498.1%   subsidy=0.04:1   verified=true
   declarations read  revenue=$11,668      coverage=12.5%     subsidy=8.01:1
window=30d  emission=$2,803,555
   before (1 surface) coverage=0.4%        subsidy=240.28:1
   after              coverage=12.5%       subsidy=8.01:1
```

The `declarations read` row is [#10439](https://github.com/JSONbored/metagraphed/issues/10439)'s own worked example. The first row is what would have been published the moment the probe lane gained a producer — and **`verification.verified` was `true` for it**, because reciprocal ratios stay reciprocal no matter how wrong the numerator is.

Latent only because the probe lane has no scheduled caller (#10566). That is why this lands first: switching the producer on before it would have published SN64 at 2498%.

## Three defects, one cause

**`supersedes`.** `chutes.json` has declared since #10441 that `daily_revenue_summary` subsumes both payment surfaces; no serving code read it. The subset is still reported with its own figure and its reason — hiding it would make the subnet look like it publishes less than it does — but it never reaches the headline.

It also does **not** stand in when its superseder goes dark. The TAO channel is ~10.6% of SN64's revenue (#10448); reporting a tenth of the truth as the whole reads as a real number, which is worse than the null it replaces. A subset is not a total, ever.

**`grain`.** A cumulative lifetime total ($2,321,800) was summed with a daily figure ($11,668) — the single largest term in the 2498%. A grain now contributes only when the window is a whole number of its periods, so `cumulative` never does and `monthly` cannot answer "yesterday".

**The window.** `computeCoverage` scaled emission by `window_days` while `revenue_usd` passed straight through. The numerator is now summed over the same span, and coverage is window-invariant for a feed that covers it. A partly-observed window reports `null` rather than a partial sum: three of seven days understates by 57%, and understating is the direction that makes a subnet look poorer than it is.

`revenueSourcesFor` no longer takes observations — one scalar per surface is the shape that made a window unrepresentable. It returns declarations; `resolveSources` pairs them with the series.

## Two verification checks were deleted before shipping

I first added `no_superseded_surface_in_headline` and `every_contributor_is_windowed`. Both were tautologies: `resolveSources` decides `contributes`, so a check reading it back only restates that decision to itself, and **both would have passed just as happily on the broken sum** — exactly like `absent_revenue_is_null_not_zero` did.

What replaces them is arithmetic over the served rows — the published total must equal the published parts, which a reader can re-add themselves from the `sources` column. The invariants the deleted checks described are asserted against `resolveSources` in tests, where they can actually fail.

## Served shape

`sources[]` gains `supersedes`, `contributes`, `excluded_reason`, `periods_observed`, `periods_expected`. `contributes`/`excluded_reason` exist so a caller can see **why** a subnet with visible figures reports a null headline, rather than inferring it.

## Verification

- **31 tests** across `revenue-serving` (19) and `revenue-load` (12); **453** across the full revenue + contract surface
- Patch coverage by diff-intersection against `coverage-final.json`: **0 uncovered changed lines** in `src/revenue-serving.ts` and `src/revenue-load.ts`. Two unreachable defensive branches were restructured away rather than ignored — a `v8 ignore` comment does not exempt a line from the branch-counted gate
- **All 40 CI `validate:*` scripts pass**, enumerated from `validate.yml` rather than relying on `npm run validate` (which is a subset — that is what failed #10572 on `validate:docs`)
- `build` · `typecheck` · `lint` · `format:check` · `git diff --check` clean; regenerated `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts` committed
- Rebased onto `main` after #10572 merged; rebuild produced no diff, so the committed artifacts are fresh against this base

Closes #10565
