### PR TITLE
fix(watchdog): stop alarming a once-at-startup lane for being quiet

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -288,6 +288,51 @@ export function laneSilenceThresholdMs(cadenceMs: number): number {
   );
 }
 
+/**
+ * Lanes that report a VALUE rather than a heartbeat, so their silence carries
+ * no information (#10634).
+ *
+ * The silence check infers cadence from a lane's own history. For a lane that
+ * writes on a timer that is exactly right. For a lane that writes once per
+ * process lifetime it is not a cadence at all — it is the interval between
+ * DEPLOYS — and once that number exists the lane alarms for being quiet, which
+ * for these lanes is the healthy state.
+ *
+ * Measured: `poller-build` alarmed continuously for two days ("silent: 2.0
+ * days") while the poller was 31 seconds behind head and writing normally. Five
+ * deploys inside the 7-day cadence window were enough to calibrate a "cadence",
+ * and the first quiet stretch longer than 3× it opened an alarm.
+ *
+ * ── WHAT STILL COVERS THESE LANES, so this map is not a blind spot ──────────
+ *
+ * An exemption that removes the only check on something is worse than the false
+ * alarm it silences, so each entry below has to be able to answer "then what
+ * would catch it".
+ *
+ * `poller-build`: the poller reports EVERY periodic job through its own lane
+ * (`log_job_outcome` in the indexer's poller — "ok" throttled, "stale" on a
+ * failed tick), so a dead or wedged poller trips those lanes on their real
+ * cadences. `/api/v1/chain/indexer-lag` shows the same thing independently as
+ * head age. `poller-build` uniquely reports WHICH BUILD is running, so that a
+ * container which rebooted onto a stale image is visible — a value that changes
+ * only on reboot and has nothing to say on a timer.
+ *
+ * ── SCOPE: silence only ────────────────────────────────────────────────────
+ *
+ * These lanes are still fully subject to the STALE check. If the poller reports
+ * `poller-build` as stale, that is the lane saying something is wrong, and it
+ * alarms exactly as before. Nothing here suppresses a verdict; it only stops
+ * the ABSENCE of a verdict being read as one.
+ *
+ * Keep this map small, and prefer fixing a lane's cadence over adding to it.
+ */
+export const LANE_SILENCE_EXEMPT: Record<string, string> = {
+  "poller-build":
+    "Written once at container startup to announce the running build. " +
+    "Silence means the container has not rebooted, which is healthy. Poller " +
+    "liveness is covered by every periodic job lane and by indexer-lag.",
+};
+
 export interface LaneAlarmPlanInput {
   /** Newest verdict per lane, from loadLatestLaneHealth. */
   latest: Record<string, LaneHealthRecord>;
@@ -345,6 +390,11 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     // watchdog said so itself; that it then stopped saying so is the same
     // outage, and two issues for one fault is the noise this is trying to end.
     if (record.verdict === "stale") continue;
+    // A lane whose silence carries no information (#10634). Checked here, in
+    // the SILENT loop only, so the stale loop above still alarms on a verdict
+    // these lanes actually report. See LANE_SILENCE_EXEMPT for what covers
+    // each one instead.
+    if (record.lane in LANE_SILENCE_EXEMPT) continue;
     const cadenceMs = cadence[record.lane] ?? null;
     if (cadenceMs === null) continue;
     const quietFor = nowMs - record.checked_at;

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -33,6 +33,7 @@ vi.mock("pg", () => pg.module);
 import {
   LANE_ALARM_MAX_OPENS_PER_TICK,
   LANE_ALARM_MIN_STALE_MS,
+  LANE_SILENCE_EXEMPT,
   LANE_ALARM_TITLE_PREFIX,
   LANE_CADENCE_SQL,
   LANE_STALE_RUN_SQL,
@@ -156,6 +157,83 @@ describe("laneAlarmPlan", () => {
       },
       { lane: "a", kind: "stale", ticks: 112, cadence: 15 * 60_000 },
     );
+  });
+
+  // #10634: a lane that reports a VALUE, not a heartbeat.
+  //
+  // `poller-build` is written once per container start, to announce the running
+  // build. It alarmed continuously for two days ("silent: 2.0 days") while the
+  // poller was 31 seconds behind head and writing normally — five deploys in the
+  // cadence window were enough to calibrate a "cadence" out of DEPLOY intervals,
+  // after which the healthy state (no reboot) reads as an outage.
+  test("never alarms an exempt lane for silence, however long it is quiet", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        "poller-build": record({
+          lane: "poller-build",
+          verdict: "ok",
+          checked_at: NOW - 30 * 24 * HOUR,
+        }),
+      },
+      // A calibrated cadence, which is exactly the state that produced the
+      // false alarm — the exemption has to hold even so.
+      cadence: { "poller-build": 12 * HOUR },
+    });
+    assert.deepEqual(plan.open, []);
+  });
+
+  // The exemption is SILENCE-ONLY. A verdict the lane actually reports is the
+  // lane saying something is wrong, and must still alarm — otherwise this would
+  // be suppressing a watchdog rather than fixing its cadence model.
+  test("still alarms an exempt lane that reports itself STALE", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        "poller-build": record({ lane: "poller-build", verdict: "stale" }),
+      },
+      runs: { "poller-build": { since: NOW - 28 * HOUR, ticks: 40 } },
+      cadence: { "poller-build": 12 * HOUR },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].lane, "poller-build");
+    assert.equal(plan.open[0].kind, "stale");
+  });
+
+  // Proving the exemption is narrow: without this, an `in` check against the
+  // wrong object (or a blanket skip) would pass both tests above.
+  test("a non-exempt lane with the same shape still alarms as silent", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        neurons: record({
+          lane: "neurons",
+          verdict: "ok",
+          checked_at: NOW - 30 * 24 * HOUR,
+        }),
+      },
+      cadence: { neurons: 12 * HOUR },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].lane, "neurons");
+    assert.equal(plan.open[0].kind, "silent");
+  });
+
+  // Every exemption has to carry a reason naming what covers the lane instead,
+  // so the map cannot grow into a place things go to stop being checked.
+  test("every exempt lane declares a non-trivial reason", () => {
+    const entries = Object.entries(LANE_SILENCE_EXEMPT);
+    assert.ok(entries.length > 0);
+    // Small on purpose. If this ever needs raising, the lane probably wants its
+    // cadence fixed instead.
+    assert.ok(
+      entries.length <= 3,
+      `the exempt map should stay small, has ${entries.length}`,
+    );
+    for (const [lane, reason] of entries) {
+      assert.ok(reason.length > 40, `${lane} needs a real reason`);
+      assert.match(reason, /covered by|indexer-lag|liveness/i);
+    }
   });
 
   test("a one-tick flicker never reaches the threshold", () => {


### PR DESCRIPTION
Closes #10634.

`poller-build` alarmed continuously for two days — `lane poller-build is silent:
2.0 days`, climbing every 30 minutes — and read as a producer outage in error
tracking. It was the healthy state.

## What was actually happening

The lane is written **once per container start**, and the poller says so where it
writes it:

> Reported ONCE, at startup, because that is when it is true — a value that only
> changes on a reboot has nothing to say on a timer.

The silence check infers cadence from a lane's own history. For a timer-driven
lane that is exactly right; for this one the "cadence" is the interval between
**deploys**. Five deploys inside the 7-day window were enough to calibrate one,
after which the first quiet stretch longer than 3× it opened an alarm.

Meanwhile, measured at the same time:

```
GET /api/v1/chain/indexer-lag
head_age_ms:        31023      (31 seconds behind head)
newest_observed_at: 2026-08-11T05:40:12Z
```

## Scope: silence only

The **stale** check is untouched. If the poller reports `poller-build` as stale,
that is the lane saying something is wrong and it alarms exactly as before. This
stops the *absence* of a verdict being read as one; it never suppresses a
verdict.

## The exemption names what covers the lane instead

An exemption that removes the only check on something is worse than the false
alarm it silences, so each entry has to answer "then what would catch it":

- **Every periodic poller job has its own lane.** `log_job_outcome` reports each
  one on its real cadence — `ok` (throttled) and `stale` on a failed tick — so a
  dead or wedged poller trips those.
- **`indexer-lag` shows it independently** as head age.
- `poller-build` uniquely reports *which build is running*, so a container that
  rebooted onto a stale image stays visible. That is a value, not a heartbeat.

The map is asserted **small** (≤3), because a lane that needs an entry usually
wants its cadence model fixed instead.

## What the tests hold

| property | why it matters |
|---|---|
| an exempt lane never alarms silent, however long it is quiet, **even with a calibrated cadence** | that calibrated state is exactly what produced the false alarm |
| an exempt lane reporting itself **stale** still alarms | proves this is not suppressing a watchdog |
| a **non-exempt** lane of the same shape still alarms silent | proves the exemption is narrow — a blanket skip would pass the first two |
| every entry carries a reason naming its alternative coverage | keeps the map from becoming where things go to stop being checked |

## Verification

- `tsc --noEmit` clean.
- 80 tests pass across `lane-alarm`, `lane-health`, `observability` (54 in
  `lane-alarm` alone, 4 new).
- `validate:types`, `unreferenced-exports`, `contract-drift` pass.
