### PR TITLE
refactor(lakehouse): read the column tuples the schema already generates

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -100,13 +100,13 @@ import {
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import { readStore } from "./read-store.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
-const EVENT_COLUMNS =
-  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
-  "netuid, uid, amount_tao, alpha_amount, observed_at";
+// The generated tuple, not a retyped copy -- see src/r2-sql-blocks.ts for why.
+const EVENT_COLUMNS = ACCOUNT_EVENTS_COLUMNS.join(", ");
 
 /** EXACTLY the Postgres tier's feed order -- the public cursor token encodes
  * this composite key, so a different order would emit tokens the other tier

--- a/src/chain-events-cold-tier.ts
+++ b/src/chain-events-cold-tier.ts
@@ -40,6 +40,7 @@ import { formatChainEvent } from "./chain-detail-hot-tier.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { type ChainNetworkId, chainTable } from "./chain-network.ts";
 import { r2SqlQuery, safeBlockNumber, safeNameLiteral } from "./r2-sql.ts";
+import { CHAIN_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import { lakehouseHeadBlock } from "./blocks-cold-tier.ts";
 import {
   SUBNET_LEASE_CREATED_KIND,
@@ -48,9 +49,8 @@ import {
 
 /** Kept identical to the deleted handler's SELECT list so both tiers hand the
  * caller the same event shape. */
-const EVENT_COLUMNS =
-  "block_number, event_index, pallet, method, args, phase, extrinsic_index, " +
-  "observed_at";
+// The generated tuple, not a retyped copy -- see src/r2-sql-blocks.ts for why.
+const EVENT_COLUMNS = CHAIN_EVENTS_COLUMNS.join(", ");
 
 /**
  * How many blocks one page may scan. ~16.7 hours of chain at 12s/block, and

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -49,12 +49,14 @@ import {
   safeSs58Literal,
 } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
-const EVENT_COLUMNS =
-  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
-  "netuid, uid, amount_tao, alpha_amount, observed_at";
+// The generated tuple, not a retyped copy -- see src/r2-sql-blocks.ts for why.
+// This exact eleven-name list was written out by hand in four separate files;
+// they now share one source.
+const EVENT_COLUMNS = ACCOUNT_EVENTS_COLUMNS.join(", ");
 
 /** The 3-part key the account-events feed pages on, mirroring data-api. */
 const CURSOR_ARITY = 3;

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -48,21 +48,22 @@ import {
   safeSs58Literal,
 } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import {
+  ACCOUNT_EVENTS_COLUMNS,
+  EXTRINSICS_COLUMNS,
+} from "../generated/lakehouse/types.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
-const EXTRINSIC_COLUMNS =
-  "block_number, extrinsic_index, extrinsic_hash, signer, call_module, " +
-  "call_function, success, fee_tao, tip_tao, call_args, observed_at";
+// The generated tuples, not retyped copies -- see src/r2-sql-blocks.ts for why.
+const EXTRINSIC_COLUMNS = EXTRINSICS_COLUMNS.join(", ");
 
 /** Events emitted by one extrinsic, embedded in the detail payload. The
  * column list and the bound match the Postgres tier's embedded-events query
  * exactly, and rows go through the same formatAccountEvent before embedding
  * -- buildExtrinsic embeds what it is given verbatim, so handing it raw rows
  * would leak an unformatted shape into a payload callers already parse. */
-const EVENT_COLUMNS =
-  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
-  "netuid, uid, amount_tao, alpha_amount, observed_at";
+const EVENT_COLUMNS = ACCOUNT_EVENTS_COLUMNS.join(", ");
 const MAX_EMBEDDED_EVENTS = 50;
 
 /** EXACTLY the Postgres tier's feed order. The observed_at-leading key is not

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -25,6 +25,7 @@
 import { buildBlock, buildBlockFeed } from "./blocks.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { type ChainNetworkId, chainTable } from "./chain-network.ts";
+import { BLOCKS_COLUMNS } from "../generated/lakehouse/types.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -34,8 +35,13 @@ import {
 
 /** Columns the formatters need — kept identical to the Postgres tier's SELECT
  * list so both tiers hand the formatter the same shape. */
-const BLOCK_COLUMNS =
-  "block_number, block_hash, parent_hash, author, extrinsic_count, event_count, spec_version, observed_at";
+// FROM THE GENERATED TUPLE, not retyped. generated/lakehouse/types.ts is
+// snapshotted from the live Iceberg catalog (#10315/#10350), so a column
+// renamed upstream lands here as a compile error instead of a query selecting a
+// column the table no longer has. Byte-identical to the literal it replaces --
+// this is a no-op today and a tripwire tomorrow, which is the whole point of
+// generating the tuple at all.
+const BLOCK_COLUMNS = BLOCKS_COLUMNS.join(", ");
 
 /**
  * How deep an emulated OFFSET may go. Past this the over-fetch stops being a

--- a/src/subnet-event-summary-cold-tier.ts
+++ b/src/subnet-event-summary-cold-tier.ts
@@ -37,14 +37,14 @@ import {
 } from "./account-events.ts";
 import { SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT } from "./route-limits.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 
 type Row = Record<string, unknown>;
 
 /** Kept identical to the sibling feed's SELECT list so both hand
  * `formatAccountEvent` the same shape. */
-const EVENT_COLUMNS =
-  "block_number, event_index, extrinsic_index, event_kind, hotkey, coldkey, " +
-  "netuid, uid, amount_tao, alpha_amount, observed_at";
+// The generated tuple, not a retyped copy -- see src/r2-sql-blocks.ts for why.
+const EVENT_COLUMNS = ACCOUNT_EVENTS_COLUMNS.join(", ");
 
 /**
  * `count(DISTINCT <column>)` per event_kind, expressed as a nested GROUP BY.


### PR DESCRIPTION
## Summary

`generated/lakehouse/types.ts` is snapshotted from the live Iceberg catalog and drift-gated in CI
(#10315 / #10350) — and had **zero production consumers**. The only importer repo-wide was its own
test. Meanwhile seven literals retyped the same lists by hand, four of them the *identical* eleven
`account_events` names in four different files.

Nothing linked the two. A column renamed upstream would update the snapshot and the generated tuple
while the literals kept selecting the old name — the artifact recording the drift instead of
preventing it, which is precisely the failure #10315 exists to end.

## Verified byte-identical first

Each literal was compared to `<TABLE>_COLUMNS.join(", ")` before being replaced:

```
IDENTICAL  subnet-event-summary EVENT -> ACCOUNT_EVENTS_COLUMNS
IDENTICAL  account-feeds EVENT        -> ACCOUNT_EVENTS_COLUMNS
IDENTICAL  events-cold EVENT          -> ACCOUNT_EVENTS_COLUMNS
IDENTICAL  extrinsics-cold EVENT      -> ACCOUNT_EVENTS_COLUMNS
IDENTICAL  extrinsics-cold EXTRINSIC  -> EXTRINSICS_COLUMNS
IDENTICAL  chain-events-cold EVENT    -> CHAIN_EVENTS_COLUMNS
IDENTICAL  r2-sql-blocks BLOCK        -> BLOCKS_COLUMNS
```

So no emitted SQL changes today, and the swap becomes a compile error the moment the schema moves.

## Deliberately not touched

`src/chain-detail-hot-tier.ts`'s `EXTRINSIC_COLUMNS` **looks** identical but reads Neon's
`chain_detail_extrinsics`, not the lakehouse's `chain.extrinsics`. Two different tables that happen to
share a column list today — pointing it at the Iceberg tuple would couple a Postgres read to the
lakehouse schema, which is a new bug rather than a fixed one. It stays hand-written.

## What this does not finish

`r2SqlQuery` still returns `Promise<Record<string, unknown>[] | null>` with no row type parameter
(`src/r2-sql.ts:355`), so the generated **interfaces** (`BlocksRow` and friends) remain unusable. That
change, plus a lakehouse counterpart to Neon's `MAX_UNTYPED_READS` ratchet, is the rest of the
adoption and belongs in its own PR.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` / `format:check` / `typecheck` | pass |
| `npm run validate` | pass |
| Cold-tier + lakehouse suites (r2-sql-blocks, blocks-cold-tier, chain-events-degraded, extrinsics, extrinsic-detail, block-events, chain-detail-serving, lakehouse-schema) | **205 passed** |

Branched from current `main` and validated there.

Closes #10623
