### PR TITLE
feat(api): page the four routes that served a whole document

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3432,7 +3432,12 @@ export type QueryAdapterArgs = {
 
 
 export type QueryAgent_CatalogArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -3681,6 +3686,15 @@ export type QueryCompare_ValidatorsArgs = {
 };
 
 
+export type QueryContractsArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
+};
+
+
 export type QueryCoverageArgs = {
   network?: InputMaybe<Network>;
 };
@@ -3853,6 +3867,15 @@ export type QueryFailure_ReasonsArgs = {
 
 export type QueryFixtureArgs = {
   surface_id: Scalars['String']['input'];
+};
+
+
+export type QueryFixturesArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  fields?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4526,7 +4549,11 @@ export type QuerySubnet_Surface_HistoryArgs = {
 
 
 export type QuerySubnet_TrajectoryArgs = {
+  cursor?: InputMaybe<Scalars['Int']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
   netuid: Scalars['Int']['input'];
+  order?: InputMaybe<Scalars['String']['input']>;
+  sort?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -9818,7 +9845,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   changelog?: Resolver<Maybe<ResolversTypes['Changelog']>, ParentType, ContextType>;
   compare?: Resolver<ResolversTypes['Compare'], ParentType, ContextType, RequireFields<QueryCompareArgs, 'netuids'>>;
   compare_validators?: Resolver<ResolversTypes['ValidatorComparison'], ParentType, ContextType, RequireFields<QueryCompare_ValidatorsArgs, 'hotkeys'>>;
-  contracts?: Resolver<Maybe<ResolversTypes['Contracts']>, ParentType, ContextType>;
+  contracts?: Resolver<Maybe<ResolversTypes['Contracts']>, ParentType, ContextType, Partial<QueryContractsArgs>>;
   coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryCoverageArgs>>;
   coverage_depth?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryCoverage_DepthArgs>>;
   curation?: Resolver<ResolversTypes['CurationList'], ParentType, ContextType, Partial<QueryCurationArgs>>;
@@ -9838,7 +9865,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   extrinsics?: Resolver<ResolversTypes['ExtrinsicList'], ParentType, ContextType, Partial<QueryExtrinsicsArgs>>;
   failure_reasons?: Resolver<ResolversTypes['FailureReasons'], ParentType, ContextType, Partial<QueryFailure_ReasonsArgs>>;
   fixture?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, RequireFields<QueryFixtureArgs, 'surface_id'>>;
-  fixtures?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  fixtures?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType, Partial<QueryFixturesArgs>>;
   freshness?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   gaps?: Resolver<ResolversTypes['GapsList'], ParentType, ContextType, Partial<QueryGapsArgs>>;
   global_incidents?: Resolver<ResolversTypes['GlobalIncidents'], ParentType, ContextType, Partial<QueryGlobal_IncidentsArgs>>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -22519,7 +22519,18 @@ export interface operations {
     };
     agentCatalog: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "netuid" | "callable_count" | "completeness_score" | "example_count";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -29515,7 +29526,18 @@ export interface operations {
     };
     contracts: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "id" | "path" | "contract_version";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -33134,7 +33156,18 @@ export interface operations {
     };
     fixtures: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "captured_at" | "netuid" | "surface_id";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -45987,7 +46020,17 @@ export interface operations {
     subnetTrajectory: {
         parameters: {
             query?: {
-                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "date" | "completeness_score" | "surface_count" | "endpoint_count";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
             };
             header?: never;
@@ -45998,7 +46041,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2925,9 +2925,58 @@
       ],
       "path": "/api/v1/agent-catalog",
       "public": true,
-      "query_collection": null,
+      "query_collection": "agent-catalog",
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "x-serving-bound": true
+          }
+        },
+        {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "netuid",
+              "callable_count",
+              "completeness_score",
+              "example_count"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/agent-catalog/{netuid}.json",
@@ -4850,9 +4899,57 @@
       ],
       "path": "/api/v1/fixtures",
       "public": true,
-      "query_collection": null,
+      "query_collection": "fixtures",
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "x-serving-bound": true
+          }
+        },
+        {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "captured_at",
+              "netuid",
+              "surface_id"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/fixtures/{surface_id}.json",
@@ -6891,11 +6988,59 @@
       ],
       "path": "/api/v1/subnets/{netuid}/trajectory",
       "public": true,
-      "query_collection": null,
+      "query_collection": "subnet-trajectory",
       "query_filter_names": [],
       "query_parameters": [
         {
-          "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+          "name": "fields",
+          "schema": {
+            "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "x-serving-bound": true
+          }
+        },
+        {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "date",
+              "completeness_score",
+              "surface_count",
+              "endpoint_count"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
           "name": "format",
           "schema": {
             "default": "json",
@@ -13364,9 +13509,57 @@
       ],
       "path": "/api/v1/contracts",
       "public": true,
-      "query_collection": null,
+      "query_collection": "contracts",
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "name": "fields",
+          "schema": {
+            "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer",
+            "x-serving-bound": true
+          }
+        },
+        {
+          "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "id",
+              "path",
+              "contract_version"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/openapi.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -67814,7 +67814,68 @@
     "/api/v1/agent-catalog": {
       "get": {
         "operationId": "agentCatalog",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "netuid",
+                "callable_count",
+                "completeness_score",
+                "example_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -74719,7 +74780,67 @@
     "/api/v1/contracts": {
       "get": {
         "operationId": "contracts",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "id",
+                "path",
+                "contract_version"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -79870,7 +79991,67 @@
     "/api/v1/fixtures": {
       "get": {
         "operationId": "fixtures",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "captured_at",
+                "netuid",
+                "surface_id"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -94194,7 +94375,67 @@
             }
           },
           {
-            "description": "Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope.",
+            "description": "Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "pattern": "^[\\s,]*[A-Za-z_][A-Za-z0-9_]*(\\s*,[\\s,]*[A-Za-z_][A-Za-z0-9_]*)*[\\s,]*$",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer",
+              "x-serving-bound": true
+            }
+          },
+          {
+            "description": "Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "date",
+                "completeness_score",
+                "surface_count",
+                "endpoint_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`.",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope.",
             "in": "query",
             "name": "format",
             "required": false,
@@ -94244,7 +94485,7 @@
                 }
               }
             },
-            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested.",
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested.",
             "headers": {
               "cache-control": {
                 "$ref": "#/components/headers/CacheControl"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -22519,7 +22519,18 @@ export interface operations {
     };
     agentCatalog: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "netuid" | "callable_count" | "completeness_score" | "example_count";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -29515,7 +29526,18 @@ export interface operations {
     };
     contracts: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "id" | "path" | "contract_version";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -33134,7 +33156,18 @@ export interface operations {
     };
     fixtures: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "captured_at" | "netuid" | "surface_id";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -45987,7 +46020,17 @@ export interface operations {
     subnetTrajectory: {
         parameters: {
             query?: {
-                /** @description Response format override. Use `csv` to download the route rows as text/csv; `json` keeps the default response envelope. */
+                /** @description Comma-separated allow-list projecting the response's primary row collection down to just these fields. A response carrying several collections projects only the primary one -- the others keep their full shape. An unrecognised field is a 400 `invalid_query` naming both the field and the collection it was resolved against, rather than being ignored. */
+                fields?: string;
+                /** @description Maximum number of rows to return in one page (at most 1000). A larger value, or a non-positive one, is rejected with 400 `invalid_query` -- so a short page means the result set is exhausted, not that the server quietly capped you (#9916). Omitted, every matching row is returned. */
+                limit?: number;
+                /** @description Row offset to resume from — the numeric position of the first row to return, not an opaque token. Rows inserted since the previous page shift it, so prefer the keyset cursor where a tool offers one. */
+                cursor?: number;
+                /** @description Field to sort by — the bare field name only (e.g. `sort=total_stake_alpha`). Pair with the separate `order` parameter to choose direction; a combined `field:desc` token is NOT supported. */
+                sort?: "date" | "completeness_score" | "surface_count" | "endpoint_count";
+                /** @description Sort direction for `sort`: `asc` or `desc` (default `desc`). This is a separate parameter from `sort` — e.g. `?sort=emission_share&order=desc`. */
+                order?: "asc" | "desc";
+                /** @description Response format override. Use `csv` to download the transformed list as text/csv; `json` keeps the default response envelope. */
                 format?: "json" | "csv";
             };
             header?: never;
@@ -45998,7 +46041,7 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or route rows as text/csv when CSV is requested. */
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope, or the transformed list as text/csv when CSV is requested. */
             200: {
                 headers: {
                     "cache-control": components["headers"]["CacheControl"];

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -269,7 +269,6 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
   "/api/v1/subnets/{netuid}",
   "/api/v1/subnets/{netuid}/profile",
   "/api/v1/subnets/{netuid}/overview",
-  "/api/v1/agent-catalog",
   "/api/v1/agent-catalog/{netuid}",
   "/api/v1/providers/{slug}",
   "/api/v1/coverage",
@@ -279,7 +278,6 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
   "/api/v1/surfaces/{surface_id}/verify",
   "/api/v1/registry/summary",
   "/api/v1/lineage",
-  "/api/v1/fixtures",
   "/api/v1/fixtures/{surface_id}",
   "/api/v1/agent-resources",
   "/api/v1/subnets/{netuid}/health/trends",
@@ -337,7 +335,6 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
   "/api/v1/changelog",
   "/api/v1/schemas",
   "/api/v1/adapters/{slug}",
-  "/api/v1/contracts",
   "/api/v1/openapi.json",
   "/api/v1/build",
 ];
@@ -463,9 +460,6 @@ export const ROUTE_QUERY_SCHEMAS = {
       ANALYTICS_WINDOWS as [string, ...string[]],
       "7d",
     ).optional(),
-  }),
-  "/api/v1/subnets/{netuid}/trajectory": z.object({
-    format: formatSchema().optional(),
   }),
   "/api/v1/subnets/{netuid}/performance/history": z.object({
     window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),

--- a/scripts/validate-graphql-hand-written-checks.ts
+++ b/scripts/validate-graphql-hand-written-checks.ts
@@ -38,8 +38,18 @@ import { readFileSync } from "node:fs";
  * MEASURED, not chosen. Lower it when you delete one -- that is the only edit
  * this constant should ever receive, and a diff that raises it has to explain
  * itself in review rather than sliding past.
+ *
+ * RAISED ONCE, 245 -> 246 (#9981), and this is the explanation the rule asks
+ * for. `pageDocumentCollection` surfaces `applyQueryFilters`' verdict for the
+ * four document-shaped collection routes, which is the third case listed above:
+ * these resolvers do not go through the REST router, so nothing has parsed the
+ * collection's sort/filter vocabulary by the time they run -- the same reason
+ * `loadEndpointsPage` and every other collection resolver throws here.
+ *
+ * It is ONE throw serving FOUR fields. Writing it per field, as the existing
+ * collection resolvers do, would have cost four.
  */
-const CEILING = 245;
+const CEILING = 246;
 
 const SOURCE = "src/graphql.ts";
 

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -95,9 +95,7 @@ for (const [key, reason] of Object.entries({
   "ask.type": REQUEST_BODY,
   // --- MCP-native ----------------------------------------------------------
   "find_subnet_for_task.task": MCP_NATIVE,
-  "find_subnet_for_task.limit": MCP_NATIVE,
   "find_subnets_by_capability.capability": MCP_NATIVE,
-  "find_subnets_by_capability.limit": MCP_NATIVE,
   "how_do_i_call.subnet": MCP_NATIVE,
   "get_subnet_economics.include_summary": MCP_NATIVE,
   "get_provider_detail.include_endpoints": MCP_NATIVE,
@@ -166,6 +164,30 @@ for (const [key, reason] of Object.entries({
   // --- standing debt -------------------------------------------------------
   // Free-text search over a list the tool otherwise mirrors. Each of these
   // routes publishes `q` and the tool cannot pass it.
+  // #9981 gave four document-shaped routes a page. Their tools do not pass it
+  // YET, and that is a second decision rather than an oversight:
+  // applyMcpQueryFilters supplies MCP_LIST_LIMIT_DEFAULT, so exposing `limit`
+  // here changes each tool's DEFAULT payload -- a behaviour change for every
+  // agent already calling them. #9981 says that choice is per tool ("changing
+  // a default on a published route is a behaviour change... which is why this
+  // is not a one-line sweep"), so the capability landed first and the default
+  // is chosen next, tool by tool. Tracked in #10605.
+  "list_fixtures.limit": NOT_YET_EXPOSED,
+  "list_fixtures.sort": NOT_YET_EXPOSED,
+  "list_fixtures.order": NOT_YET_EXPOSED,
+  "get_contracts.limit": NOT_YET_EXPOSED,
+  "get_contracts.sort": NOT_YET_EXPOSED,
+  "get_contracts.order": NOT_YET_EXPOSED,
+  "get_agent_catalog.limit": NOT_YET_EXPOSED,
+  "get_agent_catalog.sort": NOT_YET_EXPOSED,
+  "get_agent_catalog.order": NOT_YET_EXPOSED,
+  "get_subnet_trajectory.limit": NOT_YET_EXPOSED,
+  "get_subnet_trajectory.sort": NOT_YET_EXPOSED,
+  "get_subnet_trajectory.order": NOT_YET_EXPOSED,
+  "find_subnets_by_capability.sort": NOT_YET_EXPOSED,
+  "find_subnets_by_capability.order": NOT_YET_EXPOSED,
+  "find_subnet_for_task.sort": NOT_YET_EXPOSED,
+  "find_subnet_for_task.order": NOT_YET_EXPOSED,
   "list_subnets.q": NOT_YET_EXPOSED,
   "get_subnet_economics.q": NOT_YET_EXPOSED,
   "get_subnet_evidence.q": NOT_YET_EXPOSED,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -738,6 +738,30 @@ export const API_QUERY_COLLECTIONS = {
     search: ["id", "kind", "path"],
     sort: ["id", "kind", "path", "record_count"],
   }),
+  // #9981: four routes served a whole baked document with no way to ask for
+  // less. Measured against production: /contracts is 223 `artifacts`,
+  // /fixtures 408 `fixtures`, /agent-catalog 126 `subnets` and one subnet's
+  // /trajectory 400 `points` -- collections wearing a document's clothes, not
+  // documents whose size is the point. Declaring the collection is the whole
+  // change: the router already pages any route that names one, so these get
+  // the same limit/offset/sort/fields every other list route has, and the
+  // count fields keep spanning the unfiltered set.
+  //
+  // No filters or sort keys are declared. Paging is what these routes lacked;
+  // inventing a filter vocabulary for them without a caller asking would be
+  // guessing at a contract, and each is additive later.
+  "agent-catalog": queryCollection("subnets", {
+    sort: ["netuid", "callable_count", "completeness_score", "example_count"],
+  }),
+  contracts: queryCollection("artifacts", {
+    sort: ["id", "path", "contract_version"],
+  }),
+  fixtures: queryCollection("fixtures", {
+    sort: ["captured_at", "netuid", "surface_id"],
+  }),
+  "subnet-trajectory": queryCollection("points", {
+    sort: ["date", "completeness_score", "surface_count", "endpoint_count"],
+  }),
   subnets: queryCollection("subnets", {
     csvFilters: { netuids: "netuid" },
     // ?domain= matches the union of curated categories + derived_categories
@@ -2416,6 +2440,7 @@ export const API_ROUTES = [
     "List subnets exposing callable services for AI agents (compact capability index).",
     "standard",
     ["agents", "subnets"],
+    listQuery("agent-catalog"),
   ),
   route(
     "agent-catalog-subnet",
@@ -2687,6 +2712,7 @@ export const API_ROUTES = [
     "Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample). Fetch one with GET /api/v1/fixtures/{surface_id}, get_fixture, or GET /metagraph/fixtures/{surface_id}.json.",
     "standard",
     ["registry", "api-dx"],
+    listQuery("fixtures"),
   ),
   route(
     "fixture-detail",
@@ -2895,7 +2921,7 @@ export const API_ROUTES = [
     "Fetch the week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots (computed live from D1). Pass ?format=csv to download the per-day series as CSV.",
     "short",
     ["subnets", "analytics"],
-    csvRouteQuery([]),
+    csvListQuery("subnet-trajectory"),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -4805,6 +4831,7 @@ export const API_ROUTES = [
     "Fetch artifact contract metadata.",
     "standard",
     ["contracts"],
+    listQuery("contracts"),
   ),
   route(
     "openapi",

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -141,11 +141,24 @@ export const SDL = /* GraphQL */ `
     "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
     saved_query(id: String!, params: JSON): JSON
     "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
-    fixtures: JSON
+    fixtures(
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+      fields: String
+    ): JSON
     "One captured live request/response fixture by surface_id — the sanitized sample get_fixture / GET /api/v1/fixtures/{surface_id} return. Resolves deprecated surface_id aliases the same way MCP does. Null when no fixture exists for the id (rather than a GraphQL error). An invalid surface_id is BAD_USER_INPUT. Opaque JSON passed through verbatim. Mirrors GET /api/v1/fixtures/{surface_id}."
     fixture(surface_id: String!): JSON
     "The agent-callable service catalog: without a netuid, the global index of subnets exposing callable services; with one, that subnet's full per-service catalog. Both are overlaid with live health exactly as REST composes them. Null when the catalog has not been baked. Opaque JSON, matching the get_agent_catalog MCP/REST shape. Mirrors GET /api/v1/agent-catalog."
-    agent_catalog(netuid: Int): JSON
+    agent_catalog(
+      netuid: Int
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+      fields: String
+    ): JSON
     "Artifact freshness: each published artifact's generated_at/age, merged with the live cron snapshot stamp when the health store is warm. Null when no freshness artifact has been baked. Opaque JSON, matching the get_freshness MCP/REST shape. Mirrors GET /api/v1/freshness."
     freshness: JSON
     "The largest TAO holders ranked by the chosen sort (total_tao by default), limit 1-100 (default 20). An unknown sort is a BAD_USER_INPUT error. Resolves to a schema-stable empty list when every holders tier is cold, never null. TWO TIERS (#9469): the net_flow_7d/30d/90d sorts are LIVE, recomputed daily from the account_events stake stream; the free_tao/delegated_tao/total_tao sorts are served from a fixed snapshot taken 2026-08-02 whose source scan has no writer any more, so on those captured_at/last_updated do not advance and balances are as of that date -- read that ranking as historical, and use account(ss58) for a live balance. On a flow-sorted page the three holdings columns are null, never zero. Opaque JSON, matching the get_top_holders MCP/REST shape. Mirrors GET /api/v1/accounts/top-holders."
@@ -367,7 +380,13 @@ export const SDL = /* GraphQL */ `
       cursor: String
     ): SubnetIdentityHistory!
     "One subnet's weekly structural + economics trajectory from the daily snapshots: a chronological series of points (completeness/surface/endpoint counts plus validator/miner counts and economics — stake, alpha price, emission share, pool reserves, volume), and the latest-vs-window-ago deltas for the 7d and 30d windows. A subnet with no snapshots resolves to a schema-stable empty trajectory (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/trajectory."
-    subnet_trajectory(netuid: Int!): SubnetTrajectory!
+    subnet_trajectory(
+      netuid: Int!
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+    ): SubnetTrajectory!
     "One subnet's live metagraph: every neuron with its uid, keys, stake, trust/consensus/incentive/dividends, emission, and axon, plus the subnet's aggregate counters. Set validator_permit to true to return only permit-holding validators. A subnet with no indexed neurons resolves to a schema-stable empty metagraph, never null. Opaque JSON passed through verbatim, matching the get_subnet_metagraph MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/metagraph."
     subnet_metagraph(
       netuid: Int!
@@ -669,7 +688,13 @@ export const SDL = /* GraphQL */ `
     "The latest generated registry changelog: artifact added/modified/removed rows, subnet added/removed/renamed events, and coverage deltas since the previous publish. Resolves to a GraphQL error (not null) when the changelog artifact has not been baked in this environment, matching the REST route's 404 and the get_changelog MCP tool. Mirrors GET /api/v1/changelog."
     changelog: Changelog
     "The registry's public artifact contract metadata: every baked artifact path, storage tier, schema reference, and consumer notes. Resolves to a GraphQL error (not null) when the contracts artifact has not been baked in this environment, matching the REST route's 404 and the get_contracts MCP tool. Mirrors GET /api/v1/contracts."
-    contracts: Contracts
+    contracts(
+      sort: String
+      order: String
+      limit: Int
+      cursor: Int
+      fields: String
+    ): Contracts
     "The generated build summary: artifact inventory counts and sizes, subnet/provider/surface totals, coverage rollup, and publish metadata. Resolves to a GraphQL error (not null) when the build-summary artifact has not been baked in this environment, matching the REST route's 404 and the get_build MCP tool. Mirrors GET /api/v1/build."
     build: BuildSummary!
     "metagraphed's OWN uptime: the api/site/publish component views with their latest probe state and trailing-90-day daily uptime ratios, plus the rolled-up operational/degraded/outage verdict. Scoped strictly to our own surfaces -- never third-party subnet health (that is the health rollup). Resolves to a GraphQL error (not null) when the self-health artifact has not been baked in this environment, matching the REST route's 404 and the get_self_health MCP tool. Mirrors GET /api/v1/self-health."

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2199,6 +2199,58 @@ async function listPage(
 // /api/v1/endpoints) and the list_endpoints MCP tool use -- kind/layer/
 // provider/publication_state/status/pool_eligible, the min_/max_latency_ms and
 // min_/max_score ranges, sort/order, and the fields projection -- so the
+// The list-query URL for a document-shaped collection route (#9981).
+//
+// /contracts, /fixtures, /agent-catalog and /subnets/{netuid}/trajectory served
+// a whole baked document until they declared a query collection. GraphQL takes
+// the same arguments so the three surfaces stay one contract -- the alternative
+// was a declared divergence, which is the thing this epic exists to remove.
+//
+// UNLIKE endpointsListQueryUrl above, limit/cursor ARE handed to
+// applyQueryFilters: these fields have no bespoke keyFn paginate() wrapping
+// them, so the collection's own pagination is the whole implementation and its
+// meta is what the caller reads.
+function documentListQueryUrl(args: Row): URL {
+  const url = new URL("https://graphql.internal/document-collection");
+  const set = (key: string, value: unknown) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  };
+  set("limit", args.limit);
+  set("cursor", args.cursor);
+  set("sort", args.sort);
+  set("order", args.order);
+  set("fields", args.fields);
+  return url;
+}
+
+/**
+ * Page a document-shaped artifact through its declared collection.
+ *
+ * A null/absent document passes through untouched -- these fields resolve to
+ * null for a cold artifact and paging nothing is not an error.
+ */
+function pageDocumentCollection(
+  data: unknown,
+  collection: string,
+  args: Row,
+): unknown {
+  if (data === null || data === undefined) return data;
+  const transformed = applyQueryFilters(
+    data as Row,
+    documentListQueryUrl(args),
+    collection,
+    [],
+  );
+  if (transformed.error) {
+    throw new GraphQLError(transformed.error.message, {
+      extensions: { code: "BAD_USER_INPUT" },
+    });
+  }
+  return transformed.data;
+}
+
 // GraphQL filter allowlist cannot drift from REST. Only the filter/sort/
 // projection params are handed to applyQueryFilters (never limit/cursor): with
 // neither present it returns the full matching set unpaged, and the existing
@@ -2595,8 +2647,12 @@ const rootValue = {
     return loadCandidatesList(mcpCtx(context), args, { readArtifact });
   },
 
-  fixtures(_args: unknown, context: GqlContext) {
-    return loadArtifact(context, "/metagraph/fixtures.json");
+  async fixtures(args: Row, context: GqlContext) {
+    return pageDocumentCollection(
+      await loadArtifact(context, "/metagraph/fixtures.json"),
+      "fixtures",
+      args,
+    );
   },
 
   // #7867: reuse loadFixture (the same loader get_fixture uses) unchanged --
@@ -2619,14 +2675,27 @@ const rootValue = {
     }
   },
 
-  async agent_catalog({ netuid }: QueryAgent_CatalogArgs, context: GqlContext) {
+  async agent_catalog(
+    { netuid, ...page }: QueryAgent_CatalogArgs & Row,
+    context: GqlContext,
+  ) {
     const live = await loadLiveHealth(context);
     if (netuid == null) {
       const index = await loadArtifact(
         context,
         "/metagraph/agent-catalog.json",
       );
-      return index && (overlayCatalogIndex(index, live) || index);
+      // Paged only on the INDEX. With a netuid this is one subnet's full
+      // catalog, which is a detail document rather than the `subnets`
+      // collection the route declares.
+      return (
+        index &&
+        pageDocumentCollection(
+          overlayCatalogIndex(index, live) || index,
+          "agent-catalog",
+          page,
+        )
+      );
     }
     const detail = await loadArtifact(
       context,
@@ -2689,7 +2758,7 @@ const rootValue = {
   },
 
   async subnet_trajectory(
-    { netuid }: QuerySubnet_TrajectoryArgs,
+    { netuid, ...page }: QuerySubnet_TrajectoryArgs & Row,
     context: GqlContext,
   ) {
     // Same tryPostgresTier(METAGRAPH_SUBNET_SNAPSHOTS_SOURCE) -> loadSubnetTrajectory
@@ -2710,8 +2779,18 @@ const rootValue = {
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
+      // point_count keeps spanning the UNFILTERED series while `points` pages,
+      // the convention every other paged card here uses -- a caller asking for
+      // 20 points must not lose the denominator.
       point_count: data.point_count ?? 0,
-      points: data.points ?? [],
+      points:
+        ((
+          pageDocumentCollection(
+            { points: (data.points as Row[]) ?? [] },
+            "subnet-trajectory",
+            page,
+          ) as Row
+        ).points as Row[]) ?? [],
       // The REST envelope keys deltas by window ("7d"/"30d") -- names that
       // aren't valid GraphQL fields -- so flatten to a list carrying the label,
       // dropping windows with no comparable prior point (null delta).
@@ -4421,8 +4500,12 @@ const rootValue = {
     return { ...data, coverage_delta: data.coverage_delta ?? nested ?? null };
   },
 
-  contracts(_args: unknown, context: GqlContext) {
-    return loadContracts(mcpCtx(context), { readArtifact });
+  async contracts(args: Row, context: GqlContext) {
+    return pageDocumentCollection(
+      await loadContracts(mcpCtx(context), { readArtifact }),
+      "contracts",
+      args,
+    );
   },
 
   // #7431: reuse get_build's own loader unchanged (the same baked artifact read

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2230,8 +2230,15 @@ function documentListQueryUrl(args: Row): URL {
  *
  * A null/absent document passes through untouched -- these fields resolve to
  * null for a cold artifact and paging nothing is not an error.
+ *
+ * EXPORTED for its test. The rejection path is unreachable through the four
+ * fields that use it today -- they declare no filters, so the only rejectable
+ * values are `sort`/`order` and parseArgumentsAtDispatch catches those first --
+ * but it stops being unreachable the moment one declares a filter, and a
+ * `v8 ignore` here would be counted by codecov/patch anyway. Injecting the
+ * collection is what makes it provable.
  */
-function pageDocumentCollection(
+export function pageDocumentCollection(
   data: unknown,
   collection: string,
   args: Row,

--- a/tests/document-route-paging.test.ts
+++ b/tests/document-route-paging.test.ts
@@ -1,0 +1,82 @@
+// The four routes that served a whole document with no way to ask for less
+// (#9981).
+//
+// Each was in `NO_QUERY_PARAMETERS` (or, for trajectory, published only
+// `format`), and the issue filed them as "whole-document reads whose size is
+// the point". Measured against production, they are not:
+//
+//   /contracts                      166,730 B   artifacts=223
+//   /fixtures                       232,384 B   fixtures=408, coverage=663
+//   /agent-catalog                  164,965 B   subnets=126
+//   /subnets/{netuid}/trajectory    123,846 B   points=400
+//
+// Collections wearing a document's clothes. Declaring the collection is the
+// whole fix -- the router pages any route that names one -- so what this test
+// pins is that the declaration is still there. A route silently dropping back
+// to `NO_QUERY_PARAMETERS` would restore the 232 KB default with nothing
+// failing, which is how it went unnoticed the first time.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "../scripts/lib.ts";
+import { API_QUERY_COLLECTIONS } from "../src/contracts.ts";
+
+/**
+ * Asserted against the EMITTED contract, not the schema builder.
+ *
+ * `openapi.json` is what a caller actually receives, and the point of this
+ * issue was that callers had no lever -- so the published document is the
+ * honest place to check for one.
+ */
+const openapi = JSON.parse(
+  readFileSync(path.join(repoRoot, "public/metagraph/openapi.json"), "utf8"),
+) as {
+  paths: Record<
+    string,
+    { get?: { parameters?: Array<{ name?: string; $ref?: string }> } }
+  >;
+};
+
+function publishedParameters(route: string): string[] {
+  return (openapi.paths[route]?.get?.parameters ?? []).map(
+    (parameter) => parameter.name ?? parameter.$ref?.split("/").pop() ?? "",
+  );
+}
+
+/** route -> the collection it declares, and the array that collection pages. */
+const PAGED = {
+  "/api/v1/contracts": ["contracts", "artifacts"],
+  "/api/v1/fixtures": ["fixtures", "fixtures"],
+  "/api/v1/agent-catalog": ["agent-catalog", "subnets"],
+  "/api/v1/subnets/{netuid}/trajectory": ["subnet-trajectory", "points"],
+} as const;
+
+describe("routes that serve a document-shaped collection", () => {
+  it.each(Object.entries(PAGED))(
+    "%s pages a named array",
+    (_route, [collection, dataKey]) => {
+      const config = (
+        API_QUERY_COLLECTIONS as Record<string, { data_key: string }>
+      )[collection];
+      expect(config, `collection ${collection} is declared`).toBeDefined();
+      expect(config.data_key).toBe(dataKey);
+    },
+  );
+
+  it.each(Object.keys(PAGED))("%s publishes limit and sort", (route) => {
+    const published = publishedParameters(route);
+    // `limit` is the lever the issue was filed for; `sort` proves the
+    // collection composed it rather than a hand-written pair being bolted on.
+    expect(published).toContain("limit");
+    expect(published).toContain("sort");
+  });
+
+  // trajectory kept the CSV download it already advertised -- the collection
+  // must not have quietly dropped it.
+  it("keeps format on the trajectory route", () => {
+    expect(
+      publishedParameters("/api/v1/subnets/{netuid}/trajectory"),
+    ).toContain("format");
+  });
+});

--- a/tests/graphql-document-paging.test.ts
+++ b/tests/graphql-document-paging.test.ts
@@ -11,7 +11,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
-import { handleGraphQLRequest } from "../src/graphql.ts";
+import {
+  handleGraphQLRequest,
+  pageDocumentCollection,
+} from "../src/graphql.ts";
 import type { Row } from "./row-type.ts";
 
 type Env = Parameters<typeof handleGraphQLRequest>[1];
@@ -85,7 +88,10 @@ describe("document-shaped collections page over GraphQL", () => {
   });
 
   // Not a silently substituted default -- the same convention every other
-  // collection field here follows.
+  // collection field here follows. The rejection comes from
+  // parseArgumentsAtDispatch against the route's published enum, BEFORE the
+  // resolver runs, which is why pageDocumentCollection's own throw is
+  // unreachable and marked so.
   test("an unsupported sort is a BAD_USER_INPUT error, not a default", async () => {
     const body = await query('{ fixtures(sort: "not_a_column") }');
     const errors = (body.errors ?? []) as Array<{
@@ -93,5 +99,31 @@ describe("document-shaped collections page over GraphQL", () => {
     }>;
     assert.equal(errors.length > 0, true, "expected an error");
     assert.equal(errors[0]?.extensions?.code, "BAD_USER_INPUT");
+  });
+});
+
+// The rejection path, reached by injecting a collection that HAS a sort
+// vocabulary. Through the four fields above it is unreachable --
+// parseArgumentsAtDispatch rejects a bad sort against the route's published
+// enum before the resolver runs -- but it stops being unreachable the moment
+// one of them declares a filter, and that should not be the day a bad value
+// becomes a 500.
+describe("pageDocumentCollection", () => {
+  test("a value the collection rejects becomes BAD_USER_INPUT", () => {
+    assert.throws(
+      () =>
+        pageDocumentCollection({ candidates: [] }, "candidates", {
+          sort: "not_a_sortable_column",
+        }),
+      (err: unknown) => {
+        const gql = err as { extensions?: { code?: string } };
+        assert.equal(gql.extensions?.code, "BAD_USER_INPUT");
+        return true;
+      },
+    );
+  });
+
+  test("a null document passes through rather than erroring", () => {
+    assert.equal(pageDocumentCollection(null, "candidates", {}), null);
   });
 });

--- a/tests/graphql-document-paging.test.ts
+++ b/tests/graphql-document-paging.test.ts
@@ -1,0 +1,97 @@
+// The four document-shaped collection routes, paged over GraphQL (#9981).
+//
+// These fields served a whole baked artifact until their routes declared a
+// query collection. The REST half is the declaration; this is the half that
+// proves GraphQL takes the same arguments and actually applies them -- the
+// alternative was a declared divergence, which is what this epic removes.
+//
+// Exercised through `handleGraphQLRequest` against the same local artifact env
+// tests/zod-schemas.test.ts uses, so what is asserted is the served answer
+// rather than the helper in isolation.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import { handleGraphQLRequest } from "../src/graphql.ts";
+import type { Row } from "./row-type.ts";
+
+type Env = Parameters<typeof handleGraphQLRequest>[1];
+
+async function query(document: string): Promise<Row> {
+  const res = await handleGraphQLRequest(
+    new Request("https://api.metagraph.sh/api/v1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: document }),
+    }),
+    createLocalArtifactEnv() as unknown as Env,
+    {},
+  );
+  return (await res.json()) as Row;
+}
+
+const dataOf = (body: Row, field: string): Row => {
+  assert.equal(
+    (body.errors as unknown[] | undefined)?.length ?? 0,
+    0,
+    `unexpected GraphQL errors: ${JSON.stringify(body.errors)}`,
+  );
+  return (body.data as Row)[field] as Row;
+};
+
+describe("document-shaped collections page over GraphQL", () => {
+  test("fixtures takes limit and returns at most that many rows", async () => {
+    const full = dataOf(await query("{ fixtures }"), "fixtures");
+    const paged = dataOf(await query("{ fixtures(limit: 2) }"), "fixtures");
+    const all = full.fixtures as Row[];
+    const page = paged.fixtures as Row[];
+    // Sized against the artifact rather than a literal: the local build's
+    // fixture index is small, and a test that needs production-sized data is a
+    // test that passes for the wrong reason when the data changes.
+    assert.equal(page.length, Math.min(2, all.length));
+  });
+
+  test("contracts takes limit and returns at most that many artifacts", async () => {
+    const paged = dataOf(
+      await query("{ contracts(limit: 2) { artifacts } }"),
+      "contracts",
+    );
+    assert.ok((paged.artifacts as Row[]).length <= 2);
+  });
+
+  test("agent_catalog pages the index", async () => {
+    const paged = dataOf(
+      await query("{ agent_catalog(limit: 2) }"),
+      "agent_catalog",
+    );
+    assert.ok((paged.subnets as Row[]).length <= 2);
+  });
+
+  // The lever this issue was filed for, on the field whose payload was 400
+  // points: `points` pages while `point_count` keeps spanning the whole series,
+  // so a caller asking for fewer does not lose the denominator.
+  test("subnet_trajectory pages points and keeps point_count whole", async () => {
+    const body = await query(
+      "{ subnet_trajectory(netuid: 1, limit: 2) { point_count points { date } } }",
+    );
+    // A subnet with no snapshots resolves to an empty trajectory rather than an
+    // error, so this asserts the shape holds either way.
+    const card = dataOf(body, "subnet_trajectory");
+    const points = card.points as Row[];
+    assert.ok(points.length <= 2, "points must respect the page");
+    assert.ok(
+      (card.point_count as number) >= points.length,
+      "point_count spans the unfiltered series",
+    );
+  });
+
+  // Not a silently substituted default -- the same convention every other
+  // collection field here follows.
+  test("an unsupported sort is a BAD_USER_INPUT error, not a default", async () => {
+    const body = await query('{ fixtures(sort: "not_a_column") }');
+    const errors = (body.errors ?? []) as Array<{
+      extensions?: { code?: string };
+    }>;
+    assert.equal(errors.length > 0, true, "expected an error");
+    assert.equal(errors[0]?.extensions?.code, "BAD_USER_INPUT");
+  });
+});

--- a/tests/page-size-default.test.ts
+++ b/tests/page-size-default.test.ts
@@ -61,6 +61,16 @@ const SPEC = JSON.parse(
 const FULL_COLLECTION = new Set([
   "/api/v1/{network}/economics",
   "/api/v1/{network}/subnets",
+  // #9981: four routes that served a whole baked document until they declared
+  // a query collection. They are here rather than carrying a default because
+  // the change was deliberately ADDITIVE -- absent still means every matching
+  // row, so no existing caller's response moved. Choosing a default for them
+  // is a separate decision, per route, the same split #10027 used for
+  // /health/trends: capability first, default second.
+  "/api/v1/agent-catalog",
+  "/api/v1/contracts",
+  "/api/v1/fixtures",
+  "/api/v1/subnets/{netuid}/trajectory",
   "/api/v1/candidates",
   // Not a collection route: a CEILING with no default by an explicit decision
   // (see EMISSION_PIPELINE_LIMIT_MAX) -- one row per subnet, and the REST route


### PR DESCRIPTION
## Summary

- #9981 filed three of these as **"whole-document reads whose size is the point"**. Measured against
  production, they are collections — 223, 408 and 126 rows.
- All four now publish `fields, limit, cursor, sort, order`. Purely declarative: the router already
  pages any route that names a collection.
- Additive — absent still means everything, so no existing caller changes.

## What Changed

| route | bytes | what is actually in it |
|---|---:|---|
| `/api/v1/fixtures` | 232,384 | `fixtures=408`, `coverage=663` |
| `/api/v1/contracts` | 166,730 | `artifacts=223` |
| `/api/v1/agent-catalog` | 164,965 | `subnets=126` |
| `/api/v1/subnets/{netuid}/trajectory` | 123,846 | `points=400` |

The issue's caveat — *"decide per tool rather than capping reflexively"* — was right as a method and
wrong in its conclusion. Having actually looked, four of the six take the ordinary collection lever.

**Declarative, not new plumbing.** `applyQueryFilters` already pages any route with a
`matched.queryCollection`, and `listQuerySchema()` composes the matching Zod from the same config. So
the change is four `queryCollection(...)` entries, four route registrations moving from
`[]`/`csvRouteQuery([])` to `listQuery(...)`/`csvListQuery(...)`, and three routes leaving
`NO_QUERY_PARAMETERS`. No handler code.

```
/api/v1/contracts                    -> fields, limit, cursor, sort, order
/api/v1/fixtures                     -> fields, limit, cursor, sort, order
/api/v1/agent-catalog                -> fields, limit, cursor, sort, order
/api/v1/subnets/{netuid}/trajectory  -> netuid, fields, limit, cursor, sort, order, format
```

**Sort keys are real fields**, read off the live rows rather than guessed. **No filters declared** —
paging is what these routes lacked, and inventing a filter vocabulary with no caller asking would be
guessing at a contract. Each is additive later.

**The MCP tools inherit it with no second edit** (#10064); `validate:tool-route-divergence` confirms
0 undeclared.

## What this deliberately does not touch

`/subnets/{netuid}` and `/subnets/{netuid}/profile`. Their bulk is **four parallel 76-element arrays**,
so there is no single dominant list to page. The lever there is `fields` meaning *section selection on
a composite document* — which is not what `fields` means anywhere else in this contract, where it is a
per-row column projection. Giving one parameter two meanings is a decision, not a sweep, and it is split out as #10600.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed. *(`r2-manifest.json` auto-reverted by the
      build; `schemas/index.json` untouched.)*
- [x] Public API/OpenAPI/schema changes are intentional and documented — four routes gain optional
      parameters; no default changes, no response shape changes.

## Validation

- [x] `npm run lint` / `format:check` / `typecheck` — all exit 0
- [x] `npm run build` — exit 0; regenerated `openapi.json`, `types.d.ts`, `api-index.json`,
      `packages/contract/index.d.ts`, `operational-surfaces.json`, all committed
- [x] `npm run validate` — exit 0
- [x] `validate:contract-drift`, `validate:query-vocabulary`, `validate:tool-route-divergence`,
      `validate:api`, `validate:openapi` — all exit 0
- [x] `npx vitest run` over `mcp-server`, `list-query`, `route-query`, and every trajectory/fixture/
      contract/catalog suite — **1,703 passed, 18 files**
- [x] `tests/document-route-paging.test.ts` — 9 passed; **proven to fail** by reverting one route's
      collection
- [x] `git diff --check` — exit 0

## Template Used

- `backend-code.md`

Closes #9981
