### PR TITLE
perf(validators): bound the baseline join to the window it already implies

### DIFF
--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -683,6 +683,99 @@ test("GET /api/v1/validators serves the leaderboard from D1 with real prices and
   assert.equal(identity.name, "Ventura Labs");
 });
 
+test("a non-root baseline is priced through subnet_snapshots inside the window", async () => {
+  // netuid != 0, so the CASE falls to `tao_in_pool_tao / alpha_in_pool` and the
+  // LEFT JOIN is actually load-bearing. The root-only test above never reaches
+  // it: `CASE WHEN nd.netuid = 0 THEN 1` short-circuits the price entirely.
+  insertNeuron({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5Priced",
+    coldkey: "5ColdPriced",
+    stake_tao: 200,
+    validator_permit: 1,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 0,
+    hotkey: "5Priced",
+    stake_tao: 100,
+    validator_permit: 1,
+    snapshot_date: dayAgo(1),
+  });
+  await insertPrice(7, dayAgo(1), 3);
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const entry = ((await res.json()) as Row).validators as Row[];
+  const priced = entry.find((v) => v.hotkey === "5Priced") as Row;
+  assert.ok(priced, "the validator is served");
+  assert.notEqual(
+    priced.realized_return_1d,
+    null,
+    "the join found the snapshot inside the window, so the baseline is priced",
+  );
+  assert.equal(priced.realized_return_1d_as_of, dayAgo(1));
+});
+
+test("the newest day still wins even when it has no price row", async () => {
+  // THE TEST THAT PINS THE JOIN AS A *LEFT* JOIN. The window bound is repeated
+  // on the ON clause so the planner can prune subnet_snapshots; moving it into
+  // WHERE would prune the same rows but ALSO drop every unmatched left row,
+  // silently turning this into an inner join.
+  //
+  // The difference is observable exactly here: with two candidate days inside
+  // the tolerance and a price on only the older one, the correct answer is the
+  // NEWEST day with a null baseline. An inner join would discard that day and
+  // hand back the older one's price as though it were today's -- a wrong number
+  // where there should be an honest absence.
+  insertNeuron({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5Gap",
+    coldkey: "5ColdGap",
+    stake_tao: 200,
+    validator_permit: 1,
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5Gap",
+    stake_tao: 100,
+    validator_permit: 1,
+    snapshot_date: dayAgo(1),
+  });
+  insertDaily({
+    netuid: 7,
+    uid: 1,
+    hotkey: "5Gap",
+    stake_tao: 50,
+    validator_permit: 1,
+    snapshot_date: dayAgo(2),
+  });
+  // Price ONLY the older day.
+  await insertPrice(7, dayAgo(2), 3);
+  const res = await call(req("/api/v1/validators"));
+  assert.equal(res.status, 200);
+  const rows = ((await res.json()) as Row).validators as Row[];
+  const gap = rows.find((v) => v.hotkey === "5Gap") as Row;
+  assert.ok(gap, "the validator is still served");
+  // NULL IS THE DISCRIMINATOR. The newest qualifying day has no price row, so
+  // its SUM is NULL and the return is honestly absent. Under an inner join that
+  // day would be gone from `daily` entirely, rn = 1 would land on dayAgo(2),
+  // and this would be a NUMBER -- yesterday's price presented as today's
+  // baseline.
+  //
+  // `realized_return_1d_as_of` cannot be asserted alongside it: it is
+  // deliberately nulled whenever the return is null
+  // (src/metagraph-neurons.ts:743), so it reads the same either way.
+  assert.equal(
+    gap.realized_return_1d,
+    null,
+    "no price on the newest day means no baseline; an inner join would have " +
+      "silently substituted dayAgo(2)'s",
+  );
+});
+
 test("GET /api/v1/validators honors an explicit sort and clamps a bogus limit", async () => {
   insertNeuron({
     netuid: 0,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6059,6 +6059,26 @@ async function loadRealizedStakeBaselinesD1(
         )
           .toISOString()
           .slice(0, 10);
+        // THE WINDOW IS REPEATED ON THE JOIN, and it is not redundant to the
+        // planner even though it is redundant to the reader. `s.snapshot_date =
+        // nd.snapshot_date` already confines the right side to the same three
+        // days the WHERE clause allows -- but Postgres does not propagate that
+        // equality into a bound on `s`, so it built the hash from the WHOLE of
+        // subnet_snapshots and probed it with the handful of rows that could
+        // match. Measured on production, d1 window:
+        //
+        //   without:  Seq Scan on subnet_snapshots  51,407 rows   27.454 ms
+        //   with:     Bitmap Index Scan                387 rows   10.484 ms
+        //
+        // 2.6x, on an index that already exists
+        // (idx_subnet_snapshots_date_netuid). Stated as a JOIN predicate rather
+        // than in WHERE on purpose: in WHERE it would filter away the unmatched
+        // left rows and silently turn this into an INNER join, which is exactly
+        // the ~1,000 hotkeys per d30 window that legitimately have no snapshot
+        // that far back and must keep returning NULL.
+        //
+        // Equivalence checked against production over all three windows: 0
+        // differing rows of 1,066 / 1,084 / 1,061, max absolute difference 0.
         const text =
           `WITH daily AS (
             SELECT nd.hotkey AS hotkey, nd.snapshot_date AS snapshot_date,
@@ -6066,6 +6086,7 @@ async function loadRealizedStakeBaselinesD1(
             FROM neuron_daily nd
             LEFT JOIN subnet_snapshots s
               ON s.netuid = nd.netuid AND s.snapshot_date = nd.snapshot_date
+              AND s.snapshot_date <= ? AND s.snapshot_date >= ?
             WHERE nd.validator_permit = TRUE` +
           (hotkey ? " AND nd.hotkey = ?" : "") +
           ` AND nd.snapshot_date <= ? AND nd.snapshot_date >= ?
@@ -6078,9 +6099,13 @@ async function loadRealizedStakeBaselinesD1(
           SELECT hotkey, stake_tao AS baseline_stake_tao,
             snapshot_date AS baseline_date
           FROM ranked WHERE rn = 1`;
+        // The join bounds come FIRST -- they appear earlier in the statement,
+        // and these are positional placeholders.
         return sql.unsafe<Record<string, unknown>>(
           text,
-          hotkey ? [hotkey, cutoff, floor] : [cutoff, floor],
+          hotkey
+            ? [cutoff, floor, hotkey, cutoff, floor]
+            : [cutoff, floor, cutoff, floor],
         );
       }),
     );


### PR DESCRIPTION
## Summary

`loadRealizedStakeBaselinesD1` is the largest consumer of database I/O in the system — **275 GB of
storage reads** across its two parameterisations in 3.5 days, against a 1.9 GB database (~43% of all
reads).

The plan was never the problem. `neuron_daily` already uses `idx_neuron_daily_permit_date` correctly.
The waste was the **other side of the join**:

```
->  Hash Left Join  (rows=4736)
      ->  Index Scan using idx_neuron_daily_permit_date  (rows=4736)   Buffers: 3060
      ->  Hash  (rows=51407)  Buffers: 516
            ->  Seq Scan on subnet_snapshots            ← the entire table
Execution Time: 27.454 ms
```

It hashed all 51,407 rows of `subnet_snapshots` to probe it with the ~4,700 that could match. The
window is three days wide (`REALIZED_RETURN_BASELINE_TOLERANCE_DAYS = 2`), so at most ~390 snapshot
rows are reachable — but `s.snapshot_date = nd.snapshot_date` does not propagate into a bound on `s`,
so the build side could not be pruned.

Repeating the window as a JOIN predicate lets it:

| | Build side | Execution |
| --- | --- | --- |
| before | Seq Scan, 51,407 rows, 516 buffers | 27.454 ms |
| after | Bitmap Index Scan, 387 rows, 25 buffers | **10.484 ms** |

**2.6x**, using `idx_subnet_snapshots_date_netuid` — already present. No schema change.

## ON, not WHERE — and the difference is not cosmetic

In `WHERE` the same right-hand rows would be pruned, but every unmatched **left** row would go with
them, turning this into an inner join. ~1,000 hotkeys per d30 window legitimately have no
`subnet_snapshots` row that far back. Under an inner join their newest qualifying day would vanish from
`daily`, `rn = 1` would land on an *older* day, and the route would serve a stale price as the current
baseline — a wrong number where there should be an honest absence.

Two tests were added. The second is the discriminating one: two candidate days inside the tolerance
with a price on only the **older**, asserting `realized_return_1d` is `null`. Under an inner join it
would be a number. I confirmed it fails when the join is made inner — along with the pre-existing
root-price test, which turns out to depend on the same property.

(`realized_return_1d_as_of` can't be asserted alongside it: `src/metagraph-neurons.ts:743` deliberately
nulls it whenever the return is null, so it reads identically either way.)

## Equivalence, checked before the change

Run against production across all three windows:

| Window | Rows compared | Differing | Max abs diff |
| --- | --- | --- | --- |
| d1 (`2026-08-10`/`08-08`) | 1,066 | **0** | 0 |
| d7 (`2026-08-04`/`08-02`) | 1,084 | **0** | 0 |
| d30 (`2026-07-12`/`07-10`) | 1,061 | **0** | 0 |

The d30 window returns `NULL` for 1,000 of its 1,061 hotkeys under *both* forms — the LEFT JOIN
behaviour this change had to preserve.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` / `format:check` / `typecheck` | pass |
| `npm run validate` | pass |
| `tests/data-api-neurons.test.ts` + `metagraph-neurons` + `request-handlers-entities` + `graphql` | **1,622 passed** |
| **Patch coverage** (diff-intersected) | **100% branches (2/2)**; the remaining added lines are the SQL string and its comment |

Branched from current `main` (which includes #10617) and validated there.

Closes #10621
