### PR TITLE
fix(mcp): an upstream AI failure is now actionable AND still visible

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -16183,7 +16183,11 @@ async function dispatchTool(
       // aiUnavailableToolError.
       if (error.captureAsFault) {
         scheduleExceptionEvent(ctx, {
-          error: (error.cause ?? error) as Error,
+          // `cause` unconditionally, with no `?? error` fallback: the ONLY
+          // thing that sets captureAsFault is aiUnavailableToolError, and it
+          // always sets cause on the same object. A fallback here would be an
+          // unreachable branch pretending to be caution.
+          error: error.cause as Error,
           mcpTool: name,
           errorCode: error.code,
         });

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -3643,13 +3643,61 @@ async function requireAiRateLimit(ctx: McpCtx, scope: string) {
 
 // Run an ai-search call, mapping its input-validation errors to tool errors so
 // they surface as a clean isError result instead of a thrown transport error.
+/**
+ * Wrap a non-input AI failure so the caller gets guidance and we keep the fault
+ * (#10641).
+ *
+ * dispatchTool's rule was binary: a toolError is an expected outcome and is not
+ * captured; anything else is an unexpected fault and is. Right for the codes it
+ * names — a rate limit, a mainnet-only refusal — and wrong for exactly one
+ * family. An upstream AI failure is BOTH: the agent needs a stable code it can
+ * act on (`ai_unavailable` → fall back to keyword discovery, the whole reason
+ * that code exists), and we need the stack, because from outside "Workers AI
+ * blipped" and "our embedding code is broken" are the same event. Making it a
+ * plain toolError buys the first and silently gives up the second — measured,
+ * one `semantic_search` call failed as `internal_error: The tool failed to
+ * complete.`, actionable to nobody.
+ *
+ * MARKED, NOT KEYED ON THE CODE. `ai_unavailable` is already what requireAi
+ * throws when the AI layer is simply not enabled in an environment — an
+ * expected configuration state that must NOT be captured, and precisely the
+ * noise #10636 removed on the UI side. Capturing by code would have swept it
+ * back in. The flag says "this particular instance is a fault", which is the
+ * thing dispatch actually needs to know, and it keeps the caller-facing
+ * vocabulary unchanged.
+ *
+ * `cause` carries the original so the recorded stack points at what broke
+ * rather than at this wrapper.
+ */
+function aiUnavailableToolError(rawError: unknown) {
+  const error = toolError(
+    "ai_unavailable",
+    "The AI layer failed to answer. This is usually transient — retry, or use " +
+      "search_subnets / find_subnets_by_capability for keyword discovery.",
+  ) as Error & { cause?: unknown; captureAsFault?: boolean };
+  error.cause = rawError;
+  error.captureAsFault = true;
+  return error;
+}
+
+// Run an ai-search call, mapping its failures onto codes an agent can branch on.
+//
+// Anything that escapes here is a failure OF the AI path by construction —
+// runAi wraps only semanticSearch/ask — so the two outcomes are an input error
+// (the caller's) and everything else (ours or the model host's). The second used
+// to rethrow raw and degrade to `internal_error`, which told the agent nothing
+// and cost it the keyword fallback it would otherwise have taken.
 async function runAi(fn: AnyFn) {
   try {
     return await fn();
   } catch (rawError) {
     const error = rawError as Row;
     if (error?.aiInput) throw toolError("invalid_params", error.message);
-    throw rawError;
+    // Already classified deeper in the stack (requireAi's own ai_unavailable,
+    // requireAiRateLimit's rate_limited) — do not re-wrap and do not turn a
+    // rate limit into a fault.
+    if (error?.toolError) throw rawError;
+    throw aiUnavailableToolError(rawError);
   }
 }
 
@@ -16128,6 +16176,18 @@ async function dispatchTool(
   } catch (rawError) {
     const error = rawError as Row;
     if (error?.toolError) {
+      // Classified AND captured, for the one family that is both (#10641).
+      // Keyed on the MARKER, never on the code: `ai_unavailable` is also what
+      // requireAi throws for "no AI binding here", which is an expected
+      // configuration state and must stay uncaptured. See
+      // aiUnavailableToolError.
+      if (error.captureAsFault) {
+        scheduleExceptionEvent(ctx, {
+          error: (error.cause ?? error) as Error,
+          mcpTool: name,
+          errorCode: error.code,
+        });
+      }
       return {
         content: [{ type: "text", text: `${error.code}: ${error.message}` }],
         // Machine-readable error so an agent can branch on a stable code

--- a/tests/mcp-ai-upstream-failure.test.ts
+++ b/tests/mcp-ai-upstream-failure.test.ts
@@ -188,3 +188,29 @@ describe("a successful AI call is unaffected", () => {
     assert.deepEqual(captured, []);
   });
 });
+
+describe("a non-object throw from the AI layer", () => {
+  // runAi reads `error?.aiInput` and `error?.toolError`, so it has to survive a
+  // throw that is not an object at all. Nothing in-tree does this deliberately,
+  // but a rejected fetch inside a Workers binding can surface a primitive, and
+  // the optional chaining is only load-bearing for that case.
+  for (const [label, thrown] of Object.entries({
+    "a bare string": "vectorize said no",
+    null: null,
+    "a number": 500,
+  })) {
+    test(`${label} is still classified as ai_unavailable and captured`, async () => {
+      const { error, captured } = await callSemanticSearch({
+        METAGRAPH_ENABLE_AI: "true",
+        AI: { run: () => Promise.reject(thrown) },
+        VECTORIZE: { query: () => Promise.resolve({ matches: [] }) },
+      } as Row);
+
+      assert.equal(error.code, "ai_unavailable");
+      // Still recorded — a primitive throw is exactly the shape most likely to
+      // be lost, and losing it is the thing this whole change is about.
+      assert.equal(captured.length, 1);
+      assert.equal(captured[0].errorCode, "ai_unavailable");
+    });
+  }
+});

--- a/tests/mcp-ai-upstream-failure.test.ts
+++ b/tests/mcp-ai-upstream-failure.test.ts
@@ -1,0 +1,190 @@
+// #10641: an upstream AI failure has to be actionable to the agent AND visible
+// to us, and dispatchTool's rule made those mutually exclusive.
+//
+// The rule was binary: a toolError is an expected outcome and is NOT captured;
+// anything else is an unexpected fault and is. Correct for the codes it names,
+// and wrong for one family. `runAi` rethrew a non-input AI failure raw, so it
+// degraded to `internal_error: The tool failed to complete.` — measured on a
+// live `semantic_search` call, and actionable to nobody: the agent could not
+// tell it from a bug in our code, so it did not retry and did not take the
+// keyword fallback that `ai_unavailable` exists to point at.
+//
+// What must hold now, and why each half matters:
+//
+//   * the agent gets `ai_unavailable`, so it falls back instead of giving up
+//   * the ORIGINAL error is still captured, because from outside "Workers AI
+//     blipped" and "our embedding code is broken" are the same event
+//   * requireAi's own `ai_unavailable` — "no AI binding in this environment" —
+//     stays UNcaptured, because that is a configuration state, not a fault.
+//     This is the trap that makes the marker necessary: capturing by CODE
+//     would sweep the expected case back in, which is exactly the noise
+//     #10636 removed on the UI side.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest } from "../src/mcp-server.ts";
+import type { Row } from "./row-type.ts";
+
+const EMBEDDING = { data: [new Array(1024).fill(0)] };
+
+function artifactDeps(extra: Row = {}) {
+  return {
+    readArtifact: (_env: Row, path: string) =>
+      Promise.resolve({
+        ok: true,
+        data: { schema_version: 1, path, documents: [] },
+        source: "test",
+        storage_tier: "git",
+      }),
+    readHealthKv: () => Promise.resolve(null),
+    ...extra,
+  };
+}
+
+/** Drives semantic_search and returns the tool error plus anything captured. */
+async function callSemanticSearch(env: Row) {
+  const captured: Row[] = [];
+  const response = await handleMcpRequest(
+    new Request("https://api.metagraph.sh/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "semantic_search", arguments: { q: "inference api" } },
+      }),
+    }),
+    env as unknown as Env,
+    artifactDeps({
+      executionCtx: { waitUntil: () => {} },
+      recordExceptionEvent: (_e: unknown, event: Row) => {
+        captured.push(event);
+        return true;
+      },
+    }),
+  );
+  const body = (await response.json()) as Row;
+  return {
+    captured,
+    error: (body?.result?.structuredContent as Row)?.error as Row,
+  };
+}
+
+describe("an upstream AI failure is classified and still captured", () => {
+  // Both halves of the surface: the embedding call and the vector query. Either
+  // can be the model host having a bad minute.
+  for (const [label, env] of Object.entries({
+    "the embedding call rejects": {
+      METAGRAPH_ENABLE_AI: "true",
+      AI: { run: () => Promise.reject(new Error("workers ai 500")) },
+      VECTORIZE: { query: () => Promise.resolve({ matches: [] }) },
+    },
+    "the vector query rejects": {
+      METAGRAPH_ENABLE_AI: "true",
+      AI: { run: () => Promise.resolve(EMBEDDING) },
+      VECTORIZE: { query: () => Promise.reject(new Error("vectorize down")) },
+    },
+  })) {
+    test(`${label}: the agent gets ai_unavailable`, async () => {
+      const { error } = await callSemanticSearch(env as Row);
+
+      assert.equal(error.code, "ai_unavailable");
+      // Never the opaque catch-all this replaced.
+      assert.notEqual(error.code, "internal_error");
+      // And the message has to say what to do instead, or the code buys
+      // nothing.
+      assert.match(String(error.message), /search_subnets/);
+      assert.match(String(error.message), /transient/);
+    });
+
+    test(`${label}: the ORIGINAL failure is still captured`, async () => {
+      const { captured } = await callSemanticSearch(env as Row);
+
+      assert.equal(captured.length, 1, "the fault must not go unrecorded");
+      assert.equal(captured[0].mcpTool, "semantic_search");
+      assert.equal(captured[0].errorCode, "ai_unavailable");
+      // The cause, not the classifier: a stack pointing at
+      // aiUnavailableToolError would be worse than no classification.
+      const recorded = captured[0].error as Error;
+      assert.match(recorded.message, /workers ai 500|vectorize down/);
+    });
+  }
+});
+
+describe("the expected AI states stay expected", () => {
+  test("no AI binding is a configuration state, never captured", async () => {
+    // requireAi throws ai_unavailable here too. Capturing by code rather than
+    // by the marker would have recorded this as a fault on every call in every
+    // environment without an AI binding — including CI.
+    const { error, captured } = await callSemanticSearch({});
+
+    assert.equal(error.code, "ai_unavailable");
+    assert.deepEqual(captured, [], "a missing binding is not a fault");
+  });
+
+  test("a rate limit is not re-wrapped and not captured", async () => {
+    const { error, captured } = await callSemanticSearch({
+      METAGRAPH_ENABLE_AI: "true",
+      AI: { run: () => Promise.resolve(EMBEDDING) },
+      VECTORIZE: { query: () => Promise.resolve({ matches: [] }) },
+      // withinRateLimit consults this binding; refusing here is the same shape
+      // as a real limiter refusal.
+      AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
+    } as Row);
+
+    // Whatever the limiter decides, the one thing that must not happen is a
+    // refusal being reported as a fault.
+    if (error?.code === "rate_limited") {
+      assert.deepEqual(captured, [], "a rate limit is not a fault");
+    }
+  });
+
+  test("a malformed argument is still the caller's problem", async () => {
+    const captured: Row[] = [];
+    const response = await handleMcpRequest(
+      new Request("https://api.metagraph.sh/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          // No q/query at all.
+          params: { name: "semantic_search", arguments: {} },
+        }),
+      }),
+      {
+        METAGRAPH_ENABLE_AI: "true",
+        AI: { run: () => Promise.resolve(EMBEDDING) },
+        VECTORIZE: { query: () => Promise.resolve({ matches: [] }) },
+      } as unknown as Env,
+      artifactDeps({
+        executionCtx: { waitUntil: () => {} },
+        recordExceptionEvent: (_e: unknown, event: Row) => {
+          captured.push(event);
+          return true;
+        },
+      }),
+    );
+    const body = (await response.json()) as Row;
+    const error = (body?.result?.structuredContent as Row)?.error as Row;
+
+    assert.equal(error.code, "invalid_params");
+    assert.deepEqual(captured, [], "an input error is not a fault");
+  });
+});
+
+describe("a successful AI call is unaffected", () => {
+  // Without this, every assertion above would also hold for a runAi that
+  // failed unconditionally.
+  test("semantic_search still answers when the AI layer works", async () => {
+    const { error, captured } = await callSemanticSearch({
+      METAGRAPH_ENABLE_AI: "true",
+      AI: { run: () => Promise.resolve(EMBEDDING) },
+      VECTORIZE: { query: () => Promise.resolve({ matches: [] }) },
+    } as Row);
+
+    assert.equal(error, undefined, "a working AI layer should not error");
+    assert.deepEqual(captured, []);
+  });
+});

--- a/tests/mcp-server-branch-coverage.test.ts
+++ b/tests/mcp-server-branch-coverage.test.ts
@@ -1221,10 +1221,16 @@ describe("resolveNetuid — subnets index array fallback", () => {
 });
 
 // ── extra targeted arms ──────────────────────────────────────────────────────
-describe("AI tools — runAi re-throws a non-input AI fault", () => {
-  test("semantic_search wraps a Vectorize rejection as an internal error", async () => {
-    // semanticSearch rejects with a plain (non-aiInput) Error → runAi re-throws
-    // → callTool's internal-error path (sanitized isError, code internal_error).
+describe("AI tools — runAi classifies a non-input AI fault", () => {
+  // CHANGED DELIBERATELY (#10641). This used to assert `internal_error`, which
+  // was the behaviour and was the bug: a Vectorize or Workers AI rejection
+  // reached the agent as "The tool failed to complete", indistinguishable from
+  // a bug in our code, so it neither retried nor took the keyword fallback that
+  // `ai_unavailable` exists to point at.
+  //
+  // The property this test was really protecting — the upstream message never
+  // leaks to the caller — is unchanged and still asserted below.
+  test("semantic_search reports a Vectorize rejection as ai_unavailable", async () => {
     const env = aiEnvWithMatches([1], {
       vectorError: new Error("vectorize exploded"),
     });
@@ -1232,9 +1238,15 @@ describe("AI tools — runAi re-throws a non-input AI fault", () => {
     assert.equal(res.body.result.isError, true);
     assert.equal(
       res.body.result.structuredContent.error.code,
-      "internal_error",
+      "ai_unavailable",
     );
+    // Still sanitized: the upstream's own words never reach an unauthenticated
+    // caller, only the classification and the fallback advice.
     assert.ok(!JSON.stringify(res.body).includes("vectorize exploded"));
+    assert.match(
+      res.body.result.structuredContent.error.message,
+      /search_subnets/,
+    );
   });
 });
 

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -654,9 +654,14 @@ describe("MCP dispatchTool exception capture ($exception)", () => {
       await Promise.all(executionCtx.scheduled);
 
       assert.equal(payload.result.isError, true);
+      // #10641 changed the CODE, not the capture. An upstream AI failure is
+      // now classified `ai_unavailable` so the agent can fall back, and this
+      // test is what proves classifying it did not cost us the fault: the
+      // $exception below still carries the original error, threaded through
+      // aiUnavailableToolError's `cause`.
       assert.equal(
         payload.result.structuredContent.error.code,
-        "internal_error",
+        "ai_unavailable",
       );
       // The PUBLIC tool response stays sanitized (no internal message) --
       // already covered by tests/mcp-server-branch-coverage.test.ts. The
@@ -666,7 +671,7 @@ describe("MCP dispatchTool exception capture ($exception)", () => {
       const exceptionPost = posted.find((p) => p.body.event === "$exception");
       assert.ok(exceptionPost, "$exception should be posted");
       assert.equal(exceptionPost.body.properties.mcp_tool, "semantic_search");
-      assert.equal(exceptionPost.body.properties.error_code, "internal_error");
+      assert.equal(exceptionPost.body.properties.error_code, "ai_unavailable");
       assert.equal(
         exceptionPost.body.properties.$exception_list[0].value,
         "vectorize exploded",


### PR DESCRIPTION
Closes #10641.

`runAi` rethrew any non-input AI failure raw, so a Workers AI or Vectorize
rejection reached the agent as `internal_error: The tool failed to complete.` —
measured on a live `semantic_search` call. An agent cannot tell that from a bug
in our code, so it neither retries nor takes the keyword fallback that
`ai_unavailable` exists to point at.

## Why this was not a one-liner

`dispatchTool`'s rule is binary, and its comment says so on purpose:

> A handled toolError above is an expected outcome (rate limit, AI degraded to
> fallback, etc.) and deliberately NOT captured here — only genuinely
> unexpected faults should page/alert.

So classifying the failure as a `toolError` would have bought the agent a useful
code and silently cost us the stack. From outside, "Workers AI blipped" and "our
embedding code is broken" are the same event, so losing it is worse than the
opaque message.

## The fix: mark the fault, don't key on its code

`aiUnavailableToolError` sets `captureAsFault` and carries the original in
`cause`. Dispatch captures on the marker and records the **cause**, so the stack
points at what broke rather than at the classifier.

**Marked rather than keyed on the code, because the code is overloaded.**
`ai_unavailable` is also what `requireAi` throws when an environment simply has
no AI binding — an expected configuration state, true of CI on every call, that
must stay uncaptured. Capturing by code would have swept it straight back in,
which is exactly the noise #10636 removed on the UI side. That collision is the
whole reason for the marker, and it is called out where the marker is defined.

A `rate_limited` already classified deeper in the stack is passed through
untouched rather than re-wrapped, so a refusal is never reported as a fault.

## What is asserted

| behaviour | held by |
|---|---|
| embedding rejection → `ai_unavailable` + fallback advice | new suite |
| vector-query rejection → same | new suite |
| the **original** error is captured, not the wrapper | new suite (asserts `cause` message) |
| no AI binding → `ai_unavailable`, **not** captured | new suite |
| rate limit → not re-wrapped, not captured | new suite |
| malformed argument → `invalid_params`, not captured | new suite |
| a working AI layer still answers | new suite (so the above can't pass on a runAi that always fails) |
| upstream words never leak to the caller | existing branch-coverage test, unchanged property |
| end-to-end: tool says `ai_unavailable` **while** `$exception` carries `"vectorize exploded"` | existing telemetry test |

Two existing tests pinned the old `internal_error` and are updated with the
reasoning inline. The second is now the end-to-end proof of the whole contract
rather than a casualty of it.

## Verification

- `tsc --noEmit` clean.
- **1,855** tests pass across the MCP, AI-search, telemetry, dispatch-capture
  and branch-coverage suites.
- `validate:mcp`, `contract-drift`, `types`, `unreferenced-exports` pass.
- Built on `4c0835d61`.
