### PR TITLE
feat(owner-cut): the accrual series, and the rate it must not hardcode

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2594,6 +2594,10 @@ export type NetworkParameters = {
   queried_at?: Maybe<Scalars['String']['output']>;
   schema_version: Scalars['Int']['output'];
   stake_threshold_tao?: Maybe<Scalars['Float']['output']>;
+  /** SubnetOwnerCut AS STORED -- the u16 numerator over 65535, null when the storage item is unset, which is its current state on finney. NOT the share the runtime applies. */
+  subnet_owner_cut?: Maybe<Scalars['Float']['output']>;
+  /** The share the runtime actually applies: the stored numerator over 65535, or the runtime default 11796/65535 = 0.17999... when the item is unset. Never 0 from absence -- a zero here would claim subnet owners receive nothing, for every subnet at once. */
+  subnet_owner_cut_effective?: Maybe<Scalars['Float']['output']>;
   tao_weight?: Maybe<Scalars['Float']['output']>;
   total_issuance_tao?: Maybe<Scalars['Float']['output']>;
 };
@@ -9535,6 +9539,8 @@ export type NetworkParametersResolvers<ContextType = GqlContext, ParentType exte
   queried_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   stake_threshold_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  subnet_owner_cut?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  subnet_owner_cut_effective?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   tao_weight?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_issuance_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9001,6 +9001,10 @@ export interface components {
             queried_at?: string | null;
             schema_version: number;
             stake_threshold_tao?: number | null;
+            /** @description SubnetOwnerCut as stored: the u16 numerator over 65535, or null when the storage item is unset (its current state on finney). NOT the share the runtime applies -- read subnet_owner_cut_effective for that. */
+            subnet_owner_cut?: number | null;
+            /** @description The share the runtime actually applies: the stored numerator over 65535, or the runtime default 11796/65535 = 0.17999... when the item is unset. Never 0 from absence. */
+            subnet_owner_cut_effective?: number | null;
             tao_weight?: number | null;
             total_issuance_tao?: number | null;
         } & {
@@ -17571,6 +17575,8 @@ export interface operations {
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "stake_threshold_tao": 0.5,
+                     *         "subnet_owner_cut": 0.5,
+                     *         "subnet_owner_cut_effective": 0.5,
                      *         "tao_weight": 0.5,
                      *         "total_issuance_tao": 0.5
                      *       },
@@ -34632,6 +34638,8 @@ export interface operations {
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "stake_threshold_tao": 0.5,
+                     *         "subnet_owner_cut": 0.5,
+                     *         "subnet_owner_cut_effective": 0.5,
                      *         "tao_weight": 0.5,
                      *         "total_issuance_tao": 0.5
                      *       },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6633,6 +6633,8 @@
             "queried_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "stake_threshold_tao": 0.5,
+            "subnet_owner_cut": 0.5,
+            "subnet_owner_cut_effective": 0.5,
             "tao_weight": 0.5,
             "total_issuance_tao": 0.5
           },
@@ -35761,6 +35763,28 @@
                 "type": "null"
               }
             ]
+          },
+          "subnet_owner_cut": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "SubnetOwnerCut as stored: the u16 numerator over 65535, or null when the storage item is unset (its current state on finney). NOT the share the runtime applies -- read subnet_owner_cut_effective for that."
+          },
+          "subnet_owner_cut_effective": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The share the runtime actually applies: the stored numerator over 65535, or the runtime default 11796/65535 = 0.17999... when the item is unset. Never 0 from absence."
           },
           "tao_weight": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9001,6 +9001,10 @@ export interface components {
             queried_at?: string | null;
             schema_version: number;
             stake_threshold_tao?: number | null;
+            /** @description SubnetOwnerCut as stored: the u16 numerator over 65535, or null when the storage item is unset (its current state on finney). NOT the share the runtime applies -- read subnet_owner_cut_effective for that. */
+            subnet_owner_cut?: number | null;
+            /** @description The share the runtime actually applies: the stored numerator over 65535, or the runtime default 11796/65535 = 0.17999... when the item is unset. Never 0 from absence. */
+            subnet_owner_cut_effective?: number | null;
             tao_weight?: number | null;
             total_issuance_tao?: number | null;
         } & {
@@ -17571,6 +17575,8 @@ export interface operations {
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "stake_threshold_tao": 0.5,
+                     *         "subnet_owner_cut": 0.5,
+                     *         "subnet_owner_cut_effective": 0.5,
                      *         "tao_weight": 0.5,
                      *         "total_issuance_tao": 0.5
                      *       },
@@ -34632,6 +34638,8 @@ export interface operations {
                      *         "queried_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "stake_threshold_tao": 0.5,
+                     *         "subnet_owner_cut": 0.5,
+                     *         "subnet_owner_cut_effective": 0.5,
                      *         "tao_weight": 0.5,
                      *         "total_issuance_tao": 0.5
                      *       },

--- a/schemas-src/routes/network-singletons.ts
+++ b/schemas-src/routes/network-singletons.ts
@@ -50,6 +50,19 @@ export const NetworkParametersArtifactSchema = z
     emission_bar_quantile: z.number().nullable().optional(),
     emission_gate_exponent: z.number().nullable().optional(),
     emission_gate_exponent_effective: z.number().nullable().optional(),
+    // #10484: the owner's share of alpha emission, the same raw/effective pair
+    // and for the same reason -- SubnetOwnerCut is ALSO unset on chain, so the
+    // stored numerator is null and the effective share comes from the runtime
+    // default 11796/65535. A single collapsed field would read 0 for "absent",
+    // which claims subnet owners receive nothing, for every subnet at once.
+    subnet_owner_cut: z.number().nullable().optional().meta({
+      description:
+        "SubnetOwnerCut as stored: the u16 numerator over 65535, or null when the storage item is unset (its current state on finney). NOT the share the runtime applies -- read subnet_owner_cut_effective for that.",
+    }),
+    subnet_owner_cut_effective: z.number().nullable().optional().meta({
+      description:
+        "The share the runtime actually applies: the stored numerator over 65535, or the runtime default 11796/65535 = 0.17999... when the item is unset. Never 0 from absence.",
+    }),
     queried_at: z.string().nullable().optional(),
     // #9078. Required, not optional: it is attached outside the KV cache on
     // every read (src/network-parameters.ts), so there is no response shape

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -4510,6 +4510,10 @@ export const SDL = /* GraphQL */ `
     emission_bar_quantile: Float
     emission_gate_exponent: Float
     emission_gate_exponent_effective: Float
+    "SubnetOwnerCut AS STORED -- the u16 numerator over 65535, null when the storage item is unset, which is its current state on finney. NOT the share the runtime applies."
+    subnet_owner_cut: Float
+    "The share the runtime actually applies: the stored numerator over 65535, or the runtime default 11796/65535 = 0.17999... when the item is unset. Never 0 from absence -- a zero here would claim subnet owners receive nothing, for every subnet at once."
+    subnet_owner_cut_effective: Float
     queried_at: String
     "Per-field { kind, storage } map: every value labelled measured (with the storage item it came from) or reconstructed (ours). READ IT BEFORE CITING block_emission_tao, block_emission_halvings, or emission_gate_exponent_effective -- all three are reconstructed. The first two are derived from TotalIssuance rather than the stale BlockEmission item, and the third is the runtime default whenever the storage item is unset, which is its current state. ADR 0023 decision 5, generalised in #9078."
     field_sources: JSON!

--- a/src/network-parameters.ts
+++ b/src/network-parameters.ts
@@ -61,6 +61,30 @@ export const EMISSION_GATE_BAR_STORAGE_KEY =
 export const EMISSION_BAR_QUANTILE_STORAGE_KEY =
   "0x658faa385070e074c85bf6b568cf0555a772007dde2ed63e0f21b5f9d7f16650";
 // twox128("SubtensorModule") ++ twox128("EmissionGateExponent").
+// twox128("SubtensorModule") ++ twox128("SubnetOwnerCut"). Verified against
+// finney by deriving TaoWeight's key the same way and getting the constant
+// above byte-for-byte.
+export const SUBNET_OWNER_CUT_STORAGE_KEY =
+  "0x658faa385070e074c85bf6b568cf0555e799290d4a088ada42cf32b591c69203";
+
+/**
+ * `DefaultSubnetOwnerCut` -- 11796 over u16::MAX, i.e. 17.999...%.
+ *
+ * THE STORAGE ITEM IS UNSET ON FINNEY, and absent means "use this", NOT zero.
+ * Verified 2026-08-10: state_getStorage returns null for the key above while
+ * TaoWeight, derived identically, returns a value. A reader that coalesces the
+ * absent item to 0 reports ZERO OWNER-CUT ACCRUAL FOR ALL 128 SUBNETS -- a
+ * confidently wrong number that looks measured, which is exactly the failure
+ * DEFAULT_EMISSION_GATE_EXPONENT below exists to prevent for its own item.
+ *
+ * The cut is 18%, not one sixth. At SN64's scale the difference between 16.7%
+ * and 18% is ~6 TAO/day, which would surface as an unexplained residual in the
+ * very reconciliation this feeds (#10440).
+ */
+export const DEFAULT_SUBNET_OWNER_CUT_NUMERATOR = 11796;
+/** u16::MAX -- the denominator SubnetOwnerCut is expressed over. */
+export const SUBNET_OWNER_CUT_DENOMINATOR = 65535;
+
 export const EMISSION_GATE_EXPONENT_STORAGE_KEY =
   "0x658faa385070e074c85bf6b568cf055588c70e8dd0cf4af3aeb977ba2eee1df4";
 
@@ -187,6 +211,14 @@ async function fetchStorageU64(
  * perfectly good 16-byte value is exactly how these three parameters would
  * have read as "unavailable" forever.
  */
+/** A little-endian u16 StorageValue. Exactly four hex digits -- the width
+ * check is the point: decodeLeU64 would reject a u16 and decodeLeU128 a u64,
+ * and a silently wrong width is a silently wrong number. */
+export function decodeLeU16(hex: unknown): number | null {
+  if (typeof hex !== "string" || !/^0x[0-9a-fA-F]{4}$/.test(hex)) return null;
+  return parseInt(hex.slice(4, 6) + hex.slice(2, 4), 16);
+}
+
 export function decodeLeU128(hex: unknown): bigint | null {
   if (typeof hex !== "string" || !/^0x[0-9a-fA-F]{32}$/.test(hex)) {
     return null;
@@ -232,6 +264,49 @@ export function u96f32U128ToFloat(bits: bigint): number {
  */
 type StorageU128Result =
   { state: "value"; bits: bigint } | { state: "unset" } | { state: "failed" };
+
+/**
+ * The RAW hex of a StorageValue, tri-state.
+ *
+ * Width-agnostic on purpose: fetchStorageU64 and fetchStorageU128 each decode
+ * at a fixed width, and SubnetOwnerCut is a u16. Returning the bytes lets the
+ * caller decode at its own width without a third near-identical fetcher.
+ *
+ * `unset` and `failed` stay distinct for the same reason they do above -- for
+ * an item whose absence means "use the runtime default", collapsing them turns
+ * a successful read into a failure, or worse into a zero.
+ */
+type StorageRawResult =
+  { state: "value"; hex: string } | { state: "unset" } | { state: "failed" };
+
+async function fetchStorageRaw(
+  storageKey: string,
+  timeoutMs: number,
+  network?: ChainNetworkId,
+): Promise<StorageRawResult> {
+  try {
+    const rpcResp = await fetch(rpcUrlForNetwork(network), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "state_getStorage",
+        params: [storageKey],
+      }),
+    });
+    if (!rpcResp.ok) return { state: "failed" };
+    const rpcBody = (await rpcResp.json()) as Record<string, unknown>;
+    const raw = rpcBody?.result;
+    if (raw === null) return { state: "unset" };
+    return typeof raw === "string"
+      ? { state: "value", hex: raw }
+      : { state: "failed" };
+  } catch {
+    return { state: "failed" };
+  }
+}
 
 async function fetchStorageU128(
   storageKey: string,
@@ -313,6 +388,14 @@ export const NETWORK_PARAMETERS_FIELD_SOURCES = {
     storage: "SubtensorModule.EmissionGateExponent",
   },
   emission_gate_exponent_effective: { kind: "reconstructed", storage: null },
+  subnet_owner_cut: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetOwnerCut",
+  },
+  // Reconstructed even when the item IS set and the two agree, for the same
+  // reason emission_gate_exponent_effective is: which source it came from
+  // depends on chain state the caller cannot see.
+  subnet_owner_cut_effective: { kind: "reconstructed", storage: null },
 } as const satisfies FieldSources;
 
 /**
@@ -342,6 +425,19 @@ export interface NetworkParametersSnapshot {
   emission_gate_exponent: number | null;
   /** The exponent the gate actually applies: the stored value, or the runtime default. */
   emission_gate_exponent_effective: number | null;
+  /**
+   * SubnetOwnerCut AS STORED -- the u16 numerator, null when the item is unset,
+   * which is its current state on finney. NOT the share the runtime applies;
+   * see the effective field.
+   */
+  subnet_owner_cut: number | null;
+  /**
+   * The share the runtime actually applies: the stored numerator over 65535, or
+   * the runtime default 11796/65535 when the item is unset. NEVER null and
+   * never 0 from absence -- a zero here would report that subnet owners receive
+   * nothing, for every subnet at once.
+   */
+  subnet_owner_cut_effective: number | null;
   queried_at: string;
 }
 
@@ -413,6 +509,7 @@ async function loadNetworkParametersSnapshot(
     emissionGateBarResult,
     emissionBarQuantileResult,
     emissionGateExponentResult,
+    subnetOwnerCutResult,
   ] = await Promise.all([
     // TaoWeight, StakeThreshold and TotalIssuance all declare a 0 default, so
     // they keep fetchStorageU64's implicit whenUnset. Only the cooldown does
@@ -451,6 +548,11 @@ async function loadNetworkParametersSnapshot(
     ),
     fetchStorageU128(
       EMISSION_GATE_EXPONENT_STORAGE_KEY,
+      NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
+      network,
+    ),
+    fetchStorageRaw(
+      SUBNET_OWNER_CUT_STORAGE_KEY,
       NETWORK_PARAMETERS_RPC_TIMEOUT_MS,
       network,
     ),
@@ -504,6 +606,20 @@ async function loadNetworkParametersSnapshot(
       : emissionGateExponentResult.state === "unset"
         ? DEFAULT_EMISSION_GATE_EXPONENT
         : null;
+  // Raw and effective as SEPARATE fields, the same shape emission_gate_exponent
+  // takes: which one a caller is looking at depends on chain state they cannot
+  // see, and a single field whose meaning flips per response is not a contract.
+  const subnetOwnerCutRaw =
+    subnetOwnerCutResult.state === "value"
+      ? decodeLeU16(subnetOwnerCutResult.hex)
+      : null;
+  const subnetOwnerCutEffective =
+    subnetOwnerCutRaw != null
+      ? subnetOwnerCutRaw / SUBNET_OWNER_CUT_DENOMINATOR
+      : subnetOwnerCutResult.state === "unset"
+        ? DEFAULT_SUBNET_OWNER_CUT_NUMERATOR / SUBNET_OWNER_CUT_DENOMINATOR
+        : null;
+
   const rpcOk =
     taoWeight != null &&
     stakeThresholdTao != null &&
@@ -514,7 +630,10 @@ async function loadNetworkParametersSnapshot(
     // "unset" is a successful read, not a failure -- caching it for the full
     // TTL is correct, and treating it as a partial failure would put this
     // whole response on the 10s negative TTL indefinitely.
-    emissionGateExponentResult.state !== "failed";
+    emissionGateExponentResult.state !== "failed" &&
+    // Same reading as the exponent above: "unset" is a successful read of an
+    // item whose absence means the runtime default.
+    subnetOwnerCutResult.state !== "failed";
 
   const payload: NetworkParametersSnapshot = {
     schema_version: 1,
@@ -529,6 +648,8 @@ async function loadNetworkParametersSnapshot(
     emission_bar_quantile: emissionBarQuantile,
     emission_gate_exponent: emissionGateExponent,
     emission_gate_exponent_effective: emissionGateExponentEffective,
+    subnet_owner_cut: subnetOwnerCutRaw,
+    subnet_owner_cut_effective: subnetOwnerCutEffective,
     queried_at: queriedAt,
   };
 

--- a/src/owner-cut-accrual.ts
+++ b/src/owner-cut-accrual.ts
@@ -1,0 +1,193 @@
+// #10484: how much owner cut a subnet accrued, per day.
+//
+// The network hands every subnet owner a share of alpha emission,
+// unconditionally. This is the ACCRUAL half -- what was credited. Where it went
+// afterwards is #10485, and the two are deliberately separate: the amount is
+// knowable from emission alone, the destination is not.
+//
+// THREE THINGS THIS GETS RIGHT THAT A NAIVE VERSION DOES NOT.
+//
+// 1. The cut is 18%, not one sixth. SubnetOwnerCut is 11796/65535 = 0.17999...
+//    At SN64's scale the difference between 16.7% and 18% is ~6 TAO/day
+//    (~$1.2k/day), which would surface as an unexplained residual in exactly
+//    the reconciliation #10440 is built on.
+//
+// 2. The rate is READ, not hardcoded -- and reading it correctly is the whole
+//    difficulty, because `SubtensorModule.SubnetOwnerCut` is UNSET on chain.
+//    src/network-parameters.ts resolves absent to the runtime default and
+//    publishes raw and effective separately; this module takes the effective
+//    share and refuses to invent one. A caller that passes 0 because it read
+//    the raw field gets zero accrual, which is why `owner_cut` is required and
+//    validated rather than defaulted here.
+//
+// 3. The cut is paid in ALPHA. Pricing it needs the subnet's own alpha price at
+//    the instant it accrued, not a window average and not the TAO figure --
+//    alpha is a different token per subnet, and 1 alpha on two subnets is two
+//    different values.
+//
+// ZERO AND NULL ARE DIFFERENT ANSWERS HERE, as everywhere in this epic. A
+// subnet with `owner_cut_enabled: false` genuinely accrues nothing and reports
+// 0 with a stated reason. A subnet whose price or emission we could not read
+// reports null. Collapsing them would say "this owner earned nothing" about a
+// subnet we simply failed to measure.
+
+/** One day of blocks at 12s. Mirrors src/revenue-coverage.ts's own constant. */
+export const BLOCKS_PER_DAY = 7200;
+
+export interface OwnerCutAccrualInput {
+  netuid: number;
+  /** Alpha emitted to the subnet per block, from the economics capture. */
+  alpha_out_per_block: number | null | undefined;
+  /** The subnet's alpha price in TAO, for pricing the alpha share. */
+  alpha_price_tao: number | null | undefined;
+  /** TAO/USD at the instant being priced. Null yields a null USD leg only. */
+  usd_per_tao?: number | null;
+  /**
+   * The share the runtime applies -- network-parameters'
+   * `subnet_owner_cut_effective`, NOT the raw numerator. Null when the
+   * parameter could not be read, which makes the whole accrual null rather
+   * than silently 18%.
+   */
+  owner_cut: number | null | undefined;
+  /**
+   * The subnet's own `owner_cut_enabled` hyperparameter. FALSE accrues zero for
+   * a stated reason; NULL/undefined means we did not read it and must not
+   * assume either way.
+   */
+  owner_cut_enabled?: boolean | null;
+  /** Days this row covers. Defaults to one. */
+  window_days?: number;
+}
+
+export interface OwnerCutAccrual {
+  netuid: number;
+  window_days: number;
+  /** The share applied, echoed so a reader never has to assume 18%. */
+  owner_cut: number | null;
+  /** Alpha credited over the window. Null when unmeasurable. */
+  alpha: number | null;
+  /** That alpha priced in TAO. Null when no alpha price resolves. */
+  tao: number | null;
+  /** That TAO priced in USD. Null when no rate resolves. */
+  usd: number | null;
+  /** Did the subnet accrue at all, as far as we can tell? */
+  accrues: boolean;
+  /** Why the figures are null or zero. Null when they are neither. */
+  reason: string | null;
+}
+
+function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function round(value: number, places = 9): number {
+  const f = 10 ** places;
+  return Math.round(value * f) / f;
+}
+
+/**
+ * One subnet's accrual over a window.
+ *
+ * Never throws: this runs over 128 subnets at a time and one unreadable row
+ * must not take the other 127 with it.
+ */
+export function computeOwnerCutAccrual(
+  input: OwnerCutAccrualInput,
+): OwnerCutAccrual {
+  const window_days = finite(input.window_days) ?? 1;
+  const owner_cut = finite(input.owner_cut);
+  const base: OwnerCutAccrual = {
+    netuid: input.netuid,
+    window_days,
+    owner_cut,
+    alpha: null,
+    tao: null,
+    usd: null,
+    accrues: false,
+    reason: null,
+  };
+
+  // A DISABLED cut is a real zero, and the only zero this function produces.
+  // "The owner receives nothing" is a fact about the subnet; every other empty
+  // answer below is a fact about our reading of it.
+  if (input.owner_cut_enabled === false) {
+    return {
+      ...base,
+      alpha: 0,
+      tao: 0,
+      usd: 0,
+      accrues: false,
+      reason: "owner_cut_enabled is false, so nothing accrues",
+    };
+  }
+  if (owner_cut === null || owner_cut < 0) {
+    return { ...base, reason: "owner cut share not read" };
+  }
+  const alphaPerBlock = finite(input.alpha_out_per_block);
+  if (alphaPerBlock === null || alphaPerBlock < 0) {
+    return { ...base, reason: "alpha_out_emission not read" };
+  }
+
+  const alpha = alphaPerBlock * BLOCKS_PER_DAY * window_days * owner_cut;
+  const alphaPrice = finite(input.alpha_price_tao);
+  // A missing alpha price leaves the ALPHA figure standing. It is the measured
+  // quantity; TAO and USD are conversions of it, and dropping the measurement
+  // because a conversion is unavailable throws away the part we actually know.
+  if (alphaPrice === null || alphaPrice < 0) {
+    return {
+      ...base,
+      alpha: round(alpha),
+      accrues: alpha > 0,
+      reason: "no alpha price, so the TAO and USD legs are unpriced",
+    };
+  }
+  const tao = alpha * alphaPrice;
+  const usdRate = finite(input.usd_per_tao);
+  return {
+    ...base,
+    alpha: round(alpha),
+    tao: round(tao),
+    usd: usdRate !== null && usdRate > 0 ? round(tao * usdRate, 6) : null,
+    accrues: alpha > 0,
+    reason:
+      usdRate !== null && usdRate > 0
+        ? null
+        : "no TAO/USD rate, so the USD leg is unpriced",
+  };
+}
+
+/**
+ * The whole network's accrual for one window.
+ *
+ * A row we cannot read is INCLUDED with null figures rather than dropped --
+ * omitting it would make the measured set look like the whole network, the
+ * same rule the coverage table holds.
+ */
+export function computeOwnerCutAccrualSeries(
+  rows: Array<Record<string, unknown>> | null | undefined,
+  options: {
+    owner_cut: number | null | undefined;
+    usd_per_tao?: number | null;
+    window_days?: number;
+    /** netuid -> owner_cut_enabled, where it was read. */
+    enabledByNetuid?: Map<number, boolean>;
+  },
+): OwnerCutAccrual[] {
+  const out: OwnerCutAccrual[] = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    const netuid = Number(row?.netuid);
+    if (!Number.isInteger(netuid)) continue;
+    out.push(
+      computeOwnerCutAccrual({
+        netuid,
+        alpha_out_per_block: row?.alpha_out_emission as number | null,
+        alpha_price_tao: row?.alpha_price_tao as number | null,
+        usd_per_tao: options.usd_per_tao ?? null,
+        owner_cut: options.owner_cut,
+        owner_cut_enabled: options.enabledByNetuid?.get(netuid) ?? null,
+        window_days: options.window_days,
+      }),
+    );
+  }
+  return out;
+}

--- a/tests/network-parameters.test.ts
+++ b/tests/network-parameters.test.ts
@@ -52,6 +52,9 @@ const BAR_QUANTILE_KEY =
   "0x658faa385070e074c85bf6b568cf0555a772007dde2ed63e0f21b5f9d7f16650";
 const GATE_EXPONENT_KEY =
   "0x658faa385070e074c85bf6b568cf055588c70e8dd0cf4af3aeb977ba2eee1df4";
+// twox128("SubtensorModule") ++ twox128("SubnetOwnerCut").
+const OWNER_CUT_KEY =
+  "0x658faa385070e074c85bf6b568cf0555e799290d4a088ada42cf32b591c69203";
 const GOLDEN_GATE_BAR_RAW = "0xf552a5fa90c449020000000000000000";
 const GOLDEN_GATE_BAR = 0.008938107867512188;
 const GOLDEN_BAR_QUANTILE_RAW = "0x00000000000000c00000000000000000";
@@ -93,7 +96,12 @@ function goldenFetchStub() {
       json: async () => ({
         jsonrpc: "2.0",
         id: 1,
-        result: key === GATE_EXPONENT_KEY ? null : byKey[key],
+        // SubnetOwnerCut is genuinely UNSET on chain too (verified against
+        // finney 2026-08-10), so it returns a real null for the same reason.
+        result:
+          key === GATE_EXPONENT_KEY || key === OWNER_CUT_KEY
+            ? null
+            : byKey[key],
       }),
     };
   };
@@ -141,7 +149,8 @@ describe("loadNetworkParameters", () => {
         assert.ok(seenKeys.has(GATE_BAR_KEY));
         assert.ok(seenKeys.has(BAR_QUANTILE_KEY));
         assert.ok(seenKeys.has(GATE_EXPONENT_KEY));
-        assert.equal(seenKeys.size, 7);
+        assert.ok(seenKeys.has(OWNER_CUT_KEY));
+        assert.equal(seenKeys.size, 8);
       },
     );
   });
@@ -195,6 +204,81 @@ describe("loadNetworkParameters", () => {
         const data = await loadNetworkParameters(mockEnv());
         assert.equal(data.emission_gate_exponent, 4);
         assert.equal(data.emission_gate_exponent_effective, 4);
+      },
+    );
+  });
+
+  // #10484: the same trap as the exponent, on the parameter the entire owner-cut
+  // accrual is multiplied by. Absent means the runtime default 11796/65535;
+  // absent read as 0 would report that subnet owners receive NOTHING, for all
+  // 128 subnets at once, and it would look like a measurement.
+  test("serves the unset owner cut as null, with the runtime default beside it", async () => {
+    await withFetchStub(goldenFetchStub(), async () => {
+      const data = await loadNetworkParameters(mockEnv());
+      assert.equal(data.subnet_owner_cut, null);
+      assert.ok(
+        Math.abs((data.subnet_owner_cut_effective as number) - 11796 / 65535) <
+          1e-12,
+      );
+      // 18%, not one sixth. At SN64's scale that difference is ~6 TAO/day.
+      assert.notEqual(data.subnet_owner_cut_effective, 1 / 6);
+      assert.notEqual(data.subnet_owner_cut_effective, 0);
+    });
+  });
+
+  // The day governance sets it, raw and effective must BOTH report it -- the
+  // unset case must not be the only one that works. 11796 as a little-endian
+  // u16 is 0x142e -> "0x142e".
+  test("reports a set owner cut as both the raw numerator and the share", async () => {
+    await withFetchStub(
+      async (_url: unknown, init: Row) => {
+        const key = JSON.parse(init.body).params[0];
+        if (key === OWNER_CUT_KEY) {
+          return {
+            ok: true,
+            json: async () => ({ jsonrpc: "2.0", id: 1, result: "0x1027" }),
+          };
+        }
+        return goldenFetchStub()(_url, init);
+      },
+      async () => {
+        const data = await loadNetworkParameters(mockEnv());
+        // 0x1027 little-endian = 10000.
+        assert.equal(data.subnet_owner_cut, 10000);
+        assert.ok(
+          Math.abs(
+            (data.subnet_owner_cut_effective as number) - 10000 / 65535,
+          ) < 1e-12,
+        );
+      },
+    );
+  });
+
+  // A width mismatch must not decode to a plausible number. decodeLeU16 takes
+  // exactly four hex digits, so a u64-width value is rejected rather than
+  // silently truncated to its low two bytes.
+  test("a wrong-width owner cut decodes to null, not to a truncated value", async () => {
+    await withFetchStub(
+      async (_url: unknown, init: Row) => {
+        const key = JSON.parse(init.body).params[0];
+        if (key === OWNER_CUT_KEY) {
+          return {
+            ok: true,
+            json: async () => ({
+              jsonrpc: "2.0",
+              id: 1,
+              result: "0x1027000000000000",
+            }),
+          };
+        }
+        return goldenFetchStub()(_url, init);
+      },
+      async () => {
+        const data = await loadNetworkParameters(mockEnv());
+        assert.equal(data.subnet_owner_cut, null);
+        // A failed DECODE is not an unset item, so no default is substituted:
+        // reporting 18% here would claim a value we could not read.
+        assert.equal(data.subnet_owner_cut_effective, null);
       },
     );
   });
@@ -455,7 +539,7 @@ describe("loadNetworkParameters", () => {
       },
       async () => {
         await loadNetworkParameters(mockEnv());
-        assert.equal(seenSignals.length, 7);
+        assert.equal(seenSignals.length, 8);
         for (const signal of seenSignals) {
           assert.ok(signal);
           assert.equal(typeof signal.aborted, "boolean");

--- a/tests/owner-cut-accrual.test.ts
+++ b/tests/owner-cut-accrual.test.ts
@@ -1,0 +1,209 @@
+// #10484: the accrual half of the money map.
+//
+// The two mechanics #10440 says a naive design gets wrong are both asserted
+// here: the cut is 18% rather than one sixth, and it is paid in ALPHA, so
+// pricing it needs the subnet's own alpha price rather than a TAO figure.
+//
+// The third, which cost the most to find: SubnetOwnerCut is UNSET on chain, so
+// the share must be READ from network-parameters' effective field. This module
+// refuses to default it -- a caller that passes null gets a null accrual and a
+// stated reason, never a silent 18%.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BLOCKS_PER_DAY,
+  computeOwnerCutAccrual,
+  computeOwnerCutAccrualSeries,
+} from "../src/owner-cut-accrual.ts";
+
+/** The runtime default, the value network-parameters resolves an unset item to. */
+const OWNER_CUT = 11796 / 65535;
+
+/** SN64 as the economics capture reports it. */
+const SN64 = {
+  netuid: 64,
+  alpha_out_per_block: 1,
+  alpha_price_tao: 0.086933658,
+  usd_per_tao: 204.03,
+  owner_cut: OWNER_CUT,
+};
+
+describe("the accrual", () => {
+  test("is 18% of a day's alpha emission, priced through alpha", () => {
+    const r = computeOwnerCutAccrual(SN64);
+    // 1 alpha/block x 7200 x 0.17999... = 1295.9 alpha/day, the figure #10440
+    // quotes as the standing accrual rate.
+    assert.ok(Math.abs((r.alpha as number) - 7200 * OWNER_CUT) < 1e-6);
+    assert.ok(Math.abs((r.alpha as number) - 1295.9) < 0.1);
+    assert.ok(
+      Math.abs((r.tao as number) - (r.alpha as number) * 0.086933658) < 1e-6,
+    );
+    assert.ok(Math.abs((r.usd as number) - (r.tao as number) * 204.03) < 1e-3);
+    assert.equal(r.accrues, true);
+    assert.equal(r.reason, null);
+  });
+
+  test("18%, not one sixth", () => {
+    // The difference is 7200 x (11796/65535 - 1/6) = 95.96 alpha/day, which at
+    // SN64's alpha price is 8.34 TAO/day. #10440 quotes ~6 TAO/day for this
+    // gap; that figure was taken at a different alpha_out_emission, so the
+    // arithmetic is asserted here rather than the epic's number.
+    const correct = computeOwnerCutAccrual(SN64);
+    const sixth = computeOwnerCutAccrual({ ...SN64, owner_cut: 1 / 6 });
+    const deltaAlpha = (correct.alpha as number) - (sixth.alpha as number);
+    assert.ok(
+      Math.abs(deltaAlpha - 7200 * (11796 / 65535 - 1 / 6)) < 1e-6,
+      `delta was ${deltaAlpha} alpha/day`,
+    );
+    // Whatever the emission, the error is real money and one-directional:
+    // one sixth always UNDER-reports what the owner was credited.
+    assert.ok((correct.tao as number) > (sixth.tao as number));
+  });
+
+  test("echoes the share it applied, so nobody has to assume 18%", () => {
+    assert.equal(computeOwnerCutAccrual(SN64).owner_cut, OWNER_CUT);
+  });
+
+  test("scales with the window", () => {
+    const one = computeOwnerCutAccrual(SN64);
+    const seven = computeOwnerCutAccrual({ ...SN64, window_days: 7 });
+    assert.ok(
+      Math.abs((seven.alpha as number) - (one.alpha as number) * 7) < 1e-6,
+    );
+    assert.equal(seven.window_days, 7);
+  });
+});
+
+describe("zero and null are different answers", () => {
+  test("owner_cut_enabled false is a REAL zero, with a reason", () => {
+    // The one zero this function produces: a fact about the subnet, not about
+    // our reading of it.
+    const r = computeOwnerCutAccrual({ ...SN64, owner_cut_enabled: false });
+    assert.equal(r.alpha, 0);
+    assert.equal(r.tao, 0);
+    assert.equal(r.usd, 0);
+    assert.equal(r.accrues, false);
+    assert.match(String(r.reason), /owner_cut_enabled is false/);
+  });
+
+  test("an unread cut share is NULL, never a silent 18%", () => {
+    // The trap this module exists for. SubnetOwnerCut is unset on chain, so a
+    // caller reading the RAW field gets null -- and defaulting here would hide
+    // that the parameter was never resolved.
+    for (const owner_cut of [null, undefined]) {
+      const r = computeOwnerCutAccrual({ ...SN64, owner_cut });
+      assert.equal(r.alpha, null);
+      assert.equal(r.usd, null);
+      assert.equal(r.accrues, false);
+      assert.match(String(r.reason), /owner cut share not read/);
+    }
+  });
+
+  test("a zero share accrues zero rather than being treated as unread", () => {
+    // 0 is a legitimate value for the parameter. It must not read as "missing".
+    const r = computeOwnerCutAccrual({ ...SN64, owner_cut: 0 });
+    assert.equal(r.alpha, 0);
+    assert.equal(r.accrues, false);
+    assert.equal(r.reason, null);
+  });
+
+  test("unreadable emission is null, not zero", () => {
+    for (const alpha_out_per_block of [null, undefined, Number.NaN, -1]) {
+      const r = computeOwnerCutAccrual({ ...SN64, alpha_out_per_block });
+      assert.equal(r.alpha, null);
+      assert.match(String(r.reason), /alpha_out_emission not read/);
+    }
+  });
+
+  test("owner_cut_enabled unknown does not assume either way", () => {
+    // Absent means we did not read it. Accrual still reports, because the
+    // emission is real -- but nothing here claims the flag is true.
+    const r = computeOwnerCutAccrual({ ...SN64, owner_cut_enabled: null });
+    assert.ok((r.alpha as number) > 0);
+  });
+});
+
+describe("pricing degrades one leg at a time", () => {
+  test("no alpha price keeps the ALPHA figure, which is the measured one", () => {
+    // TAO and USD are conversions; dropping the measurement because a
+    // conversion is unavailable throws away the part we actually know.
+    const r = computeOwnerCutAccrual({ ...SN64, alpha_price_tao: null });
+    assert.ok((r.alpha as number) > 0);
+    assert.equal(r.tao, null);
+    assert.equal(r.usd, null);
+    assert.match(String(r.reason), /no alpha price/);
+  });
+
+  test("no TAO/USD rate keeps alpha and TAO", () => {
+    for (const usd_per_tao of [null, 0]) {
+      const r = computeOwnerCutAccrual({ ...SN64, usd_per_tao });
+      assert.ok((r.alpha as number) > 0);
+      assert.ok((r.tao as number) > 0);
+      assert.equal(r.usd, null, `usd_per_tao=${usd_per_tao}`);
+      assert.match(String(r.reason), /no TAO\/USD rate/);
+    }
+  });
+
+  test("alpha is priced through the SUBNET's own price, not a shared one", () => {
+    // 1 alpha on two subnets is two different values; a shared rate would make
+    // the two comparable by token count, which is meaningless.
+    const a = computeOwnerCutAccrual({ ...SN64, alpha_price_tao: 0.1 });
+    const b = computeOwnerCutAccrual({
+      ...SN64,
+      netuid: 51,
+      alpha_price_tao: 0.5,
+    });
+    assert.ok(Math.abs((b.tao as number) / (a.tao as number) - 5) < 1e-9);
+  });
+});
+
+describe("the network series", () => {
+  const ROWS = [
+    { netuid: 64, alpha_out_emission: 1, alpha_price_tao: 0.0869 },
+    { netuid: 51, alpha_out_emission: 0.5, alpha_price_tao: 0.02 },
+    // Unreadable, and included rather than dropped.
+    { netuid: 7, alpha_out_emission: null, alpha_price_tao: null },
+    { netuid: "junk" },
+  ];
+
+  test("includes the unmeasurable rather than dropping them", () => {
+    // Omitting a row would make the measured set look like the whole network.
+    const out = computeOwnerCutAccrualSeries(ROWS, { owner_cut: OWNER_CUT });
+    assert.equal(
+      out.length,
+      3,
+      "the junk netuid is skipped, the null row is not",
+    );
+    const seven = out.find((r) => r.netuid === 7);
+    assert.ok(seven);
+    assert.equal(seven.alpha, null);
+    assert.match(String(seven.reason), /alpha_out_emission not read/);
+  });
+
+  test("applies a per-subnet enabled flag where it was read", () => {
+    const out = computeOwnerCutAccrualSeries(ROWS, {
+      owner_cut: OWNER_CUT,
+      enabledByNetuid: new Map([[51, false]]),
+    });
+    const disabled = out.find((r) => r.netuid === 51);
+    assert.equal(disabled?.alpha, 0);
+    assert.match(String(disabled?.reason), /owner_cut_enabled is false/);
+    // The subnet with no flag read is unaffected.
+    assert.ok((out.find((r) => r.netuid === 64)?.alpha as number) > 0);
+  });
+
+  test("junk input yields no rows rather than throwing", () => {
+    for (const rows of [null, undefined, [], "no" as unknown as []]) {
+      assert.deepEqual(
+        computeOwnerCutAccrualSeries(rows as never, { owner_cut: OWNER_CUT }),
+        [],
+      );
+    }
+  });
+
+  test("BLOCKS_PER_DAY matches the coverage module's own constant", () => {
+    // Two modules computing a daily figure from a per-block one must agree, or
+    // the accrual and the emission denominator drift against each other.
+    assert.equal(BLOCKS_PER_DAY, 7200);
+  });
+});


### PR DESCRIPTION
## The instruction that produces the worst bug if followed literally

#10484 says to read the cut from chain state rather than hardcoding it. Doing exactly that returns `null`:

```
SubtensorModule.SubnetOwnerCut  ->  null
SubtensorModule.TaoWeight       ->  0x7a14ae47e17a142e
```

Both keys derived the same way, and the `TaoWeight` one matches the constant already in `network-parameters.ts` **byte-for-byte** — so the key is right and **the item is genuinely unset on finney.** Absent means the runtime default, not zero.

A reader that coalesces absent to `0` reports **zero owner-cut accrual for all 128 subnets**, and it looks like a measurement rather than a failure. That is the whole difficulty of this issue.

## The capture

Handled the way this file already handles `EmissionGateExponent`, unset for the same reason — a tri-state read, raw and effective as **separate fields**:

- `subnet_owner_cut` — the stored u16 numerator, `null` today
- `subnet_owner_cut_effective` — the share the runtime applies, `11796/65535`

The effective one is labelled `reconstructed` **even when the item is set and the two agree**: which source it came from depends on chain state the caller cannot see, and a field whose `kind` flips per response is not a contract.

`decodeLeU16` is added because the item is a `u16` — `decodeLeU64` and `decodeLeU128` are width-strict, and a silently wrong width is a silently wrong number. A wrong-width value decodes to `null` and **no default is substituted**, because a failed decode is not an unset item.

## Both fields shipped undeclared at first

The route schema is `.passthrough()`, so my two new fields serialised while **every gate stayed green** — the contract simply did not describe the response. Declaring them in Zod immediately made `graphql-component-parity` fail on the missing SDL fields, which is the gate doing its job. Both are now declared in Zod and in the SDL.

## The compute

`src/owner-cut-accrual.ts` is pure and store-free, so #10488 can wire it without this module knowing about a store.

- **Refuses to default the share.** A caller passing `null` gets a null accrual and a stated reason, never a silent 18%.
- **Prices through the subnet's own alpha price.** The cut is paid in alpha, and 1 alpha on two subnets is two different values.
- **Keeps zero and null apart.** `owner_cut_enabled: false` is a real zero *about the subnet*; an unread price or emission is `null` *about our reading of it*.
- **A missing alpha price still reports the ALPHA figure** — that is the measured quantity, and dropping it because a conversion is unavailable throws away what we actually know.
- The network series **includes** unmeasurable subnets with null figures rather than dropping them.

## Verification

- **16 tests**, `0` uncovered lines by diff-intersection on `src/owner-cut-accrual.ts`
- **Full suite: 825 files, 18,883 tests.** Two count assertions move with the eighth storage read (7→8 keys, 7→8 abort signals)
- All 40 CI `validate:*` pass; `build` · `typecheck` · `lint` · `format:check` clean
- Rebased onto `bf59b12b3`; rebuild produced no diff

Closes #10484
