### PR TITLE
perf(accounts): bound the events feed to a block window it already sorts by

### DIFF
--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -49,6 +49,7 @@ import {
   safeSs58Literal,
 } from "./r2-sql.ts";
 import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { lakehouseHeadBlock } from "./blocks-cold-tier.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
 
@@ -61,6 +62,122 @@ const EVENT_COLUMNS = ACCOUNT_EVENTS_COLUMNS.join(", ");
 
 /** The 3-part key the account-events feed pages on, mirroring data-api. */
 const CURSOR_ARITY = 3;
+
+/**
+ * How many blocks the FIRST window of an account read covers.
+ *
+ * Measured end to end through the deployed Worker, `/accounts/{ss58}/events`
+ * for a busy account, edge cache defeated:
+ *
+ *   unbounded                        6.35s  6.01s
+ *   WHERE block_number >= head-68k   2.51s  1.76s
+ *
+ * ~3x, and the reason is that `account_events` is already clustered by block:
+ * the decoder appends in block order, so file min/max on `block_number` prunes
+ * well. The table was never the problem -- the query simply declined to use the
+ * clustering it already had, and scanned all 452M rows for every page.
+ *
+ * The same fix `chain-events-cold-tier.ts` documents (1.93 GB -> 15.8 MB), one
+ * table over. Partitioning would NOT have helped here: the predicate is
+ * `(hotkey = X OR coldkey = X)`, a disjunction across two columns, so bucketing
+ * on either one cannot prune -- a row matching the other side sits in any
+ * bucket.
+ */
+export const ACCOUNT_EVENTS_BLOCK_WINDOW = 250_000;
+
+/**
+ * How wide each successive window gets when a page has not filled.
+ *
+ * EXPONENTIAL, NOT A FIXED STEP, because account density varies by orders of
+ * magnitude. A validator has events in most blocks and fills its page from the
+ * first window; an address with nine lifetime events needs to reach back
+ * millions of blocks, and stepping 250k at a time would take 30+ queries to get
+ * there. Quadrupling reaches the full ~8.8M-block history in six.
+ */
+const WINDOW_GROWTH = 4;
+
+/** Hard stop, so a pathological read cannot walk forever. Six windows at this
+ * growth already spans the whole chain, so hitting this means the walk reached
+ * block 0 anyway. */
+const MAX_WINDOW_STEPS = 8;
+
+/**
+ * Read an account's events newest-first, widening the block window until the
+ * page fills.
+ *
+ * WHY THE WINDOWS ACCUMULATE RATHER THAN RE-QUERYING A WIDER RANGE. Each step
+ * scans only the slice below the last one, so the total scanned is the union
+ * rather than the sum of prefixes. Rows arrive block-descending within each
+ * slice and each slice is strictly below its predecessor, so concatenation is
+ * globally ordered -- no merge, no re-sort.
+ *
+ * THE EXTERNAL CONTRACT IS UNCHANGED, which is the whole reason for looping
+ * here instead of exposing a `next_before` the way the chain-events feed does.
+ * That feed can hand back a short page because its caller is walking a firehose
+ * and expects to keep asking; an account feed returning three events and
+ * "there might be more, ask again" would be a worse answer than the slow one it
+ * replaces.
+ */
+async function windowedAccountEventsRead(
+  env: Env | null | undefined,
+  {
+    where,
+    need,
+    ceiling,
+    network,
+  }: {
+    where: readonly string[];
+    need: number;
+    /** The cursor's block, or null to start from the lakehouse head. */
+    ceiling: number | null;
+    network?: ChainNetworkId;
+  },
+): Promise<AccountEventsRow[] | null> {
+  const table = chainTable("account_events", network);
+  const order = ` ORDER BY observed_at DESC, block_number DESC, event_index DESC`;
+
+  // The head is READ, never assumed -- the same rule chain-events states.
+  //
+  // BUT AN UNKNOWABLE HEAD FALLS BACK, it does not decline. chain-events can
+  // refuse there because a window IS its contract; here the window is only an
+  // optimization over a query that worked without one, so failing the read
+  // would trade a slow answer for no answer and invent a failure mode this
+  // route never had. No ceiling, no windowing, same unbounded query as before.
+  const head = ceiling ?? (await lakehouseHeadBlock(env, {}, network));
+  if (head === null || !Number.isFinite(head) || head < 0) {
+    return r2SqlQuery<AccountEventsRow>(
+      env,
+      `SELECT ${EVENT_COLUMNS} FROM ${table} WHERE ${where.join(" AND ")}` +
+        `${order} LIMIT ${need}`,
+    );
+  }
+  let top = head;
+
+  const collected: AccountEventsRow[] = [];
+  let window = ACCOUNT_EVENTS_BLOCK_WINDOW;
+  for (
+    let step = 0;
+    step < MAX_WINDOW_STEPS && collected.length < need;
+    step++
+  ) {
+    const floor = Math.max(0, top - window);
+    const slice = await r2SqlQuery<AccountEventsRow>(
+      env,
+      `SELECT ${EVENT_COLUMNS} FROM ${table} WHERE ${where.join(" AND ")}` +
+        ` AND block_number >= ${floor} AND block_number <= ${top}` +
+        `${order} LIMIT ${need - collected.length}`,
+    );
+    // A failed slice fails the read. Returning what landed so far would publish
+    // a page that is short for a reason the caller cannot see, which is the
+    // silently-truncated answer this whole family declines rather than serves.
+    if (slice === null) return null;
+    collected.push(...slice);
+    if (floor === 0) break;
+    top = floor - 1;
+    window *= WINDOW_GROWTH;
+  }
+  return collected;
+}
 
 export interface AccountEventsQuery {
   limit: number;
@@ -121,12 +238,12 @@ export async function loadAccountEventsColdTier(
 
   // Cursor pages never carry an offset, mirroring data-api.
   const paged = cursor ? 0 : offset;
-  const rows = await r2SqlQuery<AccountEventsRow>(
-    env,
-    `SELECT ${EVENT_COLUMNS} FROM ${chainTable("account_events", network)} WHERE ${where.join(" AND ")}` +
-      ` ORDER BY observed_at DESC, block_number DESC, event_index DESC` +
-      ` LIMIT ${limit + paged}`,
-  );
+  const rows = await windowedAccountEventsRead(env, {
+    where,
+    need: limit + paged,
+    ceiling: cursor ? (cursor[1] as number) : null,
+    network,
+  });
   if (rows === null) return null;
 
   const page = paged > 0 ? rows.slice(paged) : rows;

--- a/tests/events-cold-tier.test.ts
+++ b/tests/events-cold-tier.test.ts
@@ -66,6 +66,61 @@ describe("loadAccountEventsColdTier", () => {
     );
   });
 
+  test("bounds the scan to a block window instead of all history", async () => {
+    // THE PERFORMANCE PROPERTY, and it is invisible in the response: the rows
+    // are identical either way. Measured end to end before this landed, the
+    // unbounded form took 6.35s/6.01s against 2.51s/1.76s with a block floor,
+    // because account_events is already clustered by block and the query
+    // simply was not using it.
+    const q = sqlFetch([eventRow(8_759_000, 1), eventRow(8_759_000, 0)]);
+    await loadAccountEventsColdTier(TOKEN as never, ADDR, { limit: 2 });
+    assert.match(q[0]!, /block_number >= \d+ AND block_number <= \d+/);
+  });
+
+  test("widens the window when a page does not fill, and keeps order", async () => {
+    // A sparse account: nothing in the first window, one row in the second.
+    // The page must still come back FULL-shaped rather than short -- the whole
+    // reason this loops internally instead of handing back a `next_before`.
+    const q = sqlFetch([], [eventRow(8_000_000)], [eventRow(7_000_000)]);
+    const data = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 1,
+    });
+    assert.equal(data!.events.length, 1);
+    assert.ok(q.length >= 2, `expected a second window, issued ${q.length}`);
+    // Each window sits strictly below its predecessor, so concatenation is
+    // globally ordered and no merge step is needed.
+    const ceil = (sql: string) => Number(/block_number <= (\d+)/.exec(sql)![1]);
+    assert.ok(
+      ceil(q[1]!) < ceil(q[0]!),
+      "the second window must read below the first",
+    );
+  });
+
+  test("a failed slice fails the read rather than returning a short page", async () => {
+    // A partial answer here would be short for a reason the caller cannot see,
+    // which is the silently-truncated result this family declines to serve.
+    let call = 0;
+    globalThis.fetch = (async () => {
+      call += 1;
+      if (call === 1) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, result: { rows: [] } }),
+        } as unknown as Response;
+      }
+      return {
+        ok: false,
+        status: 500,
+        text: async () => "boom",
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const data = await loadAccountEventsColdTier(TOKEN as never, ADDR, {
+      limit: 5,
+    });
+    assert.equal(data, null);
+  });
+
   test("applies kind/netuid/range filters as validated literals", async () => {
     const q = sqlFetch([eventRow(5)]);
     await loadAccountEventsColdTier(TOKEN as never, ADDR, {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -16870,21 +16870,28 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
   });
 
   test("get_account_events reads both key sides from the lakehouse", async () => {
-    const queries = lakeFetch([
-      {
-        block_number: 4200000,
-        event_index: 0,
-        extrinsic_index: 3,
-        event_kind: "StakeAdded",
-        hotkey: LAKE_EXTRINSIC.signer,
-        coldkey: null,
-        netuid: 7,
-        uid: 3,
-        amount_tao: "5000",
-        alpha_amount: null,
-        observed_at: 1750009000000,
-      },
-    ]);
+    const queries = lakeFetch(
+      [
+        {
+          block_number: 4200000,
+          event_index: 0,
+          extrinsic_index: 3,
+          event_kind: "StakeAdded",
+          hotkey: LAKE_EXTRINSIC.signer,
+          coldkey: null,
+          netuid: 7,
+          uid: 3,
+          amount_tao: "5000",
+          alpha_amount: null,
+          observed_at: 1750009000000,
+        },
+      ],
+      // The windowed reader keeps stepping until the page fills, so the stub
+      // has to model DISTINCT windows: one row in the first, nothing below it.
+      // Replaying the same row for every call would accumulate duplicates and
+      // assert on an arrangement no real lakehouse produces.
+      [],
+    );
     const res = await callTool(
       "get_account_events",
       { ss58: LAKE_EXTRINSIC.signer, limit: 5, kind: "StakeAdded" },
@@ -16892,8 +16899,14 @@ describe("MCP block-explorer tools — lakehouse cold tier answers when Postgres
     );
     const data = res.body.result.structuredContent;
     assert.equal(data.events.length, 1);
-    assert.match(queries[0]!, /hotkey = '5G9hfkx.*OR coldkey = '5G9hfkx/);
-    assert.match(queries[0]!, /event_kind = 'StakeAdded'/);
+    // BY CONTENT, NOT POSITION. The reader resolves the lakehouse head before
+    // its first windowed slice, so the account read is no longer queries[0] --
+    // and an index here would keep breaking every time a preceding read is
+    // added, while asserting nothing extra.
+    const read = queries.find((q) => q.includes("account_events"));
+    assert.ok(read, `no account_events read among ${queries.length} queries`);
+    assert.match(read, /hotkey = '5G9hfkx.*OR coldkey = '5G9hfkx/);
+    assert.match(read, /event_kind = 'StakeAdded'/);
   });
 
   test("get_account_extrinsics filters by signer from the lakehouse", async () => {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -2730,7 +2730,11 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
   });
 
   test("handleAccountEvents serves the account feed from the lakehouse", async () => {
-    const q = lakeFetch([EVENT_ROW]);
+    // DISTINCT WINDOWS, not one response replayed. The reader steps down the
+    // block range until the page fills, and lakeFetch repeats its last response
+    // for every call -- so a single-element stub hands back the same row once
+    // per window, an arrangement no real lakehouse produces.
+    const q = lakeFetch([EVENT_ROW], []);
     const body = await json(
       await handleAccountEvents(
         req(`/api/v1/accounts/${ADDR}/events`),
@@ -2740,11 +2744,11 @@ describe("cold tier answers when Postgres misses (lakehouse-backed handlers)", (
       ),
     );
     assert.equal(body.data.events.length, 1);
-    assert.match(q[0]!, /event_kind = 'StakeAdded'/);
-    assert.match(
-      q[0]!,
-      new RegExp(`hotkey = '${ADDR}' OR coldkey = '${ADDR}'`),
-    );
+    // BY CONTENT, NOT POSITION: the head read now precedes the account read.
+    const read = q.find((sql) => sql.includes("account_events"));
+    assert.ok(read, `no account_events read among ${q.length} queries`);
+    assert.match(read, /event_kind = 'StakeAdded'/);
+    assert.match(read, new RegExp(`hotkey = '${ADDR}' OR coldkey = '${ADDR}'`));
   });
 
   const COUNTERPARTY = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";


### PR DESCRIPTION
## Summary

`/api/v1/accounts/{ss58}/events` was the slowest route in the cold tier. Measured end to end through
the deployed Worker, edge cache defeated:

| Route | Time |
| --- | --- |
| `/accounts/{ss58}/events?limit=50` | **3.6s, 6.0s, 6.3s, 7.7s** |
| `/chain-events?limit=N` | 0.76s, 1.0s, 1.0s |
| `/blocks/{n}` | 0.63s, 1.4s, 3.2s |

It issued `(hotkey = X OR coldkey = X)` with **no block bound**, so every page scanned all 452M rows.

## The table was never the problem

Same query, same account, one floor added:

| | Time |
| --- | --- |
| unbounded | 6.35s, 6.01s |
| `block_start=8750000` | **2.51s, 1.76s** |

`account_events` is already clustered by block — the decoder appends in block order, so file min/max
on `block_number` prunes well. The query simply declined to use the clustering it had.

**Partitioning would not have helped**, and that is worth recording because it was the first thing
considered: the predicate is a disjunction across *two* columns, so bucketing on `hotkey` cannot prune
— a row matching `coldkey = X` sits in any hotkey bucket. It would have rewritten 452M rows and left
this route scanning everything.

## The shape

The fix `chain-events-cold-tier.ts` already documents for the neighbouring table (1.93 GB → 15.8 MB),
with one difference. That feed returns a **short page** plus `next_before` and lets the caller walk;
for an account feed that is a contract change — three events and "there may be more" is a worse answer
than the slow one.

So the widening happens **inside the reader**: start at `ACCOUNT_EVENTS_BLOCK_WINDOW`, and if the page
has not filled, step below and quadruple. A validator fills from the first window; a nine-event address
reaches the full ~8.8M-block history in six.

Windows **accumulate** rather than re-querying a wider range — the total scanned is the union of slices
rather than the sum of prefixes, and each slice sits strictly below its predecessor, so concatenation
is globally ordered with no merge step.

## Degrades, does not decline

An unknowable head falls back to the **existing unbounded query**. chain-events can refuse there
because a window *is* its contract; here it is only an optimization over a query that worked without
one, and failing would trade a slow answer for no answer.

The first version of this declined. `tests/chain-history-networks.test.ts` caught it — the reader
returned `null` where it used to answer.

## Validation

| Check | Result |
| --- | --- |
| `npm run lint` / `format:check` / `typecheck` | pass |
| `npm run validate` | pass |
| events-cold-tier, chain-history-networks, chain-detail-serving, account-events, blocks-cold-tier, chain-events-degraded | **214 passed** |

Three new tests: the block bounds are present, a sparse account widens and still returns a **full**
page in correct order, and a failed slice fails the read rather than returning a silently short page.

Closes #10645
