### PR TITLE
fix(ci): pipeline:check ran a script that does not exist

### DIFF
--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -71,7 +71,6 @@ function checkCommands(): Step[] {
     step("verify:candidates:dry-run"),
     step("curate:baseline:dry-run"),
     step("review:promote:dry-run"),
-    step("schemas:bundle:check"),
     step("schemas:snapshot:dry-run"),
     step("adapters:snapshot:dry-run"),
     step("openapi:generate:dry-run"),

--- a/tests/pipeline-steps.test.ts
+++ b/tests/pipeline-steps.test.ts
@@ -1,0 +1,46 @@
+// Every `step("...")` in scripts/pipeline.ts must name a real npm script (#10567).
+//
+// `pipeline:check` ran `step("schemas:bundle:check")` for months after #9848
+// deleted that script. Nothing noticed, because `pipeline:check` is a leg of
+// `npm run check` and `npm run check` is NOT run by CI -- so the failure only
+// ever appeared on a contributor's machine, at the very end of the chain, in
+// the command the backend-code PR template tells them to run first. It read
+// like they had broken something.
+//
+// Asserted here rather than in a validator because pipeline.ts self-executes on
+// import (it spawns the steps), so nothing can import its step lists -- and a
+// test already runs in CI, which is the property the original gap lacked.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "../scripts/lib.ts";
+
+const source = readFileSync(path.join(repoRoot, "scripts/pipeline.ts"), "utf8");
+const scripts = new Set(
+  Object.keys(
+    (
+      JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
+        scripts?: Record<string, string>;
+      }
+    ).scripts ?? {},
+  ),
+);
+
+/** Every distinct script name the pipeline declares a step for. */
+const stepNames = [
+  ...new Set([...source.matchAll(/step\("([^"]+)"/g)].map((m) => m[1])),
+];
+
+describe("pipeline steps", () => {
+  // Without this the test below passes on an empty list -- the exact shape of
+  // failure it exists to catch, one level up.
+  it("finds the step list at all", () => {
+    expect(stepNames.length).toBeGreaterThan(50);
+  });
+
+  it("names only scripts that exist in package.json", () => {
+    const missing = stepNames.filter((name) => !scripts.has(name));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `scripts/pipeline.ts` declared `step("schemas:bundle:check")`; #9848 deleted that npm script and left the step behind.
- That makes `npm run check` — **the first box on the backend-code PR template's checklist** — fail on a clean checkout of `main`.
- Removed, all 77 other step names audited, and guarded by a test so it cannot recur.

## What Changed

```
$ npm run schemas:bundle:check
npm error Missing script: "schemas:bundle:check"
```

`pipeline:check` is a leg of `check`:

```
check -> lint && format:check && typecheck && pipeline:check && validate:docs
```

Everything before it passes, so the failure lands at the very end and reads like the contributor broke
something. CI never caught it because `validate.yml` does not run `pipeline:check` — which is exactly
why `main` stayed green while the documented local command did not.

**Audited the other 77 `step()` names against `package.json`: this was the only orphan.**

**The guard is a test, not a validator**, for two reasons. `pipeline.ts` self-executes on import (it
spawns its steps), so nothing can import its step lists and a validator would read the source anyway.
And a test already runs in CI — the property the original gap lacked, since the broken step lived only
in a command CI never invoked. It asserts the step list is *found* before asserting it is *clean*, so
it cannot pass on an empty match.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none.)*

## Validation

- [x] `npm run lint` — exit 0
- [x] `npm run format:check` — exit 0
- [x] `npm run typecheck` — exit 0
- [x] `npx vitest run tests/pipeline-steps.test.ts` — 2 passed; proven to fail by re-adding the orphan
- [x] Step-name audit: 78 names, 0 missing after this change
- [x] `git diff --check` — exit 0

## Template Used

- `backend-code.md`

Closes #10567