### PR TITLE
fix(freshness): the registry cluster names its producer lane, not a time bound

### DIFF
--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -95,6 +95,26 @@ export interface FreshnessExpectation {
   /** An open issue explaining a table that is ALREADY breaching, so the alarm
    * points somewhere instead of merely being loud. */
   knownIssue?: string;
+  /**
+   * The `lane_health` lane that carries this table's liveness instead of a time
+   * bound. Only meaningful alongside `maxAgeMs: null`.
+   *
+   * A THIRD CLASSIFICATION, distinct from the two `null` already meant.
+   * `api_keys` is null because staleness is *meaningless* — a quiet signup
+   * table is not a fault in any sense. The registry cluster is different: it
+   * has a producer that CAN die, and when it did, five days passed unnoticed
+   * (#9779). Calling that "meaningless" would be the exemption this file's
+   * header warns about.
+   *
+   * What makes null correct there now is that the producer reports itself. So
+   * the classification is not "cannot be stale", it is "asked somewhere else",
+   * and naming where turns an exemption into a redirection that a reader — and
+   * the test beside this file — can follow and check.
+   *
+   * The bar for adding one: the named lane must alarm on BOTH the producer
+   * failing and the producer stopping, or this is a blind spot with a citation.
+   */
+  coveredBy?: string;
 }
 
 /**
@@ -398,33 +418,55 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   // Not exempted. #9779 is a real outage -- the only writer was a retired
   // GitHub Actions lane -- and suppressing it here to keep the lane green
   // would be the exact thing a watchdog must never do.
+  // THE REGISTRY CLUSTER, and why a time bound was the wrong instrument.
+  //
+  // All four are written by src/registry-sync-neon.ts, on merge, when registry
+  // files change. A `MAX(updated_at)` bound on a change-driven producer measures
+  // TIME SINCE THE LAST REGISTRY CHANGE, not producer health -- so two quiet days
+  // breached the 48h cap with nothing wrong. Observed 2026-08-11: `providers`
+  // 57.2h > 48h while the producer had run 6 minutes earlier and correctly
+  // written nothing (`registry-sync` verdict `ok`, "no registry files changed").
+  //
+  // Widening the cap keeps the category error and buys quiet proportional to the
+  // guess. What changed since #9779 is that the producer now reports itself --
+  // its closing ask was "the cluster needs a lane_health lane so this cannot
+  // recur unseen", and src/registry-sync-lane.ts is that lane. It alarms on the
+  // producer failing (non-`ok` verdict) AND on the producer stopping (lane-alarm
+  // silence), which is the pair `coveredBy` requires.
+  //
+  // NOT the same `null` as api_keys. See `coveredBy` above: this is "asked
+  // somewhere else", not "cannot be stale". #9779 is dropped from all four
+  // because it is CLOSED and completed, and a citation to a closed issue was
+  // itself sending readers to a dead end (#10657).
   subnets: {
     column: "updated_at",
     kind: "ms",
-    maxAgeMs: 48 * HOUR,
-    reason: "registry sync on merge",
-    knownIssue: "#9779",
+    maxAgeMs: null,
+    reason: "registry sync on merge; quiet means the registry did not change",
+    coveredBy: "registry-sync",
   },
   surfaces: {
     column: "updated_at",
     kind: "ms",
-    maxAgeMs: 48 * HOUR,
-    reason: "registry sync on merge",
-    knownIssue: "#9779",
+    maxAgeMs: null,
+    reason: "registry sync on merge; quiet means the registry did not change",
+    coveredBy: "registry-sync",
   },
   providers: {
     column: "updated_at",
     kind: "ms",
-    maxAgeMs: 48 * HOUR,
-    reason: "registry sync on merge",
-    knownIssue: "#9779",
+    maxAgeMs: null,
+    reason: "registry sync on merge; quiet means the registry did not change",
+    coveredBy: "registry-sync",
   },
   surface_history: {
     column: "recorded_at",
     kind: "ms",
     maxAgeMs: null,
-    reason: "append-on-change, but its writer is dead",
-    knownIssue: "#9779",
+    // Was "append-on-change, but its writer is dead" -- the writer was re-homed
+    // when #9779 was fixed, so that half had been false since 2026-08-08.
+    reason: "append-on-change; quiet means no surface changed state",
+    coveredBy: "registry-sync",
   },
 
   // --- user state and control: change only when a human acts --------------

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -28,6 +28,10 @@ import {
   TABLE_FRESHNESS_LANE,
   type FreshnessExpectation,
 } from "../src/table-freshness-watchdog.ts";
+// Imported, not spelled as a literal: the registry cluster's `coveredBy` has to
+// stay pinned to the lane the producer actually writes, so renaming that lane
+// breaks this test instead of silently orphaning four tables (#10657).
+import { REGISTRY_SYNC_LANE } from "../src/registry-sync-lane.ts";
 
 const HOUR = 60 * 60 * 1000;
 const NOW = 1_785_800_000_000;
@@ -231,13 +235,66 @@ describe("TABLE_FRESHNESS coverage", () => {
     }
   });
 
-  test("the registry cluster is NOT exempted", () => {
-    // #9779 is a live outage. Classifying these `null` to keep the lane green
-    // is precisely what a watchdog must never do -- quiet only when healthy.
-    for (const table of ["subnets", "surfaces", "providers"]) {
+  // WHAT REPLACED "the registry cluster is NOT exempted" (#10657).
+  //
+  // That test required these three to keep a time bound, because #9779 was a
+  // live outage and classifying them `null` to keep the lane green is exactly
+  // what a watchdog must never do. Both halves of its premise have since
+  // changed: #9779 is closed completed (2026-08-08), and its own closing ask --
+  // a lane_health lane for the cluster -- was built. The 48h bound meanwhile
+  // measured time since the last registry CHANGE, so a quiet registry breached
+  // it with nothing wrong.
+  //
+  // The protection has to survive that, or this is just the exemption the old
+  // test forbade with a nicer comment. So the invariant moves rather than
+  // disappearing: a registry-cluster table may drop its bound ONLY by naming
+  // the lane that answers the question instead, and that name is checked
+  // against the producer's own exported constant -- not a string literal that
+  // could rot the way `knownIssue: "#9779"` did.
+  test("the registry cluster names its covering lane instead of a bound", () => {
+    for (const table of [
+      "subnets",
+      "surfaces",
+      "providers",
+      "surface_history",
+    ]) {
       const e = TABLE_FRESHNESS[table];
-      assert.ok(e.maxAgeMs !== null, `${table} must stay alarmed`);
-      assert.equal(e.knownIssue, "#9779", `${table} should point at its issue`);
+      assert.equal(
+        e.maxAgeMs,
+        null,
+        `${table}: a change-driven producer cannot carry a time bound`,
+      );
+      assert.equal(
+        e.coveredBy,
+        REGISTRY_SYNC_LANE,
+        `${table} must name the lane that carries its liveness`,
+      );
+      // The dead citation this issue was about. #9779 is closed; pointing at it
+      // sent readers to a completed fix with no explanation for 57.2h.
+      assert.equal(
+        e.knownIssue,
+        undefined,
+        `${table} should not cite a closed issue`,
+      );
+    }
+  });
+
+  test("no table drops its bound without naming a covering lane", () => {
+    // The general form, so a future `maxAgeMs: null` cannot quietly mean
+    // "silenced". Either staleness is genuinely meaningless here -- the
+    // signup-driven and append-on-change tables, which say so in `reason` --
+    // or something else is watching and this says which.
+    for (const [table, e] of Object.entries(TABLE_FRESHNESS)) {
+      if (e.coveredBy === undefined) continue;
+      assert.equal(
+        e.maxAgeMs,
+        null,
+        `${table}: coveredBy is only meaningful without a bound`,
+      );
+      assert.ok(
+        e.reason.length > 0,
+        `${table}: a redirected table still owes a reason`,
+      );
     }
   });
 });


### PR DESCRIPTION
`subnets`, `surfaces` and `providers` carried `maxAgeMs: 48h` with the reason "registry sync on merge". A `MAX(updated_at)` bound on a merge-driven producer measures **time since the last registry change**, not producer health — so a quiet registry breaches it with nothing wrong.

Observed 2026-08-11 in the `table-freshness` verdict:

```
providers 57.2h > 48h (known: #9779)
```

while the producer had run six minutes earlier and correctly written nothing:

```
{"lane":"registry-sync","verdict":"ok","detail":"no registry files changed","checked_at":"2026-08-11T07:10:52.905Z"}
```

That stale entry also **masked a real `unknown`** in the same sweep, since `stale` outranks it in the verdict priority (#10656 was hiding behind it).

## The obvious fix was explicitly forbidden — and why that changed

`tests/table-freshness-watchdog.test.ts` had a test named *"the registry cluster is NOT exempted"*, requiring a non-null bound because "#9779 is a live outage" and classifying these `null` "to keep the lane green" is what a watchdog must never do. **Correct at the time.** Both halves of its premise have since changed:

- #9779 closed completed 2026-08-08T01:33:06Z, and `providers` was written 2026-08-08T21:34Z — ~20h after — so the re-homed writer works.
- #9779's closing ask was *"the cluster needs a `lane_health` lane so this cannot recur unseen."* `src/registry-sync-lane.ts` is that lane, and `src/registry-sync-neon.ts` writes all four tables (`providers` :164, `subnets` :190, `surfaces` :298, `surface_history` :331/:361).

So the question any exemption owes — *then what would catch it* — now has an answer it did not have:

| failure | what catches it |
| --- | --- |
| producer fails | non-`ok` `registry-sync` verdict → lane-alarm STALE |
| producer stops | `registry-sync` goes silent → lane-alarm SILENT |
| registry simply quiet | `ok` + "no registry files changed" — correct, and silent |

## A third classification, not a reuse of the second

This is deliberately **not** the same `null` as `api_keys`. A quiet signup table cannot be a fault in any sense. The registry cluster has a producer that *can* die, and when it did, five days passed unnoticed — calling that "meaningless" would be the exemption this file's header warns about.

So `coveredBy` names the lane carrying liveness, turning an exemption into a redirection a reader can follow. Its doc comment states the bar for adding one: *the named lane must alarm on both the producer failing and the producer stopping, or this is a blind spot with a citation.*

## The protection moves rather than disappearing

The replacement test asserts a registry-cluster table may drop its bound **only** by naming its covering lane — and checks that name against `REGISTRY_SYNC_LANE` **imported from the producer**, not a string literal. Renaming the lane now breaks the test instead of silently orphaning four tables, which is exactly how `knownIssue: "#9779"` rotted. A second, general test pins that any `coveredBy` implies a null bound and a non-empty reason, so a future `null` cannot quietly mean "silenced".

## Proven to fail three ways

```
dropped coveredBy from providers  → providers must name the lane that carries its liveness
coveredBy: "registry-synk"        → same assertion, caught on the typo
coveredBy beside a 48h bound      → "a change-driven producer cannot carry a time bound"
                                  + "coveredBy is only meaningful without a bound"
```

## Also

- `knownIssue: "#9779"` dropped from all four — it pointed at a **closed** issue, sending readers to a completed fix with no explanation for the 57.2h in front of them.
- `surface_history`'s reason read "append-on-change, but its writer is dead". False since the writer was re-homed on 2026-08-08.

## Verification

- `tsc --noEmit` clean
- 123 tests pass across all six suites that touch `TABLE_FRESHNESS`
- `prettier --check` clean
- Rebased onto `508fd152f`, then tsc + 50 tests re-run and `coveredBy` re-confirmed present

Closes #10657
