### PR TITLE
ci(lakehouse): ratchet the reads that still take the default row type

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -465,6 +465,7 @@ jobs:
           # gap went 30 -> 35 with nothing watching.
           run_step npm run validate:ui-route-coverage
           run_step npm run validate:untyped-db-reads
+          run_step npm run validate:untyped-lakehouse-reads
           run_step npm run validate:readme-catalog
           report_steps
 

--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
     "curation:identity-divergence": "node scripts/identity-field-divergence.ts",
     "endpoint:brief": "node scripts/endpoint-ops-brief.ts",
     "validate:ui-route-coverage": "node scripts/validate-ui-route-coverage.ts",
-    "validate:untyped-db-reads": "node scripts/validate-untyped-db-reads.ts"
+    "validate:untyped-db-reads": "node scripts/validate-untyped-db-reads.ts",
+    "validate:untyped-lakehouse-reads": "node scripts/validate-untyped-lakehouse-reads.ts"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.3",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -123,6 +123,7 @@ function checkCommands(): Step[] {
     // build artifacts.
     step("validate:ui-route-coverage"),
     step("validate:untyped-db-reads"),
+    step("validate:untyped-lakehouse-reads"),
     // Same shape, and it was in neither the pipeline nor CI until #10251: the
     // registry README's catalog section is generated, so a registry change
     // invalidates it without touching the README.
@@ -237,6 +238,7 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     // build artifacts.
     step("validate:ui-route-coverage"),
     step("validate:untyped-db-reads"),
+    step("validate:untyped-lakehouse-reads"),
     // Same shape, and it was in neither the pipeline nor CI until #10251: the
     // registry README's catalog section is generated, so a registry change
     // invalidates it without touching the README.

--- a/scripts/validate-untyped-lakehouse-reads.ts
+++ b/scripts/validate-untyped-lakehouse-reads.ts
@@ -1,0 +1,145 @@
+// Lakehouse reads that still take the default row type -- a ceiling that only
+// falls.
+//
+// THE NEON SIDE ALREADY HAS THIS, and the lakehouse needed its own rather than
+// a share of it. scripts/validate-untyped-db-reads.ts counts the ESCAPE HATCH:
+// #10311 removed the default from the Postgres runners, so an untyped read has
+// to write `sql<Record<string, unknown>>` and can be counted. That inversion is
+// not available here. `r2SqlQuery`'s row parameter DEFAULTS, deliberately --
+// removing it would have meant touching 38 call sites in the same change that
+// made typing them possible at all, and 30 of them read aggregates or column
+// subsets that need a `Pick<>` nobody has written yet.
+//
+// So this counts the ABSENCE of a type argument instead. Same ratchet, opposite
+// polarity, and it must be a separate number: the Neon counter matches
+// `<Record<string, unknown>>(`, which an escape hatch here would satisfy, so
+// folding the two together would let lakehouse work push a ceiling that is
+// supposed to only fall.
+//
+// A RATCHET, NOT A PASS/FAIL ON ZERO. Zero is not reachable today and
+// pretending otherwise would mean an allowlist, which is worse -- an exemption
+// list stops being read the moment it is longer than a screen. Same shape and
+// same reasoning as the Neon counter it sits beside.
+//
+// ## What is NOT derivable, and therefore not a failure of this gate
+//
+// A read whose SQL is `SELECT ${<TABLE>_COLUMNS} FROM …` returns exactly the
+// generated row type, and those are typed. A read that selects `count(*)`,
+// `MAX(observed_at)`, or a hand-written column subset does not, and guessing
+// there would replace a hand-written assumption with a generated one that is
+// equally wrong and now looks authoritative. Those stay untyped until an author
+// writes the projection type.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { repoRoot } from "./lib.ts";
+import { sourceFiles } from "./validate-untyped-db-reads.ts";
+
+/**
+ * The most untyped lakehouse reads allowed. THE CEILING ONLY FALLS.
+ *
+ * 31 when this landed: 39 `r2SqlQuery` call sites, of which 8 select a full
+ * generated column tuple and carry the matching row type. Lower it whenever a
+ * read is given one.
+ */
+// Annotated `number` rather than left as the literal so the "none left" branch
+// below stays reachable code as the ceiling falls to zero.
+export const MAX_UNTYPED_LAKEHOUSE_READS: number = 31;
+
+/** Where a read can live. `scripts/` is excluded: it does not serve traffic. */
+const SOURCE_DIRS = ["src", "workers"];
+
+/**
+ * A call with NO type argument -- `r2SqlQuery(` rather than `r2SqlQuery<Row>(`.
+ *
+ * The negative lookahead is what makes this a count of untyped reads rather
+ * than of all reads. Whitespace-tolerant for the same reason the Neon counter
+ * is: prettier splits long calls across lines, and a matcher written against
+ * the single-line spelling undercounts -- which is the direction that quietly
+ * lowers a ratchet.
+ */
+const UNTYPED_READ = /\br2SqlQuery\s*\(/g;
+/** Any call at all, typed or not, so the two can be differenced. */
+const ANY_READ = /\br2SqlQuery\s*[<(]/g;
+
+/**
+ * Comment lines, dropped before counting.
+ *
+ * Prose about this gate names the very pattern it counts -- the docblock above
+ * writes `r2SqlQuery(` more than once. Counting those would make this file its
+ * own regression. Only WHOLE comment lines are dropped, never a trailing
+ * `// ...` after code: stripping to end-of-line would also eat anything after a
+ * `https://` inside a string, which is a silent UNDERCOUNT.
+ */
+const COMMENT_LINE = /^\s*(\/\/|\/\*|\*)/;
+
+export function countUntypedLakehouseReads(source: string): number {
+  const code = source
+    .split("\n")
+    .filter((line) => !COMMENT_LINE.test(line))
+    .join("\n");
+  // An import or a type position (`typeof r2SqlQuery`) is not a read.
+  const withoutRefs = code
+    .replace(/import[^;]*?from\s*"[^"]*r2-sql\.ts";/gs, "")
+    .replace(/typeof\s+r2SqlQuery/g, "");
+  return [...withoutRefs.matchAll(UNTYPED_READ)].length;
+}
+
+/** Typed + untyped, for the report line. */
+export function countLakehouseReads(source: string): number {
+  const code = source
+    .split("\n")
+    .filter((line) => !COMMENT_LINE.test(line))
+    .join("\n")
+    .replace(/import[^;]*?from\s*"[^"]*r2-sql\.ts";/gs, "")
+    .replace(/typeof\s+r2SqlQuery/g, "");
+  return [...code.matchAll(ANY_READ)].length;
+}
+
+export function main(): number {
+  const files = sourceFiles(SOURCE_DIRS, repoRoot);
+  const byFile: [string, number][] = [];
+  let untyped = 0;
+  let total = 0;
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const n = countUntypedLakehouseReads(source);
+    total += countLakehouseReads(source);
+    if (n === 0) continue;
+    untyped += n;
+    byFile.push([path.relative(repoRoot, file), n]);
+  }
+
+  if (untyped > MAX_UNTYPED_LAKEHOUSE_READS) {
+    console.error(
+      `validate-untyped-lakehouse-reads: ${untyped} reads take the default row ` +
+        `type, ceiling is ${MAX_UNTYPED_LAKEHOUSE_READS}.\n` +
+        `Give the new read a row type from generated/lakehouse/types.ts, or a ` +
+        `Pick<> of one when it selects a subset:`,
+    );
+    for (const [file, n] of byFile.sort((a, b) => b[1] - a[1])) {
+      console.error(`  ${n}  ${file}`);
+    }
+    return 1;
+  }
+
+  if (untyped < MAX_UNTYPED_LAKEHOUSE_READS) {
+    console.log(
+      `validate-untyped-lakehouse-reads: ${untyped} of ${total} untyped, ` +
+        `below the ceiling of ${MAX_UNTYPED_LAKEHOUSE_READS}. LOWER IT to ${untyped}.`,
+    );
+    return 0;
+  }
+
+  console.log(
+    untyped === 0
+      ? `validate-untyped-lakehouse-reads: none left -- every read names its row.`
+      : `validate-untyped-lakehouse-reads: ${untyped} of ${total} untyped, at the ceiling.`,
+  );
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exit(main());
+}

--- a/tests/validate-untyped-lakehouse-reads.test.ts
+++ b/tests/validate-untyped-lakehouse-reads.test.ts
@@ -1,0 +1,65 @@
+// The lakehouse read ratchet (scripts/validate-untyped-lakehouse-reads.ts).
+//
+// The property worth testing is the COUNTING, not the ceiling: a matcher that
+// silently undercounts lowers a ratchet nobody earned, which is the direction
+// the Neon counter's own header calls out as the worst way to be wrong.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  countLakehouseReads,
+  countUntypedLakehouseReads,
+  MAX_UNTYPED_LAKEHOUSE_READS,
+} from "../scripts/validate-untyped-lakehouse-reads.ts";
+
+describe("countUntypedLakehouseReads", () => {
+  test("counts a call with no type argument", () => {
+    assert.equal(countUntypedLakehouseReads("await r2SqlQuery(env, sql);"), 1);
+  });
+
+  test("does NOT count one that names its row", () => {
+    assert.equal(
+      countUntypedLakehouseReads("await r2SqlQuery<BlocksRow>(env, sql);"),
+      0,
+    );
+  });
+
+  test("counts across the line break prettier introduces", () => {
+    // The Neon counter was wrong this way once: a single-line matcher read 92
+    // of 105 and reported the difference as an improvement.
+    assert.equal(
+      countUntypedLakehouseReads("await r2SqlQuery\n  (env, sql);"),
+      1,
+    );
+  });
+
+  test("prose about the gate is not a read", () => {
+    // This file and the script both write `r2SqlQuery(` in comments. Counting
+    // those would make the gate its own regression.
+    assert.equal(
+      countUntypedLakehouseReads("// call r2SqlQuery( here\n * r2SqlQuery("),
+      0,
+    );
+  });
+
+  test("an import or a `typeof` position is not a read", () => {
+    assert.equal(
+      countUntypedLakehouseReads(
+        'import { r2SqlQuery } from "./r2-sql.ts";\nlet f: typeof r2SqlQuery;',
+      ),
+      0,
+    );
+  });
+
+  test("the total counts typed and untyped alike", () => {
+    const src = "r2SqlQuery(a);\nr2SqlQuery<BlocksRow>(b);";
+    assert.equal(countLakehouseReads(src), 2);
+    assert.equal(countUntypedLakehouseReads(src), 1);
+  });
+
+  test("the ceiling is a number, so it can fall to zero", () => {
+    // Annotated rather than left as a literal precisely so the "none left"
+    // branch stays reachable code.
+    assert.equal(typeof MAX_UNTYPED_LAKEHOUSE_READS, "number");
+    assert.ok(MAX_UNTYPED_LAKEHOUSE_READS >= 0);
+  });
+});


### PR DESCRIPTION
## Summary

#10643 made the generated lakehouse types adoptable and typed 8 of 39 `r2SqlQuery` call sites. Nothing
stopped that number sitting at 8 forever — which is the exact decay `validate-untyped-db-reads.ts`
already documents for Neon: a default row type *loses*, because opting sites in one at a time is
outpaced by the next read someone writes untyped.

## Why a separate counter, not a share of the Neon one

The Neon ratchet counts the **escape hatch**. #10311 removed the default from the Postgres runners, so
an untyped read must *write* `sql<Record<string, unknown>>` and can be matched.

That inversion isn't available here. `r2SqlQuery`'s parameter **defaults**, deliberately — removing it
would have meant touching 39 call sites in the same change that made typing them possible at all, and
31 read aggregates (`count(*)`, `MAX`) or column subsets needing a `Pick<>` nobody has written. So this
counts the **absence** of a type argument: same ratchet, opposite polarity.

It also has to be a separate **number**. The Neon matcher is `<Record<string, unknown>>(`, which a
lakehouse escape hatch would satisfy — folding them together would let lakehouse work push a ceiling
that is supposed to only fall.

## Behaviour

```
validate-untyped-lakehouse-reads: 31 of 40 untyped, at the ceiling.
```

Over the ceiling it fails and names the files, worst first. Under it, it passes and asks for the
ceiling to be lowered. Not a pass/fail on zero — zero isn't reachable today, and pretending otherwise
would mean an allowlist, which stops being read the moment it's longer than a screen.

Registered in `validate.yml` with `run_step`, beside `validate:untyped-db-reads`.

## Validation

| Check | Result |
| --- | --- |
| `npm run format:check` / `lint` / `typecheck` | pass |
| `npm run validate:workflows` | pass |
| **Proven to fail** | exit **1** at a ceiling of 30, exit **0** at 31 |

Closes #10647
