### PR TITLE
perf(neon): coalesce capture-lane verdicts instead of one row per write

### DIFF
--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -34,7 +34,12 @@
 // this records on every attempt: metagraphed#9698 reads it, so a Neon store
 // that stops accepting writes surfaces the same way any other lane does.
 
-import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import {
+  recordLaneVerdict,
+  type LaneHealthDb,
+  type LaneVerdict,
+} from "./lane-health.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 
 /**
  * Postgres' hard ceiling on bound parameters in one statement.
@@ -297,6 +302,83 @@ export async function pruneKeysInNeon(
 }
 
 /**
+ * How long an UNCHANGED `ok` verdict may be re-asserted without writing again.
+ *
+ * TEN MINUTES, against a bound of two hours. `lane_health`'s own freshness
+ * expectation is `2 * HOUR` (src/table-freshness-watchdog.ts, "every watchdog
+ * writes here; silence means they all stopped"), so a heartbeat at ten minutes
+ * sits twelve ticks inside the contract that already exists -- the window can
+ * be widened later without renegotiating anything, and a lane that genuinely
+ * dies still trips the same watchdog at the same threshold it always did.
+ */
+export const NEON_WRITE_VERDICT_COALESCE_MS = 10 * 60 * 1000;
+
+/**
+ * The last verdict actually WRITTEN per lane, per isolate.
+ *
+ * Per-isolate is the honest description and not a caveat to apologise for: a
+ * fresh isolate simply writes once more than it strictly had to, which is the
+ * safe direction. The map is bounded by the lane set (~50 compile-time
+ * constants, never user input), so it cannot grow without bound.
+ *
+ * It gates WRITES ONLY. Every read of lane health still goes to the database,
+ * so a stale or missing entry here can never produce a wrong verdict -- at
+ * worst it produces a redundant row.
+ */
+const lastWrittenVerdict = new Map<
+  string,
+  { verdict: LaneVerdict; checkedAt: number }
+>();
+
+/**
+ * Forget which verdicts have been written, so the next one is unconditional.
+ *
+ * Exported for tests, which drive many mirror runs through one isolate on a
+ * frozen clock — a shape production never has, and one where a coalesced write
+ * looks like a missing write. Registered centrally too, so the memo cannot leak
+ * ACROSS test files (see src/module-state-registry.ts).
+ */
+export function resetNeonWriteVerdictMemo(): void {
+  lastWrittenVerdict.clear();
+}
+
+registerModuleStateReset("src/neon-write.ts", resetNeonWriteVerdictMemo);
+
+/**
+ * Whether this verdict has to be written, or is a repeat inside the window.
+ *
+ * Pure and exported so the policy can be asserted directly rather than
+ * inferred from a mock's call count -- the same reason `pgValuesClause` above
+ * is exported.
+ *
+ * THREE THINGS ALWAYS WRITE, and the order matters less than the fact that
+ * none of them can be coalesced away:
+ *
+ *   1. A FAILURE. Never suppressed, however often it repeats. Failures are
+ *      rare, so they cost no volume, and their `detail` carries the reason
+ *      triage actually needs -- withholding it for up to ten minutes would
+ *      trade the only thing worth having for nothing.
+ *   2. A CHANGED VERDICT. `ok` -> `stale` is the transition every watchdog
+ *      exists to catch, and delaying it by even one tick would make this a
+ *      suppression rather than a coalescing.
+ *   3. A LANE THIS ISOLATE HAS NOT SEEN, or one whose clock moved backwards
+ *      (a replay, a fixed clock in a test, two isolates disagreeing). Unknown
+ *      state resolves to "write", never to "skip".
+ */
+export function shouldWriteNeonWriteVerdict(
+  previous: { verdict: LaneVerdict; checkedAt: number } | undefined,
+  verdict: LaneVerdict,
+  nowMs: number,
+  coalesceMs: number = NEON_WRITE_VERDICT_COALESCE_MS,
+): boolean {
+  if (verdict !== "ok") return true;
+  if (!previous) return true;
+  if (previous.verdict !== verdict) return true;
+  if (nowMs < previous.checkedAt) return true;
+  return nowMs - previous.checkedAt >= coalesceMs;
+}
+
+/**
  * Record one Neon write's outcome as a lane verdict.
  *
  * THIS IS THE INVARIANT THE PILOT WAS MISSING. A store with no lane is
@@ -307,6 +389,27 @@ export async function pruneKeysInNeon(
  * `age_ms` is deliberately null: this is a write outcome, and there is no
  * meaningful "how far behind" to report from inside a single write. Inventing
  * one would put a fabricated number in the column triage reads.
+ *
+ * ## Why this coalesces, and why that is not a weakened invariant
+ *
+ * The invariant above is "a Neon that stops accepting writes surfaces as a
+ * lane", and it is satisfied by the NEWEST row per lane -- which is the only
+ * row `loadLatestLaneHealth` ever reads (src/lane-health.ts: `WHERE (lane,
+ * checked_at) IN (SELECT lane, MAX(checked_at) ...)`). Every additional row
+ * written between two reads is written to be discarded.
+ *
+ * That cost was invisible while this was dual-write bookkeeping and became the
+ * dominant one once Neon was the sole store: measured 2026-08-11, `lane_health`
+ * took 8,953 writes in six hours, a maximum inter-write gap of 16.7s, and every
+ * one of them carried a second statement (the retention DELETE inside
+ * `recordLaneVerdict`). A gap that never reaches 60s is a compute that can
+ * never autosuspend, at ~2.8% utilisation -- see #10659.
+ *
+ * So the repetition goes and the signal stays: failures and transitions write
+ * immediately, and a steady `ok` heartbeats. `detail` is the one thing that
+ * lags -- a coalesced `ok` holds the previous row count for up to the window --
+ * and it lags deliberately, because it changes on EVERY write (row counts) and
+ * keying on it would coalesce exactly nothing.
  */
 export async function recordNeonWriteVerdict(
   db: LaneHealthDb | null | undefined,
@@ -314,15 +417,29 @@ export async function recordNeonWriteVerdict(
   result: NeonWriteResult,
   nowMs: number,
 ): Promise<boolean> {
-  return recordLaneVerdict(db, {
-    lane: `neon:${lane}`,
-    verdict: result.ok ? "ok" : "stale",
+  const key = `neon:${lane}`;
+  const verdict: LaneVerdict = result.ok ? "ok" : "stale";
+  if (!shouldWriteNeonWriteVerdict(lastWrittenVerdict.get(key), verdict, nowMs))
+    // TRUE, not false. `false` is this function's word for "the verdict is NOT
+    // on record", and a coalesced verdict IS on record -- an identical row
+    // inside the window says the same thing. No caller reads the return today
+    // (every call site awaits it bare), which is exactly why the value has to
+    // be right now: the first one that does will be reading it as health.
+    return true;
+  const written = await recordLaneVerdict(db, {
+    lane: key,
+    verdict,
     age_ms: null,
     detail: result.ok
       ? `${result.rows} row(s) in ${result.statements} statement(s)`
       : `${result.rows} row(s) written before failure: ${result.reason ?? "unknown"}`,
     checked_at: nowMs,
   });
+  // Only a row that LANDED may suppress the next one. Recording the attempt
+  // instead would let a database outage silence the lane for the whole window,
+  // which is precisely the lane going quiet when it matters most.
+  if (written) lastWrittenVerdict.set(key, { verdict, checkedAt: nowMs });
+  return written;
 }
 
 /**

--- a/tests/neon-write.test.ts
+++ b/tests/neon-write.test.ts
@@ -13,7 +13,7 @@
 //   * THE FLAG DEFAULTS OFF. A flag defaulting on would repeat the pilot's
 //     failure on the very deploy that introduced it.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import {
   buildPgUpsert,
   neonDualWriteEnabled,
@@ -22,8 +22,11 @@ import {
   PG_PARAM_LIMIT,
   pgFlatValues,
   pgValuesClause,
+  NEON_WRITE_VERDICT_COALESCE_MS,
   recordNeonWriteVerdict,
+  resetNeonWriteVerdictMemo,
   rowsPerPgStatement,
+  shouldWriteNeonWriteVerdict,
   writeRowsToNeon,
 } from "../src/neon-write.ts";
 
@@ -315,6 +318,10 @@ describe("writeRowsToNeon", () => {
 });
 
 describe("recordNeonWriteVerdict", () => {
+  // The coalescing memo is module-level and every test here shares one frozen
+  // clock, so without this a later test's unchanged `ok` reads as unwritten.
+  beforeEach(resetNeonWriteVerdictMemo);
+
   function spy() {
     const rows: Record<string, unknown>[] = [];
     return {
@@ -444,5 +451,222 @@ describe("neonDualWriteLanes", () => {
     assert.equal(neonDualWriteEnabled(env, "neurons"), true);
     assert.equal(neonDualWriteEnabled(env, "neuron_daily"), false);
     assert.equal(neonDualWriteEnabled({}, "neurons"), false);
+  });
+});
+
+describe("shouldWriteNeonWriteVerdict", () => {
+  // The POLICY, asserted directly rather than inferred from a mock's call
+  // count. What matters is not that writes get skipped -- it is exactly WHICH
+  // ones never can.
+  const PREV_OK = { verdict: "ok" as const, checkedAt: NOW };
+
+  test("a failure always writes, however often it repeats", () => {
+    // Failures are rare, so they cost no volume, and their detail carries the
+    // reason triage needs. Withholding it for the window would trade the only
+    // thing worth having for nothing.
+    assert.equal(
+      shouldWriteNeonWriteVerdict(
+        { verdict: "stale", checkedAt: NOW },
+        "stale",
+        NOW + 1,
+      ),
+      true,
+    );
+  });
+
+  test("a lane this isolate has not seen writes", () => {
+    assert.equal(shouldWriteNeonWriteVerdict(undefined, "ok", NOW), true);
+  });
+
+  test("a RECOVERY writes immediately, not on the next heartbeat", () => {
+    // stale -> ok is a transition, and a transition delayed is a transition
+    // suppressed.
+    assert.equal(
+      shouldWriteNeonWriteVerdict(
+        { verdict: "stale", checkedAt: NOW },
+        "ok",
+        NOW + 1,
+      ),
+      true,
+    );
+  });
+
+  test("a clock that moved backwards writes rather than guessing", () => {
+    // A replay, a fixed clock, or two isolates disagreeing. Unknown state
+    // resolves to "write", never to "skip".
+    assert.equal(shouldWriteNeonWriteVerdict(PREV_OK, "ok", NOW - 1), true);
+  });
+
+  test("an unchanged ok inside the window does NOT write", () => {
+    assert.equal(
+      shouldWriteNeonWriteVerdict(
+        PREV_OK,
+        "ok",
+        NOW + NEON_WRITE_VERDICT_COALESCE_MS - 1,
+      ),
+      false,
+    );
+  });
+
+  test("an unchanged ok AT the window writes -- the heartbeat", () => {
+    // Boundary is inclusive, so a lane cannot drift past its own freshness
+    // bound by repeatedly landing one millisecond short of it.
+    assert.equal(
+      shouldWriteNeonWriteVerdict(
+        PREV_OK,
+        "ok",
+        NOW + NEON_WRITE_VERDICT_COALESCE_MS,
+      ),
+      true,
+    );
+  });
+
+  test("the window is twelve heartbeats inside lane_health's own bound", () => {
+    // src/table-freshness-watchdog.ts holds lane_health to 2 * HOUR. If this
+    // ever exceeds that, a healthy lane starts tripping its own watchdog.
+    assert.ok(NEON_WRITE_VERDICT_COALESCE_MS * 12 <= 2 * 60 * 60 * 1000);
+  });
+});
+
+describe("verdict coalescing, end to end", () => {
+  beforeEach(resetNeonWriteVerdictMemo);
+
+  function countingDb() {
+    const inserts: Record<string, unknown>[] = [];
+    return {
+      inserts,
+      db: {
+        prepare(sql: string) {
+          return {
+            bind(...values: unknown[]) {
+              return {
+                async run() {
+                  if (sql.startsWith("INSERT"))
+                    inserts.push({ lane: values[0], verdict: values[1] });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("a repeated ok costs ONE row, not one per write", async () => {
+    const s = countingDb();
+    for (let i = 0; i < 50; i += 1) {
+      await recordNeonWriteVerdict(
+        s.db,
+        "blocks-head",
+        { ok: true, rows: 1, statements: 1 },
+        NOW + i * 1000,
+      );
+    }
+    assert.equal(s.inserts.length, 1);
+  });
+
+  test("and reports true while coalescing -- the verdict IS on record", async () => {
+    // `false` means "not on record". Every call site awaits this bare today,
+    // so nothing would catch a wrong value until the first caller reads it as
+    // health -- which is why it has to be right before one does.
+    const s = countingDb();
+    const first = await recordNeonWriteVerdict(
+      s.db,
+      "blocks-head",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+    );
+    const second = await recordNeonWriteVerdict(
+      s.db,
+      "blocks-head",
+      { ok: true, rows: 1, statements: 1 },
+      NOW + 1000,
+    );
+    assert.equal(first, true);
+    assert.equal(second, true);
+    assert.equal(s.inserts.length, 1);
+  });
+
+  test("a failure lands even between two coalesced oks", async () => {
+    const s = countingDb();
+    await recordNeonWriteVerdict(
+      s.db,
+      "chain-detail",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+    );
+    await recordNeonWriteVerdict(
+      s.db,
+      "chain-detail",
+      { ok: false, rows: 0, statements: 0, reason: "deadlock" },
+      NOW + 1000,
+    );
+    await recordNeonWriteVerdict(
+      s.db,
+      "chain-detail",
+      { ok: true, rows: 1, statements: 1 },
+      NOW + 2000,
+    );
+    assert.deepEqual(
+      s.inserts.map((r) => r.verdict),
+      ["ok", "stale", "ok"],
+    );
+  });
+
+  test("a write that did NOT land cannot suppress the next one", async () => {
+    // Recording the attempt rather than the landing would let a database
+    // outage silence the lane for the whole window -- the lane going quiet at
+    // precisely the moment it matters most.
+    const s = countingDb();
+    assert.equal(
+      await recordNeonWriteVerdict(
+        null,
+        "blocks-head",
+        { ok: true, rows: 1, statements: 1 },
+        NOW,
+      ),
+      false,
+    );
+    await recordNeonWriteVerdict(
+      s.db,
+      "blocks-head",
+      { ok: true, rows: 1, statements: 1 },
+      NOW + 1000,
+    );
+    assert.equal(s.inserts.length, 1);
+  });
+
+  test("lanes coalesce independently of one another", async () => {
+    const s = countingDb();
+    for (const lane of ["blocks-head", "chain-detail", "account-balances"]) {
+      await recordNeonWriteVerdict(
+        s.db,
+        lane,
+        { ok: true, rows: 1, statements: 1 },
+        NOW,
+      );
+    }
+    assert.deepEqual(
+      s.inserts.map((r) => r.lane),
+      ["neon:blocks-head", "neon:chain-detail", "neon:account-balances"],
+    );
+  });
+
+  test("the memo reset makes the next verdict unconditional", async () => {
+    const s = countingDb();
+    await recordNeonWriteVerdict(
+      s.db,
+      "blocks-head",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+    );
+    resetNeonWriteVerdictMemo();
+    await recordNeonWriteVerdict(
+      s.db,
+      "blocks-head",
+      { ok: true, rows: 1, statements: 1 },
+      NOW + 1000,
+    );
+    assert.equal(s.inserts.length, 2);
   });
 });

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -30,6 +30,7 @@ import {
   NEURONS_NEON_LANE,
   pruneNeuronsToCapture,
 } from "../src/neurons-neon-write.ts";
+import { resetNeonWriteVerdictMemo } from "../src/neon-write.ts";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
 const NOW = 1_785_800_000_000;
@@ -87,6 +88,10 @@ beforeEach(() => {
   pg.control.onQuery = null;
   pg.control.failNext = null;
   pg.control.rows = null;
+  // Every test here drives a mirror run on the SAME frozen millisecond, which
+  // an isolate never sees in production. Without this, the second run's
+  // unchanged `ok` coalesces and reads as a verdict that was never written.
+  resetNeonWriteVerdictMemo();
 });
 
 describe("NEURON_MIRROR_PLANS", () => {


### PR DESCRIPTION
## Summary

`recordNeonWriteVerdict` fired on **every Neon write attempt**, and each call cost two statements —
the `INSERT` plus the retention `DELETE` inside `recordLaneVerdict`. Measured against production
2026-08-11, over six hours:

```
lane_health: 8,953 writes | avg gap 2.4s | MAX gap 16.7s
gaps over 60s: 0    gaps over 300s: 0
```

Only the newest row per lane is ever read — `loadLatestLaneHealth` selects
`WHERE (lane, checked_at) IN (SELECT lane, MAX(checked_at) FROM lane_health GROUP BY lane)`
(`src/lane-health.ts`). Every row written between two reads was written to be discarded, and the
retention `DELETE` matched zero rows nearly every time (retention is 90 days).

The per-write cadence is **dual-write residue**. `src/neon-write.ts`'s own header justified it by the
D1 mirror — *"a Neon failure must cost a mirror and a lane verdict -- not the pass"*. D1 is
decommissioned and Neon is the sole store, so a failed write now fails the actual write; there is no
mirror left to silently fall behind.

## What is NOT coalesced

The invariant is "a Neon that stops accepting writes surfaces as a lane", and it is satisfied by the
newest row. So the repetition goes and the signal stays — three things always write:

- **A failure**, however often it repeats. Failures are rare, so they cost no volume, and their
  `detail` carries the reason triage needs.
- **A changed verdict.** `ok`→`stale` is what the watchdogs exist to catch; delaying it by one tick
  would make this a suppression rather than a coalescing.
- **An unseen lane, or a clock that moved backwards.** Unknown state resolves to "write", never "skip".

A write that did **not** land cannot suppress the next one, so a database outage can never silence a
lane for the window.

The heartbeat is 10 minutes against `lane_health`'s own `2 * HOUR` freshness bound
(`src/table-freshness-watchdog.ts`, *"every watchdog writes here; silence means they all stopped"*) —
twelve ticks inside a contract that already exists, and asserted as a test so widening the window
cannot silently outrun the watchdog.

`detail` is the one thing that lags: a coalesced `ok` holds the previous row count for up to the
window. That is deliberate — it changes on every write (row counts), so keying on it would coalesce
nothing.

## Module state

The memo is module-level and per-isolate, so it registers with `src/module-state-registry.ts` and
exports a named reset (the same shape as `src/decode-watermark.ts`). `validate:module-state-resets`
fails without this, and `tests/module-state-registry.test.ts` covers it.

## Validation

```
npm run typecheck                    # clean
npm run lint                         # clean
npm run validate                     # exit 0
node scripts/validate-module-state-resets.ts   # passed
npx vitest run <7 neon-write suites + 8 lane-health/module-state suites>   # 217 passed
```

Patch coverage: the only uncovered lines in `src/neon-write.ts` are 547–552 (`assertIdentifier`,
pre-existing and covered by suites outside this set). Every changed line — ranges 37–42, 304–380,
392–412, 420–431, 438–442 — is covered, including all six branches of
`shouldWriteNeonWriteVerdict`.

## Follow-up

This removes the highest-frequency writer and shrinks what #10659 has to carry, but on its own it does
**not** let the compute autosuspend — the capture lanes still write well inside the 60s floor. #10659
is the change that closes that.

Closes #10658
