### PR TITLE
refactor(lakehouse): give r2SqlQuery a row type, and make the generated types usable

### DIFF
--- a/generated/lakehouse/types.ts
+++ b/generated/lakehouse/types.ts
@@ -7,7 +7,7 @@
 // and therefore the order a hand-built row must be written in.
 
 /** `chain.blocks` */
-export interface BlocksRow {
+export type BlocksRow = {
   block_number: number | null;
   block_hash: string | null;
   parent_hash: string | null;
@@ -16,7 +16,7 @@ export interface BlocksRow {
   event_count: number | null;
   spec_version: number | null;
   observed_at: number | null;
-}
+};
 
 /** `chain.blocks` columns, in field-id order. */
 export const BLOCKS_COLUMNS = [
@@ -31,7 +31,7 @@ export const BLOCKS_COLUMNS = [
 ] as const;
 
 /** `chain.extrinsics` */
-export interface ExtrinsicsRow {
+export type ExtrinsicsRow = {
   block_number: number | null;
   extrinsic_index: number | null;
   extrinsic_hash: string | null;
@@ -43,7 +43,7 @@ export interface ExtrinsicsRow {
   tip_tao: number | null;
   call_args: string | null;
   observed_at: number | null;
-}
+};
 
 /** `chain.extrinsics` columns, in field-id order. */
 export const EXTRINSICS_COLUMNS = [
@@ -61,7 +61,7 @@ export const EXTRINSICS_COLUMNS = [
 ] as const;
 
 /** `chain.chain_events` */
-export interface ChainEventsRow {
+export type ChainEventsRow = {
   block_number: number | null;
   event_index: number | null;
   pallet: string | null;
@@ -70,7 +70,7 @@ export interface ChainEventsRow {
   phase: string | null;
   extrinsic_index: number | null;
   observed_at: number | null;
-}
+};
 
 /** `chain.chain_events` columns, in field-id order. */
 export const CHAIN_EVENTS_COLUMNS = [
@@ -85,7 +85,7 @@ export const CHAIN_EVENTS_COLUMNS = [
 ] as const;
 
 /** `chain.account_events` */
-export interface AccountEventsRow {
+export type AccountEventsRow = {
   block_number: number | null;
   event_index: number | null;
   extrinsic_index: number | null;
@@ -97,7 +97,7 @@ export interface AccountEventsRow {
   amount_tao: number | null;
   alpha_amount: number | null;
   observed_at: number | null;
-}
+};
 
 /** `chain.account_events` columns, in field-id order. */
 export const ACCOUNT_EVENTS_COLUMNS = [
@@ -115,7 +115,7 @@ export const ACCOUNT_EVENTS_COLUMNS = [
 ] as const;
 
 /** `chain.account_identity` */
-export interface AccountIdentityRow {
+export type AccountIdentityRow = {
   account: string | null;
   name: string | null;
   url: string | null;
@@ -125,7 +125,7 @@ export interface AccountIdentityRow {
   description: string | null;
   additional: string | null;
   captured_at: number | null;
-}
+};
 
 /** `chain.account_identity` columns, in field-id order. */
 export const ACCOUNT_IDENTITY_COLUMNS = [
@@ -141,7 +141,7 @@ export const ACCOUNT_IDENTITY_COLUMNS = [
 ] as const;
 
 /** `chain.account_identity_history` */
-export interface AccountIdentityHistoryRow {
+export type AccountIdentityHistoryRow = {
   id: number | null;
   account: string | null;
   observed_at: number | null;
@@ -153,7 +153,7 @@ export interface AccountIdentityHistoryRow {
   description: string | null;
   additional: string | null;
   identity_hash: string | null;
-}
+};
 
 /** `chain.account_identity_history` columns, in field-id order. */
 export const ACCOUNT_IDENTITY_HISTORY_COLUMNS = [
@@ -171,13 +171,13 @@ export const ACCOUNT_IDENTITY_HISTORY_COLUMNS = [
 ] as const;
 
 /** `chain.nominator_positions` */
-export interface NominatorPositionsRow {
+export type NominatorPositionsRow = {
   coldkey: string | null;
   hotkey: string | null;
   netuid: number | null;
   share_fraction: number | null;
   captured_at: number | null;
-}
+};
 
 /** `chain.nominator_positions` columns, in field-id order. */
 export const NOMINATOR_POSITIONS_COLUMNS = [
@@ -189,7 +189,7 @@ export const NOMINATOR_POSITIONS_COLUMNS = [
 ] as const;
 
 /** `chain.rpc_proxy_events` */
-export interface RpcProxyEventsRow {
+export type RpcProxyEventsRow = {
   id: number | null;
   observed_at: number | null;
   network: string | null;
@@ -200,7 +200,7 @@ export interface RpcProxyEventsRow {
   attempts: number | null;
   latency_ms: number | null;
   cache: string | null;
-}
+};
 
 /** `chain.rpc_proxy_events` columns, in field-id order. */
 export const RPC_PROXY_EVENTS_COLUMNS = [
@@ -217,12 +217,12 @@ export const RPC_PROXY_EVENTS_COLUMNS = [
 ] as const;
 
 /** `chain.self_health_daily` */
-export interface SelfHealthDailyRow {
+export type SelfHealthDailyRow = {
   day: string | null;
   component: string | null;
   checks: number | null;
   ok_count: number | null;
-}
+};
 
 /** `chain.self_health_daily` columns, in field-id order. */
 export const SELF_HEALTH_DAILY_COLUMNS = [
@@ -233,7 +233,7 @@ export const SELF_HEALTH_DAILY_COLUMNS = [
 ] as const;
 
 /** `chain.subnet_hyperparams` */
-export interface SubnetHyperparamsRow {
+export type SubnetHyperparamsRow = {
   netuid: number | null;
   kappa_ratio: number | null;
   immunity_period: number | null;
@@ -270,7 +270,7 @@ export interface SubnetHyperparamsRow {
   min_childkey_take_ratio: number | null;
   block_number: number | null;
   captured_at: number | null;
-}
+};
 
 /** `chain.subnet_hyperparams` columns, in field-id order. */
 export const SUBNET_HYPERPARAMS_COLUMNS = [
@@ -313,7 +313,7 @@ export const SUBNET_HYPERPARAMS_COLUMNS = [
 ] as const;
 
 /** `chain.subnet_hyperparams_history` */
-export interface SubnetHyperparamsHistoryRow {
+export type SubnetHyperparamsHistoryRow = {
   id: number | null;
   netuid: number | null;
   block_number: number | null;
@@ -352,7 +352,7 @@ export interface SubnetHyperparamsHistoryRow {
   owner_cut_auto_lock_enabled: boolean | null;
   min_childkey_take_ratio: number | null;
   hyperparams_hash: string | null;
-}
+};
 
 /** `chain.subnet_hyperparams_history` columns, in field-id order. */
 export const SUBNET_HYPERPARAMS_HISTORY_COLUMNS = [
@@ -397,7 +397,7 @@ export const SUBNET_HYPERPARAMS_HISTORY_COLUMNS = [
 ] as const;
 
 /** `chain.subnet_identity_history` */
-export interface SubnetIdentityHistoryRow {
+export type SubnetIdentityHistoryRow = {
   id: number | null;
   netuid: number | null;
   block_number: number | null;
@@ -410,7 +410,7 @@ export interface SubnetIdentityHistoryRow {
   discord: string | null;
   logo_url: string | null;
   identity_hash: string | null;
-}
+};
 
 /** `chain.subnet_identity_history` columns, in field-id order. */
 export const SUBNET_IDENTITY_HISTORY_COLUMNS = [
@@ -429,13 +429,13 @@ export const SUBNET_IDENTITY_HISTORY_COLUMNS = [
 ] as const;
 
 /** `chain.subnet_ownership_history` */
-export interface SubnetOwnershipHistoryRow {
+export type SubnetOwnershipHistoryRow = {
   id: number | null;
   netuid: number | null;
   owner_hotkey: string | null;
   owner_coldkey: string | null;
   captured_at: number | null;
-}
+};
 
 /** `chain.subnet_ownership_history` columns, in field-id order. */
 export const SUBNET_OWNERSHIP_HISTORY_COLUMNS = [

--- a/scripts/generate-lakehouse-types.ts
+++ b/scripts/generate-lakehouse-types.ts
@@ -114,12 +114,18 @@ export function emitTypes(columns: LakehouseColumn[]): string {
       );
     }
     out.push(`/** \`chain.${table}\` */`);
-    out.push(`export interface ${pascal(table)}Row {`);
+    // A TYPE ALIAS, NOT AN INTERFACE, and the difference is load-bearing. An
+    // interface has no implicit index signature, so `BlocksRow` is not
+    // assignable to `Record<string, unknown>` -- and every formatter these rows
+    // feed takes exactly that. Emitting an interface made the generated types
+    // unusable at the boundary they exist to cross; a type alias gets the
+    // implicit signature and passes straight through.
+    out.push(`export type ${pascal(table)}Row = {`);
     for (const c of cols) {
       const optional = c.required ? "" : " | null";
       out.push(`  ${c.column}: ${TS_TYPE[c.type]}${optional};`);
     }
-    out.push("}");
+    out.push("};");
     out.push("");
     out.push(`/** \`chain.${table}\` columns, in field-id order. */`);
     out.push(

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -99,8 +99,10 @@ import {
 } from "./validator-nominators.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
+import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
 import { readStore } from "./read-store.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
@@ -219,7 +221,7 @@ export async function loadAccountTransfersColdTier(
 
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<AccountEventsRow>(
     env,
     `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where.join(" AND ")}` +
       ` ${FEED_ORDER} LIMIT ${limit + paged}`,
@@ -871,7 +873,7 @@ export async function loadAccountSummaryColdTier(
     query = r2SqlQuery,
   }: {
     recentLimit?: number;
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   } = {},
 ): Promise<AccountSummaryColdTierResult> {
   const addr = safeSs58Literal(ss58);

--- a/src/account-history-cold-tier.ts
+++ b/src/account-history-cold-tier.ts
@@ -38,6 +38,7 @@ import {
 } from "./account-events.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -102,7 +103,7 @@ export async function loadAccountHistoryColdTier(
   env: Env | null | undefined,
   ss58: string,
   query: AccountHistoryQuery,
-  { queryFn = r2SqlQuery }: { queryFn?: typeof r2SqlQuery } = {},
+  { queryFn = r2SqlQuery }: { queryFn?: R2SqlReader } = {},
 ): Promise<AccountHistoryResult | null> {
   // An unusable address is a decline, not an unfiltered scan of every account.
   const addr = safeSs58Literal(ss58);
@@ -210,7 +211,7 @@ async function loadKindsForPage(
   env: Env | null | undefined,
   where: string[],
   page: Array<Row & { day: string }>,
-  queryFn: typeof r2SqlQuery,
+  queryFn: R2SqlReader,
 ): Promise<Map<string, string> | null> {
   if (page.length === 0) return new Map();
   const newest = dayStartMs(page[0]!.day);

--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -27,6 +27,7 @@
 // both account_events and chain_events, and PrometheusServed exists only in
 // chain_events with its hotkey inside the args JSON. See the survey on #9146.
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -185,7 +186,7 @@ export interface ChainEventRollup {
  * degrades to null instead of blanking the card (#10249).
  */
 export async function loadChainEventRollup(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   spec: ChainEventRollupSpec,
   {
     windowDays,
@@ -199,7 +200,7 @@ export async function loadChainEventRollup(
     windowDays: number;
     now?: number;
     limit?: number;
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ChainEventRollup | null> {
   const kind = safeEventKind(spec.eventKind);
@@ -364,7 +365,7 @@ export interface ChainEventIdentityRollup {
  * COUNT(DISTINCT) left is in the ungrouped totals, over a single row.
  */
 export async function loadChainEventIdentityRollup(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   spec: ChainEventRollupSpec,
   {
     windowDays,
@@ -382,7 +383,7 @@ export async function loadChainEventIdentityRollup(
      * the identity shape the builders read either way.
      */
     netuid?: number;
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ChainEventIdentityRollup | null> {
   const kind = safeEventKind(spec.eventKind);

--- a/src/chain-events-cold-tier.ts
+++ b/src/chain-events-cold-tier.ts
@@ -41,6 +41,7 @@ import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { type ChainNetworkId, chainTable } from "./chain-network.ts";
 import { r2SqlQuery, safeBlockNumber, safeNameLiteral } from "./r2-sql.ts";
 import { CHAIN_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
+import type { ChainEventsRow } from "../generated/lakehouse/types.ts";
 import { lakehouseHeadBlock } from "./blocks-cold-tier.ts";
 import {
   SUBNET_LEASE_CREATED_KIND,
@@ -216,7 +217,7 @@ export async function loadChainEventsColdTier(
     }
   }
 
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<ChainEventsRow>(
     env,
     `SELECT ${EVENT_COLUMNS} FROM ${chainTable("chain_events", network)} WHERE ${where.join(" AND ")}` +
       ` ORDER BY block_number DESC, event_index DESC LIMIT ${limit}`,

--- a/src/chain-prometheus-loader.ts
+++ b/src/chain-prometheus-loader.ts
@@ -30,14 +30,14 @@ import {
   CHAIN_PROMETHEUS_ROLLUP,
   loadChainEventRollup,
 } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 /**
  * One window of prometheus-serving activity from the lakehouse, already built
  * into the response shape -- or null when the lakehouse cannot answer.
  */
 export async function loadChainPrometheusColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   {
     window,
     limit,
@@ -48,7 +48,7 @@ export async function loadChainPrometheusColdTier(
      * have to restate it here. */
     limit?: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildChainPrometheus> | null> {
   const label = Object.hasOwn(ANALYTICS_WINDOW_DAYS, window)

--- a/src/chain-serving-loader.ts
+++ b/src/chain-serving-loader.ts
@@ -22,7 +22,7 @@ import {
   CHAIN_SERVING_ROLLUP,
   loadChainEventRollup,
 } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 /**
  * One window of chain-serving activity from the lakehouse, already built into
@@ -46,7 +46,7 @@ import type { r2SqlQuery } from "./r2-sql.ts";
  * from the REST call site's types rather than merely defensive.
  */
 export async function loadChainServingColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   {
     window,
     limit,
@@ -57,7 +57,7 @@ export async function loadChainServingColdTier(
      * have to restate it here. */
     limit?: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildChainServing> | null> {
   const label = Object.hasOwn(ANALYTICS_WINDOW_DAYS, window)

--- a/src/chain-weight-setters-loader.ts
+++ b/src/chain-weight-setters-loader.ts
@@ -23,7 +23,7 @@ import {
   CHAIN_WEIGHTS_ROLLUP,
   loadChainEventIdentityRollup,
 } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 /**
  * One window of weight-setting activity per setter, already built into the
@@ -34,7 +34,7 @@ import type { r2SqlQuery } from "./r2-sql.ts";
  * schema-stable card rather than an error, and that belongs at the call site.
  */
 export async function loadChainWeightSettersColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   {
     window,
     limit,
@@ -43,7 +43,7 @@ export async function loadChainWeightSettersColdTier(
     window: string;
     limit?: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildChainWeightSetters> | null> {
   const rollup = await loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {

--- a/src/chain-weights-loader.ts
+++ b/src/chain-weights-loader.ts
@@ -22,7 +22,7 @@ import {
   CHAIN_WEIGHTS_ROLLUP,
   loadChainEventRollup,
 } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 /**
  * One window of weight-setting activity from the lakehouse, already built into
@@ -33,7 +33,7 @@ import type { r2SqlQuery } from "./r2-sql.ts";
  * schema-stable card rather than an error, and that belongs at the call site.
  */
 export async function loadChainWeightsColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   {
     window,
     limit,
@@ -42,7 +42,7 @@ export async function loadChainWeightsColdTier(
     window: string;
     limit?: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildChainWeights> | null> {
   const rollup = await loadChainEventRollup(env, CHAIN_WEIGHTS_ROLLUP, {

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -50,6 +50,7 @@ import {
 } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
+import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -120,7 +121,7 @@ export async function loadAccountEventsColdTier(
 
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<AccountEventsRow>(
     env,
     `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} WHERE ${where.join(" AND ")}` +
       ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
@@ -212,7 +213,7 @@ export async function loadSubnetEventsColdTier(
 
   // Cursor pages never carry an offset, mirroring the account feed.
   const paged = cursor ? 0 : offset;
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<AccountEventsRow>(
     env,
     `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} WHERE ${where.join(" AND ")}` +
       ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
@@ -252,7 +253,7 @@ export async function loadBlockEventsColdTier(
   const height = await resolveBlockHeight(env, ref, network);
   if (height === null) return null;
 
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<AccountEventsRow>(
     env,
     `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} ` +
       `WHERE block_number = ${height} ` +

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -52,6 +52,10 @@ import {
   ACCOUNT_EVENTS_COLUMNS,
   EXTRINSICS_COLUMNS,
 } from "../generated/lakehouse/types.ts";
+import type {
+  AccountEventsRow,
+  ExtrinsicsRow,
+} from "../generated/lakehouse/types.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -314,7 +318,7 @@ export async function loadExtrinsicColdTier(
     predicate = `extrinsic_hash = '${hash}'`;
   }
 
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<ExtrinsicsRow>(
     env,
     `SELECT ${EXTRINSIC_COLUMNS} FROM ${chainTable("extrinsics", network)} WHERE ${predicate} LIMIT 1`,
   );
@@ -328,7 +332,7 @@ export async function loadExtrinsicColdTier(
   const index = safeBlockNumber(row.extrinsic_index);
   let events: unknown[] = [];
   if (block !== null && index !== null) {
-    const found = await r2SqlQuery(
+    const found = await r2SqlQuery<AccountEventsRow>(
       env,
       `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} ` +
         `WHERE block_number = ${block} AND extrinsic_index = ${index} ` +

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -34,6 +34,7 @@
 // them duplicated as a repository secret, plus a third-party trigger hop, to
 // ask a question the Worker can ask itself.
 import { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import {
   recordLaneVerdict,
@@ -261,12 +262,12 @@ const LAKEHOUSE_SEAM_LANE = "lakehouse-seam";
 type LaneVerdictInput = Omit<LaneHealthRecord, "lane" | "checked_at">;
 
 export async function runLakehouseSeamWatchdog(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   // Injectable so the MEASURED path is testable without a lakehouse. Same seam
   // as r2-sql.ts's scheduleAbort and webhooks.ts's sleepFn: a branch that can
   // only run against live infrastructure is a branch nothing verifies.
   deps: {
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
     now?: () => number;
     laneHealthDb?: LaneHealthDb;
     recordExceptionEvent?: typeof recordExceptionEvent;

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -26,6 +26,7 @@ import { buildBlock, buildBlockFeed } from "./blocks.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { type ChainNetworkId, chainTable } from "./chain-network.ts";
 import { BLOCKS_COLUMNS } from "../generated/lakehouse/types.ts";
+import type { BlocksRow } from "../generated/lakehouse/types.ts";
 import {
   r2SqlQuery,
   safeBlockNumber,
@@ -206,7 +207,7 @@ export async function loadBlockFromR2Sql(
     asNumber !== null
       ? `block_number = ${asNumber}`
       : `block_hash = '${asHash}'`;
-  const rows = await r2SqlQuery(
+  const rows = await r2SqlQuery<BlocksRow>(
     env,
     `SELECT ${BLOCK_COLUMNS} FROM ${chainTable("blocks", network)} WHERE ${predicate} LIMIT 1`,
   );

--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -352,11 +352,29 @@ export function isExpectedR2SqlFailure(errorCode: string): boolean {
  * injection surface. Callers pass literal-safe values (integers they parsed,
  * hashes they regex-validated) and are responsible for that validation.
  */
-export async function r2SqlQuery(
+/**
+ * The shape an injected r2-sql reader must have.
+ *
+ * NOT `R2SqlReader`, now that the real one is generic. A generic
+ * signature is not satisfied by the concrete stubs every loader test passes --
+ * a double returning `Promise<Record<string, unknown>[] | null>` cannot stand
+ * in for a function that promises `Row[]` for any `Row` the CALLER picks.
+ *
+ * The seam does not need that freedom: every loader that takes a `query` dep
+ * reads the default row shape and narrows afterwards. `r2SqlQuery` itself is
+ * assignable here, because its type parameter defaults.
+ */
+export type R2SqlReader = (
+  env: Env | null | undefined,
+  sql: string,
+  deps?: R2SqlDeps,
+) => Promise<Record<string, unknown>[] | null>;
+
+export async function r2SqlQuery<Row = Record<string, unknown>>(
   env: Env | null | undefined,
   sql: string,
   deps: R2SqlDeps = {},
-): Promise<Record<string, unknown>[] | null> {
+): Promise<Row[] | null> {
   if (!isR2SqlConfigured(env)) {
     // Unconfigured is not a fault: self-hosters and local/CI runs simply have
     // no lakehouse, and the caller's existing empty payload is correct there.
@@ -439,7 +457,7 @@ export async function r2SqlQuery(
     const rows = body?.result?.rows;
     // A successful query with no rows is a legitimate answer (no such block),
     // and must not be conflated with a failure — hence [] rather than null.
-    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+    return Array.isArray(rows) ? (rows as Row[]) : [];
   } catch (error) {
     r2SqlFailureGeneration += 1;
     const detail = String((error as Error)?.message ?? error);

--- a/src/rpc-usage-cold-tier.ts
+++ b/src/rpc-usage-cold-tier.ts
@@ -33,6 +33,7 @@
 import { ANALYTICS_WINDOW_DAYS, RPC_USAGE_BUCKETS } from "../workers/config.ts";
 import { formatRpcUsage } from "./health-serving.ts";
 import { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -81,7 +82,7 @@ export function windowCutoffMs(
  * different and wrong claim.
  */
 export async function loadRpcUsageColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   {
     window = "7d",
     now = Date.now(),
@@ -101,7 +102,7 @@ export async function loadRpcUsageColdTier(
     window?: string;
     now?: number;
     until?: number | null;
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   } = {},
 ): Promise<Record<string, unknown> | null> {
   const windowLabel = Object.hasOwn(ANALYTICS_WINDOW_DAYS, window)

--- a/src/runtime-versions-cold-tier.ts
+++ b/src/runtime-versions-cold-tier.ts
@@ -26,6 +26,7 @@
 // genuinely absent — and `coverage_complete` finally means what it says
 // instead of being true only because an empty timeline has no gaps in it.
 import { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 import { buildRuntimeVersionHistory } from "./runtime-versions.ts";
 
 // One row per distinct spec_version: the earliest block that carried that
@@ -63,8 +64,8 @@ const LATEST_SQL =
  * failure this route was already shipping.
  */
 export async function loadRuntimeVersionHistoryColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
-  { query = r2SqlQuery }: { query?: typeof r2SqlQuery } = {},
+  env: Parameters<R2SqlReader>[0],
+  { query = r2SqlQuery }: { query?: R2SqlReader } = {},
 ): Promise<ReturnType<typeof buildRuntimeVersionHistory> | null> {
   const [rows, latestRows] = await Promise.all([
     query(env, TRANSITIONS_SQL),

--- a/src/subnet-event-card-loader.ts
+++ b/src/subnet-event-card-loader.ts
@@ -21,7 +21,7 @@
 // would have been a fix for a bug that is not there.
 import { loadChainEventIdentityRollup } from "./chain-event-rollup-cold-tier.ts";
 import type { ChainEventRollupSpec } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 type Row = Record<string, unknown>;
 
@@ -38,7 +38,7 @@ type Row = Record<string, unknown>;
  * because a summary card needs no rows.
  */
 export async function loadSubnetEventCardColdTier<T>(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   spec: ChainEventRollupSpec,
   netuid: number,
   build: (row: Row | null, netuid: unknown, options: { window?: unknown }) => T,
@@ -50,7 +50,7 @@ export async function loadSubnetEventCardColdTier<T>(
     windowLabel?: string;
     windowDays: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<T | null> {
   const rollup = await loadChainEventIdentityRollup(env, spec, {

--- a/src/subnet-event-summary-cold-tier.ts
+++ b/src/subnet-event-summary-cold-tier.ts
@@ -37,6 +37,7 @@ import {
 } from "./account-events.ts";
 import { SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT } from "./route-limits.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 
 type Row = Record<string, unknown>;
@@ -131,7 +132,7 @@ export async function loadSubnetEventSummaryColdTier(
      * `?limit=` must serve the default page, not an empty card. */
     limit?: number | null;
     /** Injectable for tests. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildSubnetEventSummary> | null> {
   // An unusable netuid is a decline, not an unfiltered scan of every subnet.

--- a/src/subnet-weight-setters-loader.ts
+++ b/src/subnet-weight-setters-loader.ts
@@ -18,7 +18,7 @@ import {
   CHAIN_WEIGHTS_ROLLUP,
   loadChainEventIdentityRollup,
 } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 /**
  * One subnet's window of weight-setting activity per setter, already built into
@@ -29,7 +29,7 @@ import type { r2SqlQuery } from "./r2-sql.ts";
  * that decision belongs at the call site.
  */
 export async function loadSubnetWeightSettersColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   netuid: number,
   {
     windowLabel,
@@ -41,7 +41,7 @@ export async function loadSubnetWeightSettersColdTier(
     windowDays: number;
     limit?: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildSubnetWeightSetters> | null> {
   const rollup = await loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {
@@ -74,7 +74,7 @@ export async function loadSubnetWeightSettersColdTier(
  * because a cadence was unknown would trade a useful answer for no answer.
  */
 async function loadSubnetTempo(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   netuid: number,
 ): Promise<unknown> {
   // readStore, NOT observationsReadDb (#10179). Two reasons, either fatal:

--- a/src/subnet-weights-loader.ts
+++ b/src/subnet-weights-loader.ts
@@ -27,7 +27,7 @@ import {
   CHAIN_WEIGHTS_ROLLUP,
   loadChainEventIdentityRollup,
 } from "./chain-event-rollup-cold-tier.ts";
-import type { r2SqlQuery } from "./r2-sql.ts";
+import type { R2SqlReader } from "./r2-sql.ts";
 
 /**
  * One subnet's window of weight-setting activity as the summary card — or null when the
@@ -44,7 +44,7 @@ import type { r2SqlQuery } from "./r2-sql.ts";
  * also why no limit is passed -- the card needs no rows at all.
  */
 export async function loadSubnetWeightsColdTier(
-  env: Parameters<typeof r2SqlQuery>[0],
+  env: Parameters<R2SqlReader>[0],
   netuid: number,
   {
     windowLabel,
@@ -54,7 +54,7 @@ export async function loadSubnetWeightsColdTier(
     windowLabel?: string;
     windowDays: number;
     /** Injectable for tests; forwarded to the rollup reader. */
-    query?: typeof r2SqlQuery;
+    query?: R2SqlReader;
   },
 ): Promise<ReturnType<typeof buildSubnetWeights> | null> {
   const rollup = await loadChainEventIdentityRollup(env, CHAIN_WEIGHTS_ROLLUP, {


### PR DESCRIPTION
## Summary

`r2SqlQuery` returned `Promise<Record<string, unknown>[] | null>` with **no row type parameter**, so
the generated lakehouse types had zero production consumers. They were decorative *by construction* —
there was no way to adopt them — rather than by neglect.

Two things blocked it, neither obvious until the change was attempted.

## 1. The injection seam

Fifteen modules type their test hook as `query?: typeof r2SqlQuery`. Once the real function is generic,
a concrete stub returning `Promise<Record<string, unknown>[] | null>` no longer satisfies it: a double
cannot stand in for a function that promises `Row[]` for **any** `Row` the *caller* picks.

The seam never needed that freedom — every loader reads the default shape and narrows afterwards — so
it takes a concrete `R2SqlReader` alias. `r2SqlQuery` remains assignable to it because its type
parameter defaults.

## 2. The generated types were `interface`, and that made them unusable

An interface has **no implicit index signature**, so `BlocksRow` is not assignable to
`Record<string, unknown>` — which is exactly what every formatter these rows feed takes. Emitting an
interface made the artifact unusable at the one boundary it exists to cross.

A `type` alias gets the implicit signature and passes straight through. One word in the generator; 13
regenerated aliases.

## Adoption

Eight call sites — the ones whose SQL is `SELECT ${<TABLE>_COLUMNS} FROM …`, where the row shape *is*
the generated type by construction:

```
5  r2SqlQuery<AccountEventsRow>
1  r2SqlQuery<BlocksRow>
1  r2SqlQuery<ChainEventsRow>
1  r2SqlQuery<ExtrinsicsRow>
```

The remaining 30 read aggregates (`count(*)`, `MAX`) or column subsets and keep the default. Typing
those means `Pick<>` or a projection type, and guessing would replace a hand-written assumption with a
generated one that is equally wrong and now looks authoritative — the same reasoning
`scripts/validate-untyped-db-reads.ts` gives for the Neon side.

## One trap worth flagging for review

The row imports **must** be `import type`. A value import of a type-only alias **typechecks and then
fails at runtime**:

```
SyntaxError: The requested module '../generated/lakehouse/types.ts'
does not provide an export named 'BlocksRow'
```

`npm run typecheck` passed on the broken form. `npm run validate` is what caught it. A green typecheck
is not proof here.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` / `format:check` / `typecheck` | pass |
| `npm run validate` | pass (this is the one that caught the import bug) |
| `npm run validate:lakehouse-types-drift` | pass |
| 10 cold-tier + loader + schema suites | **222 passed** |

Rebased onto current `main` and re-validated.

Closes #10643
