### PR TITLE
registry(entities): create the layer, and say plainly why it is empty (#10483)

### DIFF
--- a/registry/entities/README.md
+++ b/registry/entities/README.md
@@ -1,0 +1,64 @@
+# `registry/entities/`
+
+One file per address: `registry/entities/<ss58>.json`, matching
+`schemas/entity.schema.json`. This is the curated layer that names the
+addresses the chain never will — exchange wallets, bridge escrows, foundation
+and team treasuries, burn addresses.
+
+**It is empty, and that is a real state.** Nothing has been attributed yet
+because nothing has cleared the bar. An empty directory here is the honest
+answer, not an oversight — see below for why filling it carelessly would be
+worse than leaving it empty.
+
+## Before you add a file
+
+Read **[`docs/nametag-evidence-bar.md`](../../docs/nametag-evidence-bar.md)**.
+It answers the only question that matters: what counts as proof that this
+address belongs to this entity?
+
+The short version: at least one **independent, public, verifiable-by-anyone**
+source that ties **this specific address** to **this specific entity**. Not
+that the entity exists. Not that the address exists. That the two are the same
+thing.
+
+Not accepted on their own: folklore, a third party's assertion, inference from
+transaction patterns, or a truncated address that "matches".
+
+> A wrong nametag is actively worse than no nametag: it's a specific,
+> confident, _wrong_ claim rendered next to real financial activity, not a
+> merely incomplete one.
+
+## Two categories carry extra rules
+
+**`owner` is not a declarable category.** It is read from
+`SubtensorModule.SubnetOwner` and served with `chain_derived: true`. A
+hand-written `owner` entry is dropped rather than honoured, so no file here can
+impersonate a chain read.
+
+**`burn` requires proof of unspendability** — `unspendable_proof.basis` is one
+of `known-black-hole`, `provably-keyless`, or `documented-recycle-call`. An
+address with no observed outbound movement is **not** a basis: silence is not
+inability to spend. A team saying "we will not spend this" is a promise, which
+is a `treasury`.
+
+## What happens after you add one
+
+Every entry enters as `review.state: "community-submitted"`. A maintainer
+promotes it to `maintainer-reviewed` after checking the cited source actually
+supports the claim, or marks it `rejected` if it does not. `review.reviewed_at`
+records when that happened, separately from `submitted_at` — a submission and a
+review are different claims.
+
+The entries here are published at `/metagraph/entities.json` and surface on
+`GET /api/v1/subnets/{netuid}/wallets`, where **every attribution carries its
+`source_urls` in the response** so a reader repeating it can check it without a
+second call.
+
+## Whether anyone has looked
+
+Separately from this directory, a scheduled lane records — per subnet, with a
+date — that its published surfaces were searched for an address, and what was
+found. That is an observation and lives in Neon, not here; it surfaces as
+`attribution_search` on the wallets route. An empty wallet list beside a
+`none-published` verdict means somebody looked; beside a null one it means
+nobody has.


### PR DESCRIPTION
## Summary

Creates `registry/entities/` with the README a contributor needs before writing a file into it.

## State of #10483's five deliverables

| Deliverable | Status |
| --- | --- |
| Add `treasury`, `burn`, `payment-collector`, `multisig` to the category enum | already shipped |
| Optional `netuid` link | already shipped |
| `unspendable_proof` for `burn` | already shipped |
| Wire the artifact so `/metagraph/entities.json` serves | already shipped — it returns `{"entities":[]}` in production today |
| **Create `registry/entities/`** | **this PR** |
| Seed with the verifiable set | **empty — see below** |

The artifact has been serving from a directory that did not exist.

## The seed is empty, and that is a real state

Nothing has cleared [`docs/nametag-evidence-bar.md`](https://github.com/JSONbored/metagraphed/blob/main/docs/nametag-evidence-bar.md).

I checked the two subnets most likely to qualify — SN64 (Chutes) and SN51 (lium.io), the only two publishing readable revenue endpoints. Neither publishes an address that ties to them as an entity. lium.io's OpenAPI *does* contain checksum-valid ss58 strings; every one is a `validator_hotkey` in a scores payload — somebody else's key, published by them.

Filling this directory with a technically-valid entry that attributes nothing to anyone would be filler. Filling it with a plausible guess would be worse than leaving it empty:

> A wrong nametag is actively worse than no nametag: it's a specific, confident, _wrong_ claim rendered next to real financial activity, not a merely incomplete one.

The issue asks for "the verifiable set only — quality over count". Today that set is empty, and the README says so in those terms rather than leaving an empty directory to read as an oversight.

## What the README covers

- The evidence bar, in one paragraph, with a pointer to the full document.
- **`owner` is not declarable** — read from `SubnetOwner`, served with `chain_derived: true`, and a hand-written `owner` entry is dropped rather than honoured, so no file here can impersonate a chain read.
- **`burn` requires proof of unspendability** — an address with no observed outbound is not a basis; silence is not inability to spend, and "we will not spend this" is a promise, which is a `treasury`.
- What happens after submission: `community-submitted` → a maintainer checks the cited source actually supports the claim.
- That every attribution carries its `source_urls` **in the response**, so a reader repeating it can check it without a second call.
- A pointer to the separate lane recording *whether anyone has looked* (#10687), so an empty wallet list reads as "searched on this date, nothing published" rather than as silence.

## Validation

```
npm run validate              pass (registry validators accept the new directory)
npm run build                 no drift
npm run scan:public-safety    pass
npm run format:check          clean
```

Registry-only change — no code, schema, or contract surface touched.

Closes #10483
