### PR TITLE
fix(prometheus): give the per-subnet and per-account cards the tier the chain card already had

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 619,
+  "surface_count": 620,
   "surfaces": [
     {
       "auth_required": false,
@@ -6150,6 +6150,26 @@
       "surface_id": "sn-53-engy-epoch-latest",
       "surface_key": "srf-3fcac91046896130",
       "url": "https://provider.engy.ai/api/subnet/v1/epoch/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 53,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "hanlinai",
+      "public_safe": true,
+      "revenue": null,
+      "schema_source": null,
+      "subnet_name": "engy",
+      "subnet_slug": "engy",
+      "surface_id": "sn-53-engy-gateway-meta",
+      "surface_key": "srf-bee52a48fea8d3bb",
+      "url": "https://api.engy.ai/gw/meta"
     },
     {
       "auth_required": false,

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -85,6 +85,12 @@ import {
   DEFAULT_SERVING_WINDOW,
 } from "./account-serving.ts";
 import {
+  buildAccountPrometheus,
+  PROMETHEUS_EVENT_KIND,
+  PROMETHEUS_WINDOWS,
+  DEFAULT_PROMETHEUS_WINDOW,
+} from "./account-prometheus.ts";
+import {
   buildValidatorNominators,
   DEFAULT_NOMINATOR_SORT,
   DEFAULT_NOMINATOR_WINDOW,
@@ -412,6 +418,44 @@ export async function loadAccountServingColdTier(
   if (rows === null) return null;
   return {
     data: buildAccountServing(rows, ss58, { window: label }),
+    generatedAt: latestObservedIso(rows),
+  };
+}
+
+/**
+ * One account's per-subnet PrometheusServed footprint -- the telemetry
+ * companion to loadAccountServingColdTier above, same query shape, same
+ * hotkey-only attribution, differing only in event kind.
+ *
+ * #10322: this rung did not exist, so `/accounts/{ss58}/prometheus` bottomed
+ * out in `buildAccountPrometheus([])` for every account while the chain-level
+ * card answered from the same PrometheusServed stream.
+ */
+export async function loadAccountPrometheusColdTier(
+  env: Env | null | undefined,
+  ss58: string,
+  query: { window?: string | null } = {},
+): Promise<{
+  data: ReturnType<typeof buildAccountPrometheus>;
+  generatedAt: string | null;
+} | null> {
+  const addr = safeSs58Literal(ss58);
+  if (addr === null) return null;
+  const { label, cutoff } = windowCutoff(
+    PROMETHEUS_WINDOWS,
+    DEFAULT_PROMETHEUS_WINDOW,
+    query.window,
+  );
+  const rows = await r2SqlQuery(
+    env,
+    `SELECT netuid, COUNT(*) AS announcements, MIN(observed_at) AS first_observed, ` +
+      `MAX(observed_at) AS last_observed FROM chain.account_events ` +
+      `WHERE hotkey = '${addr}' AND event_kind = '${PROMETHEUS_EVENT_KIND}' ` +
+      `AND observed_at >= ${cutoff} GROUP BY netuid`,
+  );
+  if (rows === null) return null;
+  return {
+    data: buildAccountPrometheus(rows, ss58, { window: label }),
     generatedAt: latestObservedIso(rows),
   };
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -4,6 +4,7 @@ import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
 import { loadSubnetAlphaVolumeFromArtifact } from "./subnet-alpha-volume-artifact.ts";
 import {
+  CHAIN_PROMETHEUS_ROLLUP,
   CHAIN_SERVING_ROLLUP,
   CHAIN_STAKE_MOVES_ROLLUP,
   CHAIN_STAKE_TRANSFERS_ROLLUP,
@@ -39,6 +40,7 @@ import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
 import {
   loadAccountCounterpartiesColdTier,
   loadAccountRegistrationsColdTier,
+  loadAccountPrometheusColdTier,
   loadAccountServingColdTier,
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
@@ -3964,6 +3966,21 @@ const rootValue = {
         ),
         "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       )) as Row | null) ??
+      // #10322: the same cold-tier rung REST's handleSubnetPrometheus gained.
+      // Without it this resolver bottomed out in the zeroed builder while
+      // `chain_prometheus` answered from the same PrometheusServed stream.
+      ((await loadSubnetEventCardColdTier(
+        context.env as unknown as Parameters<
+          typeof loadSubnetEventCardColdTier
+        >[0],
+        CHAIN_PROMETHEUS_ROLLUP,
+        netuid,
+        buildSubnetPrometheus,
+        {
+          windowLabel: windowParam,
+          windowDays: SUBNET_PROMETHEUS_WINDOWS[windowParam] ?? 7,
+        },
+      )) as Row | null) ??
       buildSubnetPrometheus(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -6521,6 +6538,13 @@ const rootValue = {
     );
     const data =
       (pg?.data as Row | undefined) ??
+      // #10322: the same cold-tier rung REST's handleAccountPrometheus gained.
+      // Without it this resolver answered a confident zero for every account.
+      ((
+        await loadAccountPrometheusColdTier(context.env, ss58, {
+          window: requestedWindow,
+        })
+      )?.data as Row | undefined) ??
       buildAccountPrometheus([], ss58, { window: requestedWindow });
     return {
       schema_version: data.schema_version ?? 1,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -239,6 +239,7 @@ import {
   loadExtrinsicFeedColdTier,
 } from "./extrinsics-cold-tier.ts";
 import {
+  loadAccountPrometheusColdTier,
   loadAccountCounterpartiesColdTier,
   loadAccountStakeFlowColdTier,
   loadAccountStakeMovesColdTier,
@@ -1325,6 +1326,7 @@ import { loadSubnetWeightsColdTier } from "./subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "./subnet-event-card-loader.ts";
 import { loadSubnetAlphaVolumeFromArtifact } from "./subnet-alpha-volume-artifact.ts";
 import {
+  CHAIN_PROMETHEUS_ROLLUP,
   CHAIN_SERVING_ROLLUP,
   CHAIN_STAKE_MOVES_ROLLUP,
   CHAIN_STAKE_TRANSFERS_ROLLUP,
@@ -7438,7 +7440,21 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             window,
           }),
           "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetPrometheus(null, netuid, { window })
+        )) ??
+        // #10322: same cold-tier rung as its REST and GraphQL twins.
+        (await loadSubnetEventCardColdTier(
+          ctx.env as unknown as Parameters<
+            typeof loadSubnetEventCardColdTier
+          >[0],
+          CHAIN_PROMETHEUS_ROLLUP,
+          netuid,
+          buildSubnetPrometheus,
+          {
+            windowLabel: window,
+            windowDays: SUBNET_PROMETHEUS_WINDOWS[window] ?? 7,
+          },
+        )) ??
+        buildSubnetPrometheus(null, netuid, { window })
       );
     },
   },
@@ -10337,7 +10353,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             }),
             "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
           )
-        )?.data ?? buildAccountPrometheus([], ss58, { window })
+        )?.data ??
+        // #10322: the cold-tier rung REST and GraphQL gained; without it this
+        // tool alone would answer a confident zero and the three surfaces
+        // would disagree on one event stream.
+        (await loadAccountPrometheusColdTier(ctx.env, ss58, { window }))
+          ?.data ??
+        buildAccountPrometheus([], ss58, { window })
       );
     },
   },

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -19,6 +19,7 @@ vi.mock("pg", () => pg.module);
 
 import {
   loadAccountRegistrationsColdTier,
+  loadAccountPrometheusColdTier,
   loadAccountServingColdTier,
   loadAccountCounterpartiesColdTier,
   loadAccountStakeFlowColdTier,
@@ -948,6 +949,66 @@ describe("loadValidatorNominatorsColdTier", () => {
     failingFetch();
     assert.equal(
       await loadValidatorNominatorsColdTier(TOKEN as never, ADDR, { limit: 5 }),
+      null,
+    );
+  });
+});
+
+// #10322: the rung this family never had. Every surface answered
+// `buildAccountPrometheus([])` while /api/v1/chain/prometheus read the same
+// PrometheusServed stream and reported real numbers.
+describe("loadAccountPrometheusColdTier", () => {
+  const PROM_ROW = {
+    netuid: 112,
+    announcements: "1",
+    first_observed: 1_784_016_000_001,
+    last_observed: 1_785_342_888_001,
+  };
+
+  test("groups PrometheusServed by netuid and reads the announcements column", async () => {
+    const q = sqlFetch([PROM_ROW]);
+    const res = await loadAccountPrometheusColdTier(TOKEN as never, ADDR, {
+      window: "7d",
+    });
+    const sql = q[0]!;
+    // The event kind is the ONLY thing that differs from the serving sibling;
+    // getting it wrong yields a healthy-looking card of somebody else's events.
+    assert.match(sql, /event_kind = 'PrometheusServed'/);
+    assert.match(sql, /COUNT\(\*\) AS announcements/);
+    assert.equal(res!.data.total_announcements, 1);
+    assert.equal(res!.data.window, "7d");
+  });
+
+  test("attributes on the hotkey ALONE, never widening to the coldkey", async () => {
+    const q = sqlFetch([PROM_ROW]);
+    await loadAccountPrometheusColdTier(TOKEN as never, ADDR, {});
+    assert.match(q[0]!, new RegExp(`hotkey = '${ADDR}'`));
+    assert.doesNotMatch(q[0]!, /coldkey/);
+  });
+
+  test("an empty window answers zeros with a null generatedAt", async () => {
+    sqlFetch([]);
+    const res = await loadAccountPrometheusColdTier(TOKEN as never, ADDR);
+    assert.equal(res!.data.total_announcements, 0);
+    assert.equal(res!.generatedAt, null);
+  });
+
+  test("declines an unusable address rather than scanning every account", async () => {
+    const q = sqlFetch([]);
+    assert.equal(
+      await loadAccountPrometheusColdTier(TOKEN as never, "not-an-ss58"),
+      null,
+    );
+    assert.equal(q.length, 0);
+  });
+
+  // DECLINES rather than degrades: a null here lets the caller fall through to
+  // the zeroed builder, which is a different answer from "zero announcements".
+  test("declines when the lakehouse cannot answer", async () => {
+    globalThis.fetch = (async () =>
+      new Response("nope", { status: 500 })) as typeof fetch;
+    assert.equal(
+      await loadAccountPrometheusColdTier(TOKEN as never, ADDR),
       null,
     );
   });

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -254,20 +254,13 @@ const NO_TIER_ANYWHERE: Record<string, string> = {
   get_subnet_axon_removals:
     "the MCP twin of subnet_axon_removals -- same absent lane",
 
-  // ── PROMETHEUS. Never curated into a tier on any surface (#10248 wired the
-  // cold rung for the chain-level card; these three remain uncurated). All
-  // three surfaces bottom out in the same empty builder, so they agree -- which
-  // is what makes this a lane question rather than a wiring bug.
-  account_prometheus:
-    "get_account_prometheus falls to buildAccountPrometheus([]) on MCP too -- no lane exists for it",
-  subnet_prometheus:
-    "get_subnet_prometheus falls to buildSubnetPrometheus(null) on MCP too -- no lane exists for it",
-  handleSubnetPrometheus:
-    "the REST twin of subnet_prometheus -- same uncurated lane, same correct empty",
-  get_account_prometheus:
-    "the MCP twin of account_prometheus -- same uncurated lane",
-  get_subnet_prometheus:
-    "the MCP twin of subnet_prometheus -- same uncurated lane",
+  // ── PROMETHEUS is no longer here (#10322). The entries said all surfaces
+  // "agree, which is what makes this a lane question rather than a wiring
+  // bug" -- and that was false: /api/v1/chain/prometheus read the same
+  // PrometheusServed stream through CHAIN_PROMETHEUS_ROLLUP and reported
+  // netuid 112 with 1 exporter over 30d, while the per-subnet, per-account and
+  // GraphQL cards all answered 0 for it. They agreed with each other and
+  // disagreed with the chain card. All four now take the same cold rung.
 };
 
 // Positive control. A pure "nothing is broken" assertion passes just as well

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -20,6 +20,7 @@
 import { loadSubnetWeightSettersColdTier } from "../../src/subnet-weight-setters-loader.ts";
 import { loadSubnetWeightsColdTier } from "../../src/subnet-weights-loader.ts";
 import { loadSubnetEventCardColdTier } from "../../src/subnet-event-card-loader.ts";
+import { CHAIN_PROMETHEUS_ROLLUP } from "../../src/chain-event-rollup-cold-tier.ts";
 import {
   CHAIN_SERVING_ROLLUP,
   CHAIN_STAKE_MOVES_ROLLUP,
@@ -246,6 +247,7 @@ import {
 } from "../../src/chain-detail-hot-tier.ts";
 import {
   loadAccountRegistrationsColdTier,
+  loadAccountPrometheusColdTier,
   loadAccountServingColdTier,
   loadAccountCounterpartiesColdTier,
   loadAccountStakeFlowColdTier,
@@ -2812,6 +2814,24 @@ export async function handleSubnetPrometheus(
       request,
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
     )) as ReturnType<typeof buildSubnetPrometheus> | null) ??
+    // #10322: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired", so the tier above declines unconditionally and the zeroed
+    // builder below was the only thing left -- a confident 0 for every subnet,
+    // while /api/v1/chain/prometheus reads the SAME PrometheusServed stream
+    // through CHAIN_PROMETHEUS_ROLLUP and answers. Measured 2026-08-10: the
+    // chain card reported netuid 112 with 1 exporter and 1 announcement over
+    // 30d while this route answered 0 for that same subnet, so the two
+    // contradicted each other on one event stream.
+    (await loadSubnetEventCardColdTier(
+      env as unknown as Parameters<typeof loadSubnetEventCardColdTier>[0],
+      CHAIN_PROMETHEUS_ROLLUP,
+      netuid,
+      buildSubnetPrometheus,
+      {
+        windowLabel: windowParam,
+        windowDays: SUBNET_PROMETHEUS_WINDOWS[windowParam] ?? 7,
+      },
+    )) ??
     buildSubnetPrometheus(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed PrometheusServed event, mirroring the sibling serving route.
@@ -4448,6 +4468,13 @@ export const handleAccountPrometheus = makeAccountEventHandler({
   defaultWindow: DEFAULT_PROMETHEUS_WINDOW,
   build: buildAccountPrometheus,
   urlSuffix: "prometheus",
+  // #10322: the rung this family never had. Without it the handler fell to
+  // `buildAccountPrometheus([])` for every account, because
+  // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" so the tier above declines
+  // unconditionally -- a confident zero while the chain-level card answered
+  // from the same PrometheusServed stream.
+  coldTier: (env, ss58, window) =>
+    loadAccountPrometheusColdTier(env, ss58, { window }),
 });
 
 // GET /api/v1/accounts/{ss58}/deregistrations: the account's per-subnet NeuronDeregistered footprint


### PR DESCRIPTION
## Summary

- #10322 read this as GraphQL lagging its REST and MCP twins. **None of the three had the rung** — the
  issue's premise that #10317 wired REST and MCP does not survive checking.
- It was a **wrong answer, not an absent lane**: the chain card and the subnet card contradicted each
  other on one event stream.
- All four surfaces now take the same cold rung.

## The measurement

```
/api/v1/chain/prometheus?window=30d        subnets: [{netuid: 112,
                                                     distinct_exporters: 1,
                                                     announcements: 1}]

/api/v1/subnets/112/prometheus?window=30d  distinct_exporters: 0,
                                           announcements: 0,
                                           observed_at: null
```

Same `PrometheusServed` stream, same window, same subnet, opposite answers. The chain card reads it
through `CHAIN_PROMETHEUS_ROLLUP` (#10248); the per-subnet and per-account cards bottomed out in the
zeroed builder because `METAGRAPH_ACCOUNT_EVENTS_SOURCE` reads `"retired"`, so the tier above them
declines unconditionally.

**What the issue got wrong**, verified before acting on it:

| | issue said | actually |
|---|---|---|
| `handleSubnetPrometheus` | wired by #10317 | `tryPostgresTier(…) ?? buildSubnetPrometheus(null, …)` — no cold tier |
| `handleAccountPrometheus` | wired by #10317 | `makeAccountEventHandler` with **no** `coldTier`, unlike its deregistrations sibling |
| `loadAccountPrometheusColdTier` | exists | did not exist |

## What changed

| surface | change |
|---|---|
| REST subnet | `loadSubnetEventCardColdTier(CHAIN_PROMETHEUS_ROLLUP, …)` |
| REST account | `coldTier: loadAccountPrometheusColdTier(…)` — **new loader** |
| GraphQL | both resolvers, same fallbacks |
| MCP | both handlers, same fallbacks |

`loadAccountPrometheusColdTier` mirrors `loadAccountServingColdTier` query for query — same shape, same
hotkey-only attribution, differing only in event kind.

**Wiring all four is the point.** Fixing only GraphQL, as the issue asked, would have left MCP
answering zero beside a REST twin that answers — trading a *consistent* wrong answer for an
*inconsistent* one.

## The exemption the gate caught

Removing the GraphQL pair made `handleSubnetPrometheus` stale in `NO_TIER_ANYWHERE`, and
`tests/graphql-tier-cascade.test.ts` **failed until that came out too** — the staleness check doing
exactly its job. Its comment claimed the three surfaces *"agree, which is what makes this a lane
question rather than a wiring bug"*. They agreed with each other and disagreed with the chain card,
which is the reading that framing prevented. All five prometheus entries are gone.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited.
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes are intentional and documented — no schema change; these cards
      already published these fields and answered zero for them.

## Validation

- [x] `npm run lint` / `format:check` / `typecheck` — all exit 0
- [x] `npm run build` — exit 0; `operational-surfaces.json` regenerated and committed
- [x] `npm run validate:contract-drift` — exit 0
- [x] `npx vitest run tests/mcp-server.test.ts tests/graphql-tier-cascade.test.ts tests/graphql-component-parity.test.ts` — **1,430 passed**
- [x] prometheus / account-feeds / subnet-event-card suites — 144 passed, 8 files
- [x] `git diff --check` — exit 0

## Template Used

- `backend-code.md`

Closes #10322