### PR TITLE
feat(wallets): the burn watchdog, and what it refuses to conclude

### DIFF
--- a/src/burn-outflow-watchdog.ts
+++ b/src/burn-outflow-watchdog.ts
@@ -1,0 +1,152 @@
+// #10487: do the tokens they said they burned ever move again?
+//
+// The sharpest question in either money-map epic, and the one with the largest
+// blast radius, so the framing is part of the contract rather than a nicety.
+//
+// A FIRE IS A DISCREPANCY BETWEEN A CLAIM AND THE CHAIN, NOT AN ACCUSATION.
+// Three things can produce one, and only the third is misconduct:
+//
+//   1. OUR ATTRIBUTION IS WRONG -- we labelled an address `burn` that is not
+//      one. Given #10448 nearly recorded a protocol-derived account as a
+//      collector, this is a live possibility and is named first on purpose.
+//   2. THE UNSPENDABILITY PROOF WAS WEAKER THAN IT LOOKED -- an address
+//      believed keyless turning out not to be.
+//   3. The team moved tokens they said were destroyed.
+//
+// Every emitted finding carries all three readings. A watchdog that says "SN X
+// moved burned tokens" has decided between them; this one reports what moved
+// and states that it cannot.
+//
+// WHAT IS NOT A THRESHOLD. A burn address should have EXACTLY zero outbound, so
+// there is no tolerance band to tune -- `min_amount` exists only to floor
+// index noise (a dust row from a decode artefact), not to permit small
+// movements. Sizing it "to the producer cadence" the way a staleness watchdog
+// is sized would be a category error: this lane is not watching for silence.
+//
+// AND IT IS NEVER SUPPRESSED. There is no known-bad state that makes an
+// outbound move from a declared burn address expected -- if one moves, that is
+// precisely the signal, and silencing it because we already know would defeat
+// the only thing this lane does.
+
+import type { DeclaredWallet, WalletFlowRow } from "./wallet-activity.ts";
+
+/** The floor below which a row is index noise rather than a movement. Alpha and
+ * TAO are both 9dp on chain, so anything under a nanounit is not a transfer. */
+export const BURN_OUTFLOW_DUST_FLOOR = 1e-9;
+
+export interface BurnDiscrepancy {
+  address: string;
+  netuid: number | null;
+  denomination: "tao" | "alpha";
+  amount: number;
+  observed_at: string | null;
+  /** The declared evidence for the burn claim, carried so a reader can check
+   * the attribution that produced this finding without a second lookup. */
+  source_urls: string[];
+  /** The wording is fixed here, once, rather than improvised per event. */
+  reading: string;
+}
+
+const READING =
+  "An address declared unspendable shows outbound movement. This is a " +
+  "discrepancy between a published claim and the chain, not a finding of " +
+  "misconduct: our attribution may be wrong, the unspendability proof may " +
+  "have been weaker than it looked, or the tokens may have moved. This lane " +
+  "cannot distinguish those.";
+
+function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Every outbound movement from the declared burn addresses in `wallets`.
+ *
+ * ONE FINDING PER EVENT, with its own amount and stamp -- not a rolling summary.
+ * A summary answers "how much left this quarter", which is a different and less
+ * actionable question than "which movement, when": the second can be looked up
+ * on chain and argued with, the first cannot.
+ */
+export function detectBurnOutflow(
+  wallets: DeclaredWallet[] | null | undefined,
+  rowsByAddress: Map<string, WalletFlowRow[]> | null | undefined,
+  { minAmount = BURN_OUTFLOW_DUST_FLOOR }: { minAmount?: number } = {},
+): BurnDiscrepancy[] {
+  const out: BurnDiscrepancy[] = [];
+  for (const wallet of Array.isArray(wallets) ? wallets : []) {
+    // ONLY declared burns. A treasury moving funds is ordinary activity and
+    // reporting it here would drown the one signal that matters.
+    if (wallet?.category !== "burn") continue;
+    const address = typeof wallet.ss58 === "string" ? wallet.ss58 : "";
+    if (!address) continue;
+
+    for (const row of rowsByAddress?.get(address) ?? []) {
+      if (row?.address !== address) continue;
+      if (row.direction !== "out") continue;
+      const amount = finite(row.amount);
+      if (amount === null || amount <= minAmount) continue;
+      if (row.denomination !== "tao" && row.denomination !== "alpha") continue;
+      out.push({
+        address,
+        netuid:
+          row.denomination === "alpha" ? (finite(row.netuid) ?? null) : null,
+        denomination: row.denomination,
+        amount,
+        observed_at:
+          typeof row.observed_at === "string" ? row.observed_at : null,
+        source_urls: Array.isArray(wallet.source_urls)
+          ? [...wallet.source_urls]
+          : [],
+        reading: READING,
+      });
+    }
+  }
+  return out;
+}
+
+export interface BurnWatchdogResult {
+  /** How many declared burn addresses were watched this pass. */
+  watched: number;
+  findings: BurnDiscrepancy[];
+  /** ok when nothing moved; `alert` on any finding. */
+  verdict: "ok" | "alert" | "idle";
+  detail: string;
+}
+
+/**
+ * One pass.
+ *
+ * `idle` when there is nothing to watch, and it is DELIBERATELY NOT `ok`. Zero
+ * declared burn addresses is the current state of the registry, and a lane that
+ * reports success while watching nothing is indistinguishable from one that
+ * watched something and found it clean -- the exact confusion that let the
+ * revenue probe sit dead for two months (#10566).
+ */
+export function runBurnOutflowWatchdog(
+  wallets: DeclaredWallet[] | null | undefined,
+  rowsByAddress: Map<string, WalletFlowRow[]> | null | undefined,
+  options: { minAmount?: number } = {},
+): BurnWatchdogResult {
+  const declared = (Array.isArray(wallets) ? wallets : []).filter(
+    (w) => w?.category === "burn" && typeof w?.ss58 === "string" && w.ss58,
+  );
+  const findings = detectBurnOutflow(wallets, rowsByAddress, options);
+  if (declared.length === 0) {
+    return {
+      watched: 0,
+      findings: [],
+      verdict: "idle",
+      detail:
+        "no addresses are declared category:burn, so this pass watched " +
+        "nothing -- not the same claim as finding nothing",
+    };
+  }
+  return {
+    watched: declared.length,
+    findings,
+    verdict: findings.length > 0 ? "alert" : "ok",
+    detail:
+      findings.length > 0
+        ? `${findings.length} outbound movement(s) from ${declared.length} declared burn address(es)`
+        : `${declared.length} declared burn address(es), no outbound movement`,
+  };
+}

--- a/tests/burn-outflow-watchdog.test.ts
+++ b/tests/burn-outflow-watchdog.test.ts
@@ -1,0 +1,225 @@
+// #10487: do the tokens they said they burned ever move again?
+//
+// A watchdog that has never fired is indistinguishable from a broken one, so
+// the first requirement is proving it CAN fire. That is done twice here: on
+// crafted rows, and -- because no address is declared `burn` yet -- against
+// real outbound transfers pulled from production and fed in under a synthetic
+// declaration held in memory. See the PR for that run's output.
+//
+// The second requirement is that an empty registry reports IDLE rather than OK.
+// Zero declared burn addresses is the current state, and a lane reporting
+// success while watching nothing is exactly how the revenue probe sat dead for
+// two months (#10566).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  BURN_OUTFLOW_DUST_FLOOR,
+  detectBurnOutflow,
+  runBurnOutflowWatchdog,
+} from "../src/burn-outflow-watchdog.ts";
+import type { WalletFlowRow } from "../src/wallet-activity.ts";
+
+const BURN = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM";
+const TREASURY = "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9";
+
+const declaredBurn = [
+  { ss58: BURN, category: "burn", netuid: 64, source_urls: ["https://x/burn"] },
+];
+
+function row(over: Partial<WalletFlowRow> = {}): WalletFlowRow {
+  return {
+    address: BURN,
+    denomination: "tao",
+    direction: "out",
+    amount: 5,
+    observed_at: "2026-08-10T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("it fires", () => {
+  test("any outbound movement from a declared burn address is a finding", () => {
+    const r = runBurnOutflowWatchdog(declaredBurn, new Map([[BURN, [row()]]]));
+    assert.equal(r.verdict, "alert");
+    assert.equal(r.watched, 1);
+    assert.equal(r.findings.length, 1);
+    assert.equal(r.findings[0].amount, 5);
+  });
+
+  test("one finding PER EVENT, with its own amount and stamp", () => {
+    // A rolling summary answers "how much left this quarter", which cannot be
+    // looked up on chain and argued with. A single movement can.
+    const r = runBurnOutflowWatchdog(
+      declaredBurn,
+      new Map([
+        [
+          BURN,
+          [
+            row({ amount: 1, observed_at: "2026-08-01T00:00:00Z" }),
+            row({ amount: 2, observed_at: "2026-08-02T00:00:00Z" }),
+          ],
+        ],
+      ]),
+    );
+    assert.equal(r.findings.length, 2);
+    assert.deepEqual(
+      r.findings.map((f) => [f.amount, f.observed_at]),
+      [
+        [1, "2026-08-01T00:00:00Z"],
+        [2, "2026-08-02T00:00:00Z"],
+      ],
+    );
+  });
+
+  test("alpha outbound fires too, and carries its netuid", () => {
+    const r = runBurnOutflowWatchdog(
+      declaredBurn,
+      new Map([
+        [BURN, [row({ denomination: "alpha", netuid: 64, amount: 9 })]],
+      ]),
+    );
+    assert.equal(r.findings[0].denomination, "alpha");
+    assert.equal(r.findings[0].netuid, 64);
+  });
+
+  test("every finding carries the evidence behind the claim it contradicts", () => {
+    // A reader must be able to check the ATTRIBUTION without a second lookup --
+    // our own attribution being wrong is the first listed reading.
+    const r = runBurnOutflowWatchdog(declaredBurn, new Map([[BURN, [row()]]]));
+    assert.deepEqual(r.findings[0].source_urls, ["https://x/burn"]);
+  });
+
+  test("the wording is fixed, and refuses to allege intent", () => {
+    // Settled once here rather than improvised per event: this is the
+    // highest-blast-radius thing either epic emits.
+    const [finding] = detectBurnOutflow(
+      declaredBurn,
+      new Map([[BURN, [row()]]]),
+    );
+    assert.match(finding.reading, /not a finding of misconduct/);
+    assert.match(finding.reading, /attribution may be wrong/);
+    assert.match(finding.reading, /cannot distinguish/);
+  });
+});
+
+describe("it does not fire on the wrong things", () => {
+  test("inbound movement is not a discrepancy", () => {
+    // Tokens ARRIVING at a burn address is the burn happening.
+    const r = runBurnOutflowWatchdog(
+      declaredBurn,
+      new Map([[BURN, [row({ direction: "in", amount: 1000 })]]]),
+    );
+    assert.equal(r.verdict, "ok");
+    assert.equal(r.findings.length, 0);
+  });
+
+  test("a treasury moving funds is ordinary activity", () => {
+    // Reporting it here would drown the one signal that matters.
+    const r = runBurnOutflowWatchdog(
+      [{ ss58: TREASURY, category: "treasury" }],
+      new Map([[TREASURY, [row({ address: TREASURY, amount: 10_000 })]]]),
+    );
+    assert.equal(r.verdict, "idle", "no burn addresses were watched at all");
+    assert.equal(r.findings.length, 0);
+  });
+
+  test("dust below the noise floor is not a movement", () => {
+    // The floor is about index artefacts, NOT tolerance: a burn address should
+    // have exactly zero outbound, so there is no band to tune.
+    const r = runBurnOutflowWatchdog(
+      declaredBurn,
+      new Map([[BURN, [row({ amount: BURN_OUTFLOW_DUST_FLOOR / 2 })]]]),
+    );
+    assert.equal(r.findings.length, 0);
+    // But anything above it fires, however small.
+    const fires = runBurnOutflowWatchdog(
+      declaredBurn,
+      new Map([[BURN, [row({ amount: BURN_OUTFLOW_DUST_FLOOR * 10 })]]]),
+    );
+    assert.equal(fires.findings.length, 1);
+  });
+
+  test("unreadable rows do not fabricate a finding", () => {
+    const r = runBurnOutflowWatchdog(
+      declaredBurn,
+      new Map([
+        [
+          BURN,
+          [
+            row({ amount: null }),
+            row({ amount: Number.NaN }),
+            row({ denomination: "usd" as never }),
+            row({ address: TREASURY }),
+          ],
+        ],
+      ]),
+    );
+    assert.equal(r.findings.length, 0);
+    assert.equal(r.verdict, "ok");
+  });
+});
+
+describe("watching nothing is not the same as finding nothing", () => {
+  test("an empty registry is IDLE, never ok", () => {
+    for (const wallets of [
+      null,
+      undefined,
+      [],
+      [{ ss58: "", category: "burn" }],
+    ]) {
+      const r = runBurnOutflowWatchdog(wallets as never, new Map());
+      assert.equal(r.verdict, "idle");
+      assert.equal(r.watched, 0);
+      assert.match(r.detail, /not the same claim as finding nothing/);
+    }
+  });
+
+  test("a declared burn address with no rows is OK, because it WAS watched", () => {
+    const r = runBurnOutflowWatchdog(declaredBurn, new Map());
+    assert.equal(r.verdict, "ok");
+    assert.equal(r.watched, 1);
+  });
+
+  test("degenerate declarations and rows produce no half-formed finding", () => {
+    // Each of these is a shape the registry should never hold, but a watchdog
+    // whose output is read as an allegation must not emit a partial record
+    // from one.
+    const findings = detectBurnOutflow(
+      [
+        // Non-string ss58: not an address, so nothing is watched for it.
+        { ss58: undefined as unknown as string, category: "burn" },
+        // Declared burn with NO evidence -- the finding still carries an empty
+        // source_urls rather than undefined, so a reader sees "no evidence
+        // was recorded" instead of a missing key.
+        { ss58: BURN, category: "burn" },
+      ],
+      new Map([
+        [
+          BURN,
+          [
+            // Alpha with an unreadable netuid still fires -- the movement is
+            // real even when we cannot say which subnet's token it was.
+            row({ denomination: "alpha", netuid: null, amount: 3 }),
+            // A stampless row fires too; the amount is the finding.
+            row({ observed_at: null, amount: 4 }),
+          ],
+        ],
+      ]),
+    );
+    assert.equal(findings.length, 2);
+    const alpha = findings.find((f) => f.denomination === "alpha");
+    assert.equal(alpha?.netuid, null);
+    assert.deepEqual(
+      alpha?.source_urls,
+      [],
+      "no evidence recorded, not absent",
+    );
+    const stampless = findings.find((f) => f.denomination === "tao");
+    assert.equal(stampless?.observed_at, null);
+  });
+
+  test("junk input yields no findings rather than throwing", () => {
+    assert.deepEqual(detectBurnOutflow(null, null), []);
+    assert.deepEqual(detectBurnOutflow("no" as never, new Map()), []);
+  });
+});


### PR DESCRIPTION
## What it refuses to conclude

*"Do the tokens they said they burned ever move again"* is the sharpest question in either money-map epic and the one with the largest blast radius, so the **framing is part of the contract**, not a nicety.

Three things produce a fire, and only the third is misconduct:

1. **Our attribution is wrong** — we labelled an address `burn` that is not one
2. **The unspendability proof was weaker than it looked** — an address believed keyless turning out not to be
3. The team moved tokens they said were destroyed

Every finding carries all three readings and states plainly that this lane cannot distinguish them. The wording is fixed once in the module rather than improvised per event.

**Attribution being wrong is listed first on purpose.** #10448 nearly recorded SN64's own protocol TAO reserve as a payment collector on entirely reasonable inference — so "we labelled this wrong" is a live possibility, not a disclaimer.

## There is no threshold to tune

A burn address should have **exactly zero** outbound. The dust floor rejects index artefacts below a nanounit; it is not a tolerance band. Sizing it "to the producer cadence" the way a staleness watchdog is sized would be a category error — **this lane is not watching for silence.** And it is never suppressed: there is no known-bad state that makes an outbound move from a declared burn address expected.

**One finding per event**, with its own amount and stamp. A rolling summary answers *"how much left this quarter"*, which cannot be looked up on chain and argued with. A single movement can.

## An empty registry reports `idle`, not `ok`

Zero declared burn addresses is the current state, and a lane reporting success while watching nothing is exactly how the revenue probe sat dead for two months (#10566). A declared address with no rows **is** `ok` — it was actually watched.

## Proven against production, with the limit stated

My own rule is that a watchdog which has never fired is indistinguishable from a broken one. No address is declared `burn` yet, so it cannot be run over real declared ones. Instead it was run over **real outbound transfers pulled from the live API** for `5FRYKhbm…AyS9`, fed in under a synthetic declaration held in memory and never written to the registry:

```
verdict: alert   watched: 1   findings: 2
  tao 0.5   2026-08-09T10:44:48.000Z
  tao 45    2026-08-06T08:07:12.000Z

empty registry -> verdict: idle
```

That proves the **detection path** against real chain data. What stays unproven until an attribution issue produces a real burn entry is the **registry read** itself — recorded here rather than glossed.

## Verification

- **13 tests**, `0` uncovered lines by diff-intersection on `src/burn-outflow-watchdog.ts`
- All 40 CI `validate:*` pass; `build` · `typecheck` · `lint` · `format:check` clean
- Rebased onto main after #10608; note that the suite briefly passed while `tsc` failed on a missing import from that PR — vitest held a stale module graph, so tests alone did not prove the import resolved

Closes #10487
