### PR TITLE
feat(ui): the coverage leaderboard, where the unmeasured are never ranked (#10478)

### DIFF
--- a/apps/ui/src/components/metagraphed/subnet-revenue-panel.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-revenue-panel.tsx
@@ -1,0 +1,148 @@
+import { useQuery } from "@tanstack/react-query";
+import { subnetRevenueQuery } from "@/lib/metagraphed/queries";
+import { StatTile, Chip } from "@jsonbored/ui-kit";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, ErrorState } from "@/components/metagraphed/states";
+import { formatTao } from "@/lib/metagraphed/format";
+import {
+  coverageLabel,
+  coverageNote,
+  finite,
+  isHeadlineEligible,
+  subsidyLabel,
+  tierLabel,
+  usdLabel,
+} from "@/lib/metagraphed/revenue-panel-model";
+import { Link } from "@tanstack/react-router";
+
+/**
+ * #10477: what this subnet earns from outside Bittensor, against what the
+ * network emits to it.
+ *
+ * THE ONE WAY THIS PANEL DOES HARM is rendering an unmeasured subnet as a
+ * measured zero. 127 of 129 subnets have no observable external revenue, and
+ * "0% covered" is a false claim about every one of them -- at a scale that
+ * makes it defamatory rather than merely wrong. So `null` renders as "not
+ * observed" everywhere, in prose that says what was and was not looked at, and
+ * an observed 0 (a real reading of zero) renders as a real 0.
+ *
+ * The provenance tier sits NEXT TO the number, never in a tooltip: a ratio is
+ * only as good as the rung it was read from, and hiding the rung behind a hover
+ * makes the number look better than it is on a screenshot.
+ */
+
+/**
+ * The provenance chip.
+ *
+ * Local rather than ui-kit's `ProvenanceChip`, which takes a `level` from the
+ * registry's review vocabulary -- a different ladder with different rungs. The
+ * masthead already keeps its own `ReviewProvenanceChip` for the same reason.
+ *
+ * Neutral tone on purpose, including for the tiers that cannot reach the
+ * headline. A subnet that publishes an operator-attested figure has done more
+ * than one that publishes nothing, and colouring the lower rungs as a warning
+ * would punish disclosure -- the perverse incentive this whole feature has to
+ * avoid.
+ */
+function RevenueProvenanceChip({ provenance }: { provenance: unknown }) {
+  const eligible = isHeadlineEligible(provenance);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <Chip tone={eligible ? "accent" : "muted"}>{tierLabel(provenance)}</Chip>
+      {eligible ? null : (
+        <span className="mg-type-caption text-ink-muted">not headline-eligible</span>
+      )}
+    </span>
+  );
+}
+
+export function SubnetRevenuePanel({ netuid }: { netuid: number }) {
+  const q = useQuery(subnetRevenueQuery(netuid));
+
+  if (q.isError) {
+    return (
+      <ErrorState error={q.error} onRetry={() => q.refetch()} context="subnet revenue coverage" />
+    );
+  }
+  if (q.isLoading) return <Skeleton className="h-56 w-full" />;
+
+  const data = q.data?.data ?? {};
+  const revenue = (data.revenue ?? {}) as Record<string, unknown>;
+  const emission = (revenue.emission ?? {}) as Record<string, unknown>;
+  const sources = Array.isArray(revenue.sources) ? revenue.sources : [];
+  const observedUsd = finite(revenue.revenue_usd);
+  const coverage = finite(revenue.coverage_ratio);
+  const windowDays = finite(data.window_days);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <StatTile
+          eyebrow="Emission received"
+          value={formatTao(finite(emission.tao))}
+          hint={usdLabel(emission.usd) ?? "TAO/USD not read for this window"}
+        />
+        <StatTile
+          eyebrow="External revenue"
+          value={usdLabel(observedUsd) ?? "Not observed"}
+          hint={observedUsd == null ? "No readable public figure" : `over ${windowDays ?? 1}d`}
+        />
+        <StatTile eyebrow="Coverage" value={coverageLabel(coverage)} />
+        <StatTile
+          eyebrow="Subsidy multiple"
+          value={subsidyLabel(revenue.subsidy_multiple)}
+          hint="Emission per dollar earned"
+        />
+      </div>
+
+      <Panel as="div" dense>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <span className="mg-type-caption text-ink-muted">Provenance</span>
+            <RevenueProvenanceChip provenance={revenue.provenance} />
+          </div>
+          <Link
+            to="/docs/$"
+            params={{ _splat: "revenue-coverage" }}
+            className="mg-type-caption text-accent hover:underline"
+          >
+            How this is derived
+          </Link>
+        </div>
+      </Panel>
+
+      {/* The sentence that keeps a null from being read as a zero. It is prose
+          rather than a tooltip because it is the most important thing on the
+          panel for 127 of 129 subnets. */}
+      <Panel as="div" dense bodyClassName="mg-type-caption text-ink-muted">
+        {coverageNote(observedUsd)}
+      </Panel>
+
+      {sources.length > 0 ? (
+        <div className="space-y-2">
+          <div className="mg-type-caption text-ink-muted">
+            Declared revenue sources ({sources.length})
+          </div>
+          <ul className="space-y-1">
+            {sources.map((raw, i) => {
+              const source = (raw ?? {}) as Record<string, unknown>;
+              const id = String(source.id ?? source.surface_id ?? `source-${i}`);
+              return (
+                <li
+                  key={id}
+                  className="flex flex-wrap items-center gap-2 rounded-xl border border-border/80 px-3 py-2"
+                >
+                  <span className="font-mono mg-type-caption text-ink-strong">{id}</span>
+                  <RevenueProvenanceChip provenance={source.provenance} />
+                  {source.grain ? (
+                    <span className="mg-type-caption text-ink-muted">{String(source.grain)}</span>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/coverage-leaderboard-model.test.ts
+++ b/apps/ui/src/lib/metagraphed/coverage-leaderboard-model.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  isMeasured,
+  notObservedNote,
+  partitionAndSort,
+  provenanceOptions,
+  toCoverageRows,
+  type CoverageRow,
+} from "./coverage-leaderboard-model";
+
+// #10478: the ordering is where this table can do harm. Sorting `null` as `0`
+// would rank 127 subnets as the network's worst performers — a claim about each
+// of them at once. These tests exist for that.
+
+function row(over: Partial<CoverageRow> = {}): CoverageRow {
+  return {
+    netuid: 1,
+    name: null,
+    provenance: null,
+    coverage_ratio: null,
+    subsidy_multiple: null,
+    revenue_usd: null,
+    emission_usd: 1000,
+    ...over,
+  };
+}
+
+describe("unmeasured subnets are never ranked", () => {
+  const rows = [
+    row({ netuid: 64, revenue_usd: 5000, subsidy_multiple: 8.2, provenance: "probe-derived" }),
+    row({ netuid: 51, revenue_usd: 200, subsidy_multiple: 40, provenance: "probe-derived" }),
+    row({ netuid: 7 }),
+    row({ netuid: 3 }),
+  ];
+
+  it("partitions them out instead of sorting them to the bottom", () => {
+    const { measured, notObserved } = partitionAndSort(rows, "subsidy_multiple", "asc");
+    expect(measured.map((r) => r.netuid)).toEqual([64, 51]);
+    expect(notObserved.map((r) => r.netuid)).toEqual([3, 7]);
+  });
+
+  it("keeps them out of the ranking in BOTH directions", () => {
+    // Sorted ascending by subsidy multiple, a null-as-zero would put every
+    // unmeasured subnet at the very top as the "best covered" — the same lie
+    // wearing the opposite face.
+    for (const dir of ["asc", "desc"] as const) {
+      const { measured } = partitionAndSort(rows, "subsidy_multiple", dir);
+      expect(measured.every(isMeasured)).toBe(true);
+      expect(measured).toHaveLength(2);
+    }
+  });
+
+  it("orders the unmeasured group by netuid — a fact about them", () => {
+    const { notObserved } = partitionAndSort(rows, "revenue_usd", "desc");
+    expect(notObserved.map((r) => r.netuid)).toEqual([3, 7]);
+  });
+
+  it("says why they are listed separately, never '0% covered'", () => {
+    const note = notObservedNote(127, 129);
+    expect(note).toContain("no observable external revenue");
+    expect(note).toContain("not one the data supports");
+    expect(note).not.toMatch(/0%|worst performer(?!s —)/);
+  });
+});
+
+describe("ranking the measured group", () => {
+  it("treats an OBSERVED zero as a real value", () => {
+    // A subnet measured at zero revenue has been measured. It ranks.
+    const rows = [
+      row({ netuid: 1, revenue_usd: 0, coverage_ratio: 0 }),
+      row({ netuid: 2, revenue_usd: 100, coverage_ratio: 0.5 }),
+    ];
+    const { measured, notObserved } = partitionAndSort(rows, "coverage_ratio", "desc");
+    expect(notObserved).toHaveLength(0);
+    expect(measured.map((r) => r.netuid)).toEqual([2, 1]);
+  });
+
+  it("sorts a null column LAST in either direction, not as a zero", () => {
+    // A measured subnet whose emission side could not be priced has no ratio.
+    // It must not top the ascending sort on that column.
+    const rows = [
+      row({ netuid: 1, revenue_usd: 100, coverage_ratio: null }),
+      row({ netuid: 2, revenue_usd: 100, coverage_ratio: 0.9 }),
+    ];
+    expect(partitionAndSort(rows, "coverage_ratio", "asc").measured.map((r) => r.netuid)).toEqual([
+      2, 1,
+    ]);
+    expect(partitionAndSort(rows, "coverage_ratio", "desc").measured.map((r) => r.netuid)).toEqual([
+      2, 1,
+    ]);
+  });
+
+  it("breaks ties by netuid so the order is stable across renders", () => {
+    const rows = [
+      row({ netuid: 9, revenue_usd: 100, subsidy_multiple: 2 }),
+      row({ netuid: 4, revenue_usd: 100, subsidy_multiple: 2 }),
+    ];
+    expect(
+      partitionAndSort(rows, "subsidy_multiple", "desc").measured.map((r) => r.netuid),
+    ).toEqual([4, 9]);
+  });
+});
+
+describe("the provenance filter", () => {
+  const rows = [
+    row({ netuid: 64, revenue_usd: 1, provenance: "probe-derived" }),
+    row({ netuid: 51, revenue_usd: 1, provenance: "probe-derived" }),
+    row({ netuid: 7, provenance: "operator-attested" }),
+    row({ netuid: 3 }),
+  ];
+
+  it("counts each tier so the thinness of the verified set is visible", () => {
+    const options = provenanceOptions(rows);
+    expect(options[0]).toEqual({
+      value: "probe-derived",
+      count: 2,
+      headlineEligible: true,
+    });
+    expect(options.find((o) => o.value === "none")?.count).toBe(1);
+    expect(options.find((o) => o.value === "operator-attested")?.headlineEligible).toBe(false);
+  });
+
+  it("shows every tier by default", () => {
+    const { measured, notObserved } = partitionAndSort(rows, "netuid", "asc");
+    expect(measured.length + notObserved.length).toBe(4);
+  });
+
+  it("narrows to one tier without reordering the partition rule", () => {
+    const { measured, notObserved } = partitionAndSort(rows, "netuid", "asc", {
+      provenance: "probe-derived",
+    });
+    expect(measured.map((r) => r.netuid)).toEqual([51, 64]);
+    expect(notObserved).toHaveLength(0);
+  });
+});
+
+describe("reading the served artifact", () => {
+  it("takes the nested revenue block and the emission price", () => {
+    const [r] = toCoverageRows([
+      {
+        netuid: 64,
+        name: "Chutes",
+        revenue: {
+          provenance: "probe-derived",
+          coverage_ratio: 0.12,
+          subsidy_multiple: 8.2,
+          revenue_usd: 5000,
+          emission: { usd: 41000 },
+        },
+      },
+    ]);
+    expect(r.name).toBe("Chutes");
+    expect(r.provenance).toBe("probe-derived");
+    expect(r.emission_usd).toBe(41000);
+  });
+
+  it("drops a row with no netuid rather than rendering a nameless one", () => {
+    expect(toCoverageRows([{ name: "x" }, null, "nope"])).toEqual([]);
+    expect(toCoverageRows(null)).toEqual([]);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/coverage-leaderboard-model.ts
+++ b/apps/ui/src/lib/metagraphed/coverage-leaderboard-model.ts
@@ -1,0 +1,172 @@
+/**
+ * #10478: the network-wide coverage leaderboard's ordering, extracted because
+ * the ordering is where this table can do harm.
+ *
+ * SORTING `null` AS `0` WOULD RANK 127 SUBNETS AS THE WORST PERFORMERS ON THE
+ * NETWORK. They are not the worst performers; they are the unmeasured ones, and
+ * a table that ranks them is making a claim about each of them at once. So
+ * unmeasured subnets never enter the ranking at all — they are partitioned into
+ * their own group, which the page renders separately and labels as what it is.
+ *
+ * The measured group sorts normally. Within it, `0` is a real value and ranks
+ * like one, because an observed zero IS a measurement.
+ */
+
+export const COVERAGE_SORT_FIELDS = [
+  "subsidy_multiple",
+  "coverage_ratio",
+  "emission_usd",
+  "revenue_usd",
+  "netuid",
+] as const;
+
+export type CoverageSortField = (typeof COVERAGE_SORT_FIELDS)[number];
+
+export interface CoverageRow {
+  netuid: number;
+  name: string | null;
+  provenance: string | null;
+  coverage_ratio: number | null;
+  subsidy_multiple: number | null;
+  revenue_usd: number | null;
+  emission_usd: number | null;
+}
+
+function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}
+
+/** One row of the served coverage artifact, defensively. */
+export function toCoverageRow(raw: unknown): CoverageRow | null {
+  const row = (raw ?? {}) as Record<string, unknown>;
+  const netuid = finite(row.netuid);
+  if (netuid == null) return null;
+  const revenue = (row.revenue ?? row) as Record<string, unknown>;
+  const emission = (revenue.emission ?? {}) as Record<string, unknown>;
+  return {
+    netuid,
+    name: text(row.name) ?? text(row.subnet_name),
+    provenance: text(revenue.provenance),
+    coverage_ratio: finite(revenue.coverage_ratio),
+    subsidy_multiple: finite(revenue.subsidy_multiple),
+    revenue_usd: finite(revenue.revenue_usd),
+    emission_usd: finite(emission.usd) ?? finite(row.emission_usd),
+  };
+}
+
+export function toCoverageRows(raw: unknown): CoverageRow[] {
+  if (!Array.isArray(raw)) return [];
+  const out: CoverageRow[] = [];
+  for (const item of raw) {
+    const row = toCoverageRow(item);
+    if (row) out.push(row);
+  }
+  return out;
+}
+
+/**
+ * A subnet is MEASURED when it has an observed revenue figure.
+ *
+ * Keyed on `revenue_usd` rather than on the ratio, because the ratio can also
+ * be null for a measured subnet whose emission side failed to price — and that
+ * subnet has still been measured. It just cannot be ranked on that column.
+ */
+export function isMeasured(row: CoverageRow): boolean {
+  return row.revenue_usd != null;
+}
+
+export interface PartitionedCoverage {
+  /** Ranked. Every row here has an observed revenue figure. */
+  measured: CoverageRow[];
+  /** NOT ranked, and never interleaved with the above. */
+  notObserved: CoverageRow[];
+}
+
+function compare(
+  a: CoverageRow,
+  b: CoverageRow,
+  field: CoverageSortField,
+  direction: "asc" | "desc",
+): number {
+  const av = a[field];
+  const bv = b[field];
+  // Within the measured group a null is still possible — an unpriced emission
+  // side, say. It sorts LAST in either direction rather than as a zero, so a
+  // column it cannot answer never promotes it to the top of that column.
+  if (av == null && bv == null) return a.netuid - b.netuid;
+  if (av == null) return 1;
+  if (bv == null) return -1;
+  const delta = direction === "asc" ? av - bv : bv - av;
+  return delta || a.netuid - b.netuid;
+}
+
+/**
+ * Split, then sort. The unmeasured group is never ordered by a metric it has no
+ * value for — it is ordered by netuid, which is a fact about it.
+ */
+export function partitionAndSort(
+  rows: CoverageRow[],
+  field: CoverageSortField,
+  direction: "asc" | "desc",
+  { provenance }: { provenance?: string | null } = {},
+): PartitionedCoverage {
+  const filtered =
+    provenance == null || provenance === ""
+      ? rows
+      : rows.filter((r) => r.provenance === provenance);
+  const measured = filtered.filter(isMeasured);
+  const notObserved = filtered.filter((r) => !isMeasured(r));
+  return {
+    measured: [...measured].sort((a, b) => compare(a, b, field, direction)),
+    notObserved: [...notObserved].sort((a, b) => a.netuid - b.netuid),
+  };
+}
+
+/** The tiers that can reach a headline ratio, for the filter's own labelling. */
+export const HEADLINE_TIERS = new Set(["chain-verified", "probe-derived"]);
+
+export interface ProvenanceOption {
+  value: string;
+  count: number;
+  headlineEligible: boolean;
+}
+
+/**
+ * The provenance filter's options, with counts.
+ *
+ * The counts are the point: the filter is how a reader learns the verified set
+ * is two subnets wide, which a table showing only its own rows would hide.
+ */
+export function provenanceOptions(rows: CoverageRow[]): ProvenanceOption[] {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const key = row.provenance ?? "none";
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([value, count]) => ({
+      value,
+      count,
+      headlineEligible: HEADLINE_TIERS.has(value),
+    }))
+    .sort(
+      (a, b) =>
+        Number(b.headlineEligible) - Number(a.headlineEligible) ||
+        b.count - a.count ||
+        a.value.localeCompare(b.value),
+    );
+}
+
+/** The line above the unmeasured group. Never "0% covered". */
+export function notObservedNote(count: number, total: number): string {
+  return (
+    `${count} of ${total} subnets have no observable external revenue. ` +
+    "They are listed separately rather than ranked, because ordering them by a " +
+    "figure nobody measured would rank them as the network's worst performers — " +
+    "which is a claim about each of them, and not one the data supports."
+  );
+}

--- a/apps/ui/src/lib/metagraphed/revenue-panel-model.test.ts
+++ b/apps/ui/src/lib/metagraphed/revenue-panel-model.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+  coverageLabel,
+  coverageNote,
+  isHeadlineEligible,
+  subsidyLabel,
+  tierLabel,
+  usdLabel,
+} from "./revenue-panel-model";
+
+// #10477: the single most likely way this feature does harm is rendering an
+// unmeasured subnet as a measured zero. These tests exist for that one rule.
+
+describe("a null ratio is never a zero", () => {
+  it('renders null coverage as "Not observed", not 0%', () => {
+    expect(coverageLabel(null)).toBe("Not observed");
+    expect(coverageLabel(undefined)).toBe("Not observed");
+    expect(coverageLabel(Number.NaN)).toBe("Not observed");
+    expect(coverageLabel("0")).toBe("Not observed");
+  });
+
+  it("keeps an OBSERVED zero as a real 0%", () => {
+    // A subnet measured at zero and a subnet nobody could measure are different
+    // facts. Collapsing them is the whole defect.
+    expect(coverageLabel(0)).toBe("0.0%");
+  });
+
+  it("applies the same rule to the subsidy multiple", () => {
+    expect(subsidyLabel(null)).toBe("Not observed");
+    expect(subsidyLabel(0)).toBe("0.0×");
+    expect(subsidyLabel(8.2)).toBe("8.2×");
+  });
+
+  it("says 'no observable external revenue', never 'no revenue'", () => {
+    const note = coverageNote(null);
+    expect(note).toContain("No observable external revenue");
+    expect(note).toContain("has not been judged");
+    expect(note).not.toMatch(/\bearns nothing\b|\bno revenue\b/);
+  });
+
+  it("switches to the reading caveats once something IS observed", () => {
+    const note = coverageNote(1234);
+    expect(note).toContain("not an accusation");
+    expect(note).not.toContain("No observable external revenue");
+  });
+});
+
+describe("the provenance tier", () => {
+  it("marks only chain-verified and probe-derived as headline-eligible", () => {
+    expect(isHeadlineEligible("chain-verified")).toBe(true);
+    expect(isHeadlineEligible("probe-derived")).toBe(true);
+    for (const tier of [
+      "operator-attested",
+      "third-party-reported",
+      "self-reported",
+      "inferred",
+      null,
+      "",
+    ]) {
+      expect(isHeadlineEligible(tier)).toBe(false);
+    }
+  });
+
+  it("labels an unknown tier by its own name rather than inventing one", () => {
+    expect(tierLabel("probe-derived")).toBe("Probe-derived");
+    expect(tierLabel("something-new")).toBe("something-new");
+    expect(tierLabel(null)).toBe("Unrecorded");
+    expect(tierLabel(42)).toBe("Unrecorded");
+  });
+});
+
+describe("dollar figures", () => {
+  it("formats an amount that is ALREADY dollars", () => {
+    expect(usdLabel(1234.5)).toBe("$1.2k");
+    expect(usdLabel(2_500_000)).toBe("$2.50M");
+    expect(usdLabel(12.345)).toBe("$12.35");
+  });
+
+  it("returns null rather than $0 for an unread figure", () => {
+    expect(usdLabel(null)).toBeNull();
+    expect(usdLabel("1234")).toBeNull();
+    expect(usdLabel(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/revenue-panel-model.ts
+++ b/apps/ui/src/lib/metagraphed/revenue-panel-model.ts
@@ -1,0 +1,75 @@
+/**
+ * #10477: the revenue panel's display decisions, extracted so the one that
+ * matters can be tested without rendering.
+ *
+ * THE DECISION: a null ratio renders as "Not observed", never as 0%. 127 of 129
+ * subnets have no observable external revenue, and "0% covered" is a false claim
+ * about every one of them — at a scale that makes it defamatory rather than
+ * merely wrong. An OBSERVED zero is a different value and survives as a real 0%.
+ *
+ * Same shape as stake-moves-tile.ts: a pure model beside the panel that renders
+ * it, so the rule is checkable rather than asserted in a comment.
+ */
+
+/** Only these two rungs reach the headline ratio. */
+export const HEADLINE_TIERS = new Set(["chain-verified", "probe-derived"]);
+
+const TIER_LABEL: Record<string, string> = {
+  "chain-verified": "Chain-verified",
+  "probe-derived": "Probe-derived",
+  "operator-attested": "Operator-attested",
+  "third-party-reported": "Third-party reported",
+  "self-reported": "Self-reported",
+  inferred: "Inferred",
+};
+
+export function tierLabel(provenance: unknown): string {
+  const key = typeof provenance === "string" ? provenance : "";
+  return TIER_LABEL[key] ?? (key || "Unrecorded");
+}
+
+export function isHeadlineEligible(provenance: unknown): boolean {
+  return HEADLINE_TIERS.has(String(provenance ?? ""));
+}
+
+export function finite(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** A figure ALREADY in dollars. `formatUsdApprox` converts TAO at a price,
+ * which is a different job — handing it dollars would price the currency
+ * against itself. */
+export function usdLabel(value: unknown): string | null {
+  const n = finite(value);
+  if (n == null) return null;
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (abs >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
+  return `$${n.toFixed(2)}`;
+}
+
+/** A ratio as a percentage, or the honest absence. NEVER "0%" for a null. */
+export function coverageLabel(value: unknown): string {
+  const n = finite(value);
+  return n == null ? "Not observed" : `${(n * 100).toFixed(1)}%`;
+}
+
+export function subsidyLabel(value: unknown): string {
+  const n = finite(value);
+  return n == null ? "Not observed" : `${n.toFixed(1)}×`;
+}
+
+/**
+ * The sentence under the tiles.
+ *
+ * Prose rather than a tooltip, because for 127 of 129 subnets it is the most
+ * important thing on the panel — and a tooltip does not survive a screenshot.
+ */
+export function coverageNote(observedUsd: unknown): string {
+  return finite(observedUsd) == null
+    ? "No observable external revenue. This subnet has not been measured — it has not been judged. " +
+        "A subnet that publishes no figure gets no ratio, which is not the same as earning nothing, " +
+        "and a subnet that publishes one will usually look worse than one that hides it."
+    : "Only chain-verified and probe-derived readings reach this ratio. The numerator is external revenue, " +
+        "not profit; the denominator is emission received, not cost. A high subsidy multiple is not an accusation.";
+}

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as GapsRouteImport } from './routes/gaps'
 import { Route as HealthRouteImport } from './routes/health'
 import { Route as LeaderboardsRouteImport } from './routes/leaderboards'
 import { Route as PortfolioRouteImport } from './routes/portfolio'
+import { Route as RevenueRouteImport } from './routes/revenue'
 import { Route as SchemasRouteImport } from './routes/schemas'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as StatusRouteImport } from './routes/status'
@@ -132,6 +133,11 @@ const LeaderboardsRoute = LeaderboardsRouteImport.update({
 const PortfolioRoute = PortfolioRouteImport.update({
   id: '/portfolio',
   path: '/portfolio',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RevenueRoute = RevenueRouteImport.update({
+  id: '/revenue',
+  path: '/revenue',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SchemasRoute = SchemasRouteImport.update({
@@ -350,6 +356,7 @@ export interface FileRoutesByFullPath {
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/portfolio': typeof PortfolioRoute
+  '/revenue': typeof RevenueRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -404,6 +411,7 @@ export interface FileRoutesByTo {
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/portfolio': typeof PortfolioRoute
+  '/revenue': typeof RevenueRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -461,6 +469,7 @@ export interface FileRoutesById {
   '/health': typeof HealthRoute
   '/leaderboards': typeof LeaderboardsRoute
   '/portfolio': typeof PortfolioRoute
+  '/revenue': typeof RevenueRoute
   '/schemas': typeof SchemasRoute
   '/settings': typeof SettingsRoute
   '/status': typeof StatusRoute
@@ -519,6 +528,7 @@ export interface FileRouteTypes {
     | '/health'
     | '/leaderboards'
     | '/portfolio'
+    | '/revenue'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -573,6 +583,7 @@ export interface FileRouteTypes {
     | '/health'
     | '/leaderboards'
     | '/portfolio'
+    | '/revenue'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -629,6 +640,7 @@ export interface FileRouteTypes {
     | '/health'
     | '/leaderboards'
     | '/portfolio'
+    | '/revenue'
     | '/schemas'
     | '/settings'
     | '/status'
@@ -686,6 +698,7 @@ export interface RootRouteChildren {
   HealthRoute: typeof HealthRoute
   LeaderboardsRoute: typeof LeaderboardsRoute
   PortfolioRoute: typeof PortfolioRoute
+  RevenueRoute: typeof RevenueRoute
   SchemasRoute: typeof SchemasRoute
   SettingsRoute: typeof SettingsRoute
   StatusRoute: typeof StatusRoute
@@ -814,6 +827,13 @@ declare module '@tanstack/react-router' {
       path: '/portfolio'
       fullPath: '/portfolio'
       preLoaderRoute: typeof PortfolioRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/revenue': {
+      id: '/revenue'
+      path: '/revenue'
+      fullPath: '/revenue'
+      preLoaderRoute: typeof RevenueRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/schemas': {
@@ -1154,6 +1174,7 @@ const rootRouteChildren: RootRouteChildren = {
   HealthRoute: HealthRoute,
   LeaderboardsRoute: LeaderboardsRoute,
   PortfolioRoute: PortfolioRoute,
+  RevenueRoute: RevenueRoute,
   SchemasRoute: SchemasRoute,
   SettingsRoute: SettingsRoute,
   StatusRoute: StatusRoute,

--- a/apps/ui/src/routes/-revenue-page.tsx
+++ b/apps/ui/src/routes/-revenue-page.tsx
@@ -1,0 +1,268 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { Chip, StatTile } from "@jsonbored/ui-kit";
+import { Route } from "./revenue";
+import { chainRevenueCoverageQuery } from "@/lib/metagraphed/queries";
+import { Panel } from "@/components/metagraphed/primitives";
+import { Skeleton, ErrorState } from "@/components/metagraphed/states";
+import { SortHeader, ariaSort } from "@/components/metagraphed/table-controls";
+import {
+  COVERAGE_SORT_FIELDS,
+  HEADLINE_TIERS,
+  notObservedNote,
+  partitionAndSort,
+  provenanceOptions,
+  toCoverageRows,
+  type CoverageRow,
+  type CoverageSortField,
+} from "@/lib/metagraphed/coverage-leaderboard-model";
+import {
+  coverageLabel,
+  subsidyLabel,
+  tierLabel,
+  usdLabel,
+} from "@/lib/metagraphed/revenue-panel-model";
+
+/**
+ * #10478: every subnet's coverage, in one table.
+ *
+ * THE ORDERING IS WHERE THIS PAGE CAN DO HARM. Sorting `null` as `0` would rank
+ * 127 subnets as the worst performers on the network — a claim about each of
+ * them at once, and one the data does not support. So unmeasured subnets are
+ * never ranked: they sit in their own group below the table, labelled as what
+ * they are. The rule lives in coverage-leaderboard-model.ts, where it is tested.
+ *
+ * The provenance filter shows every tier by default, with counts, because the
+ * count is how a reader learns the headline-eligible set is two subnets wide.
+ */
+
+const TH = "px-4 py-3 text-left mg-type-caption text-ink-muted";
+
+function ProvenanceCell({ provenance }: { provenance: string | null }) {
+  const eligible = HEADLINE_TIERS.has(provenance ?? "");
+  return <Chip tone={eligible ? "accent" : "muted"}>{tierLabel(provenance)}</Chip>;
+}
+
+function SubnetCell({ row }: { row: CoverageRow }) {
+  return (
+    <Link
+      to="/subnets/$netuid"
+      params={{ netuid: row.netuid }}
+      className="font-mono mg-type-caption text-ink-strong hover:text-accent hover:underline"
+    >
+      SN{row.netuid}
+      {row.name ? <span className="ml-2 font-sans text-ink-muted">{row.name}</span> : null}
+    </Link>
+  );
+}
+
+export function RevenuePage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const q = useQuery(chainRevenueCoverageQuery());
+
+  const rows = useMemo(() => toCoverageRows(q.data?.data?.subnets), [q.data?.data?.subnets]);
+  const options = useMemo(() => provenanceOptions(rows), [rows]);
+  const { measured, notObserved } = useMemo(
+    () =>
+      partitionAndSort(rows, search.sort, search.dir, {
+        provenance: search.provenance,
+      }),
+    [rows, search.sort, search.dir, search.provenance],
+  );
+
+  const onSort = (field: string) =>
+    navigate({
+      search: (prev: { sort?: string; dir?: "asc" | "desc" }) =>
+        ({
+          ...prev,
+          sort: field,
+          dir: prev.sort === field && prev.dir === "desc" ? "asc" : "desc",
+        }) as never,
+    });
+
+  if (q.isError) {
+    return <ErrorState error={q.error} onRetry={() => q.refetch()} context="revenue coverage" />;
+  }
+  if (q.isLoading) return <Skeleton className="h-96 w-full" />;
+
+  const sortField = COVERAGE_SORT_FIELDS.includes(search.sort)
+    ? search.sort
+    : ("subsidy_multiple" as CoverageSortField);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <StatTile
+          eyebrow="Subnets measured"
+          value={String(measured.length)}
+          hint="With an observable external revenue figure"
+        />
+        <StatTile
+          eyebrow="Not observed"
+          value={String(notObserved.length)}
+          hint="No readable public figure — not measured, not judged"
+        />
+        <StatTile
+          eyebrow="Headline-eligible"
+          value={String(rows.filter((r) => HEADLINE_TIERS.has(r.provenance ?? "")).length)}
+          hint="Chain-verified or probe-derived"
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="mg-type-caption text-ink-muted">Provenance</span>
+        <button
+          type="button"
+          onClick={() => navigate({ search: (p) => ({ ...p, provenance: "" }) as never })}
+          className={`rounded-full border px-3 py-1 mg-type-caption ${
+            search.provenance ? "border-border/80 text-ink-muted" : "border-accent text-ink-strong"
+          }`}
+        >
+          All ({rows.length})
+        </button>
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() =>
+              navigate({
+                search: (p) => ({ ...p, provenance: option.value }) as never,
+              })
+            }
+            className={`rounded-full border px-3 py-1 mg-type-caption ${
+              search.provenance === option.value
+                ? "border-accent text-ink-strong"
+                : "border-border/80 text-ink-muted"
+            }`}
+          >
+            {tierLabel(option.value === "none" ? null : option.value)} ({option.count})
+            {option.headlineEligible ? " ★" : ""}
+          </button>
+        ))}
+      </div>
+
+      <div className="overflow-x-auto rounded-2xl border border-border/80">
+        <table className="w-full min-w-[52rem]">
+          <thead>
+            <tr className="border-b border-border/80">
+              <th className={TH} aria-sort={ariaSort(sortField === "netuid", search.dir)}>
+                <SortHeader
+                  label="Subnet"
+                  field="netuid"
+                  active={sortField === "netuid"}
+                  order={search.dir}
+                  onSort={onSort}
+                />
+              </th>
+              <th className={TH}>Provenance</th>
+              <th
+                className={`${TH} text-right`}
+                aria-sort={ariaSort(sortField === "emission_usd", search.dir)}
+              >
+                <SortHeader
+                  label="Emission"
+                  field="emission_usd"
+                  active={sortField === "emission_usd"}
+                  order={search.dir}
+                  onSort={onSort}
+                  align="right"
+                />
+              </th>
+              <th
+                className={`${TH} text-right`}
+                aria-sort={ariaSort(sortField === "revenue_usd", search.dir)}
+              >
+                <SortHeader
+                  label="Revenue"
+                  field="revenue_usd"
+                  active={sortField === "revenue_usd"}
+                  order={search.dir}
+                  onSort={onSort}
+                  align="right"
+                />
+              </th>
+              <th
+                className={`${TH} text-right`}
+                aria-sort={ariaSort(sortField === "coverage_ratio", search.dir)}
+              >
+                <SortHeader
+                  label="Coverage"
+                  field="coverage_ratio"
+                  active={sortField === "coverage_ratio"}
+                  order={search.dir}
+                  onSort={onSort}
+                  align="right"
+                />
+              </th>
+              <th
+                className={`${TH} text-right`}
+                aria-sort={ariaSort(sortField === "subsidy_multiple", search.dir)}
+              >
+                <SortHeader
+                  label="Subsidy"
+                  field="subsidy_multiple"
+                  active={sortField === "subsidy_multiple"}
+                  order={search.dir}
+                  onSort={onSort}
+                  align="right"
+                />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {measured.map((row) => (
+              <tr key={row.netuid} className="border-b border-border/40">
+                <td className="px-4 py-3">
+                  <SubnetCell row={row} />
+                </td>
+                <td className="px-4 py-3">
+                  <ProvenanceCell provenance={row.provenance} />
+                </td>
+                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                  {usdLabel(row.emission_usd) ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                  {usdLabel(row.revenue_usd) ?? "—"}
+                </td>
+                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                  {coverageLabel(row.coverage_ratio)}
+                </td>
+                <td className="px-4 py-3 text-right mg-type-data tabular-nums text-ink">
+                  {subsidyLabel(row.subsidy_multiple)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {notObserved.length > 0 ? (
+        <div className="space-y-2">
+          {/* Visually distinct and OUTSIDE the ranked table, because ordering
+              these by a figure nobody measured is the defect this page exists
+              not to have. */}
+          <Panel as="div" dense bodyClassName="mg-type-caption text-ink-muted">
+            {notObservedNote(notObserved.length, rows.length)}
+          </Panel>
+          <div className="flex flex-wrap gap-2">
+            {notObserved.map((row) => (
+              <span key={row.netuid} className="rounded-full border border-border/60 px-3 py-1">
+                <SubnetCell row={row} />
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <Link
+        to="/docs/$"
+        params={{ _splat: "revenue-coverage" }}
+        className="mg-type-caption text-accent hover:underline"
+      >
+        How the ratio is derived, and what it does not mean
+      </Link>
+    </div>
+  );
+}

--- a/apps/ui/src/routes/-subnets-netuid-page.tsx
+++ b/apps/ui/src/routes/-subnets-netuid-page.tsx
@@ -60,6 +60,7 @@ import { SearchInput } from "@/components/metagraphed/table-controls";
 import { ReliabilityPanel } from "@/components/metagraphed/reliability-panel";
 import { EconomicsPanel } from "@/components/metagraphed/economics-panel";
 import { SubnetEmissionPanel } from "@/components/metagraphed/subnet-emission-panel";
+import { SubnetRevenuePanel } from "@/components/metagraphed/subnet-revenue-panel";
 import { EndpointSnippet, apiSnippet } from "@/components/metagraphed/endpoint-snippet";
 import { SubnetHistoryChart } from "@/components/metagraphed/subnet-history-chart";
 import { SubnetOhlcChart } from "@/components/metagraphed/subnet-ohlc-chart";
@@ -642,6 +643,17 @@ function EconomicsTabPanel({ netuid }: { netuid: number }) {
         info="Live chain economics from the Bittensor metagraph — emission share, alpha price, stake, validator/miner counts, and subnet volume."
       >
         <EconomicsPanel netuid={netuid} />
+      </SectionAnchor>
+
+      <SectionAnchor
+        id="revenue-coverage"
+        title="Revenue vs emissions"
+        subtitle="What this subnet earns from outside Bittensor, against the TAO the network emits to it."
+        info="GET /api/v1/subnets/{netuid}/revenue — external revenue over emission received. Only chain-verified and probe-derived readings reach the ratio; a subnet with no readable public figure shows 'not observed', which is not the same as zero. 127 of 129 subnets are in that state."
+      >
+        <QueryErrorBoundary>
+          <SubnetRevenuePanel netuid={netuid} />
+        </QueryErrorBoundary>
       </SectionAnchor>
 
       <SectionAnchor

--- a/apps/ui/src/routes/revenue.tsx
+++ b/apps/ui/src/routes/revenue.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
+import { fallback, zodValidator } from "@tanstack/zod-adapter";
+import { RevenuePage } from "./-revenue-page";
+
+// Sort/filter state lives in the URL so a specific view ("the probe-derived
+// subnets, by subsidy multiple") is shareable — the same reason /chain/emissions
+// puts its own sort there.
+const revenueSearchSchema = z.object({
+  sort: fallback(
+    z.enum(["subsidy_multiple", "coverage_ratio", "emission_usd", "revenue_usd", "netuid"]),
+    "subsidy_multiple",
+  ).default("subsidy_multiple"),
+  dir: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
+  // Empty means every tier, which is the default: the counts beside each tier
+  // are how a reader learns the headline-eligible set is two subnets wide, and
+  // defaulting to a filtered view would hide exactly that.
+  provenance: fallback(z.string(), "").default(""),
+});
+
+export type RevenueSearch = z.infer<typeof revenueSearchSchema>;
+
+const DESCRIPTION =
+  "What every Bittensor subnet earns from outside the network, against the TAO the network emits to it. Only chain-verified and probe-derived readings reach the ratio; subnets with no observable external revenue are listed separately rather than ranked as zero.";
+
+export const Route = createFileRoute("/revenue")({
+  validateSearch: zodValidator(revenueSearchSchema),
+  head: () => ({
+    meta: [
+      { title: "Revenue coverage — Metagraphed" },
+      { name: "description", content: DESCRIPTION },
+      { property: "og:title", content: "Revenue coverage — Metagraphed" },
+      { property: "og:description", content: DESCRIPTION },
+    ],
+  }),
+  component: RevenuePage,
+});

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -519,6 +519,13 @@ export const OG_SECTIONS: Record<string, OgCopy> = {
     subtitle: "Where each block's TAO goes, decomposed per subnet",
     eyebrow: "Explorer",
   },
+  "/revenue": {
+    title: "Revenue coverage",
+    // "not observed", not "0%" -- the card is the most-shared surface this
+    // page has, and it must not assert a measurement nobody made (#10478).
+    subtitle: "What each subnet earns outside Bittensor, against what it is emitted",
+    eyebrow: "Explorer",
+  },
   "/chain/blocks": {
     title: "Blocks",
     subtitle: "Recent Bittensor blocks, extrinsics and events",


### PR DESCRIPTION
> **Stacked on [#10667](https://github.com/JSONbored/metagraphed/pull/10667)** — shares `usdLabel`/`coverageLabel`/`tierLabel` from that PR's model rather than keeping a second copy. Rebases cleanly onto main once #10667 lands.

## Summary

A new **`/revenue`** route: every subnet's external revenue against the TAO the network emits to it. Sortable by subsidy multiple, coverage ratio, emission, or revenue. Provenance tier as a first-class, filterable column. Sort/filter state in the URL, so a specific view is shareable.

## The ordering is where this page can do harm

**Sorting `null` as `0` would rank 127 subnets as the worst performers on the network.** They are not the worst performers — they are the unmeasured ones, and a table that ranks them makes a claim about each of them at once.

So unmeasured subnets **never enter the ranking**. They are partitioned into their own group below the table, ordered by netuid (a fact about them), under a line saying why.

The test covers **both** directions, deliberately:

```js
// Ascending, a null-as-zero would put every unmeasured subnet at the TOP
// as the "best covered" — the same lie wearing the opposite face.
for (const dir of ["asc", "desc"]) {
  expect(partitionAndSort(rows, "subsidy_multiple", dir).measured).toHaveLength(2);
}
```

Within the measured group:

- an **observed** zero ranks like the real value it is;
- a measured subnet whose *emission* side could not be priced has no ratio, and sorts **last** on that column in either direction rather than reading as a zero;
- ties break by netuid, so the order is stable across renders.

## The provenance filter shows every tier by default — with counts

The count is how a reader learns the headline-eligible set is **two subnets wide**. Defaulting to a filtered view would hide exactly that. Headline-eligible tiers are marked (★).

## Also

Adds the route's OG card copy. The existing `server.og-copy.test.ts` gate caught it as missing before this could ship with a generic card — worth noting that the gate did its job unprompted.

12 tests on `coverage-leaderboard-model.ts`.

## Screenshots

Maintainer PR. Against production today the ranked table has **2 rows** (SN64, SN51) and the "not observed" group has the other 127 — which is the shape this page is designed around, not a loading state.

## Validation

```
apps/ui: npm run typecheck    clean
apps/ui: npm run lint         0 errors
apps/ui: npx vitest run       2000 passed
apps/ui: prettier --check .   clean
apps/ui: npm run build        clean (routeTree regenerated + committed)
root:    format:check         clean
```

Closes #10478
