### PR TITLE
fix(owner-cut): read the share that exists, and stop tests reaching a live node (#10680)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2145,6 +2145,11 @@ const TOOL_ANNOTATIONS_BY_NAME: Record<
   get_account_snapshot: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_evm_address_mapping: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_network_parameters: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
+  // #10514-adjacent: reads the effective SubnetOwnerCut live, because "unset on
+  // chain, so use the runtime default" and "the read failed" are different
+  // answers and only a real read tells them apart. That is outbound I/O to a
+  // node we do not operate, so the annotation says so.
+  get_subnet_owner_cut: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_randomness_status: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_subnet_burn: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
   get_subnet_lease: OPEN_WORLD_READ_ONLY_TOOL_ANNOTATIONS,
@@ -9016,14 +9021,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       const economics = await mcpEconomicsRow(ctx, netuid);
-      const parameters = (await ctx.readArtifact!(
-        ctx.env,
-        "/metagraph/network/parameters.json",
-      )) as { ok?: boolean; data?: Record<string, unknown> } | null;
-      const ownerCut = parameters?.ok
-        ? (parameters.data?.subnet_owner_cut_effective as
-            number | null | undefined)
-        : null;
+      // The LIVE parameters read, not the served artifact: that artifact
+      // publishes no owner-cut field, so reading it returned undefined for
+      // every subnet and this tool reported "owner cut share not read" for all
+      // 129 (#10566's shape -- a decline standing in for a read that never
+      // happened). loadNetworkParameters is KV-cached.
+      // Injected when the caller supplies one, so a test drives the share
+      // without an outbound RPC -- the suite has no global fetch stub, and a
+      // live read here would put a public Bittensor node in the test path.
+      const loadParams =
+        (ctx as { loadNetworkParameters?: typeof loadNetworkParameters })
+          .loadNetworkParameters ?? loadNetworkParameters;
+      const parameters = await loadParams(ctx.env as never);
+      const ownerCut = parameters?.subnet_owner_cut_effective;
       const view = loadSubnetOwnerCut({
         netuid,
         window_days: 30,

--- a/tests/mcp-tool-annotations.test.ts
+++ b/tests/mcp-tool-annotations.test.ts
@@ -76,7 +76,14 @@ describe("MCP tool annotations", () => {
     // 22 since #9968 added list_crowdloans/get_crowdloan, which read the
     // Crowdloan pallet over live RPC -- genuinely outside our closed world,
     // the same reason get_subnet_lease carries the annotation.
-    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 22);
+    //
+    // 23 since get_subnet_owner_cut started reading the effective
+    // SubnetOwnerCut live. It used to read a served artifact that publishes no
+    // owner-cut field at all, so it reported "share not read" for all 129
+    // subnets -- a closed-world annotation that was only true because the read
+    // was broken. Widening the set here is the annotation catching up with a
+    // tool that now genuinely leaves our infrastructure.
+    assert.equal(OPEN_WORLD_TOOL_NAMES.length, 23);
     assert.ok(
       definitions.length > 200,
       `expected the full catalogue, saw ${definitions.length}`,

--- a/tests/no-outbound-fetch.test.ts
+++ b/tests/no-outbound-fetch.test.ts
@@ -1,0 +1,73 @@
+// The guard that keeps live hosts out of this suite, and the proof it fires.
+//
+// Written the way every gate in this repo has to be: the failing case first.
+// A guard nobody has seen refuse anything is indistinguishable from a guard
+// that silently allows everything, and this one wraps `fetch` — the single
+// easiest thing to accidentally neutralise.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { __guard } from "./setup/no-outbound-fetch.ts";
+
+describe("the outbound-fetch guard", () => {
+  test("REFUSES a call to a host we do not operate", async () => {
+    await assert.rejects(
+      () => globalThis.fetch("https://entrypoint-finney.opentensor.ai/"),
+      /Outbound network call to entrypoint-finney\.opentensor\.ai/,
+    );
+  });
+
+  test("names both ways out, so the failure is actionable", async () => {
+    const error = await globalThis.fetch("https://example.invalid/x").then(
+      () => null,
+      (e: Error) => e,
+    );
+    assert.ok(error);
+    assert.match(error.message, /inject the loader/);
+    assert.match(error.message, /stub `globalThis\.fetch`/);
+  });
+
+  test("allows loopback, which is the local harness and not somebody's API", () => {
+    for (const host of ["localhost", "127.0.0.1", "0.0.0.0"]) {
+      assert.equal(__guard.hostOf(`http://${host}:8787/x`), host);
+    }
+  });
+
+  test("does not treat a relative URL as outbound", () => {
+    // Resolved by whatever harness serves it; it never leaves the process.
+    assert.equal(__guard.hostOf("/api/v1/subnets/64"), null);
+    assert.equal(__guard.hostOf(""), null);
+    assert.equal(__guard.hostOf(undefined), null);
+  });
+
+  test("reads the host off a Request and a URL, not just a string", () => {
+    assert.equal(
+      __guard.hostOf(new Request("https://api.example.com/v1")),
+      "api.example.com",
+    );
+    assert.equal(
+      __guard.hostOf(new URL("https://other.example/x")),
+      "other.example",
+    );
+  });
+
+  test("a malformed URL is not silently treated as allowed", () => {
+    // hostOf returns null (unparseable), which the guard reads as "cannot
+    // leave the process" — the same as a relative URL. Asserted so a future
+    // change that starts throwing here is a visible decision.
+    assert.equal(__guard.hostOf("http://[not a url"), null);
+  });
+
+  test("a test's own stub still wins, so the existing convention is untouched", async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("stubbed", { status: 200 })) as typeof fetch;
+    try {
+      const res = await globalThis.fetch(
+        "https://entrypoint-finney.opentensor.ai/",
+      );
+      assert.equal(await res.text(), "stubbed");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/tests/setup/no-outbound-fetch.ts
+++ b/tests/setup/no-outbound-fetch.ts
@@ -1,0 +1,78 @@
+// No test may reach a host we do not operate.
+//
+// THE BUG THIS EXISTS TO STOP, which happened: a handler was switched from
+// reading a served artifact to `loadNetworkParameters`, which reads a public
+// Bittensor RPC. Its tests started making live calls to somebody else's node.
+// They PASSED IN ISOLATION -- the node answered -- and failed only under file
+// parallelism, which is the worst way to find out: the symptom looks like flake
+// and the cause looks like nothing.
+//
+// The convention was already right (`withFetchStub` in subnet-burn.test.ts, the
+// inline stub in account-balance-loader.test.ts). It was simply unenforced, and
+// an unenforced convention is one PR away from being untrue.
+//
+// ## Why this cooperates with per-test stubs rather than replacing them
+//
+// Most tests that exercise an outbound loader install their own
+// `globalThis.fetch` and assert on the request body. That is the right pattern
+// and this guard must not fight it: it snapshots the ORIGINAL fetch and only
+// refuses calls that reach THAT. A test which has replaced the global never
+// touches this code at all, so nothing about those tests changes.
+//
+// The guard is restored before each test, so a test that replaces the global
+// and forgets to restore it cannot leak its stub into the next file's tests --
+// a second failure mode the old convention also left open.
+import { beforeEach } from "vitest";
+
+/** Hosts a test may legitimately reach: none. The loopback entries exist for
+ * the workerd/miniflare harnesses, which serve the worker under test locally
+ * rather than calling anybody's API. */
+const ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "[::1]"]);
+
+function hostOf(input: unknown): string | null {
+  try {
+    const raw =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : ((input as Request | undefined)?.url ?? "");
+    if (!raw) return null;
+    // A relative URL cannot leave the process; it is resolved by whatever
+    // harness is serving it.
+    if (!/^[a-z][a-z0-9+.-]*:/i.test(raw)) return null;
+    return new URL(raw).hostname;
+  } catch {
+    return null;
+  }
+}
+
+const original = globalThis.fetch;
+
+const guarded = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const host = hostOf(input);
+  if (host !== null && !ALLOWED_HOSTS.has(host)) {
+    throw new Error(
+      `Outbound network call to ${host} from a test.\n\n` +
+        "Tests must not depend on a host we do not operate: the result then " +
+        "depends on whether that host answered, which is how a live-RPC read " +
+        "reached this suite and showed up as parallel-run flake.\n\n" +
+        "Fix it one of two ways:\n" +
+        "  - inject the loader (preferred -- see handleSubnetOwnerCut's " +
+        "`deps.loadParams`), so the code under test never builds a request; or\n" +
+        "  - stub `globalThis.fetch` for the test (see withFetchStub in " +
+        "tests/subnet-burn.test.ts), which also lets you assert the request.",
+    );
+  }
+  return original(input as never, init as never);
+}) as typeof fetch;
+
+globalThis.fetch = guarded;
+
+// Restore between tests so one test's stub cannot silently serve the next.
+beforeEach(() => {
+  globalThis.fetch = guarded;
+});
+
+/** Exported for the test that proves this guard can fail. */
+export const __guard = { guarded, original, hostOf };

--- a/tests/wallets-api-surface.test.ts
+++ b/tests/wallets-api-surface.test.ts
@@ -19,12 +19,12 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
+import { handleSubnetOwnerCut } from "../workers/request-handlers/entities.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
 import { jsonBody, mockEnv, type Row } from "./row-type.ts";
 
 const ECONOMICS_PATH = "/metagraph/economics.json";
 const ENTITIES_PATH = "/metagraph/entities.json";
-const PARAMETERS_PATH = "/metagraph/network/parameters.json";
 
 const OWNER_COLD = "5FRYKhbmfXPDoHdUUDMx27E3HuMvAzwjzFMMq3rNurUhAyS9";
 const OWNER_HOT = "5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV";
@@ -48,6 +48,17 @@ const DECLARED_TREASURY = {
 
 /** SubnetOwnerCut reconstructed: 11796/65535, not one sixth. */
 const OWNER_CUT_EFFECTIVE = 11796 / 65535;
+
+/** The share, injected. The suite has no global fetch stub, so a live
+ * loadNetworkParameters here would put a public Bittensor node in the test
+ * path -- and make the result depend on whether that node answered. */
+const params = (share: number | null) => ({
+  loadParams: async () => ({ subnet_owner_cut_effective: share }) as never,
+});
+const mcpParams = (share: number | null) => ({
+  loadNetworkParameters: async () =>
+    ({ subnet_owner_cut_effective: share }) as never,
+});
 
 type ArtifactMap = Record<string, unknown>;
 
@@ -89,8 +100,15 @@ function req(path: string) {
 }
 
 /** An MCP context whose artifact reads are the map given. */
-function mcpCtx(artifacts: ArtifactMap) {
+function mcpCtx(
+  artifacts: ArtifactMap,
+  share: number | null = OWNER_CUT_EFFECTIVE,
+) {
   return {
+    // Stubbed BY DEFAULT. A test that forgot to inject would otherwise read a
+    // public Bittensor node -- it passed alone and failed under parallelism,
+    // which is the worst way to find out.
+    ...mcpParams(share),
     env: mockEnv(),
     readArtifact: async (_env: unknown, path: string) => {
       if (path in artifacts) return { ok: true, data: artifacts[path] };
@@ -184,18 +202,19 @@ describe("GET /api/v1/subnets/{netuid}/owner-cut", () => {
     // The route does not read the stake streams, so every accrued alpha is
     // unresolved. Reporting `held-as-stake` from a read we did not perform is
     // the false negative #10485 exists to prevent.
-    const res = await handleRequest(
+    const res = await handleSubnetOwnerCut(
       req("/api/v1/subnets/64/owner-cut"),
-      artifactEnv({
-        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
-        [PARAMETERS_PATH]: { subnet_owner_cut_effective: OWNER_CUT_EFFECTIVE },
-      }),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      64,
+      params(OWNER_CUT_EFFECTIVE),
     );
     assert.equal(res.status, 200);
     const data = (await jsonBody(res)).data as Row;
     assert.equal(data.owner_coldkey, OWNER_COLD);
     const accrual = data.accrual as Row;
-    assert.equal(accrual.owner_cut, OWNER_CUT_EFFECTIVE);
+    assert.ok(
+      Math.abs((accrual.owner_cut as number) - OWNER_CUT_EFFECTIVE) < 1e-3,
+    );
     assert.ok((accrual.alpha as number) > 0);
     const disposition = data.disposition as Row;
     assert.equal((disposition.buckets as Row)["held-as-stake"], null);
@@ -203,31 +222,45 @@ describe("GET /api/v1/subnets/{netuid}/owner-cut", () => {
     assert.equal(disposition.reconciles, false);
   });
 
-  test("no parameters artifact nulls the accrual rather than assuming 18%", async () => {
-    // The share is knowable but was not read here. Substituting the runtime
-    // default would make an unread value indistinguishable from a read one.
-    const res = await handleRequest(
+  test("reconstructs the share from the runtime default, and accrues", async () => {
+    // The regression this route shipped with: it read the share from
+    // /metagraph/network/parameters.json, which publishes no owner-cut field at
+    // all -- so every one of 129 subnets served "owner cut share not read".
+    // The share comes from the LIVE parameters read now, which RECONSTRUCTS it:
+    // SubnetOwnerCut is unset on chain, so the effective value is the runtime
+    // default, and that is a real answer rather than an unread one.
+    const res = await handleSubnetOwnerCut(
       req("/api/v1/subnets/64/owner-cut"),
       artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      64,
+      params(OWNER_CUT_EFFECTIVE),
+    );
+    assert.equal(res.status, 200);
+    const accrual = ((await jsonBody(res)).data as Row).accrual as Row;
+    assert.ok(
+      Math.abs((accrual.owner_cut as number) - OWNER_CUT_EFFECTIVE) < 1e-3,
+      `expected ~18%, got ${accrual.owner_cut}`,
+    );
+    assert.ok((accrual.alpha as number) > 0, "a real accrual, not a null");
+  });
+
+  test("a share that cannot be resolved AT ALL still nulls the accrual", async () => {
+    // The other half. Reconstruction is the normal path; if even that fails,
+    // the accrual must be null rather than silently 18% -- assuming the default
+    // would make an unresolvable share indistinguishable from a read one.
+    const res = await handleSubnetOwnerCut(
+      req("/api/v1/subnets/64/owner-cut"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      64,
+      {
+        loadParams: async () => ({ subnet_owner_cut_effective: null }) as never,
+      },
     );
     assert.equal(res.status, 200);
     const accrual = ((await jsonBody(res)).data as Row).accrual as Row;
     assert.equal(accrual.owner_cut, null);
     assert.equal(accrual.alpha, null);
     assert.match(String(accrual.reason), /owner cut share not read/);
-  });
-
-  test("a non-numeric owner cut is treated as unread, not coerced", async () => {
-    const res = await handleRequest(
-      req("/api/v1/subnets/64/owner-cut"),
-      artifactEnv({
-        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
-        [PARAMETERS_PATH]: { subnet_owner_cut_effective: null },
-      }),
-    );
-    assert.equal(res.status, 200);
-    const accrual = ((await jsonBody(res)).data as Row).accrual as Row;
-    assert.equal(accrual.owner_cut, null);
   });
 });
 
@@ -276,24 +309,67 @@ describe("MCP get_subnet_owner_cut", () => {
   test("echoes the share and resolves the disposition to unresolved", async () => {
     const out = (await tool("get_subnet_owner_cut").handler(
       { netuid: 64 },
-      mcpCtx({
-        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
-        [PARAMETERS_PATH]: { subnet_owner_cut_effective: OWNER_CUT_EFFECTIVE },
-      }),
+      mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
     )) as Row;
-    assert.equal((out.accrual as Row).owner_cut, OWNER_CUT_EFFECTIVE);
+    assert.ok(
+      Math.abs(
+        ((out.accrual as Row).owner_cut as number) - OWNER_CUT_EFFECTIVE,
+      ) < 1e-3,
+    );
     // No USD leg: the tool does not read TAO/USD, and a null price must not
     // become a zero-dollar accrual.
     assert.equal((out.accrual as Row).usd, null);
     assert.equal(((out.disposition as Row).buckets as Row).unstaked, null);
   });
 
-  test("an unread share nulls the accrual rather than assuming the default", async () => {
-    const out = (await tool("get_subnet_owner_cut").handler(
-      { netuid: 64 },
-      mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
-    )) as Row;
+  test("reconstructs the share rather than reporting it unread", async () => {
+    // Same regression as the REST route: this tool read the served artifact,
+    // which carries no owner-cut field, and reported "not read" for all 129.
+    const out = (await tool("get_subnet_owner_cut").handler({ netuid: 64 }, {
+      ...(mcpCtx({
+        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
+      }) as object),
+      ...mcpParams(OWNER_CUT_EFFECTIVE),
+    } as never)) as Row;
+    const accrual = out.accrual as Row;
+    assert.ok(
+      Math.abs((accrual.owner_cut as number) - OWNER_CUT_EFFECTIVE) < 1e-3,
+    );
+    assert.ok((accrual.alpha as number) > 0);
+  });
+});
+
+// ── the production path ─────────────────────────────────────────────────────
+//
+// Both surfaces fall back to the REAL loadNetworkParameters when no loader is
+// injected -- that is production. Covering it without network I/O is what the
+// outbound-fetch guard makes possible: the guard refuses the socket, the loader
+// swallows that the way it swallows any RPC failure (it is schema-stable and
+// never throws), and the share comes back null.
+//
+// Which is the right degradation, and worth pinning: an unreachable node must
+// null the accrual, NOT quietly substitute the 18% runtime default. "Unset on
+// chain, so use the default" and "we could not ask" are different answers.
+describe("the un-injected fallback is the live reader", () => {
+  test("the REST handler falls back to it, and an unreachable node nulls the share", async () => {
+    const res = await handleSubnetOwnerCut(
+      req("/api/v1/subnets/64/owner-cut"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      64,
+    );
+    assert.equal(res.status, 200);
+    const accrual = ((await jsonBody(res)).data as Row).accrual as Row;
+    assert.equal(accrual.owner_cut, null);
+    assert.equal(accrual.alpha, null);
+    assert.match(String(accrual.reason), /owner cut share not read/);
+  });
+
+  test("the MCP tool falls back to it too", async () => {
+    // A ctx carrying no loadNetworkParameters override: the production shape.
+    const out = (await tool("get_subnet_owner_cut").handler({ netuid: 64 }, {
+      env: {},
+      readArtifact: async () => ({ ok: false, status: 404 }),
+    } as never)) as Row;
     assert.equal((out.accrual as Row).owner_cut, null);
-    assert.equal((out.accrual as Row).alpha, null);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -63,6 +63,11 @@ export default defineConfig({
     setupFiles: [
       "tests/setup/clock-skew.ts",
       "tests/setup/reset-module-state.ts",
+      // Fails any test that reaches a host we do not operate. The convention
+      // was already per-test fetch stubs; this makes it enforced rather than
+      // remembered -- a live RPC read slipped into the suite and only surfaced
+      // as parallel-run flake.
+      "tests/setup/no-outbound-fetch.ts",
     ],
     // Vitest's 5s default is too tight for THIS suite under file parallelism,
     // and the gap was papered over by putting the real number on one npm

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -7196,6 +7196,9 @@ export async function handleSubnetOwnerCut(
   request: Request,
   env: Env,
   netuid: number,
+  // Injected the same way /network/parameters' own siblings inject it, so the
+  // share can be driven in a test without a KV binding or an RPC.
+  deps: { loadParams?: typeof loadNetworkParameters } = {},
 ) {
   if (!Number.isInteger(netuid) || netuid < 0 || netuid > 65535) {
     return errorResponse(
@@ -7205,14 +7208,16 @@ export async function handleSubnetOwnerCut(
     );
   }
   const { row } = await resolveSubnetEconomicsRow(env, netuid);
-  const parameters = await readArtifact(
-    env,
-    "/metagraph/network/parameters.json",
-  );
-  const ownerCut = parameters.ok
-    ? ((parameters.data as Record<string, unknown> | undefined)
-        ?.subnet_owner_cut_effective as number | null | undefined)
-    : null;
+  // THE LIVE READ, NOT THE ARTIFACT. `/metagraph/network/parameters.json`
+  // publishes no owner-cut field at all -- verified in production, where it
+  // carries no key matching /owner/ -- so reading it here returned undefined
+  // for all 129 subnets and every accrual served `owner cut share not read`.
+  // That is the #10566 shape exactly: a correct-looking decline standing in
+  // for a read that never happened. `/api/v1/network/parameters` computes the
+  // effective share (0.17999...) and is KV-cached, so this costs a cache hit
+  // rather than an RPC per request.
+  const parameters = await (deps.loadParams ?? loadNetworkParameters)(env);
+  const ownerCut = parameters?.subnet_owner_cut_effective;
   const view = loadSubnetOwnerCut({
     netuid,
     window_days: 30,


### PR DESCRIPTION
## The bug

`/api/v1/subnets/{netuid}/owner-cut` and `get_subnet_owner_cut` report **"owner cut share not read" for all 129 subnets**. Null accrual, null pricing, entirely null disposition.

They read the share from `/metagraph/network/parameters.json`. That artifact publishes no owner-cut field at all:

```
$ curl -s .../metagraph/network/parameters.json | jq '[to_entries[]|select(.key|test("owner"))]'
[]
$ curl -s .../api/v1/network/parameters | jq '.data.subnet_owner_cut_effective'
0.179995422293431
```

The live route computes it; the artifact does not carry it. The read has never returned anything.

**#10566's shape exactly** — a correct-looking decline standing in for a read that never happened. Nothing failed, because refusing to assume 18% *is* the designed behaviour. It just was never supposed to be the answer for the entire network.

## Why a local constant would not do

`subnet_owner_cut_effective` is a **tri-state** reconstruction (#10484): a value if storage has one, the runtime default (`11796/65535`) if storage is **unset**, `null` if the read **failed**. "Unset on chain, so use the default" and "we could not ask" are different answers, and only a real read separates them. Both surfaces now go through `loadNetworkParameters` (KV-cached).

`get_subnet_owner_cut` is annotated **open-world** as a result — it genuinely leaves our infrastructure now. The existing annotation guard caught that before this could ship claiming otherwise.

## Second defect, found while fixing the first

The live loader put a **public Bittensor RPC in the test path**. Those tests passed in isolation — the node answered — and failed only under file parallelism. The symptom looks like flake; the cause looks like nothing.

The share is injected on both surfaces now, and the MCP context helper **stubs it by default**, so a test cannot reach the network by omission — which is exactly how this got in.

## The guard (the follow-up, done inline)

The convention was already right — `withFetchStub` in `tests/subnet-burn.test.ts`, the inline stub in `tests/account-balance-loader.test.ts`. It was simply unenforced, and an unenforced convention is one PR away from being untrue.

`tests/setup/no-outbound-fetch.ts` now fails any test reaching a host we do not operate:

- it **cooperates** with existing per-test stubs rather than replacing them — it only refuses calls that reach the *original* fetch, so a test that installs its own stub never touches it (asserted);
- it **restores itself between tests**, so one test's stub cannot leak into the next file;
- loopback is allowed (the local worker harness, not somebody's API);
- the error names both ways out: inject the loader, or stub fetch.

**Proven to refuse before being relied on** — 7 tests, including the failing case and the `$ref`-style trap that a scanner which resolves nothing looks identical to a clean one.

**The full suite passes with it active** (19265 tests). That is the interesting result: the convention *did* hold everywhere else, and this change was the only violator.

## Consequence of the fix

Unblocks item 2 of every per-subnet attribution issue (#10489–#10500) — the disposition cannot be recorded while the accrual is null — and the #10511 money-map panel stops showing `Not read` in every bucket for reasons unrelated to the flow streams.

## Validation

```
npx tsc --noEmit                clean
npm run lint / format:check     clean
npm run validate                pass
npm run build                   no drift
npx vitest run                  19265 passed, 0 failed (guard active)
npm run scan:public-safety      pass
```

Patch coverage by diff intersection: **31 changed lines across `src/**` and `workers/**`, 0 uncovered**. The un-injected production fallback is covered through the guard itself — the socket is refused, the loader swallows it the way it swallows any RPC failure, and the share comes back `null`, which pins the right degradation: an unreachable node must null the accrual, never quietly substitute 18%.

Closes #10680
