### PR TITLE
feat(wallets): declared-wallet activity, without ever deciding whose it is

### DIFF
--- a/src/wallet-activity.ts
+++ b/src/wallet-activity.ts
@@ -1,0 +1,202 @@
+// #10486: what moves through a DECLARED wallet, per window.
+//
+// Aggregation only. Attribution comes from registry/entities/ (#10483) and is
+// never inferred here -- this module is handed a set of addresses somebody
+// already proved belong to somebody, and it reports what moved through them.
+// That separation is the point: a high-volume address receiving from many
+// parties looks exactly like a treasury, and #10448 nearly recorded SN64's own
+// protocol TAO reserve as a Chutes collector on precisely that reasoning. An
+// aggregator that could also decide ownership would make that mistake cheap.
+//
+// TAO AND ALPHA ARE NEVER SUMMED. They are different tokens -- and alpha is a
+// different token PER SUBNET, so even two alpha figures are only comparable
+// when they share a netuid. A single "value moved" field would be the unit trap
+// this epic already catalogues (a path named /tao returning USD), except
+// self-inflicted. Each denomination is reported on its own leg, and a caller
+// that wants one number has to say which rate it used.
+//
+// No new capture: the inputs are the same rows that already power
+// /accounts/{ss58}/transfers (native TAO) and the stake streams (alpha).
+
+/** What kind of movement a row represents. */
+export type WalletFlowDenomination = "tao" | "alpha";
+
+export interface WalletFlowRow {
+  /** The declared address this row belongs to. */
+  address: string;
+  denomination: WalletFlowDenomination;
+  /** Required for alpha: 1 alpha on two subnets is two different values. */
+  netuid?: number | null;
+  direction: "in" | "out";
+  amount: number | null;
+  observed_at?: string | null;
+}
+
+export interface WalletLeg {
+  denomination: WalletFlowDenomination;
+  /** Null for TAO; the subnet whose alpha this is, otherwise. */
+  netuid: number | null;
+  in: number;
+  out: number;
+  /** in - out. Negative is a real answer: more left than arrived. */
+  net: number;
+  events: number;
+}
+
+export interface WalletActivity {
+  address: string;
+  window_days: number;
+  /** One leg per (denomination, netuid). Never collapsed into a total. */
+  legs: WalletLeg[];
+  event_count: number;
+  first_observed_at: string | null;
+  last_observed_at: string | null;
+  /** Rows that could not be attributed to a leg, and why. */
+  skipped: Array<{ reason: string; count: number }>;
+}
+
+function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e9) / 1e9;
+}
+
+function legKey(denomination: string, netuid: number | null): string {
+  return `${denomination}:${netuid ?? "-"}`;
+}
+
+/** TAO sorts before every alpha leg; alpha legs sort by netuid. */
+function legOrder(leg: WalletLeg): number {
+  return leg.denomination === "tao" ? -1 : (leg.netuid as number);
+}
+
+/**
+ * Aggregate one declared wallet's flows.
+ *
+ * Never throws and never drops a row silently: a row it cannot place is counted
+ * in `skipped` with a reason, because a quietly-discarded movement is exactly
+ * the kind of gap that makes a net figure look complete when it is not.
+ */
+export function aggregateWalletActivity(
+  address: string,
+  rows: WalletFlowRow[] | null | undefined,
+  { window_days = 30 }: { window_days?: number } = {},
+): WalletActivity {
+  const legs = new Map<string, WalletLeg>();
+  const skipped = new Map<string, number>();
+  let events = 0;
+  let first: string | null = null;
+  let last: string | null = null;
+
+  const skip = (reason: string) =>
+    skipped.set(reason, (skipped.get(reason) ?? 0) + 1);
+
+  for (const row of Array.isArray(rows) ? rows : []) {
+    if (row?.address !== address) {
+      skip("row belongs to a different address");
+      continue;
+    }
+    const amount = finite(row?.amount);
+    if (amount === null || amount < 0) {
+      skip("amount not readable");
+      continue;
+    }
+    if (row.denomination !== "tao" && row.denomination !== "alpha") {
+      skip("unknown denomination");
+      continue;
+    }
+    // Alpha WITHOUT a netuid cannot be placed on a leg, because there is no
+    // single "alpha" to add it to. Dropping it into a shared bucket is the
+    // exact conflation this module refuses to make.
+    const netuid =
+      row.denomination === "alpha" ? (finite(row.netuid) ?? null) : null;
+    if (row.denomination === "alpha" && netuid === null) {
+      skip("alpha row carries no netuid, so it belongs to no leg");
+      continue;
+    }
+    if (row.direction !== "in" && row.direction !== "out") {
+      skip("direction not readable");
+      continue;
+    }
+
+    const key = legKey(row.denomination, netuid);
+    const leg = legs.get(key) ?? {
+      denomination: row.denomination,
+      netuid,
+      in: 0,
+      out: 0,
+      net: 0,
+      events: 0,
+    };
+    if (row.direction === "in") leg.in = round(leg.in + amount);
+    else leg.out = round(leg.out + amount);
+    leg.net = round(leg.in - leg.out);
+    leg.events += 1;
+    legs.set(key, leg);
+
+    events += 1;
+    const at = typeof row.observed_at === "string" ? row.observed_at : null;
+    if (at) {
+      if (first === null || at < first) first = at;
+      if (last === null || at > last) last = at;
+    }
+  }
+
+  return {
+    address,
+    window_days,
+    // Deterministic order so two callers comparing the same wallet see the
+    // same shape: TAO first, then alpha by netuid. No nullish fallback in the
+    // comparator -- an alpha leg always carries a netuid (enforced above) and
+    // there is at most one TAO leg, so a `?? -1` would be a branch nothing can
+    // reach.
+    legs: [...legs.values()].sort((a, b) => legOrder(a) - legOrder(b)),
+    event_count: events,
+    first_observed_at: first,
+    last_observed_at: last,
+    skipped: [...skipped.entries()].map(([reason, count]) => ({
+      reason,
+      count,
+    })),
+  };
+}
+
+export interface DeclaredWallet {
+  ss58: string;
+  /** The declared role, from registry/entities/. Never derived here. */
+  category: string;
+  netuid?: number | null;
+  /** The evidence, carried through so a consumer never has to re-look it up. */
+  source_urls?: string[];
+}
+
+/**
+ * Every declared wallet's activity for one subnet.
+ *
+ * A declared wallet with NO rows is included with empty legs rather than
+ * dropped -- "we watched this address and nothing moved" is a finding, and
+ * omitting it would make the set of active wallets look like the set of
+ * declared ones.
+ */
+export function aggregateDeclaredWallets(
+  wallets: DeclaredWallet[] | null | undefined,
+  rowsByAddress: Map<string, WalletFlowRow[]> | null | undefined,
+  options: { window_days?: number } = {},
+): Array<DeclaredWallet & { activity: WalletActivity }> {
+  const out: Array<DeclaredWallet & { activity: WalletActivity }> = [];
+  for (const wallet of Array.isArray(wallets) ? wallets : []) {
+    const ss58 = typeof wallet?.ss58 === "string" ? wallet.ss58 : "";
+    if (!ss58) continue;
+    out.push({
+      ...wallet,
+      activity: aggregateWalletActivity(
+        ss58,
+        rowsByAddress?.get(ss58) ?? [],
+        options,
+      ),
+    });
+  }
+  return out;
+}

--- a/tests/wallet-activity.test.ts
+++ b/tests/wallet-activity.test.ts
@@ -1,0 +1,180 @@
+// #10486: what moves through a declared wallet.
+//
+// The load-bearing rule is that TAO and alpha are never summed, and that two
+// alpha figures are only comparable when they share a netuid. A single "value
+// moved" field would be the unit trap this epic already catalogues -- a path
+// named /tao returning USD -- except self-inflicted.
+//
+// The second is that this module never decides ownership. It is handed
+// addresses somebody already proved, and reports what moved through them.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  aggregateDeclaredWallets,
+  aggregateWalletActivity,
+  type WalletFlowRow,
+} from "../src/wallet-activity.ts";
+
+const A = "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9";
+const B = "5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV";
+
+function row(over: Partial<WalletFlowRow> = {}): WalletFlowRow {
+  return {
+    address: A,
+    denomination: "tao",
+    direction: "in",
+    amount: 10,
+    observed_at: "2026-08-10T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("denominations are never mixed", () => {
+  test("TAO and alpha land on separate legs", () => {
+    const r = aggregateWalletActivity(A, [
+      row({ denomination: "tao", amount: 100 }),
+      row({ denomination: "alpha", netuid: 64, amount: 5 }),
+    ]);
+    assert.equal(r.legs.length, 2);
+    const tao = r.legs.find((l) => l.denomination === "tao");
+    const alpha = r.legs.find((l) => l.denomination === "alpha");
+    assert.equal(tao?.in, 100);
+    assert.equal(alpha?.in, 5);
+    // There is deliberately no total field to assert against.
+    assert.ok(!Object.hasOwn(r, "total"));
+  });
+
+  test("alpha on two subnets stays on two legs", () => {
+    // 1 alpha on SN64 and 1 alpha on SN51 are different values; summing them
+    // would produce a number that means nothing.
+    const r = aggregateWalletActivity(A, [
+      row({ denomination: "alpha", netuid: 64, amount: 3 }),
+      row({ denomination: "alpha", netuid: 51, amount: 7 }),
+    ]);
+    assert.equal(r.legs.length, 2);
+    assert.deepEqual(
+      r.legs.map((l) => [l.netuid, l.in]),
+      [
+        [51, 7],
+        [64, 3],
+      ],
+    );
+  });
+
+  test("alpha with no netuid is skipped with a reason, not pooled", () => {
+    // There is no single "alpha" bucket to add it to, so pooling it would be
+    // the exact conflation this module refuses.
+    const r = aggregateWalletActivity(A, [
+      row({ denomination: "alpha", netuid: null, amount: 9 }),
+    ]);
+    assert.equal(r.legs.length, 0);
+    assert.equal(r.event_count, 0);
+    assert.match(r.skipped[0].reason, /no netuid/);
+  });
+});
+
+describe("the arithmetic", () => {
+  test("net is in minus out, and may be negative", () => {
+    // More left than arrived is a real answer about a treasury, not an error.
+    const r = aggregateWalletActivity(A, [
+      row({ direction: "in", amount: 10 }),
+      row({ direction: "out", amount: 25 }),
+    ]);
+    const tao = r.legs[0];
+    assert.equal(tao.in, 10);
+    assert.equal(tao.out, 25);
+    assert.equal(tao.net, -15);
+    assert.equal(tao.events, 2);
+  });
+
+  test("tracks the observed window bounds", () => {
+    const r = aggregateWalletActivity(A, [
+      row({ observed_at: "2026-08-05T00:00:00Z" }),
+      row({ observed_at: "2026-08-09T00:00:00Z" }),
+      row({ observed_at: null }),
+    ]);
+    assert.equal(r.first_observed_at, "2026-08-05T00:00:00Z");
+    assert.equal(r.last_observed_at, "2026-08-09T00:00:00Z");
+    assert.equal(r.event_count, 3, "a stampless row still counts as movement");
+  });
+});
+
+describe("nothing is dropped silently", () => {
+  test("a row for a different address is skipped, with a reason", () => {
+    // Attribution belongs to the registry. A row that arrived here for the
+    // wrong wallet must not quietly become this wallet's flow.
+    const r = aggregateWalletActivity(A, [row({ address: B, amount: 999 })]);
+    assert.equal(r.event_count, 0);
+    assert.match(r.skipped[0].reason, /different address/);
+  });
+
+  test("unreadable rows are counted rather than discarded", () => {
+    // A quietly-discarded movement makes a net figure look complete when it is
+    // not.
+    const r = aggregateWalletActivity(A, [
+      row({ amount: null }),
+      row({ amount: Number.NaN }),
+      row({ amount: -1 }),
+      row({ direction: "sideways" as never }),
+      row({ denomination: "usd" as never }),
+    ]);
+    assert.equal(r.event_count, 0);
+    const total = r.skipped.reduce((s, e) => s + e.count, 0);
+    assert.equal(total, 5);
+    assert.ok(r.skipped.some((e) => /amount not readable/.test(e.reason)));
+    assert.ok(r.skipped.some((e) => /direction/.test(e.reason)));
+    assert.ok(r.skipped.some((e) => /denomination/.test(e.reason)));
+  });
+
+  test("junk input yields an empty activity rather than throwing", () => {
+    for (const rows of [null, undefined, [], "no" as unknown as []]) {
+      const r = aggregateWalletActivity(A, rows as never);
+      assert.equal(r.event_count, 0);
+      assert.deepEqual(r.legs, []);
+    }
+  });
+});
+
+describe("the declared set", () => {
+  const WALLETS = [
+    { ss58: A, category: "treasury", netuid: 64, source_urls: ["https://x"] },
+    { ss58: B, category: "burn", netuid: 64 },
+    { ss58: "", category: "treasury" },
+    // A non-string ss58 is not an address; it must not become one.
+    { ss58: undefined as unknown as string, category: "treasury" },
+  ];
+
+  test("a declared wallet with no rows is INCLUDED, with empty legs", () => {
+    // "We watched this address and nothing moved" is a finding. Dropping it
+    // would make the set of ACTIVE wallets look like the set of DECLARED ones.
+    const out = aggregateDeclaredWallets(
+      WALLETS,
+      new Map([[A, [row({ amount: 42 })]]]),
+    );
+    assert.equal(
+      out.length,
+      2,
+      "the empty and non-string ss58 entries are skipped",
+    );
+    const burn = out.find((w) => w.ss58 === B);
+    assert.ok(burn);
+    assert.deepEqual(burn.activity.legs, []);
+    assert.equal(burn.activity.event_count, 0);
+  });
+
+  test("the declared role and its evidence are carried through untouched", () => {
+    // A consumer reading an attribution must be able to check it without a
+    // second call -- and this module must never be the thing that decided it.
+    const out = aggregateDeclaredWallets(WALLETS, new Map());
+    const treasury = out.find((w) => w.ss58 === A);
+    assert.equal(treasury?.category, "treasury");
+    assert.deepEqual(treasury?.source_urls, ["https://x"]);
+    assert.equal(treasury?.netuid, 64);
+  });
+
+  test("junk input yields no wallets rather than throwing", () => {
+    for (const wallets of [null, undefined, [], "no" as unknown as []]) {
+      assert.deepEqual(aggregateDeclaredWallets(wallets as never, null), []);
+    }
+  });
+});


### PR DESCRIPTION
## Aggregation only — it never decides whose wallet it is

Attribution comes from `registry/entities/` (#10483) and is never inferred here. This module is handed addresses somebody already proved, and reports what moved through them.

That separation is the point rather than tidiness. A high-volume address receiving from many parties **looks exactly like a treasury** — and #10448 nearly recorded SN64's own protocol TAO reserve as a Chutes payment collector on precisely that reasoning. An aggregator that could also decide ownership would make that mistake cheap to repeat.

## TAO and alpha are never summed

And alpha is a different token **per subnet**, so even two alpha figures are only comparable when they share a netuid.

There is deliberately **no `total` field to assert against**. A single "value moved" number would be the unit trap this epic already catalogues — a path named `/tao` returning USD — except self-inflicted. Each denomination gets its own leg, and a caller who wants one number has to say which rate it used.

An alpha row carrying no netuid belongs to no leg and is **skipped rather than pooled**: there is no single "alpha" bucket to add it to.

## Nothing is dropped silently

A row for the wrong address, an unreadable amount, an unknown denomination or direction — each is counted in `skipped` with its reason. A quietly discarded movement is what makes a net figure look complete when it is not.

A declared wallet with **no rows is included** with empty legs rather than omitted. *"We watched this address and nothing moved"* is a finding; dropping it would make the set of **active** wallets look like the set of **declared** ones.

`net` may be negative — more left than arrived is a real answer about a treasury, not an error.

## One branch removed rather than argued around

The leg comparator originally carried `(a.netuid ?? -1)`. An alpha leg always has a netuid (enforced at insertion) and there is at most one TAO leg, so that fallback was a branch nothing could reach. Restructured into a small ordering function with no nullish coalescing, rather than left as dead code the coverage gate would have to be reasoned around.

## Verification

- **11 tests**, `0` uncovered lines by diff-intersection on `src/wallet-activity.ts`
- **Full suite: 827 files, 18,903 tests**
- All 40 CI `validate:*` pass; `build` · `typecheck` · `lint` · `format:check` clean
- No new capture: the inputs are the rows already behind `/accounts/{ss58}/transfers` and the stake streams
- Rebased onto main after #10604 and #10607 merged; `contract-drift` clean afterwards

Closes #10486
