### PR TITLE
data(sn53): register the gateway's capacity meta endpoint

### DIFF
--- a/registry/subnets/engy.json
+++ b/registry/subnets/engy.json
@@ -82,6 +82,24 @@
     {
       "auth_required": false,
       "authority": "official",
+      "id": "sn-53-engy-gateway-meta",
+      "kind": "subnet-api",
+      "name": "engy gateway capacity meta",
+      "notes": "First-party no-auth GET on the gateway host returning its live worker/leg count. Miners divide their declared concurrency by this number, so a change silently re-scales every miner's effective capacity -- which makes it the one gateway value a reader needs to interpret the roster's capacity figures correctly. The README publishes the gateway at wss://api.engy.ai/gw and states the 8-worker minimum this endpoint reports.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "hanlinai",
+      "public_safe": true,
+      "source_urls": ["https://github.com/hanlinai/engy/blob/HEAD/README.md"],
+      "url": "https://api.engy.ai/gw/meta"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-53-engy-miners",
       "kind": "subnet-api",
       "name": "engy provider miner roster",


### PR DESCRIPTION
## Summary

- Registers `https://api.engy.ai/gw/meta` — the engy gateway's live worker/leg count.
- This is the whole of #10345 that belongs in this repo; the archive half is **declined**, with reasons
  posted on the issue.

## What Changed

One surface appended to `registry/subnets/engy.json`, nothing else:

```json
{ "id": "sn-53-engy-gateway-meta", "kind": "subnet-api",
  "url": "https://api.engy.ai/gw/meta", "authority": "official" }
```

Miners divide their declared concurrency by this number, so a change silently re-scales every miner's
effective capacity — which makes it the one gateway value a reader needs before the roster's capacity
figures mean anything.

**Proven, not assumed.** Probed live: `200`, `{"workers":8,"instance":"1387198d"}`. The engy README
publishes the gateway at `wss://api.engy.ai/gw` and states the 8-worker minimum this endpoint reports —
that is the `source_url`.

**The parameterized `/epoch/{index}` family is deliberately not added.** The surface schema has no
template mechanism, and `epoch/1` is already registered with a note saying it is pinned to the earliest
finalized epoch *so the probe target does not age out*. A literal `/epoch/{index}` would duplicate that
or break the probe every epoch. `epoch/latest` covers the other end.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented. *(none.)*

## Validation

- [x] `npm run validate:surface -- registry/subnets/engy.json` — passed, 6 surfaces
- [x] `npm run scan:public-safety` — exit 0
- [x] `npx prettier --check` — clean
- [x] `git diff --stat` — one file, **18 insertions, 0 deletions**
- [x] Endpoint probed live before registering

## Template Used

- `surface.md`

Closes #10345