### PR TITLE
refactor(neon): type blocks_head against the generated row, not seven unknowns

### DIFF
--- a/src/capture-state-neon-write.ts
+++ b/src/capture-state-neon-write.ts
@@ -19,6 +19,7 @@
 // erase one an earlier tick already stored. Rebuilding these as a generic
 // upsert would silently drop that and replace a known value with NULL -- the
 // same shape as #9634's last_ok, one table over.
+import type { BlocksHead } from "../generated/db/types.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { neonWriteRunner } from "./neon-write-buffer.ts";
 import {
@@ -103,15 +104,7 @@ async function record(
 export async function mirrorBlocksHeadToNeon(
   env: Record<string, unknown> | null | undefined,
   ctx: WaitUntilLike | null | undefined,
-  row: {
-    block_number: unknown;
-    block_hash: unknown;
-    parent_hash: unknown;
-    extrinsic_count: unknown;
-    event_count: unknown;
-    author: unknown;
-    observed_at: unknown;
-  },
+  row: BlocksHead,
   deps: CaptureStateMirrorDeps = {},
 ): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
   const { sql, laneDb, now, attempted } = await runner(

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -1081,7 +1081,7 @@ export class ChainFirehoseHub implements DurableObject {
         await mirrorBlocksHeadToNeon(
           this.env as unknown as Record<string, unknown>,
           this.state,
-          block as unknown as Parameters<typeof mirrorBlocksHeadToNeon>[2],
+          block,
         );
         await this.state.storage.put("head:last_seen", block.block_number);
       }


### PR DESCRIPTION
## Summary

`src/capture-state-neon-write.ts` declared its own row shape with every field `unknown`, and
`workers/chain-firehose-hub.ts` threw the producer's type away to satisfy it:

```ts
block as unknown as Parameters<typeof mirrorBlocksHeadToNeon>[2]
```

Together those were **pure type erasure** — the cast discarded the type, the `unknown` shape accepted
the result, and `generated/db/types.ts` already carried the same seven columns properly typed.

## Why there is no zod parse here

The issue originally prescribed one. Reading the producer, that would have been wrong: `fetchBlockAt`
(`src/head-poller.ts`) **already** parses the RPC response with zod and returns a fully typed object.
Adding a parse at the mirror would be a second validator for a condition already enforced — precisely
what that file warns against:

> two validators for one condition is how a guard becomes unreachable and stops being exercised

So this takes the generated `BlocksHead` and deletes the cast. Nothing is validated twice, and nothing
is validated less.

## Why the generated type is now load-bearing

- `BlocksHead` is drift-checked by `validate:db-types-drift`, so a column added or retyped in
  `schema.sql` regenerates it and **fails the build at the mirror** instead of leaving a hand-written
  copy silently stale.
- With the cast gone, a future change to `fetchBlockAt`'s shape fails at the call site rather than
  passing an `unknown` through.
- **That the cast could simply be removed with `tsc` clean is the proof the two shapes already
  agreed** — this tightens types without changing a single runtime behaviour.

## Validation

```
npx tsc --noEmit                  # clean, with the cast removed
npm run lint · format:check       # clean
npm run validate                  # exit 0
npm run validate:db-types-drift   # current (55 tables, 498 columns)
npx vitest run capture-state-neon-write, chain-firehose-hub, head-poller   # 206 passed
```

No runtime change, so no new tests: the existing 206 cover the paths, and the guarantee this adds is
one `tsc` enforces.

Closes #10669