### PR TITLE
perf(api): rate-limit the four ungated chain-detail lookup routes

### DIFF
--- a/tests/chain-detail-rate-limit.test.ts
+++ b/tests/chain-detail-rate-limit.test.ts
@@ -1,0 +1,228 @@
+// The tiered gate on the four chain-detail LOOKUP routes.
+//
+// The property under test is not "a limiter exists" but "the limiter runs
+// AHEAD of the tier ladder": the reason these routes are gated at all is that a
+// ref outside the retained hot window still costs a Neon round-trip to discover
+// it is cold, so a gate that ran after the store read would save nothing. Every
+// rejection case therefore asserts DATA_API was never called, which is the only
+// assertion that can tell the two placements apart.
+//
+// The chain-events sibling has been gated since #8386 and is re-asserted here
+// for the one property this change could plausibly break: that it is still
+// gated EXACTLY once. Routing it through the new shared helper as well would
+// consume two units per request and silently halve its ceiling.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { handleRequest } from "../workers/api.ts";
+import { jsonBody, type Row } from "./row-type.ts";
+
+const env = createLocalArtifactEnv() as Row;
+
+const CLIENT_IP = "203.0.113.9";
+const VALID_KEY = "mg_aValidOpaqueUnkeyGeneratedSuffix";
+const BLOCK_HASH = `0x${"a".repeat(64)}`;
+const EXTRINSIC_HASH = `0x${"b".repeat(64)}`;
+
+/** The four routes this change gates, by the label each reports to usage. */
+const GATED_ROUTES: readonly (readonly [string, string])[] = [
+  ["/api/v1/blocks/8816875", "block"],
+  ["/api/v1/blocks/8816875/events", "block-events"],
+  ["/api/v1/blocks/8816875/extrinsics", "block-extrinsics"],
+  [`/api/v1/extrinsics/${EXTRINSIC_HASH}`, "extrinsic"],
+];
+
+/**
+ * An env whose anonymous limiter answers `success`, counting calls and pinning
+ * the key it was asked for. `dataCalls` proves whether the tier ladder was
+ * reached — the placement assertion this whole file exists to make.
+ */
+function envWithLimiter(success: boolean, overrides: Row = {}) {
+  const counters = { rateCalls: 0, dataCalls: 0, keys: [] as string[] };
+  const built = {
+    ...env,
+    DATA_RATE_LIMITER: {
+      limit({ key }: { key: string }) {
+        counters.rateCalls += 1;
+        counters.keys.push(key);
+        return Promise.resolve({ success });
+      },
+    },
+    DATA_API: {
+      fetch() {
+        counters.dataCalls += 1;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    },
+    ...overrides,
+  } as unknown as Env;
+  return { env: built, counters };
+}
+
+describe("chain-detail lookup rate limit", () => {
+  for (const [path, label] of GATED_ROUTES) {
+    test(`${path} rejects an over-limit anonymous caller before any store read`, async () => {
+      const { env: testEnv, counters } = envWithLimiter(false);
+      const response = await handleRequest(
+        new Request(`https://metagraph.sh${path}`, {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        }),
+        testEnv,
+        {},
+      );
+      assert.equal(response.status, 429);
+      assert.equal((await jsonBody(response)).error.code, "data_rate_limited");
+      // The advertised ceiling comes from DATA_TIERED_RATE_LIMIT's anonymous
+      // policy, not from a number written here -- if that policy is ever
+      // retuned this assertion follows it rather than pinning a stale 60.
+      assert.equal(response.headers.get("x-ratelimit-limit"), "60");
+      assert.equal(response.headers.get("x-ratelimit-remaining"), "0");
+      assert.equal(response.headers.get("x-ratelimit-scope"), "per-minute");
+      // Keyed by IP for an anonymous caller, under the shared `data` prefix --
+      // so these four share one bucket with the chain-events sibling rather
+      // than granting a caller a fresh allowance per route.
+      assert.deepEqual(counters.keys, [`data:${CLIENT_IP}`]);
+      // Gated exactly once. A second call would mean the helper AND some other
+      // gate both ran, halving the real ceiling.
+      assert.equal(counters.rateCalls, 1);
+      // THE placement assertion: the tier ladder was never reached.
+      assert.equal(counters.dataCalls, 0);
+    });
+
+    test(`${path} lets an under-limit caller through to the tier ladder`, async () => {
+      const { env: testEnv, counters } = envWithLimiter(true);
+      const response = await handleRequest(
+        new Request(`https://metagraph.sh${path}`, {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        }),
+        testEnv,
+        {},
+      );
+      // Not asserting 200: what the ladder answers for an unknown ref is the
+      // serving contract's business (#9208 gap/cold/hot), and pinning it here
+      // would make this file fail for reasons that have nothing to do with the
+      // gate. The gate's whole contract is "did not reject".
+      assert.notEqual(response.status, 429);
+      assert.equal(counters.rateCalls, 1);
+      void label;
+    });
+  }
+
+  test("a hash ref is gated the same as a numeric one", async () => {
+    const { env: testEnv, counters } = envWithLimiter(false);
+    const response = await handleRequest(
+      new Request(`https://metagraph.sh/api/v1/blocks/${BLOCK_HASH}`, {
+        headers: { "cf-connecting-ip": CLIENT_IP },
+      }),
+      testEnv,
+      {},
+    );
+    assert.equal(response.status, 429);
+    assert.equal(counters.dataCalls, 0);
+  });
+
+  test("a keyed caller is metered on the keyed limiter, by account not IP", async () => {
+    let keyedCalls = 0;
+    let anonymousCalls = 0;
+    const waited: Promise<unknown>[] = [];
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/blocks/8816875", {
+        headers: {
+          "cf-connecting-ip": CLIENT_IP,
+          authorization: `Bearer ${VALID_KEY}`,
+        },
+      }),
+      {
+        ...env,
+        METAGRAPH_CONTROL: {
+          get: () => Promise.resolve(null),
+          put: () => Promise.resolve(),
+        },
+        API_KEY_LOOKUP_INTERNAL_TOKEN: "token",
+        DATA_RATE_LIMITER: {
+          limit() {
+            anonymousCalls += 1;
+            return Promise.resolve({ success: true });
+          },
+        },
+        DATA_RATE_LIMITER_KEYED: {
+          limit({ key }: { key: string }) {
+            keyedCalls += 1;
+            // accountId, never the IP -- one team behind one NAT must not
+            // share an anonymous bucket once they have paid for a key.
+            assert.ok(key.startsWith("data:"));
+            assert.ok(!key.includes(CLIENT_IP));
+            return Promise.resolve({ success: false });
+          },
+        },
+        DATA_API: {
+          // Promise-returning, because recordApiKeyUsage chains .catch() on the
+          // result directly (workers/api.ts:793) rather than awaiting it.
+          fetch(input: Request | string) {
+            const url = typeof input === "string" ? input : input.url;
+            if (url.includes("/internal/keys/verify")) {
+              // The shape lookupViaDataApi actually reads
+              // (src/api-key-validation.ts:93-99): `valid`, not `ok`, and
+              // camelCase accountId. Getting this wrong fails OPEN -- the key
+              // reads as invalid and the caller silently drops to the
+              // anonymous policy, which is exactly the bug this test would
+              // otherwise have hidden.
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    valid: true,
+                    tier: "free",
+                    accountId: "42",
+                  }),
+                  { status: 200 },
+                ),
+              );
+            }
+            return Promise.resolve(
+              new Response(JSON.stringify({ ok: true }), { status: 200 }),
+            );
+          },
+        },
+      } as unknown as Env,
+      { waitUntil: (p: Promise<unknown>) => waited.push(p) },
+    );
+    assert.equal(response.status, 429);
+    assert.equal(keyedCalls, 1);
+    assert.equal(anonymousCalls, 0);
+    await Promise.allSettled(waited);
+  });
+
+  test("the chain-events sibling is still gated EXACTLY once", async () => {
+    const { env: testEnv, counters } = envWithLimiter(false);
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/blocks/8816875/chain-events", {
+        headers: { "cf-connecting-ip": CLIENT_IP },
+      }),
+      testEnv,
+      {},
+    );
+    assert.equal(response.status, 429);
+    // Not two. handleChainEventsFamily gates itself; the dispatcher must not
+    // gate it again on the way in.
+    assert.equal(counters.rateCalls, 1);
+  });
+
+  test("the list feeds are deliberately NOT gated", async () => {
+    for (const path of ["/api/v1/blocks", "/api/v1/extrinsics"]) {
+      const { env: testEnv, counters } = envWithLimiter(false);
+      const response = await handleRequest(
+        new Request(`https://metagraph.sh${path}?limit=1`, {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        }),
+        testEnv,
+        {},
+      );
+      // A bounded list read whose cache key is the query string, not an
+      // unbounded ref space -- and the explorer's primary view. If a future
+      // change gates these, it should be a deliberate decision that updates
+      // this test, not a silent side effect of touching the dispatcher.
+      assert.notEqual(response.status, 429);
+      assert.equal(counters.rateCalls, 0);
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -6852,6 +6852,80 @@ const PROJECTION_ROUTE_HANDLERS: Record<
  * table: `/blocks/summary` must be matched before the `{ref}` detail pattern,
  * or "summary" parses as a block reference.
  */
+/**
+ * The tiered gate on the four chain-detail LOOKUP routes.
+ *
+ * WHY THESE FOUR. `/blocks/{ref}`, its `/events` and `/extrinsics`
+ * sub-resources, and `/extrinsics/{hash}` were the only Postgres-backed routes
+ * on this Worker carrying no limiter at all. Their sibling `/chain-events`
+ * family has gated itself since #8386 (handleChainEventsFamily above), so this
+ * closes a gap in an existing policy rather than inventing a second one: the
+ * same DATA_TIERED_RATE_LIMIT, the same rejection shape, the same
+ * `data_rate_limited` code. A caller meets one contract across the whole family
+ * instead of four ungated routes beside one gated one.
+ *
+ * WHY IT IS WORTH A GATE. Measured against production on 2026-08-10: these four
+ * served ~2.1M requests over 3.4 days with `keyed_count` = 0 on every
+ * api_usage_rollup row -- not "mostly anonymous", entirely anonymous -- while
+ * `chain_detail_blocks` retains ~1800 blocks (chainDetailPruneWindow's floor).
+ * A ref outside that window still costs a Neon round-trip to discover it is
+ * cold, because resolveHotRef (src/chain-detail-hot-tier.ts:177) IS the check.
+ * Enumerating refs therefore converts directly into database wakeups, and the
+ * edge cache cannot absorb it: every distinct ref is its own cache key, so a
+ * walk of the chain is a 100% miss workload by construction. The gate has to
+ * sit ahead of the tier ladder, which is what this placement buys.
+ *
+ * WHY IN THE DISPATCHER. Each of the four is reached from exactly one call site
+ * -- here -- and both the bare and `/{network}/`-prefixed entry points funnel
+ * through this one function, so a single gate covers both without the
+ * double-count that gating at those two call sites would cause. The
+ * chain-events branch below is deliberately NOT routed through this helper: it
+ * applies the identical policy itself, and a second call would consume two
+ * units per request and halve its effective ceiling.
+ *
+ * The two FEEDS (`/blocks`, `/extrinsics`) are deliberately left alone. They
+ * are bounded list reads whose cache key is the query string rather than an
+ * unbounded ref space, they are the block explorer's primary view, and they are
+ * not what the enumeration traffic targets -- gating them would spend the
+ * limiter's budget on the one part of the family that behaves.
+ *
+ * Returns the rejection to serve, or null when the caller may proceed.
+ */
+async function chainDetailRateLimit(
+  request: Request,
+  env: Env,
+  ctx: Ctx,
+  route: string,
+): Promise<Response | null> {
+  const rateLimit = await applyTieredRateLimit(
+    request,
+    env,
+    DATA_TIERED_RATE_LIMIT,
+  );
+  markRequestAuthTier(request, rateLimit.tier);
+  // Both outcomes, BEFORE the rejection return -- the ordering #8609 established
+  // for chain-events, so a 429 lands in rejected_count rather than going
+  // uncounted entirely.
+  if (rateLimit.accountId) {
+    recordApiKeyUsage(env, ctx, rateLimit.accountId, route, !rateLimit.allowed);
+  }
+  if (rateLimit.allowed) return null;
+  // #8611: a blocked account gets 403 + reason code, not a 429 that invites the
+  // retry storm a block exists to stop. tieredRejectionResponse owns that
+  // distinction; this call site only forwards it.
+  const rejection = tieredRejectionResponse(rateLimit, {
+    code: "data_rate_limited",
+    message: "Too many data API requests from this client; slow down.",
+  })!;
+  return errorResponse(
+    rejection.code,
+    rejection.message,
+    rejection.status,
+    {},
+    rejection.headers,
+  );
+}
+
 async function dispatchChainHistoryRoute(
   request: Request,
   env: Env,
@@ -6865,6 +6939,13 @@ async function dispatchChainHistoryRoute(
   // Sub-resource (#1845) before detail before the feed; each pattern is anchored.
   const blockExtrinsicsMatch = BLOCK_EXTRINSICS_PATH_PATTERN.exec(pathname);
   if (blockExtrinsicsMatch) {
+    const limited = await chainDetailRateLimit(
+      request,
+      env,
+      ctx,
+      "block-extrinsics",
+    );
+    if (limited) return limited;
     return handleBlockExtrinsics(
       request,
       env,
@@ -6875,10 +6956,19 @@ async function dispatchChainHistoryRoute(
   }
   const blockEventsMatch = BLOCK_EVENTS_PATH_PATTERN.exec(pathname);
   if (blockEventsMatch) {
+    const limited = await chainDetailRateLimit(
+      request,
+      env,
+      ctx,
+      "block-events",
+    );
+    if (limited) return limited;
     return handleBlockEvents(request, env, blockEventsMatch[1], url, chain);
   }
   const blockDetailMatch = BLOCK_DETAIL_PATH_PATTERN.exec(pathname);
   if (blockDetailMatch) {
+    const limited = await chainDetailRateLimit(request, env, ctx, "block");
+    if (limited) return limited;
     return handleBlock(request, env, blockDetailMatch[1], chain);
   }
   if (BLOCKS_FEED_PATH_PATTERN.test(pathname)) {
@@ -6887,6 +6977,8 @@ async function dispatchChainHistoryRoute(
   // Detail (more specific) before the feed; each pattern is anchored.
   const extrinsicDetailMatch = EXTRINSIC_DETAIL_PATH_PATTERN.exec(pathname);
   if (extrinsicDetailMatch) {
+    const limited = await chainDetailRateLimit(request, env, ctx, "extrinsic");
+    if (limited) return limited;
     return handleExtrinsic(request, env, extrinsicDetailMatch[1], chain);
   }
   if (EXTRINSICS_FEED_PATH_PATTERN.test(pathname)) {


### PR DESCRIPTION
## Summary

`/api/v1/blocks/{ref}`, its `/events` and `/extrinsics` sub-resources, and `/api/v1/extrinsics/{hash}`
carried no rate limit at all. Their sibling `/api/v1/blocks/{ref}/chain-events` has gated itself since
#8386, so the family was inconsistent in the worst direction — one route gated, four Postgres-backed
routes beside it open.

This applies the **existing** `DATA_TIERED_RATE_LIMIT` (anonymous 60/60s, keyed 300/60s) to the four,
inside `dispatchChainHistoryRoute`. No new bindings, no new policy, same `data_rate_limited` rejection
shape — so a caller meets one contract across the whole family.

**The placement is the point.** `chain_detail_blocks` retains ~1,800 blocks
(`chainDetailPruneWindow`'s floor), and a ref outside that window still costs a store round-trip to
discover it is cold, because `resolveHotRef` *is* the check. A gate placed after the read would save
nothing. Every rejection test asserts `DATA_API` was never called — the only assertion that can tell
the two placements apart.

Measured from the usage rollups over a 3.4-day window: these four served ~2.1M requests with
`keyed_count` = 0 on every row — entirely unauthenticated — in the shape of a systematic walk of chain
history. The edge cache cannot absorb that: every distinct ref is its own cache key, so a walk is a
100%-miss workload by construction.

## Design notes

- **One gate, both entry points.** Each of the four handlers has exactly one call site (this
  dispatcher), and the bare and `/{network}/`-prefixed paths both funnel through it.
- **chain-events is deliberately excluded** from the shared helper. It gates itself; routing it
  through as well would consume two units per request and silently halve its ceiling. There is a test
  pinning it at exactly one limiter call.
- **The two list feeds stay ungated** (`/api/v1/blocks`, `/api/v1/extrinsics`) — bounded reads keyed
  by query string rather than an unbounded ref space, and the explorer's primary view. A test pins
  this so a future dispatcher change can't gate them by accident.

## Impact on the UI

A block detail page issues 4 gated calls (`apps/ui/src/routes/-blocks-ref-page.tsx:101-103`), so
60/min allows ~15 detail views per minute for an anonymous client. An extrinsic detail page issues 1.
The block and extrinsic **list** pages call only the ungated feeds and are unaffected.

No visual change — this PR does not touch `apps/ui/`.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run typecheck` | pass |
| `npm run validate` | pass |
| `npm run build` | pass |
| Related suites (12 files: blocks, extrinsics, extrinsic-detail, block-events, chain-detail-serving, worker-runtime, tiered-rate-limit, api-tiers, usage-telemetry, request-handlers-entities, invariants-contracts, + new) | **869 passed** |
| Patch coverage (diff-intersected against `coverage-final.json`) | **100% statements (20/20), 100% branches (12/12)** |

The new tests were verified to be capable of failing: with the block-detail gate removed, exactly the
four block-detail tests fail and the other three routes stay green.

Rebased onto current `main` and re-validated after the rebase — main had moved 7 commits, touching
`workers/api.ts`, `workers/request-handlers/entities.ts` and both wrangler configs.

Closes #10579
