### PR TITLE
feat(wallets): a subnet-level wallet_search record, so an absence is evidence

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10866,6 +10866,18 @@ export interface components {
             surface_count: number;
             symbol?: string | null;
             tempo?: number;
+            wallet_search?: {
+                /** @description Where the search actually looked. Without it, "we searched" is unfalsifiable and nobody else can re-run it. `chain` means the on-chain owner keys were read (SubnetOwner), which is always available and is NOT a declaration by the team. */
+                checked: ("website" | "docs" | "blog" | "source-repo" | "explorer" | "whitepaper" | "chain")[];
+                notes?: string;
+                /**
+                 * @description Cross-checked against registry/entities/ itself, so the summary cannot drift from the data it summarises.
+                 * @enum {string}
+                 */
+                outcome: "none-found" | "wallets-declared";
+                /** @description An absence with no date is not evidence. */
+                searched_at: string;
+            };
             website_url?: string | null;
         };
         SubnetDetailArtifact: {
@@ -18413,6 +18425,13 @@ export interface operations {
                      *           "surface_count": 1,
                      *           "symbol": "example",
                      *           "tempo": 1,
+                     *           "wallet_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "website_url": "https://api.metagraph.sh/example"
                      *         },
                      *         "surfaces": [
@@ -39298,6 +39317,13 @@ export interface operations {
                      *           "surface_count": 1,
                      *           "symbol": "example",
                      *           "tempo": 1,
+                     *           "wallet_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "website_url": "https://api.metagraph.sh/example"
                      *         },
                      *         "surfaces": [
@@ -44546,6 +44572,13 @@ export interface operations {
                      *           "surface_count": 1,
                      *           "symbol": "example",
                      *           "tempo": 1,
+                     *           "wallet_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "website_url": "https://api.metagraph.sh/example"
                      *         },
                      *         "surfaces": [

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9250,6 +9250,13 @@
               "surface_count": 1,
               "symbol": "example",
               "tempo": 1,
+              "wallet_search": {
+                "checked": [
+                  "website"
+                ],
+                "outcome": "none-found",
+                "searched_at": "2026-06-01T00:00:00.000Z"
+              },
               "website_url": "https://api.metagraph.sh/example"
             },
             "surfaces": [
@@ -11017,6 +11024,13 @@
               "surface_count": 1,
               "symbol": "example",
               "tempo": 1,
+              "wallet_search": {
+                "checked": [
+                  "website"
+                ],
+                "outcome": "none-found",
+                "searched_at": "2026-06-01T00:00:00.000Z"
+              },
               "website_url": "https://api.metagraph.sh/example"
             },
             "surfaces": [
@@ -44801,6 +44815,49 @@
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "wallet_search": {
+            "additionalProperties": false,
+            "properties": {
+              "checked": {
+                "description": "Where the search actually looked. Without it, \"we searched\" is unfalsifiable and nobody else can re-run it. `chain` means the on-chain owner keys were read (SubnetOwner), which is always available and is NOT a declaration by the team.",
+                "items": {
+                  "enum": [
+                    "website",
+                    "docs",
+                    "blog",
+                    "source-repo",
+                    "explorer",
+                    "whitepaper",
+                    "chain"
+                  ],
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "outcome": {
+                "description": "Cross-checked against registry/entities/ itself, so the summary cannot drift from the data it summarises.",
+                "enum": [
+                  "none-found",
+                  "wallets-declared"
+                ],
+                "type": "string"
+              },
+              "searched_at": {
+                "description": "An absence with no date is not evidence.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "checked",
+              "outcome",
+              "searched_at"
+            ],
+            "type": "object"
           },
           "website_url": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10866,6 +10866,18 @@ export interface components {
             surface_count: number;
             symbol?: string | null;
             tempo?: number;
+            wallet_search?: {
+                /** @description Where the search actually looked. Without it, "we searched" is unfalsifiable and nobody else can re-run it. `chain` means the on-chain owner keys were read (SubnetOwner), which is always available and is NOT a declaration by the team. */
+                checked: ("website" | "docs" | "blog" | "source-repo" | "explorer" | "whitepaper" | "chain")[];
+                notes?: string;
+                /**
+                 * @description Cross-checked against registry/entities/ itself, so the summary cannot drift from the data it summarises.
+                 * @enum {string}
+                 */
+                outcome: "none-found" | "wallets-declared";
+                /** @description An absence with no date is not evidence. */
+                searched_at: string;
+            };
             website_url?: string | null;
         };
         SubnetDetailArtifact: {
@@ -18413,6 +18425,13 @@ export interface operations {
                      *           "surface_count": 1,
                      *           "symbol": "example",
                      *           "tempo": 1,
+                     *           "wallet_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "website_url": "https://api.metagraph.sh/example"
                      *         },
                      *         "surfaces": [
@@ -39298,6 +39317,13 @@ export interface operations {
                      *           "surface_count": 1,
                      *           "symbol": "example",
                      *           "tempo": 1,
+                     *           "wallet_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "website_url": "https://api.metagraph.sh/example"
                      *         },
                      *         "surfaces": [
@@ -44546,6 +44572,13 @@ export interface operations {
                      *           "surface_count": 1,
                      *           "symbol": "example",
                      *           "tempo": 1,
+                     *           "wallet_search": {
+                     *             "checked": [
+                     *               "website"
+                     *             ],
+                     *             "outcome": "none-found",
+                     *             "searched_at": "2026-06-01T00:00:00.000Z"
+                     *           },
                      *           "website_url": "https://api.metagraph.sh/example"
                      *         },
                      *         "surfaces": [

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -382,6 +382,50 @@ export const RevenueSearchSchema = z
   })
   .strict();
 
+// #10586: the sibling of RevenueSearchSchema, one phase later.
+//
+// registry/entities/ holds addresses that EXIST, so a subnet declaring no
+// treasury has no address to write and its absence has nowhere to live. Without
+// this record, "N of 128 subnets publish no treasury address" cannot be claimed
+// at all -- nothing distinguishes a subnet nobody looked at from one that was
+// looked at and had none.
+//
+// Both value sets are exported so validate:schema-vocabularies can pin them
+// against schemas/subnet-manifest.schema.json. The entity-category enum drifted
+// exactly this way (#10483): the JSON Schema gained four values, the Zod copy
+// did not, and nothing noticed because no document used them yet.
+export const WALLET_SEARCH_OUTCOME_VALUES = [
+  "none-found",
+  "wallets-declared",
+] as const;
+
+export const WALLET_SEARCH_CHECKED_VALUES = [
+  "website",
+  "docs",
+  "blog",
+  "source-repo",
+  "explorer",
+  "whitepaper",
+  "chain",
+] as const;
+
+export const WalletSearchSchema = z
+  .object({
+    checked: z.array(z.enum(WALLET_SEARCH_CHECKED_VALUES)).min(1).meta({
+      description:
+        'Where the search actually looked. Without it, "we searched" is unfalsifiable and nobody else can re-run it. `chain` means the on-chain owner keys were read (SubnetOwner), which is always available and is NOT a declaration by the team.',
+    }),
+    notes: z.string().optional(),
+    outcome: z.enum(WALLET_SEARCH_OUTCOME_VALUES).meta({
+      description:
+        "Cross-checked against registry/entities/ itself, so the summary cannot drift from the data it summarises.",
+    }),
+    searched_at: z.string().meta({
+      description: "An absence with no date is not evidence.",
+    }),
+  })
+  .strict();
+
 export const SubnetDetailSchema = z
   .object({
     block: z.int().min(0).optional(),
@@ -457,6 +501,7 @@ export const SubnetDetailSchema = z
     netuid: z.int().min(0),
     notes: z.string().nullable().optional(),
     revenue_search: RevenueSearchSchema.optional(),
+    wallet_search: WalletSearchSchema.optional(),
     participant_count: z.int().min(0).optional(),
     partnership: z.union([PartnershipMetadataSchema, z.null()]).optional(),
     previously_known_as: z.array(z.string()).optional(),

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -65,6 +65,9 @@
     "revenue_search": {
       "$ref": "#/$defs/revenue_search"
     },
+    "wallet_search": {
+      "$ref": "#/$defs/wallet_search"
+    },
     "curation": {
       "$ref": "#/$defs/curation"
     },
@@ -683,6 +686,45 @@
         "redirect_target": {
           "type": ["string", "null"],
           "format": "uri"
+        }
+      }
+    },
+    "wallet_search": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["searched_at", "outcome", "checked"],
+      "description": "Whether this subnet has been searched for DECLARED WALLETS -- a treasury, a multisig, or a burn address the team has published -- and when. The sibling of `revenue_search`, and it exists for the same reason one phase later: `registry/entities/` holds addresses that EXIST, so a subnet that declares none has no address to write and its absence has nowhere to live. Without this the claim \"N of 128 subnets publish no treasury address\" cannot be made at all, because nothing distinguishes a subnet nobody looked at from one that was looked at and had none.",
+      "properties": {
+        "searched_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the search was run. An absence with no date is not evidence."
+        },
+        "outcome": {
+          "enum": ["none-found", "wallets-declared"],
+          "description": "`none-found` asserts the team publishes no wallet address; `wallets-declared` says at least one is registered in `registry/entities/` against this netuid. Cross-checked against the entity files themselves, so the summary cannot drift from the data it summarises.",
+          "type": "string"
+        },
+        "checked": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "website",
+              "docs",
+              "blog",
+              "source-repo",
+              "explorer",
+              "whitepaper",
+              "chain"
+            ],
+            "type": "string"
+          },
+          "description": "Where the search actually looked. Without it, \"we searched\" is unfalsifiable and nobody else can re-run it. `chain` means the on-chain owner keys were read (SubnetOwner), which is always available and is NOT a declaration by the team."
+        },
+        "notes": {
+          "type": "string"
         }
       }
     },

--- a/scripts/validate-revenue-provenance.ts
+++ b/scripts/validate-revenue-provenance.ts
@@ -172,6 +172,56 @@ export function checkRevenueSearch(
   return [];
 }
 
+/**
+ * #10586: the subnet-level WALLET search record must agree with the entities.
+ *
+ * The exact sibling of checkRevenueSearch, against a different store. A summary
+ * that cannot disagree with its data is a comment, not a record -- and this one
+ * rots in a direction that matters: "96 of 128 subnets publish no treasury
+ * address" is the headline claim the attribution issues exist to earn, and a
+ * subnet recorded `none-found` in August keeps asserting it after a treasury is
+ * registered in September.
+ *
+ * `netuidsWithEntities` is passed in rather than read here so the check stays a
+ * pure function over two inputs -- the same reason checkSurfaceRevenue takes a
+ * document instead of a path.
+ */
+export function checkWalletSearch(
+  subnet: Row,
+  netuidsWithEntities: ReadonlySet<number>,
+  file = "<memory>",
+): ProvenanceViolation[] {
+  const search = subnet?.wallet_search;
+  if (!search || typeof search !== "object") return [];
+  const netuid = Number(subnet?.netuid);
+  const declared = Number.isInteger(netuid) && netuidsWithEntities.has(netuid);
+  const subject = `netuid ${subnet?.netuid ?? "?"}`;
+  if (search.outcome === "none-found" && declared) {
+    return [
+      {
+        file,
+        subject,
+        message:
+          'wallet_search says "none-found" but registry/entities/ registers at least one ' +
+          "address against this netuid. The search record has gone stale against its own data.",
+      },
+    ];
+  }
+  if (search.outcome === "wallets-declared" && !declared) {
+    return [
+      {
+        file,
+        subject,
+        message:
+          'wallet_search says "wallets-declared" but no entity file carries this netuid. ' +
+          "Either the entry was removed and the summary was not updated, or the outcome " +
+          'should be "none-found".',
+      },
+    ];
+  }
+  return [];
+}
+
 /** Check one entity label. Exported for the same reason as above. */
 export function checkEntityRole(
   entity: Row,
@@ -196,18 +246,24 @@ export function checkEntityRole(
 export async function collectViolations(): Promise<ProvenanceViolation[]> {
   const violations: ProvenanceViolation[] = [];
 
+  // Entities first: the wallet-search cross-check needs to know which netuids
+  // have a registered address before it can judge a subnet's own summary.
+  const entityDir = path.join(repoRoot, "registry/entities");
+  const netuidsWithEntities = new Set<number>();
+  for (const file of await listJsonFiles(entityDir)) {
+    const entity = (await readJson(file)) as Row;
+    violations.push(...checkEntityRole(entity, path.relative(repoRoot, file)));
+    const netuid = Number(entity?.netuid);
+    if (Number.isInteger(netuid)) netuidsWithEntities.add(netuid);
+  }
+
   const subnetDir = path.join(repoRoot, "registry/subnets");
   for (const file of await listJsonFiles(subnetDir)) {
     const subnet = (await readJson(file)) as Row;
     const rel = path.relative(repoRoot, file);
     violations.push(...checkSurfaceRevenue(subnet, rel));
     violations.push(...checkRevenueSearch(subnet, rel));
-  }
-
-  const entityDir = path.join(repoRoot, "registry/entities");
-  for (const file of await listJsonFiles(entityDir)) {
-    const entity = (await readJson(file)) as Row;
-    violations.push(...checkEntityRole(entity, path.relative(repoRoot, file)));
+    violations.push(...checkWalletSearch(subnet, netuidsWithEntities, rel));
   }
 
   return violations;

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -246,22 +246,49 @@ for (const [name, collection] of Object.entries(MIRRORED_VOCABULARIES)) {
 const JSON_SCHEMA_MIRRORS: Array<{
   schemaFile: string;
   pointer: string[];
+  module: string;
   zodExport: string;
 }> = [
   {
     schemaFile: "schemas/entity.schema.json",
     pointer: ["properties", "category", "enum"],
+    module: "../schemas-src/shared.ts",
     zodExport: "ENTITY_CATEGORY_VALUES",
+  },
+  // #10586, declared alongside the vocabulary rather than after it drifted.
+  // The entity-category pair above was added the other way round.
+  {
+    schemaFile: "schemas/subnet-manifest.schema.json",
+    pointer: ["$defs", "wallet_search", "properties", "outcome", "enum"],
+    module: "../schemas-src/routes/subnet-detail.ts",
+    zodExport: "WALLET_SEARCH_OUTCOME_VALUES",
+  },
+  {
+    schemaFile: "schemas/subnet-manifest.schema.json",
+    pointer: [
+      "$defs",
+      "wallet_search",
+      "properties",
+      "checked",
+      "items",
+      "enum",
+    ],
+    module: "../schemas-src/routes/subnet-detail.ts",
+    zodExport: "WALLET_SEARCH_CHECKED_VALUES",
   },
 ];
 
-const schemaSrcShared =
-  (await import("../schemas-src/shared.ts")) as unknown as Record<
-    string,
-    readonly string[]
-  >;
+const mirrorModules = new Map<string, Record<string, readonly string[]>>();
+for (const { module } of JSON_SCHEMA_MIRRORS) {
+  if (mirrorModules.has(module)) continue;
+  mirrorModules.set(
+    module,
+    (await import(module)) as unknown as Record<string, readonly string[]>,
+  );
+}
 
-for (const { schemaFile, pointer, zodExport } of JSON_SCHEMA_MIRRORS) {
+for (const { schemaFile, pointer, module, zodExport } of JSON_SCHEMA_MIRRORS) {
+  const schemaSrcShared = mirrorModules.get(module)!;
   const raw = JSON.parse(
     await fs.readFile(path.join(repoRoot, schemaFile), "utf8"),
   ) as unknown;

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -278,12 +278,37 @@ const JSON_SCHEMA_MIRRORS: Array<{
   },
 ];
 
+/**
+ * Every mirror module, imported by LITERAL specifier.
+ *
+ * `await import(module)` with a variable reads better and is invisible to
+ * static analysis: knip resolves a literal specifier and nothing else, so the
+ * moment this stopped being one, `schemas-src/shared.ts` went from "reached
+ * from an entry" to 18 unreferenced type exports and
+ * validate:unreferenced-exports counted 898 against its 880 ceiling (#10292).
+ * The table above stays the declaration; this is only how it is loaded.
+ */
+const MIRROR_MODULE_LOADERS: Record<string, () => Promise<unknown>> = {
+  "../schemas-src/shared.ts": () => import("../schemas-src/shared.ts"),
+  "../schemas-src/routes/subnet-detail.ts": () =>
+    import("../schemas-src/routes/subnet-detail.ts"),
+};
+
 const mirrorModules = new Map<string, Record<string, readonly string[]>>();
 for (const { module } of JSON_SCHEMA_MIRRORS) {
   if (mirrorModules.has(module)) continue;
+  const load = MIRROR_MODULE_LOADERS[module];
+  if (!load) {
+    // A new mirror whose module was added to the table but not here would
+    // otherwise throw a bare TypeError at the call below.
+    throw new Error(
+      `${module} is named by JSON_SCHEMA_MIRRORS but has no entry in ` +
+        `MIRROR_MODULE_LOADERS -- add one, with a literal import specifier.`,
+    );
+  }
   mirrorModules.set(
     module,
-    (await import(module)) as unknown as Record<string, readonly string[]>,
+    (await load()) as unknown as Record<string, readonly string[]>,
   );
 }
 

--- a/scripts/validate-unreferenced-exports.ts
+++ b/scripts/validate-unreferenced-exports.ts
@@ -54,10 +54,20 @@ import { repoRoot } from "./lib.ts";
 /**
  * The most unreferenced exports allowed. THE CEILING ONLY FALLS.
  *
- * 752 after #10582 deleted the 164 precomputed response envelopes. Lower it
- * whenever exports are removed.
+/**
+ * The most unreferenced exports allowed. THE CEILING ONLY FALLS.
+ *
+ * 752 after #10582 deleted the 164 precomputed response envelopes.
+ *
+ * Then lower again (#10586): nothing was deleted.
+ * `scripts/validate-schema-vocabularies.ts` loads its mirror modules through
+ * literal import specifiers, so knip can see `schemas-src/shared.ts` and
+ * `schemas-src/routes/subnet-detail.ts` as reached from an entry -- exports
+ * that were only ever counted as unreferenced because the linkage was
+ * invisible, not because nothing used them. A measurement fix, and the ceiling
+ * takes it the same way it takes a deletion.
  */
-export const MAX_UNREFERENCED_EXPORTS: number = 752;
+export const MAX_UNREFERENCED_EXPORTS: number = 738;
 
 /** knip's JSON shape, as much of it as this gate reads. */
 interface KnipIssue {

--- a/tests/validate-revenue-provenance.test.ts
+++ b/tests/validate-revenue-provenance.test.ts
@@ -7,6 +7,7 @@ import { describe, test } from "vitest";
 import {
   checkEntityRole,
   checkRevenueSearch,
+  checkWalletSearch,
   checkSurfaceRevenue,
   collectViolations,
 } from "../scripts/validate-revenue-provenance.ts";
@@ -203,6 +204,57 @@ describe("revenue provenance validator (#10443/#10516)", () => {
         [],
         role,
       );
+    }
+  });
+
+  test("wallet_search none-found contradicted by a registered entity is rejected", () => {
+    // The direction that rots: a subnet recorded none-found in August keeps
+    // asserting it after a treasury is registered in September, and the
+    // "N of 128 publish no treasury" headline silently overcounts.
+    const v = checkWalletSearch(
+      { netuid: 64, wallet_search: { outcome: "none-found" } },
+      new Set([64]),
+    );
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /none-found/);
+  });
+
+  test("wallet_search wallets-declared with no entity is rejected", () => {
+    const v = checkWalletSearch(
+      { netuid: 64, wallet_search: { outcome: "wallets-declared" } },
+      new Set([51]),
+    );
+    assert.equal(v.length, 1);
+    assert.match(v[0].message, /wallets-declared/);
+  });
+
+  test("wallet_search that agrees with the entities passes, both ways", () => {
+    assert.deepEqual(
+      checkWalletSearch(
+        { netuid: 64, wallet_search: { outcome: "wallets-declared" } },
+        new Set([64]),
+      ),
+      [],
+    );
+    assert.deepEqual(
+      checkWalletSearch(
+        { netuid: 64, wallet_search: { outcome: "none-found" } },
+        new Set([51]),
+      ),
+      [],
+    );
+  });
+
+  test("a subnet with no wallet_search is not the validator's business", () => {
+    // 128 subnets have none yet. Absence of the record is not a violation --
+    // only a record that disagrees with its data is.
+    for (const subnet of [
+      { netuid: 1 },
+      { netuid: 1, wallet_search: null },
+      { netuid: 1, wallet_search: "yes" },
+      {},
+    ]) {
+      assert.deepEqual(checkWalletSearch(subnet, new Set([1])), []);
     }
   });
 


### PR DESCRIPTION
## Summary

The 21 attribution issues have nowhere to record their most common outcome. #10501–#10509 each say, of the subnets in their batch:

> Most of these will have nothing published. **That is the expected result and it is worth recording with a date** — "no declared treasury as of \<date\>" is evidence; an undated silence is not.

There was no field for it. `registry/entities/` holds addresses that **exist**, so a subnet declaring no treasury has no address to write and its absence has nowhere to live. Without a home for it, 21 issues either produce nothing committable or each invent a shape — and the network-wide claim this epic exists to earn, *"N of 128 subnets publish no treasury address"*, cannot be made at all, because nothing distinguishes a subnet nobody looked at from one that was looked at and had none.

## The precedent

Exactly the gap #10543 closed for the revenue sweeps, one phase earlier. `wallet_search` mirrors `revenue_search`:

```json
"wallet_search": {
  "searched_at": "2026-08-10T00:00:00Z",
  "outcome": "none-found",
  "checked": ["website", "docs", "chain"]
}
```

`checked[]` is the part that matters — without it "we searched" is unfalsifiable and nobody can re-run it. **`chain` is in the vocabulary and explicitly is not a declaration by the team**: the owner keys are readable for every subnet whether or not anyone published anything, so "we read SubnetOwner" must not be mistakable for "the team published an address."

## The cross-check

`checkWalletSearch` validates the summary against `registry/entities/` the way `checkRevenueSearch` validates against surfaces. A summary that cannot disagree with its data is a comment, not a record — and this one rots in the direction that matters: a subnet recorded `none-found` in August keeps asserting it after a treasury is registered in September, and the headline silently overcounts.

Both contradictions are **proven to fail** in tests, not asserted against a clean registry:

- `none-found` while an entity file carries that netuid → rejected
- `wallets-declared` with no entity → rejected
- agreement in both directions → passes
- **no record at all → not a violation.** 128 subnets have none yet; absence of the record is not an error, only a record that disagrees with its data is.

## The vocabularies are pinned this time

Both value sets are exported and checked against the JSON Schema that owns them by `validate:schema-vocabularies` — **declared alongside the vocabulary rather than after it drifted**, which is how the entity-category enum went 12-vs-8 and shipped that way in #10483.

That gate is generalised here to name its source module (it previously only read `schemas-src/shared.ts`), and demonstrated failing before shipping:

```
WALLET_SEARCH_CHECKED_VALUES has drifted from
  schemas/subnet-manifest.schema.json#$defs.wallet_search.properties.checked.items.enum:
    schemas-src: blog,docs,explorer,source-repo,website
    JSON Schema: blog,chain,docs,explorer,source-repo,website,whitepaper
  The JSON Schema OWNS this vocabulary — widen the Zod copy, not the source.
```

## Verification

- **23 tests** in `tests/validate-revenue-provenance.test.ts` (4 new for `checkWalletSearch`)
- **Full suite: 821 files, 18,837 tests, all green** — run in full rather than the files I wrote, after the last PR failed CI on a validator's own test file
- All 40 CI `validate:*` scripts pass
- `build` · `typecheck` · `lint` · `format:check` clean; regenerated `openapi.json`, `types.d.ts`, `packages/contract/index.d.ts` committed
- Rebased onto `6561c57cb`; rebuild produced no diff

Closes #10586
