### PR TITLE
fix(graphql): the equivalence report asks for its remainder instead of restating it

### DIFF
--- a/scripts/report-graphql-sdl-equivalence.ts
+++ b/scripts/report-graphql-sdl-equivalence.ts
@@ -8,11 +8,20 @@
 // differs from `src/graphql-sdl.ts`.
 //
 // A REPORT, not a gate, and deliberately so. The remaining differences are
-// things to FIX -- 24 fields the SDL under-types as `JSON`, 4 types whose shape
-// lives only in resolver code (#10409) -- and a gate that failed on them would
-// just be red until they are all closed. What a report gives instead is one
-// number per class that can be watched down to zero, at which point the cutover
-// is a no-op rather than a leap.
+// things to FIX, and a gate that failed on them would just be red until they
+// are all closed. What a report gives instead is one number per class that can
+// be watched down to zero, at which point the cutover is a no-op rather than a
+// leap.
+//
+// EVERY NUMBER IT PRINTS IS DERIVED, including the count of what is left. It
+// used to name its own remainder in prose -- "24 fields the SDL under-types as
+// JSON, 4 types whose shape lives only in resolver code (#10409)" -- and both
+// halves rotted: the under-typings are 50 (the scalar-identity check reached
+// projections and paginated views in #10409, counting debt that had never been
+// counted), and `RESOLVER_BUILT_TYPES` is EMPTY, because those four now have
+// schemas in `schemas-src/graphql/graphql-only.ts`. A report that is the
+// answer to "how far is the cutover" cannot carry a hand-written number that
+// disagrees with the checker it points at, so it asks the checker.
 //
 // SEMANTIC, not byte-for-byte. Argument ORDER is not significant in GraphQL and
 // the derived order is the route's, so comparing text would report ~31 fields
@@ -33,7 +42,11 @@ import {
   deriveQueryArguments,
   type OpenApiParameters,
 } from "../schemas-src/graphql/query-arguments.ts";
-import { extractSdl } from "./validate-graphql-component-parity.ts";
+import {
+  checkComponentParity,
+  extractSdl,
+  type OpenApiDocument,
+} from "./validate-graphql-component-parity.ts";
 
 const SDL_PATH = "src/graphql-sdl.ts";
 const OPENAPI_PATH = "public/metagraph/openapi.json";
@@ -169,10 +182,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     console.error(`sdl-equivalence: no SDL template literal in ${SDL_PATH}`);
     process.exit(1);
   }
-  const report = reportEquivalence(
-    sdl,
-    JSON.parse(readFileSync(OPENAPI_PATH, "utf8")) as OpenApiParameters,
-  );
+  const openapi = JSON.parse(readFileSync(OPENAPI_PATH, "utf8")) as unknown;
+  const report = reportEquivalence(sdl, openapi as OpenApiParameters);
   console.log(
     `sdl-equivalence: ${report.generatedTypes} of ${report.publishedTypes} published object ` +
       `type(s) have a generator source (the Query/Subscription roots excluded); ` +
@@ -180,12 +191,20 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       `${report.queryArgumentsExact} argument list(s) reproduce exactly.`,
   );
   if (!report.missingTypes.length && !report.differences.length) {
+    // Asked, not restated. `undertyped` is the same number
+    // `validate:graphql-component-parity` prints, so the two can never
+    // disagree the way the prose here used to.
+    const { undertyped } = checkComponentParity(
+      sdl,
+      openapi as OpenApiDocument,
+    );
     console.log(
       "\nEvery published type, every Query return type and every derivable\n" +
         "argument list has a source. What remains before the SDL can be\n" +
-        "GENERATED rather than compared is not coverage but content: the JSON\n" +
-        "under-typings `validate:graphql-component-parity` counts, and the four\n" +
-        "resolver-built types in #10409.",
+        "GENERATED rather than compared is not coverage but content: " +
+        `${undertyped} field(s)\n` +
+        "the SDL publishes as opaque `JSON` where the component has a shape.\n" +
+        "Closing one means publishing a named type; the count is the distance.",
     );
   }
   if (report.missingTypes.length) {


### PR DESCRIPTION
## Summary

- `report:graphql-sdl-equivalence` ended every clean run by naming remaining work that no longer
  exists, and understating what does.
- Fixed by making it **ask** the checker that owns the number rather than restating it, so the two
  cannot disagree again.

## What Changed

The report closed with:

```
... the JSON under-typings `validate:graphql-component-parity` counts,
and the four resolver-built types in #10409.
```

Both halves had rotted:

| claim | reality |
|---|---|
| four resolver-built types remain (#10409) | `RESOLVER_BUILT_TYPES` is **empty** — verified, length 0. Those four have schemas in `schemas-src/graphql/graphql-only.ts`; #10409 is closed. |
| header says 24 under-typings | **50**. Not drift: #10409's scalar-identity check reached projections and paginated views for the first time, counting debt that had never been counted. |

It printed on the **success path, unconditionally** — so the one report someone consults before
attempting the cutover sent them hunting four finished types while understating the real remainder by
half.

**The fix is not a corrected number**, which would rot identically. `checkComponentParity` is already
exported from `scripts/validate-graphql-component-parity.ts`, and this file already reads both inputs
it needs, so it now calls it and prints the count that checker computes.

Before / after, same tree:

```
- ... the JSON under-typings `validate:graphql-component-parity` counts, and the four
- resolver-built types in #10409.
+ ... 50 field(s) the SDL publishes as opaque `JSON` where the component has a shape.
+ Closing one means publishing a named type; the count is the distance.
```

50 is exactly what `validate:graphql-component-parity` reports.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — this is a report's
      output text and the derivation behind it.)*

## Validation

- [x] `npm run lint` — exit 0
- [x] `npm run format:check` — exit 0
- [x] `npm run typecheck` — exit 0
- [x] `npm run report:graphql-sdl-equivalence` — prints `50 field(s)`, matching
      `validate:graphql-component-parity`
- [x] `npx vitest run tests/graphql-sdl-equivalence.test.ts tests/graphql-component-parity.test.ts` — 33 passed
- [x] `git diff --check` — exit 0
- [ ] `npm run check` — still fails on `main` for the unrelated reason in #10567
- [ ] `npm run test:coverage` — not run; `scripts/` only, no `src/**`/`workers/**` lines changed

## Template Used

- `backend-code.md`

Closes #10584
