### PR TITLE
fix(ui): pass an explicit locale everywhere, and gate the pattern that returns

### DIFF
--- a/apps/ui/src/components/metagraphed/account-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-history-chart.tsx
@@ -17,7 +17,7 @@ interface AccountHistorySeriesDay extends AccountDay {
 function formatDay(day: string, withYear = false): string {
   const date = new Date(`${day}T00:00:00Z`);
   if (!Number.isFinite(date.getTime())) return day;
-  return new Intl.DateTimeFormat(undefined, {
+  return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     ...(withYear ? { year: "numeric" } : {}),

--- a/apps/ui/src/components/metagraphed/api-keys-manager.tsx
+++ b/apps/ui/src/components/metagraphed/api-keys-manager.tsx
@@ -66,7 +66,7 @@ function describeApiError(error: unknown): string {
 
 function formatTimestamp(ms: number | null): string {
   if (!ms) return "never";
-  return new Date(ms).toLocaleString();
+  return new Date(ms).toLocaleString("en-US");
 }
 
 /**
@@ -391,7 +391,8 @@ function UsageDashboard({ usage, token }: { usage: ApiKeyUsage | undefined; toke
           <div className="flex items-baseline justify-between gap-2 mg-type-caption">
             <span className="text-ink-muted">Daily quota</span>
             <span className="font-mono text-ink-strong">
-              {quota.units_spent.toLocaleString()} / {quota.daily_units.toLocaleString()} units
+              {quota.units_spent.toLocaleString("en-US")} /{" "}
+              {quota.daily_units.toLocaleString("en-US")} units
             </span>
           </div>
           <div
@@ -414,8 +415,8 @@ function UsageDashboard({ usage, token }: { usage: ApiKeyUsage | undefined; toke
             />
           </div>
           <p className="mg-type-caption text-ink-subtle">
-            {quota.remaining.toLocaleString()} units left · resets{" "}
-            {new Date(quota.resets_at).toLocaleTimeString(undefined, {
+            {quota.remaining.toLocaleString("en-US")} units left · resets{" "}
+            {new Date(quota.resets_at).toLocaleTimeString("en-US", {
               hour: "numeric",
               minute: "2-digit",
               // The quota resets at 00:00 UTC and the label says UTC, so the
@@ -436,7 +437,7 @@ function UsageDashboard({ usage, token }: { usage: ApiKeyUsage | undefined; toke
 
       {usage.rejected_total > 0 ? (
         <p className="mg-type-caption text-health-warn">
-          {usage.rejected_total.toLocaleString()} request
+          {usage.rejected_total.toLocaleString("en-US")} request
           {usage.rejected_total === 1 ? " was" : "s were"} rate-limited in this window. Rate-limited
           requests are not counted against your quota.
         </p>
@@ -444,7 +445,7 @@ function UsageDashboard({ usage, token }: { usage: ApiKeyUsage | undefined; toke
 
       <BarMini
         data={chronological.map((d) => ({
-          label: new Date(d.day).toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+          label: new Date(d.day).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
           value: d.count,
         }))}
         ariaLabel={`Daily request count, last ${usage.window_days} days`}
@@ -459,7 +460,7 @@ function UsageDashboard({ usage, token }: { usage: ApiKeyUsage | undefined; toke
                 className="flex items-center justify-between gap-2 mg-type-caption text-ink-muted"
               >
                 <span className="font-mono text-ink-strong">{r.route}</span>
-                <span>{r.count.toLocaleString()}</span>
+                <span>{r.count.toLocaleString("en-US")}</span>
               </li>
             ))}
           </ul>

--- a/apps/ui/src/components/metagraphed/dev-activity-panel.tsx
+++ b/apps/ui/src/components/metagraphed/dev-activity-panel.tsx
@@ -25,7 +25,8 @@ export function DevActivityPanel({ profile }: { profile?: SubnetProfile }) {
       <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mg-type-caption text-ink-muted">
         {profile.github_stars != null ? (
           <span className="inline-flex items-center gap-1.5">
-            <Star className="size-3.5" aria-hidden /> {profile.github_stars.toLocaleString()} stars
+            <Star className="size-3.5" aria-hidden /> {profile.github_stars.toLocaleString("en-US")}{" "}
+            stars
           </span>
         ) : null}
         {profile.github_last_push_at ? (
@@ -43,7 +44,7 @@ export function DevActivityPanel({ profile }: { profile?: SubnetProfile }) {
         <div className="mt-4">
           <BarMini
             data={weeks.map((w) => ({
-              label: new Date(w.week).toLocaleDateString(undefined, {
+              label: new Date(w.week).toLocaleDateString("en-US", {
                 month: "short",
                 day: "numeric",
               }),

--- a/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-compare-panel.tsx
@@ -219,7 +219,7 @@ function CompareColumn({
           {values.length > 1 ? (
             <Sparkline
               values={values}
-              points={series.map((p) => ({ t: new Date(p.t).toLocaleTimeString(), v: p.v }))}
+              points={series.map((p) => ({ t: new Date(p.t).toLocaleTimeString("en-US"), v: p.v }))}
               width={240}
               height={36}
               color={healthColor(endpoint.health)}

--- a/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-detail-drawer.tsx
@@ -157,7 +157,7 @@ export function EndpointDetailDrawer({
             {latencyValues.length > 1 ? (
               <Sparkline
                 values={latencyValues}
-                points={series.map((p) => ({ t: new Date(p.t).toLocaleString(), v: p.v }))}
+                points={series.map((p) => ({ t: new Date(p.t).toLocaleString("en-US"), v: p.v }))}
                 width={560}
                 height={88}
                 color="var(--accent)"
@@ -180,7 +180,7 @@ export function EndpointDetailDrawer({
                   <div className="mg-label">{index === 0 ? "Latest" : `Prior ${index}`}</div>
                   <div className="mt-1 mg-type-data text-ink-strong">{Math.round(p.v)}ms</div>
                   <div className="mt-0.5 truncate mg-type-data-sm text-ink-muted">
-                    {new Date(p.t).toLocaleString()}
+                    {new Date(p.t).toLocaleString("en-US")}
                   </div>
                 </div>
               ))}
@@ -274,7 +274,9 @@ export function EndpointDetailDrawer({
                         </span>
                         <span className="flex items-center gap-1">
                           <span className="mg-type-data-sm text-ink-muted tabular-nums">
-                            {inc.started_at ? new Date(inc.started_at).toLocaleString() : "—"}
+                            {inc.started_at
+                              ? new Date(inc.started_at).toLocaleString("en-US")
+                              : "—"}
                           </span>
                           <CopyLinkButton
                             hash={`incident-${inc.id}`}
@@ -297,7 +299,7 @@ export function EndpointDetailDrawer({
                           {affected.length > 12 ? "…" : ""}
                         </a>
                         {inc.ended_at ? (
-                          <span>· ended {new Date(inc.ended_at).toLocaleString()}</span>
+                          <span>· ended {new Date(inc.ended_at).toLocaleString("en-US")}</span>
                         ) : (
                           <span className="text-health-warn-text">· active</span>
                         )}

--- a/apps/ui/src/components/metagraphed/self-health-verdict.tsx
+++ b/apps/ui/src/components/metagraphed/self-health-verdict.tsx
@@ -94,9 +94,9 @@ export function SelfHealthVerdict() {
               colour: 3 subnet APIs being down is not our outage, and colouring
               it like one is exactly the bug this rebuild fixes. */}
           <p className="mt-1 mg-type-caption text-ink-muted">
-            Tracking {total.toLocaleString()} subnet surfaces: {ok.toLocaleString()} up ·{" "}
-            {warn.toLocaleString()} slow · {down.toLocaleString()} down
-            {unknown > 0 ? ` · ${unknown.toLocaleString()} unknown` : ""}. Those are other
+            Tracking {total.toLocaleString("en-US")} subnet surfaces: {ok.toLocaleString("en-US")}{" "}
+            up · {warn.toLocaleString("en-US")} slow · {down.toLocaleString("en-US")} down
+            {unknown > 0 ? ` · ${unknown.toLocaleString("en-US")} unknown` : ""}. Those are other
             teams&rsquo; endpoints, not ours.
           </p>
           {!selfData ? (

--- a/apps/ui/src/lib/locale-hydration.test.ts
+++ b/apps/ui/src/lib/locale-hydration.test.ts
@@ -1,0 +1,98 @@
+// The guard that stops site #25.
+//
+// #8356 fixed React #418 by passing an explicit locale to two components, and
+// wrote down exactly why: `toLocaleDateString(undefined, ...)` resolves to the
+// RUNTIME's default, "which Cloudflare Workers (SSR) and a non-en-US browser
+// (hydration) never agree on -- that mismatch is exactly what threw React #418
+// on mobile UA."
+//
+// It fixed the two sites it was looking at. Twenty-four others kept the pattern,
+// and #418 kept firing for months. A fix that depends on everyone remembering it
+// is not a fix, so this asserts the property over the whole tree instead.
+//
+// NUMBERS COUNT, not just dates: (1234).toLocaleString() is "1,234" in en-US and
+// "1.234" in de-DE, so an SSR'd stat line mismatches for most of the world. Three
+// of them were on routes/-agents-page.tsx.
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dirname, "..");
+
+/**
+ * Whitespace-tolerant on purpose.
+ *
+ * A source-regex gate goes blind the moment prettier wraps the call it is
+ * looking for, so `\s*` spans the newline that `toLocaleString(\n  undefined,`
+ * would otherwise hide behind.
+ */
+const RUNTIME_DEFAULT_LOCALE =
+  /\.toLocale(?:String|DateString|TimeString)\(\s*(?:\)|undefined\b)|Intl\.(?:DateTimeFormat|NumberFormat)\(\s*(?:\)|undefined\b)/;
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+      continue;
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue;
+    if (/\.test\.(ts|tsx)$/.test(entry)) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+describe("locale-dependent formatting never resolves to the runtime default", () => {
+  it("finds no unlocalised toLocale*/Intl call anywhere under src", () => {
+    const offenders: string[] = [];
+    for (const file of sourceFiles(SRC)) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        // Skip the two comments that DOCUMENT the pattern — they quote it on
+        // purpose, and a gate that trips on its own explanation is a gate
+        // people delete.
+        const code = line.replace(/\/\/.*$/, "").replace(/\/\*.*?\*\//g, "");
+        if (RUNTIME_DEFAULT_LOCALE.test(code)) {
+          offenders.push(`${file.slice(SRC.length + 1)}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      `Pass an explicit locale ("en-US") — an unlocalised call renders one way on ` +
+        `the Worker and another in the visitor's browser, which is React #418 ` +
+        `(see #8356, #10638):\n${offenders.join("\n")}`,
+    ).toEqual([]);
+  });
+
+  // Proving the gate can fail. Without this, a regex that matched nothing would
+  // pass the assertion above forever.
+  it("matches the shapes it is meant to catch, including a wrapped one", () => {
+    for (const bad of [
+      "n.toLocaleString()",
+      "d.toLocaleDateString(undefined, { month: 'short' })",
+      "d.toLocaleTimeString(undefined)",
+      "new Intl.DateTimeFormat(undefined, {})",
+      "new Intl.NumberFormat()",
+      // The formatting a prettier line-wrap would produce.
+      "n.toLocaleString(\n  undefined,\n)".replace(/\n/g, "\n"),
+    ]) {
+      expect(RUNTIME_DEFAULT_LOCALE.test(bad), bad).toBe(true);
+    }
+  });
+
+  it("does not flag a correctly localised call", () => {
+    for (const ok of [
+      'n.toLocaleString("en-US")',
+      'd.toLocaleDateString("en-US", { month: "short" })',
+      'new Intl.DateTimeFormat("en-US", {})',
+      // A locale held in a variable is a deliberate choice, not the default.
+      "n.toLocaleString(locale)",
+    ]) {
+      expect(RUNTIME_DEFAULT_LOCALE.test(ok), ok).toBe(false);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/freshness.ts
+++ b/apps/ui/src/lib/metagraphed/freshness.ts
@@ -25,7 +25,7 @@ export function formatFreshnessAbsolute(updatedAt?: string | null): string | nul
   if (!updatedAt) return null;
   const t = new Date(updatedAt);
   if (Number.isNaN(t.getTime())) return null;
-  return t.toLocaleString();
+  return t.toLocaleString("en-US");
 }
 
 /**

--- a/apps/ui/src/routes/-agents-page.tsx
+++ b/apps/ui/src/routes/-agents-page.tsx
@@ -41,9 +41,12 @@ export function AgentsPage() {
 /** The masthead's numbers, said once and out loud instead of buried mid-paragraph. */
 function StatRail({ res }: { res: AgentResources }) {
   const stats: { label: string; value: string }[] = [
-    { label: "Subnets covered", value: res.summary.subnet_count.toLocaleString() },
-    { label: "Callable services", value: res.summary.callable_service_count.toLocaleString() },
-    { label: "MCP tools", value: res.mcp.tools.length.toLocaleString() },
+    { label: "Subnets covered", value: res.summary.subnet_count.toLocaleString("en-US") },
+    {
+      label: "Callable services",
+      value: res.summary.callable_service_count.toLocaleString("en-US"),
+    },
+    { label: "MCP tools", value: res.mcp.tools.length.toLocaleString("en-US") },
   ];
   return (
     <div className="flex flex-wrap gap-x-8 gap-y-3 border-b border-border pb-6">

--- a/apps/ui/src/routes/-design-primitives-page.tsx
+++ b/apps/ui/src/routes/-design-primitives-page.tsx
@@ -621,7 +621,7 @@ function DataDisplaySection() {
           </div>
         </Show>
         <Show name="BarMini">
-          <BarMini data={BAR_DATA} showValue formatValue={(v) => v.toLocaleString()} />
+          <BarMini data={BAR_DATA} showValue formatValue={(v) => v.toLocaleString("en-US")} />
         </Show>
         <Show name="Donut, DonutLegend">
           <div className="flex items-center gap-4">

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -2052,7 +2052,7 @@ function FinancialTrendCell({
         ? `${(n / 1_000_000).toFixed(2)}M`
         : n >= 1_000
           ? `${(n / 1_000).toFixed(1)}K`
-          : n.toLocaleString(undefined, { maximumFractionDigits: digits });
+          : n.toLocaleString("en-US", { maximumFractionDigits: digits });
     return `${compactNum} ${unit}`;
   };
   return (


### PR DESCRIPTION
Closes #10638.

React #418 is still firing on the live site, and no reproduction was needed —
this repo already diagnosed the class and left the reason in the code.
`subnet-ohlc-chart.tsx`:

> The explicit `"en-US"` locale is the #8356 fix, not a style choice:
> `toLocaleDateString(undefined, ...)` resolves to the RUNTIME's default, which
> Cloudflare Workers (SSR) and a non-en-US browser (hydration) never agree on —
> **that mismatch is exactly what threw React #418 on mobile UA.**

#8356 fixed the two components it was looking at. **24 other sites across 10
files kept the pattern**, so the mismatch kept happening — for any visitor whose
browser locale differs from the Worker's, which is most of them, and which
matches the observed ~1/day rate.

## Numbers count, not just dates

The half most likely to be overlooked: `(1234).toLocaleString()` is `"1,234"` in
en-US and `"1.234"` in de-DE. Three of them render on
`routes/-agents-page.tsx` — a server-rendered route — making it the most likely
source of the captured events.

## What changed

Every site passes `"en-US"` explicitly, matching the two in-tree precedents
(`subnet-ohlc-chart`, `registry-leaderboards`):

| area | files |
|---|---|
| routes (SSR, highest-risk) | `-agents-page`, `-subnets-index-page`, `-design-primitives-page` |
| components | `self-health-verdict`, `dev-activity-panel`, `account-history-chart`, `endpoint-compare-panel`, `endpoint-detail-drawer`, `api-keys-manager` |
| lib | `metagraphed/freshness.ts` |

**No visible change for an en-US reader.** For everyone else the server and
client now agree, which is the entire point.

## The guard matters more than the 24 edits

A fix that depends on everyone remembering it is not a fix — that is precisely
how #8356 left 24 sites behind. So the property is asserted over the whole tree:

- **Whitespace-tolerant across newlines.** A source regex goes blind the moment
  prettier wraps the call it is watching, so `\s*` spans the newline that
  `toLocaleString(\n  undefined,` would hide behind.
- **Comment-stripped**, so the two comments that *document* the pattern do not
  trip it. A gate that fails on its own explanation is a gate people delete.
- **Proven able to fail.** The shapes it must catch (including a wrapped one) and
  the shapes it must not (`"en-US"`, and a locale held in a variable — a
  deliberate choice, not the default) are both asserted, so a regex matching
  nothing could not pass.

## Also noted, not changed

`status-diagnostics.tsx:52` calls `new Date().toISOString()` during render as a
fallback, which mismatches across a UTC midnight boundary — same class, far
rarer, and a different fix (the guarded pattern in `endpoint-uptime-bar.tsx:28`,
`hydrated ? Date.now() : 0`). Left out so this PR stays one property.

## Verification

- `tsc --noEmit` clean in `apps/ui`.
- **1,970** tests pass across 247 files, including the 3 new guard cases.
- Grep confirms the only remaining matches in the tree are the two explanatory
  comments.
