### PR TITLE
fix(mcp): name the 409 refusal, now that it is known to happen

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17149,6 +17149,18 @@ export function mcpRefusalReason(response: Response): string | null {
           ? "blocked"
           : "rate_limited";
     }
+    // A second SSE stream on a session that already has one (the push channel
+    // is single-holder — see the GET /mcp branch, which keeps 409 rather than
+    // flattening it to 405 because a stream IS on offer there, just taken).
+    //
+    // Named because it is now known to HAPPEN: the refusal usage_event started
+    // landing once its missing durationMs was fixed, and the first thing it
+    // showed was 8 of these in six hours, previously invisible. The catch-all
+    // `status_409` spelling was fine while nothing was known to produce it and
+    // is worse than nothing now — an anonymous number in a breakdown that
+    // somebody has to go and decode.
+    case 409:
+      return "stream_taken";
     case 405:
       return "method_not_allowed";
     case 413:

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -659,6 +659,11 @@ export const MCP_ERROR_TYPE_BY_CODE: Record<string, McpErrorType> = {
   body_too_large: "validation",
   daily_quota: "rate_limited",
   method_not_allowed: "validation",
+  // A duplicate SSE stream on one session. `validation` rather than a 4xx
+  // bucket for the same reason method_not_allowed and bad_request are: this is
+  // OUR refusal of a caller's request, not an upstream's 4xx reaching us, and
+  // the caller fixes it by not opening a second stream.
+  stream_taken: "validation",
   unauthorized: "permission",
   // "This surface exists but declares no callable path/schema" — the caller
   // is missing context about the target, not sending bad syntax.

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -114,6 +114,9 @@ describe("pre-dispatch refusals reach the $mcp_* family", () => {
     [400, {}, "bad_request", "validation"],
     [405, {}, "method_not_allowed", "validation"],
     [413, {}, "body_too_large", "validation"],
+    // Named after the refusal usage_event started landing and showed 8 of
+    // these in six hours — a second SSE stream on a session that has one.
+    [409, {}, "stream_taken", "validation"],
     [503, {}, "status_503", "api_5xx"],
     [418, {}, "status_418", "api_4xx"],
   ] as [number, Record<string, string>, string, string][]) {


### PR DESCRIPTION
A follow-on found by the fix in #10633, not by reading code.

Once the refusal `usage_event`'s missing `durationMs` was fixed, that event
started landing for the first time — and the first thing it showed was traffic
nobody could see before:

```
mcp:refused:status_409   × 8   GET  /mcp     (six hours)
mcp:refused:bad_request  × 2   POST /mcp
```

## What the 409 is

One thing: **a second SSE stream on a session that already holds one.** The
`GET /mcp` branch deliberately keeps 409 rather than flattening it to 405,
because "a stream IS on offer there, just already taken".

`status_409` is `mcpRefusalReason`'s anonymous catch-all spelling. That was
reasonable while nothing was known to produce a 409; it is worse than nothing now
— a bare number in a breakdown that whoever reads it has to go and decode. It is
now `stream_taken`.

## Why the explicit bucket matters

Mapped to `validation`, matching `method_not_allowed` and `bad_request`: this is
**our** refusal of a caller's request, not an upstream 4xx reaching us, and the
caller fixes it by not opening a second stream.

Without the explicit entry it would fall through the naming rules to `internal`
and report a caller's duplicate request as a server fault — the same class of
mis-bucketing that made `blocked` and `rate_limited` need explicit entries in
#10633.

## Verification

- `tsc --noEmit` clean.
- **1,691** tests pass; the reason → bucket table in
  `tests/mcp-analytics-completeness.test.ts` gains a `409 → stream_taken →
  validation` row, so this cannot regress silently.
- `validate:mcp`, `types`, `contract-drift`, `unreferenced-exports` pass.

Relates to #10637 — this is the one piece of that issue's "what should the server
do when it refuses" question that turned out to be a concrete code fix rather
than a policy decision.
