### PR TITLE
feat(ui): revenue against emissions, where a null is never a zero (#10477)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-revenue-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-revenue-panel.tsx
@@ -1,0 +1,148 @@
+import { useQuery } from "@tanstack/react-query";
+import { subnetRevenueQuery } from "@/lib/metagraphed/queries";
+import { StatTile, Chip } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, ErrorState } from "@/components/metagraphed/states";
+import { formatTao } from "@/lib/metagraphed/format";
+import {
+  coverageLabel,
+  coverageNote,
+  finite,
+  isHeadlineEligible,
+  subsidyLabel,
+  tierLabel,
+  usdLabel,
+} from "@/lib/metagraphed/revenue-panel-model";
+import { Link } from "@tanstack/react-router";
+
+/**
+ * #10477: what this subnet earns from outside Bittensor, against what the
+ * network emits to it.
+ *
+ * THE ONE WAY THIS PANEL DOES HARM is rendering an unmeasured subnet as a
+ * measured zero. 127 of 129 subnets have no observable external revenue, and
+ * "0% covered" is a false claim about every one of them -- at a scale that
+ * makes it defamatory rather than merely wrong. So `null` renders as "not
+ * observed" everywhere, in prose that says what was and was not looked at, and
+ * an observed 0 (a real reading of zero) renders as a real 0.
+ *
+ * The provenance tier sits NEXT TO the number, never in a tooltip: a ratio is
+ * only as good as the rung it was read from, and hiding the rung behind a hover
+ * makes the number look better than it is on a screenshot.
+ */
+
+/**
+ * The provenance chip.
+ *
+ * Local rather than ui-kit's `ProvenanceChip`, which takes a `level` from the
+ * registry's review vocabulary -- a different ladder with different rungs. The
+ * masthead already keeps its own `ReviewProvenanceChip` for the same reason.
+ *
+ * Neutral tone on purpose, including for the tiers that cannot reach the
+ * headline. A subnet that publishes an operator-attested figure has done more
+ * than one that publishes nothing, and colouring the lower rungs as a warning
+ * would punish disclosure -- the perverse incentive this whole feature has to
+ * avoid.
+ */
+function RevenueProvenanceChip({ provenance }: { provenance: unknown }) {
+  const eligible = isHeadlineEligible(provenance);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <Chip tone={eligible ? "accent" : "muted"}>{tierLabel(provenance)}</Chip>
+      {eligible ? null : (
+        <span className="mg-type-caption text-ink-muted">not headline-eligible</span>
+      )}
+    </span>
+  );
+}
+
+export function SubnetRevenuePanel({ netuid }: { netuid: number }) {
+  const q = useQuery(subnetRevenueQuery(netuid));
+
+  if (q.isError) {
+    return (
+      <ErrorState error={q.error} onRetry={() => q.refetch()} context="subnet revenue coverage" />
+    );
+  }
+  if (q.isLoading) return <Skeleton className="h-56 w-full" />;
+
+  const data = q.data?.data ?? {};
+  const revenue = (data.revenue ?? {}) as Record<string, unknown>;
+  const emission = (revenue.emission ?? {}) as Record<string, unknown>;
+  const sources = Array.isArray(revenue.sources) ? revenue.sources : [];
+  const observedUsd = finite(revenue.revenue_usd);
+  const coverage = finite(revenue.coverage_ratio);
+  const windowDays = finite(data.window_days);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <StatTile
+          eyebrow="Emission received"
+          value={formatTao(finite(emission.tao))}
+          hint={usdLabel(emission.usd) ?? "TAO/USD not read for this window"}
+        />
+        <StatTile
+          eyebrow="External revenue"
+          value={usdLabel(observedUsd) ?? "Not observed"}
+          hint={observedUsd == null ? "No readable public figure" : `over ${windowDays ?? 1}d`}
+        />
+        <StatTile eyebrow="Coverage" value={coverageLabel(coverage)} />
+        <StatTile
+          eyebrow="Subsidy multiple"
+          value={subsidyLabel(revenue.subsidy_multiple)}
+          hint="Emission per dollar earned"
+        />
+      </div>
+
+      <Panel as="div" dense>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <span className="mg-type-caption text-ink-muted">Provenance</span>
+            <RevenueProvenanceChip provenance={revenue.provenance} />
+          </div>
+          <Link
+            to="/docs/$"
+            params={{ _splat: "revenue-coverage" }}
+            className="mg-type-caption text-accent hover:underline"
+          >
+            How this is derived
+          </Link>
+        </div>
+      </Panel>
+
+      {/* The sentence that keeps a null from being read as a zero. It is prose
+          rather than a tooltip because it is the most important thing on the
+          panel for 127 of 129 subnets. */}
+      <Panel as="div" dense bodyClassName="mg-type-caption text-ink-muted">
+        {coverageNote(observedUsd)}
+      </Panel>
+
+      {sources.length > 0 ? (
+        <div className="space-y-2">
+          <div className="mg-type-caption text-ink-muted">
+            Declared revenue sources ({sources.length})
+          </div>
+          <ul className="space-y-1">
+            {sources.map((raw, i) => {
+              const source = (raw ?? {}) as Record<string, unknown>;
+              const id = String(source.id ?? source.surface_id ?? `source-${i}`);
+              return (
+                <li
+                  key={id}
+                  className="flex flex-wrap items-center gap-2 rounded-xl border border-border/80 px-3 py-2"
+                >
+                  <span className="font-mono mg-type-caption text-ink-strong">{id}</span>
+                  <RevenueProvenanceChip provenance={source.provenance} />
+                  {source.grain ? (
+                    <span className="mg-type-caption text-ink-muted">{String(source.grain)}</span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/revenue-panel-model.test.ts
+++ b/apps/ui/src/lib/metagraphed/revenue-panel-model.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  coverageLabel,
+  coverageNote,
+  isHeadlineEligible,
+  subsidyLabel,
+  tierLabel,
+  usdLabel,
+} from "./revenue-panel-model";
+
+// #10477: the single most likely way this feature does harm is rendering an
+// unmeasured subnet as a measured zero. These tests exist for that one rule.
+
+describe("a null ratio is never a zero", () => {
+  it('renders null coverage as "Not observed", not 0%', () => {
+    expect(coverageLabel(null)).toBe("Not observed");
+    expect(coverageLabel(undefined)).toBe("Not observed");
+    expect(coverageLabel(Number.NaN)).toBe("Not observed");
+    expect(coverageLabel("0")).toBe("Not observed");
+  });
+
+  it("keeps an OBSERVED zero as a real 0%", () => {
+    // A subnet measured at zero and a subnet nobody could measure are different
+    // facts. Collapsing them is the whole defect.
+    expect(coverageLabel(0)).toBe("0.0%");
+  });
+
+  it("applies the same rule to the subsidy multiple", () => {
+    expect(subsidyLabel(null)).toBe("Not observed");
+    expect(subsidyLabel(0)).toBe("0.0×");
+    expect(subsidyLabel(8.2)).toBe("8.2×");
+  });
+
+  it("says 'no observable external revenue', never 'no revenue'", () => {
+    const note = coverageNote(null);
+    expect(note).toContain("No observable external revenue");
+    expect(note).toContain("has not been judged");
+    expect(note).not.toMatch(/\bearns nothing\b|\bno revenue\b/);
+  });
+
+  it("switches to the reading caveats once something IS observed", () => {
+    const note = coverageNote(1234);
+    expect(note).toContain("not an accusation");
+    expect(note).not.toContain("No observable external revenue");
+  });
+});
+
+describe("the provenance tier", () => {
+  it("marks only chain-verified and probe-derived as headline-eligible", () => {
+    expect(isHeadlineEligible("chain-verified")).toBe(true);
+    expect(isHeadlineEligible("probe-derived")).toBe(true);
+    for (const tier of [
+      "operator-attested",
+      "third-party-reported",
+      "self-reported",
+      "inferred",
+      null,
+      "",
+    ]) {
+      expect(isHeadlineEligible(tier)).toBe(false);
+    }
+  });
+
+  it("labels an unknown tier by its own name rather than inventing one", () => {
+    expect(tierLabel("probe-derived")).toBe("Probe-derived");
+    expect(tierLabel("something-new")).toBe("something-new");
+    expect(tierLabel(null)).toBe("Unrecorded");
+    expect(tierLabel(42)).toBe("Unrecorded");
+  });
+});
+
+describe("dollar figures", () => {
+  it("formats an amount that is ALREADY dollars", () => {
+    expect(usdLabel(1234.5)).toBe("$1.2k");
+    expect(usdLabel(2_500_000)).toBe("$2.50M");
+    expect(usdLabel(12.345)).toBe("$12.35");
+  });
+
+  it("returns null rather than $0 for an unread figure", () => {
+    expect(usdLabel(null)).toBeNull();
+    expect(usdLabel("1234")).toBeNull();
+    expect(usdLabel(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/revenue-panel-model.ts
+++ b/apps/ui/src/lib/metagraphed/revenue-panel-model.ts
@@ -1,0 +1,75 @@
+/**
+ * #10477: the revenue panel's display decisions, extracted so the one that
+ * matters can be tested without rendering.
+ *
+ * THE DECISION: a null ratio renders as "Not observed", never as 0%. 127 of 129
+ * subnets have no observable external revenue, and "0% covered" is a false claim
+ * about every one of them — at a scale that makes it defamatory rather than
+ * merely wrong. An OBSERVED zero is a different value and survives as a real 0%.
+ *
+ * Same shape as stake-moves-tile.ts: a pure model beside the panel that renders
+ * it, so the rule is checkable rather than asserted in a comment.
+ */
+
+/** Only these two rungs reach the headline ratio. */
+export const HEADLINE_TIERS = new Set(["chain-verified", "probe-derived"]);
+
+const TIER_LABEL: Record<string, string> = {
+  "chain-verified": "Chain-verified",
+  "probe-derived": "Probe-derived",
+  "operator-attested": "Operator-attested",
+  "third-party-reported": "Third-party reported",
+  "self-reported": "Self-reported",
+  inferred: "Inferred",
+};
+
+export function tierLabel(provenance: unknown): string {
+  const key = typeof provenance === "string" ? provenance : "";
+  return TIER_LABEL[key] ?? (key || "Unrecorded");
+}
+
+export function isHeadlineEligible(provenance: unknown): boolean {
+  return HEADLINE_TIERS.has(String(provenance ?? ""));
+}
+
+export function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** A figure ALREADY in dollars. `formatUsdApprox` converts TAO at a price,
+ * which is a different job — handing it dollars would price the currency
+ * against itself. */
+export function usdLabel(value: unknown): string | null {
+  const n = finite(value);
+  if (n == null) return null;
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (abs >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
+  return `$${n.toFixed(2)}`;
+}
+
+/** A ratio as a percentage, or the honest absence. NEVER "0%" for a null. */
+export function coverageLabel(value: unknown): string {
+  const n = finite(value);
+  return n == null ? "Not observed" : `${(n * 100).toFixed(1)}%`;
+}
+
+export function subsidyLabel(value: unknown): string {
+  const n = finite(value);
+  return n == null ? "Not observed" : `${n.toFixed(1)}×`;
+}
+
+/**
+ * The sentence under the tiles.
+ *
+ * Prose rather than a tooltip, because for 127 of 129 subnets it is the most
+ * important thing on the panel — and a tooltip does not survive a screenshot.
+ */
+export function coverageNote(observedUsd: unknown): string {
+  return finite(observedUsd) == null
+    ? "No observable external revenue. This subnet has not been measured — it has not been judged. " +
+        "A subnet that publishes no figure gets no ratio, which is not the same as earning nothing, " +
+        "and a subnet that publishes one will usually look worse than one that hides it."
+    : "Only chain-verified and probe-derived readings reach this ratio. The numerator is external revenue, " +
+        "not profit; the denominator is emission received, not cost. A high subsidy multiple is not an accusation.";
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -60,6 +60,7 @@ import { SearchInput } from "@/components/metagraphed/table-controls";
 import { ReliabilityPanel } from "@/components/metagraphed/reliability-panel";
 import { EconomicsPanel } from "@/components/metagraphed/economics-panel";
 import { SubnetEmissionPanel } from "@/components/metagraphed/subnet-emission-panel";
+import { SubnetRevenuePanel } from "@/components/metagraphed/subnet-revenue-panel";
 import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-chart";
 import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
@@ -642,6 +643,17 @@ function EconomicsTabPanel({ netuid }: { netuid: number }) {
         info="Live chain economics from the Bittensor metagraph — emission share, alpha price, stake, validator/miner counts, and subnet volume."
       >
         <EconomicsPanel netuid={netuid} />
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="revenue-coverage"
+        title="Revenue vs emissions"
+        subtitle="What this subnet earns from outside Bittensor, against the TAO the network emits to it."
+        info="GET /api/v1/subnets/{netuid}/revenue — external revenue over emission received. Only chain-verified and probe-derived readings reach the ratio; a subnet with no readable public figure shows 'not observed', which is not the same as zero. 127 of 129 subnets are in that state."
+      >
+        <QueryErrorBoundary>
+          <SubnetRevenuePanel netuid={netuid} />
+        </QueryErrorBoundary>
       </SectionAnchor>
 
       <SectionAnchor


### PR DESCRIPTION
## Summary

A **Revenue vs emissions** section on the subnet page's economics tab: emission received (TAO + USD), external revenue, coverage ratio, subsidy multiple, and the provenance tier beside the number.

## The one rule this panel exists to hold

**`null` renders as "Not observed", never as 0%.** 127 of 129 subnets have no observable external revenue. Rendering them as "0% covered" is a false claim about each — at a scale that makes it defamatory rather than merely wrong.

An **observed** zero is a different value and survives as a real `0.0%`. That distinction is a test, not a comment:

```js
expect(coverageLabel(null)).toBe("Not observed");
expect(coverageLabel(0)).toBe("0.0%");
```

The display rules live in `apps/ui/src/lib/metagraphed/revenue-panel-model.ts`, a pure model beside the panel — the same shape as `stake-moves-tile.ts` — so the rule is checkable without rendering. 9 tests.

## The other non-negotiables from the issue

**Provenance sits next to the number, not in a tooltip.** A ratio is only as good as the rung it was read from, and a hover does not survive a screenshot.

**"No observable external revenue", never "no revenue".** The prose under the tiles says the subnet *has not been measured — it has not been judged*, and that a subnet publishing a figure will usually look worse than one that hides it. Asserted by test, including that it never says "no revenue" or "earns nothing".

**The tier chip is neutral for non-headline rungs.** A subnet publishing an operator-attested figure has done more than one publishing nothing; colouring the lower rungs as a warning would punish disclosure.

## Notes

The chip is local rather than ui-kit's `ProvenanceChip`, which takes a `level` from the registry's *review* vocabulary — a different ladder. The masthead already keeps its own `ReviewProvenanceChip` for the same reason.

`formatUsdApprox` converts TAO→USD at a price; these figures are already dollars, so the model has its own `usdLabel` rather than pricing the currency against itself.

## Screenshots

Maintainer PR. The section renders under `#revenue-coverage` on `/subnets/{netuid}`; against production data today it shows "Not observed" for every subnet except SN64 and SN51, which is the state the panel is designed around.

## Validation

```
apps/ui: npm run typecheck    clean
apps/ui: npm run lint         0 errors
apps/ui: npx vitest run       1988 passed
apps/ui: prettier --check .   clean
root:    format:check         clean
```

apps/ui-only change — no root schema, route, or contract surface touched.

Closes #10477
