### PR TITLE
ci(api): make the postgres-tier gate test the branch production runs

### DIFF
--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -3091,7 +3091,7 @@ for (const [route, assertion, options = {}] of checks) {
   assert.equal(
     postgresTierChecks.length,
     8,
-    "postgres-tier AJV coverage must include all 8 production SOURCE flags",
+    "postgres-tier AJV coverage must include all 8 flags that gate a DATA_API leg",
   );
 
   for (const {
@@ -3133,8 +3133,106 @@ for (const [route, assertion, options = {}] of checks) {
     assertion(body);
   }
 
+  // THE BRANCH PRODUCTION ACTUALLY RUNS (#10660). Every case above drives the
+  // gate with "postgres", and no deployment sets that: measured 2026-08-11
+  // against the deployed Workers, `metagraphed` reads "retired" x8 + "d1" x5,
+  // `metagraphed-data-api` reads "d1" x3, and nothing reads "postgres". So the
+  // forwarding proven above is proven through the one disjunct production
+  // cannot take, while the live one -- `"d1"` AND membership in
+  // postgres-tier.ts's DATA_API_FORWARD_FLAGS -- had no coverage at all.
+  //
+  // Both directions matter, and the negative is the load-bearing one:
+  //
+  //   forwards     the three flags in the set must forward on "d1", or three
+  //                live routes silently start serving the empty fallback.
+  //   does NOT     a flag outside the set must not forward on "d1". That is
+  //                the condition src/health-status-live.ts argues at length
+  //                and nothing pinned. Widening the set (or fat-fingering a
+  //                flag name into it) would make those routes forward, take a
+  //                non-2xx, and fire capturePostgresTierFallback on every
+  //                request -- with this gate still green.
+  //
+  // Mirrored rather than imported because the real set is module-private to
+  // workers/postgres-tier.ts. The membership assertion below is what keeps the
+  // mirror honest: add a flag there without adding a case here and it fails.
+  const d1ForwardFlags = new Set<string>([
+    "METAGRAPH_NEURONS_SOURCE",
+    "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
+    "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
+  ]);
+  assert.equal(
+    postgresTierChecks.filter((check) => d1ForwardFlags.has(check.flag)).length,
+    d1ForwardFlags.size,
+    'every DATA_API_FORWARD_FLAGS flag needs a case here to drive at "d1"',
+  );
+
+  for (const {
+    flag,
+    route,
+    upstreamPath,
+    data,
+    assertion,
+  } of postgresTierChecks) {
+    const shouldForward = d1ForwardFlags.has(flag);
+    let capturedPath: string | null = null;
+    const d1Env = createLocalArtifactEnv({
+      [flag]: "d1",
+      DATA_API: {
+        async fetch(request: Request) {
+          const url = new URL(request.url);
+          capturedPath = `${url.pathname}${url.search}`;
+          return new Response(JSON.stringify(data), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    });
+    const response = await handleRequest(
+      new Request(`https://metagraph.sh${route}`),
+      d1Env as unknown as Env,
+      {},
+    );
+    if (!shouldForward) {
+      // Only that DATA_API was never asked. The status is deliberately not
+      // asserted: what this route answers with no tier is the cold-artifact
+      // path's business, and pinning it here would couple this check to it.
+      assert.equal(
+        capturedPath,
+        null,
+        `${flag} at "d1": must NOT forward (absent from DATA_API_FORWARD_FLAGS)`,
+      );
+      continue;
+    }
+    assert.equal(
+      response.status,
+      200,
+      `${flag} ${route} at "d1": expected 200`,
+    );
+    assert.equal(
+      capturedPath,
+      upstreamPath,
+      `${flag} at "d1": DATA_API must receive the forwarded path`,
+    );
+    const body = (await response.json()) as Row;
+    assert.equal(
+      body.ok,
+      true,
+      `${flag} ${route} at "d1": expected ok envelope`,
+    );
+    assert.equal(
+      body.schema_version,
+      1,
+      `${flag} ${route} at "d1": schema_version`,
+    );
+    validateWorkerResponse(route, body);
+    assertion(body);
+  }
+
   console.log(
-    `Validated ${postgresTierChecks.length} Postgres-tier Worker API route(s).`,
+    `Validated ${postgresTierChecks.length} Postgres-tier Worker API route(s) ` +
+      `at "postgres", plus ${d1ForwardFlags.size} forwarding and ` +
+      `${postgresTierChecks.length - d1ForwardFlags.size} non-forwarding at "d1".`,
   );
 }
 


### PR DESCRIPTION
The gate drove all eight `METAGRAPH_*_SOURCE` flags with `"postgres"` and asserted it covered "all 8 production SOURCE flags". **No deployment sets `"postgres"`.**

Measured against the deployed Workers via the Cloudflare API, not the configs:

| Worker | `*_SOURCE` values |
| --- | --- |
| `metagraphed` | `retired` x8, `d1` x5 |
| `metagraphed-data-api` | `d1` x3 |
| `metagraphed-registry-sync-api` | none |

`tryPostgresTier` forwards on either of two disjuncts:

```ts
const forwards =
  value === "postgres" ||
  (value === "d1" && DATA_API_FORWARD_FLAGS.has(flagName as string));
```

The gate exercised only the first. In production only the second can fire, and it carries an extra condition — set membership — that the first does not. The AJV response shapes were genuinely proven; the forwarding **decision** was not.

## What this adds

A second pass over the same eight cases at `"d1"`, split by membership:

- **3 forwarding** — the flags in the set must forward, or three live routes silently start serving the empty fallback.
- **5 non-forwarding** — a flag outside the set must NOT forward. This is the condition `src/health-status-live.ts` argues at length: widening the set makes those routes forward, take a non-2xx, and fire `capturePostgresTierFallback` **on every request**. Nothing pinned it.

The non-forwarding cases assert only that DATA_API was never asked, deliberately not the status — what a route answers with no tier belongs to the cold-artifact path, and pinning it here would couple this check to it.

The mirror set is kept honest by an assertion rather than a comment: add a flag to `postgres-tier.ts` without adding a case here and the gate fails. Mirrored because the real set is module-private.

## Proven to fail, against the real set rather than the mirror

A gate that cannot fail is not a gate, so both directions were broken deliberately:

```
dropped METAGRAPH_NEURONS_SOURCE from DATA_API_FORWARD_FLAGS
  → AssertionError: METAGRAPH_NEURONS_SOURCE at "d1": DATA_API must receive the forwarded path

added METAGRAPH_BLOCKS_SOURCE to DATA_API_FORWARD_FLAGS
  → AssertionError: METAGRAPH_BLOCKS_SOURCE at "d1": must NOT forward (absent from DATA_API_FORWARD_FLAGS)
```

`git diff --stat workers/postgres-tier.ts` was empty afterwards — the file is byte-identical to HEAD.

## Also

The count assertion's message said "all 8 production SOURCE flags". Five of those read `"retired"` in production and cannot forward at all, so that overstated the coverage; reworded to "all 8 flags that gate a DATA_API leg".

## Verification

- `tsc --noEmit` clean
- `validate:api` green: `Validated 8 Postgres-tier Worker API route(s) at "postgres", plus 3 forwarding and 5 non-forwarding at "d1".`
- 13 `tests/postgres-tier.test.ts` tests pass
- `prettier --check` clean
- `scripts/` is outside `src/**`/`workers/**`, so no patch-coverage surface

Closes #10660
