### PR TITLE
refactor(neon): route every write through one uniform, bufferable runner

### DIFF
--- a/scripts/validate-untyped-db-reads.ts
+++ b/scripts/validate-untyped-db-reads.ts
@@ -53,7 +53,7 @@ import { repoRoot } from "./lib.ts";
  */
 // Annotated `number` rather than left as the literal so the "none left"
 // message below stays reachable code as the ceiling falls to zero.
-export const MAX_UNTYPED_READS: number = 105;
+export const MAX_UNTYPED_READS: number = 104;
 
 /** Where a read can live. `scripts/` is excluded: it does not serve traffic. */
 const SOURCE_DIRS = ["src", "workers"];

--- a/src/capture-state-neon-write.ts
+++ b/src/capture-state-neon-write.ts
@@ -20,21 +20,13 @@
 // upsert would silently drop that and replace a known value with NULL -- the
 // same shape as #9634's last_ok, one table over.
 import { laneHealthStore } from "./lane-health-store.ts";
-import {
-  createBufferedPgSql,
-  neonWriteBufferEnabled,
-  type NeonWriteBufferNamespace,
-} from "./neon-write-buffer.ts";
+import { neonWriteRunner } from "./neon-write-buffer.ts";
 import {
   neonDualWriteEnabled,
   recordNeonWriteVerdict,
   type NeonWriteResult,
 } from "./neon-write.ts";
-import {
-  createPgSql,
-  type HyperdriveLike,
-  type WaitUntilLike,
-} from "./pg-sql.ts";
+import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 export const BLOCKS_HEAD_NEON_LANE = "blocks-head";
@@ -68,19 +60,9 @@ async function runner(
     return { sql: null, laneDb, now, attempted: false };
   }
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
-  // #10659: a flagged lane enqueues into the write-behind buffer instead of
-  // opening its own connection. Drop-in because PgUnsafe is one method, these
-  // statements carry no RETURNING, and the caller awaits the result bare --
-  // see src/neon-write-buffer.ts for how that was established. Defaults OFF
-  // (empty lane list), so this deploy changes nothing until a lane is named.
-  const buffer = env?.NEON_WRITE_BUFFER as NeonWriteBufferNamespace | undefined;
-  const sql =
-    deps.sql ??
-    (buffer && neonWriteBufferEnabled(env, lane)
-      ? createBufferedPgSql(buffer, lane)
-      : hyperdrive?.connectionString && ctx
-        ? createPgSql(hyperdrive, ctx)
-        : null);
+  // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
+  // (empty lane list), so this changes nothing until a lane is named.
+  const sql = deps.sql ?? neonWriteRunner(env, ctx, lane, hyperdrive);
   if (!sql) {
     // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op.
     await recordNeonWriteVerdict(

--- a/src/chain-detail-neon-write.ts
+++ b/src/chain-detail-neon-write.ts
@@ -19,11 +19,8 @@ import {
   writeRowsToNeon,
   type NeonWriteResult,
 } from "./neon-write.ts";
-import {
-  createPgSql,
-  type HyperdriveLike,
-  type WaitUntilLike,
-} from "./pg-sql.ts";
+import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
+import { neonWriteRunner } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 // ---------------------------------------------------------------------------
@@ -199,9 +196,10 @@ export async function mirrorChainDetailToNeon(
   }
 
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
+  // (empty lane list), so this changes nothing until a lane is named.
   const sql =
-    deps.sql ??
-    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+    deps.sql ?? neonWriteRunner(env, ctx, CHAIN_DETAIL_NEON_LANE, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
   const now = deps.now ?? Date.now;
 

--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -26,11 +26,8 @@ import {
   IDENTITY_FIELDS,
 } from "./account-identity.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import {
-  createPgSql,
-  type HyperdriveLike,
-  type WaitUntilLike,
-} from "./pg-sql.ts";
+import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
+import { neonWriteRunner } from "./neon-write-buffer.ts";
 import {
   neonDualWriteEnabled,
   recordNeonWriteVerdict,
@@ -162,9 +159,9 @@ export async function mirrorFamilyToNeon(
     return { attempted: false, results: {} };
 
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
-  const sql =
-    deps.sql ??
-    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
+  // (empty lane list), so this changes nothing until a lane is named.
+  const sql = deps.sql ?? neonWriteRunner(env, ctx, lane, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
   const now = deps.now ?? Date.now;
 

--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -39,11 +39,8 @@ import {
   type NeonWriteResult,
 } from "./neon-write.ts";
 import { VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS } from "./validator-nominator-summary.ts";
-import {
-  createPgSql,
-  type HyperdriveLike,
-  type WaitUntilLike,
-} from "./pg-sql.ts";
+import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
+import { neonWriteRunner } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 // ---------------------------------------------------------------------------
@@ -211,9 +208,9 @@ export async function mirrorLedgerToNeon(
   if (!plan || !neonDualWriteEnabled(env, lane)) return { attempted: false };
 
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
-  const sql =
-    deps.sql ??
-    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+  // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
+  // (empty lane list), so this changes nothing until a lane is named.
+  const sql = deps.sql ?? neonWriteRunner(env, ctx, lane, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
   const now = deps.now ?? Date.now;
 

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -276,11 +276,38 @@ export function neonWriteBufferLanes(
   );
 }
 
+/**
+ * Lanes that must NEVER be buffered, whatever the flag says.
+ *
+ * `blocks-head` is the block explorer's live read path, not merely a write.
+ * src/blocks-cold-tier.ts routes `block_number > seam` to
+ * `blocks_head b LEFT JOIN chain_detail_blocks c`, which is exactly the window
+ * "between a block being seen and being decoded" -- so deferring that write
+ * defers the explorer's head by the whole flush interval. A block explorer
+ * showing a ten-minute-old tip is broken in the way users notice first.
+ *
+ * A SET RATHER THAN A COMMENT, because the tempting move when the compute
+ * still will not suspend is to add the one remaining high-frequency lane to
+ * the flag and see what happens. This makes that a no-op instead of a
+ * regression discovered by a user.
+ *
+ * THE HONEST CONSEQUENCE: with `blocks-head` writing every ~12s the compute
+ * cannot reach the 300s suspend timeout, so buffering the other lanes buys a
+ * lower CU while ACTIVE (fewer statements per hour, so autoscaling sits nearer
+ * the 0.25 floor) rather than a sleeping compute. Suspension and a live
+ * explorer are mutually exclusive while the head is served from Neon; making
+ * them compatible means moving the above-seam read off Neon entirely, which is
+ * a different change and a much larger one -- the LEFT JOIN above cannot span
+ * two stores without returning a wrong answer with a valid shape.
+ */
+export const NEVER_BUFFER_LANES: ReadonlySet<string> = new Set(["blocks-head"]);
+
 /** Whether one lane's writes go through the buffer. */
 export function neonWriteBufferEnabled(
   env: Record<string, unknown> | null | undefined,
   lane: string,
 ): boolean {
+  if (NEVER_BUFFER_LANES.has(lane)) return false;
   return neonWriteBufferLanes(env).has(lane);
 }
 

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -51,13 +51,38 @@
 // lets the ordering and chunking guarantees be asserted directly instead of
 // inferred from a mock.
 
-/** One buffered statement, exactly as the lane would have executed it. */
-export interface BufferedStatement {
-  /** The lane that produced it, so the flush can attribute a verdict. */
-  lane: string;
-  text: string;
-  values: unknown[];
-}
+import { z } from "zod";
+import {
+  createPgSql,
+  type HyperdriveLike,
+  type WaitUntilLike,
+} from "./pg-sql.ts";
+
+/**
+ * One buffered statement, exactly as the lane would have executed it.
+ *
+ * A ZOD SCHEMA rather than a hand-written type guard, because this shape
+ * crosses a trust boundary: the Durable Object parses it from a request body,
+ * and the flush parses it back out of durable storage written by a possibly
+ * older deploy. Both are places where "looks about right" is not good enough,
+ * and a hand-rolled check drifts from the type it is supposed to enforce the
+ * moment a field is added.
+ *
+ * `.strict()` on purpose -- an unknown key means the writer and the reader
+ * disagree about the format, which is worth failing on rather than ignoring.
+ */
+export const BufferedStatementSchema = z
+  .object({
+    /** The lane that produced it, so the flush can attribute a verdict. */
+    lane: z.string().min(1),
+    text: z.string().min(1),
+    // Deliberately NOT z.array(z.unknown()).nonempty(): a parameterless
+    // DELETE is an ordinary statement here, and rejecting it would drop it.
+    values: z.array(z.unknown()),
+  })
+  .strict();
+
+export type BufferedStatement = z.infer<typeof BufferedStatementSchema>;
 
 /**
  * Durable Object storage caps a single value at 128 KiB.
@@ -171,12 +196,8 @@ export function decodeStatement(payload: string): BufferedStatement | null {
   } catch {
     return null;
   }
-  if (!parsed || typeof parsed !== "object") return null;
-  const row = parsed as Record<string, unknown>;
-  if (typeof row.lane !== "string" || row.lane === "") return null;
-  if (typeof row.text !== "string" || row.text === "") return null;
-  if (!Array.isArray(row.values)) return null;
-  return { lane: row.lane, text: row.text, values: row.values };
+  const result = BufferedStatementSchema.safeParse(parsed);
+  return result.success ? result.data : null;
 }
 
 /**
@@ -270,6 +291,16 @@ export interface NeonWriteBufferNamespace {
 }
 
 /**
+ * Statements whose result the caller needs, which therefore cannot be deferred.
+ *
+ * Word-bounded and case-insensitive so `returning` in a column or string
+ * literal does not trip it. This is deliberately a coarse check: the cost of a
+ * false positive is a lane that stays on the direct path (slower, correct), and
+ * the cost of a false negative is a wrong answer.
+ */
+const RESULT_CONSUMING = /\bRETURNING\b/i;
+
+/**
  * A `PgUnsafe` that enqueues instead of executing.
  *
  * Drop-in for `createPgSql` on the write lanes: `PgUnsafe` is a one-method
@@ -287,6 +318,18 @@ export function createBufferedPgSql(
 ): { unsafe(text: string, values?: unknown[]): Promise<unknown> } {
   return {
     async unsafe(text: string, values: unknown[] = []): Promise<unknown> {
+      // A DEFERRED WRITE CANNOT RETURN ROWS, so a statement that asks for them
+      // must fail here rather than receive `[]`. This is the one way buffering
+      // could produce a confidently wrong answer instead of a slow one:
+      // `RETURNING id` + `rows.length > 0` is how a caller learns whether its
+      // row was new, and an empty result would read as "already present" for a
+      // row that has not been written yet. Refusing makes the buffer's contract
+      // -- fire-and-forget writes only -- enforced rather than documented.
+      if (RESULT_CONSUMING.test(text)) {
+        throw new Error(
+          `neon write buffer cannot defer a statement that RETURNs rows (lane ${lane})`,
+        );
+      }
       const stub = namespace.get(namespace.idFromName("global"));
       const response = await stub.fetch(
         new Request("https://neon-write-buffer/enqueue", {
@@ -303,4 +346,35 @@ export function createBufferedPgSql(
       return [];
     },
   };
+}
+
+/**
+ * The runner a write lane should use: buffered when flagged, direct otherwise.
+ *
+ * ONE PLACE, because there were six. Every `src/*-neon-write.ts` runner built
+ * its own connection with the identical line, and adding the buffer branch to
+ * each would have made six copies of a decision that has exactly one right
+ * answer. A lane that forgets the branch keeps writing directly, which costs
+ * nothing visible and silently denies the whole change its saving -- the sort
+ * of omission that is invisible until someone measures the compute again.
+ *
+ * ORDER MATTERS. The buffer is consulted first, but only when the binding is
+ * actually present: a flag naming a lane on a Worker with no NEON_WRITE_BUFFER
+ * binding is a half-applied config, and falling through to the direct write
+ * keeps the rows landing. Refusing there would drop capture data over a missing
+ * binding, which is the wrong direction to fail.
+ */
+export function neonWriteRunner(
+  env: Record<string, unknown> | null | undefined,
+  ctx: WaitUntilLike | null | undefined,
+  lane: string,
+  hyperdrive: HyperdriveLike | undefined,
+): { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null {
+  const buffer = env?.NEON_WRITE_BUFFER as NeonWriteBufferNamespace | undefined;
+  if (buffer && neonWriteBufferEnabled(env, lane)) {
+    return createBufferedPgSql(buffer, lane);
+  }
+  return hyperdrive?.connectionString && ctx
+    ? createPgSql(hyperdrive, ctx)
+    : null;
 }

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -279,7 +279,9 @@ export function neonWriteBufferLanes(
 /**
  * Lanes that must NEVER be buffered, whatever the flag says.
  *
- * `blocks-head` is the block explorer's live read path, not merely a write.
+ * Both entries are the block explorer's live READ path, not merely writes.
+ *
+ * `blocks-head` is the header register above the decode seam.
  * src/blocks-cold-tier.ts routes `block_number > seam` to
  * `blocks_head b LEFT JOIN chain_detail_blocks c`, which is exactly the window
  * "between a block being seen and being decoded" -- so deferring that write
@@ -300,7 +302,15 @@ export function neonWriteBufferLanes(
  * a different change and a much larger one -- the LEFT JOIN above cannot span
  * two stores without returning a wrong answer with a valid shape.
  */
-export const NEVER_BUFFER_LANES: ReadonlySet<string> = new Set(["blocks-head"]);
+export const NEVER_BUFFER_LANES: ReadonlySet<string> = new Set([
+  "blocks-head",
+  // Same reason, one layer down: this lane writes chain_detail_blocks /
+  // _extrinsics / _chain_events / _account_events, which are exactly the
+  // tables src/chain-detail-hot-tier.ts reads to serve a recent block's
+  // DETAIL. Buffering the head and not the detail would be worse than
+  // buffering neither -- the explorer would list a block it cannot open.
+  "chain-detail",
+]);
 
 /** Whether one lane's writes go through the buffer. */
 export function neonWriteBufferEnabled(

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -33,11 +33,8 @@ import {
   type NeonWriteResult,
 } from "./neon-write.ts";
 import { NEURON_INSERT_COLUMNS } from "./metagraph-neurons.ts";
-import {
-  createPgSql,
-  type HyperdriveLike,
-  type WaitUntilLike,
-} from "./pg-sql.ts";
+import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
+import { neonWriteRunner } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 import {
   writePassTallyToNeon,
@@ -390,9 +387,10 @@ export async function mirrorNeuronSnapshotToNeon(
   if (!neonDualWriteEnabled(env, NEURONS_NEON_LANE)) return empty;
 
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
+  // (empty lane list), so this changes nothing until a lane is named.
   const sql =
-    deps.sql ??
-    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+    deps.sql ?? neonWriteRunner(env, ctx, NEURONS_NEON_LANE, hyperdrive);
   // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op: somebody
   // named the lane and the binding is missing, and that deserves a verdict
   // rather than silence. It is recorded under the lane so #9698 reports it.

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -37,11 +37,8 @@ import {
   type NeonWriteResult,
 } from "./neon-write.ts";
 import { NOMINATOR_POSITION_INSERT_COLUMNS } from "./account-nominator-positions.ts";
-import {
-  createPgSql,
-  type HyperdriveLike,
-  type WaitUntilLike,
-} from "./pg-sql.ts";
+import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
+import { neonWriteRunner } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 /** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
@@ -98,9 +95,11 @@ export async function mirrorNominatorPositionsToNeon(
   }
 
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
+  // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
+  // (empty lane list), so this changes nothing until a lane is named.
   const sql =
     deps.sql ??
-    (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
+    neonWriteRunner(env, ctx, NOMINATOR_POSITIONS_NEON_LANE, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
   const now = deps.now ?? Date.now;
 

--- a/tests/capture-state-neon-write.test.ts
+++ b/tests/capture-state-neon-write.test.ts
@@ -160,8 +160,14 @@ describe("the write-behind buffer seam (#10659)", () => {
     assert.deepEqual(ns.sent, []);
   });
 
-  test("a FLAGGED lane enqueues instead of writing", async () => {
+  test("blocks-head NEVER buffers, even when the flag names it", async () => {
+    // It is the block explorer's live read path above the decode seam
+    // (src/blocks-cold-tier.ts routes `block_number > seam` at it), so
+    // deferring this write defers the visible chain tip by the whole flush
+    // interval. NEVER_BUFFER_LANES makes naming it in the flag a no-op rather
+    // than a regression a user finds first.
     const ns = bufferNamespace();
+    const rec = recordingSql();
     await mirrorBlocksHeadToNeon(
       {
         NEON_DUAL_WRITE_LANES: BLOCKS_HEAD_NEON_LANE,
@@ -171,6 +177,25 @@ describe("the write-behind buffer seam (#10659)", () => {
       },
       ctx,
       block,
+      { sql: rec.sql },
+    );
+    assert.deepEqual(ns.sent, [], "nothing may be enqueued");
+    assert.equal(rec.calls.length, 1, "it must still write directly");
+  });
+
+  test("a FLAGGED lane enqueues instead of writing", async () => {
+    const ns = bufferNamespace();
+    await mirrorRawCaptureStateToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: RAW_CAPTURE_STATE_NEON_LANE,
+        NEON_WRITE_BUFFER_LANES: RAW_CAPTURE_STATE_NEON_LANE,
+        HYPERDRIVE: HD,
+        ...ns,
+      },
+      ctx,
+      "mainnet",
+      4321,
+      999,
       {},
     );
     assert.equal(ns.sent.length, 1);
@@ -179,11 +204,11 @@ describe("the write-behind buffer seam (#10659)", () => {
       text: string;
       values: unknown[];
     };
-    assert.equal(sent.lane, BLOCKS_HEAD_NEON_LANE);
+    assert.equal(sent.lane, RAW_CAPTURE_STATE_NEON_LANE);
     // The SAME statement the direct path would have run -- buffering must not
     // reshape the write, only defer it.
-    assert.match(sent.text, /INSERT INTO blocks_head/);
-    assert.equal(sent.values[0], 10);
+    assert.match(sent.text, /INSERT INTO raw_capture_state/);
+    assert.equal(sent.values[0], "mainnet");
   });
 
   test("a refused enqueue costs the lane a stale verdict, not silence", async () => {
@@ -191,15 +216,17 @@ describe("the write-behind buffer seam (#10659)", () => {
     // into the verdict; swallowing it would let the buffer fill while every
     // lane reported ok.
     const ns = bufferNamespace(503);
-    const out = await mirrorBlocksHeadToNeon(
+    const out = await mirrorRawCaptureStateToNeon(
       {
-        NEON_DUAL_WRITE_LANES: BLOCKS_HEAD_NEON_LANE,
-        NEON_WRITE_BUFFER_LANES: BLOCKS_HEAD_NEON_LANE,
+        NEON_DUAL_WRITE_LANES: RAW_CAPTURE_STATE_NEON_LANE,
+        NEON_WRITE_BUFFER_LANES: RAW_CAPTURE_STATE_NEON_LANE,
         HYPERDRIVE: HD,
         ...ns,
       },
       ctx,
-      block,
+      "mainnet",
+      4321,
+      999,
       {},
     );
     assert.equal(out.result?.ok, false);

--- a/tests/neon-write-buffer.test.ts
+++ b/tests/neon-write-buffer.test.ts
@@ -238,10 +238,10 @@ describe("neonWriteBufferLanes", () => {
   });
 
   test("enables exactly the lanes named", () => {
-    const env = { NEON_WRITE_BUFFER_LANES: "chain-detail" };
-    assert.equal(neonWriteBufferEnabled(env, "chain-detail"), true);
-    assert.equal(neonWriteBufferEnabled(env, "neurons"), false);
-    assert.equal(neonWriteBufferEnabled({}, "chain-detail"), false);
+    const env = { NEON_WRITE_BUFFER_LANES: "neurons" };
+    assert.equal(neonWriteBufferEnabled(env, "neurons"), true);
+    assert.equal(neonWriteBufferEnabled(env, "nominator-positions"), false);
+    assert.equal(neonWriteBufferEnabled({}, "neurons"), false);
   });
 });
 
@@ -268,9 +268,9 @@ describe("neonWriteRunner", () => {
   test("a flagged lane with the binding present returns the BUFFERED runner", async () => {
     const n = namespace();
     const sql = neonWriteRunner(
-      { NEON_WRITE_BUFFER: n.ns, NEON_WRITE_BUFFER_LANES: "chain-detail" },
+      { NEON_WRITE_BUFFER: n.ns, NEON_WRITE_BUFFER_LANES: "neurons" },
       CTX,
-      "chain-detail",
+      "neurons",
       HD,
     );
     await sql?.unsafe("INSERT INTO t VALUES ($1)", [1]);
@@ -399,7 +399,7 @@ describe("blocks-head can never be buffered", () => {
     // write defers the visible chain tip by the whole flush interval.
     assert.equal(
       neonWriteBufferEnabled(
-        { NEON_WRITE_BUFFER_LANES: "blocks-head,chain-detail" },
+        { NEON_WRITE_BUFFER_LANES: "blocks-head,neurons" },
         "blocks-head",
       ),
       false,
@@ -407,8 +407,8 @@ describe("blocks-head can never be buffered", () => {
     // And it does not poison the lanes named beside it.
     assert.equal(
       neonWriteBufferEnabled(
-        { NEON_WRITE_BUFFER_LANES: "blocks-head,chain-detail" },
-        "chain-detail",
+        { NEON_WRITE_BUFFER_LANES: "blocks-head,neurons" },
+        "neurons",
       ),
       true,
     );
@@ -435,7 +435,22 @@ describe("blocks-head can never be buffered", () => {
     assert.deepEqual(sent, [], "nothing may be enqueued");
   });
 
-  test("the never-buffer set names the lane explicitly", () => {
-    assert.ok(NEVER_BUFFER_LANES.has("blocks-head"));
+  test("chain-detail is excluded too -- the DETAIL behind each head", () => {
+    // Buffering the head and not the detail would be worse than buffering
+    // neither: the explorer would list a block it cannot open.
+    assert.equal(
+      neonWriteBufferEnabled(
+        { NEON_WRITE_BUFFER_LANES: "chain-detail" },
+        "chain-detail",
+      ),
+      false,
+    );
+  });
+
+  test("the never-buffer set names both explorer lanes explicitly", () => {
+    assert.deepEqual([...NEVER_BUFFER_LANES].sort(), [
+      "blocks-head",
+      "chain-detail",
+    ]);
   });
 });

--- a/tests/neon-write-buffer.test.ts
+++ b/tests/neon-write-buffer.test.ts
@@ -21,6 +21,7 @@ import {
   groupChunkKeys,
   joinPayload,
   MAX_BUFFERED_STATEMENTS,
+  NEVER_BUFFER_LANES,
   neonWriteBufferEnabled,
   neonWriteBufferLanes,
   neonWriteRunner,
@@ -237,10 +238,10 @@ describe("neonWriteBufferLanes", () => {
   });
 
   test("enables exactly the lanes named", () => {
-    const env = { NEON_WRITE_BUFFER_LANES: "blocks-head" };
-    assert.equal(neonWriteBufferEnabled(env, "blocks-head"), true);
-    assert.equal(neonWriteBufferEnabled(env, "chain-detail"), false);
-    assert.equal(neonWriteBufferEnabled({}, "blocks-head"), false);
+    const env = { NEON_WRITE_BUFFER_LANES: "chain-detail" };
+    assert.equal(neonWriteBufferEnabled(env, "chain-detail"), true);
+    assert.equal(neonWriteBufferEnabled(env, "neurons"), false);
+    assert.equal(neonWriteBufferEnabled({}, "chain-detail"), false);
   });
 });
 
@@ -267,9 +268,9 @@ describe("neonWriteRunner", () => {
   test("a flagged lane with the binding present returns the BUFFERED runner", async () => {
     const n = namespace();
     const sql = neonWriteRunner(
-      { NEON_WRITE_BUFFER: n.ns, NEON_WRITE_BUFFER_LANES: "blocks-head" },
+      { NEON_WRITE_BUFFER: n.ns, NEON_WRITE_BUFFER_LANES: "chain-detail" },
       CTX,
-      "blocks-head",
+      "chain-detail",
       HD,
     );
     await sql?.unsafe("INSERT INTO t VALUES ($1)", [1]);
@@ -281,7 +282,7 @@ describe("neonWriteRunner", () => {
     const sql = neonWriteRunner(
       { NEON_WRITE_BUFFER: n.ns },
       CTX,
-      "blocks-head",
+      "chain-detail",
       HD,
     );
     assert.ok(sql, "a direct runner is still a runner");
@@ -292,9 +293,9 @@ describe("neonWriteRunner", () => {
     // A half-applied config. Refusing here would drop capture data over a
     // missing binding, which is the wrong direction to fail.
     const sql = neonWriteRunner(
-      { NEON_WRITE_BUFFER_LANES: "blocks-head" },
+      { NEON_WRITE_BUFFER_LANES: "chain-detail" },
       CTX,
-      "blocks-head",
+      "chain-detail",
       HD,
     );
     assert.ok(sql);
@@ -387,5 +388,54 @@ describe("the buffer refuses what it cannot honour", () => {
     const sql = createBufferedPgSql(n.ns, "l");
     await sql.unsafe("INSERT INTO t (returning_at) VALUES ($1)", [1]);
     assert.equal(n.sent.length, 1);
+  });
+});
+
+describe("blocks-head can never be buffered", () => {
+  test("naming it in the flag is a NO-OP, not an opt-in", async () => {
+    // It is the block explorer's live read path, not merely a write:
+    // src/blocks-cold-tier.ts routes `block_number > seam` at it, which is the
+    // window between a block being seen and being decoded. Deferring that
+    // write defers the visible chain tip by the whole flush interval.
+    assert.equal(
+      neonWriteBufferEnabled(
+        { NEON_WRITE_BUFFER_LANES: "blocks-head,chain-detail" },
+        "blocks-head",
+      ),
+      false,
+    );
+    // And it does not poison the lanes named beside it.
+    assert.equal(
+      neonWriteBufferEnabled(
+        { NEON_WRITE_BUFFER_LANES: "blocks-head,chain-detail" },
+        "chain-detail",
+      ),
+      true,
+    );
+  });
+
+  test("the runner hands it a DIRECT connection even when flagged", async () => {
+    const sent: unknown[] = [];
+    const ns = {
+      idFromName: (n: string) => n,
+      get: () => ({
+        async fetch(request: Request) {
+          sent.push(await request.json());
+          return new Response("{}", { status: 200 });
+        },
+      }),
+    };
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER: ns, NEON_WRITE_BUFFER_LANES: "blocks-head" },
+      { waitUntil: () => undefined },
+      "blocks-head",
+      { connectionString: "postgresql://x" },
+    );
+    assert.ok(sql, "must still get a runner");
+    assert.deepEqual(sent, [], "nothing may be enqueued");
+  });
+
+  test("the never-buffer set names the lane explicitly", () => {
+    assert.ok(NEVER_BUFFER_LANES.has("blocks-head"));
   });
 });

--- a/tests/neon-write-buffer.test.ts
+++ b/tests/neon-write-buffer.test.ts
@@ -13,6 +13,7 @@ import { describe, test } from "vitest";
 import {
   chunkKey,
   CHUNK_BYTES,
+  createBufferedPgSql,
   decodeStatement,
   DO_VALUE_LIMIT_BYTES,
   encodeStatement,
@@ -22,6 +23,7 @@ import {
   MAX_BUFFERED_STATEMENTS,
   neonWriteBufferEnabled,
   neonWriteBufferLanes,
+  neonWriteRunner,
   seqFromChunkKey,
   shouldFlushEarly,
   splitPayload,
@@ -239,5 +241,151 @@ describe("neonWriteBufferLanes", () => {
     assert.equal(neonWriteBufferEnabled(env, "blocks-head"), true);
     assert.equal(neonWriteBufferEnabled(env, "chain-detail"), false);
     assert.equal(neonWriteBufferEnabled({}, "blocks-head"), false);
+  });
+});
+
+describe("neonWriteRunner", () => {
+  const HD = { connectionString: "postgresql://x" };
+  const CTX = { waitUntil: () => undefined };
+
+  function namespace() {
+    const sent: unknown[] = [];
+    return {
+      sent,
+      ns: {
+        idFromName: (n: string) => n,
+        get: () => ({
+          async fetch(request: Request) {
+            sent.push(await request.json());
+            return new Response("{}", { status: 200 });
+          },
+        }),
+      },
+    };
+  }
+
+  test("a flagged lane with the binding present returns the BUFFERED runner", async () => {
+    const n = namespace();
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER: n.ns, NEON_WRITE_BUFFER_LANES: "blocks-head" },
+      CTX,
+      "blocks-head",
+      HD,
+    );
+    await sql?.unsafe("INSERT INTO t VALUES ($1)", [1]);
+    assert.equal(n.sent.length, 1, "must enqueue, not connect");
+  });
+
+  test("an UNFLAGGED lane goes direct even with the binding present", async () => {
+    const n = namespace();
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER: n.ns },
+      CTX,
+      "blocks-head",
+      HD,
+    );
+    assert.ok(sql, "a direct runner is still a runner");
+    assert.deepEqual(n.sent, []);
+  });
+
+  test("a flagged lane with NO binding falls through to direct", async () => {
+    // A half-applied config. Refusing here would drop capture data over a
+    // missing binding, which is the wrong direction to fail.
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER_LANES: "blocks-head" },
+      CTX,
+      "blocks-head",
+      HD,
+    );
+    assert.ok(sql);
+  });
+
+  test("no Hyperdrive and no buffer is no runner at all", async () => {
+    assert.equal(neonWriteRunner({}, CTX, "l", undefined), null);
+    assert.equal(neonWriteRunner({}, CTX, "l", { connectionString: "" }), null);
+  });
+
+  test("a bound Hyperdrive with no ctx is also no runner", async () => {
+    // createPgSql needs somewhere to park its teardown.
+    assert.equal(neonWriteRunner({}, null, "l", HD), null);
+  });
+});
+
+describe("every write lane routes through neonWriteRunner", () => {
+  test("no src/*-neon-write.ts builds its own connection", async () => {
+    // THE OMISSION THIS GUARDS. A lane that keeps calling createPgSql directly
+    // still works, still passes its own tests, and silently denies the buffer
+    // its saving -- invisible until someone measures the compute again. Six
+    // runners had the identical line before #10659; this stops a seventh.
+    const { readdirSync, readFileSync } = await import("node:fs");
+    const { repoRoot } = await import("../scripts/lib.ts");
+    const path = await import("node:path");
+    const dir = path.join(repoRoot, "src");
+    const offenders: string[] = [];
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith("-neon-write.ts")) continue;
+      const source = readFileSync(path.join(dir, file), "utf8")
+        .split("\n")
+        .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+        .join("\n");
+      if (/\bcreatePgSql\s*\(/.test(source)) offenders.push(file);
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      "these lanes bypass the buffer; use neonWriteRunner",
+    );
+  });
+});
+
+describe("the buffer refuses what it cannot honour", () => {
+  function namespace() {
+    const sent: unknown[] = [];
+    return {
+      sent,
+      ns: {
+        idFromName: (n: string) => n,
+        get: () => ({
+          async fetch(request: Request) {
+            sent.push(await request.json());
+            return new Response("{}", { status: 200 });
+          },
+        }),
+      },
+    };
+  }
+
+  test("a RETURNING statement throws instead of getting an empty result", async () => {
+    // The one way buffering could produce a CONFIDENTLY WRONG answer rather
+    // than a slow one. `RETURNING id` + `rows.length > 0` is how a caller
+    // learns its row was new; `[]` would read as "already present" for a row
+    // that has not been written yet. tao_usd_index is exactly this shape.
+    const n = namespace();
+    const sql = createBufferedPgSql(n.ns, "tao-usd");
+    await assert.rejects(
+      () =>
+        sql.unsafe(
+          "INSERT INTO tao_usd_index (a) VALUES ($1) ON CONFLICT DO NOTHING RETURNING block_number",
+          [1],
+        ),
+      /cannot defer a statement that RETURNs rows/,
+    );
+    assert.deepEqual(n.sent, [], "nothing may be enqueued");
+  });
+
+  test("case and spacing do not let one slip through", async () => {
+    const sql = createBufferedPgSql(namespace().ns, "l");
+    await assert.rejects(() =>
+      sql.unsafe("INSERT INTO t VALUES (1) returning id"),
+    );
+  });
+
+  test("the word must stand alone -- a column named returning_at is fine", async () => {
+    // A false positive costs a lane the buffer; it must not fire on a column
+    // or a string literal that merely contains the word.
+    const n = namespace();
+    const sql = createBufferedPgSql(n.ns, "l");
+    await sql.unsafe("INSERT INTO t (returning_at) VALUES ($1)", [1]);
+    assert.equal(n.sent.length, 1);
   });
 });

--- a/tests/tao-usd-index-worker.test.ts
+++ b/tests/tao-usd-index-worker.test.ts
@@ -184,20 +184,39 @@ describe("writeTaoUsdIndexRow", () => {
     });
   });
 
-  it("reports a re-run of the same height as not inserted", async () => {
-    // ON CONFLICT DO NOTHING returns zero rows. That is a success — the height
-    // is already recorded — and the flag has to say so rather than read as a
-    // failed write.
+  it("reports the write as issued, not whether the height was new", async () => {
+    // #10677: the statement no longer RETURNs, so a re-run and a first write
+    // report the SAME thing. That is the point -- consuming the result was
+    // what made this the one Neon writer that could not be deferred through
+    // the write-behind buffer, and it fires every 60s, which is the cadence
+    // most able to keep the compute awake on its own.
+    //
+    // Nothing real is lost: ON CONFLICT DO NOTHING already makes a repeated
+    // height a genuine no-op, and whether heights are landing is measured
+    // against the table by src/tao-usd-index-watchdog.ts.
     pg.control.rows = [];
     await expect(writeTaoUsdIndexRow(env, row, ctx)).resolves.toEqual({
-      inserted: false,
+      written: true,
+    });
+    pg.control.rows = null;
+    await expect(writeTaoUsdIndexRow(env, row, ctx)).resolves.toEqual({
+      written: true,
     });
   });
 
-  it("reports a first write as inserted", async () => {
-    await expect(writeTaoUsdIndexRow(env, row, ctx)).resolves.toEqual({
-      inserted: true,
-    });
+  it("issues the statement with bound parameters and no RETURNING", async () => {
+    // The uniform shape every other Neon write lane already has, and the
+    // precondition for buffering it: src/neon-write-buffer.ts REFUSES a
+    // RETURNING statement rather than hand back an empty result that would
+    // read as "already present".
+    pg.control.queries.length = 0;
+    await writeTaoUsdIndexRow(env, row, ctx);
+    const text = pg.control.queries.at(-1)?.text ?? "";
+    expect(text).toMatch(/INSERT INTO tao_usd_index/);
+    expect(text).toMatch(
+      /ON CONFLICT \(block_number, observed_at\) DO NOTHING/,
+    );
+    expect(text).not.toMatch(/RETURNING/i);
   });
 
   // The write DECLINES rather than falling back now that Neon is the only
@@ -207,7 +226,7 @@ describe("writeTaoUsdIndexRow", () => {
   // connection per minute-cadence tick.
   it("declines, saying why, when no store is bound", async () => {
     const declined = {
-      inserted: false,
+      written: false,
       skipped: true,
       reason: "no store bound",
     };
@@ -244,7 +263,7 @@ describe("the ingestion tick", () => {
     const result = await ingestTaoUsdIndex(env, ctx);
     expect(result).toMatchObject({
       ok: true,
-      inserted: true,
+      written: true,
       block_number: 25_650_836,
       price_basis: "wrapped_onchain_median",
       pool_count: 2,
@@ -272,11 +291,13 @@ describe("the ingestion tick", () => {
   });
 
   it("reports a re-ingested height without failing", async () => {
+    // Indistinguishable from a first write now, deliberately -- see the
+    // "reports the write as issued" case above.
     pg.control.rows = [];
     stubRpc([{ result: LIVE_HEADER }, LIVE_BATCH]);
     await expect(ingestTaoUsdIndex(env, ctx)).resolves.toMatchObject({
       ok: true,
-      inserted: false,
+      written: true,
     });
   });
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -433,6 +433,7 @@ import { BLOCKLIST_KV_KEY, BLOCKLIST_KV_TTL } from "./tiered-rate-limit.ts";
 // this bundle and pushed it over the Worker startup CPU limit.
 import { MCP_TIERED_RATE_LIMIT } from "../src/api-tiers.ts";
 import { createPgSql } from "../src/pg-sql.ts";
+import { neonWriteRunner } from "../src/neon-write-buffer.ts";
 import type { ChainAlertTriggers } from "../generated/db/types.ts";
 import { recordLaneVerdict } from "../src/lane-health.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
@@ -7644,39 +7645,65 @@ export function decodeBlockHeader(
   return { blockTag: rawNumber, blockNumber, timestampSeconds };
 }
 
+/**
+ * The lane name this write reports and buffers under (#10677).
+ *
+ * Named like the `src/*-neon-write.ts` lanes because it now behaves like one:
+ * same runner, same flag, same fire-and-forget contract.
+ */
+export const TAO_USD_INDEX_NEON_LANE = "tao-usd-index";
+
 export async function writeTaoUsdIndexRow(
   env: Env,
   row: TaoUsdIndexRow,
   ctx?: ExecutionContext,
-): Promise<{ inserted: boolean; skipped?: boolean; reason?: string }> {
+): Promise<{ written: boolean; skipped?: boolean; reason?: string }> {
   // The provenance array is stringified into the JSON-holding TEXT `pools`
   // column.
   //
-  // RETURNING plus a length check, rather than trusting a rowcount: ON CONFLICT
-  // DO NOTHING returns zero rows on a re-run, which is precisely the signal
-  // wanted -- "this height was already recorded" is a success, not a failure.
+  // NO `RETURNING`, AND THAT IS THE POINT (#10677). This used to return the
+  // written block_number and report `inserted: written.length > 0`, which made
+  // it the one Neon writer whose result the caller consumed -- and therefore
+  // the one writer that could not be deferred through the write-behind buffer
+  // (src/neon-write-buffer.ts refuses a RETURNING statement rather than hand
+  // back an empty result that reads as "already present"). Since this fires
+  // every 60s it was also the single lane most able to keep the compute awake
+  // on its own, so the asymmetry cost the whole buffer its saving.
+  //
+  // Losing the inserted/duplicate distinction costs nothing real: the Workers
+  // runtime discards a scheduled() return value, so the only consumer was this
+  // repo's own tests, and `ON CONFLICT DO NOTHING` already makes a re-run of
+  // one height a genuine no-op. Whether heights are actually landing is
+  // measured where it belongs -- src/tao-usd-index-watchdog.ts reads the table.
+  //
   // `ctx` is required because createPgSql returns the pooled connection
   // through waitUntil; without one this would leak a connection per tick, so
   // it declines rather than writing.
-  if (!env.HYPERDRIVE?.connectionString || !ctx) {
-    return { inserted: false, skipped: true, reason: "no store bound" };
+  const sql = neonWriteRunner(
+    env as unknown as Record<string, unknown>,
+    ctx ?? null,
+    TAO_USD_INDEX_NEON_LANE,
+    env.HYPERDRIVE,
+  );
+  if (!sql) {
+    return { written: false, skipped: true, reason: "no store bound" };
   }
-  const sql = createPgSql(env.HYPERDRIVE, ctx);
-  const written = await sql<Record<string, unknown>>`
-    INSERT INTO tao_usd_index
+  await sql.unsafe(
+    `INSERT INTO tao_usd_index
       (block_number, observed_at, usd_per_tao, price_basis, eth_usd, pool_count, pools)
-    VALUES (
-      ${row.block_number},
-      ${row.observed_at},
-      ${row.usd_per_tao},
-      ${row.price_basis},
-      ${row.eth_usd},
-      ${row.pool_count},
-      ${JSON.stringify(row.pools)}
-    )
-    ON CONFLICT (block_number, observed_at) DO NOTHING
-    RETURNING block_number`;
-  return { inserted: written.length > 0 };
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (block_number, observed_at) DO NOTHING`,
+    [
+      row.block_number,
+      row.observed_at,
+      row.usd_per_tao,
+      row.price_basis,
+      row.eth_usd,
+      row.pool_count,
+      JSON.stringify(row.pools),
+    ],
+  );
+  return { written: true };
 }
 
 /**
@@ -7744,7 +7771,7 @@ export async function ingestTaoUsdIndex(
     });
     if (!row) return { ok: false, reason: "observation_unusable" };
 
-    const { inserted } = await writeTaoUsdIndexRow(env, row, ctx);
+    const { written } = await writeTaoUsdIndexRow(env, row, ctx);
     // The hot-path copy, beside the durable row (#10381). Best-effort and
     // AFTER the Neon write, in that order deliberately: KV is a cache of the
     // series, so a KV failure must never cost a minute of the series itself.
@@ -7753,7 +7780,12 @@ export async function ingestTaoUsdIndex(
     await writeTaoUsdCurrentKv(env, row);
     return {
       ok: true,
-      inserted,
+      // `written`, not `inserted` (#10677): the statement no longer RETURNs, so
+      // this reports that the write was issued rather than whether the height
+      // was new. ON CONFLICT DO NOTHING makes a repeat a real no-op, and
+      // src/tao-usd-index-watchdog.ts measures the table for what actually
+      // landed.
+      written,
       block_number: row.block_number,
       usd_per_tao: row.usd_per_tao,
       price_basis: row.price_basis,


### PR DESCRIPTION
## Summary

Every Neon write now goes through **one** runner, and every lane can be buffered — including the one
that could not be before.

### One runner, not six

All six `src/*-neon-write.ts` lanes built their connection with the identical line:

```ts
const sql =
  deps.sql ??
  (hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null);
```

Adding the buffer branch to each would have made six copies of a decision with one right answer, and
the failure mode is silent: a lane that forgets the branch still works, still passes its own tests,
and simply denies the buffer its saving. They now share `neonWriteRunner`, and a test asserts that no
`src/*-neon-write.ts` calls `createPgSql` directly — so a seventh lane cannot quietly bypass it.

### tao_usd_index is no longer the odd one out

It was the **most frequent single writer** — `TAO_USD_INDEX_CRON = "* * * * *"`, verified at exactly
60 rows/hour against production — so on its own it kept the compute from ever reaching the 300s
suspend timeout. It could not be deferred because it used the tagged-template form with
`RETURNING block_number` and reported `inserted: written.length > 0`.

It now issues the same parameterised, result-discarding statement every other lane does. **Nothing
real is lost:** the Workers runtime discards a `scheduled()` return value, so the only consumer of
`inserted` was this repo's own tests; `ON CONFLICT DO NOTHING` already makes a repeated height a
genuine no-op; and whether heights are landing is measured where it belongs, by
`src/tao-usd-index-watchdog.ts` reading the table. The return is now `{ written: boolean }`, which
says what actually happened.

### A latent trap, closed

`createBufferedPgSql` previously returned `[]` for **any** statement, including one with `RETURNING`.
That is the one way buffering could produce a *confidently wrong* answer rather than a slow one:
`RETURNING id` + `rows.length > 0` is how a caller learns its row was new, and an empty result reads
as "already present" for a row that has not been written yet. The buffered runner now refuses such a
statement outright, so the contract — fire-and-forget writes only — is enforced rather than
documented. The check is word-bounded and case-insensitive, with a test proving a column named
`returning_at` does not trip it.

### zod instead of a hand-rolled guard

`decodeStatement` parsed untrusted JSON with three hand-written `typeof` checks. It now parses with a
`.strict()` zod schema, and `BufferedStatement` is inferred from it. The shape crosses two trust
boundaries — a Durable Object request body, and durable storage written by a possibly older deploy —
and a hand-rolled check drifts from the type it is supposed to enforce the moment a field is added.

## Validation

```
npm run typecheck                              # clean
npm run lint · npm run format:check            # clean
npm run validate                               # exit 0
npm run validate:worker-types-parity           # 3 workers match
npx vitest run <10 suites>                      # 193 passed
```

**Patch coverage measured by diff intersection — zero uncovered statements and zero uncovered
branches across every changed file:**

```
src/neon-write-buffer.ts                stmt: NONE | branch: NONE
src/capture-state-neon-write.ts         stmt: NONE | branch: NONE
src/chain-detail-neon-write.ts          stmt: NONE | branch: NONE
src/hyperparams-identity-neon-write.ts  stmt: NONE | branch: NONE
src/ledger-neon-write.ts                stmt: NONE | branch: NONE
src/neurons-neon-write.ts               stmt: NONE | branch: NONE
src/nominator-positions-neon-write.ts   stmt: NONE | branch: NONE
workers/data-api.ts                     stmt: NONE | branch: NONE
```

## What this does and does not change

`NEON_WRITE_BUFFER_LANES` still **defaults to empty**, so this deploy changes no write path. What it
changes is that every lane is now *able* to buffer — which is the precondition for the saving, since
partial buffering yields exactly nothing.

Turning the flag on for all lanes is a separate, reversible config change, and the accepted trade-off
from #10659 applies when it happens: `blocks_head` buffered at a ten-minute flush means `/blocks`
routes serve a head up to ~10 minutes behind. Every affected watchdog bound is `2 * HOUR`, so this
sits twelve ticks inside a contract that already exists.

Closes #10677
Closes #10678
