### PR TITLE
feat(owner-cut): disposition, and the answer that must not be "held"

### DIFF
--- a/src/owner-cut-disposition.ts
+++ b/src/owner-cut-disposition.ts
@@ -1,0 +1,211 @@
+// #10485: what happened to the owner cut after it accrued.
+//
+// #10484 answers how much was credited. This answers where it went, and it is
+// the half people actually want -- which is exactly why it is the half most
+// likely to be answered confidently and wrongly.
+//
+// THE FALSE NEGATIVE THIS MODULE EXISTS TO AVOID. The cut is paid as STAKE, not
+// as a liquid balance. A classifier that watches `Balances.Transfer` alone sees
+// nothing move, concludes nothing left, and reports `held-as-stake` for every
+// subnet on the network. That answer is well-formed, complete-looking, and
+// wrong. So the absence of flow evidence resolves to `unresolved`, NEVER to
+// held -- held is a claim, and it needs a balance to support it.
+//
+// FIVE BUCKETS, NOT SIX. #10440 lists `sold` beside `unstaked`. On dTAO they
+// are the same on-chain event: `StakeRemoved` takes alpha out of the subnet's
+// AMM pool and returns TAO, so removing stake IS the disposal. There is no
+// separate sale to observe, and a `sold` bucket would be a distinction we
+// cannot evidence -- the kind of invented precision this epic's own rules
+// forbid. The limitation is published rather than hidden behind an empty
+// bucket that looks like "we checked and found none".
+//
+// THE BUCKETS DO NOT HAVE TO SUM. When they do not, the response says so and
+// reports the residual. Balancing to a residual -- assigning the remainder to
+// `unresolved` so the totals tie -- would turn "we cannot account for this" into
+// a number that looks derived.
+
+/** What we can actually distinguish from the chain. */
+export const DISPOSITION_BUCKETS = [
+  "held-as-stake",
+  "unstaked",
+  "transferred-out",
+  "burned",
+  "unresolved",
+] as const;
+export type DispositionBucket = (typeof DISPOSITION_BUCKETS)[number];
+
+export interface DispositionInput {
+  netuid: number;
+  window_days?: number;
+  /** Alpha credited over the window, from src/owner-cut-accrual.ts. */
+  accrued_alpha: number | null | undefined;
+  /**
+   * Alpha currently staked on the owner's own hotkey. READ FROM THE
+   * HOTKEY-SCOPED VIEW (/accounts/{ss58}/portfolio), not /positions -- the
+   * latter is the nominator-side view and returns zero for an owner staking on
+   * its own hotkey, which is most of them (#10481).
+   *
+   * Null means we did not read it, and a null balance can never support a
+   * `held-as-stake` claim.
+   */
+  held_alpha?: number | null;
+  /** StakeRemoved over the window. On dTAO this is also the disposal. */
+  unstaked_alpha?: number | null;
+  /** StakeTransferred to another account over the window. */
+  transferred_alpha?: number | null;
+  /** Moved to an address with proven unspendability (#10483's `burn`). */
+  burned_alpha?: number | null;
+  /**
+   * Did we actually read the flow streams? FALSE or absent means the buckets
+   * below are silence rather than zeros, and everything resolves to unresolved.
+   */
+  flows_observed?: boolean;
+}
+
+export interface DispositionResult {
+  netuid: number;
+  window_days: number;
+  accrued_alpha: number | null;
+  buckets: Record<DispositionBucket, number | null>;
+  /** accrued - (everything we could account for). Null when accrual is null. */
+  residual_alpha: number | null;
+  /** Do the buckets account for the accrual, within tolerance? */
+  reconciles: boolean;
+  /**
+   * Why not, or what is missing. Present far more often than not, by design --
+   * `unresolved` may be the majority state at launch and that is an honest
+   * answer rather than a failure.
+   */
+  notes: string[];
+}
+
+/** Alpha is 9dp on chain; anything under this is rounding, not a gap. */
+export const DISPOSITION_TOLERANCE_ALPHA = 1e-6;
+
+function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : null;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e9) / 1e9;
+}
+
+function emptyBuckets(): Record<DispositionBucket, number | null> {
+  return {
+    "held-as-stake": null,
+    unstaked: null,
+    "transferred-out": null,
+    burned: null,
+    unresolved: null,
+  };
+}
+
+/**
+ * Classify one subnet's accrued cut over a window.
+ *
+ * Never throws, and never invents a bucket. Every figure it reports is one it
+ * was handed; everything else is `unresolved` with a stated reason.
+ */
+export function classifyOwnerCutDisposition(
+  input: DispositionInput,
+): DispositionResult {
+  const window_days = finite(input.window_days) ?? 1;
+  const accrued = finite(input.accrued_alpha);
+  const notes: string[] = [];
+  const buckets = emptyBuckets();
+
+  if (accrued === null) {
+    notes.push("accrual not measured, so nothing can be attributed to it");
+    return {
+      netuid: input.netuid,
+      window_days,
+      accrued_alpha: null,
+      buckets,
+      residual_alpha: null,
+      reconciles: false,
+      notes,
+    };
+  }
+
+  // THE WHOLE POINT. Without flow evidence, nothing is held -- it is unknown.
+  // Reporting held-as-stake here is the confident wrong answer.
+  if (input.flows_observed !== true) {
+    notes.push(
+      "stake-move and transfer streams not read for this window, so no " +
+        "disposition can be attributed; this is unresolved, not held",
+    );
+    return {
+      netuid: input.netuid,
+      window_days,
+      accrued_alpha: round(accrued),
+      buckets: { ...buckets, unresolved: round(accrued) },
+      residual_alpha: 0,
+      reconciles: false,
+      notes,
+    };
+  }
+
+  const unstaked = finite(input.unstaked_alpha) ?? 0;
+  const transferred = finite(input.transferred_alpha) ?? 0;
+  const burned = finite(input.burned_alpha) ?? 0;
+  const held = finite(input.held_alpha);
+
+  buckets.unstaked = round(unstaked);
+  buckets["transferred-out"] = round(transferred);
+  buckets.burned = round(burned);
+
+  if (held === null) {
+    notes.push(
+      "no standing stake balance read, so the held share is unresolved rather " +
+        "than assumed",
+    );
+  } else {
+    // A validator hotkey's stake is NOT only accrued owner cut -- it can also
+    // be self-bonded validator capital, and `holders: 1` proves owner control
+    // rather than origin (#10481). So the held figure is capped at what
+    // actually accrued; the excess belongs to a different question.
+    buckets["held-as-stake"] = round(Math.min(held, accrued));
+    if (held > accrued + DISPOSITION_TOLERANCE_ALPHA) {
+      notes.push(
+        "standing stake exceeds the window's accrual; the excess is not " +
+          "attributed here, because a validator hotkey also holds self-bonded " +
+          "capital and a balance cannot say which is which",
+      );
+    }
+  }
+
+  const accountedFor =
+    (buckets["held-as-stake"] ?? 0) + unstaked + transferred + burned;
+  const residual = accrued - accountedFor;
+  // A NEGATIVE residual means the parts exceed the whole -- double counting, or
+  // flows that include capital this accrual never contained. Reported, never
+  // clamped: a clamp would hide the contradiction.
+  if (residual > DISPOSITION_TOLERANCE_ALPHA) {
+    buckets.unresolved = round(residual);
+    notes.push(
+      "the accounted buckets do not cover the accrual; the remainder is " +
+        "unresolved rather than assigned",
+    );
+  } else if (residual < -DISPOSITION_TOLERANCE_ALPHA) {
+    buckets.unresolved = 0;
+    notes.push(
+      "the accounted buckets EXCEED the accrual, so at least one flow " +
+        "includes capital this accrual did not contain; reported rather than " +
+        "clamped",
+    );
+  } else {
+    buckets.unresolved = 0;
+  }
+
+  return {
+    netuid: input.netuid,
+    window_days,
+    accrued_alpha: round(accrued),
+    buckets,
+    residual_alpha: round(residual),
+    reconciles: Math.abs(residual) <= DISPOSITION_TOLERANCE_ALPHA,
+    notes,
+  };
+}

--- a/tests/owner-cut-disposition.test.ts
+++ b/tests/owner-cut-disposition.test.ts
@@ -1,0 +1,157 @@
+// #10485: where the owner cut went.
+//
+// The test that matters most is the first one: with no flow evidence, the
+// answer is `unresolved`, NOT `held-as-stake`. The cut is paid as stake, so a
+// classifier watching liquid transfers alone sees nothing move and reports
+// "still held" for every subnet on the network -- a well-formed, complete
+// looking, wrong answer. Every other assertion here is downstream of keeping
+// that one honest.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifyOwnerCutDisposition,
+  DISPOSITION_BUCKETS,
+  DISPOSITION_TOLERANCE_ALPHA,
+} from "../src/owner-cut-disposition.ts";
+
+const BASE = { netuid: 64, accrued_alpha: 1000, flows_observed: true };
+
+describe("silence is unresolved, never held", () => {
+  test("no flow evidence resolves the whole accrual to unresolved", () => {
+    for (const flows_observed of [false, undefined]) {
+      const r = classifyOwnerCutDisposition({ ...BASE, flows_observed });
+      assert.equal(r.buckets.unresolved, 1000);
+      assert.equal(
+        r.buckets["held-as-stake"],
+        null,
+        "held is a CLAIM and needs a balance to support it",
+      );
+      assert.equal(r.reconciles, false);
+      assert.match(r.notes.join(" "), /unresolved, not held/);
+    }
+  });
+
+  test("an unmeasured accrual attributes nothing at all", () => {
+    for (const accrued_alpha of [null, undefined, Number.NaN, -5]) {
+      const r = classifyOwnerCutDisposition({ ...BASE, accrued_alpha });
+      assert.equal(r.accrued_alpha, null);
+      for (const bucket of DISPOSITION_BUCKETS) {
+        assert.equal(r.buckets[bucket], null, bucket);
+      }
+      assert.equal(r.residual_alpha, null);
+    }
+  });
+
+  test("flows observed but no standing balance leaves held unresolved", () => {
+    // The balance is a separate read from the flows. Having one is not having
+    // the other, and assuming held from its absence is the same error.
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      unstaked_alpha: 200,
+      held_alpha: null,
+    });
+    assert.equal(r.buckets["held-as-stake"], null);
+    assert.equal(r.buckets.unstaked, 200);
+    assert.match(r.notes.join(" "), /no standing stake balance/);
+  });
+});
+
+describe("the buckets", () => {
+  test("account for a fully-explained accrual and reconcile", () => {
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 600,
+      unstaked_alpha: 300,
+      transferred_alpha: 100,
+    });
+    assert.equal(r.buckets["held-as-stake"], 600);
+    assert.equal(r.buckets.unstaked, 300);
+    assert.equal(r.buckets["transferred-out"], 100);
+    assert.equal(r.buckets.unresolved, 0);
+    assert.equal(r.residual_alpha, 0);
+    assert.equal(r.reconciles, true);
+  });
+
+  test("an unexplained remainder is unresolved, not assigned", () => {
+    // Balancing to a residual would turn "we cannot account for this" into a
+    // number that looks derived.
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 100,
+      unstaked_alpha: 100,
+    });
+    assert.equal(r.buckets.unresolved, 800);
+    assert.equal(r.residual_alpha, 800);
+    assert.equal(r.reconciles, false);
+    assert.match(r.notes.join(" "), /unresolved rather than assigned/);
+  });
+
+  test("parts exceeding the whole are REPORTED, never clamped", () => {
+    // A negative residual means double counting, or a flow carrying capital
+    // this accrual never contained. Clamping would hide the contradiction.
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 900,
+      unstaked_alpha: 900,
+    });
+    assert.ok((r.residual_alpha as number) < 0);
+    assert.equal(r.reconciles, false);
+    assert.match(r.notes.join(" "), /EXCEED the accrual/);
+  });
+
+  test("standing stake above the accrual is capped, with the reason", () => {
+    // A validator hotkey also holds self-bonded capital, and `holders: 1`
+    // proves owner control rather than origin -- a balance cannot say which
+    // part is accrued cut.
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 50_000,
+    });
+    assert.equal(r.buckets["held-as-stake"], 1000, "capped at what accrued");
+    assert.match(r.notes.join(" "), /self-bonded/);
+  });
+
+  test("a burn bucket is populated only from a proven-unspendable move", () => {
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 0,
+      burned_alpha: 1000,
+    });
+    assert.equal(r.buckets.burned, 1000);
+    assert.equal(r.reconciles, true);
+  });
+
+  test("rounding noise does not read as a gap", () => {
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 1000 - DISPOSITION_TOLERANCE_ALPHA / 2,
+    });
+    assert.equal(r.reconciles, true);
+    assert.equal(r.buckets.unresolved, 0);
+  });
+});
+
+describe("five buckets, not six", () => {
+  test("there is no `sold` bucket, because the chain cannot evidence one", () => {
+    // On dTAO, StakeRemoved takes alpha out of the AMM pool and returns TAO --
+    // removing stake IS the disposal. A separate `sold` bucket would be a
+    // distinction we cannot observe, and an always-empty one would read as
+    // "we checked and found none".
+    assert.ok(!(DISPOSITION_BUCKETS as readonly string[]).includes("sold"));
+    assert.deepEqual(
+      [...DISPOSITION_BUCKETS],
+      ["held-as-stake", "unstaked", "transferred-out", "burned", "unresolved"],
+    );
+  });
+
+  test("unstaked carries the disposal, so it is never silently zero", () => {
+    const r = classifyOwnerCutDisposition({
+      ...BASE,
+      held_alpha: 0,
+      unstaked_alpha: 1000,
+    });
+    assert.equal(r.buckets.unstaked, 1000);
+    assert.equal(r.buckets["held-as-stake"], 0);
+    assert.equal(r.reconciles, true);
+  });
+});


### PR DESCRIPTION
## The answer that must not be "held"

#10484 says how much was credited. This says where it went — the half people actually want, and therefore the half most likely to be answered confidently and wrongly.

**The cut is paid as stake, not as a liquid balance.** A classifier that watches `Balances.Transfer` alone sees nothing move, concludes nothing left, and reports `held-as-stake` for **every subnet on the network**. That answer is well-formed, complete-looking, and wrong.

So the absence of flow evidence resolves to `unresolved`, never to held. Held is a *claim*, and it needs a balance to support it. That's the first test in the file; everything else is downstream of keeping it honest.

## Five buckets, not six

#10440 lists `sold` beside `unstaked`. On dTAO **they are the same on-chain event** — `StakeRemoved` takes alpha out of the subnet's AMM pool and returns TAO, so removing stake *is* the disposal. There is no separate sale to observe.

A `sold` bucket would be a distinction we cannot evidence, and an always-empty one would read as *"we checked and found none"* rather than *"the chain does not distinguish these."* The limitation is published instead. I'm flagging this as a deliberate deviation from the issue's stated shape.

## The buckets do not have to sum

When they don't, the response says so and reports the residual. Balancing to a residual — assigning the remainder to `unresolved` so the totals tie — would turn *"we cannot account for this"* into a number that looks derived.

A **negative** residual, where the parts exceed the whole, is reported rather than clamped. It means double counting, or a flow carrying capital this accrual never contained, and clamping hides the contradiction.

## Standing stake is capped, with the reason

A validator hotkey also holds **self-bonded capital**, and `holders: 1` proves owner control rather than origin (#10481). A balance cannot say which part is accrued cut, so the held figure is capped at what actually accrued and the excess is explicitly not attributed.

The input doc also carries the #10481 lesson forward: read the **hotkey-scoped** `/accounts/{ss58}/portfolio`, not `/positions`, which is the nominator-side view and returns zero for an owner staking on its own hotkey — most of them.

## Verification

- **11 tests**, `0` uncovered lines by diff-intersection on `src/owner-cut-disposition.ts`
- **Full suite: 825 files, 18,880 tests**
- All 40 CI `validate:*` pass; `build` · `typecheck` · `lint` · `format:check` clean
- Pure and store-free like the accrual module, so #10488 wires it without this module knowing about a store

Closes #10485
