### PR TITLE
perf(lane-health): stop writing an enqueue-time verdict for buffered lanes

### DIFF
--- a/src/capture-state-neon-write.ts
+++ b/src/capture-state-neon-write.ts
@@ -21,7 +21,10 @@
 // same shape as #9634's last_ok, one table over.
 import type { BlocksHead } from "../generated/db/types.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
-import { neonWriteRunner } from "./neon-write-buffer.ts";
+import {
+  neonWriteBufferEnabled,
+  neonWriteRunner,
+} from "./neon-write-buffer.ts";
 import {
   neonDualWriteEnabled,
   recordNeonWriteVerdict,
@@ -54,11 +57,13 @@ async function runner(
   laneDb: LaneHealthDb | undefined;
   now: () => number;
   attempted: boolean;
+  /** Whether `sql` enqueues rather than writes -- see record() below. */
+  buffered: boolean;
 }> {
   const now = deps.now ?? Date.now;
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
   if (!neonDualWriteEnabled(env, lane)) {
-    return { sql: null, laneDb, now, attempted: false };
+    return { sql: null, laneDb, now, attempted: false, buffered: false };
   }
   const hyperdrive = env?.HYPERDRIVE as HyperdriveLike | undefined;
   // #10659: buffered when the lane is flagged, direct otherwise. Defaults OFF
@@ -66,6 +71,10 @@ async function runner(
   const sql = deps.sql ?? neonWriteRunner(env, ctx, lane, hyperdrive);
   if (!sql) {
     // Enabled but unbound is a MISCONFIGURATION, not a quiet no-op.
+    //
+    // No `buffered` argument, and it is not an oversight: this branch is only
+    // reachable when there is NO runner at all, so nothing was buffered -- and
+    // it is a failure either way, which records regardless.
     await recordNeonWriteVerdict(
       laneDb,
       lane,
@@ -73,7 +82,11 @@ async function runner(
       now(),
     );
   }
-  return { sql, laneDb, now, attempted: true };
+  // Only a runner we BUILT can be buffered: an injected deps.sql is whatever
+  // the caller handed us, and calling it buffered would suppress its verdict on
+  // a write that went straight to a test double or a real connection.
+  const buffered = !deps.sql && neonWriteBufferEnabled(env, lane);
+  return { sql, laneDb, now, attempted: true, buffered };
 }
 
 async function record(
@@ -82,6 +95,7 @@ async function record(
   rows: number,
   now: () => number,
   run: () => Promise<unknown>,
+  buffered = false,
 ): Promise<NeonWriteResult> {
   let result: NeonWriteResult;
   try {
@@ -95,7 +109,7 @@ async function record(
       reason: String((error as Error)?.message ?? error),
     };
   }
-  await recordNeonWriteVerdict(laneDb, lane, result, now());
+  await recordNeonWriteVerdict(laneDb, lane, result, now(), buffered);
   return result;
 }
 
@@ -107,16 +121,21 @@ export async function mirrorBlocksHeadToNeon(
   row: BlocksHead,
   deps: CaptureStateMirrorDeps = {},
 ): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
-  const { sql, laneDb, now, attempted } = await runner(
+  const { sql, laneDb, now, attempted, buffered } = await runner(
     env,
     ctx,
     BLOCKS_HEAD_NEON_LANE,
     deps,
   );
   if (!attempted || !sql) return { attempted };
-  const result = await record(laneDb, BLOCKS_HEAD_NEON_LANE, 1, now, () =>
-    sql.unsafe(
-      `INSERT INTO blocks_head (block_number, block_hash, parent_hash, extrinsic_count, event_count, author, observed_at)
+  const result = await record(
+    laneDb,
+    BLOCKS_HEAD_NEON_LANE,
+    1,
+    now,
+    () =>
+      sql.unsafe(
+        `INSERT INTO blocks_head (block_number, block_hash, parent_hash, extrinsic_count, event_count, author, observed_at)
        VALUES (?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(block_number) DO UPDATE SET
          block_hash=excluded.block_hash,
@@ -125,16 +144,17 @@ export async function mirrorBlocksHeadToNeon(
          event_count=COALESCE(excluded.event_count, blocks_head.event_count),
          author=COALESCE(excluded.author, blocks_head.author),
          observed_at=excluded.observed_at`,
-      [
-        row.block_number,
-        row.block_hash,
-        row.parent_hash,
-        row.extrinsic_count,
-        row.event_count,
-        row.author,
-        row.observed_at,
-      ],
-    ),
+        [
+          row.block_number,
+          row.block_hash,
+          row.parent_hash,
+          row.extrinsic_count,
+          row.event_count,
+          row.author,
+          row.observed_at,
+        ],
+      ),
+    buffered,
   );
   return { attempted: true, result };
 }
@@ -148,22 +168,28 @@ export async function mirrorRawCaptureStateToNeon(
   updatedAt: number,
   deps: CaptureStateMirrorDeps = {},
 ): Promise<{ attempted: boolean; result?: NeonWriteResult }> {
-  const { sql, laneDb, now, attempted } = await runner(
+  const { sql, laneDb, now, attempted, buffered } = await runner(
     env,
     ctx,
     RAW_CAPTURE_STATE_NEON_LANE,
     deps,
   );
   if (!attempted || !sql) return { attempted };
-  const result = await record(laneDb, RAW_CAPTURE_STATE_NEON_LANE, 1, now, () =>
-    sql.unsafe(
-      `INSERT INTO raw_capture_state (network, last_contiguous_block, updated_at)
+  const result = await record(
+    laneDb,
+    RAW_CAPTURE_STATE_NEON_LANE,
+    1,
+    now,
+    () =>
+      sql.unsafe(
+        `INSERT INTO raw_capture_state (network, last_contiguous_block, updated_at)
          VALUES (?, ?, ?)
          ON CONFLICT(network) DO UPDATE SET
            last_contiguous_block = excluded.last_contiguous_block,
            updated_at = excluded.updated_at`,
-      [network, lastContiguousBlock, updatedAt],
-    ),
+        [network, lastContiguousBlock, updatedAt],
+      ),
+    buffered,
   );
   return { attempted: true, result };
 }

--- a/src/chain-detail-neon-write.ts
+++ b/src/chain-detail-neon-write.ts
@@ -20,7 +20,10 @@ import {
   type NeonWriteResult,
 } from "./neon-write.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
-import { neonWriteRunner } from "./neon-write-buffer.ts";
+import {
+  neonWriteBufferEnabled,
+  neonWriteRunner,
+} from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 // ---------------------------------------------------------------------------
@@ -201,6 +204,12 @@ export async function mirrorChainDetailToNeon(
   const sql =
     deps.sql ?? neonWriteRunner(env, ctx, CHAIN_DETAIL_NEON_LANE, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
+  // #10690: a buffered SUCCESS records no verdict here -- the flush owns the
+  // honest per-lane one. A buffered FAILURE still does: that is the enqueue
+  // being refused, which nothing else reports. Only a runner we BUILT counts,
+  // since an injected deps.sql went wherever the caller pointed it.
+  const buffered =
+    !deps.sql && neonWriteBufferEnabled(env, CHAIN_DETAIL_NEON_LANE);
   const now = deps.now ?? Date.now;
 
   if (!sql) {
@@ -210,6 +219,7 @@ export async function mirrorChainDetailToNeon(
       CHAIN_DETAIL_NEON_LANE,
       { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
       now(),
+      buffered,
     );
     return { attempted: true, results: {} };
   }
@@ -267,6 +277,7 @@ export async function mirrorChainDetailToNeon(
         : {}),
     },
     now(),
+    buffered,
   );
   return { attempted: true, results };
 }

--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -27,7 +27,10 @@ import {
 } from "./account-identity.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
-import { neonWriteRunner } from "./neon-write-buffer.ts";
+import {
+  neonWriteBufferEnabled,
+  neonWriteRunner,
+} from "./neon-write-buffer.ts";
 import {
   neonDualWriteEnabled,
   recordNeonWriteVerdict,
@@ -163,6 +166,11 @@ export async function mirrorFamilyToNeon(
   // (empty lane list), so this changes nothing until a lane is named.
   const sql = deps.sql ?? neonWriteRunner(env, ctx, lane, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
+  // #10690: a buffered SUCCESS records no verdict here -- the flush owns the
+  // honest per-lane one. A buffered FAILURE still does: that is the enqueue
+  // being refused, which nothing else reports. Only a runner we BUILT counts,
+  // since an injected deps.sql went wherever the caller pointed it.
+  const buffered = !deps.sql && neonWriteBufferEnabled(env, lane);
   const now = deps.now ?? Date.now;
 
   if (!sql) {
@@ -173,6 +181,7 @@ export async function mirrorFamilyToNeon(
       lane,
       { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
       now(),
+      buffered,
     );
     return { attempted: true, results: {} };
   }
@@ -199,7 +208,13 @@ export async function mirrorFamilyToNeon(
       undefined,
     );
   }
-  await recordNeonWriteVerdict(laneDb, lane, summarise(results), now());
+  await recordNeonWriteVerdict(
+    laneDb,
+    lane,
+    summarise(results),
+    now(),
+    buffered,
+  );
   return { attempted: true, results };
 }
 

--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -40,7 +40,10 @@ import {
 } from "./neon-write.ts";
 import { VALIDATOR_NOMINATOR_COUNT_INSERT_COLUMNS } from "./validator-nominator-summary.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
-import { neonWriteRunner } from "./neon-write-buffer.ts";
+import {
+  neonWriteBufferEnabled,
+  neonWriteRunner,
+} from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 // ---------------------------------------------------------------------------
@@ -212,6 +215,11 @@ export async function mirrorLedgerToNeon(
   // (empty lane list), so this changes nothing until a lane is named.
   const sql = deps.sql ?? neonWriteRunner(env, ctx, lane, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
+  // #10690: a buffered SUCCESS records no verdict here -- the flush owns the
+  // honest per-lane one. A buffered FAILURE still does: that is the enqueue
+  // being refused, which nothing else reports. Only a runner we BUILT counts,
+  // since an injected deps.sql went wherever the caller pointed it.
+  const buffered = !deps.sql && neonWriteBufferEnabled(env, lane);
   const now = deps.now ?? Date.now;
 
   if (!sql) {
@@ -221,6 +229,7 @@ export async function mirrorLedgerToNeon(
       lane,
       { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
       now(),
+      buffered,
     );
     return { attempted: true };
   }
@@ -235,7 +244,7 @@ export async function mirrorLedgerToNeon(
     plan.filter,
     plan.columnTypes,
   );
-  await recordNeonWriteVerdict(laneDb, lane, result, now());
+  await recordNeonWriteVerdict(laneDb, lane, result, now(), buffered);
 
   // THE TALLY GOES LAST, AND ONLY IF THE ROWS LANDED (#10056).
   //
@@ -257,6 +266,7 @@ export async function mirrorLedgerToNeon(
         ...(tally.reason ? { reason: tally.reason } : {}),
       },
       now(),
+      buffered,
     );
   }
   return { attempted: true, result };

--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -416,9 +416,27 @@ export async function recordNeonWriteVerdict(
   lane: string,
   result: NeonWriteResult,
   nowMs: number,
+  /**
+   * Whether this write went into the write-behind buffer rather than to Neon.
+   *
+   * A BUFFERED SUCCESS RECORDS NOTHING HERE (#10690). The verdict would say
+   * "ok" for rows that are durably enqueued and not yet in Neon, which is a
+   * weaker claim than the one the flush already records per lane -- and it
+   * would be written at ~758/hr to say it. The flush owns the honest verdict;
+   * this path owning a second, vaguer one is how the buffer ends up costing a
+   * Neon write per write it was built to defer.
+   *
+   * A BUFFERED FAILURE STILL RECORDS. `result.ok` is false when the enqueue
+   * itself was refused -- the buffer full, or the DO unreachable -- and that is
+   * backpressure nobody else reports. The flush cannot: the rows never reached
+   * it. Suppressing this is the one way this change could go quiet exactly when
+   * it matters.
+   */
+  buffered = false,
 ): Promise<boolean> {
   const key = `neon:${lane}`;
   const verdict: LaneVerdict = result.ok ? "ok" : "stale";
+  if (buffered && result.ok) return true;
   if (!shouldWriteNeonWriteVerdict(lastWrittenVerdict.get(key), verdict, nowMs))
     // TRUE, not false. `false` is this function's word for "the verdict is NOT
     // on record", and a coalesced verdict IS on record -- an identical row

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -34,7 +34,10 @@ import {
 } from "./neon-write.ts";
 import { NEURON_INSERT_COLUMNS } from "./metagraph-neurons.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
-import { neonWriteRunner } from "./neon-write-buffer.ts";
+import {
+  neonWriteBufferEnabled,
+  neonWriteRunner,
+} from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 import {
   writePassTallyToNeon,
@@ -395,6 +398,11 @@ export async function mirrorNeuronSnapshotToNeon(
   // named the lane and the binding is missing, and that deserves a verdict
   // rather than silence. It is recorded under the lane so #9698 reports it.
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
+  // #10690: a buffered SUCCESS records no verdict here -- the flush owns the
+  // honest per-lane one. A buffered FAILURE still does: that is the enqueue
+  // being refused, which nothing else reports. Only a runner we BUILT counts,
+  // since an injected deps.sql went wherever the caller pointed it.
+  const buffered = !deps.sql && neonWriteBufferEnabled(env, NEURONS_NEON_LANE);
   const now = deps.now ?? Date.now;
   if (!sql) {
     await recordNeonWriteVerdict(
@@ -402,6 +410,7 @@ export async function mirrorNeuronSnapshotToNeon(
       NEURONS_NEON_LANE,
       { ok: false, rows: 0, statements: 0, reason: "hyperdrive unbound" },
       now(),
+      buffered,
     );
     return { attempted: true, results: {} };
   }
@@ -425,7 +434,7 @@ export async function mirrorNeuronSnapshotToNeon(
       plan.guard,
     );
     results[name] = result;
-    await recordNeonWriteVerdict(laneDb, name, result, now());
+    await recordNeonWriteVerdict(laneDb, name, result, now(), buffered);
   }
 
   // THE DEREGISTRATION PRUNE (#10184). D1's writer ran this and the Neon mirror
@@ -466,6 +475,7 @@ export async function mirrorNeuronSnapshotToNeon(
       `${NEURONS_NEON_LANE}-prune`,
       prune,
       now(),
+      buffered,
     );
   }
 
@@ -496,6 +506,7 @@ export async function mirrorNeuronSnapshotToNeon(
       `${NEURONS_NEON_LANE}-pass`,
       verdict,
       now(),
+      buffered,
     );
     results[`${NEURONS_NEON_LANE}_passes`] = verdict;
   }

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -38,7 +38,10 @@ import {
 } from "./neon-write.ts";
 import { NOMINATOR_POSITION_INSERT_COLUMNS } from "./account-nominator-positions.ts";
 import { type HyperdriveLike, type WaitUntilLike } from "./pg-sql.ts";
-import { neonWriteRunner } from "./neon-write-buffer.ts";
+import {
+  neonWriteBufferEnabled,
+  neonWriteRunner,
+} from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
 /** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
@@ -101,6 +104,12 @@ export async function mirrorNominatorPositionsToNeon(
     deps.sql ??
     neonWriteRunner(env, ctx, NOMINATOR_POSITIONS_NEON_LANE, hyperdrive);
   const laneDb = laneHealthStore(env, deps.laneHealthDb);
+  // #10690: a buffered SUCCESS records no verdict here -- the flush owns the
+  // honest per-lane one. A buffered FAILURE still does: that is the enqueue
+  // being refused, which nothing else reports. Only a runner we BUILT counts,
+  // since an injected deps.sql went wherever the caller pointed it.
+  const buffered =
+    !deps.sql && neonWriteBufferEnabled(env, NOMINATOR_POSITIONS_NEON_LANE);
   const now = deps.now ?? Date.now;
 
   if (!sql) {
@@ -116,6 +125,7 @@ export async function mirrorNominatorPositionsToNeon(
       NOMINATOR_POSITIONS_NEON_LANE,
       failure,
       now(),
+      buffered,
     );
     return { attempted: true };
   }
@@ -135,6 +145,7 @@ export async function mirrorNominatorPositionsToNeon(
     NOMINATOR_POSITIONS_NEON_LANE,
     write,
     now(),
+    buffered,
   );
 
   // THE PRUNE IS SKIPPED WHEN THE UPSERT FAILED, and that ordering is load
@@ -154,6 +165,7 @@ export async function mirrorNominatorPositionsToNeon(
     `${NOMINATOR_POSITIONS_NEON_LANE}-prune`,
     prune,
     now(),
+    buffered,
   );
 
   // AFTER THE PRUNE, not just after the upsert. This lane's pass is only
@@ -185,6 +197,7 @@ export async function mirrorNominatorPositionsToNeon(
         ...(tally.reason ? { reason: tally.reason } : {}),
       },
       now(),
+      buffered,
     );
   }
   return { attempted: true, write, prune, pass: passResult };

--- a/tests/capture-state-neon-write.test.ts
+++ b/tests/capture-state-neon-write.test.ts
@@ -282,3 +282,88 @@ describe("no store bound at all", () => {
     assert.equal(out.result, undefined);
   });
 });
+
+describe("a buffered lane writes no enqueue-time verdict (#10690)", () => {
+  function laneSpy() {
+    const rows: unknown[][] = [];
+    return {
+      rows,
+      db: {
+        prepare(sql: string) {
+          return {
+            bind(...values: unknown[]) {
+              return {
+                async run() {
+                  if (sql.startsWith("INSERT")) rows.push(values);
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+  function bufferNs(status = 200) {
+    return {
+      NEON_WRITE_BUFFER: {
+        idFromName: (n: string) => n,
+        get: () => ({
+          async fetch() {
+            return new Response("{}", { status });
+          },
+        }),
+      },
+    };
+  }
+  const enabled = {
+    NEON_DUAL_WRITE_LANES: RAW_CAPTURE_STATE_NEON_LANE,
+    NEON_WRITE_BUFFER_LANES: RAW_CAPTURE_STATE_NEON_LANE,
+    HYPERDRIVE: HD,
+  };
+
+  test("a successful enqueue records nothing -- the flush owns the verdict", async () => {
+    const spy = laneSpy();
+    await mirrorRawCaptureStateToNeon(
+      { ...enabled, ...bufferNs() },
+      ctx,
+      "mainnet",
+      4321,
+      999,
+      { laneHealthDb: spy.db },
+    );
+    assert.deepEqual(spy.rows, []);
+  });
+
+  test("a REFUSED enqueue still records -- backpressure must stay visible", async () => {
+    const spy = laneSpy();
+    await mirrorRawCaptureStateToNeon(
+      { ...enabled, ...bufferNs(503) },
+      ctx,
+      "mainnet",
+      4321,
+      999,
+      { laneHealthDb: spy.db },
+    );
+    assert.equal(spy.rows.length, 1);
+    assert.equal(spy.rows[0][0], `neon:${RAW_CAPTURE_STATE_NEON_LANE}`);
+    assert.equal(spy.rows[0][1], "stale");
+  });
+
+  test("an INJECTED sql is never treated as buffered", async () => {
+    // deps.sql went wherever the caller pointed it -- a test double or a real
+    // connection. Calling that buffered would suppress a verdict for a write
+    // the buffer never saw.
+    const spy = laneSpy();
+    const rec = recordingSql();
+    await mirrorRawCaptureStateToNeon(
+      { ...enabled, ...bufferNs() },
+      ctx,
+      "mainnet",
+      4321,
+      999,
+      { laneHealthDb: spy.db, sql: rec.sql },
+    );
+    assert.equal(rec.calls.length, 1);
+    assert.equal(spy.rows.length, 1, "an injected write still reports");
+  });
+});

--- a/tests/neon-write.test.ts
+++ b/tests/neon-write.test.ts
@@ -670,3 +670,96 @@ describe("verdict coalescing, end to end", () => {
     assert.equal(s.inserts.length, 2);
   });
 });
+
+describe("a buffered lane's enqueue-time verdict", () => {
+  beforeEach(resetNeonWriteVerdictMemo);
+
+  function countingDb() {
+    const rows: Record<string, unknown>[] = [];
+    return {
+      rows,
+      db: {
+        prepare(sql: string) {
+          return {
+            bind(...values: unknown[]) {
+              return {
+                async run() {
+                  if (sql.startsWith("INSERT"))
+                    rows.push({ lane: values[0], verdict: values[1] });
+                },
+              };
+            },
+          };
+        },
+      },
+    };
+  }
+
+  test("a buffered SUCCESS records nothing -- the flush owns that verdict", async () => {
+    // ~758 rows/hour of bookkeeping saying "ok" about rows that are enqueued
+    // and not yet in Neon. The flush records the honest per-lane verdict once
+    // it has actually written them.
+    const s = countingDb();
+    const landed = await recordNeonWriteVerdict(
+      s.db,
+      "neurons",
+      { ok: true, rows: 30_000, statements: 11 },
+      NOW,
+      true,
+    );
+    assert.equal(landed, true, "the caller is not told this failed");
+    assert.deepEqual(s.rows, []);
+  });
+
+  test("a buffered FAILURE still records -- nothing else reports backpressure", async () => {
+    // ok:false here is the ENQUEUE being refused (buffer full, DO unreachable).
+    // The flush cannot report it: those rows never reached the flush. This is
+    // the one path where suppressing would go quiet exactly when it matters.
+    const s = countingDb();
+    await recordNeonWriteVerdict(
+      s.db,
+      "neurons",
+      { ok: false, rows: 0, statements: 0, reason: "buffer full" },
+      NOW,
+      true,
+    );
+    assert.deepEqual(
+      s.rows.map((r) => [r.lane, r.verdict]),
+      [["neon:neurons", "stale"]],
+    );
+  });
+
+  test("an UNBUFFERED lane is unchanged", async () => {
+    // blocks-head and chain-detail stay direct, so their verdicts must keep
+    // reporting exactly as before.
+    const s = countingDb();
+    await recordNeonWriteVerdict(
+      s.db,
+      "blocks-head",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+    );
+    assert.equal(s.rows.length, 1);
+  });
+
+  test("a buffered success does not poison the coalescing memo", async () => {
+    // It records nothing, so it must also not remember having recorded --
+    // otherwise the next DIRECT write on that lane would be coalesced away
+    // against a row that was never written.
+    const s = countingDb();
+    await recordNeonWriteVerdict(
+      s.db,
+      "neurons",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+      true,
+    );
+    await recordNeonWriteVerdict(
+      s.db,
+      "neurons",
+      { ok: true, rows: 1, statements: 1 },
+      NOW + 1000,
+    );
+    assert.equal(s.rows.length, 1, "the direct write must still land");
+  });
+});


### PR DESCRIPTION
## Summary

The write-behind buffer deferred a write and then **immediately wrote a row to Neon about having
deferred it**. Measured over 2h on 2026-08-11, verdicts for the now-buffered lanes ran at **~758/hr** —
the buffer was costing a Neon write per write it was built to defer.

Since #10659 that verdict means only "durably enqueued", which is weaker than the one the flush
already records per lane once the rows are actually in Neon. So a buffered **success** now records
nothing and lets the flush own it.

## The distinction that is the whole care here

A buffered **failure** still records. `ok:false` on a buffered lane is the *enqueue* being refused —
buffer full, or the DO unreachable — and **nothing else reports it**. The flush cannot: those rows
never reached the flush. Suppressing it is the one way this change could go quiet exactly when it
matters, so it does not.

| | Verdict written? |
|---|---|
| Buffered lane, write enqueued | **No** — flush records it |
| Buffered lane, enqueue refused | **Yes** — `stale`, the backpressure signal |
| Unbuffered lane (`blocks-head`, `chain-detail`) | **Yes** — unchanged |
| Injected `deps.sql` | **Yes** — see below |

## Threaded, not inferred

Each lane computes `buffered` where it builds its runner and passes it to `recordNeonWriteVerdict`.
The `!deps.sql &&` in that expression is deliberate: an injected runner went wherever the caller
pointed it — a test double or a real connection — and calling that buffered would suppress a verdict
for a write the buffer never saw.

16 of 17 call sites carry the flag. The one that does not is capture-state's
unbound-misconfiguration path, reachable only when there is **no runner at all**, so nothing was
buffered and it is a failure either way. That is documented in place rather than left to be
rediscovered.

The coalescing memo is left untouched on the suppressed path, so a later **direct** write on the same
lane is not coalesced away against a row that was never written. There is a test for exactly that.

## Validation

```
npx tsc --noEmit                               # clean
npm run lint · format:check                    # clean
npm run validate                               # exit 0
node scripts/validate-module-state-resets.ts   # passed
npx vitest run <10 suites>                     # 203 passed
```

**Patch coverage by diff intersection — zero uncovered statements and zero uncovered branches across
all seven changed source files.**

## What this does not do

It does not enable autosuspension. `blocks-head` and `chain-detail` keep the compute awake by design
(#10682, your call), leaving ~11s gaps. This is the last avoidable write volume, so it moves
autoscaling closer to the 0.25 CU floor and no further.

Closes #10690