### PR TITLE
feat(mcp): close the last three holes in the $mcp_* family

### DIFF
--- a/schemas-src/mcp-tools/missing-capability.ts
+++ b/schemas-src/mcp-tools/missing-capability.ts
@@ -1,0 +1,35 @@
+// MCP tool `get_more_tools` -- the capability-gap report.
+//
+// THE ONE TOOL HERE WITH NO ROUTE BEHIND IT, and therefore the one output
+// schema in this directory that is not imported from a route's own
+// ArtifactSchema. That is not the drift #9796 warned about: there is no REST
+// surface for "an agent told us what we do not have", nothing for this shape
+// to drift FROM, and inventing a route to host it would add a public endpoint
+// nobody calls in order to satisfy a convention whose whole purpose is to keep
+// two real definitions in agreement.
+//
+// The tool answers a fixed, contentless acknowledgement by design. Everything
+// of value in the call travels as the standard `context` argument
+// (withIntentArgument), which reaches PostHog as $mcp_intent.
+import { z } from "zod";
+
+export const GetMoreToolsInputSchema = z.object({}).strict();
+export type GetMoreToolsInput = z.infer<typeof GetMoreToolsInputSchema>;
+
+// No `GetMoreToolsOutput` type alias to go with this one. The sibling files
+// export input/output pairs because something consumes both; here the handler
+// builds the object literally and only the SCHEMA is imported (by
+// TOOL_OUTPUT_SCHEMAS), so an alias would be an export nothing reads --
+// exactly what validate:unreferenced-exports exists to keep out.
+export const GetMoreToolsOutputSchema = z
+  .object({
+    /** Always true -- the gap was recorded. Present so a client can tell a
+     * successful report from a transport failure without parsing prose. */
+    acknowledged: z.boolean(),
+    /** Always false. Named positively rather than as an error so an agent
+     * reads it as a settled answer instead of a retryable fault. */
+    additional_tools_available: z.boolean(),
+    /** Plain-language instruction to stop looking. */
+    message: z.string(),
+  })
+  .strict();

--- a/src/mcp-route-map.ts
+++ b/src/mcp-route-map.ts
@@ -56,6 +56,13 @@ export const MCP_TOOL_ROUTES: Readonly<Record<string, McpToolRoute>> = {
     reason:
       "Composes five subnet routes in one round trip; no single route answers it.",
   },
+  get_more_tools: {
+    route: null,
+    reason:
+      "Reports a capability this server lacks; it reads no data and has no " +
+      "REST equivalent, because the caller is an MCP agent telling us what " +
+      "the catalogue is missing rather than asking for anything.",
+  },
   get_network_health: { route: "/api/v1/health" },
   get_health_history: { route: "/api/v1/health/history/{date}" },
   get_subnet_health: { route: "/api/v1/subnets/{netuid}/health" },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -201,6 +201,7 @@ import {
   recordAiDegradedEvent,
   recordExceptionEvent,
   recordMcpInitializeEvent,
+  recordMcpMissingCapabilityEvent,
   recordMcpPromptGetEvent,
   recordMcpPromptsListEvent,
   recordMcpResourceReadEvent,
@@ -1021,6 +1022,11 @@ import {
   GetCoverageDepthInputSchema,
   GetCoverageDepthOutputSchema,
 } from "../schemas-src/mcp-tools/meta-artifacts-2.ts";
+import {
+  type GetMoreToolsInput,
+  GetMoreToolsInputSchema,
+  GetMoreToolsOutputSchema,
+} from "../schemas-src/mcp-tools/missing-capability.ts";
 import { GetFeedInputSchema } from "../schemas-src/mcp-tools/feed.ts";
 import { GetAdapterInputSchema } from "../schemas-src/mcp-tools/get-adapter.ts";
 import {
@@ -1768,6 +1774,7 @@ interface McpCtx {
   recordMcpToolCallEvent?: AnyFn;
   recordMcpInitializeEvent?: AnyFn;
   recordMcpToolsListEvent?: AnyFn;
+  recordMcpMissingCapabilityEvent?: AnyFn;
   recordMcpResourcesListEvent?: AnyFn;
   recordMcpResourceReadEvent?: AnyFn;
   recordMcpPromptsListEvent?: AnyFn;
@@ -4952,7 +4959,50 @@ export function withIntentArgument(tool: McpToolDefinition): McpToolDefinition {
 //
 // Once at module load, not per request: 224 shallow copies at cold start
 // against one on every tools/list.
+/** The name PostHog's own MCP analytics uses for the missing-capability tool.
+ * Matching it is what makes the event land in their prebuilt views rather than
+ * in a bespoke one nobody opens. */
+export const MCP_MISSING_CAPABILITY_TOOL = "get_more_tools";
+
 const MCP_TOOLS_BASE: McpToolDefinition[] = [
+  {
+    // The only tool here that answers nothing and exists to be told something.
+    //
+    // With 232 tools an agent that cannot find what it needs simply gives up,
+    // and that giving-up is invisible: no call, no error, no row. This is the
+    // one signal that names a gap in the catalogue in the agent's own words,
+    // which is why PostHog treats it as the most actionable event an MCP
+    // server owner can collect. The reasoning rides on the standard `context`
+    // argument (withIntentArgument puts it on every tool) so it lands in
+    // $mcp_intent, which is the field their missing-capability views read.
+    //
+    // Deliberately NOT annotated open-world: it reads nothing at all.
+    name: MCP_MISSING_CAPABILITY_TOOL,
+    title: "Report a capability this server does not have",
+    description:
+      "Call this ONLY when you have looked through the available tools and " +
+      "none of them can do what you need. Describe what you were trying to " +
+      "accomplish in the `context` argument, in plain language -- that text " +
+      "is the whole point of the call and is what gets read. This tool " +
+      "returns no data and unlocks no additional tools; it records the gap " +
+      "so the capability can be built. Do not call it as a discovery step: " +
+      "the full catalogue is already in tools/list.",
+    inputSchema: inputJsonSchema(GetMoreToolsInputSchema),
+    async handler(_args: GetMoreToolsInput, _ctx: McpCtx) {
+      // Answering honestly matters as much as recording. An agent told
+      // something vague retries; told plainly that no more tools exist, it
+      // stops and reports back to its user, which is the correct outcome.
+      return {
+        acknowledged: true,
+        additional_tools_available: false,
+        message:
+          "No additional tools exist beyond those already listed by " +
+          "tools/list. Your request has been recorded as a capability gap. " +
+          "Do not retry -- use the closest available tool, or tell the user " +
+          "this is not supported.",
+      };
+    },
+  },
   {
     name: "search_subnets",
     title: "Search Bittensor subnets",
@@ -14632,6 +14682,7 @@ const TOOL_OUTPUT_SCHEMAS = {
   get_feed: GET_FEED_OUTPUT_SCHEMA,
   get_build: GET_BUILD_OUTPUT_SCHEMA,
   get_self_health: GET_SELF_HEALTH_OUTPUT_SCHEMA,
+  [MCP_MISSING_CAPABILITY_TOOL]: outputJsonSchema(GetMoreToolsOutputSchema),
   get_adapter: GET_ADAPTER_OUTPUT_SCHEMA,
   get_agent_catalog: outputJsonSchema(GetAgentCatalogOutputSchema),
   get_agent_resources: GET_AGENT_RESOURCES_OUTPUT_SCHEMA,
@@ -15452,6 +15503,18 @@ async function callTool(params: Row, ctx: McpCtx) {
   );
   scheduleMcpToolCallEvent(ctx, {
     toolName: toolLabel,
+    // $mcp_tool_description: the description the agent actually chose from,
+    // which is the ADVERTISED one -- tools/list appends UNTRUSTED_DATA_NOTE,
+    // so the raw registry entry is not the text any caller ever saw. PostHog
+    // defines this property as the description "at the moment of the call"
+    // and their own SDK caches it from tools/list; recording the unadvertised
+    // string would quietly answer a different question than the one the field
+    // is for. Built from the same expression tools/list uses so the two
+    // cannot drift.
+    //
+    // Never from the request, and absent for an unregistered name — there is
+    // no description to report for a tool that does not exist.
+    toolDescription: advertisedToolDescription(params?.name),
     isError: result.isError === true,
     durationMs,
     sessionId: ctx?.sessionId,
@@ -15468,6 +15531,21 @@ async function callTool(params: Row, ctx: McpCtx) {
       : {}),
     ...mcpAttributionFor(ctx),
   });
+  // The capability gap, recorded from the same split intent the tool call
+  // already carries -- not from the handler, which never sees `context`
+  // (validateToolArguments strips it before dispatch, by design).
+  //
+  // Only when the agent actually said something. A bare `get_more_tools()`
+  // with no context reports nothing, because an empty gap report is not a
+  // data point -- it would inflate the count of unmet asks with calls that
+  // name no ask.
+  if (params?.name === MCP_MISSING_CAPABILITY_TOOL && intent) {
+    scheduleMcpMissingCapabilityEvent(ctx, {
+      intent,
+      sessionId: ctx?.sessionId,
+      ...mcpAttributionFor(ctx),
+    });
+  }
   return result;
 }
 
@@ -15595,6 +15673,21 @@ function mcpToolLabel(name: unknown): string | undefined {
   return TOOLS_BY_NAME.has(name) ? name : UNREGISTERED_MCP_TOOL_LABEL;
 }
 
+/**
+ * The description tools/list PUBLISHED for this tool, or undefined.
+ *
+ * Shares listToolDefinitions' own expression rather than reading
+ * `tool.description` directly: the advertised text carries
+ * UNTRUSTED_DATA_NOTE, and `$mcp_tool_description` is defined as what the
+ * agent saw. Two spellings of "the description" is exactly how this field
+ * would come to disagree with the catalogue it claims to quote.
+ */
+function advertisedToolDescription(name: unknown): string | undefined {
+  if (typeof name !== "string") return undefined;
+  const tool = TOOLS_BY_NAME.get(name);
+  return tool ? `${tool.description} ${UNTRUSTED_DATA_NOTE}` : undefined;
+}
+
 function scheduleMcpProtocolUsageEvent(
   ctx: McpCtx,
   method: string,
@@ -15647,6 +15740,19 @@ function scheduleMcpToolsListEvent(ctx: McpCtx, event: Row) {
 // per method rather than one that takes an event name, so the dispatch site
 // reads as a statement of WHICH event it emits and a test can stub exactly one.
 // Same waitUntil/no-throw discipline as every scheduler here.
+function scheduleMcpMissingCapabilityEvent(ctx: McpCtx, event: Row) {
+  try {
+    const record =
+      ctx?.recordMcpMissingCapabilityEvent ?? recordMcpMissingCapabilityEvent;
+    const pending = Promise.resolve(
+      record(ctx?.env, event, { distinctId: ctx?.distinctId }),
+    ).catch(() => false);
+    ctx?.executionCtx?.waitUntil?.(pending);
+  } catch {
+    // Telemetry must never surface into the tool path.
+  }
+}
+
 function scheduleMcpResourcesListEvent(ctx: McpCtx, event: Row) {
   try {
     const record =
@@ -16481,6 +16587,7 @@ function buildContext(
     // The resource/prompt four belong in the same list for the same reason the
     // comment above gives -- declaring them on McpCtx without copying them here
     // is precisely the silent fall-through it describes.
+    recordMcpMissingCapabilityEvent: deps.recordMcpMissingCapabilityEvent,
     recordMcpResourcesListEvent: deps.recordMcpResourcesListEvent,
     recordMcpResourceReadEvent: deps.recordMcpResourceReadEvent,
     recordMcpPromptsListEvent: deps.recordMcpPromptsListEvent,
@@ -17041,6 +17148,50 @@ export function scheduleMcpRefusalEvent(
       ),
     ).catch(() => false);
     (deps.executionCtx as Row | undefined)?.waitUntil?.(pending);
+
+    // ...and the same refusal in PostHog's OWN event family.
+    //
+    // Until now a refusal produced a usage_event and nothing else, so every
+    // MCP Analytics error breakdown was computed over dispatched calls only.
+    // A caller being rate-limited, blocked, or rejected as unauthorized is a
+    // failed MCP call by any reading, and it was the one class of failure
+    // invisible on the surface built to show failures -- the error rate looked
+    // best exactly when the gate was refusing the most traffic.
+    //
+    // No `$mcp_tool_name`: the refusal happens in front of the dispatcher, so
+    // there is no registered tool to name, and inventing one would put gate
+    // traffic in a real tool's breakdown. The reason rides on
+    // `$mcp_error_code` instead, which classifyMcpErrorType buckets into
+    // rate_limited / permission / validation / api_5xx -- see the
+    // refusal-vocabulary block in MCP_ERROR_TYPE_BY_CODE.
+    //
+    // Shares admitMcpRefusalCapture's throttle by construction: this is inside
+    // the same `suppressed === null` early return, so a storm cannot double
+    // its own cost by being counted twice.
+    const recordMcp = (deps.recordMcpToolCallEvent ??
+      recordMcpToolCallEvent) as AnyFn;
+    const pendingMcp = Promise.resolve(
+      recordMcp(
+        env,
+        {
+          isError: true,
+          errorCode: reason,
+          // Unmeasurable rather than instant: the gate rejected before any
+          // handler ran, so there is no duration to report. The recorder omits
+          // a zero for exactly this reason.
+          durationMs: 0,
+          clientName: parseUserAgentClient(
+            request.headers.get("user-agent") ?? undefined,
+          ),
+          clientNameSource: "user_agent",
+          sessionId: request.headers.get("mcp-session-id"),
+          serverName: MCP_SERVER_INFO.name,
+          serverVersion: MCP_SERVER_VERSION,
+        },
+        {},
+      ),
+    ).catch(() => false);
+    (deps.executionCtx as Row | undefined)?.waitUntil?.(pendingMcp);
   } catch {
     // Telemetry must never surface into the MCP path.
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17142,6 +17142,24 @@ export function scheduleMcpRefusalEvent(
           ok: false,
           status: response.status,
           method: request.method,
+          // REQUIRED, and its absence meant this event never existed.
+          //
+          // buildUsageProperties returns null — and recordUsageEvent then
+          // returns false, silently, per its no-throw contract — for any event
+          // whose durationMs is not a finite non-negative number. This call
+          // passed none, so every refusal usage_event since this function was
+          // written was built, dropped, and reported as "recorded". Confirmed
+          // against the live project: `route LIKE 'mcp:refused%'` matches ZERO
+          // rows in 30 days, over a window in which the gate demonstrably
+          // refused (the 429s and 401s are in $exception and now in
+          // $mcp_tool_call).
+          //
+          // Zero is the honest value rather than a filler: the gate refuses
+          // before any handler runs, so there is no handler time to report.
+          // It cannot distort a latency read either — refusals carry their own
+          // `mcp:refused:*` route label, so any percentile broken down by
+          // route excludes them by construction.
+          durationMs: 0,
           ...(suppressed > 0 ? { suppressed_occurrences: suppressed } : {}),
         },
         {},

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -646,6 +646,20 @@ export const MCP_ERROR_TYPE_BY_CODE: Record<string, McpErrorType> = {
   forbidden: "permission",
   auth_required: "permission",
   internal_error: "internal",
+  // ── The pre-dispatch refusal vocabulary (mcpRefusalReason) ──────────────
+  // These never pass through toolError, because they are raised by the gate
+  // in front of the dispatcher rather than by a handler. They reach this
+  // projection all the same now that a refusal also emits $mcp_tool_call, and
+  // none of them would have bucketed correctly on the naming rules alone:
+  // `blocked` and `rate_limited` are bare words the `_blocked$` /
+  // `_rate_limited$` suffixes do not match, and the rest are unlike anything
+  // this codebase's handlers mint.
+  bad_request: "validation",
+  blocked: "permission",
+  body_too_large: "validation",
+  daily_quota: "rate_limited",
+  method_not_allowed: "validation",
+  unauthorized: "permission",
   // "This surface exists but declares no callable path/schema" — the caller
   // is missing context about the target, not sending bad syntax.
   no_schema: "missing_context",
@@ -695,6 +709,11 @@ const MCP_ERROR_TYPE_RULES: [RegExp, McpErrorType][] = [
   // emitted event.
   [/^rate_limited$|_rate_limited$/, "rate_limited"],
   [/^timeout$|_timeout$/, "timeout"],
+  // mcpRefusalReason's catch-all spelling for a status it has no name for
+  // (`status_503`). Mapped by class so a refusal the gate has not been taught
+  // to name still lands in the right bucket rather than in `internal`.
+  [/^status_4\d\d$/, "api_4xx"],
+  [/^status_5\d\d$/, "api_5xx"],
   [/^invalid_|^malformed_|_invalid$/, "validation"],
   // Our own dependency (a tier, a binding, an upstream provider) could not
   // serve the call. From the caller's side this is indistinguishable from a
@@ -859,6 +878,18 @@ export type McpClientNameSource = "client_info" | "user_agent";
 /** Inputs for a single MCP tool-call analytics event. */
 export interface McpToolCallEvent extends McpServerIdentity {
   toolName?: string;
+  /**
+   * The tool's description AT THE MOMENT OF THE CALL, emitted as
+   * `$mcp_tool_description` — a documented member of this event's property set
+   * that this server had never sent.
+   *
+   * Worth carrying because it is the input the agent actually chose from: when
+   * a tool's failure rate moves, the question is almost always whether the
+   * description changed, and an event that records only the name cannot
+   * answer it. Reads from the registered definition rather than the request,
+   * so it is never caller-supplied text.
+   */
+  toolDescription?: string;
   isError: boolean;
   /**
    * Elapsed wall-clock ms. Cloudflare Workers freeze Date.now() between I/O
@@ -975,6 +1006,18 @@ export async function recordMcpToolCallEvent(
 
     const toolName = sanitizeLabel(event.toolName);
     if (toolName !== undefined) properties["$mcp_tool_name"] = toolName;
+
+    // Not sanitizeLabel: a tool description is prose, and MAX_LABEL_CHARS is
+    // sized for identifiers. Same reasoning as $mcp_intent below, and the same
+    // ceiling — this is server-authored text, but it still rides on an event
+    // that is never sampled.
+    const toolDescription = trimToLength(
+      event.toolDescription,
+      MAX_MCP_INTENT_CHARS,
+    );
+    if (toolDescription !== undefined) {
+      properties["$mcp_tool_description"] = toolDescription;
+    }
 
     // Agent intent (#9642). NOT sanitizeLabel: that caps at MAX_LABEL_CHARS,
     // which is sized for identifiers like a tool or route name, and would
@@ -1276,6 +1319,78 @@ export async function recordMcpPromptGetEvent(
   deps: RecordUsageEventDeps = {},
 ): Promise<boolean> {
   return postMcpResourceEvent(env, "$mcp_prompt_get", event, deps);
+}
+
+/** Inputs for `$mcp_missing_capability`. */
+export interface McpMissingCapabilityEvent extends McpServerIdentity {
+  /**
+   * What the agent said it needed and could not find. Emitted as
+   * `$mcp_intent` -- the same property a tool call's `context` lands in,
+   * deliberately, because PostHog's missing-capability views read that field.
+   */
+  intent?: string;
+  clientName?: string;
+  clientVersion?: string;
+  clientNameSource?: McpClientNameSource;
+  authTier?: string;
+  sessionId?: string | null;
+}
+
+/**
+ * Emit `$mcp_missing_capability` -- the agent asked for something this server
+ * does not have.
+ *
+ * The one event here that is not a record of traffic. Everything else in this
+ * module measures what the server DID; this measures what it could not do, in
+ * the agent's own words, and it is the only signal that names a gap in the
+ * catalogue before somebody thinks to look for it.
+ *
+ * `$mcp_intent_source` is `context_parameter` and not `inferred`: the agent
+ * typed the string. PostHog's own docs note the same thing about this event --
+ * the SDK defined the schema, but the words are the caller's.
+ */
+export async function recordMcpMissingCapabilityEvent(
+  env: Env | null | undefined,
+  event: McpMissingCapabilityEvent,
+  deps: RecordUsageEventDeps = {},
+): Promise<boolean> {
+  try {
+    if (!isUsageTelemetryConfigured(env)) return false;
+
+    const properties: Record<string, unknown> = {};
+
+    const intent = trimToLength(event.intent, MAX_MCP_INTENT_CHARS);
+    if (intent !== undefined) {
+      properties["$mcp_intent"] = intent;
+      properties["$mcp_intent_source"] = "context_parameter";
+    }
+
+    assignMcpAttribution(properties, event);
+
+    if (typeof event.sessionId === "string" && event.sessionId.trim()) {
+      properties["$session_id"] = event.sessionId.trim();
+    }
+
+    assignDeployment(properties, env);
+    const doFetch = deps.fetch ?? globalThis.fetch;
+    const response = await doFetch(
+      `${resolvePostHogHost(env)}${POSTHOG_CAPTURE_PATH}`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          api_key: String(env?.[POSTHOG_PROJECT_TOKEN_ENV]).trim(),
+          event: "$mcp_missing_capability",
+          distinct_id: deps.distinctId ?? USAGE_EVENT_DISTINCT_ID,
+          properties,
+        }),
+      },
+    );
+
+    return response?.ok === true;
+  } catch {
+    return false;
+  }
 }
 
 // Error tracking via PostHog's `$exception` capture (#7758).

--- a/tests/field-projection.test.ts
+++ b/tests/field-projection.test.ts
@@ -159,6 +159,10 @@ describe("parseFieldsParam", () => {
     assert.equal(knownCalls, 1, "the error path is where it is paid");
   });
 
+  // The union walk's own non-object guard is covered under "the two resolvers"
+  // below ("null, arrays and primitives contribute no field names"), against
+  // the resolver directly rather than through this message.
+
   // A resolver with no `known` (nothing in-tree, but the type allows it)
   // degrades to the old message rather than emitting a dangling label.
   test("a resolver that cannot enumerate omits the list cleanly", () => {

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -1,0 +1,317 @@
+// The three remaining holes in this server's MCP analytics, closed together
+// because they are one question: does the $mcp_* family describe everything
+// that happens on this surface, or only the parts that were easy to record?
+//
+//   1. $mcp_tool_description  — a documented property of $mcp_tool_call that
+//                               was never sent, so a tool's failure rate could
+//                               not be read against the text agents chose from.
+//   2. refusals                — a rate-limited or unauthorized call produced a
+//                               usage_event and NOTHING in the $mcp_* family,
+//                               so every MCP Analytics error breakdown was
+//                               computed over dispatched calls only and looked
+//                               best exactly when the gate refused the most.
+//   3. $mcp_missing_capability — the agent asked for something that does not
+//                               exist. Previously invisible: no call, no error,
+//                               no row, just an agent giving up.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  POSTHOG_PROJECT_TOKEN_ENV,
+  classifyMcpErrorType,
+} from "../src/usage-telemetry.ts";
+import {
+  MCP_MISSING_CAPABILITY_TOOL,
+  handleMcpRequest,
+  listToolDefinitions,
+  mcpRefusalReason,
+  scheduleMcpRefusalEvent,
+} from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+const CONFIGURED_ENV = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" };
+
+function makeDeps(extra: Row = {}) {
+  return {
+    readArtifact: (_env: Row, path: string) =>
+      Promise.resolve({
+        ok: true,
+        data: { schema_version: 1, path },
+        source: "test",
+        storage_tier: "git",
+      }),
+    readHealthKv: () => Promise.resolve(null),
+    executionCtx: { waitUntil: () => {} },
+    ...extra,
+  };
+}
+
+async function callTool(name: string, args: Row = {}, extra: Row = {}) {
+  const mcp: Row[] = [];
+  const missing: Row[] = [];
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    CONFIGURED_ENV as unknown as Env,
+    makeDeps({
+      recordMcpToolCallEvent: (_e: unknown, event: Row) => {
+        mcp.push(event);
+        return true;
+      },
+      recordMcpMissingCapabilityEvent: (_e: unknown, event: Row) => {
+        missing.push(event);
+        return true;
+      },
+      ...extra,
+    }),
+  );
+  return { mcp, missing, body: (await response.json()) as Row };
+}
+
+describe("$mcp_tool_description", () => {
+  test("carries the registered description, read from the registry", async () => {
+    const { mcp } = await callTool("get_contracts");
+
+    const advertised = listToolDefinitions().find(
+      (tool: Row) => tool.name === "get_contracts",
+    ) as Row;
+    assert.equal(mcp[0].toolDescription, advertised.description);
+    assert.ok(
+      String(mcp[0].toolDescription).length > 0,
+      "the description should not be empty",
+    );
+  });
+
+  test("is absent for a tool that does not exist", async () => {
+    // There is no description to report for an unregistered name, and
+    // inventing one would put text in the property that no agent ever read.
+    const { mcp } = await callTool("no_such_tool_at_all");
+    assert.equal(mcp[0].toolDescription, undefined);
+  });
+});
+
+describe("pre-dispatch refusals reach the $mcp_* family", () => {
+  // mcpRefusalReason's whole vocabulary, and the bucket each must land in.
+  // A reason that classified as `internal` would be worse than not emitting:
+  // it would report a rate limit as a server fault.
+  for (const [status, headers, reason, bucket] of [
+    [429, {}, "rate_limited", "rate_limited"],
+    [
+      429,
+      { "x-ratelimit-scope": "daily-quota" },
+      "daily_quota",
+      "rate_limited",
+    ],
+    [429, { "x-ratelimit-scope": "blocked" }, "blocked", "permission"],
+    [401, {}, "unauthorized", "permission"],
+    [400, {}, "bad_request", "validation"],
+    [405, {}, "method_not_allowed", "validation"],
+    [413, {}, "body_too_large", "validation"],
+    [503, {}, "status_503", "api_5xx"],
+    [418, {}, "status_418", "api_4xx"],
+  ] as [number, Record<string, string>, string, string][]) {
+    test(`${status} → ${reason} → ${bucket}`, async () => {
+      const response = new Response("no", { status, headers });
+      assert.equal(mcpRefusalReason(response), reason);
+      assert.equal(classifyMcpErrorType(reason), bucket);
+
+      const events: Row[] = [];
+      const scheduled: Promise<unknown>[] = [];
+      scheduleMcpRefusalEvent(
+        new Request("https://api.metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "user-agent": "probe/1.0", "mcp-session-id": "sess-1" },
+        }),
+        CONFIGURED_ENV as unknown as Env,
+        {
+          recordUsageEvent: () => true,
+          recordMcpToolCallEvent: (_e: unknown, event: Row) => {
+            events.push(event);
+            return true;
+          },
+          executionCtx: {
+            waitUntil: (p: Promise<unknown>) => scheduled.push(p),
+          },
+        },
+        response,
+        // A distinct clock per case, so the shared refusal throttle cannot
+        // suppress the second and later cases and make them pass vacuously.
+        Date.now() + status * 3_600_000,
+      );
+
+      assert.equal(events.length, 1, `no $mcp_tool_call for ${reason}`);
+      assert.equal(events[0].isError, true);
+      assert.equal(events[0].errorCode, reason);
+      // No tool was named -- the gate refused in front of the dispatcher, and
+      // attributing gate traffic to a real tool would corrupt its breakdown.
+      assert.equal(events[0].toolName, undefined);
+      assert.equal(events[0].sessionId, "sess-1");
+      assert.equal(events[0].clientNameSource, "user_agent");
+      // Both events go through waitUntil, never awaited in the MCP path.
+      assert.equal(scheduled.length, 2);
+    });
+  }
+
+  test("a 2xx is not a refusal and records nothing", async () => {
+    const events: Row[] = [];
+    assert.equal(mcpRefusalReason(new Response("ok", { status: 200 })), null);
+    scheduleMcpRefusalEvent(
+      new Request("https://api.metagraph.sh/mcp", { method: "POST" }),
+      CONFIGURED_ENV as unknown as Env,
+      {
+        recordUsageEvent: () => true,
+        recordMcpToolCallEvent: (_e: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+        executionCtx: { waitUntil: () => {} },
+      },
+      new Response("ok", { status: 200 }),
+    );
+    assert.deepEqual(events, []);
+  });
+
+  test("a broken recorder never surfaces into the MCP path", () => {
+    assert.doesNotThrow(() =>
+      scheduleMcpRefusalEvent(
+        new Request("https://api.metagraph.sh/mcp", { method: "POST" }),
+        CONFIGURED_ENV as unknown as Env,
+        {
+          recordUsageEvent: () => true,
+          recordMcpToolCallEvent: () => {
+            throw new Error("posthog exploded");
+          },
+          executionCtx: { waitUntil: () => {} },
+        },
+        new Response("no", { status: 429 }),
+        Date.now() + 99 * 3_600_000,
+      ),
+    );
+  });
+});
+
+describe("$mcp_missing_capability", () => {
+  test("the tool is advertised and answers without reading anything", async () => {
+    const advertised = listToolDefinitions().find(
+      (tool: Row) => tool.name === MCP_MISSING_CAPABILITY_TOOL,
+    ) as Row;
+    assert.ok(advertised, "get_more_tools should be in tools/list");
+    // The reasoning rides on the standard intent argument, which is what puts
+    // it in $mcp_intent rather than in a bespoke field nothing reads.
+    assert.ok(
+      Object.hasOwn(advertised.inputSchema?.properties ?? {}, "context"),
+      "get_more_tools must accept `context`",
+    );
+
+    const { body } = await callTool(MCP_MISSING_CAPABILITY_TOOL, {
+      context: "wanted per-validator slippage curves; nothing exposes them",
+    });
+    const data = body?.result?.structuredContent as Row;
+    assert.equal(data.acknowledged, true);
+    // It must not imply more tools are coming, or the agent retries forever.
+    assert.equal(data.additional_tools_available, false);
+  });
+
+  test("records the agent's own words as the intent", async () => {
+    const words = "wanted per-validator slippage curves; nothing exposes them";
+    const { missing } = await callTool(MCP_MISSING_CAPABILITY_TOOL, {
+      context: words,
+    });
+
+    assert.equal(missing.length, 1);
+    assert.equal(missing[0].intent, words);
+    assert.equal(typeof missing[0].serverVersion, "string");
+  });
+
+  test("a report with no reasoning is not counted", async () => {
+    // An empty gap report names no gap. Counting it would inflate the tally of
+    // unmet asks with calls that asked for nothing.
+    const { missing, body } = await callTool(MCP_MISSING_CAPABILITY_TOOL, {});
+    assert.deepEqual(missing, []);
+    // ...but the tool still answers, so the agent is still told to stop.
+    assert.equal(
+      (body?.result?.structuredContent as Row).additional_tools_available,
+      false,
+    );
+  });
+
+  test("no other tool emits it", async () => {
+    // Without this, a hook that fired on every call would pass every
+    // assertion above.
+    const { missing } = await callTool("get_contracts", {
+      context: "checking the contract list",
+    });
+    assert.deepEqual(missing, []);
+  });
+
+  test("a broken recorder never surfaces into the tool path", async () => {
+    const { body } = await callTool(
+      MCP_MISSING_CAPABILITY_TOOL,
+      { context: "something" },
+      {
+        recordMcpMissingCapabilityEvent: () => {
+          throw new Error("posthog exploded");
+        },
+      },
+    );
+    assert.equal(body?.result?.isError, false);
+  });
+
+  test("an isolate that has already finished does not break the call", async () => {
+    // scheduleMcpMissingCapabilityEvent's own try/catch: waitUntil throws once
+    // the isolate is done, and that must stay a telemetry problem.
+    const { body } = await callTool(
+      MCP_MISSING_CAPABILITY_TOOL,
+      { context: "something" },
+      {
+        executionCtx: {
+          waitUntil() {
+            throw new Error("isolate already finished");
+          },
+        },
+      },
+    );
+    assert.equal(body?.result?.isError, false);
+  });
+});
+
+describe("a non-string tool name is handled everywhere it is read", () => {
+  // tools/call with a numeric `name` is malformed but reachable over the wire,
+  // and three separate readers have to survive it: the label, the description
+  // lookup, and the dispatcher itself.
+  test("records no tool name and no description, and still refuses", async () => {
+    const mcp: Row[] = [];
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: 42, arguments: {} },
+        }),
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      makeDeps({
+        recordMcpToolCallEvent: (_e: unknown, event: Row) => {
+          mcp.push(event);
+          return true;
+        },
+      }),
+    );
+    const body = (await response.json()) as Row;
+
+    assert.equal(body?.result?.isError, true);
+    assert.equal(mcp[0].toolName, undefined);
+    assert.equal(mcp[0].toolDescription, undefined);
+    assert.equal(mcp[0].errorCode, "unknown_tool");
+  });
+});

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -315,3 +315,100 @@ describe("a non-string tool name is handled everywhere it is read", () => {
     assert.equal(mcp[0].errorCode, "unknown_tool");
   });
 });
+
+// The DEFAULT recorder paths, which every test above injects past.
+//
+// `ctx?.recordX ?? recordX` and `deps.fetch ?? globalThis.fetch` are the
+// branches production actually takes — a real request injects nothing — and a
+// suite that always passes a double never executes either side. Same reasoning
+// and same shape as "falls back to the real recorder when none is injected" in
+// tests/mcp-usage-telemetry.test.ts.
+describe("the default recorders, with nothing injected", () => {
+  async function withStubbedFetch(fn: () => Promise<void>) {
+    const original = globalThis.fetch;
+    const posted: Row[] = [];
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      posted.push({ url, body: JSON.parse(String(init?.body ?? "{}")) });
+      return { ok: true };
+    }) as unknown as typeof fetch;
+    try {
+      await fn();
+    } finally {
+      globalThis.fetch = original;
+    }
+    return posted;
+  }
+
+  test("get_more_tools posts $mcp_missing_capability through the platform fetch", async () => {
+    const scheduled: Promise<unknown>[] = [];
+    const posted = await withStubbedFetch(async () => {
+      await handleMcpRequest(
+        new Request("https://api.metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: MCP_MISSING_CAPABILITY_TOOL,
+              arguments: { context: "needed per-validator slippage curves" },
+            },
+          }),
+        }),
+        CONFIGURED_ENV as unknown as Env,
+        makeDeps({
+          executionCtx: {
+            waitUntil: (p: Promise<unknown>) => scheduled.push(p),
+          },
+        }),
+      );
+      // waitUntil defers the post, so it has to be drained before asserting.
+      await Promise.all(scheduled);
+    });
+
+    const capability = posted.find(
+      (p) => (p.body as Row).event === "$mcp_missing_capability",
+    );
+    assert.ok(capability, "the real recorder should have posted the event");
+    const props = (capability.body as Row).properties as Row;
+    assert.equal(props.$mcp_intent, "needed per-validator slippage curves");
+    assert.equal(props.$mcp_intent_source, "context_parameter");
+  });
+
+  test("a refusal posts $mcp_tool_call through the platform fetch, with no user-agent", async () => {
+    const scheduled: Promise<unknown>[] = [];
+    const posted = await withStubbedFetch(async () => {
+      scheduleMcpRefusalEvent(
+        // No user-agent header at all: the `?? undefined` side of the client
+        // read, which every other refusal test skips by sending one.
+        new Request("https://api.metagraph.sh/mcp", { method: "POST" }),
+        CONFIGURED_ENV as unknown as Env,
+        {
+          executionCtx: {
+            waitUntil: (p: Promise<unknown>) => scheduled.push(p),
+          },
+        },
+        new Response("no", { status: 429 }),
+        // Far past every other case's window so the shared throttle admits it.
+        Date.now() + 4242 * 3_600_000,
+      );
+      await Promise.all(scheduled);
+    });
+
+    const call = posted.find((p) => (p.body as Row).event === "$mcp_tool_call");
+    assert.ok(call, "the real recorder should have posted the refusal");
+    const props = (call.body as Row).properties as Row;
+    assert.equal(props.$mcp_is_error, true);
+    assert.equal(props.$mcp_error_code, "rate_limited");
+    assert.equal(props.$mcp_error_type, "rate_limited");
+    // No tool named, and no client name to report.
+    assert.equal(Object.hasOwn(props, "$mcp_tool_name"), false);
+    assert.equal(Object.hasOwn(props, "$mcp_client_name"), false);
+    // usage_event rides alongside it on the same refusal.
+    assert.ok(
+      posted.some((p) => (p.body as Row).event === "usage_event"),
+      "the usage_event should still post",
+    );
+  });
+});

--- a/tests/mcp-analytics-recorder-branches.test.ts
+++ b/tests/mcp-analytics-recorder-branches.test.ts
@@ -1,0 +1,145 @@
+// The two recorder behaviours the resource/prompt suites do not reach.
+//
+// SCOPE, deliberately narrow. `tests/usage-telemetry.test.ts` already covers
+// the shared poster's optional fields (session id present/blank, arguments and
+// result present/omitted, a throwing transport) under "the resource/prompt
+// poster's optional fields", and the deployment-stamp table there covers every
+// recorder's environment/release. Re-asserting any of that here would be two
+// copies of one contract, which is how they come to disagree.
+//
+// What is left, and is only here:
+//
+//   1. $mcp_missing_capability's own recorder — new, and the only one in the
+//      family whose payload is an INTENT rather than a name. Its trimming and
+//      its source label are the whole wire contract.
+//   2. The redaction and size ceiling on a resource READ. The poster is shared
+//      with $mcp_tool_call, whose redaction is proven elsewhere; a resource
+//      body is the one payload here that can be the entire agent catalogue, so
+//      the ceiling is asserted where that risk actually lives.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  POSTHOG_PROJECT_TOKEN_ENV,
+  recordMcpMissingCapabilityEvent,
+  recordMcpResourceReadEvent,
+} from "../src/usage-telemetry.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+function fakeFetch({
+  onCall,
+  ok = true,
+  throws = false,
+}: { onCall?: (call: Row) => void; ok?: boolean; throws?: boolean } = {}) {
+  return (async (url: unknown, init: Row) => {
+    if (throws) throw new Error("network unreachable");
+    onCall?.({ url, body: JSON.parse(init.body) });
+    return { ok };
+  }) as unknown as typeof fetch;
+}
+
+function propsOf(calls: Row[]): Row {
+  return (calls[0].body as Row).properties as Row;
+}
+
+describe("$mcp_missing_capability's recorder", () => {
+  test("labels the intent as the agent's own words, trimmed", async () => {
+    const calls: Row[] = [];
+    await recordMcpMissingCapabilityEvent(
+      CONFIGURED as unknown as Env,
+      { intent: "  wanted per-validator slippage  ", sessionId: " sess-42 " },
+      { fetch: fakeFetch({ onCall: (c) => calls.push(c) }) },
+    );
+    const props = propsOf(calls);
+    assert.equal(props.$mcp_intent, "wanted per-validator slippage");
+    // Never "inferred": the agent typed this. PostHog's own docs make the same
+    // point about this event — the SDK defines the schema, the words are the
+    // caller's — and the distinction is what stops a server-invented string
+    // from later being read as agent speech.
+    assert.equal(props.$mcp_intent_source, "context_parameter");
+    assert.equal(props.$session_id, "sess-42");
+  });
+
+  test("a whitespace-only intent sets neither the intent nor its source", async () => {
+    // The pair moves together or not at all. A source with no intent would
+    // claim provenance for nothing.
+    const calls: Row[] = [];
+    await recordMcpMissingCapabilityEvent(
+      CONFIGURED as unknown as Env,
+      { intent: "   " },
+      { fetch: fakeFetch({ onCall: (c) => calls.push(c) }) },
+    );
+    const props = propsOf(calls);
+    assert.equal(Object.hasOwn(props, "$mcp_intent"), false);
+    assert.equal(Object.hasOwn(props, "$mcp_intent_source"), false);
+  });
+
+  test("posts nothing when telemetry is unconfigured", async () => {
+    let called = false;
+    const result = await recordMcpMissingCapabilityEvent(
+      mockEnv() as Env,
+      { intent: "something" },
+      { fetch: fakeFetch({ onCall: () => (called = true) }) },
+    );
+    assert.equal(result, false);
+    assert.equal(called, false, "must not reach the network");
+  });
+
+  test("reports false when PostHog rejects the post, and when fetch throws", async () => {
+    assert.equal(
+      await recordMcpMissingCapabilityEvent(
+        CONFIGURED as unknown as Env,
+        { intent: "x" },
+        { fetch: fakeFetch({ ok: false }) },
+      ),
+      false,
+    );
+    // The no-throw contract: a recorder that propagated would take the tool
+    // call down with it.
+    assert.equal(
+      await recordMcpMissingCapabilityEvent(
+        CONFIGURED as unknown as Env,
+        { intent: "x" },
+        { fetch: fakeFetch({ throws: true }) },
+      ),
+      false,
+    );
+  });
+});
+
+describe("a resource read's payload is bounded and redacted", () => {
+  test("a credential in the parameters never reaches PostHog", async () => {
+    const calls: Row[] = [];
+    await recordMcpResourceReadEvent(
+      CONFIGURED as unknown as Env,
+      {
+        resourceName: "metagraph://x",
+        parameters: {
+          uri: "metagraph://x",
+          credential: "Bearer secret-abc123",
+        },
+      },
+      { fetch: fakeFetch({ onCall: (c) => calls.push(c) }) },
+    );
+    assert.ok(
+      !JSON.stringify(calls[0].body).includes("secret-abc123"),
+      "a credential must never reach PostHog",
+    );
+  });
+
+  test("an oversized response is truncated to a preview, not dropped", async () => {
+    // A resource body can be the whole agent catalogue. Truncating keeps the
+    // event useful; dropping it would make a large read indistinguishable from
+    // one that returned nothing.
+    const calls: Row[] = [];
+    await recordMcpResourceReadEvent(
+      CONFIGURED as unknown as Env,
+      { resourceName: "metagraph://x", response: { blob: "x".repeat(20_000) } },
+      { fetch: fakeFetch({ onCall: (c) => calls.push(c) }) },
+    );
+    const body = propsOf(calls).$mcp_response as Row;
+    assert.equal(body.truncated, true);
+    assert.ok(String(body.preview).length > 0, "a preview should survive");
+  });
+});

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -23,6 +23,7 @@ import {
   recordMcpInitializeEvent,
   normalizeExceptionMessage,
   recordMcpToolCallEvent,
+  recordMcpMissingCapabilityEvent,
   recordMcpPromptGetEvent,
   recordMcpPromptsListEvent,
   recordMcpResourceReadEvent,
@@ -2901,6 +2902,15 @@ describe("every recorder stamps the deployment dimensions", () => {
         recordMcpPromptGetEvent(
           env,
           { resourceName: "integrate_with_subnet" },
+          deps,
+        ),
+    ],
+    [
+      "$mcp_missing_capability",
+      (env, deps) =>
+        recordMcpMissingCapabilityEvent(
+          env,
+          { intent: "needed per-validator slippage, no tool has it" },
           deps,
         ),
     ],


### PR DESCRIPTION
Follow-up to #10618, which closed the MCP-analytics gaps that were visible from
the live project. This closes the three that were only visible by reading
PostHog's own event contract against what this server actually does — after
which the `$mcp_*` family describes every operation on this surface.

No linked issue — none of the three had one open.

## 1. `$mcp_tool_description` was never sent

A documented property of `$mcp_tool_call`, absent since the family was added.
It is the input agents actually choose from, so when a tool's failure rate
moves, "did the description change" is the first question — and an event that
records only the name cannot answer it.

Recorded as the **advertised** description, not the registry entry: `tools/list`
appends `UNTRUSTED_DATA_NOTE`, so the raw string is not what any caller ever
saw, and PostHog defines this field as the description *at the moment of the
call* (their SDK caches it from `tools/list`). Built from the same expression
`tools/list` uses, so the two cannot drift. Absent for an unregistered name.

This was caught by a test asserting equality against `listToolDefinitions()` —
the first implementation read `TOOLS_BY_NAME` and quietly answered a different
question.

## 2. Refusals never reached the family at all

A rate-limited, blocked, or unauthorized call emitted a `usage_event`
(`mcp:refused:<reason>`) and **nothing** in the `$mcp_*` family. So every MCP
Analytics error breakdown was computed over dispatched calls only — the error
rate looked best exactly when the gate was refusing the most traffic.

Refusals now also emit `$mcp_tool_call`:

- **Inside the existing throttle.** The new emit sits within
  `admitMcpRefusalCapture`'s `suppressed === null` early return, so a storm
  cannot double its own cost by being counted twice.
- **With no `$mcp_tool_name`.** The gate refuses in front of the dispatcher;
  there is no registered tool, and attributing gate traffic to a real tool
  would corrupt its breakdown. The reason rides on `$mcp_error_code`.
- **With the whole vocabulary mapped explicitly.** `blocked` and `rate_limited`
  are bare words the existing `_blocked$` / `_rate_limited$` suffix rules do
  not match, so both would have bucketed as `internal` — reporting a rate limit
  as a server fault. `status_4xx`/`status_5xx` get rules so a status the gate
  has not been taught to name still lands in the right class.

Every reason → bucket pair is pinned by a test, each with its own clock so the
shared throttle cannot make later cases pass vacuously.

## 3. `$mcp_missing_capability` had no tool behind it

With 232 tools, an agent that cannot find what it needs simply stops — and
stopping leaves no trace: no call, no error, no row. PostHog calls this the
most actionable signal an MCP server owner can collect, and it was the one
event in the family with nothing emitting it.

`get_more_tools` records the gap in the agent's own words, carried on the
standard `context` argument so it lands in `$mcp_intent` where PostHog's own
views read it. It answers plainly that nothing more exists, so the agent stops
rather than retrying. A report with no reasoning is not counted — an empty gap
report names no gap.

Registered through the full checklist: schema file, `TOOL_OUTPUT_SCHEMAS`,
`mcp-route-map` (`route: null` with a written reason — the caller is telling us
what the catalogue lacks, not asking for anything). Default closed-world
read-only annotations are correct: it reads nothing. It is the one output schema
under `schemas-src/mcp-tools/` not derived from a route's `ArtifactSchema`,
because there is no REST surface for it to derive from — stated in the file
rather than left to look like the drift #9796 warned about.

## Verification

- `tsc --noEmit` clean.
- **1,802** tests pass across the MCP, telemetry, contract-completeness,
  annotation, published-default and field-projection suites, including two new
  files (`mcp-analytics-completeness`, `mcp-analytics-recorder-branches`).
- `validate:mcp`, `mcp-route-map`, `mcp-input-parity`, `tool-route-divergence`,
  `schemas`, `unreferenced-exports`, `contract-drift`, `api`, `openapi`,
  `types` all pass.
- Rebuilt on `36fc8a9b7` after #10618 merged, and re-verified there.

Two gates earned their keep again: `validate:unreferenced-exports` rejected two
dead type exports in the new schema file (referenced one, deleted the other,
rather than raising the ceiling), and the recorder-completeness table in
`tests/usage-telemetry.test.ts` failed until `$mcp_missing_capability` was
registered in it.

Test scope is deliberately trimmed against `a7573e277` (merged in #10618) so the
shared poster's optional-field contract is asserted in exactly one place.

No contract or schema change to the REST surface, so no regenerated artifacts.
Adding an MCP tool does not require a server-card regen (worker-computed), and
`MCP_SERVER_VERSION` / `server.json` are left alone for `sync-mcp-version`.
