### PR TITLE
chore(db): re-snapshot the live Neon schema

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -603,6 +603,36 @@ CREATE TABLE public.raw_capture_state (
 );
 
 --
+-- Name: revenue_observations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.revenue_observations (
+    surface_id text NOT NULL,
+    netuid integer NOT NULL,
+    period text NOT NULL,
+    grain text NOT NULL,
+    amount double precision NOT NULL,
+    currency text NOT NULL,
+    provenance text NOT NULL,
+    response_hash text NOT NULL,
+    observed_at bigint NOT NULL,
+    CONSTRAINT revenue_observations_observed_at_is_millis CHECK ((observed_at >= '1000000000000'::bigint)),
+    CONSTRAINT revenue_observations_provenance_is_readable CHECK ((provenance = ANY (ARRAY['probe-derived'::text, 'chain-verified'::text])))
+);
+
+--
+-- Name: revenue_probe_failures; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.revenue_probe_failures (
+    surface_id text NOT NULL,
+    netuid integer NOT NULL,
+    reason text NOT NULL,
+    observed_at bigint NOT NULL,
+    CONSTRAINT revenue_probe_failures_observed_at_is_millis CHECK ((observed_at >= '1000000000000'::bigint))
+);
+
+--
 -- Name: rpc_accounts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -667,6 +697,22 @@ CREATE TABLE public.subnet_burn_history (
     netuid integer NOT NULL,
     observed_at bigint NOT NULL,
     burn_tao double precision NOT NULL
+);
+
+--
+-- Name: subnet_deregistration_daily; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subnet_deregistration_daily (
+    netuid integer NOT NULL,
+    snapshot_date text NOT NULL,
+    moving_price double precision,
+    registered_at_block bigint,
+    subnet_mechanism integer,
+    network_immunity_period bigint,
+    pinned_block bigint,
+    captured_at bigint NOT NULL,
+    CONSTRAINT subnet_deregistration_daily_captured_at_is_millis CHECK ((captured_at >= '1000000000000'::bigint))
 );
 
 --
@@ -1307,6 +1353,20 @@ ALTER TABLE ONLY public.raw_capture_state
     ADD CONSTRAINT raw_capture_state_pkey PRIMARY KEY (network);
 
 --
+-- Name: revenue_observations revenue_observations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.revenue_observations
+    ADD CONSTRAINT revenue_observations_pkey PRIMARY KEY (surface_id, period);
+
+--
+-- Name: revenue_probe_failures revenue_probe_failures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.revenue_probe_failures
+    ADD CONSTRAINT revenue_probe_failures_pkey PRIMARY KEY (surface_id, observed_at);
+
+--
 -- Name: rpc_accounts rpc_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1347,6 +1407,13 @@ ALTER TABLE ONLY public.self_health_daily
 
 ALTER TABLE ONLY public.subnet_burn_history
     ADD CONSTRAINT subnet_burn_history_pkey PRIMARY KEY (netuid, observed_at);
+
+--
+-- Name: subnet_deregistration_daily subnet_deregistration_daily_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subnet_deregistration_daily
+    ADD CONSTRAINT subnet_deregistration_daily_pkey PRIMARY KEY (netuid, snapshot_date);
 
 --
 -- Name: subnet_emission_enabled_history subnet_emission_enabled_history_netuid_observed_at_key; Type: CONSTRAINT; Schema: public; Owner: -
@@ -1603,6 +1670,12 @@ CREATE INDEX idx_chain_concentration_daily_day ON public.chain_concentration_dai
 CREATE INDEX idx_chain_detail_account_events_extrinsic ON public.chain_detail_account_events USING btree (block_number, extrinsic_index);
 
 --
+-- Name: idx_chain_detail_account_events_observed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chain_detail_account_events_observed ON public.chain_detail_account_events USING btree (observed_at);
+
+--
 -- Name: idx_chain_detail_blocks_hash; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1615,10 +1688,22 @@ CREATE INDEX idx_chain_detail_blocks_hash ON public.chain_detail_blocks USING bt
 CREATE INDEX idx_chain_detail_chain_events_extrinsic ON public.chain_detail_chain_events USING btree (block_number, extrinsic_index);
 
 --
+-- Name: idx_chain_detail_chain_events_observed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chain_detail_chain_events_observed ON public.chain_detail_chain_events USING btree (observed_at);
+
+--
 -- Name: idx_chain_detail_extrinsics_hash_lower; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_chain_detail_extrinsics_hash_lower ON public.chain_detail_extrinsics USING btree (lower(extrinsic_hash));
+
+--
+-- Name: idx_chain_detail_extrinsics_observed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_chain_detail_extrinsics_observed ON public.chain_detail_extrinsics USING btree (observed_at);
 
 --
 -- Name: idx_github_accounts_github_user_id; Type: INDEX; Schema: public; Owner: -
@@ -1705,6 +1790,24 @@ CREATE INDEX idx_nominator_positions_hotkey ON public.nominator_positions USING 
 CREATE INDEX idx_nominator_positions_passes_completed ON public.nominator_positions_passes USING btree (completed_at DESC);
 
 --
+-- Name: idx_revenue_failures_netuid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_revenue_failures_netuid ON public.revenue_probe_failures USING btree (netuid, observed_at DESC);
+
+--
+-- Name: idx_revenue_obs_netuid_period; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_revenue_obs_netuid_period ON public.revenue_observations USING btree (netuid, period DESC);
+
+--
+-- Name: idx_revenue_obs_period; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_revenue_obs_period ON public.revenue_observations USING btree (period DESC);
+
+--
 -- Name: idx_rpc_accounts_ss58; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1727,6 +1830,18 @@ CREATE INDEX idx_self_health_daily_day ON public.self_health_daily USING btree (
 --
 
 CREATE INDEX idx_subnet_burn_history_observed ON public.subnet_burn_history USING btree (observed_at);
+
+--
+-- Name: idx_subnet_dereg_daily_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_subnet_dereg_daily_date ON public.subnet_deregistration_daily USING btree (snapshot_date DESC);
+
+--
+-- Name: idx_subnet_dereg_daily_netuid_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_subnet_dereg_daily_netuid_date ON public.subnet_deregistration_daily USING btree (netuid, snapshot_date DESC);
 
 --
 -- Name: idx_subnet_hyperparams_history_netuid_observed; Type: INDEX; Schema: public; Owner: -

--- a/generated/db/schema.json
+++ b/generated/db/schema.json
@@ -1506,6 +1506,84 @@
     "nullable": false
   },
   {
+    "table": "revenue_observations",
+    "column": "amount",
+    "udt": "float8",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "currency",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "grain",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "netuid",
+    "udt": "int4",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "observed_at",
+    "udt": "int8",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "period",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "provenance",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "response_hash",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_observations",
+    "column": "surface_id",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_probe_failures",
+    "column": "netuid",
+    "udt": "int4",
+    "nullable": false
+  },
+  {
+    "table": "revenue_probe_failures",
+    "column": "observed_at",
+    "udt": "int8",
+    "nullable": false
+  },
+  {
+    "table": "revenue_probe_failures",
+    "column": "reason",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "revenue_probe_failures",
+    "column": "surface_id",
+    "udt": "text",
+    "nullable": false
+  },
+  {
     "table": "rpc_accounts",
     "column": "created_at",
     "udt": "int8",
@@ -1618,6 +1696,54 @@
     "column": "observed_at",
     "udt": "int8",
     "nullable": false
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "captured_at",
+    "udt": "int8",
+    "nullable": false
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "moving_price",
+    "udt": "float8",
+    "nullable": true
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "netuid",
+    "udt": "int4",
+    "nullable": false
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "network_immunity_period",
+    "udt": "int8",
+    "nullable": true
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "pinned_block",
+    "udt": "int8",
+    "nullable": true
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "registered_at_block",
+    "udt": "int8",
+    "nullable": true
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "snapshot_date",
+    "udt": "text",
+    "nullable": false
+  },
+  {
+    "table": "subnet_deregistration_daily",
+    "column": "subnet_mechanism",
+    "udt": "int4",
+    "nullable": true
   },
   {
     "table": "subnet_emission_enabled_history",

--- a/generated/db/types.ts
+++ b/generated/db/types.ts
@@ -384,6 +384,27 @@ export interface RawCaptureState {
   updated_at: number | string;
 }
 
+/** `public.revenue_observations` */
+export interface RevenueObservations {
+  amount: number;
+  currency: string;
+  grain: string;
+  netuid: number;
+  observed_at: number | string;
+  period: string;
+  provenance: string;
+  response_hash: string;
+  surface_id: string;
+}
+
+/** `public.revenue_probe_failures` */
+export interface RevenueProbeFailures {
+  netuid: number;
+  observed_at: number | string;
+  reason: string;
+  surface_id: string;
+}
+
 /** `public.rpc_accounts` */
 export interface RpcAccounts {
   created_at: number | string;
@@ -421,6 +442,18 @@ export interface SubnetBurnHistory {
   burn_tao: number;
   netuid: number;
   observed_at: number | string;
+}
+
+/** `public.subnet_deregistration_daily` */
+export interface SubnetDeregistrationDaily {
+  captured_at: number | string;
+  moving_price: number | null;
+  netuid: number;
+  network_immunity_period: number | string | null;
+  pinned_block: number | string | null;
+  registered_at_block: number | string | null;
+  snapshot_date: string;
+  subnet_mechanism: number | null;
 }
 
 /** `public.subnet_emission_enabled_history` */
@@ -727,11 +760,14 @@ export interface DatabaseTables {
   NominatorPositionsPasses: NominatorPositionsPasses;
   Providers: Providers;
   RawCaptureState: RawCaptureState;
+  RevenueObservations: RevenueObservations;
+  RevenueProbeFailures: RevenueProbeFailures;
   RpcAccounts: RpcAccounts;
   SchemaMigrations: SchemaMigrations;
   SelfHealthChecks: SelfHealthChecks;
   SelfHealthDaily: SelfHealthDaily;
   SubnetBurnHistory: SubnetBurnHistory;
+  SubnetDeregistrationDaily: SubnetDeregistrationDaily;
   SubnetEmissionEnabledHistory: SubnetEmissionEnabledHistory;
   SubnetHyperparams: SubnetHyperparams;
   SubnetHyperparamsHistory: SubnetHyperparamsHistory;


### PR DESCRIPTION
## Summary

The committed schema artifacts were **three tables behind production**:

| Table | Columns | Arrived in |
| --- | --- | --- |
| `revenue_observations` | 9 | `0016_revenue_observations.sql` |
| `revenue_probe_failures` | 4 | `0016_revenue_observations.sql` |
| `subnet_deregistration_daily` | 7 | `0015_subnet_deregistration_daily.sql` |

Both migrations are merged and applied. Nothing re-snapshotted afterwards, and
`validate:db-types-drift` stayed green the entire time — it compares the committed types to the
committed *snapshot*, so two files that agree with each other pass regardless of what the database
holds. #10629 adds the scheduled workflow that catches this going forward; this PR is the backlog it
inherited.

## The diff is purely additive

- the three tables and their five indexes
- the three `idx_chain_detail_*_observed` indexes from #10617's migration 0017 — worth noting on its
  own, since their presence here **confirms that migration reached production**

**No column, index or constraint is removed.** That is the direction that would have wanted
investigating rather than committing, and it is worth stating explicitly because a removal is exactly
what a stale snapshot can hide.

`generated/db/types.ts` goes from 53 row interfaces to 56 — 498 columns across 55 tables.

## How it was taken

`npm run snapshot:neon-schema -- --write` against the live database with **pg_dump 18.4**. `pg_dump`
refuses a server newer than itself and Neon runs 18.x, so the script rejects an older client rather
than letting it take a silently different dump — the runner's stock client would have been too old.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` / `format:check` / `typecheck` | pass |
| `npm run validate` | pass |
| `npm run validate:db-types-drift` | pass |
| `neon-sole-store-tables-exist`, `read-store-tables-match-the-sql`, `validate-untyped-db-reads`, `neon-sole-store` | **41 passed** |

Rebased onto current `main` (which now includes #10627) and re-validated there.

Closes #10631
