### PR TITLE
fix(accounts): retire the cap probe, which was the query that actually aborted

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -912,7 +912,12 @@ export async function loadAccountSummaryColdTier(
   const folded = foldSummaryGroups(groupRows);
 
   // The CTE read CAP + 1, so this is min(total, CAP + 1) -- the probe's number.
-  const scanned = Number(folded.agg.c ?? 0);
+  //
+  // No `?? 0`: foldSummaryGroups starts `count` at 0 and only ever adds a
+  // finite rowCount, so `agg.c` is always a number and the nullish half is a
+  // branch no test can reach. codecov/patch counts it as an uncovered branch,
+  // which is the correct reading -- an unreachable guard is not safety.
+  const scanned = Number(folded.agg.c);
 
   return {
     // Clamped back to the PUBLISHED window so the payload is unchanged: an

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -838,14 +838,19 @@ export async function loadAccountSummaryColdTier(
   }
 
   const where = `(hotkey = '${addr}' OR coldkey = '${addr}')`;
-  // The newest CAP events, named once so the three reads that share it cannot
+  // The newest CAP + 1 events, named once so the reads that share it cannot
   // drift onto different windows.
+  //
+  // CAP + 1, not CAP, and that one extra row is what retired the separate cap
+  // probe -- see the read block below. The PUBLISHED window is still the newest
+  // CAP events: `c` is clamped back to CAP before it leaves this function, so
+  // the payload is unchanged.
   const scan =
     `SELECT netuid, event_kind, block_number, observed_at ` +
     `FROM chain.account_events WHERE ${where} ` +
-    `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`;
+    `ORDER BY block_number DESC LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`;
 
-  // THREE READS, NOT FIVE (#9386).
+  // TWO READS, NOT THREE (was five before #9386).
   //
   // This route declined ~50% of requests for a high-activity coldkey, and its shape
   // was the reason: five concurrent broad scans of `chain.account_events`, with
@@ -855,18 +860,33 @@ export async function loadAccountSummaryColdTier(
   //
   // The first three all aggregated the SAME `scan` CTE at different groupings, so one
   // `GROUP BY event_kind, netuid` yields all of them exactly -- see foldSummaryGroups
-  // for the derivation and why each one is equivalent rather than approximate. The
-  // result is bounded by the CTE: at most ACCOUNT_EVENT_SUMMARY_SCAN_CAP groups.
+  // for the derivation and why each one is equivalent rather than approximate.
   //
-  // The remaining two cannot fold in. The cap probe deliberately scans CAP+1 rows
-  // WITHOUT the CTE (that is how "exactly CAP" is told from "more than CAP"), and the
-  // recent feed selects whole rows in a different order.
+  // #9386 kept a third read because the cap probe scanned CAP+1 rows WITHOUT the CTE,
+  // and that was how "exactly CAP" was told from "more than CAP". IT WAS THE QUERY
+  // THAT ABORTED. Measured 2026-08-10, once r2-sql failures finally carried
+  // `query_shape` (the attribution #9459 shipped for exactly this question): 32 of
+  // the 34 request-path r2-sql timeouts were that probe, and nothing else in this
+  // loader. It declined `account-summary` on 92% of calls -- 347 failures to 30
+  // successes -- against a 15s ceiling the other two legs clear.
+  //
+  // A bare `LIMIT` with no ORDER BY is why. The engine cannot stop early on a sorted
+  // prefix, so proving there is no CAP+1'th row means scanning the whole unpartitioned
+  // table -- and it is SLOWEST for the accounts with the fewest events, which is
+  // backwards from what the probe was protecting against.
+  //
+  // So the CTE reads CAP + 1 and the probe is gone. `sum(count)` over the groups is
+  // the rows in the CTE, which is min(total, CAP + 1) -- byte-for-byte the number the
+  // probe returned, from a query that was already being issued. `> CAP` still means
+  // "more than the published window", so buildAccountSummary's cap logic is untouched.
+  //
+  // The recent feed cannot fold in: it selects whole rows in a different order.
   const failures: string[] = [];
   const track = (leg: string) => (detail: string) => {
     failures.push(`${leg}: ${detail}`);
   };
 
-  const [groupRows, probeRows, recentRows] = await Promise.all([
+  const [groupRows, recentRows] = await Promise.all([
     query(
       env,
       `WITH scan AS (${scan}) SELECT event_kind AS kind, netuid AS netuid, ` +
@@ -874,13 +894,6 @@ export async function loadAccountSummaryColdTier(
         `min(observed_at) AS fo, max(observed_at) AS lo ` +
         `FROM scan GROUP BY event_kind, netuid`,
       { onError: track("summary-groups") },
-    ),
-    // CAP + 1 so "exactly CAP" is distinguishable from "more than CAP".
-    query(
-      env,
-      `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events ` +
-        `WHERE ${where} LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1})`,
-      { onError: track("scan-probe") },
     ),
     query(
       env,
@@ -890,22 +903,28 @@ export async function loadAccountSummaryColdTier(
     ),
   ]);
 
-  // Any half missing is a decline: a card mixing measured aggregates with a
-  // zeroed probe would silently flip event_scan_capped and publish a first_seen
+  // Either half missing is a decline: a card mixing measured aggregates with a
+  // zeroed count would silently flip event_scan_capped and publish a first_seen
   // that is really a window floor.
-  if (!groupRows || !probeRows || !recentRows) {
+  if (!groupRows || !recentRows) {
     return { declined: failures };
-  }
-  const scanned = probeRows[0]?.c;
-  if (scanned === undefined) {
-    return { declined: [...failures, "scan-probe: no count row"] };
   }
   const folded = foldSummaryGroups(groupRows);
 
+  // The CTE read CAP + 1, so this is min(total, CAP + 1) -- the probe's number.
+  const scanned = Number(folded.agg.c ?? 0);
+
   return {
-    agg: folded.agg,
+    // Clamped back to the PUBLISHED window so the payload is unchanged: an
+    // uncapped account (total <= CAP) is already below the clamp and untouched,
+    // and a capped one reported CAP before and still does. The extra row exists
+    // to answer the capped question, not to widen what is served.
+    agg: {
+      ...folded.agg,
+      c: Math.min(scanned, ACCOUNT_EVENT_SUMMARY_SCAN_CAP),
+    },
     kinds: folded.kinds,
-    scanned: Number(scanned),
+    scanned,
     recent: recentRows,
   };
 }

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -8,7 +8,8 @@
 //
 // The two properties worth pinning are the ones a plausible implementation gets
 // wrong: the card must attribute events the same way the feed does, and the
-// capped-scan probe must stay a separate read from the aggregate it qualifies.
+// capped-scan boundary must survive the probe that used to answer it being
+// folded into the aggregate (it was the query that aborted -- see "two reads").
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
@@ -64,17 +65,17 @@ const RECENT = [
 ];
 
 /**
- * Answers each of the THREE reads by the shape of its SQL.
+ * Answers each of the TWO reads by the shape of its SQL.
  *
- * Three, not five: the aggregate, the distinct-subnet count and the per-kind counts
- * all grouped the same CTE, so one `GROUP BY event_kind, netuid` yields all of them.
- * The other two cannot fold in -- the cap probe deliberately scans CAP+1 rows outside
- * the CTE, and the recent feed selects whole rows in a different order.
+ * Two, not five: the aggregate, the distinct-subnet count and the per-kind counts all
+ * grouped the same CTE, so one `GROUP BY event_kind, netuid` yields all of them
+ * (#9386) -- and the cap probe that stayed behind is gone too, because the CTE now
+ * reads CAP + 1 and its own row count IS the probe's number. Only the recent feed
+ * cannot fold in: it selects whole rows in a different order.
  */
 function fakeEngine(
   overrides: {
     groups?: Row[] | null;
-    probe?: Row[] | null;
     recent?: Row[] | null;
   } = {},
 ) {
@@ -90,9 +91,7 @@ function fakeEngine(
     seen.push(sql);
     const answer = sql.includes("GROUP BY event_kind, netuid")
       ? pick(overrides.groups, GROUPS)
-      : sql.includes("count(*) AS c FROM (")
-        ? pick(overrides.probe, [{ c: 6 }])
-        : pick(overrides.recent, RECENT);
+      : pick(overrides.recent, RECENT);
     if (answer === null) {
       // Mirrors r2SqlQuery: the engine's own explanation is reported, then null.
       deps?.onError?.("r2 sql: HTTP 500 (stubbed failure)");
@@ -104,9 +103,24 @@ function fakeEngine(
     query,
     seen,
     errors,
-    probe: () => seen.find((s) => s.includes("count(*) AS c FROM ("))!,
     groups: () => seen.find((s) => s.includes("GROUP BY event_kind, netuid"))!,
   };
+}
+
+/** Grouped rows whose counts sum to `total`, for driving the cap boundary
+ * through the aggregate now that no separate probe reports it. */
+function groupsSummingTo(total: number): Row[] {
+  return [
+    {
+      kind: "AxonServed",
+      netuid: 55,
+      count: total,
+      fb: AGG.fb,
+      lb: AGG.lb,
+      fo: AGG.fo,
+      lo: AGG.lo,
+    },
+  ];
 }
 
 describe("loadAccountSummaryColdTier", () => {
@@ -159,16 +173,37 @@ describe("loadAccountSummaryColdTier", () => {
     assert.equal(buildAccountSummary(SS58, cold as never).subnet_count, 2);
   });
 
-  test("three reads, not five", async () => {
+  test("two reads, not five", async () => {
     // The shape of the #9386 failure: five concurrent broad scans of an
     // unpartitioned table under Promise.all, so the success probability was the
     // PRODUCT of five. A single count(*) on account_events reports ~3,390 R2
     // requests, so each removed scan is real cost as well as real risk.
+    //
+    // The third read went the same way for a measured reason: 32 of the 34
+    // request-path r2-sql timeouts on 2026-08-10 were the cap probe, and it
+    // declined this route on 92% of calls.
     const engine = fakeEngine();
     await loadAccountSummaryColdTier({} as never, SS58, {
       query: engine.query as never,
     });
-    assert.equal(engine.seen.length, 3, engine.seen.join("\n").slice(0, 400));
+    assert.equal(engine.seen.length, 2, engine.seen.join("\n").slice(0, 400));
+  });
+
+  test("no read scans without an ORDER BY to stop early on", async () => {
+    // Why the probe was the leg that aborted: `LIMIT n` with no ORDER BY gives
+    // the engine no sorted prefix to stop on, so proving there is no n'th row
+    // means scanning the whole unpartitioned table -- slowest for the accounts
+    // with the FEWEST events, which is backwards from what it protected.
+    const engine = fakeEngine();
+    await loadAccountSummaryColdTier({} as never, SS58, {
+      query: engine.query as never,
+    });
+    for (const sql of engine.seen) {
+      assert.ok(
+        /ORDER BY/.test(sql),
+        `every read must give the engine a sorted prefix: ${sql.slice(0, 160)}`,
+      );
+    }
   });
 
   test("the fold reproduces the three reads it replaced, exactly", async () => {
@@ -221,7 +256,6 @@ describe("loadAccountSummaryColdTier", () => {
           lo: 9,
         },
       ],
-      probe: [{ c: 8 }],
     });
     const card = buildAccountSummary(
       SS58,
@@ -256,7 +290,6 @@ describe("loadAccountSummaryColdTier", () => {
         },
         { kind: "Transfer", netuid: 9, count: 1, fb: 3, lb: 4, fo: 3, lo: 4 },
       ],
-      probe: [{ c: 3 }],
     });
     const card = buildAccountSummary(
       SS58,
@@ -275,7 +308,6 @@ describe("loadAccountSummaryColdTier", () => {
         { kind: "A", netuid: 1, count: 1, fb: 50, lb: 900, fo: 50, lo: 900 },
         { kind: "B", netuid: 2, count: 1, fb: 10, lb: 100, fo: 10, lo: 100 },
       ],
-      probe: [{ c: 2 }],
     });
     const card = buildAccountSummary(
       SS58,
@@ -311,7 +343,6 @@ describe("loadAccountSummaryColdTier", () => {
         },
         { kind: "B", netuid: 2, count: 3, fb: 1, lb: 2, fo: 1, lo: 2 },
       ],
-      probe: [{ c: 3 }],
     });
     const card = buildAccountSummary(
       SS58,
@@ -361,7 +392,6 @@ describe("loadAccountSummaryColdTier", () => {
           lo: null,
         },
       ],
-      probe: [{ c: 2 }],
     });
     const card = buildAccountSummary(
       SS58,
@@ -391,54 +421,57 @@ describe("loadAccountSummaryColdTier", () => {
     }
   });
 
-  test("the cap probe is a separate read over CAP + 1", async () => {
-    // Reusing the aggregate's own count would make an account with EXACTLY CAP
-    // events look capped, which nulls first_block/first_seen_at on a card whose
-    // totals are in fact exact.
+  test("the CTE looks one row past the cap, and nothing else is read", async () => {
+    // The extra row is what retired the separate probe: the CTE's own row count
+    // is min(total, CAP + 1), which is byte-for-byte what the probe returned.
     const engine = fakeEngine();
     await loadAccountSummaryColdTier({} as never, SS58, {
       query: engine.query as never,
     });
     assert.match(
-      engine.probe(),
-      new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`),
-      "the probe must look one row past the cap",
-    );
-    assert.match(
       engine.groups(),
-      new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP}`),
-      "the aggregate window is the cap itself",
+      new RegExp(`LIMIT ${ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1}`),
+      "the aggregate must look one row past the cap",
+    );
+    assert.equal(
+      engine.seen.filter((s) => s.includes("count(*) AS c FROM (")).length,
+      0,
+      "the standalone cap probe must be gone",
     );
   });
 
+  // The property #9386 added the probe to protect, now carried by the aggregate.
+  // Reusing a CAP-wide count would make an account with EXACTLY CAP events look
+  // capped, nulling first_block/first_seen_at on a card whose totals are exact.
   test("exactly CAP events is complete; CAP + 1 is capped", async () => {
-    for (const [scanned, capped] of [
+    for (const [total, capped] of [
       [ACCOUNT_EVENT_SUMMARY_SCAN_CAP, false],
       [ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 1, true],
     ] as const) {
-      const engine = fakeEngine({ probe: [{ c: scanned }] });
+      const engine = fakeEngine({ groups: groupsSummingTo(total) });
       const cold = await loadAccountSummaryColdTier({} as never, SS58, {
         query: engine.query as never,
       });
       const card = buildAccountSummary(SS58, cold as never);
-      assert.equal(card.event_scan_capped, capped, `scanned=${scanned}`);
+      assert.equal(card.event_scan_capped, capped, `total=${total}`);
       // A capped window's minimum is a floor, not the account's first-ever.
       assert.equal(card.first_block === null, capped);
       assert.equal(card.first_seen_at === null, capped);
       // The newest end stays exact either way.
       assert.equal(card.last_block, AGG.lb);
+      // The PUBLISHED window is still the cap: reading CAP + 1 rows answers the
+      // capped question without widening what the card reports.
+      assert.equal(
+        card.event_count,
+        Math.min(total, ACCOUNT_EVENT_SUMMARY_SCAN_CAP),
+      );
     }
   });
 
   test("declines when any leg misses", async () => {
-    // A card mixing measured aggregates with a zeroed probe would silently flip
+    // A card mixing measured aggregates with a zeroed count would silently flip
     // event_scan_capped and publish a window floor as first_seen_at.
-    for (const miss of [
-      { groups: null },
-      { probe: null },
-      { recent: null },
-      { probe: [] },
-    ]) {
+    for (const miss of [{ groups: null }, { recent: null }]) {
       const engine = fakeEngine(miss);
       const cold = await loadAccountSummaryColdTier({} as never, SS58, {
         query: engine.query as never,
@@ -451,7 +484,7 @@ describe("loadAccountSummaryColdTier", () => {
     // An account with no events in the window genuinely has none. Declining here
     // would turn "nothing happened" into "we could not look", which is the opposite
     // of the confident-zero this route's decline exists to prevent.
-    const engine = fakeEngine({ groups: [], probe: [{ c: 0 }], recent: [] });
+    const engine = fakeEngine({ groups: [], recent: [] });
     const cold = await loadAccountSummaryColdTier({} as never, SS58, {
       query: engine.query as never,
     });


### PR DESCRIPTION
## Summary

`/api/v1/accounts/{ss58}` declines **92% of calls** — 347 failures to 30 successes, measured 2026-08-10 — on a hard **15,058 ms** r2-sql ceiling. Successes average 11,671 ms, just under it, so this is a coin flip rather than an outage: a hand probe returned a complete card in 12.87s.

Closes #10589

## Which query aborted was, until now, unanswerable

`src/r2-sql.ts`'s `QUERY_TIMEOUT_MS` comment says so outright:

> the number should be chosen against the query that actually aborts, not against the one route probed above. That query is unidentifiable today — every failure here captures under one flat `route: "r2-sql"` — which is why this change ships the attribution first.

That attribution (#9459) has since shipped as `query_kind` / `query_shape`, so the question #9494 has been carrying is now measurable. The answer is unambiguous:

| timeouts | query |
|---|---|
| **32 of 34** | `SELECT count(*) AS c FROM (SELECT block_number FROM chain.account_events WHERE (hotkey = ? OR coldkey = ?) LIMIT ?)` |
| 1 of 34 | an `account_events` feed read |
| 1 of 34 | an `extrinsics` read |

**94% of request-path r2-sql timeouts are one query** — the cap probe #9386 kept when it folded five reads into three. Neither of this loader's other two legs appears at all.

## Why that query and not the others

A bare `LIMIT` with no `ORDER BY` gives the engine no sorted prefix to stop on, so proving there is no CAP+1'th row means scanning the whole unpartitioned table. It is **slowest for the accounts with the fewest events** — backwards from what the probe was protecting against. The other two legs both carry an `ORDER BY` and both clear the ceiling.

## The fix

The CTE reads `CAP + 1` and the probe is gone. `sum(count)` over the groups is the number of rows in the CTE — `min(total, CAP + 1)`, **byte-for-byte what the probe returned**, from a query that was already being issued.

- `> CAP` still means "more than the published window", so `buildAccountSummary` is untouched.
- `c` is clamped back to `CAP` before it leaves the loader, so **the payload is unchanged**.
- The exactly-CAP-is-exact property #9386 added the probe for is **preserved**, and still pinned by its own test — now driven through the aggregate instead of the probe.

Two reads, not three: one fewer broad scan of an unpartitioned table, and the `Promise.all` success probability becomes a product of two instead of three.

## Also worth ~250K events/cycle

`ok: false` is never sampled (correctly), so this degradation alone was emitting ~337 unsampled `usage_event`s/hour — **~251K/cycle against the 1M analytics free tier**, a quarter of it spent describing a broken route. Fixing the route is the right place to recover that; #10591 deliberately left the failure stream unthrottled rather than hide it.

## Validation

```
npm run build          exit 0
npx tsc --noEmit       exit 0
npm run lint           exit 0
npm run format:check   exit 0
npm run validate       exit 0
npm run test:coverage  824/824 test files passed
```

Patch coverage by diff intersection against `lcov.info`: **3/3 changed executable lines (100%)**.

One note for the record: an earlier full-suite run had `network-routing` / `network-capabilities` fail; both pass in isolation and the full suite is green on re-run, so that is ordering flake in vitest, unrelated to this diff.