### PR TITLE
fix(ui): stop reporting a correct network-partition 404 as an exception

### DIFF
--- a/apps/ui/src/lib/error-reporting.test.ts
+++ b/apps/ui/src/lib/error-reporting.test.ts
@@ -56,3 +56,71 @@ describe("reportError", () => {
     expect(reportLovableError).toHaveBeenCalledWith(err, {});
   });
 });
+
+// A network-partition 404 is the API working correctly, not a fault.
+//
+// 105 of 188 routes are mainnet-only, so a testnet page that touches one gets a
+// documented 404. Three of them were reaching Error Tracking from
+// testnet.metagraph.sh (/api/v1/health and /api/v1/domains from /subnets,
+// /api/v1/agent-resources from /agents). `ApiError.network` already marked
+// them; nothing read it.
+describe("reportError and expected network-partition refusals", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    reportLovableError.mockClear();
+    posthogCaptureException.mockClear();
+  });
+
+  async function partitionError(over: Record<string, unknown> = {}) {
+    const { ApiError } = await import("./metagraphed/client");
+    return new ApiError(
+      "/api/v1/agent-resources is only available on mainnet, not the testnet network.",
+      {
+        status: 404,
+        code: "not_found",
+        url: "/api/v1/agent-resources",
+        network: "testnet",
+        ...over,
+      },
+    );
+  }
+
+  it("captures neither sink for a mainnet-only refusal", async () => {
+    const { reportError } = await import("./error-reporting");
+    reportError(await partitionError(), { boundary: "panel_shell" });
+    expect(posthogCaptureException).not.toHaveBeenCalled();
+    // The Lovable channel is suppressed too: it is a reporting sink, and the
+    // condition is not worth reporting to either.
+    expect(reportLovableError).not.toHaveBeenCalled();
+  });
+
+  // The guard has to stay narrow, or it swallows real 404s. Each case below is
+  // a reason the refusal is NOT a network partition, and each must still report.
+  it("still reports an ordinary 404 that carries no network", async () => {
+    const { reportError } = await import("./error-reporting");
+    reportError(await partitionError({ network: undefined }), {});
+    expect(posthogCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a 404 whose network is an empty string", async () => {
+    const { reportError } = await import("./error-reporting");
+    reportError(await partitionError({ network: "" }), {});
+    expect(posthogCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a 500 even when it carries a network", async () => {
+    const { reportError } = await import("./error-reporting");
+    reportError(await partitionError({ status: 500 }), {});
+    expect(posthogCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reports a plain Error that merely looks like one", async () => {
+    const { reportError } = await import("./error-reporting");
+    const impostor = Object.assign(new Error("404"), {
+      status: 404,
+      network: "testnet",
+    });
+    reportError(impostor, {});
+    expect(posthogCaptureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/src/lib/error-reporting.ts
+++ b/apps/ui/src/lib/error-reporting.ts
@@ -1,5 +1,6 @@
 import { reportLovableError } from "./lovable-error-reporting";
 import { captureException as capturePostHogException } from "./analytics";
+import { ApiError } from "./metagraphed/client";
 
 /**
  * Centralized error-reporting seam for React error boundaries.
@@ -28,7 +29,56 @@ import { captureException as capturePostHogException } from "./analytics";
  * nothing upstream of this file changes.
  */
 
+/**
+ * Is this the API telling us a route does not exist on THIS network?
+ *
+ * `ApiError.network` is set on exactly the network-partition 404s
+ * (`workers/api.ts`'s `handleNetworkScopedRequest` — the mainnet-only
+ * blocklist, `local`'s no-data 404, and its unmatched-route catch-all). Its
+ * own doc comment says it exists so callers can tell "unavailable on this
+ * network by design" from an ordinary 404. Nothing read it, so those refusals
+ * were reported as exceptions.
+ *
+ * They are not faults. 105 of 188 routes are mainnet-only, so a testnet page
+ * that touches one gets a correct, documented 404 — and three of them were
+ * landing in Error Tracking from `testnet.metagraph.sh`:
+ *
+ *   /api/v1/health          → testnet.metagraph.sh/subnets
+ *   /api/v1/domains         → testnet.metagraph.sh/subnets
+ *   /api/v1/agent-resources → testnet.metagraph.sh/agents
+ *
+ * Capturing them costs signal (a correct refusal sitting beside a real
+ * defect), quota (`$exception` has its own 100K/cycle allowance, already blown
+ * once on this project), and the storm guard's headroom.
+ *
+ * Narrow on purpose: only a 404 that CARRIES a network, so an ordinary 404 —
+ * a genuinely missing subnet, a typo'd path on mainnet — still reports. The
+ * UI not requesting these at all on testnet is the better fix and is tracked
+ * separately; this stops the noise at the seam that knows the condition was
+ * expected.
+ */
+function isNetworkPartitionRefusal(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    error.status === 404 &&
+    typeof error.network === "string" &&
+    error.network.length > 0
+  );
+}
+
 export function reportError(error: unknown, context: Record<string, unknown> = {}): void {
+  // An expected refusal is still worth seeing in dev (step 3 below), but it is
+  // not an exception and must not be reported as one.
+  if (isNetworkPartitionRefusal(error)) {
+    if (import.meta.env?.DEV) {
+      console.warn(
+        "[reportError] network-partition refusal, not captured:",
+        (error as ApiError).url,
+      );
+    }
+    return;
+  }
+
   // 1. PostHog — a no-op when VITE_POSTHOG_PROJECT_TOKEN is unconfigured.
   capturePostHogException(error, context);
 


### PR DESCRIPTION
Closes #10636.

`ApiError.network` is set on exactly the network-partition 404s and its own doc
comment says it exists "so callers can distinguish 'unavailable on this network
by design' from an ordinary 404". Nothing read it, so `reportError` captured
those refusals as exceptions.

## What was in Error Tracking

| route | page | last seen |
|---|---|---|
| `/api/v1/health` | `testnet.metagraph.sh/subnets` | 2026-07-30 |
| `/api/v1/domains` | `testnet.metagraph.sh/subnets` | 2026-07-30 |
| `/api/v1/agent-resources` | `testnet.metagraph.sh/agents` | 2026-08-10 |

105 of 188 routes are mainnet-only, so each of these is the API answering
correctly. Nothing is broken and no engineer should ever be paged for one.

## Why it is worth fixing rather than ignoring

- **Signal.** A list where deliberate refusals sit next to real defects is a
  list nobody reads. This one currently shares a page with a two-day producer
  outage (#10634).
- **Quota.** `$exception` has its own 100K/cycle free-tier allowance, and this
  project has already exhausted it once.
- **Storm-guard headroom.** `recordExceptionEvent`'s throttle exists so one hot
  loop cannot spend a month of quota; expected conditions eating that budget
  make it less able to absorb a real storm.

## The guard is deliberately narrow

Only a **404 that carries a network**. Each of these must still report, and each
is pinned by its own test:

- a 404 with no `network` (an ordinary miss — a subnet that does not exist)
- a 404 whose `network` is an empty string
- a **500** that happens to carry a network
- a plain `Error` wearing `status: 404` and `network` as own properties

Without those, one loose predicate turns this into a swallow-all for 404s, which
would be strictly worse than the noise it removes.

Both sinks are suppressed, not just PostHog — the Lovable channel is a reporting
sink too, and the condition is not worth reporting to either. It stays visible
in dev through `console.warn`, because an expected refusal is worth seeing while
developing and not worth paging for.

## Not the whole fix

The better fix is the UI not requesting mainnet-only routes on testnet at all —
`src/network-capabilities.ts` already derives that matrix from
`MAINNET_ONLY_ROUTE_PATHS`, so the UI could consume it rather than discovering
the boundary by tripping over it. That is a larger change and belongs on its
own; this stops the noise at the seam that already knows the condition was
expected.

## Verification

- `tsc --noEmit` clean in `apps/ui` (workspaces built).
- **1,394** `apps/ui` tests pass, including 5 new cases in
  `error-reporting.test.ts`.
- Confined to `apps/ui/src/lib/**`, so no visual change and no screenshot table.
