### PR TITLE
perf(freshness): stop the sweep scanning the tables it asks about

### DIFF
--- a/migrations/neon/0017_chain_detail_freshness_indexes.sql
+++ b/migrations/neon/0017_chain_detail_freshness_indexes.sql
@@ -1,0 +1,67 @@
+-- The freshness sweep reads MAX(observed_at) off three chain_detail tables and
+-- gets a parallel sequential scan for it, 2026-08-11.
+--
+-- runTableFreshnessWatchdog (src/table-freshness-watchdog.ts) asks every
+-- declared table for its newest stamp once an hour, and
+-- chain-detail-staleness-watchdog asks again on `14,29,44,59`. Measured against
+-- production:
+--
+--   SELECT MAX(observed_at) FROM chain_detail_chain_events
+--     Parallel Seq Scan  134.347 ms  read=11666 buffers  (92 MB heap, 369k rows)
+--
+-- `chain_detail_account_events` (41 MB) and `chain_detail_extrinsics` (40 MB)
+-- have the same shape and the same absent index. `chain_detail_blocks` is left
+-- alone deliberately: the prune keeps it at ~1,829 rows, so its scan is a
+-- handful of pages and an index would cost more to maintain than it saves.
+--
+-- ## WHY AN INDEX IS RIGHT HERE AND WRONG ON THE SIBLING TABLES
+--
+-- This is the whole reason the file stops at three tables. The same sweep also
+-- scans `neuron_daily` (486 MB, 850 ms) and `account_position_daily` (497 MB,
+-- 551 ms) for MAX(captured_at), and indexing THOSE would be a net loss.
+--
+-- `captured_at` is the freshness stamp: it changes on every upsert. An index on
+-- a column that changes on every write means no update to that table can ever
+-- be HOT again -- Postgres skips the HOT path whenever an indexed column
+-- changes. account_position_daily takes ~10M updates per 3.5 days at a 33.6%
+-- HOT rate today; indexing captured_at would drive that toward zero and add
+-- ~10M index writes, to save roughly a hundred reads. Those two lanes get their
+-- freshness from their tiny `*_passes` companion instead, which carries the
+-- identical stamp in 88 kB.
+--
+-- These three are the opposite case. They are append-and-prune, not upsert:
+--
+--   chain_detail_chain_events    4,952,207 inserts   434 updates  (0.01%)
+--   chain_detail_account_events  3,770,357 inserts   336 updates  (0.01%)
+--   chain_detail_extrinsics        514,688 inserts    45 updates  (0.01%)
+--
+-- With effectively no updates there is no HOT to protect, so the index costs
+-- only what every insert and delete already pays on the other indexes, and buys
+-- a single descent in place of the scan.
+--
+-- BTREE, NOT BRIN, even though `observed_at` is well correlated with physical
+-- order and BRIN would be a fraction of the size. PG 16 stopped summarizing
+-- indexes from blocking HOT updates and this branch is PG 18, so BRIN would be
+-- safe on an upsert table -- but the planner cannot answer a bare MAX() from
+-- BRIN at all. It prunes ranges; it does not descend. The query here is
+-- MAX(), so btree is the only shape that helps.
+--
+-- ## CONCURRENTLY: not in a transaction
+--
+-- As 0011 and 0012. Apply statement by statement; a failed build leaves an
+-- INVALID index to drop before retrying (`SELECT indexrelid::regclass FROM
+-- pg_index WHERE NOT indisvalid`). Every statement is IF NOT EXISTS, so a
+-- half-applied run is re-runnable -- which is what pays for having no rollback.
+-- neon:no-transaction
+
+-- 1. 92 MB, the largest of the three and the one measured above.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_chain_events_observed
+  ON chain_detail_chain_events (observed_at);
+
+-- 2. 41 MB.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_account_events_observed
+  ON chain_detail_account_events (observed_at);
+
+-- 3. 40 MB. Fewer rows than the other two, but the same scan.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chain_detail_extrinsics_observed
+  ON chain_detail_extrinsics (observed_at);

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -67,6 +67,31 @@ export interface FreshnessExpectation {
    * exist.
    */
   producer?: ProducerLane;
+  /**
+   * Read the stamp from a DIFFERENT table that carries the same value.
+   *
+   * WHY A TABLE WOULD NOT ANSWER ITS OWN QUESTION. `captured_at` is the
+   * freshness stamp, so it changes on every upsert -- which means it can never
+   * be indexed on an upsert-heavy table without cost. Postgres skips the HOT
+   * path whenever an indexed column changes, and `account_position_daily`
+   * takes ~10M updates per 3.5 days at a 33.6% HOT rate; an index on
+   * `captured_at` would drive that toward zero and add ~10M index writes to
+   * save the ~24 reads a day this sweep makes. So the choice is not
+   * "index or scan", it is "scan a 497 MB table, or ask something smaller".
+   *
+   * Every lane in PASS_TABLES (src/pass-completeness.ts) already writes a
+   * `*_passes` row per producer pass, carrying the same `captured_at`.
+   * Measured 2026-08-11, `neurons_passes` is 88 kB against
+   * `account_position_daily`'s 497 MB and reports the identical value.
+   *
+   * NOT A FREE SUBSTITUTION, which is why crossCheckSql exists below. A pass
+   * row and the rows it describes are two different writes, so a stamp read
+   * from the pass table asserts "a pass was recorded", not "its rows landed" --
+   * and #9530 is this repo's own case of a freshness signal advancing over data
+   * that had not arrived. The sweep takes the cheap read; the cross-check
+   * proves the two agree and says so out loud when they do not.
+   */
+  stampFrom?: string;
   /** An open issue explaining a table that is ALREADY breaching, so the alarm
    * points somewhere instead of merely being loud. */
   knownIssue?: string;
@@ -162,6 +187,10 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: missedTicksMs("metagraph", 8),
     reason: "8 ticks of METAGRAPH_POLL_SECS (15 min)",
     producer: "metagraph",
+    // The lane this pass table is FOR (src/pass-completeness.ts:57). Redirected
+    // with its two siblings so all three read one 88 kB table rather than three
+    // scans of the same pass.
+    stampFrom: "neurons_passes",
   },
   // Added by 0030 after this map was written -- the same coverage test that
   // caught 0029's two tables caught this one, which is what it is for.
@@ -178,6 +207,11 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: missedTicksMs("metagraph", 8),
     reason: "derived from the same sync",
     producer: "metagraph",
+    // 486 MB, and MAX(captured_at) over it measured 850 ms / 40,344 buffers on
+    // a parallel sequential scan. One metagraph pass writes neurons,
+    // neuron_daily and account_position_daily from the same clock read, so
+    // neurons_passes (88 kB) carries this exact stamp.
+    stampFrom: "neurons_passes",
   },
   account_position_daily: {
     column: "captured_at",
@@ -185,6 +219,8 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: missedTicksMs("metagraph", 8),
     reason: "derived from the same sync",
     producer: "metagraph",
+    // 497 MB, 551 ms / 32,632 buffers. Same pass, same stamp.
+    stampFrom: "neurons_passes",
   },
   subnet_snapshots: {
     column: "captured_at",
@@ -231,6 +267,8 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
     maxAgeMs: missedTicksMs("account_balances", 4),
     reason: "4 ticks of ACCOUNT_BALANCES_POLL_SECS (6h)",
     producer: "account_balances",
+    // 74 MB scanned for a stamp account_balances_passes holds in 80 kB.
+    stampFrom: "account_balances_passes",
   },
   account_balances_passes: {
     column: "captured_at",
@@ -480,8 +518,84 @@ export function freshnessSql(
   spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
 ): string {
   return tables
-    .map((t) => `SELECT '${t}' AS t, MAX(${spec[t].column}) AS mx FROM ${t}`)
+    .map(
+      (t) =>
+        // The label stays `t` -- the caller asked about THIS table and every
+        // downstream map keys on it. Only the FROM moves, so a stampFrom entry
+        // is invisible to staleTables, the verdict, and the alarm text.
+        `SELECT '${t}' AS t, MAX(${spec[t].column}) AS mx FROM ${spec[t].stampFrom ?? t}`,
+    )
     .join(" UNION ALL ");
+}
+
+/**
+ * The other half of `stampFrom`: does the cheap stamp still equal the real one?
+ *
+ * One row per redirected table, carrying both values, so a divergence is
+ * reported as the two numbers rather than as a boolean. Runs on its own cadence
+ * (hourly, beside the sweep) rather than per tick -- the whole point of the
+ * redirect is not to scan these tables every time, and a cross-check that ran
+ * as often as the sweep would give the saving straight back.
+ *
+ * EQUALITY, NOT "CLOSE ENOUGH". Both sides are written by the same producer
+ * pass from the same clock read, so they are equal or something is wrong; a
+ * tolerance here would only be a way to not notice.
+ */
+export function crossCheckSql(
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): string {
+  return Object.entries(spec)
+    .filter(([, e]) => e.stampFrom && e.column !== "")
+    .map(
+      ([t, e]) =>
+        `SELECT '${t}' AS t, ` +
+        `(SELECT MAX(${e.column}) FROM ${e.stampFrom}) AS cheap, ` +
+        `(SELECT MAX(${e.column}) FROM ${t}) AS actual`,
+    )
+    .sort()
+    .join(" UNION ALL ");
+}
+
+/** The entries that read someone else's stamp, and therefore need proving. */
+export function redirectedTables(
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): [string, FreshnessExpectation][] {
+  return Object.entries(spec).filter(
+    ([, e]) => e.stampFrom && e.column !== "",
+  ) as [string, FreshnessExpectation][];
+}
+
+export interface StampDivergence {
+  table: string;
+  stampFrom: string;
+  cheap: number | null;
+  actual: number | null;
+}
+
+/**
+ * Rows where the redirected stamp and the table's own disagree.
+ *
+ * A null on EITHER side counts as a divergence rather than being skipped: an
+ * empty pass table beside a populated fact table is exactly the "the redirect
+ * is reading nothing" failure, and skipping nulls would make it look healthy.
+ * The one exception is both-null, which is a table nothing has written yet.
+ */
+export function stampDivergences(
+  rows: readonly Record<string, unknown>[],
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): StampDivergence[] {
+  const out: StampDivergence[] = [];
+  for (const row of rows) {
+    const table = String(row.t ?? "");
+    const entry = spec[table];
+    if (!entry?.stampFrom) continue;
+    const cheap = row.cheap == null ? null : Number(row.cheap);
+    const actual = row.actual == null ? null : Number(row.actual);
+    if (cheap == null && actual == null) continue;
+    if (cheap === actual) continue;
+    out.push({ table, stampFrom: entry.stampFrom, cheap, actual });
+  }
+  return out;
 }
 
 export interface StaleTable {
@@ -562,11 +676,51 @@ export interface FreshnessDeps {
   spec?: Readonly<Record<string, FreshnessExpectation>>;
 }
 
+/**
+ * Ask whether every redirected stamp still equals the table's own.
+ *
+ * ITS OWN FUNCTION, not inline in the sweep, because the sweep's early returns
+ * make the failure paths here unreachable from outside — and these are exactly
+ * the paths that matter. `failed` and `divergences.length > 0` are different
+ * findings and both have to be provable in a test.
+ *
+ * Resolves its own store rather than taking a db, so an environment that cannot
+ * reach one produces `failed` rather than a crash: no store means the redirect
+ * went unverified this tick, which is a thing to report, not a thing to throw.
+ */
+export async function crossCheckStamps(
+  env: Record<string, unknown> | null | undefined,
+  deps: FreshnessDeps = {},
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): Promise<{ divergences: StampDivergence[]; failed: boolean }> {
+  const redirected = redirectedTables(spec);
+  if (redirected.length === 0) return { divergences: [], failed: false };
+  const involved = redirected.flatMap(([t, e]) => [t, e.stampFrom as string]);
+  const db = deps.db ?? (readStore(env, involved) as FreshnessDb | undefined);
+  try {
+    const result = await db?.prepare(crossCheckSql(spec)).all();
+    if (!result) throw new Error("no result");
+    return {
+      divergences: stampDivergences(
+        (result.results ?? []) as Record<string, unknown>[],
+        spec,
+      ),
+      failed: false,
+    };
+  } catch {
+    return { divergences: [], failed: true };
+  }
+}
+
 export interface FreshnessOutcome {
   attempted: boolean;
   stale?: StaleTable[];
   checked?: number;
   reason?: string;
+  /** Redirected tables whose pass stamp no longer matches their own, empty when
+   * they all agree. Surfaced on the outcome as well as in the lane detail so a
+   * caller can act on the pair of numbers rather than parse the prose. */
+  divergences?: StampDivergence[];
 }
 
 /**
@@ -665,6 +819,43 @@ export async function runTableFreshnessWatchdog(
   }
 
   const stale = staleTables(newest, now(), spec);
+
+  // THE OTHER HALF OF `stampFrom`. Every redirected table above answered from
+  // its pass companion instead of itself, which is only sound while the two
+  // agree. This is the hour's proof that they do -- one UNION carrying both
+  // numbers per redirected table, and the only place these tables are scanned
+  // now.
+  //
+  // A DIVERGENCE IS AN `unknown`, NOT A `stale`. The data may be perfectly
+  // fresh; what has failed is the measurement, and this watchdog's job is to
+  // say what it actually established. Calling it `stale` would report a data
+  // outage that may not exist, and calling it `ok` would publish an age read
+  // off a stamp just proven wrong. #9530 is this repo's own case of a freshness
+  // signal advancing over data that had not arrived -- the redirect is exactly
+  // the shape that could reintroduce it, so it is watched rather than trusted.
+  //
+  // A cross-check that THROWS is also not a green: it means this hour proved
+  // nothing about the redirect. Recorded separately from a divergence, because
+  // "they disagree" and "we could not ask" are different findings.
+  const redirected = redirectedTables(spec);
+  const { divergences, failed: crossCheckFailed } = await crossCheckStamps(
+    env,
+    deps,
+    spec,
+  );
+  const crossCheckDetail =
+    divergences.length > 0
+      ? ` | stampFrom DIVERGED: ${divergences
+          .map(
+            (d) =>
+              `${d.table} reads ${d.cheap} from ${d.stampFrom} but holds ${d.actual}`,
+          )
+          .slice(0, 3)
+          .join("; ")}`
+      : crossCheckFailed
+        ? ` | stampFrom cross-check unreadable (${redirected.length} redirected table(s) unverified this tick)`
+        : "";
+
   // #9866: an unreadable table must reach the VERDICT, not just the detail
   // string. It used to reach only the prose, so a sweep that read 5 of 12
   // batches still published `ok` -- "every table is within its expected age |
@@ -688,7 +879,10 @@ export async function runTableFreshnessWatchdog(
   const verdict =
     stale.length > 0
       ? "stale"
-      : unreadable.length > 0 || measuredNothing
+      : unreadable.length > 0 ||
+          measuredNothing ||
+          divergences.length > 0 ||
+          crossCheckFailed
         ? "unknown"
         : ("ok" as const);
   await recordLaneVerdict(laneDb, {
@@ -699,8 +893,9 @@ export async function runTableFreshnessWatchdog(
       describeStaleTables(stale) +
       (unreadable.length > 0
         ? ` | ${unreadable.length} unreadable: ${unreadable.slice(0, 6).join(", ")}`
-        : ""),
+        : "") +
+      crossCheckDetail,
     checked_at: now(),
   });
-  return { attempted: true, stale, checked: newest.size };
+  return { attempted: true, stale, checked: newest.size, divergences };
 }

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -14,6 +14,8 @@ import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { describe, test } from "vitest";
 import {
+  crossCheckSql,
+  crossCheckStamps,
   describeStaleTables,
   FRESHNESS_BATCH,
   freshnessSql,
@@ -21,6 +23,7 @@ import {
   parseFreshnessRows,
   runTableFreshnessWatchdog,
   staleTables,
+  stampDivergences,
   TABLE_FRESHNESS,
   TABLE_FRESHNESS_LANE,
   type FreshnessExpectation,
@@ -29,7 +32,17 @@ import {
 const HOUR = 60 * 60 * 1000;
 const NOW = 1_785_800_000_000;
 
-function fakeDb(byTable: Record<string, unknown>, failOn: string[] = []) {
+function fakeDb(
+  byTable: Record<string, unknown>,
+  failOn: string[] = [],
+  // The cross-check asks a different shape -- `{t, cheap, actual}` rather than
+  // `{t, mx}` -- so the fake has to answer it as a different statement, not as
+  // the sweep with extra columns.
+  crossCheck: Record<
+    string,
+    { cheap: number | null; actual: number | null }
+  > = {},
+) {
   const calls: string[] = [];
   const written: Record<string, unknown>[] = [];
   return {
@@ -46,6 +59,15 @@ function fakeDb(byTable: Record<string, unknown>, failOn: string[] = []) {
             const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
               (m) => m[1],
             );
+            if (sql.includes("AS cheap")) {
+              return {
+                results: names.map((t) => ({
+                  t,
+                  cheap: crossCheck[t]?.cheap ?? null,
+                  actual: crossCheck[t]?.actual ?? null,
+                })),
+              };
+            }
             return {
               results: names.map((t) => ({ t, mx: byTable[t] ?? null })),
             };
@@ -222,11 +244,73 @@ describe("TABLE_FRESHNESS coverage", () => {
 
 describe("freshnessSql", () => {
   test("asks a batch in one statement", () => {
+    // Two tables that read themselves, so this stays a test about BATCHING.
+    // The redirect has its own tests below.
     assert.equal(
-      freshnessSql(["neurons", "lane_health"]),
-      "SELECT 'neurons' AS t, MAX(captured_at) AS mx FROM neurons UNION ALL " +
+      freshnessSql(["tao_usd_index", "lane_health"]),
+      "SELECT 'tao_usd_index' AS t, MAX(observed_at) AS mx FROM tao_usd_index UNION ALL " +
         "SELECT 'lane_health' AS t, MAX(checked_at) AS mx FROM lane_health",
     );
+  });
+
+  test("a stampFrom entry reads its companion but keeps its own label", () => {
+    // The label is what every downstream map keys on -- staleTables, the
+    // verdict and the alarm text all look up `neurons`. Only the FROM moves.
+    assert.equal(
+      freshnessSql(["neurons"]),
+      "SELECT 'neurons' AS t, MAX(captured_at) AS mx FROM neurons_passes",
+    );
+  });
+
+  test("the metagraph family all redirect to the one pass table", () => {
+    // One 15-minute pass writes all three from the same clock read, so three
+    // scans of 19 MB + 486 MB + 497 MB collapse to one read of 88 kB.
+    for (const t of ["neurons", "neuron_daily", "account_position_daily"]) {
+      assert.match(
+        freshnessSql([t]),
+        /FROM neurons_passes$/,
+        `${t} should read the pass table`,
+      );
+    }
+  });
+
+  test("every stampFrom names a table that is itself swept", () => {
+    // A redirect target that nothing watches would be a blind spot one level
+    // down: the sweep would trust a stamp from a table it never checks.
+    const swept = new Set(freshnessTables());
+    for (const [table, entry] of Object.entries(TABLE_FRESHNESS)) {
+      if (!entry.stampFrom) continue;
+      assert.ok(
+        swept.has(entry.stampFrom),
+        `${table} redirects to ${entry.stampFrom}, which is not swept itself`,
+      );
+    }
+  });
+
+  test("the cross-check asks for both numbers, per redirected table", () => {
+    const spec: Record<string, FreshnessExpectation> = {
+      big: {
+        column: "captured_at",
+        kind: "ms",
+        maxAgeMs: HOUR,
+        reason: "x",
+        stampFrom: "big_passes",
+      },
+      plain: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "y" },
+    };
+    assert.equal(
+      crossCheckSql(spec),
+      "SELECT 'big' AS t, (SELECT MAX(captured_at) FROM big_passes) AS cheap, " +
+        "(SELECT MAX(captured_at) FROM big) AS actual",
+    );
+  });
+
+  test("a table with no stampFrom is not cross-checked", () => {
+    // It reads itself, so there is nothing to disagree with.
+    const spec: Record<string, FreshnessExpectation> = {
+      plain: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "y" },
+    };
+    assert.equal(crossCheckSql(spec), "");
   });
 
   test("batches stay under D1's compound-SELECT term limit", () => {
@@ -238,6 +322,146 @@ describe("freshnessSql", () => {
     const swept = freshnessTables();
     assert.ok(!swept.includes("api_key_blocks"), "no timestamp column");
     assert.ok(swept.includes("neurons"));
+  });
+});
+
+describe("stampDivergences", () => {
+  const spec: Record<string, FreshnessExpectation> = {
+    big: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: HOUR,
+      reason: "x",
+      stampFrom: "big_passes",
+    },
+    plain: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "y" },
+  };
+
+  test("agreement is silence", () => {
+    assert.deepEqual(
+      stampDivergences([{ t: "big", cheap: 1000, actual: 1000 }], spec),
+      [],
+    );
+  });
+
+  test("a disagreement carries BOTH numbers, not a boolean", () => {
+    // Whoever reads the alarm needs to know which way it drifted and by how
+    // much -- "they disagree" is not actionable on its own.
+    assert.deepEqual(
+      stampDivergences([{ t: "big", cheap: 2000, actual: 1000 }], spec),
+      [{ table: "big", stampFrom: "big_passes", cheap: 2000, actual: 1000 }],
+    );
+  });
+
+  test("an empty pass table beside a populated one IS a divergence", () => {
+    // This is the redirect reading nothing at all -- the failure the
+    // cross-check exists for. Skipping nulls would make it look healthy.
+    assert.deepEqual(
+      stampDivergences([{ t: "big", cheap: null, actual: 1000 }], spec),
+      [{ table: "big", stampFrom: "big_passes", cheap: null, actual: 1000 }],
+    );
+  });
+
+  test("both empty is a table nothing has written yet, not a divergence", () => {
+    assert.deepEqual(
+      stampDivergences([{ t: "big", cheap: null, actual: null }], spec),
+      [],
+    );
+  });
+
+  test("a row for a table with no stampFrom is ignored", () => {
+    assert.deepEqual(
+      stampDivergences([{ t: "plain", cheap: 1, actual: 2 }], spec),
+      [],
+    );
+  });
+
+  test("a row with no table name is ignored rather than crashed on", () => {
+    // A store that answers without the label column must not take the sweep
+    // down with it -- the freshness result beside it is still real.
+    assert.deepEqual(stampDivergences([{ cheap: 1, actual: 2 }], spec), []);
+  });
+});
+
+describe("crossCheckStamps", () => {
+  const redirected: Record<string, FreshnessExpectation> = {
+    big: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: HOUR,
+      reason: "x",
+      stampFrom: "big_passes",
+    },
+  };
+  const plainOnly: Record<string, FreshnessExpectation> = {
+    plain: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "y" },
+  };
+
+  test("a spec with no redirects asks nothing and reports no failure", async () => {
+    // Nothing to prove is not the same as failing to prove it.
+    assert.deepEqual(await crossCheckStamps(null, {}, plainOnly), {
+      divergences: [],
+      failed: false,
+    });
+  });
+
+  test("no reachable store is a FAILURE, not a silent pass", async () => {
+    // readStore(null, ...) yields no db. The redirect went unverified this
+    // tick, which the sweep must escalate rather than absorb.
+    assert.deepEqual(await crossCheckStamps(null, {}, redirected), {
+      divergences: [],
+      failed: true,
+    });
+  });
+
+  test("a result with no rows key is treated as agreement, not a crash", async () => {
+    // D1 can answer without a `results` key at all.
+    const db = {
+      prepare() {
+        return {
+          async all() {
+            return {} as { results?: unknown[] };
+          },
+        };
+      },
+    };
+    assert.deepEqual(
+      await crossCheckStamps(null, { db: db as never }, redirected),
+      { divergences: [], failed: false },
+    );
+  });
+
+  test("rows that disagree come back as divergences", async () => {
+    const db = {
+      prepare() {
+        return {
+          async all() {
+            return { results: [{ t: "big", cheap: 2, actual: 1 }] };
+          },
+        };
+      },
+    };
+    const out = await crossCheckStamps(null, { db: db as never }, redirected);
+    assert.equal(out.failed, false);
+    assert.deepEqual(out.divergences, [
+      { table: "big", stampFrom: "big_passes", cheap: 2, actual: 1 },
+    ]);
+  });
+
+  test("a throwing store is a failure, not an exception", async () => {
+    const db = {
+      prepare() {
+        return {
+          async all(): Promise<never> {
+            throw new Error("D1_ERROR: overloaded");
+          },
+        };
+      },
+    };
+    assert.deepEqual(
+      await crossCheckStamps(null, { db: db as never }, redirected),
+      { divergences: [], failed: true },
+    );
   });
 });
 
@@ -364,6 +588,92 @@ describe("runTableFreshnessWatchdog", () => {
     skip: { column: "", kind: "ms", maxAgeMs: null, reason: "no column" },
   };
   const fresh = { a: NOW, b: NOW, c: NOW, d: NOW, e: NOW };
+
+  // --- the stampFrom cross-check ----------------------------------------
+  //
+  // The redirect is only sound while the pass stamp equals the table's own, so
+  // these cover the three outcomes of proving it: agree, disagree, unaskable.
+  const redirectSpec: Record<string, FreshnessExpectation> = {
+    big: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: 8 * HOUR,
+      reason: "redirected",
+      stampFrom: "big_passes",
+    },
+    big_passes: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: 8 * HOUR,
+      reason: "the pass table itself",
+    },
+  };
+
+  test("agreement leaves the verdict alone", async () => {
+    const spy = fakeDb({ big: NOW, big_passes: NOW }, [], {
+      big: { cheap: NOW, actual: NOW },
+    });
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec: redirectSpec,
+    });
+    assert.deepEqual(out.divergences, []);
+    assert.equal(spy.written[0].verdict, "ok");
+    assert.ok(!String(spy.written[0].detail).includes("stampFrom"));
+  });
+
+  test("a divergence is UNKNOWN, not stale, and names both numbers", async () => {
+    // The data may be perfectly fresh -- what failed is the measurement. Saying
+    // "stale" would report an outage that may not exist.
+    const spy = fakeDb({ big: NOW, big_passes: NOW }, [], {
+      big: { cheap: NOW, actual: NOW - 5 * HOUR },
+    });
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec: redirectSpec,
+    });
+    assert.equal(out.divergences?.length, 1);
+    assert.equal(spy.written[0].verdict, "unknown");
+    const detail = String(spy.written[0].detail);
+    assert.ok(detail.includes("stampFrom DIVERGED"), detail);
+    assert.ok(detail.includes(String(NOW)), detail);
+    assert.ok(detail.includes(String(NOW - 5 * HOUR)), detail);
+  });
+
+  test("an unaskable cross-check is UNKNOWN and says so distinctly", async () => {
+    // "they disagree" and "we could not ask" are different findings, and the
+    // detail has to tell them apart or the alarm points nowhere.
+    const spy = fakeDb({ big: NOW, big_passes: NOW }, ["AS cheap"]);
+    const out = await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec: redirectSpec,
+    });
+    assert.deepEqual(out.divergences, []);
+    assert.equal(spy.written[0].verdict, "unknown");
+    const detail = String(spy.written[0].detail);
+    assert.ok(detail.includes("cross-check unreadable"), detail);
+    assert.ok(!detail.includes("DIVERGED"), detail);
+  });
+
+  test("a spec with no redirects never issues a cross-check", async () => {
+    const spy = fakeDb(fresh);
+    await runTableFreshnessWatchdog(null, {
+      db: spy.db,
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      spec,
+    });
+    assert.ok(
+      !spy.calls.some((c) => c.includes("AS cheap")),
+      "nothing to cross-check, so nothing should be asked",
+    );
+  });
 
   test("records OK when every table is within its age", async () => {
     const spy = fakeDb(fresh);


### PR DESCRIPTION
## Summary

The all-tables freshness sweep asked every declared table for `MAX(<stamp>)` and got a parallel
sequential scan on the big ones. Measured against production:

| Query | Before | Plan |
| --- | --- | --- |
| `MAX(captured_at) FROM neuron_daily` | **850 ms**, 40,344 buffers | Parallel Seq Scan (486 MB) |
| `MAX(captured_at) FROM account_position_daily` | **551 ms**, 32,632 buffers | Parallel Seq Scan (497 MB) |
| `MAX(observed_at) FROM chain_detail_chain_events` | **134 ms**, 11,666 buffers | Parallel Seq Scan (92 MB) |

**Two fixes, because these are two different kinds of table.**

### 1. The upsert lanes read their pass companion (`stampFrom`)

An index would be the wrong tool here. `captured_at` is the freshness stamp — it changes on every
write — and Postgres skips the HOT path whenever an indexed column changes.
`account_position_daily` takes ~10M updates per 3.5 days at a 33.6% HOT rate and already carries
242 MB of index against 255 MB of heap; indexing `captured_at` would drive HOT toward zero and add
~10M index writes to save ~24 reads a day.

Every lane in `PASS_TABLES` already writes a `*_passes` row per producer pass carrying the same value.
Verified live — including **across a pass boundary**, which is the property that mattered:

| Source | Size | `max(captured_at)` |
| --- | --- | --- |
| `neurons_passes` | **88 kB**, 324 rows | 1786420904766 |
| `neuron_daily` | 486 MB | 1786420904766 |
| `account_position_daily` | 497 MB | 1786420904766 |

`stampFrom` moves only the `FROM`. The label stays, so `staleTables`, the verdict and the alarm text
are untouched.

### 2. The append-only tables get the index (migration 0017)

`chain_detail_chain_events` / `_account_events` / `_extrinsics` are **0.01% updates** — no HOT to
protect — so a btree on `observed_at` is a pure win. `chain_detail_blocks` stays unindexed; the prune
keeps it at ~1,829 rows.

BRIN was considered and rejected: PG 18 does exempt summarizing indexes from the HOT check, but the
planner cannot answer a bare `MAX()` from BRIN at all — it prunes ranges, it does not descend.

## The redirect is watched, not trusted

A pass row and the rows it describes are two different writes, and #9530 is this repo's own case of a
freshness signal advancing over data that had not arrived. So `crossCheckStamps` reads **both** numbers
hourly and escalates the lane to `unknown` on disagreement — deliberately not `stale`, because the data
may be perfectly fresh and what failed is the *measurement*. It names both values when they diverge,
and says so distinctly when the cross-check itself could not run: "they disagree" and "we could not
ask" are different findings.

## Validation

Branch-tested against a real Neon branch (created, applied, measured, deleted — no leftover compute):

```
MAX(observed_at) FROM chain_detail_chain_events
  before: Parallel Seq Scan  134.347 ms  read=11666 buffers
  after:  Index Only Scan Backward  0.107 ms  6 buffers  (Heap Fetches: 1)
  SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid → empty
```

The generated cross-check SQL was executed against that branch and returned agreement on all four
redirected tables.

| Check | Result |
| --- | --- |
| `npm run lint` / `format:check` / `typecheck` | pass |
| `npm run validate` | pass |
| `npm run validate:migrations` | pass (18 files, sequential) |
| Tests (11 files: freshness, cadence, lane-health, store-ownership, pass-tally, prune, migrate, no-transaction, validate-migrations) | **147 passed** |
| **Patch coverage** (diff-intersected) | **100% statements (37/37), 100% branches (43/43)** |

Rebased onto current `main` and re-validated after the rebase.

Closes #10616
