### PR TITLE
docs(tiers): stop the serving gate describing a store that was eliminated

### DIFF
--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -2861,11 +2861,20 @@ for (const [route, assertion, options = {}] of checks) {
   assertion(body);
 }
 
-// #6359: production wrangler.jsonc flips eight METAGRAPH_*_SOURCE flags to
-// "postgres", so the live Worker serves these routes via tryPostgresTier →
-// DATA_API. The cold harness above never sets those flags, so AJV only saw the
-// D1/empty fallback. Validate one representative route per flag with a DATA_API
-// mock whose body is built by the same src/* builders workers/data-api.ts uses.
+// #6359: eight METAGRAPH_*_SOURCE flags make the live Worker serve their routes
+// via tryPostgresTier → DATA_API rather than answering from the cold artifact.
+// The cold harness above never sets them, so AJV only ever saw the empty
+// fallback. Validate one representative route per flag with a DATA_API mock
+// whose body is built by the same src/* builders workers/data-api.ts uses.
+//
+// THE VALUE USED BELOW IS "postgres", WHICH NO DEPLOYMENT SETS. Measured
+// 2026-08-11 against the deployed Workers, not just the configs: metagraphed
+// reads "retired" x8 and "d1" x5, metagraphed-data-api reads "d1" x3, and
+// nothing anywhere reads "postgres". So this exercises the forwarding path
+// through the one disjunct production cannot take -- the three flags that
+// really forward do so via "d1" plus DATA_API_FORWARD_FLAGS membership, which
+// no case here covers. The AJV shapes it proves are still worth proving; the
+// gap is that the gate does not test the branch production runs. #10223.
 {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const OBSERVED_AT_MS = 1_750_009_000_000;

--- a/src/health-status-live.ts
+++ b/src/health-status-live.ts
@@ -6,7 +6,7 @@
 // Both callers used to route this through tryPostgresTier(...,
 // "METAGRAPH_HEALTH_SOURCE"), which resolved to null on every run: that flag
 // reads "d1" in production, and tryPostgresTier only forwards "d1" for the
-// three flags in DATA_API_D1_FLAGS. Adding this one to that set would have
+// three flags in DATA_API_FORWARD_FLAGS. Adding this one to that set would have
 // fixed the read and broken something else -- the flag is shared with
 // /api/v1/health/trends, /api/v1/incidents and /api/v1/internal/compare-health,
 // none of which data-api implements, so each of those would start forwarding,
@@ -18,7 +18,7 @@
 // data-api's subnet-identity-sync handler already makes for calling
 // env.DATA_API.fetch() directly.
 //
-// THE FLAG STILL GATES THE READ, just not through DATA_API_D1_FLAGS. A
+// THE FLAG STILL GATES THE READ, just not through DATA_API_FORWARD_FLAGS. A
 // deployment that has not pointed METAGRAPH_HEALTH_SOURCE at a tier must not
 // have this reach for one -- both callers' suites pin that ("never reaches
 // Postgres when the flag is off"), and it is the right contract: an unset flag

--- a/tests/data-api-health-status.test.ts
+++ b/tests/data-api-health-status.test.ts
@@ -7,7 +7,7 @@
 // with since=0 for the last known row per surface, src/health-serving.ts with
 // a freshness cutoff for its KV-cold serving fallback -- and both got null on
 // every call, because nothing answered the path AND the flag that gates the
-// forward was not in DATA_API_D1_FLAGS.
+// forward was not in DATA_API_FORWARD_FLAGS.
 //
 // The consequence was not a missing field but a broken invariant: with an
 // empty prior map the prober rewrote last_ok to null for every surface that

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -230,7 +230,7 @@ function makeDb({ priorStatus = [] as unknown[] } = {}) {
 // INSERT-statement inspection).
 // healthSource is a parameter, not a constant, because the flag VALUE is what
 // #9522 turned on: production has read "d1" since the box was retired, and
-// tryPostgresTier only forwards "d1" for flags listed in DATA_API_D1_FLAGS.
+// tryPostgresTier only forwards "d1" for flags listed in DATA_API_FORWARD_FLAGS.
 // Every continuity test below ran under "postgres", which forwards, so they
 // all passed while production silently resolved the prior read to null.
 function makeProberEnv({

--- a/tests/health-status-live.test.ts
+++ b/tests/health-status-live.test.ts
@@ -3,7 +3,7 @@
 // This helper exists because the previous route through tryPostgresTier could
 // not be fixed without collateral: METAGRAPH_HEALTH_SOURCE is shared with
 // /api/v1/health/trends, /api/v1/incidents and /api/v1/internal/compare-health,
-// none of which data-api implements, so adding it to DATA_API_D1_FLAGS would
+// none of which data-api implements, so adding it to DATA_API_FORWARD_FLAGS would
 // have made all three forward, take a non-2xx, and emit a
 // capturePostgresTierFallback exception per request.
 //

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -75,7 +75,7 @@ type SourceFlagName = Extract<keyof Env, `METAGRAPH_${string}_SOURCE`>;
  * any of the three wrangler configs holds "postgres" any more; they are all
  * "d1" or "retired". So these tests pin tryPostgresTier's own forwarding
  * CONTRACT, not a path production takes -- the live path is its other
- * disjunct, `"d1"` plus membership in DATA_API_D1_FLAGS. They are kept because
+ * disjunct, `"d1"` plus membership in DATA_API_FORWARD_FLAGS. They are kept because
  * that contract, and the `=== "postgres"` branch implementing it, are still in
  * the tree: deleting the tests while the branch stays would leave it untested
  * rather than retired. Retiring the disjunct itself is the change that makes

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7772,8 +7772,8 @@ export async function ingestTaoUsdIndex(
 export default {
   // #8600: the data-api Worker's first cron. It lives here rather than on the
   // api Worker for the same locality reason it always has -- this Worker owns
-  // the tick end to end (RPC reads + the tao_usd_index write, now on the
-  // shared user-state D1) -- routing a write through a service binding to
+  // the tick end to end (RPC reads + the tao_usd_index write, on Neon through
+  // Hyperdrive) -- routing a write through a service binding to
   // reach another Worker is the hop #4832 removed, not one to add back.
   async scheduled(
     controller: ScheduledController,
@@ -7781,7 +7781,10 @@ export default {
     ctx: ExecutionContext,
   ) {
     if (controller?.cron === TABLE_FRESHNESS_CRON) {
-      // D1 only. It reads MAX(<timestamp>) per table and writes one verdict.
+      // Reads MAX(<timestamp>) per table and writes one verdict, all on Neon
+      // through Hyperdrive. This line read "D1 only" until #10223 -- which is
+      // exactly the kind of stale marker that sends an investigation looking
+      // for a dead store instead of at the verdict (#10635).
       const bag = env as unknown as Record<string, unknown>;
       // The TAO/USD index rides this cron rather than its own (#8603). Its
       // staleness bound already lives in TABLE_FRESHNESS, the store is already
@@ -7796,10 +7799,12 @@ export default {
       return freshness;
     }
     if (controller?.cron === NEON_PRUNE_CRON) {
-      // Neon's own retention for the rolling windows (#9891). Independent of
-      // D1's prune by design -- two stores computing the same boundary from
-      // the same constant stay aligned, whereas one waiting on the other stops
-      // pruning the moment the other breaks.
+      // Neon's retention for the rolling windows (#9891). Built as a prune
+      // independent of D1's, back when there were two stores computing the same
+      // boundary from the same constant; D1 is gone, so this is now simply the
+      // prune. Kept separate from the lane that produces the rows it trims for
+      // the original reason -- a prune that waits on its producer stops pruning
+      // the moment the producer breaks.
       return runNeonPrune(env as unknown as Record<string, unknown>, ctx);
     }
     if (controller?.cron !== TAO_USD_INDEX_CRON) {

--- a/workers/postgres-tier.ts
+++ b/workers/postgres-tier.ts
@@ -1,16 +1,29 @@
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
-// Postgres-tier serving gate, one env flag per data source (originally ADR
-// 0013 Sequencing step 3's gated D1 -> Postgres cutover; D1 fully eliminated
-// 2026-07-17 -- reconfirmed live 2026-07-25, zero D1 databases remain on the
-// account -- every flag has been hardcoded "postgres" in every wrangler
-// config since, see wrangler.jsonc's own METAGRAPH_*_SOURCE vars). Each tier
-// keeps its own flag as a kill switch: a failure here degrades to a
-// schema-stable EMPTY response (never a live D1 read -- there's nothing left
-// to fall back to), so a maintainer can force that same degraded-but-never-
-// erroring state with a single flag flip if a specific Postgres tier needs
-// to be taken offline, with no code change or redeploy.
+// DATA_API-forwarding serving gate, one env flag per data source (originally
+// ADR 0013 Sequencing step 3's gated D1 -> Postgres cutover; D1 fully
+// eliminated 2026-07-17 -- reconfirmed 2026-08-11, zero `d1_databases` blocks
+// in any wrangler config and no D1 binding on any deployed Worker).
+//
+// WHAT THE FLAGS ACTUALLY READ, measured across all three configs 2026-08-11:
+// 8 read "retired", 8 read "d1", and NONE reads "postgres". The
+// `value === "postgres"` disjunct below is therefore unreachable in
+// production. It survives because 657 sites in tests/ use "postgres" as the
+// "forward this" value, so deleting it is a test migration rather than a
+// dead-branch removal -- #10223 step 2, after #10190's sweep.
+//
+// A READER WHO TRUSTS THESE NAMES WILL BE WRONG TWICE: "d1" is the live
+// forwarding value and names no D1, and "postgres" names no Postgres box --
+// both stores were wiped. The forward lands on DATA_API, which reads Neon
+// through Hyperdrive. Renaming the surviving concept is #10223's step 3, and
+// it wants the sweep to land first so 407 call sites are not churned twice.
+//
+// Each tier keeps its own flag as a kill switch: a failure here degrades to a
+// schema-stable EMPTY response (there is no second store left to fall back
+// to), so a maintainer can force that same degraded-but-never-erroring state
+// with a single flag flip if a specific tier needs to be taken offline, with
+// no code change or redeploy.
 // `request` is forwarded to the DATA_API service binding after normalizing HEAD
 // probes to GET: DATA_API is GET-only, while the public API computes HEAD
 // metadata from the GET representation and strips the body later. The caller
@@ -70,20 +83,27 @@ async function capturePostgresTierFallback(
   });
 }
 
-// Flags whose DATA_API leg can serve from D1 (the dispatcher sits in
-// workers/data-api.ts ahead of its Hyperdrive gate). For these, a "d1" value
-// must still FORWARD to DATA_API -- the D1 SQL lives there, not here -- while
-// every other flag/value combination keeps the strict postgres-only gate. A
-// blanket "forward on d1" would be wrong: the health and subnet-snapshot
-// flags also hold "d1", but their D1 loaders live in THIS worker and their
-// data-api legs are Postgres-only.
-const DATA_API_D1_FLAGS = new Set<string>([
+// Flags whose "d1" value FORWARDS to DATA_API. "d1" is a legacy token here,
+// not a store: DATA_API's dispatcher for these three routes sits ahead of its
+// Hyperdrive gate, so the rows come from Neon. Every other flag/value
+// combination keeps the strict gate.
+//
+// A BLANKET "FORWARD ON d1" WOULD BE WRONG. METAGRAPH_HEALTH_SOURCE and
+// METAGRAPH_SUBNET_SNAPSHOTS_SOURCE also hold "d1", and DATA_API does not
+// serve the routes they gate -- widening this set would make those call sites
+// forward, take a non-2xx, and fire capturePostgresTierFallback on every
+// request. src/health-status-live.ts works through that for the health flag in
+// full, including why it calls the service binding directly instead: DATA_API
+// implements exactly one of that flag's routes, and a per-flag switch cannot
+// do a per-route job.
+const DATA_API_FORWARD_FLAGS = new Set<string>([
   "METAGRAPH_NEURONS_SOURCE",
-  // tests/fixtures/sqlite-schema/0009: the hyperparams + account-identity dispatchers also
-  // live in DATA_API ahead of its Hyperdrive gate (matchHyperparamsIdentity-
-  // D1Route). Their cold-tier fallback depends on this forward too: DATA_API
-  // answers 503 while its table is still empty, which is what sends the
-  // serving handler on to the lakehouse cold-tier reader.
+  // tests/fixtures/sqlite-schema/0009: the hyperparams + account-identity
+  // dispatchers also live in DATA_API ahead of its Hyperdrive gate
+  // (matchHyperparamsIdentityD1Route -- still D1-named, tracked by #10223).
+  // Their cold-tier fallback depends on this forward too: DATA_API answers 503
+  // while its table is still empty, which is what sends the serving handler on
+  // to the lakehouse cold-tier reader.
   "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
   "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
 ]);
@@ -96,7 +116,7 @@ export async function tryPostgresTier(
   const value = env[flagName];
   const forwards =
     value === "postgres" ||
-    (value === "d1" && DATA_API_D1_FLAGS.has(flagName as string));
+    (value === "d1" && DATA_API_FORWARD_FLAGS.has(flagName as string));
   if (!forwards) return null;
   if (!env.DATA_API) return markPostgresTierFallback();
   const upstreamRequest =

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -2763,7 +2763,7 @@ export async function handleChainFees(
       // pre-check, and the var has read "retired" since #9193 -- so the whole
       // block, its rate-limiter call included, had stopped executing. Three
       // independent facts make it unrevivable rather than merely parked: the
-      // flag is not in postgres-tier.ts's DATA_API_D1_FLAGS, so a "d1" value
+      // flag is not in postgres-tier.ts's DATA_API_FORWARD_FLAGS, so a "d1" value
       // would not forward either; DATA_API serves no chain-fees route to
       // forward TO; and no deployed flag anywhere holds "postgres" now.
       // Deleting it is what the route already does at runtime.


### PR DESCRIPTION
Five comments in the serving-gate and cron paths state things that are measurably false about the store the code reads. Comments only, plus one module-private rename. No behaviour change.

## The header comment claimed the opposite of the truth, and cited the file that disproves it

`workers/postgres-tier.ts` said every `METAGRAPH_*_SOURCE` flag "has been hardcoded `postgres` in every wrangler config since, see wrangler.jsonc's own METAGRAPH_*_SOURCE vars". A reader who follows that pointer finds `retired` and `d1`.

Measured 2026-08-11 against the **deployed** Workers via the Cloudflare API, not just the configs:

| Worker | `*_SOURCE` values |
| --- | --- |
| `metagraphed` | `retired` x8, `d1` x5 |
| `metagraphed-data-api` | `d1` x3 |
| `metagraphed-registry-sync-api` | none |

Zero read `postgres`; no Worker carries a D1 binding. So `value === "postgres"` is unreachable in production — and it cannot simply be deleted, because **657 sites in `tests/` use `"postgres"` as the "forward this" value**. That correction matters for #10223's sequencing, where step 2 is described as dropping an unset disjunct.

## The other four

| where | said | actually |
| --- | --- | --- |
| `postgres-tier.ts`, forward set | "the D1 SQL lives there, not here" / "their D1 loaders live in THIS worker" | no D1 SQL in DATA_API, no D1 loaders here |
| `data-api.ts`, table-freshness cron | "D1 only." | Neon through Hyperdrive |
| `data-api.ts`, tao-usd tick | "now on the shared user-state D1" | `tao_usd_index` is in `NEON_SOLE_STORE_TABLES` |
| `data-api.ts`, Neon prune | "independent of D1's prune … two stores computing the same boundary" | one store |

## Why this is worth a PR rather than a cleanup someday

These cost time rather than merely reading oddly. Working #10635 I took "D1 only." as evidence the freshness watchdog was pointed at a dead store, and went looking for a deploy fault. The watchdog was healthy the entire time and the answer was sitting in the verdict it had been publishing every hour.

## Rename

`DATA_API_D1_FLAGS` → `DATA_API_FORWARD_FLAGS`: one definition, one use, seven comment references. The value it gates on names no store.

**Deliberately not touched**, both for reasons that outlast this PR:

- `tryPostgresTier` keeps its name. Renaming churns 407 call sites, and #10190's sweep is about to delete a large share of them — #10223 sequences the rename after the sweep for exactly that reason.
- The emitted `postgres-tier:<flag>` PostHog route tag is unchanged. It is a wire identifier; changing it would orphan the error-tracking history already keyed to it.

## Also

`scripts/validate-api.ts` repeated the same false claim. Corrected, and its comment now records what the harness actually proves: it drives all 8 flags with `"postgres"`, so it covers the AJV shapes but not the `"d1"`-plus-membership branch production runs. Filed as #10660 rather than fixed here.

## Verification

- `tsc --noEmit` clean
- `validate:api` green (exit 0 captured directly, not through a pipe)
- 246 tests pass across the five directly affected suites (`postgres-tier`, `health-status-live`, `data-api-health-status`, `health-prober`, `request-handlers-analytics`)
- `prettier --check` clean on every touched file
- Rebased onto `7cc984eff` and all four edits re-verified present afterwards

Closes #10661
