### PR TITLE
fix(ci): the deploy watchdog aged the wrong commit, so activity silenced it

### DIFF
--- a/scripts/check-worker-deploys.ts
+++ b/scripts/check-worker-deploys.ts
@@ -51,10 +51,30 @@
 //
 //   FORKED   the deployed SHA is not an ancestor of main. Always wrong: it
 //            means a deploy from a branch, or a rollback nobody recorded.
-//   STALE    behind, and main's HEAD is older than the grace window. This is
-//            the failure the issue is about.
-//   LAGGING  behind, but HEAD is younger than the grace window -- a build in
-//            flight, which is the ordinary state right after a merge.
+//   STALE    behind, and the OLDEST undeployed commit is older than the grace
+//            window. This is the failure the issue is about.
+//   LAGGING  behind, but even the oldest undeployed commit is younger than the
+//            grace window -- a build in flight, the ordinary state after a merge.
+//
+// ## The grace window measures the OLDEST undeployed commit, not the newest
+//
+// It used to measure the build TARGET -- the newest commit that should have
+// built -- and that made the check unable to report the thing it exists for.
+// A repo with steady merges always has a young newest-commit, so the grace
+// window reset on every merge and `stale` required main to go quiet for a full
+// thirty minutes. Activity silenced the alarm, which is backwards: a busy repo
+// is when a frozen deploy does the most damage.
+//
+// Measured 2026-08-10 (#10597): `metagraphed` sat SIX commits behind with three
+// consecutive failed builds over ~50 minutes, and this check exited 0 --
+// "LAGGING, HEAD is 10m old -- inside the 30m grace" -- because someone had
+// merged ten minutes earlier. The freeze was found by hand instead.
+//
+// Asking how long the OLDEST undeployed commit has waited keeps the property
+// the grace window was added for (#9301: do not alarm while a build is legitimately
+// in flight -- right after a merge the oldest undeployed commit IS the newest one,
+// so the verdict is unchanged) while making a stuck build impossible to hide
+// behind later merges.
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -79,6 +99,20 @@ export const WORKER_CONFIGS = [
   "wrangler.wss-lb.jsonc",
 ] as const;
 
+/**
+ * The oldest commit still not deployed, from `git rev-list deployed..target`.
+ *
+ * Exported and pure because THIS is where the bug was, and a test of
+ * `judgeDeploy` cannot reach it: the verdict logic was always right, it was
+ * being handed the wrong commit. `rev-list` prints newest-first, so the oldest
+ * is the LAST line -- taking the first is what let a 58-minute freeze report
+ * "10m old, inside the grace" every time somebody merged again (#10597).
+ */
+export function oldestUndeployedSha(revList: string): string | null {
+  const shas = revList.split("\n").filter(Boolean);
+  return shas.length ? shas[shas.length - 1] : null;
+}
+
 export type DeployVerdict = "ok" | "lagging" | "stale" | "forked" | "unknown";
 
 export interface DeployStatus {
@@ -101,11 +135,13 @@ export function judgeDeploy(input: {
   deployed: string | null;
   ancestor: boolean;
   behind: number;
-  headAgeMs: number;
+  /** How long the OLDEST undeployed commit has been waiting. NOT the newest:
+   * see this file's header for the freeze that hid behind later merges. */
+  undeployedAgeMs: number;
   graceMs?: number;
   failure?: DeployReadFailure;
 }): DeployStatus {
-  const { config, worker, deployed, ancestor, behind, headAgeMs } = input;
+  const { config, worker, deployed, ancestor, behind, undeployedAgeMs } = input;
   const graceMs = input.graceMs ?? DEPLOY_GRACE_MS;
   const base = { config, worker, deployed, ancestor, behind };
   if (!deployed) {
@@ -147,13 +183,13 @@ export function judgeDeploy(input: {
       detail: "running the newest commit it was asked to build",
     };
   }
-  if (headAgeMs < graceMs) {
+  if (undeployedAgeMs < graceMs) {
     return {
       ...base,
       verdict: "lagging",
       detail:
-        `${behind} commit(s) behind, HEAD is ` +
-        `${Math.round(headAgeMs / 60_000)}m old -- inside the ` +
+        `${behind} commit(s) behind, oldest undeployed is ` +
+        `${Math.round(undeployedAgeMs / 60_000)}m old -- inside the ` +
         `${Math.round(graceMs / 60_000)}m grace`,
     };
   }
@@ -161,8 +197,8 @@ export function judgeDeploy(input: {
     ...base,
     verdict: "stale",
     detail:
-      `${behind} commit(s) behind and HEAD is ` +
-      `${Math.round(headAgeMs / 60_000)}m old -- the build did not land`,
+      `${behind} commit(s) behind and the oldest undeployed is ` +
+      `${Math.round(undeployedAgeMs / 60_000)}m old -- the build did not land`,
   };
 }
 
@@ -335,19 +371,27 @@ export function checkWorkerDeploys(nowMs = Date.now()): DeployStatus[] {
     // when no build is visible in the window -- which keeps the old behaviour
     // for a repo state this cannot explain, rather than silently passing.
     const target = buildTargetSha(worker) ?? "origin/main";
-    const targetAgeMs =
-      nowMs - Number(git(["log", "-1", "--format=%ct", target])) * 1000;
     const read = deployedSha(config);
     const deployed = "sha" in read ? read.sha : null;
     let ancestor = false;
     let behind = 0;
+    // Falls back to the target's own age, which is what a Worker with nothing
+    // undeployed (or an unreadable deployment) should be judged on.
+    let undeployedAgeMs =
+      nowMs - Number(git(["log", "-1", "--format=%ct", target])) * 1000;
     if (deployed) {
       try {
         git(["merge-base", "--is-ancestor", deployed, "origin/main"]);
         ancestor = true;
         // Counted to the BUILD TARGET, not to HEAD: commits that rebuilt
         // nothing for this Worker are not commits it is behind on.
-        behind = Number(git(["rev-list", "--count", `${deployed}..${target}`]));
+        const revList = git(["rev-list", `${deployed}..${target}`]);
+        behind = revList.split("\n").filter(Boolean).length;
+        const oldest = oldestUndeployedSha(revList);
+        if (oldest) {
+          undeployedAgeMs =
+            nowMs - Number(git(["log", "-1", "--format=%ct", oldest])) * 1000;
+        }
       } catch {
         ancestor = false;
       }
@@ -358,7 +402,7 @@ export function checkWorkerDeploys(nowMs = Date.now()): DeployStatus[] {
       deployed,
       ancestor,
       behind,
-      headAgeMs: targetAgeMs,
+      undeployedAgeMs,
       failure: "failure" in read ? read.failure : undefined,
     });
   });

--- a/tests/worker-deploy-drift.test.ts
+++ b/tests/worker-deploy-drift.test.ts
@@ -18,6 +18,7 @@ import {
   WORKER_CONFIGS,
   classifyDeployReadError,
   judgeDeploy,
+  oldestUndeployedSha,
   workerName,
 } from "../scripts/check-worker-deploys.ts";
 
@@ -31,7 +32,7 @@ const base = {
 
 describe("the three states that all look like `behind`", () => {
   test("at HEAD is ok", () => {
-    const v = judgeDeploy({ ...base, behind: 0, headAgeMs: 90 * MIN });
+    const v = judgeDeploy({ ...base, behind: 0, undeployedAgeMs: 90 * MIN });
     assert.equal(v.verdict, "ok");
   });
 
@@ -39,7 +40,7 @@ describe("the three states that all look like `behind`", () => {
     // Measured 2026-08-10, minutes after a merge: wss-lb was at HEAD while the
     // ~1 MB gzip data-api was three commits back. Demanding equality would
     // alarm on every merge for as long as the slowest build takes.
-    const v = judgeDeploy({ ...base, behind: 3, headAgeMs: 9 * MIN });
+    const v = judgeDeploy({ ...base, behind: 3, undeployedAgeMs: 9 * MIN });
     assert.equal(v.verdict, "lagging");
     assert.match(v.detail, /inside the 30m grace/);
   });
@@ -48,7 +49,7 @@ describe("the three states that all look like `behind`", () => {
     const v = judgeDeploy({
       ...base,
       behind: 3,
-      headAgeMs: DEPLOY_GRACE_MS + MIN,
+      undeployedAgeMs: DEPLOY_GRACE_MS + MIN,
     });
     assert.equal(v.verdict, "stale");
     assert.match(v.detail, /the build did not land/);
@@ -59,12 +60,12 @@ describe("the three states that all look like `behind`", () => {
     const inside = judgeDeploy({
       ...base,
       behind: 1,
-      headAgeMs: DEPLOY_GRACE_MS - 1,
+      undeployedAgeMs: DEPLOY_GRACE_MS - 1,
     });
     const outside = judgeDeploy({
       ...base,
       behind: 1,
-      headAgeMs: DEPLOY_GRACE_MS,
+      undeployedAgeMs: DEPLOY_GRACE_MS,
     });
     assert.equal(inside.verdict, "lagging");
     assert.equal(outside.verdict, "stale");
@@ -79,7 +80,7 @@ describe("the states that are never merely slow", () => {
       ...base,
       ancestor: false,
       behind: 0,
-      headAgeMs: 0,
+      undeployedAgeMs: 0,
     });
     assert.equal(v.verdict, "forked");
   });
@@ -92,7 +93,7 @@ describe("the states that are never merely slow", () => {
       deployed: null,
       ancestor: false,
       behind: 0,
-      headAgeMs: 0,
+      undeployedAgeMs: 0,
     });
     assert.equal(v.verdict, "unknown");
     assert.match(v.detail, /could not be read/);
@@ -129,7 +130,12 @@ describe("an unreadable deployment names WHICH kind of unreadable (#10357)", () 
   // line of output. They have different owners: one needs a maintainer to
   // rotate a secret, the other needs nothing at all. The older check this
   // replaced (#5538) distinguished them, and that is the piece worth keeping.
-  const unread = { ...base, deployed: null, behind: 0, headAgeMs: 90 * MIN };
+  const unread = {
+    ...base,
+    deployed: null,
+    behind: 0,
+    undeployedAgeMs: 90 * MIN,
+  };
 
   test("an auth failure says a maintainer has to fix the token", () => {
     const v = judgeDeploy({ ...unread, failure: "auth" });
@@ -269,5 +275,54 @@ describe("the build target, not main's HEAD (#10370)", () => {
   test("the search depth is bounded and stated", () => {
     assert.ok(BUILD_TARGET_SEARCH_DEPTH >= 10);
     assert.ok(BUILD_TARGET_SEARCH_DEPTH <= 100);
+  });
+});
+
+// #10597: the verdict logic was never wrong. It was handed the wrong commit.
+//
+// The grace window was measured against the BUILD TARGET -- the newest commit
+// that should have built -- so on a repo with steady merges it reset on every
+// merge and `stale` required main to go quiet for a full thirty minutes.
+// Measured: `metagraphed` sat 6 commits behind with three consecutive failed
+// builds over 58 minutes and the check exited 0, because somebody had merged
+// ten minutes earlier. Activity silenced the alarm.
+//
+// judgeDeploy tests cannot catch that -- they pass whichever number they are
+// given. This pins the derivation instead.
+describe("which undeployed commit the grace window is measured against", () => {
+  // rev-list prints newest-first.
+  const NEWEST = "c8bf0843139028c9e6e3d44d7cb4c660f4cf9872";
+  const MIDDLE = "005dd7e16a1b2c3d4e5f60718293a4b5c6d7e8f9";
+  const OLDEST = "c424b1b66e45412bedb952b849fa3a97bdb1aa07";
+
+  test("takes the OLDEST undeployed commit, not the newest", () => {
+    assert.equal(
+      oldestUndeployedSha([NEWEST, MIDDLE, OLDEST].join("\n")),
+      OLDEST,
+    );
+  });
+
+  test("a single undeployed commit is both newest and oldest", () => {
+    assert.equal(oldestUndeployedSha(NEWEST), NEWEST);
+  });
+
+  test("nothing undeployed yields null rather than an empty sha", () => {
+    // An empty string here would be handed to `git log -1 ''`, which resolves
+    // to HEAD -- a silent wrong answer instead of "there is nothing to age".
+    assert.equal(oldestUndeployedSha(""), null);
+    assert.equal(oldestUndeployedSha("\n\n"), null);
+  });
+
+  // The property that actually failed, stated end to end: a fresh merge must
+  // not rescue a Worker whose oldest undeployed commit is past the window.
+  test("a fresh merge does not reset the window on an old freeze", () => {
+    const oldest = oldestUndeployedSha([NEWEST, MIDDLE, OLDEST].join("\n"))!;
+    assert.equal(oldest, OLDEST, "must age the freeze, not the newest merge");
+    const verdict = judgeDeploy({
+      ...base,
+      behind: 3,
+      undeployedAgeMs: 58 * MIN,
+    });
+    assert.equal(verdict.verdict, "stale");
   });
 });


### PR DESCRIPTION
## What

`check-worker-deploys` measured its grace window against the **build target** — the *newest* commit that should have built. On a repo with steady merges the newest commit is always young, so the window reset on every merge, and `stale` effectively required `main` to go quiet for a full thirty minutes.

**Activity silenced the alarm** — backwards, since a busy repo is when a frozen deploy does the most damage.

Refs #10597

## Measured against the live freeze

`metagraphed` sat **6 commits behind with three consecutive failed builds spanning 58 minutes**, and the check exited **0**:

```
LAGGING  metagraphed  6 commit(s) behind, HEAD is 10m old -- inside the 30m grace
Every Worker is running main, or building it.
```

…because somebody had merged ten minutes earlier. The freeze was found by hand instead.

Against that same live state, after this change:

```
STALE    metagraphed  6 commit(s) behind and the oldest undeployed is 58m old -- the build did not land
1 Worker(s) are not running main.
```

The other three Workers still report `OK`, so this is not a wider net — it is the **right commit**.

## Why this keeps the property the grace window exists for

#9301's concern was alarming while a build is legitimately in flight. Right after a merge, the oldest undeployed commit **is** the newest one, so the ordinary verdict is unchanged. Only a build that stayed stuck while later merges arrived changes answer — which is exactly the case that was invisible.

## The tests could not have caught this, so the fix ships a seam they can reach

`judgeDeploy` was never wrong; it was handed the wrong number. Its tests passed straight through the incident and would pass under either behavior, because they supply `undeployedAgeMs` directly.

So the derivation is now a pure exported function, `oldestUndeployedSha`, tested at the exact site of the bug:

- `rev-list` prints newest-first, so the oldest is the **last** line — taking `shas[0]` is what let a 58-minute freeze read as "10m old".
- An empty list returns `null`, not `""` — `git log -1 ''` silently resolves to `HEAD`, which would age the wrong commit again in a new way.

**Verified the regression test can fail**: restoring the old `shas[0]` fails 2 tests, including the end-to-end property ("a fresh merge does not reset the window on an old freeze"); restoring the fix passes.

## Validation

```
npx tsc --noEmit       exit 0
npm run lint           exit 0
npm run format:check   exit 0
npm run test:coverage  824/824 test files passed
```

`scripts/**` is outside the `src/**`/`workers/**` codecov scope, so there is no patch-coverage number to report; the new logic is covered by the tests above.