### PR TITLE
refactor(schemas): delete 164 response envelopes the server composes itself

### DIFF
--- a/schemas-src/routes/account-activity-registrations.ts
+++ b/schemas-src/routes/account-activity-registrations.ts
@@ -9,7 +9,6 @@
 // src/account-registrations.ts's buildAccountRegistrations(), and
 // src/account-weight-setters.ts's buildAccountWeightSetters().
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import {
   DeregistrationDerivationSchema,
   EventStreamDegradedSchema,
@@ -48,9 +47,6 @@ export const AccountAxonRemovalsArtifactSchema = z
 export type AccountAxonRemovalsArtifact = z.infer<
   typeof AccountAxonRemovalsArtifactSchema
 >;
-export const AccountAxonRemovalsResponseSchema = successEnvelopeSchema(
-  AccountAxonRemovalsArtifactSchema,
-);
 
 export const AccountDeregistrationsArtifactSchema = z
   .object({
@@ -83,9 +79,6 @@ export const AccountDeregistrationsArtifactSchema = z
 export type AccountDeregistrationsArtifact = z.infer<
   typeof AccountDeregistrationsArtifactSchema
 >;
-export const AccountDeregistrationsResponseSchema = successEnvelopeSchema(
-  AccountDeregistrationsArtifactSchema,
-);
 
 export const AccountRegistrationsArtifactSchema = z
   .object({
@@ -114,9 +107,6 @@ export const AccountRegistrationsArtifactSchema = z
 export type AccountRegistrationsArtifact = z.infer<
   typeof AccountRegistrationsArtifactSchema
 >;
-export const AccountRegistrationsResponseSchema = successEnvelopeSchema(
-  AccountRegistrationsArtifactSchema,
-);
 
 export const AccountWeightSettersArtifactSchema = z
   .object({
@@ -153,6 +143,3 @@ export const AccountWeightSettersArtifactSchema = z
 export type AccountWeightSettersArtifact = z.infer<
   typeof AccountWeightSettersArtifactSchema
 >;
-export const AccountWeightSettersResponseSchema = successEnvelopeSchema(
-  AccountWeightSettersArtifactSchema,
-);

--- a/schemas-src/routes/account-activity.ts
+++ b/schemas-src/routes/account-activity.ts
@@ -17,7 +17,6 @@
 // epic's established convention. AccountStakeFlowArtifact needed no fix at
 // all (diff:openapi-zod reports PASS after cosmetic normalization).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
@@ -56,9 +55,6 @@ export const AccountServingArtifactSchema = z
 export type AccountServingArtifact = z.infer<
   typeof AccountServingArtifactSchema
 >;
-export const AccountServingResponseSchema = successEnvelopeSchema(
-  AccountServingArtifactSchema,
-);
 
 export const AccountPrometheusArtifactSchema = z
   .object({
@@ -99,9 +95,6 @@ export const AccountPrometheusArtifactSchema = z
 export type AccountPrometheusArtifact = z.infer<
   typeof AccountPrometheusArtifactSchema
 >;
-export const AccountPrometheusResponseSchema = successEnvelopeSchema(
-  AccountPrometheusArtifactSchema,
-);
 
 export const AccountStakeMovesArtifactSchema = z
   .object({
@@ -136,9 +129,6 @@ export const AccountStakeMovesArtifactSchema = z
 export type AccountStakeMovesArtifact = z.infer<
   typeof AccountStakeMovesArtifactSchema
 >;
-export const AccountStakeMovesResponseSchema = successEnvelopeSchema(
-  AccountStakeMovesArtifactSchema,
-);
 
 const FLOW_DIRECTION_ENUM = [
   "accumulating",
@@ -203,6 +193,3 @@ export const AccountStakeFlowArtifactSchema = z
 export type AccountStakeFlowArtifact = z.infer<
   typeof AccountStakeFlowArtifactSchema
 >;
-export const AccountStakeFlowResponseSchema = successEnvelopeSchema(
-  AccountStakeFlowArtifactSchema,
-);

--- a/schemas-src/routes/account-balance.ts
+++ b/schemas-src/routes/account-balance.ts
@@ -9,7 +9,6 @@
 // Bucket (c): `queried_at` drops format:date-time in favor of plain
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 export const AccountBalanceArtifactSchema = z
@@ -29,6 +28,3 @@ export const AccountBalanceArtifactSchema = z
 export type AccountBalanceArtifact = z.infer<
   typeof AccountBalanceArtifactSchema
 >;
-export const AccountBalanceResponseSchema = successEnvelopeSchema(
-  AccountBalanceArtifactSchema,
-);

--- a/schemas-src/routes/account-child-delegation.ts
+++ b/schemas-src/routes/account-child-delegation.ts
@@ -12,7 +12,6 @@
 // this batch replaces (verified via repo-wide $ref grep), so all four
 // hand-edited component keys become fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 const ChildDelegationEntrySchema = z
@@ -53,9 +52,6 @@ export const AccountChildrenArtifactSchema = z
 export type AccountChildrenArtifact = z.infer<
   typeof AccountChildrenArtifactSchema
 >;
-export const AccountChildrenResponseSchema = successEnvelopeSchema(
-  AccountChildrenArtifactSchema,
-);
 
 const ParentDelegationEntrySchema = z
   .object({
@@ -95,6 +91,3 @@ export const AccountParentsArtifactSchema = z
 export type AccountParentsArtifact = z.infer<
   typeof AccountParentsArtifactSchema
 >;
-export const AccountParentsResponseSchema = successEnvelopeSchema(
-  AccountParentsArtifactSchema,
-);

--- a/schemas-src/routes/account-counterparties.ts
+++ b/schemas-src/routes/account-counterparties.ts
@@ -29,7 +29,6 @@
 // shape check) -- dropped in favor of plain z.string(), matching how every
 // other account route in this epic models ss58-shaped fields.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const CounterpartySchema = z
   .object({
@@ -109,6 +108,3 @@ export const AccountCounterpartiesArtifactSchema = z
 export type AccountCounterpartiesArtifact = z.infer<
   typeof AccountCounterpartiesArtifactSchema
 >;
-export const AccountCounterpartiesResponseSchema = successEnvelopeSchema(
-  AccountCounterpartiesArtifactSchema,
-);

--- a/schemas-src/routes/account-entities.ts
+++ b/schemas-src/routes/account-entities.ts
@@ -22,7 +22,6 @@
 // (same cosmetic finding batch 4's account-summary.ts made for the
 // identical field).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { EntityCategorySchema } from "../shared.ts";
 
 const EntityLabelSchema = z
@@ -73,6 +72,3 @@ export const AccountEntitiesArtifactSchema = z
 export type AccountEntitiesArtifact = z.infer<
   typeof AccountEntitiesArtifactSchema
 >;
-export const AccountEntitiesResponseSchema = successEnvelopeSchema(
-  AccountEntitiesArtifactSchema,
-);

--- a/schemas-src/routes/account-events-feed.ts
+++ b/schemas-src/routes/account-events-feed.ts
@@ -23,7 +23,6 @@
 // required non-nullable integers, matching the hand-edited components and
 // what the route actually returns.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
 
 export const AccountEventsArtifactSchema = z
@@ -48,9 +47,6 @@ export const AccountEventsArtifactSchema = z
     "One account's first-party chain-event feed (matched by the hotkey OR coldkey union, newest first), keyset-paginated. event_count is the page count, not a grand total. Mirrors GET /api/v1/accounts/{ss58}/events' data envelope. Each item is an AccountEvent.",
   );
 export type AccountEventsArtifact = z.infer<typeof AccountEventsArtifactSchema>;
-export const AccountEventsResponseSchema = successEnvelopeSchema(
-  AccountEventsArtifactSchema,
-);
 
 const AccountDaySchema = z
   .object({
@@ -83,9 +79,6 @@ export const AccountHistoryArtifactSchema = z
 export type AccountHistoryArtifact = z.infer<
   typeof AccountHistoryArtifactSchema
 >;
-export const AccountHistoryResponseSchema = successEnvelopeSchema(
-  AccountHistoryArtifactSchema,
-);
 
 const AccountTransferEntrySchema = z
   .object({
@@ -119,6 +112,3 @@ export const AccountTransfersArtifactSchema = z
 export type AccountTransfersArtifact = z.infer<
   typeof AccountTransfersArtifactSchema
 >;
-export const AccountTransfersResponseSchema = successEnvelopeSchema(
-  AccountTransfersArtifactSchema,
-);

--- a/schemas-src/routes/account-extrinsics.ts
+++ b/schemas-src/routes/account-extrinsics.ts
@@ -22,7 +22,6 @@
 // numbers -- same finding as account-events-feed.ts's 3 routes. Fixed to
 // required non-nullable integers.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const ExtrinsicSchema = z
   .object({
@@ -78,6 +77,3 @@ export const AccountExtrinsicsArtifactSchema = z
 export type AccountExtrinsicsArtifact = z.infer<
   typeof AccountExtrinsicsArtifactSchema
 >;
-export const AccountExtrinsicsResponseSchema = successEnvelopeSchema(
-  AccountExtrinsicsArtifactSchema,
-);

--- a/schemas-src/routes/account-identity.ts
+++ b/schemas-src/routes/account-identity.ts
@@ -20,7 +20,6 @@
 // in schemas/components/*.schema.json (verified via repo-wide $ref grep), so
 // the hand-edited component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const AccountIdentityArtifactSchema = z
   .object({
@@ -40,9 +39,6 @@ export const AccountIdentityArtifactSchema = z
 export type AccountIdentityArtifact = z.infer<
   typeof AccountIdentityArtifactSchema
 >;
-export const AccountIdentityResponseSchema = successEnvelopeSchema(
-  AccountIdentityArtifactSchema,
-);
 
 const AccountIdentityHistoryEntrySchema = z
   .object({
@@ -79,6 +75,3 @@ export const AccountIdentityHistoryArtifactSchema = z
 export type AccountIdentityHistoryArtifact = z.infer<
   typeof AccountIdentityHistoryArtifactSchema
 >;
-export const AccountIdentityHistoryResponseSchema = successEnvelopeSchema(
-  AccountIdentityHistoryArtifactSchema,
-);

--- a/schemas-src/routes/account-portfolio.ts
+++ b/schemas-src/routes/account-portfolio.ts
@@ -21,7 +21,6 @@
 // components/*.schema.json (verified via repo-wide $ref grep), so the
 // hand-edited component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ConcentrationMetricsSchema } from "../shared.ts";
 
 const PortfolioPositionSchema = z
@@ -91,6 +90,3 @@ export const AccountPortfolioArtifactSchema = z
 export type AccountPortfolioArtifact = z.infer<
   typeof AccountPortfolioArtifactSchema
 >;
-export const AccountPortfolioResponseSchema = successEnvelopeSchema(
-  AccountPortfolioArtifactSchema,
-);

--- a/schemas-src/routes/account-positions.ts
+++ b/schemas-src/routes/account-positions.ts
@@ -27,7 +27,6 @@
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
 import { POSITIONS_DEGRADED_REASONS } from "../../src/account-nominator-positions.ts";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const NominatorPositionSchema = z
   .object({
@@ -105,9 +104,6 @@ export const AccountPositionsArtifactSchema = z
 export type AccountPositionsArtifact = z.infer<
   typeof AccountPositionsArtifactSchema
 >;
-export const AccountPositionsResponseSchema = successEnvelopeSchema(
-  AccountPositionsArtifactSchema,
-);
 
 const AccountPositionHistoryPointSchema = z
   .object({
@@ -154,6 +150,3 @@ export const AccountPositionHistoryArtifactSchema = z
 export type AccountPositionHistoryArtifact = z.infer<
   typeof AccountPositionHistoryArtifactSchema
 >;
-export const AccountPositionHistoryResponseSchema = successEnvelopeSchema(
-  AccountPositionHistoryArtifactSchema,
-);

--- a/schemas-src/routes/account-root-claim.ts
+++ b/schemas-src/routes/account-root-claim.ts
@@ -18,7 +18,6 @@
 // Bucket (c): `queried_at` drops format:date-time in favor of plain
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 const RootClaimTypeSchema = z
@@ -71,6 +70,3 @@ export const AccountRootClaimArtifactSchema = z
 export type AccountRootClaimArtifact = z.infer<
   typeof AccountRootClaimArtifactSchema
 >;
-export const AccountRootClaimResponseSchema = successEnvelopeSchema(
-  AccountRootClaimArtifactSchema,
-);

--- a/schemas-src/routes/account-summary.ts
+++ b/schemas-src/routes/account-summary.ts
@@ -38,7 +38,6 @@
 // entities.json artifact), which the hand-edited component's optional
 // `labels` array already models.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
 import { EntityCategorySchema } from "../shared.ts";
 
@@ -128,9 +127,6 @@ export const AccountSummaryArtifactSchema = z
 export type AccountSummaryArtifact = z.infer<
   typeof AccountSummaryArtifactSchema
 >;
-export const AccountSummaryResponseSchema = successEnvelopeSchema(
-  AccountSummaryArtifactSchema,
-);
 
 export const AccountSubnetsArtifactSchema = z
   .object({
@@ -150,6 +146,3 @@ export const AccountSubnetsArtifactSchema = z
 export type AccountSubnetsArtifact = z.infer<
   typeof AccountSubnetsArtifactSchema
 >;
-export const AccountSubnetsResponseSchema = successEnvelopeSchema(
-  AccountSubnetsArtifactSchema,
-);

--- a/schemas-src/routes/accounts-list.ts
+++ b/schemas-src/routes/accounts-list.ts
@@ -25,7 +25,6 @@
 // anywhere in schemas/components/*.schema.json (verified via repo-wide $ref
 // grep), so both hand-edited component keys become fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const ACCOUNTS_LIST_LIST_SORTS_VALUES = [
@@ -97,6 +96,3 @@ export const AccountsListArtifactSchema = z
   })
   .passthrough();
 export type AccountsListArtifact = z.infer<typeof AccountsListArtifactSchema>;
-export const AccountsListResponseSchema = successEnvelopeSchema(
-  AccountsListArtifactSchema,
-);

--- a/schemas-src/routes/adapter.ts
+++ b/schemas-src/routes/adapter.ts
@@ -3,7 +3,7 @@
 // get_adapter MCP tool, types-epic E batch 11, #8074's get-adapter.ts).
 // Modeled from the hand-edited AdapterArtifact component it replaces.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 
 /** What the adapter last captured. Was a bare open object (#9800), so the
  * field the whole artifact exists to carry declared nothing -- not even its
@@ -75,6 +75,3 @@ export const AdapterArtifactSchema = ArtifactBaseSchema.extend({
     "One adapter-backed public metrics snapshot. snapshot and extensions are opaque JSON -- their shape is adapter-specific. Mirrors GET /api/v1/adapters/{slug}'s data envelope.",
   );
 export type AdapterArtifact = z.infer<typeof AdapterArtifactSchema>;
-export const AdapterResponseSchema = successEnvelopeSchema(
-  AdapterArtifactSchema,
-);

--- a/schemas-src/routes/ai-native.ts
+++ b/schemas-src/routes/ai-native.ts
@@ -10,7 +10,6 @@
 // the handlers in workers/api.ts, not from the prose — see the header comment
 // on each schema for what the handler actually guarantees.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /**
  * One retrieved surface backing an answer.
@@ -48,7 +47,6 @@ export const AskArtifactSchema = z
   })
   .passthrough();
 export type AskArtifact = z.infer<typeof AskArtifactSchema>;
-export const AskResponseSchema = successEnvelopeSchema(AskArtifactSchema);
 
 /**
  * The request body. POST-only: the question is prose, and a URL is the wrong
@@ -92,9 +90,6 @@ export const SemanticSearchArtifactSchema = z
 export type SemanticSearchArtifact = z.infer<
   typeof SemanticSearchArtifactSchema
 >;
-export const SemanticSearchResponseSchema = successEnvelopeSchema(
-  SemanticSearchArtifactSchema,
-);
 
 /**
  * A catalog-resolved probe of one registered surface.
@@ -127,6 +122,3 @@ export const SurfaceVerifyArtifactSchema = z
   })
   .passthrough();
 export type SurfaceVerifyArtifact = z.infer<typeof SurfaceVerifyArtifactSchema>;
-export const SurfaceVerifyResponseSchema = successEnvelopeSchema(
-  SurfaceVerifyArtifactSchema,
-);

--- a/schemas-src/routes/alert-triggers.ts
+++ b/schemas-src/routes/alert-triggers.ts
@@ -11,7 +11,6 @@
 // on the MCP side; this makes the ROUTE the owner and the tool the importer,
 // which is the direction #9796 settled on.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const AlertTriggerArtifactSchema = z
   .object({
@@ -37,6 +36,3 @@ export const AlertTriggerArtifactSchema = z
   })
   .passthrough();
 export type AlertTriggerArtifact = z.infer<typeof AlertTriggerArtifactSchema>;
-export const AlertTriggerResponseSchema = successEnvelopeSchema(
-  AlertTriggerArtifactSchema,
-);

--- a/schemas-src/routes/block-chain-events.ts
+++ b/schemas-src/routes/block-chain-events.ts
@@ -20,7 +20,6 @@
 // (unregistered), so the hand-edited `ChainEvent` component key becomes
 // fully orphaned as of this batch.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { EpochMillisSchema } from "../shared.ts";
 
 const ChainEventSchema = z
@@ -64,6 +63,3 @@ export const BlockChainEventsArtifactSchema = z
 export type BlockChainEventsArtifact = z.infer<
   typeof BlockChainEventsArtifactSchema
 >;
-export const BlockChainEventsResponseSchema = successEnvelopeSchema(
-  BlockChainEventsArtifactSchema,
-);

--- a/schemas-src/routes/block-events.ts
+++ b/schemas-src/routes/block-events.ts
@@ -6,7 +6,6 @@
 // the same reuse pattern account-events-feed.ts / extrinsics.ts's own
 // ExtrinsicDetailArtifact already use.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
 
 export const BlockEventsArtifactSchema = z
@@ -31,6 +30,3 @@ export const BlockEventsArtifactSchema = z
     "One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref.",
   );
 export type BlockEventsArtifact = z.infer<typeof BlockEventsArtifactSchema>;
-export const BlockEventsResponseSchema = successEnvelopeSchema(
-  BlockEventsArtifactSchema,
-);

--- a/schemas-src/routes/block-extrinsics.ts
+++ b/schemas-src/routes/block-extrinsics.ts
@@ -4,7 +4,6 @@
 // BlockExtrinsicsArtifact component it replaces. Reuses ExtrinsicSchema from
 // extrinsics.ts (the same batch's own conversion of that route).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ExtrinsicSchema } from "./extrinsics.ts";
 
 export const BlockExtrinsicsArtifactSchema = z
@@ -31,6 +30,3 @@ export const BlockExtrinsicsArtifactSchema = z
 export type BlockExtrinsicsArtifact = z.infer<
   typeof BlockExtrinsicsArtifactSchema
 >;
-export const BlockExtrinsicsResponseSchema = successEnvelopeSchema(
-  BlockExtrinsicsArtifactSchema,
-);

--- a/schemas-src/routes/blocks-summary.ts
+++ b/schemas-src/routes/blocks-summary.ts
@@ -8,7 +8,6 @@
 // repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ConcentrationMetricsSchema } from "../shared.ts";
 
 const BlockTimeDistributionSchema = z
@@ -58,6 +57,3 @@ export const BlocksSummaryArtifactSchema = z
     "Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary.",
   );
 export type BlocksSummaryArtifact = z.infer<typeof BlocksSummaryArtifactSchema>;
-export const BlocksSummaryResponseSchema = successEnvelopeSchema(
-  BlocksSummaryArtifactSchema,
-);

--- a/schemas-src/routes/blocks.ts
+++ b/schemas-src/routes/blocks.ts
@@ -8,7 +8,6 @@
 // in this same batch (verified via repo-wide $ref grep), so the hand-edited
 // Block component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const BlockSchema = z
   .object({
@@ -41,9 +40,6 @@ export const BlocksFeedArtifactSchema = z
   })
   .passthrough();
 export type BlocksFeedArtifact = z.infer<typeof BlocksFeedArtifactSchema>;
-export const BlocksFeedResponseSchema = successEnvelopeSchema(
-  BlocksFeedArtifactSchema,
-);
 
 export const BlockDetailArtifactSchema = z
   .object({
@@ -67,6 +63,3 @@ export const BlockDetailArtifactSchema = z
   })
   .passthrough();
 export type BlockDetailArtifact = z.infer<typeof BlockDetailArtifactSchema>;
-export const BlockDetailResponseSchema = successEnvelopeSchema(
-  BlockDetailArtifactSchema,
-);

--- a/schemas-src/routes/chain-alpha-volume.ts
+++ b/schemas-src/routes/chain-alpha-volume.ts
@@ -14,7 +14,6 @@
 // repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 import { SubnetAlphaVolumeArtifactSchema } from "./subnet-alpha-volume.ts";
 import { IntensityDistributionSchema } from "./chain-network-rollups.ts";
@@ -101,6 +100,3 @@ export const ChainAlphaVolumeArtifactSchema = z
 export type ChainAlphaVolumeArtifact = z.infer<
   typeof ChainAlphaVolumeArtifactSchema
 >;
-export const ChainAlphaVolumeResponseSchema = successEnvelopeSchema(
-  ChainAlphaVolumeArtifactSchema,
-);

--- a/schemas-src/routes/chain-analytics.ts
+++ b/schemas-src/routes/chain-analytics.ts
@@ -11,7 +11,6 @@
 // (verified via repo-wide $ref grep), so all five hand-edited component
 // keys become fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const ChainActivityDaySchema = z
   .object({
@@ -41,9 +40,6 @@ export const ChainActivityArtifactSchema = z
     "Per-UTC-day network activity series (blocks, extrinsics, events, signers) over the window, newest day first. Mirrors GET /api/v1/chain/activity's data envelope.",
   );
 export type ChainActivityArtifact = z.infer<typeof ChainActivityArtifactSchema>;
-export const ChainActivityResponseSchema = successEnvelopeSchema(
-  ChainActivityArtifactSchema,
-);
 
 const ChainCallEntrySchema = z
   .object({
@@ -72,9 +68,6 @@ export const ChainCallsArtifactSchema = z
     "Extrinsic call-mix breakdown over the window. Mirrors GET /api/v1/chain/calls's data envelope.",
   );
 export type ChainCallsArtifact = z.infer<typeof ChainCallsArtifactSchema>;
-export const ChainCallsResponseSchema = successEnvelopeSchema(
-  ChainCallsArtifactSchema,
-);
 
 const ChainSignerEntrySchema = z
   .object({
@@ -110,9 +103,6 @@ export const ChainSignersArtifactSchema = z
     "Network-wide weight-setter leaderboard over a lookback window, summed live from the account_events WeightsSet stream. The setter-level drill-in behind ChainWeights. Mirrors GET /api/v1/chain/weights/setters.",
   );
 export type ChainSignersArtifact = z.infer<typeof ChainSignersArtifactSchema>;
-export const ChainSignersResponseSchema = successEnvelopeSchema(
-  ChainSignersArtifactSchema,
-);
 
 const ChainFeeDaySchema = z
   .object({
@@ -157,6 +147,3 @@ export const ChainFeesArtifactSchema = z
     "Per-UTC-day network fee/tip series plus the top fee payers over the window. Mirrors GET /api/v1/chain/fees's data envelope.",
   );
 export type ChainFeesArtifact = z.infer<typeof ChainFeesArtifactSchema>;
-export const ChainFeesResponseSchema = successEnvelopeSchema(
-  ChainFeesArtifactSchema,
-);

--- a/schemas-src/routes/chain-concentration-history.ts
+++ b/schemas-src/routes/chain-concentration-history.ts
@@ -3,7 +3,6 @@
 // buildChainConcentrationHistory().
 import { z } from "zod";
 import { UnavailableDegradedSchema } from "./event-stream-honesty.ts";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** One distribution's scorecard, as computeConcentration produced it. Passed
  * through from the stored card rather than re-shaped, so a historical point and
@@ -94,6 +93,3 @@ export const ChainConcentrationHistoryArtifactSchema = z
 export type ChainConcentrationHistoryArtifact = z.infer<
   typeof ChainConcentrationHistoryArtifactSchema
 >;
-export const ChainConcentrationHistoryResponseSchema = successEnvelopeSchema(
-  ChainConcentrationHistoryArtifactSchema,
-);

--- a/schemas-src/routes/chain-concentration-subnets.ts
+++ b/schemas-src/routes/chain-concentration-subnets.ts
@@ -8,7 +8,6 @@
 // `row.gini` is the whole point; `row.emission.gini` would need a path syntax
 // no other list surface here has.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const CONCENTRATION_LENSES = [
   "emission",
@@ -81,6 +80,3 @@ export const ChainConcentrationSubnetsArtifactSchema = z
 export type ChainConcentrationSubnetsArtifact = z.infer<
   typeof ChainConcentrationSubnetsArtifactSchema
 >;
-export const ChainConcentrationSubnetsResponseSchema = successEnvelopeSchema(
-  ChainConcentrationSubnetsArtifactSchema,
-);

--- a/schemas-src/routes/chain-concentration.ts
+++ b/schemas-src/routes/chain-concentration.ts
@@ -5,7 +5,6 @@
 // batch 3/#8057), cross-checked against the hand-edited
 // ChainConcentrationArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ConcentrationMetricsSchema } from "../shared.ts";
 
 export const ChainConcentrationArtifactSchema = z
@@ -52,6 +51,3 @@ export const ChainConcentrationArtifactSchema = z
 export type ChainConcentrationArtifact = z.infer<
   typeof ChainConcentrationArtifactSchema
 >;
-export const ChainConcentrationResponseSchema = successEnvelopeSchema(
-  ChainConcentrationArtifactSchema,
-);

--- a/schemas-src/routes/chain-events.ts
+++ b/schemas-src/routes/chain-events.ts
@@ -19,7 +19,6 @@
 // -- ChainEventsStatsArtifact is its only referrer -- so that hand-edited
 // component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { EpochMillisSchema } from "../shared.ts";
 
 const ChainEventSchema = z
@@ -63,9 +62,6 @@ export const ChainEventsFeedArtifactSchema = z
 export type ChainEventsFeedArtifact = z.infer<
   typeof ChainEventsFeedArtifactSchema
 >;
-export const ChainEventsFeedResponseSchema = successEnvelopeSchema(
-  ChainEventsFeedArtifactSchema,
-);
 
 const ChainEventEntrySchema = z
   .object({
@@ -91,6 +87,3 @@ export const ChainEventsStatsArtifactSchema = z
 export type ChainEventsStatsArtifact = z.infer<
   typeof ChainEventsStatsArtifactSchema
 >;
-export const ChainEventsStatsResponseSchema = successEnvelopeSchema(
-  ChainEventsStatsArtifactSchema,
-);

--- a/schemas-src/routes/chain-holders.ts
+++ b/schemas-src/routes/chain-holders.ts
@@ -7,7 +7,6 @@
 // carries only counts and a median of within-subnet ratios, both of which
 // survive the mismatch.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const ChainHoldersSubnetSchema = z
   .object({
@@ -89,6 +88,3 @@ export const ChainHoldersArtifactSchema = z
   })
   .passthrough();
 export type ChainHoldersArtifact = z.infer<typeof ChainHoldersArtifactSchema>;
-export const ChainHoldersResponseSchema = successEnvelopeSchema(
-  ChainHoldersArtifactSchema,
-);

--- a/schemas-src/routes/chain-identity-history.ts
+++ b/schemas-src/routes/chain-identity-history.ts
@@ -18,7 +18,6 @@
 // via repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const ChainIdentityHistoryChangeSchema = z
   .object({
@@ -50,6 +49,3 @@ export const ChainIdentityHistoryArtifactSchema = z
 export type ChainIdentityHistoryArtifact = z.infer<
   typeof ChainIdentityHistoryArtifactSchema
 >;
-export const ChainIdentityHistoryResponseSchema = successEnvelopeSchema(
-  ChainIdentityHistoryArtifactSchema,
-);

--- a/schemas-src/routes/chain-idle-stake.ts
+++ b/schemas-src/routes/chain-idle-stake.ts
@@ -3,7 +3,6 @@
 // buildChainIdleStake(), cross-checked against the hand-edited
 // ChainIdleStakeArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const ChainIdleStakeArtifactSchema = z
   .object({
@@ -30,6 +29,3 @@ export const ChainIdleStakeArtifactSchema = z
 export type ChainIdleStakeArtifact = z.infer<
   typeof ChainIdleStakeArtifactSchema
 >;
-export const ChainIdleStakeResponseSchema = successEnvelopeSchema(
-  ChainIdleStakeArtifactSchema,
-);

--- a/schemas-src/routes/chain-network-rollups.ts
+++ b/schemas-src/routes/chain-network-rollups.ts
@@ -15,7 +15,6 @@
 // setters/weight_sets). Cross-checked against the 8 matching hand-edited
 // components they replace.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import {
   DeregistrationDerivationSchema,
   EventStreamDegradedSchema,
@@ -83,9 +82,6 @@ export const ChainAxonRemovalsArtifactSchema = z
 export type ChainAxonRemovalsArtifact = z.infer<
   typeof ChainAxonRemovalsArtifactSchema
 >;
-export const ChainAxonRemovalsResponseSchema = successEnvelopeSchema(
-  ChainAxonRemovalsArtifactSchema,
-);
 
 // #9742: how long the slots that turned over had been held. Optional so a
 // body published before this shipped still validates.
@@ -153,9 +149,6 @@ export const ChainDeregistrationsArtifactSchema = z
 export type ChainDeregistrationsArtifact = z.infer<
   typeof ChainDeregistrationsArtifactSchema
 >;
-export const ChainDeregistrationsResponseSchema = successEnvelopeSchema(
-  ChainDeregistrationsArtifactSchema,
-);
 
 export const ChainPrometheusArtifactSchema = z
   .object({
@@ -203,9 +196,6 @@ export const ChainPrometheusArtifactSchema = z
 export type ChainPrometheusArtifact = z.infer<
   typeof ChainPrometheusArtifactSchema
 >;
-export const ChainPrometheusResponseSchema = successEnvelopeSchema(
-  ChainPrometheusArtifactSchema,
-);
 
 export const ChainRegistrationsArtifactSchema = z
   .object({
@@ -250,9 +240,6 @@ export const ChainRegistrationsArtifactSchema = z
 export type ChainRegistrationsArtifact = z.infer<
   typeof ChainRegistrationsArtifactSchema
 >;
-export const ChainRegistrationsResponseSchema = successEnvelopeSchema(
-  ChainRegistrationsArtifactSchema,
-);
 
 export const ChainServingArtifactSchema = z
   .object({
@@ -298,9 +285,6 @@ export const ChainServingArtifactSchema = z
     "Network-wide axon-serving announcement leaderboard (#5873). The network-wide counterpart of subnet_serving. Mirrors GET /api/v1/chain/serving's data envelope.",
   );
 export type ChainServingArtifact = z.infer<typeof ChainServingArtifactSchema>;
-export const ChainServingResponseSchema = successEnvelopeSchema(
-  ChainServingArtifactSchema,
-);
 
 export const ChainStakeMovesArtifactSchema = z
   .object({
@@ -346,9 +330,6 @@ export const ChainStakeMovesArtifactSchema = z
 export type ChainStakeMovesArtifact = z.infer<
   typeof ChainStakeMovesArtifactSchema
 >;
-export const ChainStakeMovesResponseSchema = successEnvelopeSchema(
-  ChainStakeMovesArtifactSchema,
-);
 
 export const ChainStakeTransfersArtifactSchema = z
   .object({
@@ -394,9 +375,6 @@ export const ChainStakeTransfersArtifactSchema = z
 export type ChainStakeTransfersArtifact = z.infer<
   typeof ChainStakeTransfersArtifactSchema
 >;
-export const ChainStakeTransfersResponseSchema = successEnvelopeSchema(
-  ChainStakeTransfersArtifactSchema,
-);
 
 export const ChainWeightsArtifactSchema = z
   .object({
@@ -442,6 +420,3 @@ export const ChainWeightsArtifactSchema = z
     "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights.",
   );
 export type ChainWeightsArtifact = z.infer<typeof ChainWeightsArtifactSchema>;
-export const ChainWeightsResponseSchema = successEnvelopeSchema(
-  ChainWeightsArtifactSchema,
-);

--- a/schemas-src/routes/chain-performance.ts
+++ b/schemas-src/routes/chain-performance.ts
@@ -7,7 +7,6 @@
 // cross-checked against the hand-edited ChainPerformanceArtifact component
 // it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import {
   ConcentrationMetricsSchema,
   ScoreDistributionSchema,
@@ -47,6 +46,3 @@ export const ChainPerformanceArtifactSchema = z
 export type ChainPerformanceArtifact = z.infer<
   typeof ChainPerformanceArtifactSchema
 >;
-export const ChainPerformanceResponseSchema = successEnvelopeSchema(
-  ChainPerformanceArtifactSchema,
-);

--- a/schemas-src/routes/chain-stake-flow.ts
+++ b/schemas-src/routes/chain-stake-flow.ts
@@ -3,7 +3,6 @@
 // Modeled from src/chain-stake-flow.ts's buildChainStakeFlow(), cross-checked
 // against the hand-edited ChainStakeFlowArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const NetFlowDistributionSchema = z
   .object({
@@ -73,6 +72,3 @@ export const ChainStakeFlowArtifactSchema = z
 export type ChainStakeFlowArtifact = z.infer<
   typeof ChainStakeFlowArtifactSchema
 >;
-export const ChainStakeFlowResponseSchema = successEnvelopeSchema(
-  ChainStakeFlowArtifactSchema,
-);

--- a/schemas-src/routes/chain-transfers.ts
+++ b/schemas-src/routes/chain-transfers.ts
@@ -13,7 +13,6 @@
 // a cross-component one), so both hand-edited component keys become fully
 // orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const ChainTransferPairSchema = z
   .object({
@@ -56,9 +55,6 @@ export const ChainTransferPairsArtifactSchema = z
 export type ChainTransferPairsArtifact = z.infer<
   typeof ChainTransferPairsArtifactSchema
 >;
-export const ChainTransferPairsResponseSchema = successEnvelopeSchema(
-  ChainTransferPairsArtifactSchema,
-);
 
 const ChainTransferPartySchema = z
   .object({
@@ -94,6 +90,3 @@ export const ChainTransfersArtifactSchema = z
 export type ChainTransfersArtifact = z.infer<
   typeof ChainTransfersArtifactSchema
 >;
-export const ChainTransfersResponseSchema = successEnvelopeSchema(
-  ChainTransfersArtifactSchema,
-);

--- a/schemas-src/routes/chain-turnover.ts
+++ b/schemas-src/routes/chain-turnover.ts
@@ -3,7 +3,6 @@
 // src/chain-turnover.ts's buildChainTurnover(), cross-checked against the
 // hand-edited ChainTurnoverArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const CHAIN_TURNOVER_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
@@ -96,6 +95,3 @@ export const ChainTurnoverArtifactSchema = z
     "Network-wide validator-set churn across all subnets (#5686). Mirrors GET /api/v1/chain/turnover's data envelope.",
   );
 export type ChainTurnoverArtifact = z.infer<typeof ChainTurnoverArtifactSchema>;
-export const ChainTurnoverResponseSchema = successEnvelopeSchema(
-  ChainTurnoverArtifactSchema,
-);

--- a/schemas-src/routes/chain-weight-setters.ts
+++ b/schemas-src/routes/chain-weight-setters.ts
@@ -7,7 +7,6 @@
 // intensity distribution) -- each setter row carries an optional `netuid`
 // scoping a uid-only setter, null when a network-wide hotkey identifies it.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const ChainWeightSetterSchema = z
   .object({
@@ -54,6 +53,3 @@ export const ChainWeightSettersArtifactSchema = z
 export type ChainWeightSettersArtifact = z.infer<
   typeof ChainWeightSettersArtifactSchema
 >;
-export const ChainWeightSettersResponseSchema = successEnvelopeSchema(
-  ChainWeightSettersArtifactSchema,
-);

--- a/schemas-src/routes/chain-yield.ts
+++ b/schemas-src/routes/chain-yield.ts
@@ -7,7 +7,6 @@
 // ChainYieldArtifact is its only referrer (verified via repo-wide $ref
 // grep), so the hand-edited component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const YieldDistributionSchema = z
   .object({
@@ -62,6 +61,3 @@ export const ChainYieldArtifactSchema = z
     "Network-wide emission-yield (return rate) card across every subnet's neurons. Aggregates are null on a cold store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/chain/yield.",
   );
 export type ChainYieldArtifact = z.infer<typeof ChainYieldArtifactSchema>;
-export const ChainYieldResponseSchema = successEnvelopeSchema(
-  ChainYieldArtifactSchema,
-);

--- a/schemas-src/routes/compare-validators.ts
+++ b/schemas-src/routes/compare-validators.ts
@@ -6,7 +6,6 @@
 // it replaces. Reuses ColdkeyIdentitySchema from global-validators.ts and
 // ValidatorDetailSubnetSchema from validator-detail.ts (subnet_context).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ColdkeyIdentitySchema } from "./global-validators.ts";
 import { ValidatorDetailSubnetSchema } from "./validator-detail.ts";
 
@@ -50,6 +49,3 @@ export const CompareValidatorsArtifactSchema = z
 export type CompareValidatorsArtifact = z.infer<
   typeof CompareValidatorsArtifactSchema
 >;
-export const CompareValidatorsResponseSchema = successEnvelopeSchema(
-  CompareValidatorsArtifactSchema,
-);

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -6,11 +6,7 @@
 // replace.
 import { z } from "zod";
 import { QUERY_ENUMS } from "../query-enums.ts";
-import {
-  ArtifactBaseSchema,
-  CountMapSchema,
-  successEnvelopeSchema,
-} from "../envelope.ts";
+import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { BittensorNetworkSchema } from "../shared.ts";
 
 /** One surface kind's share of the registry: how many subnets have it, and
@@ -91,9 +87,6 @@ export const CoverageArtifactSchema = ArtifactBaseSchema.extend({
   surface_count: z.int().min(0),
 }).passthrough();
 export type CoverageArtifact = z.infer<typeof CoverageArtifactSchema>;
-export const CoverageResponseSchema = successEnvelopeSchema(
-  CoverageArtifactSchema,
-);
 
 // Shared with schemas-src/mcp-tools/registry-summary-gaps.ts's
 // COVERAGE_DEPTH_TIERS/COVERAGE_DEPTH_SEVERITIES (types-epic E batch 11,
@@ -226,6 +219,3 @@ export const CoverageDepthArtifactSchema = ArtifactBaseSchema.extend({
   ranked_queue: z.array(CoverageDepthQueueEntrySchema),
 }).passthrough();
 export type CoverageDepthArtifact = z.infer<typeof CoverageDepthArtifactSchema>;
-export const CoverageDepthResponseSchema = successEnvelopeSchema(
-  CoverageDepthArtifactSchema,
-);

--- a/schemas-src/routes/crowdloans.ts
+++ b/schemas-src/routes/crowdloans.ts
@@ -4,7 +4,6 @@
 // query params (both call validateEntityQuery(url, []), so any query string
 // is a 400).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
@@ -62,9 +61,6 @@ export const CrowdloansArtifactSchema = z
   })
   .passthrough();
 export type CrowdloansArtifact = z.infer<typeof CrowdloansArtifactSchema>;
-export const CrowdloansResponseSchema = successEnvelopeSchema(
-  CrowdloansArtifactSchema,
-);
 
 export const CrowdloanDetailArtifactSchema = z
   .object({
@@ -81,6 +77,3 @@ export const CrowdloanDetailArtifactSchema = z
 export type CrowdloanDetailArtifact = z.infer<
   typeof CrowdloanDetailArtifactSchema
 >;
-export const CrowdloanDetailResponseSchema = successEnvelopeSchema(
-  CrowdloanDetailArtifactSchema,
-);

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -8,7 +8,7 @@
 // hand-edited CurationArtifact/CurationEntry and GapsArtifact/GapsEntry
 // components they replace.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import { COVERAGE_LEVEL_VALUES, CurationLevelSchema } from "../shared.ts";
 import { CurationMetadataSchema, GapsSchema } from "./subnet-detail.ts";
 import { ENDPOINT_INCIDENT_SEVERITY_VALUES } from "./endpoints-pools.ts";
@@ -48,9 +48,6 @@ export const CurationArtifactSchema = ArtifactBaseSchema.extend({
     "Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation).",
   );
 export type CurationArtifact = z.infer<typeof CurationArtifactSchema>;
-export const CurationResponseSchema = successEnvelopeSchema(
-  CurationArtifactSchema,
-);
 
 export const GAPS_SORT_FIELDS = [
   "coverage_level",
@@ -85,4 +82,3 @@ export const GapsArtifactSchema = ArtifactBaseSchema.extend({
     "Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps).",
   );
 export type GapsArtifact = z.infer<typeof GapsArtifactSchema>;
-export const GapsResponseSchema = successEnvelopeSchema(GapsArtifactSchema);

--- a/schemas-src/routes/domains.ts
+++ b/schemas-src/routes/domains.ts
@@ -9,7 +9,6 @@
 // hand-edited DomainSummaryArtifact/DomainsArtifact components they
 // replace.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const ConcentrationScorecardSchema = z
   .object({
@@ -56,9 +55,6 @@ export const DomainSummaryArtifactSchema = z
     "One domain/capability tag's rollup (#6989). Mirrors GET /api/v1/domains/{tag}/summary.",
   );
 export type DomainSummaryArtifact = z.infer<typeof DomainSummaryArtifactSchema>;
-export const DomainSummaryResponseSchema = successEnvelopeSchema(
-  DomainSummaryArtifactSchema,
-);
 
 export const DomainsArtifactSchema = z
   .object({
@@ -71,6 +67,3 @@ export const DomainsArtifactSchema = z
     "The per-domain rollup overview across the fixed capability taxonomy (#6989). Mirrors GET /api/v1/domains.",
   );
 export type DomainsArtifact = z.infer<typeof DomainsArtifactSchema>;
-export const DomainsResponseSchema = successEnvelopeSchema(
-  DomainsArtifactSchema,
-);

--- a/schemas-src/routes/economics-trends.ts
+++ b/schemas-src/routes/economics-trends.ts
@@ -4,7 +4,6 @@
 // against the hand-edited EconomicsTrendsArtifact/EconomicsTrendsDay
 // components it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { SERIES_USD_UNAVAILABLE } from "../../src/alpha-usd-history.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
@@ -81,6 +80,3 @@ export const EconomicsTrendsArtifactSchema = z
 export type EconomicsTrendsArtifact = z.infer<
   typeof EconomicsTrendsArtifactSchema
 >;
-export const EconomicsTrendsResponseSchema = successEnvelopeSchema(
-  EconomicsTrendsArtifactSchema,
-);

--- a/schemas-src/routes/economics.ts
+++ b/schemas-src/routes/economics.ts
@@ -7,7 +7,7 @@
 // EconomicsArtifact component (built from src/contracts.ts), cross-checked
 // against real handler output — see tests/zod-schemas.test.ts.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import {
   ChainStateSchema,
   FieldSourcesSchema,
@@ -66,7 +66,3 @@ export const EconomicsArtifactSchema = ArtifactBaseSchema.extend({
   summary: EconomicsSummarySchema,
 });
 export type EconomicsArtifact = z.infer<typeof EconomicsArtifactSchema>;
-
-export const EconomicsResponseSchema = successEnvelopeSchema(
-  EconomicsArtifactSchema,
-);

--- a/schemas-src/routes/emission-gate-changes.ts
+++ b/schemas-src/routes/emission-gate-changes.ts
@@ -6,7 +6,6 @@
 // ABSENT rather than null -- an absent field says "this kind has no such thing",
 // where a null would say "it has one and we do not know it".
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** Shared by every kind. `predates_capture` is the honesty flag: true means the
  * row is the FIRST OBSERVATION of a value, not a change to it. */
@@ -77,6 +76,3 @@ export const EmissionGateChangesArtifactSchema = z
 export type EmissionGateChangesArtifact = z.infer<
   typeof EmissionGateChangesArtifactSchema
 >;
-export const EmissionGateChangesResponseSchema = successEnvelopeSchema(
-  EmissionGateChangesArtifactSchema,
-);

--- a/schemas-src/routes/emission-pipeline-history.ts
+++ b/schemas-src/routes/emission-pipeline-history.ts
@@ -3,7 +3,6 @@
 // src/emission-pipeline-history.ts's buildPipelineHistory().
 import { z } from "zod";
 import { UnavailableDegradedSchema } from "./event-stream-honesty.ts";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const PipelineHistoryPointSchema = z
   .object({
@@ -86,6 +85,3 @@ export const PipelineHistoryArtifactSchema = z
 export type PipelineHistoryArtifact = z.infer<
   typeof PipelineHistoryArtifactSchema
 >;
-export const PipelineHistoryResponseSchema = successEnvelopeSchema(
-  PipelineHistoryArtifactSchema,
-);

--- a/schemas-src/routes/emission-pipeline.ts
+++ b/schemas-src/routes/emission-pipeline.ts
@@ -3,7 +3,6 @@
 // Shape mirrors src/emission-decomposition.ts's EmissionDecomposition exactly;
 // the module is the source of truth and this is its contract projection.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ChainStateSchema, FieldSourcesSchema } from "../shared.ts";
 
 /** A fraction of block emission. Null where stage 0 excluded the subnet. */
@@ -221,7 +220,3 @@ export const EmissionPipelineArtifactSchema = z
 export type EmissionPipelineArtifact = z.infer<
   typeof EmissionPipelineArtifactSchema
 >;
-
-export const EmissionPipelineResponseSchema = successEnvelopeSchema(
-  EmissionPipelineArtifactSchema,
-);

--- a/schemas-src/routes/extrinsics.ts
+++ b/schemas-src/routes/extrinsics.ts
@@ -12,7 +12,6 @@
 // hand-edited OpenAPI document itself $refs the same ExtrinsicsFeedArtifact
 // component from all three paths, verified via repo-wide $ref grep).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
 
 export const ExtrinsicSchema = z
@@ -57,9 +56,6 @@ export const ExtrinsicsFeedArtifactSchema = z
 export type ExtrinsicsFeedArtifact = z.infer<
   typeof ExtrinsicsFeedArtifactSchema
 >;
-export const ExtrinsicsFeedResponseSchema = successEnvelopeSchema(
-  ExtrinsicsFeedArtifactSchema,
-);
 
 export const ExtrinsicDetailArtifactSchema = z
   .object({
@@ -72,6 +68,3 @@ export const ExtrinsicDetailArtifactSchema = z
 export type ExtrinsicDetailArtifact = z.infer<
   typeof ExtrinsicDetailArtifactSchema
 >;
-export const ExtrinsicDetailResponseSchema = successEnvelopeSchema(
-  ExtrinsicDetailArtifactSchema,
-);

--- a/schemas-src/routes/failure-reasons.ts
+++ b/schemas-src/routes/failure-reasons.ts
@@ -3,7 +3,6 @@
 // buildFailureReasons().
 import { z } from "zod";
 import { UnavailableDegradedSchema } from "./event-stream-honesty.ts";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const FailureReasonSchema = z
   .object({
@@ -81,6 +80,3 @@ export const FailureReasonsArtifactSchema = z
 export type FailureReasonsArtifact = z.infer<
   typeof FailureReasonsArtifactSchema
 >;
-export const FailureReasonsResponseSchema = successEnvelopeSchema(
-  FailureReasonsArtifactSchema,
-);

--- a/schemas-src/routes/fixtures.ts
+++ b/schemas-src/routes/fixtures.ts
@@ -6,7 +6,7 @@
 // neither route needs a Query schema. Modeled from the hand-edited
 // FixturesIndexArtifact/FixtureArtifact components they replace.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import { SurfaceKindSchema } from "./subnet-detail.ts";
 
 // Bare `{type:"object", additionalProperties:true}` (hand-written
@@ -54,9 +54,6 @@ export const FixturesIndexArtifactSchema = ArtifactBaseSchema.extend({
   ),
 }).passthrough();
 export type FixturesIndexArtifact = z.infer<typeof FixturesIndexArtifactSchema>;
-export const FixturesIndexResponseSchema = successEnvelopeSchema(
-  FixturesIndexArtifactSchema,
-);
 
 export const FixtureArtifactSchema = ArtifactBaseSchema.extend({
   surface_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9:._-]*$/),
@@ -87,6 +84,3 @@ export const FixtureArtifactSchema = ArtifactBaseSchema.extend({
     .passthrough(),
 }).passthrough();
 export type FixtureArtifact = z.infer<typeof FixtureArtifactSchema>;
-export const FixtureResponseSchema = successEnvelopeSchema(
-  FixtureArtifactSchema,
-);

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -12,7 +12,6 @@
 // GlobalValidatorEntry is its only referrer -- so that hand-edited key also
 // becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES = [
@@ -152,6 +151,3 @@ export const GlobalValidatorsArtifactSchema = z
 export type GlobalValidatorsArtifact = z.infer<
   typeof GlobalValidatorsArtifactSchema
 >;
-export const GlobalValidatorsResponseSchema = successEnvelopeSchema(
-  GlobalValidatorsArtifactSchema,
-);

--- a/schemas-src/routes/health.ts
+++ b/schemas-src/routes/health.ts
@@ -8,7 +8,6 @@
 // src/contracts.ts), cross-checked against real handler output including the
 // cold-store degraded case — see tests/zod-schemas.test.ts.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { HealthStatusSchema } from "../shared.ts";
 
 export const HealthSubnetSummarySchema = z
@@ -60,7 +59,3 @@ export const HealthSummaryArtifactSchema = z
   // allows generated_at: null for the cold-store case.
   .passthrough();
 export type HealthSummaryArtifact = z.infer<typeof HealthSummaryArtifactSchema>;
-
-export const HealthResponseSchema = successEnvelopeSchema(
-  HealthSummaryArtifactSchema,
-);

--- a/schemas-src/routes/indexer-lag.ts
+++ b/schemas-src/routes/indexer-lag.ts
@@ -6,7 +6,6 @@
 // here would make author clock skew a schema violation on the one route whose
 // whole subject is that difference, turning evidence into an error.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** What was actually measured. Published because chain-detail-prune keeps a
  * rolling window, so a distribution without its bounds reads as a lifetime one. */
@@ -78,6 +77,3 @@ export const IndexerLagArtifactSchema = z
   })
   .passthrough();
 export type IndexerLagArtifact = z.infer<typeof IndexerLagArtifactSchema>;
-export const IndexerLagResponseSchema = successEnvelopeSchema(
-  IndexerLagArtifactSchema,
-);

--- a/schemas-src/routes/lineage.ts
+++ b/schemas-src/routes/lineage.ts
@@ -3,7 +3,7 @@
 // types-epic E batch 11, #8074's meta-artifacts-1.ts). Modeled from the
 // hand-edited LineageArtifact component it replaces.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 
 export const LineageArtifactSchema = ArtifactBaseSchema.extend({
   published_at: z.string().nullable().optional(),
@@ -45,6 +45,3 @@ export const LineageArtifactSchema = ArtifactBaseSchema.extend({
   ),
 }).passthrough();
 export type LineageArtifact = z.infer<typeof LineageArtifactSchema>;
-export const LineageResponseSchema = successEnvelopeSchema(
-  LineageArtifactSchema,
-);

--- a/schemas-src/routes/network-singletons.ts
+++ b/schemas-src/routes/network-singletons.ts
@@ -8,7 +8,6 @@
 // EvmAddressMappingArtifact/NetworkParametersArtifact/RandomnessArtifact/
 // SudoKeyArtifact components they replace.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 export const EvmAddressMappingArtifactSchema = z
@@ -28,9 +27,6 @@ export const EvmAddressMappingArtifactSchema = z
 export type EvmAddressMappingArtifact = z.infer<
   typeof EvmAddressMappingArtifactSchema
 >;
-export const EvmAddressMappingResponseSchema = successEnvelopeSchema(
-  EvmAddressMappingArtifactSchema,
-);
 
 export const NetworkParametersArtifactSchema = z
   .object({
@@ -69,9 +65,6 @@ export const NetworkParametersArtifactSchema = z
 export type NetworkParametersArtifact = z.infer<
   typeof NetworkParametersArtifactSchema
 >;
-export const NetworkParametersResponseSchema = successEnvelopeSchema(
-  NetworkParametersArtifactSchema,
-);
 
 export const RandomnessArtifactSchema = z
   .object({
@@ -89,9 +82,6 @@ export const RandomnessArtifactSchema = z
     "Live drand randomness-beacon status read from chain via RPC. Each field is independently null on its own RPC failure (schema-stable). Mirrors GET /api/v1/network/randomness's data envelope.",
   );
 export type RandomnessArtifact = z.infer<typeof RandomnessArtifactSchema>;
-export const RandomnessResponseSchema = successEnvelopeSchema(
-  RandomnessArtifactSchema,
-);
 
 export const SudoKeyArtifactSchema = z
   .object({
@@ -108,6 +98,3 @@ export const SudoKeyArtifactSchema = z
     "The network's on-chain sudo (superuser) key, read live from chain via RPC. hotkey is null on RPC failure or a renounced sudo (schema-stable). Mirrors GET /api/v1/sudo/key's data envelope.",
   );
 export type SudoKeyArtifact = z.infer<typeof SudoKeyArtifactSchema>;
-export const SudoKeyResponseSchema = successEnvelopeSchema(
-  SudoKeyArtifactSchema,
-);

--- a/schemas-src/routes/registry-summary-leaderboards.ts
+++ b/schemas-src/routes/registry-summary-leaderboards.ts
@@ -12,11 +12,7 @@
 // hand-edited RegistrySummaryArtifact/RegistryLeaderboardsArtifact
 // components they replace.
 import { z } from "zod";
-import {
-  ArtifactBaseSchema,
-  CountMapSchema,
-  successEnvelopeSchema,
-} from "../envelope.ts";
+import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { CoverageCompletenessSchema } from "./coverage.ts";
 
 export const RegistrySummaryArtifactSchema = ArtifactBaseSchema.extend({
@@ -75,9 +71,6 @@ export const RegistrySummaryArtifactSchema = ArtifactBaseSchema.extend({
 export type RegistrySummaryArtifact = z.infer<
   typeof RegistrySummaryArtifactSchema
 >;
-export const RegistrySummaryResponseSchema = successEnvelopeSchema(
-  RegistrySummaryArtifactSchema,
-);
 
 export const ECONOMIC_LEADERBOARD_BOARDS = [
   "open-slots",
@@ -165,6 +158,3 @@ export const RegistryLeaderboardsArtifactSchema = z
 export type RegistryLeaderboardsArtifact = z.infer<
   typeof RegistryLeaderboardsArtifactSchema
 >;
-export const RegistryLeaderboardsResponseSchema = successEnvelopeSchema(
-  RegistryLeaderboardsArtifactSchema,
-);

--- a/schemas-src/routes/revenue-coverage.ts
+++ b/schemas-src/routes/revenue-coverage.ts
@@ -13,7 +13,7 @@
 //      figure as fact because the response let it is the failure mode
 //      #10439's ladder exists for.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 export const REVENUE_PROVENANCE_VALUES = [
@@ -143,10 +143,3 @@ export const ChainRevenueCoverageArtifactSchema = ArtifactBaseSchema.extend({
 export type ChainRevenueCoverageArtifact = z.infer<
   typeof ChainRevenueCoverageArtifactSchema
 >;
-
-export const SubnetRevenueResponseSchema = successEnvelopeSchema(
-  SubnetRevenueArtifactSchema,
-);
-export const ChainRevenueCoverageResponseSchema = successEnvelopeSchema(
-  ChainRevenueCoverageArtifactSchema,
-);

--- a/schemas-src/routes/review-enrichment.ts
+++ b/schemas-src/routes/review-enrichment.ts
@@ -13,11 +13,7 @@
 // components they replace.
 import { z } from "zod";
 import { QUERY_ENUMS } from "../query-enums.ts";
-import {
-  ArtifactBaseSchema,
-  CountMapSchema,
-  successEnvelopeSchema,
-} from "../envelope.ts";
+import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { CurationLevelSchema } from "../shared.ts";
 import { ReviewStateSchema, SurfaceKindSchema } from "./subnet-detail.ts";
 import { IDENTITY_LEVEL_VALUES, PROFILE_LEVEL_VALUES } from "../shared.ts";
@@ -206,9 +202,6 @@ export const ReviewEnrichmentQueueArtifactSchema = ArtifactBaseSchema.extend({
 export type ReviewEnrichmentQueueArtifact = z.infer<
   typeof ReviewEnrichmentQueueArtifactSchema
 >;
-export const ReviewEnrichmentQueueResponseSchema = successEnvelopeSchema(
-  ReviewEnrichmentQueueArtifactSchema,
-);
 
 export const EVIDENCE_SORT_FIELDS = [
   "evidence_action",
@@ -254,9 +247,6 @@ export const ReviewEnrichmentEvidenceArtifactSchema = ArtifactBaseSchema.extend(
 export type ReviewEnrichmentEvidenceArtifact = z.infer<
   typeof ReviewEnrichmentEvidenceArtifactSchema
 >;
-export const ReviewEnrichmentEvidenceResponseSchema = successEnvelopeSchema(
-  ReviewEnrichmentEvidenceArtifactSchema,
-);
 
 export const TARGET_SORT_FIELDS = [
   "auto_review_candidate",
@@ -340,9 +330,6 @@ export const ReviewEnrichmentTargetsArtifactSchema = ArtifactBaseSchema.extend({
 export type ReviewEnrichmentTargetsArtifact = z.infer<
   typeof ReviewEnrichmentTargetsArtifactSchema
 >;
-export const ReviewEnrichmentTargetsResponseSchema = successEnvelopeSchema(
-  ReviewEnrichmentTargetsArtifactSchema,
-);
 
 export const RECOMMENDED_ADAPTER_KINDS = QUERY_ENUMS.recommendedAdapterKind;
 export const ADAPTER_CANDIDATES_SORT_FIELDS = [
@@ -395,6 +382,3 @@ export const ReviewAdapterCandidatesArtifactSchema = ArtifactBaseSchema.extend({
 export type ReviewAdapterCandidatesArtifact = z.infer<
   typeof ReviewAdapterCandidatesArtifactSchema
 >;
-export const ReviewAdapterCandidatesResponseSchema = successEnvelopeSchema(
-  ReviewAdapterCandidatesArtifactSchema,
-);

--- a/schemas-src/routes/review-gaps-profile.ts
+++ b/schemas-src/routes/review-gaps-profile.ts
@@ -10,11 +10,7 @@
 // (+ReviewGapPriority), SubnetGapsArtifact, and
 // ReviewProfileCompletenessArtifact(+Entry) components they replace.
 import { z } from "zod";
-import {
-  ArtifactBaseSchema,
-  CountMapSchema,
-  successEnvelopeSchema,
-} from "../envelope.ts";
+import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { CurationLevelSchema } from "../shared.ts";
 import { ReviewStateSchema, SurfaceKindSchema } from "./subnet-detail.ts";
 import { SubnetProfileIdentityEvidenceSchema } from "./subnet-profile.ts";
@@ -58,9 +54,6 @@ export const ReviewGapPrioritiesArtifactSchema = ArtifactBaseSchema.extend({
 export type ReviewGapPrioritiesArtifact = z.infer<
   typeof ReviewGapPrioritiesArtifactSchema
 >;
-export const ReviewGapPrioritiesResponseSchema = successEnvelopeSchema(
-  ReviewGapPrioritiesArtifactSchema,
-);
 
 export const SubnetGapsArtifactSchema = ArtifactBaseSchema.extend({
   netuid: z.int().min(0),
@@ -70,9 +63,6 @@ export const SubnetGapsArtifactSchema = ArtifactBaseSchema.extend({
   enrichment_queue: z.array(ReviewEnrichmentQueueEntrySchema),
 }).passthrough();
 export type SubnetGapsArtifact = z.infer<typeof SubnetGapsArtifactSchema>;
-export const SubnetGapsResponseSchema = successEnvelopeSchema(
-  SubnetGapsArtifactSchema,
-);
 
 export const PROFILE_SORT_FIELDS = [
   "candidate_count",
@@ -146,6 +136,3 @@ export const ReviewProfileCompletenessArtifactSchema =
 export type ReviewProfileCompletenessArtifact = z.infer<
   typeof ReviewProfileCompletenessArtifactSchema
 >;
-export const ReviewProfileCompletenessResponseSchema = successEnvelopeSchema(
-  ReviewProfileCompletenessArtifactSchema,
-);

--- a/schemas-src/routes/runtime-versions.ts
+++ b/schemas-src/routes/runtime-versions.ts
@@ -8,7 +8,6 @@
 // repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const RuntimeVersionTransitionSchema = z
   .object({
@@ -53,6 +52,3 @@ export const RuntimeVersionsArtifactSchema = z
 export type RuntimeVersionsArtifact = z.infer<
   typeof RuntimeVersionsArtifactSchema
 >;
-export const RuntimeVersionsResponseSchema = successEnvelopeSchema(
-  RuntimeVersionsArtifactSchema,
-);

--- a/schemas-src/routes/search-resolve.ts
+++ b/schemas-src/routes/search-resolve.ts
@@ -7,7 +7,6 @@
 // payload is a LIST with an `exact` flag per candidate rather than a single
 // answer. A schema with one `kind` field would have forced the resolver to guess.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** One place the query could lead. */
 export const ResolvedIdentifierSchema = z
@@ -58,6 +57,3 @@ export const SearchResolveArtifactSchema = z
   })
   .passthrough();
 export type SearchResolveArtifact = z.infer<typeof SearchResolveArtifactSchema>;
-export const SearchResolveResponseSchema = successEnvelopeSchema(
-  SearchResolveArtifactSchema,
-);

--- a/schemas-src/routes/self-health.ts
+++ b/schemas-src/routes/self-health.ts
@@ -8,7 +8,6 @@
 // sub-shape gets silently inlined by the OpenAPI registry rather than
 // $ref'd -- see the Zod-registry gotcha in the schema notes.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SelfHealthDaySchema = z
   .object({
@@ -121,7 +120,3 @@ export const SelfHealthArtifactSchema = z
     "metagraphed's own uptime verdict (#8422). Mirrors GET /api/v1/self-health.",
   );
 export type SelfHealthArtifact = z.infer<typeof SelfHealthArtifactSchema>;
-
-export const SelfHealthResponseSchema = successEnvelopeSchema(
-  SelfHealthArtifactSchema,
-);

--- a/schemas-src/routes/stake-quote.ts
+++ b/schemas-src/routes/stake-quote.ts
@@ -8,7 +8,6 @@
 // counterpart, kept independent per this issue's zero-behavior-change scope.
 // Cross-checked against real handler output — see tests/zod-schemas.test.ts.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetStakeQuoteArtifactSchema = z
   .object({
@@ -40,7 +39,3 @@ export const SubnetStakeQuoteArtifactSchema = z
 export type SubnetStakeQuoteArtifact = z.infer<
   typeof SubnetStakeQuoteArtifactSchema
 >;
-
-export const StakeQuoteResponseSchema = successEnvelopeSchema(
-  SubnetStakeQuoteArtifactSchema,
-);

--- a/schemas-src/routes/subnet-activity.ts
+++ b/schemas-src/routes/subnet-activity.ts
@@ -8,7 +8,6 @@
 // verified by reading all four source files), cross-checked against the
 // four hand-edited Subnet*Artifact components they replace.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import {
   DeregistrationDerivationSchema,
   EventStreamDegradedSchema,
@@ -38,9 +37,6 @@ export const SubnetAxonRemovalsArtifactSchema = z
 export type SubnetAxonRemovalsArtifact = z.infer<
   typeof SubnetAxonRemovalsArtifactSchema
 >;
-export const SubnetAxonRemovalsResponseSchema = successEnvelopeSchema(
-  SubnetAxonRemovalsArtifactSchema,
-);
 
 export const SubnetDeregistrationsArtifactSchema = z
   .object({
@@ -101,9 +97,6 @@ export const SubnetDeregistrationsArtifactSchema = z
 export type SubnetDeregistrationsArtifact = z.infer<
   typeof SubnetDeregistrationsArtifactSchema
 >;
-export const SubnetDeregistrationsResponseSchema = successEnvelopeSchema(
-  SubnetDeregistrationsArtifactSchema,
-);
 
 export const SubnetRegistrationsArtifactSchema = z
   .object({
@@ -119,9 +112,6 @@ export const SubnetRegistrationsArtifactSchema = z
 export type SubnetRegistrationsArtifact = z.infer<
   typeof SubnetRegistrationsArtifactSchema
 >;
-export const SubnetRegistrationsResponseSchema = successEnvelopeSchema(
-  SubnetRegistrationsArtifactSchema,
-);
 
 export const SubnetServingArtifactSchema = z
   .object({
@@ -135,6 +125,3 @@ export const SubnetServingArtifactSchema = z
   })
   .strict();
 export type SubnetServingArtifact = z.infer<typeof SubnetServingArtifactSchema>;
-export const SubnetServingResponseSchema = successEnvelopeSchema(
-  SubnetServingArtifactSchema,
-);

--- a/schemas-src/routes/subnet-alpha-volume.ts
+++ b/schemas-src/routes/subnet-alpha-volume.ts
@@ -4,7 +4,6 @@
 // (every field always present, none omitted), cross-checked against the
 // hand-edited SubnetAlphaVolumeArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 import { ALPHA_USD_UNAVAILABLE } from "../../src/alpha-usd.ts";
 
@@ -81,7 +80,3 @@ export const SubnetAlphaVolumeArtifactSchema = z
 export type SubnetAlphaVolumeArtifact = z.infer<
   typeof SubnetAlphaVolumeArtifactSchema
 >;
-
-export const SubnetAlphaVolumeResponseSchema = successEnvelopeSchema(
-  SubnetAlphaVolumeArtifactSchema,
-);

--- a/schemas-src/routes/subnet-concentration.ts
+++ b/schemas-src/routes/subnet-concentration.ts
@@ -13,7 +13,6 @@
 // more times -- so the published GraphQL schema grew five anonymous twins of
 // a type it already had a name for.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ConcentrationMetricsSchema } from "../shared.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
@@ -65,9 +64,6 @@ export const SubnetConcentrationArtifactSchema = z
 export type SubnetConcentrationArtifact = z.infer<
   typeof SubnetConcentrationArtifactSchema
 >;
-export const SubnetConcentrationResponseSchema = successEnvelopeSchema(
-  SubnetConcentrationArtifactSchema,
-);
 
 const SubnetConcentrationHistoryPointSchema = z
   .object({
@@ -101,6 +97,3 @@ export const SubnetConcentrationHistoryArtifactSchema = z
 export type SubnetConcentrationHistoryArtifact = z.infer<
   typeof SubnetConcentrationHistoryArtifactSchema
 >;
-export const SubnetConcentrationHistoryResponseSchema = successEnvelopeSchema(
-  SubnetConcentrationHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-conviction.ts
+++ b/schemas-src/routes/subnet-conviction.ts
@@ -5,7 +5,6 @@
 // it replaces. No query params (verified: the DATA_API route reads only the
 // netuid path segment).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 const SubnetConvictionEntrySchema = z
@@ -38,6 +37,3 @@ export const SubnetConvictionArtifactSchema = z
 export type SubnetConvictionArtifact = z.infer<
   typeof SubnetConvictionArtifactSchema
 >;
-export const SubnetConvictionResponseSchema = successEnvelopeSchema(
-  SubnetConvictionArtifactSchema,
-);

--- a/schemas-src/routes/subnet-deregistration-ranking.ts
+++ b/schemas-src/routes/subnet-deregistration-ranking.ts
@@ -5,7 +5,6 @@
 // `Subtensor::get_network_to_prune()`; that module is the source of truth and
 // this is its contract projection.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ChainStateSchema, FieldSourcesSchema } from "../shared.ts";
 
 export const DeregistrationRankEntrySchema = z
@@ -59,7 +58,3 @@ export const SubnetDeregistrationRankingArtifactSchema = z
 export type SubnetDeregistrationRankingArtifact = z.infer<
   typeof SubnetDeregistrationRankingArtifactSchema
 >;
-
-export const SubnetDeregistrationRankingResponseSchema = successEnvelopeSchema(
-  SubnetDeregistrationRankingArtifactSchema,
-);

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -21,7 +21,7 @@ import {
   SubmissionReviewStateSchema,
 } from "../shared.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import {
   BittensorNetworkSchema,
   CoverageLevelSchema,
@@ -645,7 +645,3 @@ export const SubnetDetailArtifactSchema = ArtifactBaseSchema.extend({
   verified_surfaces: z.array(SurfaceSchema).optional(),
 });
 export type SubnetDetailArtifact = z.infer<typeof SubnetDetailArtifactSchema>;
-
-export const SubnetDetailResponseSchema = successEnvelopeSchema(
-  SubnetDetailArtifactSchema,
-);

--- a/schemas-src/routes/subnet-event-summary.ts
+++ b/schemas-src/routes/subnet-event-summary.ts
@@ -7,7 +7,6 @@
 // SubnetEventCategorySummary/SubnetEventKindSummary/SubnetEventSummaryArtifact
 // components it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { AccountEventSchema } from "./subnet-events.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
@@ -103,6 +102,3 @@ export const SubnetEventSummaryArtifactSchema = z
 export type SubnetEventSummaryArtifact = z.infer<
   typeof SubnetEventSummaryArtifactSchema
 >;
-export const SubnetEventSummaryResponseSchema = successEnvelopeSchema(
-  SubnetEventSummaryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-events.ts
+++ b/schemas-src/routes/subnet-events.ts
@@ -9,7 +9,6 @@
 // always sets every key -- AccountEvent is reused by many untouched routes
 // beyond this batch's two, so this batch makes no behavior change to it.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const AccountEventSchema = z
   .object({
@@ -70,6 +69,3 @@ export const SubnetEventsArtifactSchema = z
     "One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Each item is an AccountEvent. Empty feed on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope.",
   );
 export type SubnetEventsArtifact = z.infer<typeof SubnetEventsArtifactSchema>;
-export const SubnetEventsResponseSchema = successEnvelopeSchema(
-  SubnetEventsArtifactSchema,
-);

--- a/schemas-src/routes/subnet-history.ts
+++ b/schemas-src/routes/subnet-history.ts
@@ -8,7 +8,6 @@
 // an enum here would be a real (if inert) tightening the issue's wire-
 // compatibility constraint doesn't require -- left loose on purpose.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_HISTORY_WINDOW_VALUES = [
@@ -45,6 +44,3 @@ export const SubnetHistoryArtifactSchema = z
     "One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope.",
   );
 export type SubnetHistoryArtifact = z.infer<typeof SubnetHistoryArtifactSchema>;
-export const SubnetHistoryResponseSchema = successEnvelopeSchema(
-  SubnetHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-holders.ts
+++ b/schemas-src/routes/subnet-holders.ts
@@ -8,7 +8,6 @@
 // every count null -- so `0` in any of these fields is a MEASURED zero, and the
 // schema must not let a decline masquerade as one.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetHolderSchema = z
   .object({
@@ -119,6 +118,3 @@ export const SubnetHoldersArtifactSchema = z
   })
   .passthrough();
 export type SubnetHoldersArtifact = z.infer<typeof SubnetHoldersArtifactSchema>;
-export const SubnetHoldersResponseSchema = successEnvelopeSchema(
-  SubnetHoldersArtifactSchema,
-);

--- a/schemas-src/routes/subnet-hyperparameters.ts
+++ b/schemas-src/routes/subnet-hyperparameters.ts
@@ -17,7 +17,6 @@
 // *.schema.json file), and all three are converted together in this same
 // batch, so both hand-edited component keys become fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const SubnetHyperparametersSchema = z
   .object({
@@ -89,9 +88,6 @@ export const SubnetHyperparametersArtifactSchema = z
 export type SubnetHyperparametersArtifact = z.infer<
   typeof SubnetHyperparametersArtifactSchema
 >;
-export const SubnetHyperparametersResponseSchema = successEnvelopeSchema(
-  SubnetHyperparametersArtifactSchema,
-);
 
 const SubnetHyperparamsHistoryEntrySchema = z
   .object({
@@ -119,6 +115,3 @@ export const SubnetHyperparamsHistoryArtifactSchema = z
 export type SubnetHyperparamsHistoryArtifact = z.infer<
   typeof SubnetHyperparamsHistoryArtifactSchema
 >;
-export const SubnetHyperparamsHistoryResponseSchema = successEnvelopeSchema(
-  SubnetHyperparamsHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-identity-history.ts
+++ b/schemas-src/routes/subnet-identity-history.ts
@@ -12,7 +12,6 @@
 // schema would have rejected. Modeled here as nullable (still required --
 // the key itself is always present), matching real behavior.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetIdentityHistoryEntrySchema = z
   .object({
@@ -52,6 +51,3 @@ export const SubnetIdentityHistoryArtifactSchema = z
 export type SubnetIdentityHistoryArtifact = z.infer<
   typeof SubnetIdentityHistoryArtifactSchema
 >;
-export const SubnetIdentityHistoryResponseSchema = successEnvelopeSchema(
-  SubnetIdentityHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-idle-stake.ts
+++ b/schemas-src/routes/subnet-idle-stake.ts
@@ -4,7 +4,6 @@
 // set), cross-checked against the hand-edited SubnetIdleStakeArtifact
 // component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetIdleStakeArtifactSchema = z
   .object({
@@ -22,6 +21,3 @@ export const SubnetIdleStakeArtifactSchema = z
 export type SubnetIdleStakeArtifact = z.infer<
   typeof SubnetIdleStakeArtifactSchema
 >;
-export const SubnetIdleStakeResponseSchema = successEnvelopeSchema(
-  SubnetIdleStakeArtifactSchema,
-);

--- a/schemas-src/routes/subnet-lease.ts
+++ b/schemas-src/routes/subnet-lease.ts
@@ -8,7 +8,6 @@
 // params (verified: handleSubnetLease doesn't even accept a `url` argument;
 // the lease/history DATA_API route reads only the netuid path segment).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 const SubnetLeaseSchema = z
@@ -41,9 +40,6 @@ export const SubnetLeaseArtifactSchema = z
     "Live subnet-lease state -- whether a subnet is currently under a lease and, if so, its terms (beneficiary, coldkey, hotkey, emissions_share_percent, end_block, cost_tao) and accumulated-but-undistributed alpha dividends. leased is null (not false) on RPC failure, distinct from a confirmed no-lease (leased:false). Mirrors GET /api/v1/subnets/{netuid}/lease.",
   );
 export type SubnetLeaseArtifact = z.infer<typeof SubnetLeaseArtifactSchema>;
-export const SubnetLeaseResponseSchema = successEnvelopeSchema(
-  SubnetLeaseArtifactSchema,
-);
 
 // objectItems-equivalent looseness: no field required at the item level,
 // matching the hand-written original exactly.
@@ -78,6 +74,3 @@ export const SubnetLeaseHistoryArtifactSchema = z
 export type SubnetLeaseHistoryArtifact = z.infer<
   typeof SubnetLeaseHistoryArtifactSchema
 >;
-export const SubnetLeaseHistoryResponseSchema = successEnvelopeSchema(
-  SubnetLeaseHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-lifecycle.ts
+++ b/schemas-src/routes/subnet-lifecycle.ts
@@ -10,8 +10,6 @@
 // the neurons-staleness tick (#10262).
 import { z } from "zod";
 
-import { successEnvelopeSchema } from "../envelope.ts";
-
 /**
  * The two transitions.
  *
@@ -66,9 +64,6 @@ export const SubnetLifecycleArtifactSchema = z
 export type SubnetLifecycleArtifact = z.infer<
   typeof SubnetLifecycleArtifactSchema
 >;
-export const SubnetLifecycleResponseSchema = successEnvelopeSchema(
-  SubnetLifecycleArtifactSchema,
-);
 
 /**
  * The network-wide feed: every subnet's transitions, newest first.
@@ -98,6 +93,3 @@ export const ChainSubnetLifecycleArtifactSchema = z
 export type ChainSubnetLifecycleArtifact = z.infer<
   typeof ChainSubnetLifecycleArtifactSchema
 >;
-export const ChainSubnetLifecycleResponseSchema = successEnvelopeSchema(
-  ChainSubnetLifecycleArtifactSchema,
-);

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -22,7 +22,6 @@
 // via repo-wide $ref grep), and all three are converted together in this same
 // batch, so the hand-edited Neuron component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 // Exported so the surfaces that serve these rows can derive `fields=`'s
 // allowed set from the CONTRACT rather than from a second list (#9082) --
@@ -125,9 +124,6 @@ export const SubnetMetagraphArtifactSchema = z
 export type SubnetMetagraphArtifact = z.infer<
   typeof SubnetMetagraphArtifactSchema
 >;
-export const SubnetMetagraphResponseSchema = successEnvelopeSchema(
-  SubnetMetagraphArtifactSchema,
-);
 
 export const NeuronDetailArtifactSchema = z
   .object({
@@ -144,9 +140,6 @@ export const NeuronDetailArtifactSchema = z
     "One neuron's live metagraph detail card (#5900). Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}: neuron is null when that UID is absent from the latest snapshot.",
   );
 export type NeuronDetailArtifact = z.infer<typeof NeuronDetailArtifactSchema>;
-export const NeuronDetailResponseSchema = successEnvelopeSchema(
-  NeuronDetailArtifactSchema,
-);
 
 export const SubnetValidatorsArtifactSchema = z
   .object({
@@ -168,9 +161,6 @@ export const SubnetValidatorsArtifactSchema = z
 export type SubnetValidatorsArtifact = z.infer<
   typeof SubnetValidatorsArtifactSchema
 >;
-export const SubnetValidatorsResponseSchema = successEnvelopeSchema(
-  SubnetValidatorsArtifactSchema,
-);
 
 // Per-day neuron_daily rollup point: a Neuron's state on one snapshot_date
 // (every Neuron field, always present per the live neuron_daily rollup query,
@@ -201,6 +191,3 @@ export const NeuronHistoryArtifactSchema = z
     "One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history.",
   );
 export type NeuronHistoryArtifact = z.infer<typeof NeuronHistoryArtifactSchema>;
-export const NeuronHistoryResponseSchema = successEnvelopeSchema(
-  NeuronHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-movers.ts
+++ b/schemas-src/routes/subnet-movers.ts
@@ -3,7 +3,6 @@
 // from src/movers.ts's buildMovers()/buildNetworkSummary(), cross-checked
 // against the hand-edited SubnetMoversArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_MOVERS_MOVERS_SORTS_VALUES = [
@@ -101,6 +100,3 @@ export const SubnetMoversArtifactSchema = z
   })
   .strict();
 export type SubnetMoversArtifact = z.infer<typeof SubnetMoversArtifactSchema>;
-export const SubnetMoversResponseSchema = successEnvelopeSchema(
-  SubnetMoversArtifactSchema,
-);

--- a/schemas-src/routes/subnet-ohlc.ts
+++ b/schemas-src/routes/subnet-ohlc.ts
@@ -3,7 +3,6 @@
 // src/subnet-ohlc.ts's buildSubnetOhlc(), cross-checked against the
 // hand-edited SubnetOhlcArtifact/SubnetOhlcCandle components it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { EpochMillisSchema } from "../shared.ts";
 import { SERIES_USD_UNAVAILABLE } from "../../src/alpha-usd-history.ts";
 
@@ -98,6 +97,3 @@ export const SubnetOhlcArtifactSchema = z
     "One subnet's alpha-price OHLC candles (#6979). Mirrors GET /api/v1/subnets/{netuid}/ohlc' data envelope.",
   );
 export type SubnetOhlcArtifact = z.infer<typeof SubnetOhlcArtifactSchema>;
-export const SubnetOhlcResponseSchema = successEnvelopeSchema(
-  SubnetOhlcArtifactSchema,
-);

--- a/schemas-src/routes/subnet-overview.ts
+++ b/schemas-src/routes/subnet-overview.ts
@@ -15,7 +15,7 @@
 // real always-present behavior -- additionalProperties stays permissive
 // (.passthrough()) so this is a pure completeness gain, not a tightening.
 import { z } from "zod";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import { CurationMetadataSchema, GapsSchema } from "./subnet-detail.ts";
 import { SubnetProfileSchema } from "./subnet-profile.ts";
 
@@ -58,6 +58,3 @@ export const SubnetOverviewArtifactSchema = ArtifactBaseSchema.extend({
 export type SubnetOverviewArtifact = z.infer<
   typeof SubnetOverviewArtifactSchema
 >;
-export const SubnetOverviewResponseSchema = successEnvelopeSchema(
-  SubnetOverviewArtifactSchema,
-);

--- a/schemas-src/routes/subnet-ownership-history.ts
+++ b/schemas-src/routes/subnet-ownership-history.ts
@@ -5,7 +5,6 @@
 // SubnetOwnershipChange components it replaces. No query params (verified:
 // the DATA_API route reads only the netuid path segment).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 // objectItems-equivalent looseness: no field required at the item level,
 // matching the hand-written original exactly.
@@ -72,6 +71,3 @@ export const SubnetOwnershipHistoryArtifactSchema = z
 export type SubnetOwnershipHistoryArtifact = z.infer<
   typeof SubnetOwnershipHistoryArtifactSchema
 >;
-export const SubnetOwnershipHistoryResponseSchema = successEnvelopeSchema(
-  SubnetOwnershipHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-performance.ts
+++ b/schemas-src/routes/subnet-performance.ts
@@ -8,7 +8,6 @@
 // SubnetPerformanceHistoryArtifact components they replace, and against a live
 // get_subnet_performance/get_subnet_performance_history response for subnet 1.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import {
   ConcentrationMetricsSchema,
   ScoreDistributionSchema,
@@ -48,9 +47,6 @@ export const SubnetPerformanceArtifactSchema = z
 export type SubnetPerformanceArtifact = z.infer<
   typeof SubnetPerformanceArtifactSchema
 >;
-export const SubnetPerformanceResponseSchema = successEnvelopeSchema(
-  SubnetPerformanceArtifactSchema,
-);
 
 const SubnetPerformanceHistoryPointSchema = z
   .object({
@@ -95,6 +91,3 @@ export const SubnetPerformanceHistoryArtifactSchema = z
 export type SubnetPerformanceHistoryArtifact = z.infer<
   typeof SubnetPerformanceHistoryArtifactSchema
 >;
-export const SubnetPerformanceHistoryResponseSchema = successEnvelopeSchema(
-  SubnetPerformanceHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-prometheus.ts
+++ b/schemas-src/routes/subnet-prometheus.ts
@@ -6,7 +6,6 @@
 // window/observed_at null, every count 0, when the subnet has no
 // PrometheusServed events in the window).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
 export const SubnetPrometheusArtifactSchema = z
@@ -29,6 +28,3 @@ export const SubnetPrometheusArtifactSchema = z
 export type SubnetPrometheusArtifact = z.infer<
   typeof SubnetPrometheusArtifactSchema
 >;
-export const SubnetPrometheusResponseSchema = successEnvelopeSchema(
-  SubnetPrometheusArtifactSchema,
-);

--- a/schemas-src/routes/subnet-registration-cost.ts
+++ b/schemas-src/routes/subnet-registration-cost.ts
@@ -6,7 +6,6 @@
 // different chain storage item each), cross-checked against the
 // SubnetBurnArtifact/SubnetRecycledArtifact components they replace.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 export const SubnetBurnArtifactSchema = z
@@ -24,9 +23,6 @@ export const SubnetBurnArtifactSchema = z
     "Live current registration/burn cost for one subnet, read directly from chain via RPC. burn_tao is null on RPC failure (schema-stable, never a GraphQL error). Mirrors GET /api/v1/subnets/{netuid}/burn.",
   );
 export type SubnetBurnArtifact = z.infer<typeof SubnetBurnArtifactSchema>;
-export const SubnetBurnResponseSchema = successEnvelopeSchema(
-  SubnetBurnArtifactSchema,
-);
 
 export const SubnetRecycledArtifactSchema = z
   .object({
@@ -45,9 +41,6 @@ export const SubnetRecycledArtifactSchema = z
 export type SubnetRecycledArtifact = z.infer<
   typeof SubnetRecycledArtifactSchema
 >;
-export const SubnetRecycledResponseSchema = successEnvelopeSchema(
-  SubnetRecycledArtifactSchema,
-);
 
 // GET /api/v1/chain/burn (#9399): every subnet's live registration cost in one
 // response, ranked cheapest-first. Modeled from src/chain-burn.ts's loadChainBurn().
@@ -78,9 +71,6 @@ export const ChainBurnArtifactSchema = z
   })
   .passthrough();
 export type ChainBurnArtifact = z.infer<typeof ChainBurnArtifactSchema>;
-export const ChainBurnResponseSchema = successEnvelopeSchema(
-  ChainBurnArtifactSchema,
-);
 
 // GET /api/v1/subnets/{netuid}/burn/history (#9402). Modeled from
 // src/subnet-burn-history.ts's buildSubnetBurnHistory().
@@ -112,6 +102,3 @@ export const SubnetBurnHistoryArtifactSchema = z
 export type SubnetBurnHistoryArtifact = z.infer<
   typeof SubnetBurnHistoryArtifactSchema
 >;
-export const SubnetBurnHistoryResponseSchema = successEnvelopeSchema(
-  SubnetBurnHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-stake-flow.ts
+++ b/schemas-src/routes/subnet-stake-flow.ts
@@ -3,7 +3,6 @@
 // src/stake-flow.ts's buildStakeFlow(), cross-checked against the
 // hand-edited SubnetStakeFlowArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES = [
@@ -33,6 +32,3 @@ export const SubnetStakeFlowArtifactSchema = z
 export type SubnetStakeFlowArtifact = z.infer<
   typeof SubnetStakeFlowArtifactSchema
 >;
-export const SubnetStakeFlowResponseSchema = successEnvelopeSchema(
-  SubnetStakeFlowArtifactSchema,
-);

--- a/schemas-src/routes/subnet-stake-moves.ts
+++ b/schemas-src/routes/subnet-stake-moves.ts
@@ -3,7 +3,6 @@
 // src/subnet-stake-moves.ts's buildSubnetStakeMoves(), cross-checked
 // against the hand-edited SubnetStakeMovesArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetStakeMovesArtifactSchema = z
   .object({
@@ -19,6 +18,3 @@ export const SubnetStakeMovesArtifactSchema = z
 export type SubnetStakeMovesArtifact = z.infer<
   typeof SubnetStakeMovesArtifactSchema
 >;
-export const SubnetStakeMovesResponseSchema = successEnvelopeSchema(
-  SubnetStakeMovesArtifactSchema,
-);

--- a/schemas-src/routes/subnet-stake-transfers.ts
+++ b/schemas-src/routes/subnet-stake-transfers.ts
@@ -4,7 +4,6 @@
 // cross-checked against the hand-edited SubnetStakeTransfersArtifact
 // component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetStakeTransfersArtifactSchema = z
   .object({
@@ -23,6 +22,3 @@ export const SubnetStakeTransfersArtifactSchema = z
 export type SubnetStakeTransfersArtifact = z.infer<
   typeof SubnetStakeTransfersArtifactSchema
 >;
-export const SubnetStakeTransfersResponseSchema = successEnvelopeSchema(
-  SubnetStakeTransfersArtifactSchema,
-);

--- a/schemas-src/routes/subnet-surface-history.ts
+++ b/schemas-src/routes/subnet-surface-history.ts
@@ -1,7 +1,6 @@
 // GET /api/v1/subnets/{netuid}/surface-history (#9612): one subnet's surface
 // audit trail. Modeled from src/surface-history.ts's buildSurfaceHistory().
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SurfaceHistoryChangeSchema = z
   .object({
@@ -54,6 +53,3 @@ export const SubnetSurfaceHistoryArtifactSchema = z
 export type SubnetSurfaceHistoryArtifact = z.infer<
   typeof SubnetSurfaceHistoryArtifactSchema
 >;
-export const SubnetSurfaceHistoryResponseSchema = successEnvelopeSchema(
-  SubnetSurfaceHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-trajectory.ts
+++ b/schemas-src/routes/subnet-trajectory.ts
@@ -6,7 +6,6 @@
 // the sibling history routes, trajectory takes no ?window (the full points
 // series plus precomputed 7d/30d deltas cover that).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** One window's change, endpoint to endpoint. Every field is a DIFFERENCE
  * (`to` minus `from`), not a level -- a negative `tao_in_pool_tao` means the
@@ -79,6 +78,3 @@ export const SubnetTrajectoryArtifactSchema = z
 export type SubnetTrajectoryArtifact = z.infer<
   typeof SubnetTrajectoryArtifactSchema
 >;
-export const SubnetTrajectoryResponseSchema = successEnvelopeSchema(
-  SubnetTrajectoryArtifactSchema,
-);

--- a/schemas-src/routes/subnet-turnover.ts
+++ b/schemas-src/routes/subnet-turnover.ts
@@ -3,7 +3,6 @@
 // src/turnover.ts's buildTurnover()/buildTurnoverChanges(), cross-checked
 // against the hand-edited SubnetTurnoverArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_TURNOVER_WINDOW_VALUES = [
@@ -85,6 +84,3 @@ export const SubnetTurnoverArtifactSchema = z
 export type SubnetTurnoverArtifact = z.infer<
   typeof SubnetTurnoverArtifactSchema
 >;
-export const SubnetTurnoverResponseSchema = successEnvelopeSchema(
-  SubnetTurnoverArtifactSchema,
-);

--- a/schemas-src/routes/subnet-weights.ts
+++ b/schemas-src/routes/subnet-weights.ts
@@ -7,7 +7,6 @@
 // (confirmed every setter row's `hotkey` reads back null in practice --
 // matches the hand-edited component's declared nullability).
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const SubnetWeightsArtifactSchema = z
   .object({
@@ -21,9 +20,6 @@ export const SubnetWeightsArtifactSchema = z
   })
   .strict();
 export type SubnetWeightsArtifact = z.infer<typeof SubnetWeightsArtifactSchema>;
-export const SubnetWeightsResponseSchema = successEnvelopeSchema(
-  SubnetWeightsArtifactSchema,
-);
 
 const SubnetWeightSetterSchema = z
   .object({
@@ -87,6 +83,3 @@ export const SubnetWeightSettersArtifactSchema = z
 export type SubnetWeightSettersArtifact = z.infer<
   typeof SubnetWeightSettersArtifactSchema
 >;
-export const SubnetWeightSettersResponseSchema = successEnvelopeSchema(
-  SubnetWeightSettersArtifactSchema,
-);

--- a/schemas-src/routes/subnet-yield.ts
+++ b/schemas-src/routes/subnet-yield.ts
@@ -4,7 +4,6 @@
 // buildSubnetYieldHistory(), cross-checked against the hand-edited
 // SubnetYieldArtifact/SubnetYieldHistoryArtifact components they replace.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_YIELD_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
@@ -54,9 +53,6 @@ export const SubnetYieldArtifactSchema = z
   })
   .strict();
 export type SubnetYieldArtifact = z.infer<typeof SubnetYieldArtifactSchema>;
-export const SubnetYieldResponseSchema = successEnvelopeSchema(
-  SubnetYieldArtifactSchema,
-);
 
 const SubnetYieldHistoryPointSchema = z
   .object({
@@ -92,6 +88,3 @@ export const SubnetYieldHistoryArtifactSchema = z
 export type SubnetYieldHistoryArtifact = z.infer<
   typeof SubnetYieldHistoryArtifactSchema
 >;
-export const SubnetYieldHistoryResponseSchema = successEnvelopeSchema(
-  SubnetYieldHistoryArtifactSchema,
-);

--- a/schemas-src/routes/subnets.ts
+++ b/schemas-src/routes/subnets.ts
@@ -10,7 +10,7 @@
 // route() call in src/contracts.ts for "subnets").
 import { z } from "zod";
 import { SocialLinksSchema } from "../shared.ts";
-import { ArtifactBaseSchema, successEnvelopeSchema } from "../envelope.ts";
+import { ArtifactBaseSchema } from "../envelope.ts";
 import {
   BittensorNetworkSchema,
   CoverageLevelSchema,
@@ -123,7 +123,3 @@ export const SubnetsArtifactSchema = ArtifactBaseSchema.extend({
   subnets: z.array(SubnetIndexEntrySchema),
 });
 export type SubnetsArtifact = z.infer<typeof SubnetsArtifactSchema>;
-
-export const SubnetsResponseSchema = successEnvelopeSchema(
-  SubnetsArtifactSchema,
-);

--- a/schemas-src/routes/tao-usd.ts
+++ b/schemas-src/routes/tao-usd.ts
@@ -7,7 +7,6 @@
 // the pairing as a CHECK. Null means "not priceable at that block"; a zero
 // would mean TAO is worthless.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const TaoUsdPointSchema = z
   .object({
@@ -100,4 +99,3 @@ export const TaoUsdArtifactSchema = z
   })
   .passthrough();
 export type TaoUsdArtifact = z.infer<typeof TaoUsdArtifactSchema>;
-export const TaoUsdResponseSchema = successEnvelopeSchema(TaoUsdArtifactSchema);

--- a/schemas-src/routes/top-holders.ts
+++ b/schemas-src/routes/top-holders.ts
@@ -24,7 +24,6 @@
 // *.schema.json (verified via repo-wide $ref grep), so the hand-edited
 // component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 export const TOP_HOLDERS_SORT_VALUES = [
   "total_tao",
@@ -88,6 +87,3 @@ export const TopHoldersArtifactSchema = z
   })
   .passthrough();
 export type TopHoldersArtifact = z.infer<typeof TopHoldersArtifactSchema>;
-export const TopHoldersResponseSchema = successEnvelopeSchema(
-  TopHoldersArtifactSchema,
-);

--- a/schemas-src/routes/validator-detail.ts
+++ b/schemas-src/routes/validator-detail.ts
@@ -13,7 +13,6 @@
 // this same batch (verified via repo-wide $ref grep), so the hand-edited
 // component key becomes fully orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { ColdkeyIdentitySchema } from "./global-validators.ts";
 
 export const ValidatorDetailSubnetSchema = z
@@ -126,6 +125,3 @@ export const ValidatorDetailArtifactSchema = z
 export type ValidatorDetailArtifact = z.infer<
   typeof ValidatorDetailArtifactSchema
 >;
-export const ValidatorDetailResponseSchema = successEnvelopeSchema(
-  ValidatorDetailArtifactSchema,
-);

--- a/schemas-src/routes/validator-economics.ts
+++ b/schemas-src/routes/validator-economics.ts
@@ -8,7 +8,6 @@
 // #9285/#9114/#9121 for the same class. `degraded_reason` names the missing input
 // whenever a field was withheld, so a caller can tell "unknown" from "zero".
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { FieldSourcesSchema } from "../shared.ts";
 
 // Permitted / active / earning are three DIFFERENT sets and are published separately
@@ -163,10 +162,6 @@ export type SubnetValidatorEconomicsArtifact = z.infer<
   typeof SubnetValidatorEconomicsArtifactSchema
 >;
 
-export const SubnetValidatorEconomicsResponseSchema = successEnvelopeSchema(
-  SubnetValidatorEconomicsArtifactSchema,
-);
-
 // GET /api/v1/validators/economics (#9324) — the cross-subnet ranking.
 //
 // One row per subnet, reusing the per-subnet artifact shape so a caller reading
@@ -215,10 +210,6 @@ export const ValidatorEconomicsRankingArtifactSchema = z
 export type ValidatorEconomicsRankingArtifact = z.infer<
   typeof ValidatorEconomicsRankingArtifactSchema
 >;
-
-export const ValidatorEconomicsRankingResponseSchema = successEnvelopeSchema(
-  ValidatorEconomicsRankingArtifactSchema,
-);
 
 // GET /api/v1/subnets/{netuid}/validator-economics/history (#9326).
 //
@@ -294,6 +285,3 @@ export const SubnetValidatorEconomicsHistoryArtifactSchema = z
 export type SubnetValidatorEconomicsHistoryArtifact = z.infer<
   typeof SubnetValidatorEconomicsHistoryArtifactSchema
 >;
-
-export const SubnetValidatorEconomicsHistoryResponseSchema =
-  successEnvelopeSchema(SubnetValidatorEconomicsHistoryArtifactSchema);

--- a/schemas-src/routes/validator-history.ts
+++ b/schemas-src/routes/validator-history.ts
@@ -3,7 +3,6 @@
 // src/validator-history.ts's buildValidatorHistory(), cross-checked against
 // the hand-edited ValidatorHistoryArtifact component it replaces.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 const ValidatorHistoryPointSchema = z
   .object({
@@ -104,6 +103,3 @@ export const ValidatorHistoryArtifactSchema = z
 export type ValidatorHistoryArtifact = z.infer<
   typeof ValidatorHistoryArtifactSchema
 >;
-export const ValidatorHistoryResponseSchema = successEnvelopeSchema(
-  ValidatorHistoryArtifactSchema,
-);

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -9,7 +9,6 @@
 // via repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES = [
@@ -85,6 +84,3 @@ export const ValidatorNominatorsArtifactSchema = z
 export type ValidatorNominatorsArtifact = z.infer<
   typeof ValidatorNominatorsArtifactSchema
 >;
-export const ValidatorNominatorsResponseSchema = successEnvelopeSchema(
-  ValidatorNominatorsArtifactSchema,
-);

--- a/schemas-src/routes/webhooks.ts
+++ b/schemas-src/routes/webhooks.ts
@@ -11,7 +11,6 @@
 // modelled, but on the MCP side; this makes the ROUTE the owner and the tool
 // the importer, which is the direction #9796 settled on.
 import { z } from "zod";
-import { successEnvelopeSchema } from "../envelope.ts";
 import { OpenObjectSchema } from "../mcp-tools/shared.ts";
 
 /**
@@ -63,6 +62,3 @@ export const WebhookSubscriptionArtifactSchema = z
 export type WebhookSubscriptionArtifact = z.infer<
   typeof WebhookSubscriptionArtifactSchema
 >;
-export const WebhookSubscriptionResponseSchema = successEnvelopeSchema(
-  WebhookSubscriptionArtifactSchema,
-);

--- a/scripts/validate-unreferenced-exports.ts
+++ b/scripts/validate-unreferenced-exports.ts
@@ -9,14 +9,14 @@
 // conclusion, because the alternative to 1,135 decisions is not "no gate" --
 // it is a RATCHET. The count goes in one place, it fails when it grows, and it
 // fails when it falls without being lowered. Nobody has to adjudicate 880
-// symbols today, and nobody can add the 881st without saying so.
+// symbols today, and nobody can add the 753rd without saying so.
 //
 // ## What the number is made of, measured 2026-08-10
 //
-// 880 after the deletions in this branch (1,135 at filing). Where they live is
-// the whole story:
+// 752 after #10582 (1,135 at filing, 880 when this gate landed). Where they
+// live is the whole story:
 //
-//   874  schemas-src/**   the contract's type vocabulary
+//   746  schemas-src/**   the contract's type vocabulary
 //     6  src/**           the actual residue, in four files
 //
 // The schema layer's exports are not orphans in the ordinary sense. 250 of them
@@ -25,15 +25,10 @@
 // `src/contracts.ts` AS A STRING. knip cannot see a linkage made by name
 // through a registry, and no static tool can.
 //
-// The other ~624 are mostly `export const XResponseSchema =
-// successEnvelopeSchema(XArtifactSchema)`: 164 of them, of which 128 are
-// referenced nowhere at all and 36 only by one spot-check test. Nothing in the
-// serving path reads any of them, because
-// `src/response-validation-tripwire.ts` COMPOSES the envelope itself from the
-// registry (`successEnvelopeSchema(component)`) rather than importing the
-// precomputed alias. They are a second declaration of the same fact, which is
-// the exact shape this epic exists to remove -- and deleting them is a change
-// of its own, not something to bundle behind a gate.
+// The 164 precomputed `XResponseSchema` envelopes that made up most of the
+// rest are GONE (#10582): nothing in the serving path read them, because
+// `src/response-validation-tripwire.ts` composes the envelope itself from the
+// registry. That is where 880 -> 752 came from.
 //
 // ## Why the count is not zero, and why that is not a failure
 //
@@ -59,9 +54,10 @@ import { repoRoot } from "./lib.ts";
 /**
  * The most unreferenced exports allowed. THE CEILING ONLY FALLS.
  *
- * 880 after this branch's deletions. Lower it whenever exports are removed.
+ * 752 after #10582 deleted the 164 precomputed response envelopes. Lower it
+ * whenever exports are removed.
  */
-export const MAX_UNREFERENCED_EXPORTS: number = 880;
+export const MAX_UNREFERENCED_EXPORTS: number = 752;
 
 /** knip's JSON shape, as much of it as this gate reads. */
 interface KnipIssue {

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -8,59 +8,60 @@
 // issue's non-vacuous requirement: an empty object must fail every schema.
 import assert from "node:assert/strict";
 import { describe, test, vi, afterEach } from "vitest";
+import { successEnvelopeSchema } from "../schemas-src/envelope.ts";
 import { summarizeEvent } from "@jsonbored/chain-summaries";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
-import { SubnetsResponseSchema } from "../schemas-src/routes/subnets.ts";
-import { SubnetDetailResponseSchema } from "../schemas-src/routes/subnet-detail.ts";
-import { HealthResponseSchema } from "../schemas-src/routes/health.ts";
-import { SelfHealthResponseSchema } from "../schemas-src/routes/self-health.ts";
-import { EconomicsResponseSchema } from "../schemas-src/routes/economics.ts";
-import { StakeQuoteResponseSchema } from "../schemas-src/routes/stake-quote.ts";
-import { SubnetAlphaVolumeResponseSchema } from "../schemas-src/routes/subnet-alpha-volume.ts";
+import { SubnetsArtifactSchema } from "../schemas-src/routes/subnets.ts";
+import { SubnetDetailArtifactSchema } from "../schemas-src/routes/subnet-detail.ts";
+import { HealthSummaryArtifactSchema } from "../schemas-src/routes/health.ts";
+import { SelfHealthArtifactSchema } from "../schemas-src/routes/self-health.ts";
+import { EconomicsArtifactSchema } from "../schemas-src/routes/economics.ts";
+import { SubnetStakeQuoteArtifactSchema } from "../schemas-src/routes/stake-quote.ts";
+import { SubnetAlphaVolumeArtifactSchema } from "../schemas-src/routes/subnet-alpha-volume.ts";
 import {
-  SubnetAxonRemovalsResponseSchema,
-  SubnetDeregistrationsResponseSchema,
-  SubnetRegistrationsResponseSchema,
-  SubnetServingResponseSchema,
+  SubnetAxonRemovalsArtifactSchema,
+  SubnetDeregistrationsArtifactSchema,
+  SubnetRegistrationsArtifactSchema,
+  SubnetServingArtifactSchema,
 } from "../schemas-src/routes/subnet-activity.ts";
 import {
-  SubnetBurnResponseSchema,
-  SubnetRecycledResponseSchema,
+  SubnetBurnArtifactSchema,
+  SubnetRecycledArtifactSchema,
 } from "../schemas-src/routes/subnet-registration-cost.ts";
-import { SubnetEventsResponseSchema } from "../schemas-src/routes/subnet-events.ts";
-import { SubnetEventSummaryResponseSchema } from "../schemas-src/routes/subnet-event-summary.ts";
-import { SubnetHistoryResponseSchema } from "../schemas-src/routes/subnet-history.ts";
-import { SubnetIdentityHistoryResponseSchema } from "../schemas-src/routes/subnet-identity-history.ts";
-import { SubnetIdleStakeResponseSchema } from "../schemas-src/routes/subnet-idle-stake.ts";
-import { SubnetOverviewResponseSchema } from "../schemas-src/routes/subnet-overview.ts";
+import { SubnetEventsArtifactSchema } from "../schemas-src/routes/subnet-events.ts";
+import { SubnetEventSummaryArtifactSchema } from "../schemas-src/routes/subnet-event-summary.ts";
+import { SubnetHistoryArtifactSchema } from "../schemas-src/routes/subnet-history.ts";
+import { SubnetIdentityHistoryArtifactSchema } from "../schemas-src/routes/subnet-identity-history.ts";
+import { SubnetIdleStakeArtifactSchema } from "../schemas-src/routes/subnet-idle-stake.ts";
+import { SubnetOverviewArtifactSchema } from "../schemas-src/routes/subnet-overview.ts";
 import {
-  DomainSummaryResponseSchema,
-  DomainsResponseSchema,
+  DomainSummaryArtifactSchema,
+  DomainsArtifactSchema,
 } from "../schemas-src/routes/domains.ts";
-import { EconomicsTrendsResponseSchema } from "../schemas-src/routes/economics-trends.ts";
+import { EconomicsTrendsArtifactSchema } from "../schemas-src/routes/economics-trends.ts";
 import {
-  SubnetConcentrationResponseSchema,
-  SubnetConcentrationHistoryResponseSchema,
+  SubnetConcentrationArtifactSchema,
+  SubnetConcentrationHistoryArtifactSchema,
 } from "../schemas-src/routes/subnet-concentration.ts";
-import { SubnetTurnoverResponseSchema } from "../schemas-src/routes/subnet-turnover.ts";
-import { SubnetStakeFlowResponseSchema } from "../schemas-src/routes/subnet-stake-flow.ts";
-import { SubnetStakeMovesResponseSchema } from "../schemas-src/routes/subnet-stake-moves.ts";
-import { SubnetStakeTransfersResponseSchema } from "../schemas-src/routes/subnet-stake-transfers.ts";
-import { SubnetOhlcResponseSchema } from "../schemas-src/routes/subnet-ohlc.ts";
+import { SubnetTurnoverArtifactSchema } from "../schemas-src/routes/subnet-turnover.ts";
+import { SubnetStakeFlowArtifactSchema } from "../schemas-src/routes/subnet-stake-flow.ts";
+import { SubnetStakeMovesArtifactSchema } from "../schemas-src/routes/subnet-stake-moves.ts";
+import { SubnetStakeTransfersArtifactSchema } from "../schemas-src/routes/subnet-stake-transfers.ts";
+import { SubnetOhlcArtifactSchema } from "../schemas-src/routes/subnet-ohlc.ts";
 import {
-  SubnetYieldResponseSchema,
-  SubnetYieldHistoryResponseSchema,
+  SubnetYieldArtifactSchema,
+  SubnetYieldHistoryArtifactSchema,
 } from "../schemas-src/routes/subnet-yield.ts";
-import { SubnetMoversResponseSchema } from "../schemas-src/routes/subnet-movers.ts";
-import { SubnetTrajectoryResponseSchema } from "../schemas-src/routes/subnet-trajectory.ts";
+import { SubnetMoversArtifactSchema } from "../schemas-src/routes/subnet-movers.ts";
+import { SubnetTrajectoryArtifactSchema } from "../schemas-src/routes/subnet-trajectory.ts";
 import {
-  SubnetLeaseResponseSchema,
+  SubnetLeaseArtifactSchema,
   SubnetLeaseHistoryArtifactSchema,
 } from "../schemas-src/routes/subnet-lease.ts";
 import {
-  CrowdloansResponseSchema,
-  CrowdloanDetailResponseSchema,
+  CrowdloansArtifactSchema,
+  CrowdloanDetailArtifactSchema,
 } from "../schemas-src/routes/crowdloans.ts";
 import { SubnetOwnershipHistoryArtifactSchema } from "../schemas-src/routes/subnet-ownership-history.ts";
 import { SubnetConvictionArtifactSchema } from "../schemas-src/routes/subnet-conviction.ts";
@@ -396,18 +397,34 @@ async function realBody(path: string) {
 }
 
 const cases: [string, string, z.ZodType][] = [
-  ["subnets", "/api/v1/subnets", SubnetsResponseSchema],
-  ["subnet-detail", "/api/v1/subnets/64", SubnetDetailResponseSchema],
-  ["health", "/api/v1/health", HealthResponseSchema],
+  ["subnets", "/api/v1/subnets", successEnvelopeSchema(SubnetsArtifactSchema)],
+  [
+    "subnet-detail",
+    "/api/v1/subnets/64",
+    successEnvelopeSchema(SubnetDetailArtifactSchema),
+  ],
+  [
+    "health",
+    "/api/v1/health",
+    successEnvelopeSchema(HealthSummaryArtifactSchema),
+  ],
   // #8318: our OWN uptime, distinct from the third-party rollup above. Parses
   // the cold-store shape here (three components, verdict "degraded"), which is
   // exactly what the route serves before the poller has written anything.
-  ["self-health", "/api/v1/self-health", SelfHealthResponseSchema],
-  ["economics", "/api/v1/economics", EconomicsResponseSchema],
+  [
+    "self-health",
+    "/api/v1/self-health",
+    successEnvelopeSchema(SelfHealthArtifactSchema),
+  ],
+  [
+    "economics",
+    "/api/v1/economics",
+    successEnvelopeSchema(EconomicsArtifactSchema),
+  ],
   [
     "stake-quote",
     "/api/v1/subnets/64/stake-quote?amount=1000&direction=stake",
-    StakeQuoteResponseSchema,
+    successEnvelopeSchema(SubnetStakeQuoteArtifactSchema),
   ],
 ];
 
@@ -416,58 +433,74 @@ const batch1Cases: [string, string, z.ZodType][] = [
   [
     "subnet-volume",
     "/api/v1/subnets/64/volume",
-    SubnetAlphaVolumeResponseSchema,
+    successEnvelopeSchema(SubnetAlphaVolumeArtifactSchema),
   ],
   [
     "subnet-axon-removals",
     "/api/v1/subnets/64/axon-removals",
-    SubnetAxonRemovalsResponseSchema,
+    successEnvelopeSchema(SubnetAxonRemovalsArtifactSchema),
   ],
-  ["subnet-burn", "/api/v1/subnets/64/burn", SubnetBurnResponseSchema],
+  [
+    "subnet-burn",
+    "/api/v1/subnets/64/burn",
+    successEnvelopeSchema(SubnetBurnArtifactSchema),
+  ],
   [
     "subnet-deregistrations",
     "/api/v1/subnets/64/deregistrations",
-    SubnetDeregistrationsResponseSchema,
+    successEnvelopeSchema(SubnetDeregistrationsArtifactSchema),
   ],
   [
     "subnet-event-summary",
     "/api/v1/subnets/64/event-summary",
-    SubnetEventSummaryResponseSchema,
+    successEnvelopeSchema(SubnetEventSummaryArtifactSchema),
   ],
-  ["subnet-events", "/api/v1/subnets/64/events", SubnetEventsResponseSchema],
-  ["subnet-history", "/api/v1/subnets/64/history", SubnetHistoryResponseSchema],
+  [
+    "subnet-events",
+    "/api/v1/subnets/64/events",
+    successEnvelopeSchema(SubnetEventsArtifactSchema),
+  ],
+  [
+    "subnet-history",
+    "/api/v1/subnets/64/history",
+    successEnvelopeSchema(SubnetHistoryArtifactSchema),
+  ],
   [
     "subnet-identity-history",
     "/api/v1/subnets/64/identity-history",
-    SubnetIdentityHistoryResponseSchema,
+    successEnvelopeSchema(SubnetIdentityHistoryArtifactSchema),
   ],
   [
     "subnet-recycled",
     "/api/v1/subnets/64/recycled",
-    SubnetRecycledResponseSchema,
+    successEnvelopeSchema(SubnetRecycledArtifactSchema),
   ],
   [
     "subnet-registrations",
     "/api/v1/subnets/64/registrations",
-    SubnetRegistrationsResponseSchema,
+    successEnvelopeSchema(SubnetRegistrationsArtifactSchema),
   ],
-  ["subnet-serving", "/api/v1/subnets/64/serving", SubnetServingResponseSchema],
+  [
+    "subnet-serving",
+    "/api/v1/subnets/64/serving",
+    successEnvelopeSchema(SubnetServingArtifactSchema),
+  ],
   [
     "subnet-idle-stake",
     "/api/v1/subnets/64/idle-stake",
-    SubnetIdleStakeResponseSchema,
+    successEnvelopeSchema(SubnetIdleStakeArtifactSchema),
   ],
   [
     "subnet-overview",
     "/api/v1/subnets/64/overview",
-    SubnetOverviewResponseSchema,
+    successEnvelopeSchema(SubnetOverviewArtifactSchema),
   ],
   [
     "domain-summary",
     "/api/v1/domains/agents/summary",
-    DomainSummaryResponseSchema,
+    successEnvelopeSchema(DomainSummaryArtifactSchema),
   ],
-  ["domains", "/api/v1/domains", DomainsResponseSchema],
+  ["domains", "/api/v1/domains", successEnvelopeSchema(DomainsArtifactSchema)],
 ];
 
 // Batch 2 (#8056) -- same ground-truth pattern, 16 more routes.
@@ -475,54 +508,78 @@ const batch2Cases: [string, string, z.ZodType][] = [
   [
     "economics-trends",
     "/api/v1/economics/trends",
-    EconomicsTrendsResponseSchema,
+    successEnvelopeSchema(EconomicsTrendsArtifactSchema),
   ],
   [
     "subnet-concentration",
     "/api/v1/subnets/64/concentration",
-    SubnetConcentrationResponseSchema,
+    successEnvelopeSchema(SubnetConcentrationArtifactSchema),
   ],
   [
     "subnet-concentration-history",
     "/api/v1/subnets/64/concentration/history",
-    SubnetConcentrationHistoryResponseSchema,
+    successEnvelopeSchema(SubnetConcentrationHistoryArtifactSchema),
   ],
   [
     "subnet-turnover",
     "/api/v1/subnets/64/turnover?changes=true",
-    SubnetTurnoverResponseSchema,
+    successEnvelopeSchema(SubnetTurnoverArtifactSchema),
   ],
   [
     "subnet-stake-flow",
     "/api/v1/subnets/64/stake-flow",
-    SubnetStakeFlowResponseSchema,
+    successEnvelopeSchema(SubnetStakeFlowArtifactSchema),
   ],
   [
     "subnet-stake-moves",
     "/api/v1/subnets/64/stake-moves",
-    SubnetStakeMovesResponseSchema,
+    successEnvelopeSchema(SubnetStakeMovesArtifactSchema),
   ],
   [
     "subnet-stake-transfers",
     "/api/v1/subnets/64/stake-transfers",
-    SubnetStakeTransfersResponseSchema,
+    successEnvelopeSchema(SubnetStakeTransfersArtifactSchema),
   ],
-  ["subnet-ohlc", "/api/v1/subnets/64/ohlc", SubnetOhlcResponseSchema],
-  ["subnet-yield", "/api/v1/subnets/64/yield", SubnetYieldResponseSchema],
+  [
+    "subnet-ohlc",
+    "/api/v1/subnets/64/ohlc",
+    successEnvelopeSchema(SubnetOhlcArtifactSchema),
+  ],
+  [
+    "subnet-yield",
+    "/api/v1/subnets/64/yield",
+    successEnvelopeSchema(SubnetYieldArtifactSchema),
+  ],
   [
     "subnet-yield-history",
     "/api/v1/subnets/64/yield/history",
-    SubnetYieldHistoryResponseSchema,
+    successEnvelopeSchema(SubnetYieldHistoryArtifactSchema),
   ],
-  ["subnet-movers", "/api/v1/subnets/movers", SubnetMoversResponseSchema],
+  [
+    "subnet-movers",
+    "/api/v1/subnets/movers",
+    successEnvelopeSchema(SubnetMoversArtifactSchema),
+  ],
   [
     "subnet-trajectory",
     "/api/v1/subnets/64/trajectory",
-    SubnetTrajectoryResponseSchema,
+    successEnvelopeSchema(SubnetTrajectoryArtifactSchema),
   ],
-  ["subnet-lease", "/api/v1/subnets/64/lease", SubnetLeaseResponseSchema],
-  ["crowdloans", "/api/v1/crowdloans", CrowdloansResponseSchema],
-  ["crowdloan-detail", "/api/v1/crowdloans/0", CrowdloanDetailResponseSchema],
+  [
+    "subnet-lease",
+    "/api/v1/subnets/64/lease",
+    successEnvelopeSchema(SubnetLeaseArtifactSchema),
+  ],
+  [
+    "crowdloans",
+    "/api/v1/crowdloans",
+    successEnvelopeSchema(CrowdloansArtifactSchema),
+  ],
+  [
+    "crowdloan-detail",
+    "/api/v1/crowdloans/0",
+    successEnvelopeSchema(CrowdloanDetailArtifactSchema),
+  ],
 ];
 
 describe("pilot route response schemas parse real handler output", () => {


### PR DESCRIPTION
## Summary

- Every route module exported a precomputed 200 envelope. **164 of them; production referenced zero.**
- They are unused because `src/response-validation-tripwire.ts` **composes** the envelope from the
  registry at request time — deliberately, and by design.
- Deleted. The build emits byte-identical artifacts and `validate:contract-drift` passes.

## What Changed

```ts
export const SubnetMetagraphResponseSchema = successEnvelopeSchema(
  SubnetMetagraphArtifactSchema,
);
```

| | count |
|---|---:|
| `*ResponseSchema` exported from `schemas-src/routes/**` | **164** |
| referenced only at their own declaration | **128** |
| referenced anywhere else | 36 — all of them only by `tests/zod-schemas.test.ts` |

The tripwire resolves the component from the registry and wraps it itself, and its header says why:

> It is DERIVED now, and covers everything by construction. […] There is no list to fall behind: a
> route converted tomorrow is covered the moment its component is registered.

That is the right design — and it makes these 164 aliases **a second declaration of the same fact**:
`successEnvelopeSchema(XArtifactSchema)` written out at the module, and computed again from the
registry when it is actually needed. The duplication this epic exists to remove, in the one place the
epic had not looked.

The 36 test cases now compose the envelope the same way the tripwire does — strictly better than
before, since the test no longer depends on someone having remembered to export an alias for the route
they were adding.

## Verified it changes nothing

- `npm run build` — byte-identical artifacts; **nothing under `public/` moved**.
- `npm run validate:contract-drift` — passes. These aliases were never registered as components,
  which is precisely why nothing referenced them.
- 342 tests passing across `zod-schemas` + `response-validation-tripwire`, including all 36 cases
  parsing **real handler output** through the composed envelope.

The `successEnvelopeSchema` import went unused in 109 modules and was removed with it.

> Note: if #10292 (`validate:unreferenced-exports`) lands first, its ceiling needs lowering by this
> PRs deletion count. Happy to rebase and drop it in whichever order they merge.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none — verified by
      contract-drift and an unchanged build.)*

## Validation

- [x] `npm run lint` — exit 0
- [x] `npm run format:check` — exit 0
- [x] `npm run typecheck` — exit 0
- [x] `npm run build` — exit 0, no artifact changes
- [x] `npm run validate:contract-drift` — exit 0
- [x] `npx vitest run tests/zod-schemas.test.ts tests/response-validation-tripwire.test.ts` — **342 passed**
- [x] `git diff --check` — exit 0

## Template Used

- `backend-code.md`

Closes #10582