### PR TITLE
fix(watchdog): a lane alarm no longer eats the other lanes alarming with it

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -705,13 +705,22 @@ export async function runLaneAlarm(
   for (const alarm of plan.open) {
     const body = laneAlarmIssueBody(alarm, nowMs);
     // PostHog stays a second channel rather than the only one. It is recorded
-    // for every alarm, including the ones the cap suppressed below, so a
+    // for every alarm, including the ones the GitHub cap suppressed below, so a
     // working capture path still sees the full picture.
+    //
+    // `fingerprintDetail` IS WHAT MAKES THAT TRUE. Without it every lane in a
+    // tick fingerprinted `watchdog:lane-alarm:Error`, which is also the storm
+    // guard's throttle key -- so the first alarming lane consumed the window
+    // and every other lane in the same tick was dropped as a repeat of it.
+    // Measured on production before the fix: exactly one event per tick for six
+    // consecutive hours, while this watchdog's own verdict read "4 alarming".
+    // The lane set is declared and small, so per-lane windows are bounded.
     await record(env as never, {
       error: new Error(
         `lane ${alarm.lane} is ${alarm.kind}: ${humanDuration(nowMs - alarm.since)}`,
       ),
       route: "watchdog:lane-alarm",
+      fingerprintDetail: alarm.lane,
       errorCode: alarm.kind === "stale" ? "lane_stale" : "lane_silent",
     }).catch(() => false);
     if (!github) continue;

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -1463,6 +1463,30 @@ export interface ExceptionEvent {
   queryKind?: string;
   queryShape?: string;
   /**
+   * An extra grouping key, appended to the fingerprint between `route` and the
+   * error type. Use it ONLY where one route legitimately reports N independent
+   * subjects, and set it to the thing that makes them independent.
+   *
+   * WHY THIS EXISTS. The fingerprint is also the storm guard's throttle key, so
+   * two different findings that share a route share a window — and the second
+   * one is dropped as if it were a repeat of the first. `watchdog:lane-alarm`
+   * was doing exactly that: it emits once per alarming lane in a single tick,
+   * every emit fingerprinted `watchdog:lane-alarm:Error`, and the 5-minute
+   * window meant only the first lane in each tick was ever recorded. Measured
+   * before the fix: exactly 1 event per tick for 6 consecutive hours while the
+   * lane-alarm verdict itself read "4 alarming".
+   *
+   * KEEP THE VALUE A CLOSED SET. It multiplies both the number of PostHog
+   * issues and the number of throttle windows, so a request-derived value
+   * (an id, a path, a message) belongs in `queryShape`, not here. A declared
+   * lane name is fine; anything a caller could supply unbounded is not.
+   * `sanitizeLabel` bounds the length but cannot bound the cardinality.
+   *
+   * Omitted means the fingerprint is unchanged, so no existing capture site
+   * moves issues.
+   */
+  fingerprintDetail?: string;
+  /**
    * This failure is an EXPECTED operational condition, not a code defect.
    *
    * Set it and the occurrence is recorded as a `usage_event` (`ok: false`,
@@ -1846,7 +1870,16 @@ export async function recordExceptionEvent(
     // error type" into one PostHog issue -- matching the route/mcp_tool
     // tag Sentry already gets at these sites, so the two dashboards read
     // consistently. Falls back to "unknown" only if neither is supplied.
-    const fingerprint = `${route ?? mcpTool ?? "unknown"}:${type}`;
+    //
+    // `fingerprintDetail` splits a route that reports several independent
+    // subjects (see its doc comment). It is NOT folded into `route`, because
+    // route mirrors UsageEvent's vocabulary so insights filter consistently
+    // across usage_event/$mcp_tool_call/$exception -- a lane name is not a
+    // route, and putting it there would break that mirroring.
+    const detail = sanitizeLabel(event.fingerprintDetail);
+    const fingerprint = `${route ?? mcpTool ?? "unknown"}${
+      detail === undefined ? "" : `:${detail}`
+    }:${type}`;
 
     // Throttled on the same key PostHog groups by, so a storm of one fault
     // costs one event per window while a genuinely new fault is never delayed.

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -878,6 +878,68 @@ describe("runLaneAlarm", () => {
     assert.equal(seen.length, 1);
   });
 
+  // #10673: every alarm in a tick used to fingerprint `watchdog:lane-alarm:Error`,
+  // which is also the storm guard's throttle key — so the first alarming lane
+  // consumed the window and the rest were dropped as repeats of it. Measured on
+  // production: exactly one event per tick for six consecutive hours while this
+  // watchdog's own verdict read "4 alarming". Tagging each capture with its lane
+  // is what makes the "recorded for every alarm" claim above true.
+  test("tags each capture with its lane, so a tick's alarms do not collapse", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "table-freshness",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+        {
+          lane: "metagraph",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [
+        { lane: "table-freshness", since: NOW - 28 * HOUR, ticks: 100 },
+        { lane: "metagraph", since: NOW - 28 * HOUR, ticks: 100 },
+      ],
+    });
+    const seen: {
+      error: unknown;
+      route?: string;
+      fingerprintDetail?: string;
+    }[] = [];
+    await runLaneAlarm(db.env, {
+      now: () => NOW,
+      recordException: async (_env, payload) => {
+        seen.push(payload);
+        return true;
+      },
+    });
+    assert.equal(seen.length, 2);
+    // The route stays the shared one — it mirrors UsageEvent's vocabulary. It is
+    // fingerprintDetail that separates the findings.
+    assert.deepEqual(
+      seen.map((payload) => payload.route),
+      ["watchdog:lane-alarm", "watchdog:lane-alarm"],
+    );
+    assert.deepEqual(
+      [...seen.map((payload) => payload.fingerprintDetail)].sort(),
+      ["metagraph", "table-freshness"],
+    );
+    // Each detail equals the lane named in its own message, so a capture can
+    // never be attributed to the wrong lane.
+    for (const payload of seen) {
+      assert.match(
+        String((payload.error as Error).message),
+        new RegExp(`^lane ${payload.fingerprintDetail} is `),
+      );
+    }
+  });
+
   test("counts a rejected create as not opened", async () => {
     const db = healthDb({
       latest: [

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -1223,6 +1223,104 @@ describe("recordExceptionEvent", () => {
     assert.equal("query_shape" in calls[0].body.properties, false);
   });
 
+  // #10673: the deliberate counterpart to the test above. queryKind/queryShape
+  // stay OUT of the fingerprint so N payloads of ONE finding cost one window;
+  // fingerprintDetail goes IN, because it separates N genuinely DIFFERENT
+  // findings that happen to share a route. Collapsing those is not a saving,
+  // it is data loss: watchdog:lane-alarm emitted once per alarming lane and the
+  // storm guard dropped every lane after the first in each tick.
+  test("fingerprintDetail splits the fingerprint between route and type", async () => {
+    const calls: Row[] = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: thrownError(Error, "lane table-freshness is stale: 9.2h"),
+        route: "watchdog:lane-alarm",
+        fingerprintDetail: "table-freshness",
+        errorCode: "lane_stale",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    const { properties } = calls[0].body;
+    assert.equal(
+      properties.$exception_fingerprint,
+      "watchdog:lane-alarm:table-freshness:Error",
+    );
+    // route keeps mirroring UsageEvent's vocabulary — the lane is NOT folded in.
+    assert.equal(properties.route, "watchdog:lane-alarm");
+    assert.equal(properties.error_code, "lane_stale");
+  });
+
+  test("omitting fingerprintDetail leaves the fingerprint byte-identical", async () => {
+    // The regression guard for every pre-existing capture site: none of them
+    // may move PostHog issues because this field was added.
+    const calls: Row[] = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      { error: thrownError(Error, "boom"), route: "r2-sql" },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(
+      calls[0].body.properties.$exception_fingerprint,
+      "r2-sql:Error",
+    );
+  });
+
+  test("a fingerprintDetail longer than the label cap is truncated", async () => {
+    // sanitizeLabel bounds the LENGTH. It cannot bound the cardinality, which
+    // is why the field's contract restricts callers to a closed set.
+    const calls: Row[] = [];
+    await recordExceptionEvent(
+      CONFIGURED,
+      {
+        error: thrownError(Error, "boom"),
+        route: "watchdog:lane-alarm",
+        fingerprintDetail: "l".repeat(400),
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.equal(
+      calls[0].body.properties.$exception_fingerprint,
+      `watchdog:lane-alarm:${"l".repeat(256)}:Error`,
+    );
+  });
+
+  test("two details on one route both survive a shared storm window", async () => {
+    // THE BUG, as a test. With one window open on `watchdog:lane-alarm:Error`,
+    // the second lane in the same tick was admitted by nothing and vanished.
+    // Distinct details mean distinct windows, so both findings are recorded —
+    // and a repeat of the SAME detail is still throttled.
+    const windowed = {
+      [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token",
+      [POSTHOG_EXCEPTION_STORM_WINDOW_MS_ENV]: "300000",
+    } as unknown as Env;
+    const calls: Row[] = [];
+    const fetch = fakeFetch({ onCall: (call) => calls.push(call) });
+    const emit = (lane: string) =>
+      recordExceptionEvent(
+        windowed,
+        {
+          error: thrownError(Error, `lane ${lane} is stale: 1.0h`),
+          route: "watchdog:lane-alarm",
+          fingerprintDetail: lane,
+        },
+        { fetch },
+      );
+    assert.equal(await emit("table-freshness"), true);
+    assert.equal(await emit("metagraph"), true);
+    assert.equal(await emit("subnet-hyperparams"), true);
+    // Same lane again inside the window: still one event per finding per window.
+    assert.equal(await emit("table-freshness"), false);
+    assert.deepEqual(
+      calls.map((call) => call.body.properties.$exception_fingerprint),
+      [
+        "watchdog:lane-alarm:table-freshness:Error",
+        "watchdog:lane-alarm:metagraph:Error",
+        "watchdog:lane-alarm:subnet-hyperparams:Error",
+      ],
+    );
+  });
+
   test("a query shape longer than the label cap is truncated, not dropped", async () => {
     const calls: Row[] = [];
     await recordExceptionEvent(


### PR DESCRIPTION
`lane-alarm` emits one `$exception` per alarming lane in a tick. All of them fingerprinted `watchdog:lane-alarm:Error` — which is also the storm guard's throttle key, so the first alarming lane consumed the 5-minute window and **every other lane in the same tick was dropped as a repeat of it.**

## Measured on production

Events recorded per firing tick, `route = watchdog:lane-alarm`, 12 consecutive ticks:

| tick | recorded |
| --- | --: |
| 23:58, 23:28, 22:58, 22:28 | 1 each |
| 21:58, 21:28, 20:58, 20:28 | 1 each |
| 19:58, 19:28, 18:58, 18:28 | 1 each |

Exactly one, every tick. The watchdog's own verdict in the same window:

```
{"lane":"lane-alarm","verdict":"ok","detail":"4 alarming, 0 recovered, 52 lanes"}
```

Four alarming, one recorded. Three findings lost per tick, and the survivor is a *real* alarm about a *real* stale lane — so the inbox never looked wrong, it just always showed one lane.

The file claimed the opposite:

> PostHog stays a second channel rather than the only one. It is recorded for every alarm, including the ones the cap suppressed below, so a working capture path still sees the full picture.

True of the GitHub-issue cap it describes. False of the capture path.

## The second effect, which cost me an hour today

PostHog groups by fingerprint, so all 52 lanes shared **one** error-tracking issue, titled after the first event ever seen. It reads "lane poller-build is silent: 46.0h" while its five newest events are:

```
lane table-freshness is stale: 9.2h
lane table-freshness is stale: 8.7h
lane table-freshness is stale: 8.2h
lane table-freshness is stale: 7.7h
lane table-freshness is stale: 7.2h
```

I read that title and its last-seen stamp as evidence that #10651 had not worked. It had. A per-lane fingerprint removes that trap as well.

## The change

`ExceptionEvent` gains an optional `fingerprintDetail`, appended between `route` and the error type; lane-alarm passes `alarm.lane`.

`route` deliberately stays `watchdog:lane-alarm` — it mirrors `UsageEvent`'s vocabulary so insights filter consistently across `usage_event` / `$mcp_tool_call` / `$exception`, and a lane name is not a route.

This is the deliberate counterpart to #9459, which kept `queryKind`/`queryShape` **out** of the fingerprint. That was right: those are N payloads of ONE finding, so collapsing them saves cost and loses nothing. A lane is the opposite — N different findings sharing a route, where collapsing *is* the loss. The field's doc comment states that distinction and restricts callers to a closed declared set, because `sanitizeLabel` bounds length but cannot bound cardinality.

## Proven to fail

```
removed `fingerprintDetail: alarm.lane`  → lane-alarm suite: 1 failed | 54 passed
made the fingerprint ignore the detail   → usage-telemetry suite: 3 failed
```

`git diff --stat` confirmed both files were restored exactly afterwards.

## Cost

Each alarming lane gets its own 5-minute window: 4 alarming lanes at a 30-minute cadence is 8 events/hour instead of 2 — roughly 5.8K/month against a 100K `$exception` budget currently running at 55 events/day.

## Verification

- `tsc --noEmit` clean
- 328 tests pass across `usage-telemetry`, `lane-alarm`, `mcp-usage-telemetry`
- `prettier --check` clean
- Rebased onto `381779ccd`, then tsc + 256 tests re-run and `fingerprintDetail` re-confirmed present in both source files

Closes #10673
