### PR TITLE
docs(ci): drop the duplicated doc header on the export ceiling

### DIFF
--- a/scripts/validate-unreferenced-exports.ts
+++ b/scripts/validate-unreferenced-exports.ts
@@ -54,9 +54,6 @@ import { repoRoot } from "./lib.ts";
 /**
  * The most unreferenced exports allowed. THE CEILING ONLY FALLS.
  *
-/**
- * The most unreferenced exports allowed. THE CEILING ONLY FALLS.
- *
  * 752 after #10582 deleted the 164 precomputed response envelopes.
  *
  * Then lower again (#10586): nothing was deleted.


### PR DESCRIPTION
Closes #10609

A rebase left two `/**` openers and two copies of the title line above `MAX_UNREFERENCED_EXPORTS`.

It parses — a nested `/**` is only comment text, so `tsc` and `prettier` both pass — which is why it survived. It just reads as a mistake to the next person who opens the file.

Verified: `validate:unreferenced-exports` still reports 738 at the ceiling, its 5 tests pass, and tsc/eslint/prettier are clean.