### PR TITLE
fix(mcp): the refusals agents could not act on, and the analytics that never fired

### DIFF
--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -11,6 +11,7 @@ const startSessionRecording = vi.hoisted(() => vi.fn());
 const stopSessionRecording = vi.hoisted(() => vi.fn());
 const onFeatureFlags = vi.hoisted(() => vi.fn());
 const isFeatureEnabledSpy = vi.hoisted(() => vi.fn());
+const register = vi.hoisted(() => vi.fn());
 
 vi.mock("posthog-js", () => ({
   default: {
@@ -21,6 +22,7 @@ vi.mock("posthog-js", () => ({
     stopSessionRecording,
     onFeatureFlags,
     isFeatureEnabled: isFeatureEnabledSpy,
+    register,
   },
 }));
 
@@ -34,6 +36,7 @@ describe("analytics (PostHog web analytics)", () => {
     stopSessionRecording.mockClear();
     onFeatureFlags.mockClear();
     isFeatureEnabledSpy.mockClear();
+    register.mockClear();
   });
 
   afterEach(() => {
@@ -111,6 +114,23 @@ describe("analytics (PostHog web analytics)", () => {
       expect(options.capture_pageview).toBe(false);
       expect(typeof options.defaults).toBe("string");
       expect(options.defaults.length).toBeGreaterThan(0);
+    });
+
+    // The browser half was the only surface whose events carried no
+    // `environment`, so a developer's `vite dev` exception was indistinguishable
+    // from a production one in Error Tracking. Registered as a SUPER property
+    // on purpose: exception autocapture bypasses this module's wrappers, so a
+    // per-capture-site property would miss exactly the events that need it.
+    it("registers an environment super property on every event", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      const { initAnalytics } = await import("./analytics");
+      initAnalytics();
+      await vi.waitFor(() => expect(register).toHaveBeenCalled());
+      expect(register).toHaveBeenCalledWith({
+        // Vitest runs with import.meta.env.PROD false, which is the branch a
+        // developer's machine takes -- and the whole point of the dimension.
+        environment: "development",
+      });
     });
 
     it("respects DNT and uses localStorage (no-cookie) persistence for cross-visit continuity", async () => {

--- a/apps/ui/src/lib/analytics.test.ts
+++ b/apps/ui/src/lib/analytics.test.ts
@@ -123,6 +123,7 @@ describe("analytics (PostHog web analytics)", () => {
     // per-capture-site property would miss exactly the events that need it.
     it("registers an environment super property on every event", async () => {
       vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      vi.stubEnv("VITE_POSTHOG_RELEASE", "");
       const { initAnalytics } = await import("./analytics");
       initAnalytics();
       await vi.waitFor(() => expect(register).toHaveBeenCalled());
@@ -131,6 +132,36 @@ describe("analytics (PostHog web analytics)", () => {
         // developer's machine takes -- and the whole point of the dimension.
         environment: "development",
       });
+    });
+
+    // vite.config.ts injects this from WORKERS_CI_COMMIT_SHA on deploys only,
+    // so both branches are real: a deploy names its release, a local build has
+    // none to name.
+    it("registers the release when the build injected one", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      vi.stubEnv("VITE_POSTHOG_RELEASE", "abc123def456");
+      const { initAnalytics } = await import("./analytics");
+      initAnalytics();
+      await vi.waitFor(() => expect(register).toHaveBeenCalled());
+      expect(register).toHaveBeenCalledWith({
+        environment: "development",
+        release: "abc123def456",
+        // The field PostHog Error Tracking's own release filter reads, set
+        // alongside the generic one exactly as the Worker's assignDeployment
+        // does.
+        $exception_releases: ["abc123def456"],
+      });
+    });
+
+    it("omits release entirely when the build had none, rather than faking one", async () => {
+      vi.stubEnv("VITE_POSTHOG_PROJECT_TOKEN", "phc_test_token");
+      vi.stubEnv("VITE_POSTHOG_RELEASE", "");
+      const { initAnalytics } = await import("./analytics");
+      initAnalytics();
+      await vi.waitFor(() => expect(register).toHaveBeenCalled());
+      const registered = register.mock.calls[0][0] as Record<string, unknown>;
+      expect("release" in registered).toBe(false);
+      expect("$exception_releases" in registered).toBe(false);
     });
 
     it("respects DNT and uses localStorage (no-cookie) persistence for cross-visit continuity", async () => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -285,6 +285,28 @@ function loadPostHog(): Promise<PostHog | null> {
         // for what this replay rollout reviewed.
         enable_recording_console_log: false,
       });
+      // #8963 gave every Worker-side event an `environment` dimension
+      // (src/usage-telemetry.ts's assignDeployment). The browser half never
+      // got one, so it is the only surface left whose events cannot be
+      // separated from a developer's laptop: measured on the live project,
+      // every `$lib: web` exception in the last three days carries
+      // `environment: (unset)`, while the Worker's carry `production`.
+      //
+      // That matters most for Error Tracking, where it is the difference
+      // between "this is happening to users" and "this is somebody running
+      // `vite dev`". Registered as a super property rather than passed at
+      // each capture site because exception AUTOCAPTURE bypasses this
+      // module's wrappers entirely (the same reason before_send above exists)
+      // -- a per-call-site property would miss exactly the events that need
+      // it most.
+      //
+      // Deliberately environment only, no `release`: #7766 removed the
+      // WORKERS_CI_COMMIT_SHA -> import.meta.env bridge on the grounds that
+      // no client code read it, and re-adding a build-config bridge is a
+      // larger change than this one. import.meta.env.PROD is already there.
+      posthog.register({
+        environment: import.meta.env?.PROD ? "production" : "development",
+      });
       return posthog;
     })
     .catch((err) => {

--- a/apps/ui/src/lib/analytics.ts
+++ b/apps/ui/src/lib/analytics.ts
@@ -91,6 +91,14 @@ const POSTHOG_API_HOST = (import.meta.env?.VITE_POSTHOG_HOST as string | undefin
 const POSTHOG_UI_HOST =
   (import.meta.env?.VITE_POSTHOG_UI_HOST as string | undefined) || "https://us.posthog.com";
 
+// The deploy this bundle came from, injected by vite.config.ts from
+// WORKERS_CI_COMMIT_SHA and equal to posthogRollupPlugin's own
+// `releaseVersion` -- runtime events and uploaded source maps must name the
+// same release for Error Tracking to line them up. Absent locally and in PR
+// CI, where there is no deploy to name; the super property below is simply
+// omitted then rather than registered as a lie like "dev" or "unknown".
+const POSTHOG_RELEASE = (import.meta.env?.VITE_POSTHOG_RELEASE as string | undefined) || undefined;
+
 // Tracks PostHog's own "SDK defaults" versioning (posthog.com/docs/libraries/js#sdk-defaults) --
 // bump deliberately when adopting a newer default set, not on every release.
 // A typo here can't silently fall back to posthog-js's own default handling:
@@ -300,12 +308,19 @@ function loadPostHog(): Promise<PostHog | null> {
       // -- a per-call-site property would miss exactly the events that need
       // it most.
       //
-      // Deliberately environment only, no `release`: #7766 removed the
-      // WORKERS_CI_COMMIT_SHA -> import.meta.env bridge on the grounds that
-      // no client code read it, and re-adding a build-config bridge is a
-      // larger change than this one. import.meta.env.PROD is already there.
+      // `release` rides along when the build knows one, matching the Worker's
+      // pair of dimensions exactly. `$exception_releases` is the field
+      // PostHog Error Tracking's own release filter reads, so it is set
+      // alongside the generic `release` -- the same two-for-one
+      // assignDeployment does server-side.
       posthog.register({
         environment: import.meta.env?.PROD ? "production" : "development",
+        ...(POSTHOG_RELEASE
+          ? {
+              release: POSTHOG_RELEASE,
+              $exception_releases: [POSTHOG_RELEASE],
+            }
+          : {}),
       });
       return posthog;
     })

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -20,6 +20,29 @@ import posthogRollupPlugin from "@posthog/rollup-plugin";
 // already false anyway.
 const commitSha = process.env.WORKERS_CI_COMMIT_SHA;
 
+// #7766 removed the old WORKERS_CI_COMMIT_SHA -> import.meta.env bridge on the
+// grounds that no client code read a release value once Sentry's runtime
+// capture was gone. One now does: analytics.ts registers `release` as a
+// PostHog super property, so a browser `$exception` can be pinned to a deploy
+// the way every Worker-side event already is (src/usage-telemetry.ts's
+// assignDeployment).
+//
+// Re-exposed by SETTING the prefixed variable rather than by a `define` block,
+// which is what #7766 actually removed. Vite's own env loader prioritises
+// inline `process.env` entries matching the `VITE_` prefix, so this reaches
+// `import.meta.env` through exactly the same path as
+// VITE_POSTHOG_PROJECT_TOKEN -- and therefore reads identically at the call
+// site, optional chaining and all. A `define` would not: it is a literal
+// text substitution on `import.meta.env.VITE_POSTHOG_RELEASE`, which the
+// `import.meta.env?.` idiom every other var here uses does not match, so the
+// value would silently resolve to undefined.
+//
+// The VALUE is commitSha, matching posthogRollupPlugin's `releaseVersion`
+// below -- runtime events and the uploaded source maps have to name the same
+// release or Error Tracking cannot line them up. Undefined locally and in PR
+// CI, exactly where sourcemap upload is already off.
+if (commitSha) process.env.VITE_POSTHOG_RELEASE = commitSha;
+
 // @posthog/rollup-plugin's own `writeBundle` hook (the step that actually
 // uploads source maps, node_modules/@posthog/rollup-plugin/src/index.ts) has
 // NO `errorHandler` option, unlike sentryVitePlugin above -- a rejected

--- a/src/field-projection.ts
+++ b/src/field-projection.ts
@@ -54,7 +54,19 @@ export interface FieldProjectionResult {
  * (see {@link unknownAgainstRows}) instead of materialising every row's keys
  * to answer a question that is usually settled by the first row.
  */
-export type UnknownFieldResolver = (requested: string[]) => string[];
+export type UnknownFieldResolver = ((requested: string[]) => string[]) & {
+  /**
+   * The full vocabulary, for the unsupported-field message.
+   *
+   * Separate from the resolver call, and only ever invoked on the ERROR path,
+   * because the two have opposite cost profiles: {@link unknownAgainstRows}
+   * settles a VALID request from the first row and must keep doing so, while
+   * listing every field necessarily materialises the union. Paying that on a
+   * request that has already failed is free; paying it on every request is the
+   * lazy scan thrown away.
+   */
+  known?: () => string[];
+};
 
 /**
  * Resolve against a published row schema -- anything in its shape is a field.
@@ -67,7 +79,10 @@ export function unknownAgainstSchema(schema: {
   shape: Record<string, unknown>;
 }): UnknownFieldResolver {
   const allowed = new Set(Object.keys(schema.shape));
-  return (requested) => requested.filter((field) => !allowed.has(field));
+  const resolve: UnknownFieldResolver = (requested) =>
+    requested.filter((field) => !allowed.has(field));
+  resolve.known = () => [...allowed];
+  return resolve;
 }
 
 /**
@@ -81,7 +96,7 @@ export function unknownAgainstSchema(schema: {
  * workers/list-query.ts did before this module existed.
  */
 export function unknownAgainstRows(rows: Row[]): UnknownFieldResolver {
-  return (requested) => {
+  const resolve: UnknownFieldResolver = (requested) => {
     const unresolved = new Set(requested);
     for (const row of rows) {
       if (unresolved.size === 0) break;
@@ -91,6 +106,19 @@ export function unknownAgainstRows(rows: Row[]): UnknownFieldResolver {
     }
     return [...unresolved];
   };
+  // The full union, which is exactly what the lazy scan above exists to avoid
+  // computing. Safe here only because parseFieldsParam calls it on the error
+  // path alone -- see UnknownFieldResolver.known.
+  resolve.known = () => {
+    const union = new Set<string>();
+    for (const row of rows) {
+      if (row && typeof row === "object" && !Array.isArray(row)) {
+        for (const key of Object.keys(row)) union.add(key);
+      }
+    }
+    return [...union];
+  };
+  return resolve;
 }
 
 /**
@@ -128,10 +156,31 @@ export function parseFieldsParam(
   const fields = [...new Set(requested)];
   const unknown = resolveUnknown(fields);
   if (unknown.length > 0) {
+    // Name the vocabulary, not just the miss. Two live examples of why the
+    // bare form was a dead end, both from production $mcp_tool_call events:
+    //
+    //   get_emission_pipeline  fields=...,name    rows are pure chain state;
+    //                                             `name` is registry metadata
+    //                                             and lives on get_economics
+    //   get_economics          total_stake_tao    the row carries
+    //                                             `total_stake_alpha` -- subnet
+    //                                             stake is alpha-denominated,
+    //                                             so the guessed unit suffix
+    //                                             names nothing
+    //
+    // Both refusals are CORRECT. Both were unactionable, because the caller
+    // was told what it could not have and never what it could -- and in the
+    // second case the field it wanted was one suffix away. This is the same
+    // idiom the tool-argument guards use ("Valid fields: ...").
+    const known = resolveUnknown.known?.() ?? [];
     return {
       error: {
         parameter: "fields",
-        message: `fields includes unsupported field${unknown.length === 1 ? "" : "s"} for ${subject}: ${unknown.join(", ")}.`,
+        message:
+          `fields includes unsupported field${unknown.length === 1 ? "" : "s"} for ${subject}: ${unknown.join(", ")}.` +
+          (known.length > 0
+            ? ` Valid fields: ${[...known].sort().join(", ")}.`
+            : ""),
       },
     };
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -16110,8 +16110,11 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         // (see mcpToolLabel).
         const result = await readResource(params, ctx);
         scheduleMcpResourceReadEvent(ctx, {
-          resourceName:
-            typeof params?.uri === "string" ? params.uri : undefined,
+          // No `typeof ... : undefined` guard: readResource above THREW unless
+          // `uri` matched a resource this server serves, and every one of those
+          // is a string. The false half was unreachable, and codecov counts an
+          // unreachable branch the same as an untested one.
+          resourceName: params.uri as string,
           sessionId: ctx?.sessionId,
           parameters: params,
           response: result,
@@ -16151,8 +16154,9 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         // one of this server's own.
         const prompt = getPrompt(params);
         scheduleMcpPromptGetEvent(ctx, {
-          resourceName:
-            typeof params?.name === "string" ? params.name : undefined,
+          // Same as resources/read above: getPrompt threw unless the name is
+          // one of PROMPTS_BY_NAME's own keys, all of which are strings.
+          resourceName: params.name as string,
           sessionId: ctx?.sessionId,
           parameters: params,
           ...mcpAttributionFor(ctx),

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -201,6 +201,10 @@ import {
   recordAiDegradedEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
+  recordMcpPromptGetEvent,
+  recordMcpPromptsListEvent,
+  recordMcpResourceReadEvent,
+  recordMcpResourcesListEvent,
   recordMcpToolCallEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
@@ -1752,6 +1756,10 @@ interface McpCtx {
   recordMcpToolCallEvent?: AnyFn;
   recordMcpInitializeEvent?: AnyFn;
   recordMcpToolsListEvent?: AnyFn;
+  recordMcpResourcesListEvent?: AnyFn;
+  recordMcpResourceReadEvent?: AnyFn;
+  recordMcpPromptsListEvent?: AnyFn;
+  recordMcpPromptGetEvent?: AnyFn;
   recordExceptionEvent?: AnyFn;
   recordAiDegradedEvent?: AnyFn;
 }
@@ -3737,18 +3745,47 @@ export function validateToolArguments(tool: Row, args: Row) {
   // path skipped them (#10306).
   if (args === undefined || args === null)
     return applyPublishedDefaults(tool, {});
-  if (
-    typeof args !== "object" ||
-    Array.isArray(args) ||
-    (tool.inputSchema?.additionalProperties === false &&
-      Object.keys(args).some(
-        (key) => !Object.hasOwn(tool.inputSchema?.properties ?? {}, key),
-      ))
-  ) {
+  if (typeof args !== "object" || Array.isArray(args)) {
     throw toolError(
       "invalid_params",
-      `Invalid arguments for tool ${tool.name}.`,
+      `Invalid arguments for tool ${tool.name}: expected an object of named arguments.`,
     );
+  }
+  // Naming the rejected key, and what the tool WOULD have accepted, is the
+  // difference between a dead end and a call the agent can retry correctly.
+  //
+  // The bare "Invalid arguments for tool X." this replaced was the single
+  // most common live MCP failure that a caller could not act on: measured on
+  // production $mcp_tool_call events, agents were sending `limit` to tools
+  // that page by `window` (get_subnet_registrations, get_validator_history),
+  // `address` to a tool keyed on `ss58` (get_account_identity), and a filler
+  // `random_string` to a tool that takes nothing (get_self_health) -- then
+  // retrying the identical call, because the refusal named no key and offered
+  // no vocabulary. Every one of those is one list away from self-correcting.
+  //
+  // This does NOT introduce schema validation at dispatch -- that remains
+  // settled against (#8942, tests/mcp-schema-enforcement.test.ts). It reports
+  // the unknown-key rejection this function already performed, in the shape
+  // the handlers' own guards already use ("Valid fields: ...").
+  const declared = (tool.inputSchema?.properties ?? {}) as Record<
+    string,
+    unknown
+  >;
+  if (tool.inputSchema?.additionalProperties === false) {
+    const unknown = Object.keys(args).filter(
+      (key) => !Object.hasOwn(declared, key),
+    );
+    if (unknown.length > 0) {
+      const accepted = Object.keys(declared);
+      throw toolError(
+        "invalid_params",
+        `Unknown argument${unknown.length > 1 ? "s" : ""} for tool ` +
+          `${tool.name}: ${unknown.map((key) => `\`${key}\``).join(", ")}. ` +
+          (accepted.length > 0
+            ? `Accepted arguments: ${accepted.join(", ")}.`
+            : "This tool accepts no arguments."),
+      );
+    }
   }
   // #9642: the intent argument is analytics metadata, never tool input, so it
   // is removed before any handler sees it -- the same contract @posthog/mcp's
@@ -15240,8 +15277,11 @@ async function callTool(params: Row, ctx: McpCtx) {
   const startedAt = Date.now();
   const result = await dispatchTool(params, ctx);
   const durationMs = Date.now() - startedAt;
+  // One bucket for both events, so the tool dimension can never disagree
+  // between usage_event and $mcp_tool_call. See mcpToolLabel.
+  const toolLabel = mcpToolLabel(params?.name);
   scheduleToolUsageEvent(ctx, {
-    mcpTool: typeof params?.name === "string" ? params.name : undefined,
+    mcpTool: toolLabel,
     ok: result.isError !== true,
     durationMs,
     // metagraphed#7726: every isError result already carries a code from a
@@ -15262,7 +15302,7 @@ async function callTool(params: Row, ctx: McpCtx) {
     params?.arguments as Row,
   );
   scheduleMcpToolCallEvent(ctx, {
-    toolName: typeof params?.name === "string" ? params.name : undefined,
+    toolName: toolLabel,
     isError: result.isError === true,
     durationMs,
     sessionId: ctx?.sessionId,
@@ -15376,6 +15416,36 @@ function mcpMethodLabel(method: string): string {
   return MCP_LABELLED_METHODS.has(method) ? method : "unknown";
 }
 
+/**
+ * The bucket a tool name is COUNTED under, which is not always the name the
+ * caller sent.
+ *
+ * `params.name` on a tools/call is caller-supplied and reaches PostHog as
+ * `$mcp_tool_name` (and `usage_event`'s tool label). Unregistered names were
+ * passing through verbatim, so anyone could mint an unbounded number of
+ * distinct property values by calling tools/call in a loop with random names
+ * -- exactly the defect MCP_LABELLED_METHODS above exists to prevent for
+ * `method`, whose comment warns that "getting it right in one place and wrong
+ * in the next is how that class of bug survives". It survived here.
+ *
+ * Not hypothetical: a third-party MCP verifier probes this server with a
+ * per-run name (`__verifymcp_auth_probe_<hash>__`), and 30+ single-use tool
+ * names from it are already sitting in the project's `$mcp_tool_name`
+ * breakdown alongside the real 232, on a free-tier plan.
+ *
+ * Folding them into one sentinel costs no signal. "Agents are guessing tool
+ * names" stays countable -- dispatchTool's `unknown_tool` code still rides on
+ * $mcp_error_code, and the guessed name itself is still readable in
+ * $mcp_parameters on the sampled events that carry it -- but the breakdown
+ * dimension stops being writable by strangers.
+ */
+const UNREGISTERED_MCP_TOOL_LABEL = "unregistered_tool";
+
+function mcpToolLabel(name: unknown): string | undefined {
+  if (typeof name !== "string") return undefined;
+  return TOOLS_BY_NAME.has(name) ? name : UNREGISTERED_MCP_TOOL_LABEL;
+}
+
 function scheduleMcpProtocolUsageEvent(
   ctx: McpCtx,
   method: string,
@@ -15415,6 +15485,60 @@ function scheduleMcpToolCallEvent(ctx: McpCtx, event: Row) {
 function scheduleMcpToolsListEvent(ctx: McpCtx, event: Row) {
   try {
     const record = ctx?.recordMcpToolsListEvent ?? recordMcpToolsListEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+// The resource/prompt half of the surface, previously silent. One scheduler
+// per method rather than one that takes an event name, so the dispatch site
+// reads as a statement of WHICH event it emits and a test can stub exactly one.
+// Same waitUntil/no-throw discipline as every scheduler here.
+function scheduleMcpResourcesListEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record =
+      ctx?.recordMcpResourcesListEvent ?? recordMcpResourcesListEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+function scheduleMcpResourceReadEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record =
+      ctx?.recordMcpResourceReadEvent ?? recordMcpResourceReadEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+function scheduleMcpPromptsListEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record = ctx?.recordMcpPromptsListEvent ?? recordMcpPromptsListEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
+function scheduleMcpPromptGetEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record = ctx?.recordMcpPromptGetEvent ?? recordMcpPromptGetEvent;
     const pending = Promise.resolve(
       record(ctx?.env, event, { distinctId: ctx?.distinctId }),
     ).catch(() => false);
@@ -15926,18 +16050,44 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         const result = await callTool(params, ctx);
         return isNotification ? null : rpcResult(id, result);
       }
-      case "resources/list":
-        return isNotification
-          ? null
-          : rpcResult(id, await listResources(params, ctx));
+      // The four resource/prompt cases below each keep their original
+      // "notification does no work" behaviour -- the early return replaces the
+      // await-inside-the-ternary, it does not change when the handler runs (see
+      // the resources/subscribe note further down for why that matters here).
+      // The event is therefore scheduled only on the request path, which is the
+      // only path that did anything to record.
+      case "resources/list": {
+        if (isNotification) return null;
+        const result = await listResources(params, ctx);
+        scheduleMcpResourcesListEvent(ctx, {
+          sessionId: ctx?.sessionId,
+          ...mcpAttributionFor(ctx),
+        });
+        return rpcResult(id, result);
+      }
       case "resources/templates/list":
         return isNotification
           ? null
           : rpcResult(id, { resourceTemplates: MCP_RESOURCE_TEMPLATES });
-      case "resources/read":
-        return isNotification
-          ? null
-          : rpcResult(id, await readResource(params, ctx));
+      case "resources/read": {
+        if (isNotification) return null;
+        // Scheduled AFTER the read resolves, which is also what bounds the
+        // name: readResource throws for a uri that is neither a live-stream nor
+        // a resolvable artifact path, so `$mcp_resource_name` can only ever
+        // carry a uri this server actually serves. A caller cannot mint
+        // dimension values here the way it could through tools/call
+        // (see mcpToolLabel).
+        const result = await readResource(params, ctx);
+        scheduleMcpResourceReadEvent(ctx, {
+          resourceName:
+            typeof params?.uri === "string" ? params.uri : undefined,
+          sessionId: ctx?.sessionId,
+          parameters: params,
+          response: result,
+          ...mcpAttributionFor(ctx),
+        });
+        return rpcResult(id, result);
+      }
       // #9017: the await stays INSIDE the ternary here, deliberately. A
       // notification-shaped subscribe is a malformed request (MCP defines
       // resources/subscribe as a request, so a conforming client always sends
@@ -15954,12 +16104,30 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         return isNotification
           ? null
           : rpcResult(id, await unsubscribeResource(params, ctx));
-      case "prompts/list":
-        return isNotification
-          ? null
-          : rpcResult(id, { prompts: listPromptDefinitions() });
-      case "prompts/get":
-        return isNotification ? null : rpcResult(id, getPrompt(params));
+      case "prompts/list": {
+        if (isNotification) return null;
+        const prompts = listPromptDefinitions();
+        scheduleMcpPromptsListEvent(ctx, {
+          sessionId: ctx?.sessionId,
+          ...mcpAttributionFor(ctx),
+        });
+        return rpcResult(id, { prompts });
+      }
+      case "prompts/get": {
+        if (isNotification) return null;
+        // Same ordering, same reason as resources/read: getPrompt throws for a
+        // name PROMPTS_BY_NAME does not hold, so the recorded name is always
+        // one of this server's own.
+        const prompt = getPrompt(params);
+        scheduleMcpPromptGetEvent(ctx, {
+          resourceName:
+            typeof params?.name === "string" ? params.name : undefined,
+          sessionId: ctx?.sessionId,
+          parameters: params,
+          ...mcpAttributionFor(ctx),
+        });
+        return rpcResult(id, prompt);
+      }
       // #9686. Declared in MCP_CAPABILITIES as `completions`, so a client that
       // reads the handshake knows to offer it rather than discovering it by
       // trying.
@@ -16157,6 +16325,13 @@ function buildContext(
     recordMcpToolCallEvent: deps.recordMcpToolCallEvent,
     recordMcpInitializeEvent: deps.recordMcpInitializeEvent,
     recordMcpToolsListEvent: deps.recordMcpToolsListEvent,
+    // The resource/prompt four belong in the same list for the same reason the
+    // comment above gives -- declaring them on McpCtx without copying them here
+    // is precisely the silent fall-through it describes.
+    recordMcpResourcesListEvent: deps.recordMcpResourcesListEvent,
+    recordMcpResourceReadEvent: deps.recordMcpResourceReadEvent,
+    recordMcpPromptsListEvent: deps.recordMcpPromptsListEvent,
+    recordMcpPromptGetEvent: deps.recordMcpPromptGetEvent,
     recordExceptionEvent: deps.recordExceptionEvent,
     recordAiDegradedEvent: deps.recordAiDegradedEvent,
   };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3907,9 +3907,39 @@ export function splitMcpIntent(args: Row): { intent?: string; rest: Row } {
   };
 }
 
+/**
+ * A non-negative integer, from a number OR from the decimal string spelling
+ * of one -- because the REST side of the same request already accepts both.
+ *
+ * `GET /api/v1/subnets/080/health` serves netuid 80; `get_subnet_health` with
+ * `{"netuid":"080"}` answered `invalid_params`. Same logical request, two
+ * answers, and the MCP one was the wrong answer: HTTP hands every path and
+ * query value over as a string, so the REST parser has always had to coerce,
+ * and coercion is the established contract of this pair of surfaces rather
+ * than a leniency being invented here. Live agents hit it -- zero-padded
+ * netuids were three of the day's failures.
+ *
+ * Strictly the decimal-digit spelling, so nothing else widens with it: REST
+ * rejects `one` and `-5` (404) and so does this. `1.5`, `1e3`, `+5`, ``, and
+ * whitespace-only are rejected for the same reason -- they are not how the
+ * REST parser reads an unsigned integer either.
+ */
+const UNSIGNED_INT_TEXT = /^\d+$/;
+
+function coerceNonNegativeInt(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const text = value.trim();
+  if (!UNSIGNED_INT_TEXT.test(text)) return undefined;
+  const parsed = Number(text);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
 function requireNonNegativeInt(args: Row, key: string) {
-  const value = args?.[key];
-  if (!Number.isInteger(value) || value < 0) {
+  const value = coerceNonNegativeInt(args?.[key]);
+  if (value === undefined) {
     throw toolError(
       "invalid_params",
       `Argument \`${key}\` must be a non-negative integer.`,
@@ -3919,9 +3949,10 @@ function requireNonNegativeInt(args: Row, key: string) {
 }
 
 function optionalNonNegativeInt(args: Row, key: string) {
-  const value = args?.[key];
-  if (value === undefined || value === null) return null;
-  if (!Number.isInteger(value) || value < 0) {
+  const raw = args?.[key];
+  if (raw === undefined || raw === null) return null;
+  const value = coerceNonNegativeInt(raw);
+  if (value === undefined) {
     throw toolError(
       "invalid_params",
       `Argument \`${key}\` must be a non-negative integer.`,

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -1143,6 +1143,141 @@ export async function recordMcpToolsListEvent(
   }
 }
 
+// ─── Resource + prompt traffic ──────────────────────────────────────────────
+//
+// The other half of this server's MCP surface was uninstrumented. It advertises
+// both `resources` and `prompts` in MCP_CAPABILITIES and serves four methods
+// behind them -- resources/list, resources/read, prompts/list, prompts/get --
+// and PostHog defines an event for each ($mcp_resources_list,
+// $mcp_resource_read, $mcp_prompts_list, $mcp_prompt_get). None were emitted.
+//
+// On the analytics side that traffic therefore did not exist. A client that
+// read a resource on every turn was indistinguishable from one that never
+// touched the surface, and there was no way to ask which resources or prompts
+// were earning their place in the catalogue -- the same blind spot #8963 closed
+// for tools/list, left open one method family over.
+//
+// PostHog names the resource AND the prompt with the same property,
+// `$mcp_resource_name` -- there is no `$mcp_prompt_name` -- so both travel
+// under one field here rather than being invented separately.
+
+/** Inputs for the resource/prompt MCP analytics events. */
+export interface McpResourceEvent extends McpServerIdentity {
+  /**
+   * The resource URI, or the prompt name. Emitted as `$mcp_resource_name`.
+   * Caller-supplied, so it is sanitized to a label like every other dimension
+   * on this family. Absent on the two list events, which name nothing.
+   */
+  resourceName?: string;
+  clientName?: string;
+  clientVersion?: string;
+  clientNameSource?: McpClientNameSource;
+  authTier?: string;
+  sessionId?: string | null;
+  /**
+   * The read/get arguments and result. Redacted (redactMcpSensitiveFields) and
+   * size-capped (boundedMcpPayload) by this module before posting, exactly as
+   * on `$mcp_tool_call` -- a resource body can be the whole agent catalogue.
+   */
+  parameters?: unknown;
+  response?: unknown;
+}
+
+/**
+ * The one poster behind all four resource/prompt events.
+ *
+ * Written once rather than four times: these differ only in the event name and
+ * in which optional fields the caller populates, and four hand-copied bodies is
+ * how the deployment stamp ends up on three of them.
+ */
+async function postMcpResourceEvent(
+  env: Env | null | undefined,
+  eventName: string,
+  event: McpResourceEvent,
+  deps: RecordUsageEventDeps,
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    const properties: Record<string, unknown> = {};
+
+    const resourceName = sanitizeLabel(event.resourceName);
+    if (resourceName !== undefined) {
+      properties["$mcp_resource_name"] = resourceName;
+    }
+
+    assignMcpAttribution(properties, event);
+
+    if (typeof event.sessionId === "string" && event.sessionId.trim()) {
+      properties["$session_id"] = event.sessionId.trim();
+    }
+
+    const parameters = boundedMcpPayload(event.parameters);
+    if (parameters !== undefined) properties["$mcp_parameters"] = parameters;
+
+    const responseBody = boundedMcpPayload(event.response);
+    if (responseBody !== undefined) properties["$mcp_response"] = responseBody;
+
+    // The deployment dimensions, stamped exactly where this family already
+    // stamps its attribution -- see assignMcpAttribution above.
+    assignDeployment(properties, env);
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: eventName,
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Emit `$mcp_resources_list`. Same no-throw contract as recordUsageEvent. */
+export async function recordMcpResourcesListEvent(
+  env: Env | null | undefined,
+  event: McpResourceEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  return postMcpResourceEvent(env, "$mcp_resources_list", event, deps);
+}
+
+/** Emit `$mcp_resource_read`. Same no-throw contract as recordUsageEvent. */
+export async function recordMcpResourceReadEvent(
+  env: Env | null | undefined,
+  event: McpResourceEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  return postMcpResourceEvent(env, "$mcp_resource_read", event, deps);
+}
+
+/** Emit `$mcp_prompts_list`. Same no-throw contract as recordUsageEvent. */
+export async function recordMcpPromptsListEvent(
+  env: Env | null | undefined,
+  event: McpResourceEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  return postMcpResourceEvent(env, "$mcp_prompts_list", event, deps);
+}
+
+/** Emit `$mcp_prompt_get`. Same no-throw contract as recordUsageEvent. */
+export async function recordMcpPromptGetEvent(
+  env: Env | null | undefined,
+  event: McpResourceEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  return postMcpResourceEvent(env, "$mcp_prompt_get", event, deps);
+}
+
 // Error tracking via PostHog's `$exception` capture (#7758).
 //
 // The exception SHAPE is built by @posthog/core's own ErrorPropertiesBuilder

--- a/tests/field-projection.test.ts
+++ b/tests/field-projection.test.ts
@@ -328,3 +328,30 @@ describe("the published MCP enum is the schema's own field list (#9082)", () => 
     assert.deepEqual(schemaResolver([...NEURON_FIELD_NAMES]), []);
   });
 });
+
+// A row set is not guaranteed to be rows (#10617).
+//
+// `unknownAgainstRows` is handed whatever a route already has in hand, and the
+// error path calls `.known()` over ALL of it to name the valid fields. A JSON
+// array whose entries are null, or nested arrays, reaches here unchanged --
+// `Object.keys(null)` throws, and `Object.keys([1,2])` would offer "0" and "1"
+// as field names. The guard exists for both; this is what proves it.
+describe("unknownAgainstRows tolerates a row set that is not objects", () => {
+  test("null, arrays and primitives contribute no field names", () => {
+    const resolver = unknownAgainstRows([
+      null,
+      undefined,
+      42,
+      "a string",
+      ["nested", "array"],
+      { netuid: 64 },
+    ] as never);
+    // The one real object still resolves, so the scan is not simply skipped.
+    assert.deepEqual(resolver.known!().sort(), ["netuid"]);
+  });
+
+  test("a row set with no objects at all yields an empty known set", () => {
+    const resolver = unknownAgainstRows([null, [1, 2]] as never);
+    assert.deepEqual(resolver.known!(), []);
+  });
+});

--- a/tests/field-projection.test.ts
+++ b/tests/field-projection.test.ts
@@ -76,16 +76,35 @@ describe("parseFieldsParam", () => {
     }
   });
 
-  test("an unsupported field names itself and its collection", () => {
+  // The message now also carries the VOCABULARY, for the same reason the
+  // tool-argument guards do: naming only what the caller cannot have leaves it
+  // with nothing to retry against. Two production examples this fixes, both
+  // observed on live $mcp_tool_call events:
+  //
+  //   get_emission_pipeline  fields=...,name   correct refusal (those rows are
+  //                                            pure chain state), but `name`
+  //                                            lives on get_economics and the
+  //                                            caller had no way to learn that
+  //   get_economics          total_stake_tao   correct refusal -- the field is
+  //                                            `total_stake_alpha`, one suffix
+  //                                            away, and unlistable before now
+  test("an unsupported field names itself, its collection, and the alternatives", () => {
     const result = parseFieldsParam(
       params("?fields=uid,stake"),
       schemaResolver,
       "neurons",
     );
-    assert.equal(
-      result.error?.message,
-      "fields includes unsupported field for neurons: stake.",
+    assert.match(
+      result.error!.message,
+      /^fields includes unsupported field for neurons: stake\./,
     );
+    // Every field the schema declares, so the caller can correct in one step.
+    for (const field of Object.keys(NeuronSchema.shape)) {
+      assert.ok(
+        result.error!.message.includes(field),
+        `should offer \`${field}\`: ${result.error!.message}`,
+      );
+    }
   });
 
   test("several unsupported fields pluralize and list every one", () => {
@@ -94,9 +113,61 @@ describe("parseFieldsParam", () => {
       schemaResolver,
       "validators",
     );
+    assert.match(
+      result.error!.message,
+      /^fields includes unsupported fields for validators: stake, nope\./,
+    );
+    assert.match(result.error!.message, /Valid fields: /);
+  });
+
+  // The row-union resolver reaches the same message from a different place,
+  // and is the one the emission-pipeline surface uses.
+  test("the row-union resolver offers the union, not just the first row", () => {
+    const result = parseFieldsParam(
+      params("?fields=name"),
+      unknownAgainstRows([{ netuid: 64 }, { emission_share: 0.06 }]),
+      "emission pipeline subnets",
+    );
+    assert.match(
+      result.error!.message,
+      /^fields includes unsupported field for emission pipeline subnets: name\./,
+    );
+    // `emission_share` appears only on the SECOND row -- a message built from
+    // the first row alone would omit it and mislead the retry.
+    assert.match(
+      result.error!.message,
+      /Valid fields: emission_share, netuid\./,
+    );
+  });
+
+  // The lazy scan is the reason `known` is a separate call. A VALID request
+  // must still settle without materialising the union.
+  test("a valid request never asks for the vocabulary", () => {
+    let knownCalls = 0;
+    const resolver = unknownAgainstRows([{ netuid: 64 }, { name: "apex" }]);
+    const inner = resolver.known!;
+    resolver.known = () => {
+      knownCalls += 1;
+      return inner();
+    };
+
+    const ok = parseFieldsParam(params("?fields=netuid"), resolver, "subnets");
+    assert.deepEqual(ok.fields, ["netuid"]);
+    assert.equal(knownCalls, 0, "the happy path must not build the union");
+
+    parseFieldsParam(params("?fields=nope"), resolver, "subnets");
+    assert.equal(knownCalls, 1, "the error path is where it is paid");
+  });
+
+  // A resolver with no `known` (nothing in-tree, but the type allows it)
+  // degrades to the old message rather than emitting a dangling label.
+  test("a resolver that cannot enumerate omits the list cleanly", () => {
+    const bare = ((requested: string[]) =>
+      requested.filter((f) => f !== "uid")) as typeof schemaResolver;
+    const result = parseFieldsParam(params("?fields=nope"), bare, "things");
     assert.equal(
       result.error?.message,
-      "fields includes unsupported fields for validators: stake, nope.",
+      "fields includes unsupported field for things: nope.",
     );
   });
 });

--- a/tests/mcp-published-default.test.ts
+++ b/tests/mcp-published-default.test.ts
@@ -157,3 +157,35 @@ describe("the two tools #10306 was filed for, through the real dispatcher", () =
     );
   });
 });
+
+// The two shapes validateToolArguments has to survive that no real tool has
+// (#10617).
+describe("validateToolArguments on schemas the registry does not contain", () => {
+  test("a tool whose inputSchema declares no properties accepts anything", () => {
+    // `properties` is optional in JSON Schema, and `?? {}` is what stops the
+    // unknown-key scan below from reading keys off undefined. No shipped tool
+    // is spelled this way today, which is exactly why the fallback was never
+    // taken -- and a tool added without `properties` would hit it first.
+    const resolved = validateToolArguments(
+      { name: "no_properties", inputSchema: { type: "object" } } as Row,
+      { anything: 1 },
+    );
+    assert.deepEqual(resolved, { anything: 1 });
+  });
+
+  test("a closed schema with no properties still rejects unknown keys", () => {
+    // additionalProperties:false plus no declared properties means EVERY key
+    // is unknown -- the fallback and the rejection have to compose.
+    assert.throws(
+      () =>
+        validateToolArguments(
+          {
+            name: "closed_empty",
+            inputSchema: { type: "object", additionalProperties: false },
+          } as Row,
+          { nope: 1 },
+        ),
+      /nope/,
+    );
+  });
+});

--- a/tests/mcp-resource-prompt-telemetry.test.ts
+++ b/tests/mcp-resource-prompt-telemetry.test.ts
@@ -1,0 +1,277 @@
+// The resource and prompt half of the MCP surface was invisible to analytics.
+//
+// This server advertises both `resources` and `prompts` in its handshake
+// capabilities and serves four methods behind them. PostHog defines an event
+// for each -- $mcp_resources_list, $mcp_resource_read, $mcp_prompts_list,
+// $mcp_prompt_get -- and none of the four was emitted. A client that read a
+// resource on every turn was indistinguishable from one that never touched the
+// surface, which is the same blind spot #8963 closed for tools/list, left open
+// one method family over. Measured against the live project: zero events of all
+// four names in 30 days, against a server that answers all four methods.
+//
+// What these tests hold in place is the wiring AND its two constraints: the
+// event must never break the method (waitUntil + no-throw, like every other
+// scheduler here), and `$mcp_resource_name` must stay bounded -- it is the same
+// caller-supplied-label trap that tools/call had.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import { handleMcpRequest, listPromptDefinitions } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+
+function fakeExecutionCtx() {
+  const scheduled: Promise<unknown>[] = [];
+  return {
+    scheduled,
+    waitUntil: (promise: Promise<unknown>) => scheduled.push(promise),
+  };
+}
+
+function baseDeps(extra: Row = {}) {
+  return {
+    readArtifact: (_env: Row, path: string) =>
+      Promise.resolve({
+        ok: true,
+        data: { schema_version: 1, path },
+        source: "test",
+        storage_tier: "git",
+      }),
+    readHealthKv: () => Promise.resolve(null),
+    ...extra,
+  };
+}
+
+async function call(method: string, params: Row, extraDeps: Row = {}) {
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    }),
+    CONFIGURED_ENV as unknown as Env,
+    baseDeps(extraDeps),
+  );
+  return (await response.json()) as Row;
+}
+
+/** Captures whichever of the four recorders the method under test should hit. */
+function recorders() {
+  const seen: Record<string, Row[]> = {
+    resourcesList: [],
+    resourceRead: [],
+    promptsList: [],
+    promptGet: [],
+  };
+  return {
+    seen,
+    deps: {
+      recordMcpResourcesListEvent: (_e: unknown, event: Row) => {
+        seen.resourcesList.push(event);
+        return true;
+      },
+      recordMcpResourceReadEvent: (_e: unknown, event: Row) => {
+        seen.resourceRead.push(event);
+        return true;
+      },
+      recordMcpPromptsListEvent: (_e: unknown, event: Row) => {
+        seen.promptsList.push(event);
+        return true;
+      },
+      recordMcpPromptGetEvent: (_e: unknown, event: Row) => {
+        seen.promptGet.push(event);
+        return true;
+      },
+    },
+  };
+}
+
+const A_PROMPT = "integrate_with_subnet";
+
+describe("resources/list and prompts/list are recorded", () => {
+  for (const [method, bucket] of [
+    ["resources/list", "resourcesList"],
+    ["prompts/list", "promptsList"],
+  ] as const) {
+    test(`${method} emits exactly one discovery event`, async () => {
+      const spy = recorders();
+      const executionCtx = fakeExecutionCtx();
+
+      const payload = await call(method, {}, { ...spy.deps, executionCtx });
+
+      // The method still answers.
+      assert.ok(payload.result, `${method} should still return a result`);
+      assert.equal(spy.seen[bucket].length, 1);
+      // Drained through waitUntil rather than awaited in the request path.
+      // Two promises, not one: this server already records every protocol
+      // method as a usage_event, and the new $mcp_* event rides alongside it
+      // exactly as $mcp_tool_call rides alongside tools/call's.
+      assert.equal(executionCtx.scheduled.length, 2);
+      // A list names nothing -- PostHog's own schema has no name on these two.
+      assert.equal(spy.seen[bucket][0].resourceName, undefined);
+      // Server identity rides along, so an event can be pinned to a deploy.
+      assert.equal(typeof spy.seen[bucket][0].serverName, "string");
+      assert.equal(typeof spy.seen[bucket][0].serverVersion, "string");
+    });
+
+    test(`${method} records nothing for a notification`, async () => {
+      // Preserving the pre-existing contract: a notification-shaped call does
+      // no work, so there is nothing to record. This is the behaviour the
+      // resources/subscribe comment protects, and the change must not alter it.
+      const spy = recorders();
+      await call(method, {}, spy.deps);
+      const notification = await handleMcpRequest(
+        new Request("https://api.metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", method, params: {} }),
+        }),
+        CONFIGURED_ENV as unknown as Env,
+        baseDeps(spy.deps),
+      );
+      assert.equal(notification.status, 202);
+      // One from the request above, none from the notification.
+      assert.equal(spy.seen[bucket].length, 1);
+    });
+  }
+});
+
+describe("resources/read is recorded with a bounded name", () => {
+  test("emits the read event naming the uri it served", async () => {
+    const spy = recorders();
+    const executionCtx = fakeExecutionCtx();
+    const uri = "metagraph://registry/summary";
+
+    const payload = await call(
+      "resources/read",
+      { uri },
+      { ...spy.deps, executionCtx },
+    );
+
+    assert.ok(payload.result?.contents, "the read should still return content");
+    assert.equal(spy.seen.resourceRead.length, 1);
+    const event = spy.seen.resourceRead[0];
+    assert.equal(event.resourceName, uri);
+    // usage_event + $mcp_resource_read, both via waitUntil.
+    assert.equal(executionCtx.scheduled.length, 2);
+    // Arguments and result travel for drill-down, as on $mcp_tool_call. The
+    // recorder redacts and size-caps them; that contract is proven in
+    // tests/usage-telemetry.test.ts and is not re-asserted here.
+    assert.deepEqual(event.parameters, { uri });
+    assert.ok(event.response, "the read event should carry its response");
+  });
+
+  test("an unresolvable uri records nothing", async () => {
+    // This is what BOUNDS $mcp_resource_name: readResource throws for a uri
+    // that is neither a live stream nor a resolvable artifact path, and the
+    // event is scheduled after it resolves. So a caller cannot mint dimension
+    // values here the way it could through tools/call before mcpToolLabel.
+    const spy = recorders();
+
+    await call("resources/read", { uri: "metagraph://not-a-real/thing-92831" });
+    await call(
+      "resources/read",
+      { uri: "metagraph://not-a-real/thing-92831" },
+      spy.deps,
+    );
+
+    assert.deepEqual(spy.seen.resourceRead, []);
+  });
+});
+
+describe("prompts/get is recorded with a bounded name", () => {
+  test("emits the get event naming the prompt", async () => {
+    const spy = recorders();
+    const executionCtx = fakeExecutionCtx();
+
+    const payload = await call(
+      "prompts/get",
+      { name: A_PROMPT, arguments: { netuid: "1" } },
+      { ...spy.deps, executionCtx },
+    );
+
+    assert.ok(payload.result?.messages, "the prompt should still be returned");
+    assert.equal(spy.seen.promptGet.length, 1);
+    assert.equal(spy.seen.promptGet[0].resourceName, A_PROMPT);
+    // usage_event + $mcp_prompt_get, both via waitUntil.
+    assert.equal(executionCtx.scheduled.length, 2);
+  });
+
+  test("an unknown prompt records nothing", async () => {
+    const spy = recorders();
+    await call("prompts/get", { name: "no_such_prompt_at_all" }, spy.deps);
+    assert.deepEqual(spy.seen.promptGet, []);
+  });
+
+  test("the recorded name is always one the server advertises", async () => {
+    // Derived from the served prompt list, so this cannot drift.
+    const spy = recorders();
+    const advertised = listPromptDefinitions().map(
+      (p: Row) => p.name as string,
+    );
+    assert.ok(
+      advertised.length > 0,
+      "expected the server to advertise prompts",
+    );
+    assert.ok(advertised.includes(A_PROMPT));
+
+    await call(
+      "prompts/get",
+      { name: A_PROMPT, arguments: { netuid: "1" } },
+      spy.deps,
+    );
+    assert.ok(
+      advertised.includes(spy.seen.promptGet[0].resourceName as string),
+    );
+  });
+});
+
+describe("resource and prompt telemetry never breaks the method", () => {
+  // The same discipline every other scheduler in mcp-server.ts is held to: a
+  // broken recorder is a telemetry problem, never a request problem.
+  for (const [label, override] of Object.entries({
+    "the recorder rejects": () => Promise.reject(new Error("posthog down")),
+    "the recorder throws synchronously": () => {
+      throw new Error("posthog exploded");
+    },
+  })) {
+    test(`resources/read still answers when ${label}`, async () => {
+      const payload = await call(
+        "resources/read",
+        { uri: "metagraph://registry/summary" },
+        { recordMcpResourceReadEvent: override },
+      );
+      assert.ok(payload.result?.contents);
+      assert.equal(payload.error, undefined);
+    });
+
+    test(`prompts/get still answers when ${label}`, async () => {
+      const payload = await call(
+        "prompts/get",
+        { name: A_PROMPT, arguments: { netuid: "1" } },
+        { recordMcpPromptGetEvent: override },
+      );
+      assert.ok(payload.result?.messages);
+      assert.equal(payload.error, undefined);
+    });
+  }
+
+  test("a missing ExecutionContext does not break the method", async () => {
+    const payload = await call(
+      "resources/list",
+      {},
+      {
+        executionCtx: {
+          waitUntil() {
+            throw new Error("isolate already finished");
+          },
+        },
+      },
+    );
+    assert.ok(payload.result?.resources);
+  });
+});

--- a/tests/mcp-resource-prompt-telemetry.test.ts
+++ b/tests/mcp-resource-prompt-telemetry.test.ts
@@ -258,6 +258,30 @@ describe("resource and prompt telemetry never breaks the method", () => {
       assert.ok(payload.result?.messages);
       assert.equal(payload.error, undefined);
     });
+
+    // The two LIST methods were missing from this loop, so their schedulers'
+    // rejection path was the only half of the family never exercised -- and it
+    // is the half that matters most, because a list call is the one an agent
+    // makes on every connect.
+    test(`resources/list still answers when ${label}`, async () => {
+      const payload = await call(
+        "resources/list",
+        {},
+        { recordMcpResourcesListEvent: override },
+      );
+      assert.ok(payload.result?.resources);
+      assert.equal(payload.error, undefined);
+    });
+
+    test(`prompts/list still answers when ${label}`, async () => {
+      const payload = await call(
+        "prompts/list",
+        {},
+        { recordMcpPromptsListEvent: override },
+      );
+      assert.ok(payload.result?.prompts);
+      assert.equal(payload.error, undefined);
+    });
   }
 
   test("a missing ExecutionContext does not break the method", async () => {

--- a/tests/mcp-tool-name-cardinality.test.ts
+++ b/tests/mcp-tool-name-cardinality.test.ts
@@ -1,0 +1,153 @@
+// `$mcp_tool_name` must not be writable by strangers.
+//
+// `params.name` on a tools/call is caller-supplied and became the tool label on
+// two events -- usage_event's `mcpTool` and PostHog's `$mcp_tool_name`. An
+// unregistered name passed straight through, so anyone could mint an unbounded
+// number of distinct property values by looping tools/call over random names.
+//
+// This is the same defect MCP_LABELLED_METHODS already prevents for `method`,
+// whose own comment warns that "getting it right in one place and wrong in the
+// next is how that class of bug survives". It survived here: the project's live
+// `$mcp_tool_name` breakdown carries 30+ single-use values from one third-party
+// verifier's per-run probe name (`__verifymcp_auth_probe_<hash>__`) alongside
+// the real 232, on a free-tier plan.
+//
+// What must NOT be lost to the fix: "agents are guessing tool names" stays
+// countable. dispatchTool's `unknown_tool` code is the dimension that carries
+// it, and the guessed name is still readable in the parameters payload.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+const UNREGISTERED = "unregistered_tool";
+
+function makeDeps(extra: Row = {}) {
+  return {
+    readArtifact: (_env: Row, path: string) =>
+      Promise.resolve({
+        ok: true,
+        data: { schema_version: 1, path },
+        source: "test",
+        storage_tier: "git",
+      }),
+    readHealthKv: () => Promise.resolve(null),
+    executionCtx: { waitUntil: () => {} },
+    ...extra,
+  };
+}
+
+/** Drives one tools/call and returns both telemetry events it scheduled. */
+async function capture(name: string, args: Row = {}) {
+  const usage: Row[] = [];
+  const mcp: Row[] = [];
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    CONFIGURED_ENV as unknown as Env,
+    makeDeps({
+      recordUsageEvent: (_env: unknown, event: Row) => {
+        usage.push(event);
+        return true;
+      },
+      recordMcpToolCallEvent: (_env: unknown, event: Row) => {
+        mcp.push(event);
+        return true;
+      },
+    }),
+  );
+  const body = (await response.json()) as Row;
+  return { usage, mcp, body };
+}
+
+describe("unregistered tool names are bucketed, not recorded verbatim", () => {
+  // The exact shape observed in production, plus the two other ways a caller
+  // reaches this path.
+  for (const [label, name] of Object.entries({
+    "a third-party verifier's per-run probe":
+      "__verifymcp_auth_probe_f19d1e17e7bb1717__",
+    "a second run of the same verifier":
+      "__verifymcp_auth_probe_266c0a0e3e53c5b8__",
+    "an agent guessing a plausible name": "get_subnet_emissions",
+    "a scanner sending junk": "nope_not_a_tool",
+  })) {
+    test(`folds ${label} into one bucket`, async () => {
+      const { usage, mcp } = await capture(name);
+
+      assert.equal(usage.length, 1);
+      assert.equal(mcp.length, 1);
+      // Neither event may carry the caller's string.
+      assert.equal(usage[0].mcpTool, UNREGISTERED);
+      assert.equal(mcp[0].toolName, UNREGISTERED);
+      assert.ok(
+        !JSON.stringify(usage[0]).includes(name),
+        "usage_event must not carry the caller-supplied name",
+      );
+    });
+  }
+
+  test("two different unregistered names produce ONE label, not two", async () => {
+    // The property being protected, stated directly: cardinality. Asserting
+    // each call individually would still pass if the bucket were derived from
+    // the name.
+    const first = await capture("__verifymcp_auth_probe_aaaaaaaaaaaaaaaa__");
+    const second = await capture("__verifymcp_auth_probe_bbbbbbbbbbbbbbbb__");
+
+    const labels = new Set([
+      first.mcp[0].toolName as string,
+      second.mcp[0].toolName as string,
+    ]);
+    assert.deepEqual([...labels], [UNREGISTERED]);
+  });
+
+  test("the failure stays countable and attributable", async () => {
+    const { mcp, usage, body } = await capture("nope_not_a_tool");
+
+    // The dimension that answers "are agents guessing tool names".
+    assert.equal(mcp[0].errorCode, "unknown_tool");
+    assert.equal(usage[0].errorCode, "unknown_tool");
+    assert.equal(mcp[0].isError, true);
+    // And the caller still gets the name it got wrong, in the tool result --
+    // the bucketing is an analytics concern, not a response change.
+    assert.match(
+      String((body?.result?.content as Row[])?.[0]?.text),
+      /nope_not_a_tool/,
+    );
+  });
+
+  // Proving the bucket is not applied to everything: without this, a
+  // mcpToolLabel that returned the sentinel unconditionally would pass every
+  // assertion above.
+  test("a registered tool is still recorded under its own name", async () => {
+    const { usage, mcp } = await capture("get_contracts");
+
+    assert.equal(usage[0].mcpTool, "get_contracts");
+    assert.equal(mcp[0].toolName, "get_contracts");
+    assert.equal(mcp[0].isError, false);
+  });
+
+  test("every advertised tool survives the bucket", async () => {
+    // Derived from the served catalogue rather than a sample, so a tool
+    // registered tomorrow is covered tonight -- and so a mcpToolLabel keyed on
+    // a stale list cannot pass.
+    const names = listToolDefinitions().map((tool: Row) => tool.name as string);
+    assert.ok(
+      names.length > 200,
+      `expected the full catalogue, got ${names.length}`,
+    );
+
+    const { mcp } = await capture(names[0]);
+    assert.equal(mcp[0].toolName, names[0]);
+    assert.notEqual(mcp[0].toolName, UNREGISTERED);
+  });
+});

--- a/tests/mcp-unknown-argument-message.test.ts
+++ b/tests/mcp-unknown-argument-message.test.ts
@@ -1,0 +1,195 @@
+// An unknown-argument rejection has to name the argument it rejected.
+//
+// `validateToolArguments` has always refused a key the tool's inputSchema does
+// not declare (additionalProperties: false). What it did NOT do was say which
+// key, or what the tool would have accepted -- every one of those refusals read
+// "Invalid arguments for tool <name>." and nothing else.
+//
+// That message was the most common live MCP failure a caller could not act on.
+// Measured on production $mcp_tool_call events, the arguments agents were
+// actually sending when they hit it:
+//
+//   get_subnet_registrations   {"limit":"5","netuid":64}   pages by `window`
+//   get_validator_history      {"limit":3,"netuid":3}      pages by `window`
+//   get_account_identity       {"address":"5FWh..."}       keyed on `ss58`
+//   get_self_health            {"random_string":"check"}   takes nothing
+//
+// Each is one vocabulary list away from a correct retry, and each agent instead
+// retried the identical call. These tests pin the fix to those exact shapes.
+//
+// What is NOT being tested here, because it deliberately does not exist: schema
+// validation at dispatch. #8942 measured that and rejected it
+// (tests/mcp-schema-enforcement.test.ts records why). This only changes how the
+// unknown-key refusal that already happened is reported.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+const env = createLocalArtifactEnv() as unknown as Env;
+
+// Artifact reads are stubbed the same way tests/mcp-usage-telemetry.test.ts
+// stubs them, so the positive controls at the bottom exercise a handler that
+// actually completes. The rejection cases never reach a handler.
+const DEPS = {
+  readArtifact: (_env: Row, path: string) =>
+    Promise.resolve({
+      ok: true,
+      data: { schema_version: 1, path },
+      source: "test",
+      storage_tier: "git",
+    }),
+  readHealthKv: () => Promise.resolve(null),
+};
+
+async function callTool(name: string, args: unknown): Promise<Row> {
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    env,
+    DEPS,
+  );
+  const body = (await response.json()) as Row;
+  return (body?.result?.structuredContent as Row)?.error as Row;
+}
+
+describe("unknown MCP tool arguments are reported, not just refused", () => {
+  // The four shapes above, driven through the real dispatcher.
+  for (const [label, { tool, args, unknownKey }] of Object.entries({
+    "a limit on a tool that pages by window": {
+      tool: "get_subnet_registrations",
+      args: { limit: "5", netuid: 64 },
+      unknownKey: "limit",
+    },
+    "a numeric limit on a tool that pages by window": {
+      tool: "get_validator_history",
+      args: { limit: 3, netuid: 3 },
+      unknownKey: "limit",
+    },
+    "an address on a tool keyed on ss58": {
+      tool: "get_account_identity",
+      args: { address: "5FWh37LfVV5LE9dZA91STzbtebh6vxYa3MH71c621sYafo1L" },
+      unknownKey: "address",
+    },
+    "filler on a tool that takes no arguments": {
+      tool: "get_self_health",
+      args: { random_string: "check" },
+      unknownKey: "random_string",
+    },
+  })) {
+    test(`names the rejected key and the accepted ones: ${label}`, async () => {
+      const error = await callTool(tool, args);
+
+      assert.equal(error.code, "invalid_params");
+      const message = String(error.message);
+
+      // The key the caller got wrong, quoted the way every other argument
+      // guard in this server quotes one.
+      assert.match(message, new RegExp(`\`${unknownKey}\``));
+      // ...and the tool it was wrong for.
+      assert.ok(
+        message.includes(tool),
+        `message should name the tool: ${message}`,
+      );
+
+      // The vocabulary that makes the retry possible: every argument the
+      // served schema declares, read from the schema rather than hardcoded so
+      // this cannot drift from what tools/list advertises.
+      const declared = Object.keys(
+        (listToolDefinitions().find((t: Row) => t.name === tool) as Row)
+          ?.inputSchema?.properties ?? {},
+      );
+      assert.ok(declared.length > 0, `${tool} should declare arguments`);
+      for (const accepted of declared) {
+        assert.ok(
+          message.includes(accepted),
+          `message should offer \`${accepted}\`: ${message}`,
+        );
+      }
+    });
+  }
+
+  test("names every unknown key when more than one was sent", async () => {
+    const error = await callTool("get_self_health", {
+      random_string: "check",
+      also_wrong: 1,
+    });
+
+    assert.equal(error.code, "invalid_params");
+    const message = String(error.message);
+    assert.match(message, /`random_string`/);
+    assert.match(message, /`also_wrong`/);
+    // Plural, because two keys were wrong.
+    assert.match(message, /Unknown arguments/);
+  });
+
+  // get_self_health declares only `context`, the analytics intent argument, so
+  // "accepted arguments" is not empty for it. Guard the genuinely-empty branch
+  // against a synthetic tool rather than pinning a real one's schema in place.
+  test("says so when a tool accepts nothing at all", async () => {
+    const { validateToolArguments } = await import("../src/mcp-server.ts");
+    assert.throws(
+      () =>
+        validateToolArguments(
+          {
+            name: "takes_nothing",
+            inputSchema: { additionalProperties: false, properties: {} },
+          } as Row,
+          { nope: 1 } as Row,
+        ),
+      (error: Error) => {
+        assert.match(error.message, /`nope`/);
+        assert.match(error.message, /accepts no arguments/);
+        return true;
+      },
+    );
+  });
+
+  // The other half of the split: a non-object `arguments` is a different
+  // mistake from an unknown key, and now says which one it is.
+  for (const [label, args] of Object.entries({
+    "an array": [1, 2, 3],
+    "a string": "netuid=1",
+    "a number": 7,
+  })) {
+    test(`rejects ${label} as a shape error, not an unknown key`, async () => {
+      const error = await callTool("get_subnet_registrations", args);
+
+      assert.equal(error.code, "invalid_params");
+      const message = String(error.message);
+      assert.match(message, /expected an object of named arguments/);
+      // Not the unknown-key message -- there is no key to name.
+      assert.doesNotMatch(message, /Unknown argument/);
+    });
+  }
+
+  // Proving the gate can still pass: a correct call must not be caught by any
+  // of the above. Without this, every assertion here would also hold for a
+  // validateToolArguments that rejected everything.
+  //
+  // get_contracts is the tool the sibling telemetry suite uses for exactly this
+  // reason -- it resolves from the local artifact env, so a failure here is
+  // this change's fault rather than a missing live binding.
+  test("a call using only declared arguments is not rejected", async () => {
+    const error = await callTool("get_contracts", {});
+    assert.equal(error, undefined);
+  });
+
+  test("the intent argument is still accepted, not read as unknown", async () => {
+    // `context` is declared on every tool and stripped before the handler --
+    // it must never read as an unknown key.
+    const error = await callTool("get_contracts", {
+      context: "checking whether the registry is serving",
+    });
+    assert.equal(error, undefined);
+  });
+});

--- a/tests/mcp-unknown-argument-message.test.ts
+++ b/tests/mcp-unknown-argument-message.test.ts
@@ -184,6 +184,39 @@ describe("unknown MCP tool arguments are reported, not just refused", () => {
     assert.equal(error, undefined);
   });
 
+  // A DIFFERENT rejection that was also costing live calls, fixed alongside:
+  // MCP refused a zero-padded netuid that the REST side of the same request
+  // accepts. `GET /api/v1/subnets/080/health` serves netuid 80 (verified
+  // against production); `{"netuid":"080"}` answered invalid_params. HTTP
+  // hands every path value over as a string, so coercion is the established
+  // contract of this pair of surfaces, not a leniency invented here.
+  describe("numeric arguments accept the spellings REST already accepts", () => {
+    for (const netuid of ["080", "80", "0080", 80]) {
+      test(`accepts netuid ${JSON.stringify(netuid)}`, async () => {
+        const error = await callTool("get_subnet_metagraph", {
+          netuid,
+          fields: ["uid"],
+        });
+        // Not an argument rejection. The handler may still decline for want of
+        // a live binding; what must not happen is invalid_params on the shape.
+        assert.notEqual(error?.code, "invalid_params");
+      });
+    }
+
+    // The coercion must not widen past what REST accepts -- it 404s `one` and
+    // `-5`, and these must stay rejected for the same reason.
+    for (const netuid of ["one", "-5", "1.5", "1e3", "+5", "", "  ", true]) {
+      test(`still rejects netuid ${JSON.stringify(netuid)}`, async () => {
+        const error = await callTool("get_subnet_metagraph", {
+          netuid,
+          fields: ["uid"],
+        });
+        assert.equal(error?.code, "invalid_params");
+        assert.match(String(error.message), /non-negative integer/);
+      });
+    }
+  });
+
   test("the intent argument is still accepted, not read as unknown", async () => {
     // `context` is declared on every tool and stripped before the handler --
     // it must never read as an unknown key.

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -127,7 +127,14 @@ describe("MCP tool-dispatch usage telemetry", () => {
 
     assert.equal(payload.result.isError, true);
     assert.equal(spy.events.length, 1);
-    assert.equal(spy.events[0].event.mcpTool, "no_such_tool_at_all");
+    // The name is BUCKETED, not recorded verbatim: `params.name` is
+    // caller-supplied and reaches PostHog as a breakdown dimension, so an
+    // unregistered one is folded into a single label rather than minting a new
+    // property value per guess (see mcpToolLabel, and
+    // tests/mcp-tool-name-cardinality.test.ts for the full contract). What this
+    // test is actually about -- that an unknown tool is COUNTED as a failure --
+    // is unchanged, and rides on `ok` and `errorCode` below.
+    assert.equal(spy.events[0].event.mcpTool, "unregistered_tool");
     assert.equal(spy.events[0].event.ok, false);
     // metagraphed#7726: the one isError path with no toolError behind it
     // still gets its own literal code.

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -23,6 +23,10 @@ import {
   recordMcpInitializeEvent,
   normalizeExceptionMessage,
   recordMcpToolCallEvent,
+  recordMcpPromptGetEvent,
+  recordMcpPromptsListEvent,
+  recordMcpResourceReadEvent,
+  recordMcpResourcesListEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
   resolvePostHogHost,
@@ -2870,6 +2874,35 @@ describe("every recorder stamps the deployment dimensions", () => {
     [
       "$mcp_tools_list",
       (env, deps) => recordMcpToolsListEvent(env, { toolCount: 3 }, deps),
+    ],
+    // The resource/prompt four. They share one poster
+    // (postMcpResourceEvent), so these four rows prove the shared stamp is
+    // reached from each entry point rather than four separate stamps.
+    [
+      "$mcp_resources_list",
+      (env, deps) => recordMcpResourcesListEvent(env, {}, deps),
+    ],
+    [
+      "$mcp_resource_read",
+      (env, deps) =>
+        recordMcpResourceReadEvent(
+          env,
+          { resourceName: "metagraph://registry/summary" },
+          deps,
+        ),
+    ],
+    [
+      "$mcp_prompts_list",
+      (env, deps) => recordMcpPromptsListEvent(env, {}, deps),
+    ],
+    [
+      "$mcp_prompt_get",
+      (env, deps) =>
+        recordMcpPromptGetEvent(
+          env,
+          { resourceName: "integrate_with_subnet" },
+          deps,
+        ),
     ],
     [
       "ai_degraded",

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -3270,3 +3270,90 @@ describe("usageEventProperties #9900 dimensions", () => {
     assert.equal(props?.query_shape, "SELECT 1");
   });
 });
+
+// The optional halves of the resource/prompt poster (#10617).
+//
+// postMcpResourceEvent is the single body behind all four of
+// $mcp_resources_list / $mcp_resource_read / $mcp_prompts_list /
+// $mcp_prompt_get, and three of its fields are optional: the session id, the
+// arguments, and the result. The table above drives every recorder through the
+// same populated path, so the branch where a field is ABSENT was never taken --
+// and "absent" is the common case for the two list events, which name nothing
+// and carry no payload.
+//
+// That matters beyond coverage: an undefined slipping into `properties` as a
+// literal key is how a PostHog dimension becomes the string "undefined" for a
+// whole event family, which is only visible once it is already in the data.
+describe("the resource/prompt poster's optional fields", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  test("a session id is forwarded as $session_id", async () => {
+    const calls: Row[] = [];
+    await recordMcpResourceReadEvent(
+      mockEnv(CONFIGURED),
+      { resourceName: "metagraph://registry/summary", sessionId: " sess-1 " },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const properties = (calls[0].body as Row).properties as Row;
+    // Trimmed, not passed through raw.
+    assert.equal(properties.$session_id, "sess-1");
+  });
+
+  test("a blank or absent session id sets no key at all", async () => {
+    for (const sessionId of [undefined, null, "", "   "]) {
+      const calls: Row[] = [];
+      await recordMcpResourcesListEvent(
+        mockEnv(CONFIGURED),
+        { sessionId } as Row,
+        { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+      );
+      const properties = (calls[0].body as Row).properties as Row;
+      assert.ok(
+        !("$session_id" in properties),
+        `sessionId ${JSON.stringify(sessionId)} should leave the key unset, ` +
+          "not set it to undefined",
+      );
+    }
+  });
+
+  test("arguments and result are omitted when the caller sends none", async () => {
+    // The shape of both list events: no resource name, no parameters, no
+    // response.
+    const calls: Row[] = [];
+    await recordMcpPromptsListEvent(mockEnv(CONFIGURED), {}, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    } as Row);
+    const properties = (calls[0].body as Row).properties as Row;
+    assert.ok(!("$mcp_parameters" in properties));
+    assert.ok(!("$mcp_response" in properties));
+    assert.ok(!("$mcp_resource_name" in properties));
+  });
+
+  test("arguments and result are carried when they are present", async () => {
+    const calls: Row[] = [];
+    await recordMcpPromptGetEvent(
+      mockEnv(CONFIGURED),
+      {
+        resourceName: "explain-subnet",
+        parameters: { netuid: 64 },
+        response: { text: "ok" },
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const properties = (calls[0].body as Row).properties as Row;
+    assert.ok(properties.$mcp_parameters !== undefined);
+    assert.ok(properties.$mcp_response !== undefined);
+    assert.equal(properties.$mcp_resource_name, "explain-subnet");
+  });
+
+  test("a throwing transport returns false rather than propagating", async () => {
+    // Same no-throw contract every recorder in this module holds: telemetry
+    // must never be the reason an MCP method fails.
+    const emitted = await recordMcpResourceReadEvent(
+      mockEnv(CONFIGURED),
+      { resourceName: "metagraph://registry/summary" },
+      { fetch: fakeFetch({ throws: true }) },
+    );
+    assert.equal(emitted, false);
+  });
+});


### PR DESCRIPTION
Six defects found by reading the live PostHog project against what this server
actually serves, then verified against production. Four are agent-facing
refusals that were correct but unactionable; two are analytics blind spots.

No linked issue — none of the six had one open.

## How these were found, and one trap worth recording

A plain 30-day `$mcp_tool_call` aggregate reports `call_subnet_surface` at
**67.6% failing** and `get_subnet_ownership_history` at **86.5%**. Both are
wrong as a description of now. The window is dominated by 13,260 pre-#8963
unversioned events (14:1 over current traffic) where no error was ever
classified:

| `$mcp_server_version` | events | errors | unclassified | with intent |
| --- | --- | --- | --- | --- |
| unversioned (pre-#8963) | 13,260 | 1,697 | **1,697 (all)** | 0 |
| 1.78.12 / 1.78.13 | 706 | 58 | 0 | 0 |
| 1.78.16 (current) | 274 | 14 | 0 | 132 |

Scoped to the deployed version, every live failure is `invalid_params`.
`ownership-history` was separately confirmed serving HTTP 200 in production, so
that 86.5% is fully historical. Anything read off this event family has to be
scoped by `$mcp_server_version` first.

## The refusals that were right but unactionable

**1. `tools/call` unknown arguments** — `validateToolArguments` refused any key
a tool's `inputSchema` does not declare and reported all of them as
`Invalid arguments for tool <name>.` No key, no vocabulary. What agents were
actually sending:

| sent | tool | why it failed |
| --- | --- | --- |
| `{"limit":"5","netuid":64}` | `get_subnet_registrations` | pages by `window` |
| `{"limit":3,"netuid":3}` | `get_validator_history` | pages by `window` |
| `{"address":"5FWh…"}` | `get_account_identity` | keyed on `ss58` |
| `{"random_string":"check"}` | `get_self_health` | takes nothing |

Each is one list away from a correct retry; each agent retried the identical
call. Now names the offending key(s) and the accepted ones, in the idiom the
handlers' own guards already use. Non-object `arguments` splits out as a
distinct shape error.

This is **not** schema validation at dispatch — #8942 measured that and
rejected it, and `tests/mcp-schema-enforcement.test.ts` records why. Only the
reporting of the rejection that already happened changes.

**2. `fields=` unsupported field** — same shape, different surface. Two live
examples, both correct refusals:

- `get_emission_pipeline` + `fields=…,name` — those rows are pure chain state;
  `name` is registry metadata and lives on `get_economics`.
- `get_economics` + `total_stake_tao` — the field is `total_stake_alpha`.
  Subnet stake is alpha-denominated, so the guessed unit suffix names nothing.

Neither field should be added: the first would join registry metadata into a
chain-state artifact, the second is not a quantity that exists. The message now
lists the vocabulary. `UnknownFieldResolver` grows an optional `known()`
companion rather than returning its set, because `unknownAgainstRows`
deliberately settles a valid request from the first row — `known()` runs on the
error path only, pinned by a test that fails if the happy path ever calls it.

**3. Zero-padded netuid** — `GET /api/v1/subnets/080/health` serves netuid 80;
`get_subnet_health` with `{"netuid":"080"}` answered `invalid_params`. Same
logical request, two answers, three of the day's live failures. HTTP hands
every path value over as a string, so the REST parser has always coerced —
coercion is this pair of surfaces' established contract, not a leniency
invented here. Strictly the decimal spelling: REST 404s `one` and `-5` and so
does this, as do `1.5`, `1e3`, `+5`, empty and whitespace-only.

## The analytics blind spots

**4. Resources and prompts were never recorded.** The server advertises both
capabilities in its handshake and answers four methods behind them; PostHog
defines an event for each; **zero of all four in 30 days**. A client that read
a resource every turn was indistinguishable from one that never touched the
surface — the blind spot #8963 closed for `tools/list`, left open one method
family over. All four now emit through one shared poster, so the deployment
stamp cannot land on three of them.

Volume was measured before adding them, per the free-tier budget: existing
`mcp:resources/list` runs ~17.5/day, `prompts/list` ~5.7/day,
`resources/read` ~0/day, `prompts/get` zero. **~23 events/day, ~0.07% of the
1M budget.** That measurement is itself a finding: this server maintains a
prompt surface essentially nobody uses.

**5. `$mcp_tool_name` was writable by strangers.** `params.name` is
caller-supplied and passed through verbatim onto both `usage_event` and
`$mcp_tool_call`, so anyone could mint unbounded distinct property values by
looping `tools/call` over random names. This is exactly what
`MCP_LABELLED_METHODS` prevents for `method` — whose own comment warns that
"getting it right in one place and wrong in the next is how that class of bug
survives." It survived here: 30+ single-use `__verifymcp_auth_probe_<hash>__`
values from one third-party verifier are already in the project's breakdown
alongside the real 232, on a free-tier plan. Unregistered names now fold into
one sentinel; `unknown_tool` still counts the guesses, and the guessed name is
still readable in `$mcp_parameters`.

Resource and prompt names stay bounded by construction — both handlers throw
for input they do not serve, and the event is scheduled after they resolve.

**6. Browser events carried no `environment` or `release`.** Every `$lib: web`
exception in the last three days reads `environment: (unset)` while the
Worker's read `production` — the one surface whose events could not be told
apart from a developer's laptop, which in Error Tracking is the difference
between "this is happening to users" and "this is somebody running
`vite dev`". Registered as super properties because exception autocapture
bypasses this module's wrappers entirely (the same reason `before_send`
exists), so a per-call-site property would miss exactly the events that need
it.

`release` required restoring the `WORKERS_CI_COMMIT_SHA` bridge #7766 removed
(no client code read it then; one does now) — as the prefixed env var, not the
`define` block that was removed. `define` substitutes on
`import.meta.env.VITE_POSTHOG_RELEASE` literally, which the
`import.meta.env?.` idiom every other var here uses does not match, so it would
have resolved to undefined in silence. The value equals
`posthogRollupPlugin`'s `releaseVersion`, so runtime events and uploaded source
maps name the same release. Omitted locally and in PR CI rather than
registered as `"dev"`.

## Verification

- `tsc --noEmit` clean at the repo root and in `apps/ui` (with workspaces
  built).
- **1,977** root tests and **1,389** `apps/ui` tests pass, including three new
  suites (`mcp-unknown-argument-message`, `mcp-tool-name-cardinality`,
  `mcp-resource-prompt-telemetry`).
- `validate:mcp`, `mcp-route-map`, `mcp-input-parity`, `tool-route-divergence`,
  `no-hand-written-mjs`, `unreferenced-exports`, `contract-drift`, `api`,
  `openapi`, `types` all pass.
- Rebased onto `2778a573a` and re-verified; no file overlap with the six
  commits that landed since branching.

Two existing gates caught real bugs in this work mid-flight and are worth
naming: the recorder table in `tests/usage-telemetry.test.ts` failed until all
four new recorders were listed, and the resource/prompt tests failed until the
new deps were threaded through `buildContext` — the exact silent fall-through
the comment above that block already warns about.

No contract or schema change, so no regenerated artifacts. `apps/ui` changes
are confined to `src/lib/**` plus build config, with no visual output.
