### PR TITLE
refactor(tiers): delete the four dead flag families, and the tests pinning them

### DIFF
--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -3054,44 +3054,16 @@ for (const [route, assertion, options = {}] of checks) {
       assertion: (body) =>
         assert.equal(body.data.entries[0].identity_hash, IDENTITY_HASH),
     },
-    {
-      flag: "METAGRAPH_RPC_USAGE_SOURCE",
-      route: "/api/v1/rpc/usage",
-      upstreamPath: "/api/v1/rpc/usage",
-      data: formatRpcUsage({
-        window: "7d",
-        observedAt: new Date(OBSERVED_AT_MS).toISOString(),
-        totals: {
-          total: 10,
-          ok_count: 9,
-          failover_count: 1,
-          cache_hits: 2,
-          avg_latency_ms: 25,
-        },
-        latency: { p50: 20, p95: 40 },
-        endpointRows: [
-          {
-            endpoint_id: "finney-primary",
-            provider: "example",
-            requests: 10,
-            ok_count: 9,
-            avg_latency_ms: 25,
-          },
-        ],
-        networkRows: [{ network: "finney", requests: 10, ok_count: 9 }],
-        bucketRows: [
-          { ts: OBSERVED_AT_MS, requests: 10, errors: 1, avg_latency_ms: 25 },
-        ],
-        bucketGranularity: "1h",
-      }),
-      assertion: (body) => assert.equal(body.data.summary.total_requests, 10),
-    },
+    // METAGRAPH_RPC_USAGE_SOURCE's case was REMOVED (#10190): src/rpc-usage-answer.ts
+    // no longer has a Postgres arm at all, so there is no forward left to prove.
+    // The route's cascade is Analytics Engine, then the lakehouse, then the zeroed
+    // floor -- covered by tests/rpc-usage-answer.test.ts and tests/rpc-usage.test.ts.
   ];
 
   assert.equal(
     postgresTierChecks.length,
-    8,
-    "postgres-tier AJV coverage must include all 8 flags that gate a DATA_API leg",
+    7,
+    "postgres-tier AJV coverage must include all 7 flags that gate a DATA_API leg",
   );
 
   for (const {

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -22,7 +22,6 @@ import { buildSubnetMetagraph } from "../src/metagraph-neurons.ts";
 import { buildSubnetHyperparams } from "../src/subnet-hyperparams.ts";
 import { buildAccountIdentity } from "../src/account-identity.ts";
 import { buildSubnetIdentityHistory } from "../src/subnet-identity-history.ts";
-import { formatRpcUsage } from "../src/health-serving.ts";
 import { blockEmissionForIssuance } from "../src/block-emission.ts";
 import { taoToRao } from "../src/emission-decomposition.ts";
 import {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2741,10 +2741,8 @@ const rootValue = {
       defaultLimit: TOP_HOLDERS_LIMIT_DEFAULT,
       maxLimit: TOP_HOLDERS_LIMIT_MAX,
     });
-    const params = new URLSearchParams({
-      sort: safeSort,
-      limit: String(safeLimit),
-    });
+    // `params` used to be built here for the removed tier's upstream request;
+    // the live flow lane takes `sort`/`limit` directly.
     return (
       // NO TIER READ (#10190): METAGRAPH_TOP_HOLDERS_SOURCE is retired and
       // absent from DATA_API_FORWARD_FLAGS, so that arm resolved to null on

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2746,21 +2746,19 @@ const rootValue = {
       limit: String(safeLimit),
     });
     return (
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/accounts/top-holders", params),
-        "METAGRAPH_TOP_HOLDERS_SOURCE",
-      )) as Row | null) ??
-      // The same tier the REST handler and the MCP tool read (#9469).
-      // This resolver had NEITHER, so with the Postgres source retired it
-      // answered a schema-stable EMPTY list while /api/v1/accounts/top-holders
-      // served a leaderboard -- the same shape of dead fallback ladder the
-      // issue is about, one layer down.
+      // NO TIER READ (#10190): METAGRAPH_TOP_HOLDERS_SOURCE is retired and
+      // absent from DATA_API_FORWARD_FLAGS, so that arm resolved to null on
+      // every request.
+      //
+      // The live flow lane below is the tier the REST handler and the MCP tool
+      // read (#9469). This resolver had NEITHER, so it answered a schema-stable
+      // EMPTY list while /api/v1/accounts/top-holders served a leaderboard --
+      // the same shape of dead fallback ladder as the arm just removed above,
+      // one layer down.
       (await loadTopHoldersFlowTier(context.env, {
         sort: safeSort,
         limit: safeLimit,
-      })) ??
-      buildTopHoldersList([], { sort: safeSort, limit: safeLimit })
+      })) ?? buildTopHoldersList([], { sort: safeSort, limit: safeLimit })
     );
   },
 
@@ -7276,21 +7274,20 @@ const rootValue = {
     // sources, fetched in parallel. A cold/absent Postgres tier degrades to
     // buildAccountEntities' own zeroed card; a cold/absent R2 artifact degrades
     // to an empty labels list.
-    const [entitiesArtifact, ownershipData] = await Promise.all([
-      readArtifact(context.env, ENTITY_LABELS_ARTIFACT),
-      tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/accounts/${encodeURIComponent(ss58)}/entities`,
-        ),
-        "METAGRAPH_SUBNET_OWNERSHIP_SOURCE",
-      ),
-    ]);
+    // NO TIER READ (#10190). METAGRAPH_SUBNET_OWNERSHIP_SOURCE reads "retired"
+    // in every deployed config and is absent from DATA_API_FORWARD_FLAGS, so
+    // tryPostgresTier resolved to null on every request -- a subrequest that
+    // could not be made, awaited on the critical path. The composer's own
+    // lakehouse leg is what has been answering; it is now asked with no tier
+    // result rather than one that never arrives.
+    const entitiesArtifact = await readArtifact(
+      context.env,
+      ENTITY_LABELS_ARTIFACT,
+    );
     // Through the composer (src/account-entities-answer.ts): it owns the tier
     // order and the empty floor, so this resolver cannot drift from REST/MCP
     // the way it did while the lakehouse leg lived in entities.ts alone.
-    const data = await answerAccountEntities(context.env, ss58, ownershipData);
+    const data = await answerAccountEntities(context.env, ss58, null);
     const labels = labelsForSs58(
       entityLabelsIndex(
         entitiesArtifact.ok ? (entitiesArtifact.data as Row)?.entities : [],
@@ -9567,11 +9564,6 @@ const rootValue = {
     const data = (await answerRpcUsage(context.env, {
       window: requestedWindow,
       observedAt: await loadObservedAt(context),
-      postgresRequest: postgresTierRequest(
-        context,
-        "/api/v1/rpc/usage",
-        params,
-      ),
     })) as Row;
     const summary = data.summary ?? {};
     const latency = summary.latency_ms ?? {};

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -9934,19 +9934,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const ss58 = requireSs58(args);
-      const [entitiesArtifact, ownershipData] = await Promise.all([
-        ctx.readArtifact!(ctx.env, ENTITY_LABELS_ARTIFACT),
-        tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/entities`),
-          "METAGRAPH_SUBNET_OWNERSHIP_SOURCE",
-        ),
-      ]);
+      // NO TIER READ (#10190) -- METAGRAPH_SUBNET_OWNERSHIP_SOURCE is retired
+      // and absent from DATA_API_FORWARD_FLAGS, so this resolved to null every
+      // call. Same change on the REST and GraphQL sides; the composer's own
+      // lakehouse leg is what answers.
+      const entitiesArtifact = await ctx.readArtifact!(
+        ctx.env,
+        ENTITY_LABELS_ARTIFACT,
+      );
       // Through the composer, which owns the tier order and the empty floor for
       // all three surfaces (src/account-entities-answer.ts). The lakehouse leg
       // it adds is why this tool no longer answers ownership_ties: [] for a
       // coldkey that HAS won or lost a subnet.
-      const data = await answerAccountEntities(ctx.env, ss58, ownershipData);
+      const data = await answerAccountEntities(ctx.env, ss58, null);
       (data as Row).labels = labelsForSs58(
         entityLabelsIndex(
           entitiesArtifact?.ok ? entitiesArtifact.data?.entities : [],
@@ -11756,16 +11756,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         TOP_HOLDERS_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/accounts/top-holders", {
-            sort,
-            limit,
-          }),
-          "METAGRAPH_TOP_HOLDERS_SOURCE",
-        )) ??
-        // Same tier order handleTopHoldersList uses: the live flow lane, which
-        // ranks all six sorts since its holdings leg started proving (#9469).
+        // NO TIER READ (#10190): METAGRAPH_TOP_HOLDERS_SOURCE is retired and
+        // absent from DATA_API_FORWARD_FLAGS, so that arm resolved to null on
+        // every call. Same tier order handleTopHoldersList uses: the live flow
+        // lane, which ranks all six sorts since its holdings leg started
+        // proving (#9469).
         (await loadTopHoldersFlowTier(ctx.env, { sort, limit })) ??
         buildTopHoldersList([], { sort, limit })
       );
@@ -13046,9 +13041,6 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       return answerRpcUsage(ctx.env, {
         window: label,
         observedAt: await mcpObservedAt(ctx),
-        postgresRequest: mcpNeuronsTierRequest("/api/v1/rpc/usage", {
-          window: label,
-        }),
       });
     },
   },

--- a/src/rpc-usage-answer.ts
+++ b/src/rpc-usage-answer.ts
@@ -45,21 +45,12 @@
 // before it can be bounded, so the two cannot be issued in parallel without
 // risking a double count.
 import { ANALYTICS_WINDOW_DAYS } from "../workers/config.ts";
-import { tryPostgresTier } from "../workers/postgres-tier.ts";
-import {
-  epochMs,
-  formatRpcUsage,
-  type RpcUsageSegment,
-} from "./health-serving.ts";
+import { formatRpcUsage, type RpcUsageSegment } from "./health-serving.ts";
 import { loadRpcUsage } from "./rpc-usage-loader.ts";
 import { loadRpcUsageColdTier, windowCutoffMs } from "./rpc-usage-cold-tier.ts";
 import { loadRpcUsageHotTier } from "./rpc-usage-hot-tier.ts";
 
 type Row = Record<string, unknown>;
-
-/** The env flag that still gates the (retired) Postgres tier for this route.
- * Kept as a named export so the surfaces cannot drift onto a different flag. */
-export const RPC_USAGE_SOURCE_FLAG = "METAGRAPH_RPC_USAGE_SOURCE" as const;
 
 function num(value: unknown): number {
   const n = Number(value);
@@ -280,16 +271,11 @@ export interface AnswerRpcUsageOptions {
   /** `observed_at` for the zeroed floor -- the health cron's last run, the
    * only freshness reading available when no store answered. */
   observedAt?: unknown;
-  /** The request to forward to the (retired) Postgres tier, or null to skip
-   * it. Supplied per surface because each builds its own upstream request;
-   * the ORDER it is tried in belongs here, not at the call site. */
-  postgresRequest?: Request | null;
   now?: number;
   // Seams, so every arm of the cascade -- and the merge itself -- is testable
   // without Analytics Engine, a lakehouse, or a DATA_API binding.
   hotTier?: typeof loadRpcUsageHotTier;
   coldTier?: typeof loadRpcUsageColdTier;
-  postgresTier?: typeof tryPostgresTier;
   floor?: typeof loadRpcUsage;
 }
 
@@ -305,11 +291,9 @@ export async function answerRpcUsage(
   {
     window = "7d",
     observedAt = null,
-    postgresRequest = null,
     now = Date.now(),
     hotTier = loadRpcUsageHotTier,
     coldTier = loadRpcUsageColdTier,
-    postgresTier = tryPostgresTier,
     floor = loadRpcUsage,
   }: AnswerRpcUsageOptions = {},
 ): Promise<Row> {
@@ -329,29 +313,18 @@ export async function answerRpcUsage(
   if (hot && cold) return mergeRpcUsage(cold, hot);
   if (hot) return hot;
 
-  // Only reached when Analytics Engine had nothing. The Postgres tier stays
-  // ahead of the lakehouse here purely to preserve the order this route has
-  // always used; METAGRAPH_RPC_USAGE_SOURCE is "retired" in every deployed
-  // config, so it declines without a subrequest and the flag remains what it
-  // has always been -- a kill switch, not a live tier.
-  if (postgresRequest) {
-    const postgres = (await postgresTier(
-      env,
-      postgresRequest,
-      RPC_USAGE_SOURCE_FLAG,
-    )) as Row | null;
-    // Normalised on the way out rather than trusted (#9794/#9811). This arm
-    // forwards an upstream payload verbatim instead of going through
-    // formatRpcUsage, so it is the one path that can publish a stamp this
-    // composer never shaped. The whole defect being fixed here was `observed_at`
-    // meaning different things depending on which tier answered, and a tier
-    // whose representation is taken on faith is how that happens -- so the
-    // composer states the type for every arm, including the ones it forwards.
-    if (postgres) {
-      return { ...postgres, observed_at: epochMs(postgres.observed_at) };
-    }
-  }
-
+  // THE POSTGRES ARM IS GONE (#10190). It sat here "purely to preserve the
+  // order this route has always used", and its own comment already said
+  // METAGRAPH_RPC_USAGE_SOURCE "is retired in every deployed config, so it
+  // declines without a subrequest" -- so between Analytics Engine having nothing
+  // and the lakehouse answering there was a branch that could only ever decline.
+  //
+  // What went with it: the `observed_at` normalisation that arm needed. It was
+  // the one path forwarding an upstream payload verbatim rather than through
+  // formatRpcUsage, and it existed because a tier's representation must not be
+  // taken on faith (#9794/#9811). Every surviving arm is shaped by this composer,
+  // so there is no longer an unshaped stamp to normalise -- the invariant now
+  // holds by construction instead of by a guard.
   if (cold) return cold;
 
   return floor({ window: label, observedAt });

--- a/tests/account-entities-handler.test.ts
+++ b/tests/account-entities-handler.test.ts
@@ -103,33 +103,12 @@ describe("handleAccountEntities", () => {
     assert.equal(body.data.labels[0].name, "Example Foundation");
   });
 
-  test("a successful DATA_API response wins over the schema-stable cold fallback", async () => {
-    const env = {
-      METAGRAPH_SUBNET_OWNERSHIP_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            ownership_tie_count: 1,
-            ownership_ties: [
-              { netuid: 7, role: "gained_ownership", block_number: 100 },
-            ],
-          }),
-      },
-    };
-    const body = await json(
-      await handleAccountEntities(
-        req(`/api/v1/accounts/${SS58}/entities`),
-        env as unknown as Env,
-        SS58,
-      ),
-    );
-    assert.equal(body.data.ownership_tie_count, 1);
-    assert.equal(body.data.ownership_ties[0].netuid, 7);
-    // labels still joined locally regardless of which source served ties.
-    assert.deepEqual(body.data.labels, []);
-  });
+  // REMOVED (#10190): "a successful DATA_API response wins over the schema-stable
+  // cold fallback". METAGRAPH_SUBNET_OWNERSHIP_SOURCE is retired and absent from
+  // DATA_API_FORWARD_FLAGS, so there was never a response to win -- the ties came
+  // from this test's own stub. Ownership-tie shaping is proven against the
+  // composer's live leg in tests/account-entities-answer.test.ts, and the label
+  // join this also checked is covered by the test immediately above.
 });
 
 describe("handleAccount labels join", () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -10401,27 +10401,12 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     assert.equal(body.data.freshness, null);
   });
 
-  test("top_holders resolves the postgres tier payload", async () => {
-    let url: URL | undefined;
-    const env = {
-      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          url = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            holders: [{ ss58: "5A" }],
-          });
-        },
-      },
-    };
-    const { body } = await gql("{ top_holders(limit: 5) }", env);
-    assert.equal(body.errors, undefined);
-    assert.equal(body.data.top_holders.holders[0].ss58, "5A");
-    assert.equal(url!.pathname, "/api/v1/accounts/top-holders");
-    assert.equal(url!.searchParams.get("limit"), "5");
-    assert.equal(url!.searchParams.get("sort"), "total_tao");
-  });
+  // REMOVED (#10190): "top_holders resolves the postgres tier payload". It
+  // asserted the URL and query params forwarded to DATA_API under
+  // METAGRAPH_TOP_HOLDERS_SOURCE="postgres" -- a flag value no deployment sets,
+  // gating an arm absent from DATA_API_FORWARD_FLAGS. The live tier is the flow
+  // projection (tests/top-holders-flow-tier.test.ts), and the cold shape is
+  // pinned by the neighbouring test below.
 
   test("top_holders falls back to a schema-stable empty list when the tier is cold", async () => {
     const { body } = await gql("{ top_holders }");
@@ -10430,20 +10415,15 @@ describe("graphql — candidates / fixtures / agent_catalog / freshness / top_ho
     assert.deepEqual(body.data.top_holders.holders ?? [], []);
   });
 
-  test("top_holders forwards an explicit allowlisted sort", async () => {
-    let url: URL | undefined;
-    const env = {
-      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          url = new URL(r.url);
-          return Response.json({ schema_version: 1, holders: [] });
-        },
-      },
-    };
-    const { body } = await gql('{ top_holders(sort: "free_tao") }', env);
+  // REWRITTEN (#10190). This proved an allowlisted sort by asserting it reached
+  // DATA_API's query string -- through the retired METAGRAPH_TOP_HOLDERS_SOURCE
+  // arm, so the forwarding it checked never happened in production. The claim
+  // worth keeping is the ALLOWLIST's: a recognised sort is accepted where an
+  // unrecognised one is rejected, which is the pair the test below completes.
+  test("top_holders accepts an allowlisted sort", async () => {
+    const { body } = await gql('{ top_holders(sort: "free_tao") }');
     assert.equal(body.errors, undefined);
-    assert.equal(url!.searchParams.get("sort"), "free_tao");
+    assert.ok(body.data.top_holders);
   });
 
   test("top_holders rejects an unknown sort with BAD_USER_INPUT", async () => {
@@ -15377,35 +15357,13 @@ describe("graphql — account_entities (#6976, R2 entity labels + Postgres-tier 
     ]);
   });
 
-  test("resolves ownership ties from the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_SUBNET_OWNERSHIP_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            labels: [],
-            ownership_tie_count: 1,
-            ownership_ties: [
-              {
-                netuid: 4,
-                role: "gained_ownership",
-                block_number: 123,
-                observed_at: "2026-07-01T00:00:00.000Z",
-              },
-            ],
-          }),
-      },
-    };
-    const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
-    assert.equal(status, 200);
-    const r = body.data.account_entities;
-    assert.equal(r.ownership_tie_count, 1);
-    assert.equal(r.ownership_ties[0].netuid, 4);
-    assert.equal(r.ownership_ties[0].role, "gained_ownership");
-    assert.equal(r.ownership_ties[0].block_number, 123);
-  });
+  // REMOVED (#10190): "resolves ownership ties from the Postgres tier".
+  // METAGRAPH_SUBNET_OWNERSHIP_SOURCE is retired and absent from
+  // DATA_API_FORWARD_FLAGS, so the tie list it asserted could only ever come
+  // from its own DATA_API stub. Ownership-tie SHAPING is proven against the
+  // composer's live leg in tests/account-entities-answer.test.ts (populated
+  // ties, counts and role mapping); GraphQL's field wiring for the same card is
+  // pinned by the empty-card test immediately below.
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty ownership card", async () => {
     const env = {
@@ -19210,97 +19168,40 @@ describe("graphql — rpc_usage (#5899, Postgres-tier + D1-live fallback)", () =
     });
   });
 
-  test("resolves Postgres-tier data for a valid non-default window, forwarding it as a query param", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            bucket_granularity: "6h",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            source: "rpc-proxy",
-            summary: {
-              total_requests: 100,
-              ok_requests: 95,
-              error_requests: 5,
-              error_rate: 0.05,
-              failover_requests: 3,
-              failover_rate: 0.03,
-              cache_hits: 40,
-              cache_hit_rate: 0.4,
-              latency_ms: { p50: 20, p95: 80, avg: 30 },
-            },
-            endpoints: [
-              {
-                rank: 1,
-                endpoint_id: "ep-a",
-                provider: "prov-a",
-                requests: 60,
-                ok_requests: 58,
-                error_rate: 0.0333,
-                avg_latency_ms: 25,
-              },
-            ],
-            networks: [
-              {
-                network: "finney",
-                requests: 100,
-                ok_requests: 95,
-                error_rate: 0.05,
-              },
-            ],
-            buckets: [
-              {
-                ts: 1_750_000_000_000,
-                requests: 10,
-                errors: 1,
-                avg_latency_ms: 22,
-              },
-            ],
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(usageQuery('(window: "30d")'), env);
+  // REWRITTEN (#10190). This built a full rpc_usage payload, forwarded it through
+  // METAGRAPH_RPC_USAGE_SOURCE="postgres", and asserted every field mapped --
+  // including an `observed_at` normalisation whose own comment said it existed
+  // because "this arm forwards a tier's payload verbatim rather than building
+  // it". That arm is gone: no deployment sets the flag, and every surviving arm
+  // is shaped by the composer, so there is no unshaped stamp left to normalise.
+  //
+  // The residue worth keeping is that a valid non-default window is HONOURED
+  // rather than silently reset to the default. Field mapping for a populated
+  // payload is covered against the real tiers in tests/rpc-usage.test.ts and
+  // tests/rpc-usage-answer.test.ts.
+  test("a valid non-default window is honoured, not reset to the default", async () => {
+    const { status, body } = await gql(usageQuery('(window: "30d")'));
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/rpc/usage");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    const usage = body.data.rpc_usage;
-    assert.equal(usage.window, "30d");
-    assert.equal(usage.bucket_granularity, "6h");
-    // The mocked upstream sends an ISO string and the composer normalises it to
-    // epoch ms on the way out (#9811). This arm forwards a tier's payload
-    // verbatim rather than building it, so it is the one path that could publish
-    // a stamp the composer never shaped -- which is the exact defect being
-    // fixed, so the composer states the type here too.
-    assert.equal(usage.observed_at, Date.parse("2026-07-10T00:00:00.000Z"));
-    assert.equal(usage.summary.total_requests, 100);
-    assert.equal(usage.summary.error_rate, 0.05);
-    assert.equal(usage.summary.cache_hit_rate, 0.4);
-    assert.equal(usage.summary.latency_ms.p95, 80);
-    assert.equal(usage.endpoints[0].endpoint_id, "ep-a");
-    assert.equal(usage.endpoints[0].error_rate, 0.0333);
-    assert.equal(usage.networks[0].network, "finney");
-    assert.equal(usage.buckets[0].ts, 1_750_000_000_000);
+    assert.equal(body.data.rpc_usage.window, "30d");
   });
 
-  test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
-    const { status, body } = await gql(usageQuery(), env);
+  // REWRITTEN (#10190). This drove a malformed body through the retired
+  // METAGRAPH_RPC_USAGE_SOURCE arm; with that arm gone the cold cascade ends at
+  // the zeroed floor, and the floor publishes `bucket_granularity: "1h"` where
+  // the malformed-Postgres path published null. Production always took the floor
+  // -- the flag reads "retired" everywhere -- so this now pins the shape the
+  // surface actually serves rather than one only a stub could produce.
+  test("a cold cascade yields schema-stable defaults (no throw)", async () => {
+    const { status, body } = await gql(usageQuery());
     assert.equal(status, 200);
     const usage = body.data.rpc_usage;
     assert.equal(usage.schema_version, 1);
     assert.equal(usage.window, "7d");
-    assert.equal(usage.bucket_granularity, null);
+    assert.equal(usage.bucket_granularity, "1h");
     assert.equal(usage.observed_at, null);
-    assert.equal(usage.source, null);
+    // Also the floor's, where the malformed-Postgres path published null: the
+    // zeroed card still names the surface it describes.
+    assert.equal(usage.source, "rpc-proxy");
     assert.deepEqual(usage.summary, {
       total_requests: 0,
       ok_requests: 0,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -7888,57 +7888,10 @@ describe("MCP get_rpc_usage", () => {
   // formatRpcUsage(...) on any miss/outage, never a live D1 read. This mocks
   // the Postgres tier directly with a REST-shaped response, mirroring
   // workers/data-api.ts's own rpc/usage route.
-  test("returns usage analytics from the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            bucket_granularity: "1h",
-            observed_at: null,
-            source: "rpc-proxy",
-            summary: {
-              total_requests: 50,
-              ok_requests: 48,
-              error_requests: 2,
-              error_rate: 0.04,
-              failover_requests: 2,
-              failover_rate: 0.04,
-              cache_hits: 10,
-              cache_hit_rate: 0.2,
-              latency_ms: { p50: 70, p95: 200, avg: 80 },
-            },
-            endpoints: [
-              {
-                endpoint_id: "a",
-                provider: "p",
-                requests: 50,
-                ok_requests: 48,
-                avg_latency_ms: 80,
-              },
-            ],
-            networks: [{ network: "finney", requests: 50, ok_requests: 48 }],
-            buckets: [
-              {
-                ts: new Date(1_700_000_000_000).toISOString(),
-                requests: 5,
-                errors: 0,
-                avg_latency_ms: 75,
-              },
-            ],
-          }),
-      },
-    };
-    const res = await callTool("get_rpc_usage", { window: "7d" }, { env });
-    const out = res.body.result.structuredContent;
-    assert.equal(out.window, "7d");
-    assert.equal(out.summary.total_requests, 50);
-    assert.equal(out.endpoints[0].endpoint_id, "a");
-    assert.equal(out.networks[0].network, "finney");
-    assert.equal(out.buckets.length, 1);
-  });
+  // REMOVED (#10190): "returns usage analytics from the Postgres tier". The tier
+  // is gone from src/rpc-usage-answer.ts; this asserted a payload only its own
+  // DATA_API stub could produce. Field mapping for a populated card is covered in
+  // tests/rpc-usage.test.ts and tests/rpc-usage-answer.test.ts.
 
   test("rejects an invalid window", async () => {
     const res = await callTool("get_rpc_usage", { window: "99d" }, {});
@@ -16106,25 +16059,11 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     assert.equal(entities.body.result.structuredContent.labels.length, 1);
   });
 
-  test("get_account_entities: a successful DATA_API response wins over the schema-stable cold fallback", async () => {
-    const env = {
-      METAGRAPH_SUBNET_OWNERSHIP_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            ownership_tie_count: 1,
-            ownership_ties: [
-              { netuid: 7, role: "gained_ownership", block_number: 100 },
-            ],
-          }),
-      },
-    };
-    const res = await callTool("get_account_entities", { ss58: SS58 }, { env });
-    assert.equal(res.body.result.structuredContent.ownership_tie_count, 1);
-    assert.equal(res.body.result.structuredContent.ownership_ties[0].netuid, 7);
-  });
+  // REMOVED (#10190): "get_account_entities: a successful DATA_API response wins
+  // over the schema-stable cold fallback". METAGRAPH_SUBNET_OWNERSHIP_SOURCE is
+  // retired and absent from DATA_API_FORWARD_FLAGS, so there was no response to
+  // win -- the ties came from the test's own stub. Ownership-tie shaping is proven
+  // against the composer's live leg in tests/account-entities-answer.test.ts.
 
   test("populated account payloads validate against their declared outputSchemas", async () => {
     // validate-mcp only exercises the cold (empty-array) path, so assert the
@@ -23142,38 +23081,14 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
 // #6743), distinct from the shared METAGRAPH_NEURONS_SOURCE flag the CASES
 // table below tests -- verified separately here rather than folded into
 // that table, same isolation rationale as every other flag-scoped block.
-describe("MCP get_top_holders — Postgres tier wiring", () => {
-  test("flag=postgres uses Postgres data at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({ schema_version: 1, marker: "from-postgres" });
-        },
-      },
-    };
-    const res = await callTool("get_top_holders", {}, { env });
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(
-      captured,
-      "/api/v1/accounts/top-holders?sort=total_tao&limit=20",
-    );
-  });
-
-  test("flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool("get_top_holders", {}, { env });
+// REWRITTEN (#10190): was "MCP get_top_holders — Postgres tier wiring".
+// METAGRAPH_TOP_HOLDERS_SOURCE is retired and absent from DATA_API_FORWARD_FLAGS,
+// so the forwarded path and `marker: "from-postgres"` came only from the stub. The
+// live tier is the flow projection (tests/top-holders-flow-tier.test.ts); what this
+// tool owes on its own is a schema-stable card when nothing answers.
+describe("MCP get_top_holders — the cold shape", () => {
+  test("returns the schema-stable empty card when no tier answers", async () => {
+    const res = await callTool("get_top_holders", {}, { env: {} });
     assert.equal(res.body.result.isError, false);
     assert.equal(res.body.result.structuredContent.marker, undefined);
     assert.equal(res.body.result.structuredContent.account_count, 0);
@@ -23554,79 +23469,29 @@ describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => 
 // METAGRAPH_NEURONS_SOURCE, so it doesn't fit the shared CASES loop above
 // (which hardcodes the neurons-tier flag) -- same two-test-per-tool
 // contract, just with the correct flag name and its own CASES array.
-describe("MCP get_rpc_usage — Postgres tier wiring", () => {
-  const CASES = [
-    {
-      tool: "get_rpc_usage",
-      args: {},
-      path: "/api/v1/rpc/usage?window=7d",
-    },
-    {
-      tool: "get_rpc_usage",
-      args: { window: "30d" },
-      path: "/api/v1/rpc/usage?window=30d",
-    },
-  ];
+// REWRITTEN (#10190): was "MCP get_rpc_usage — Postgres tier wiring".
+// src/rpc-usage-answer.ts no longer has a Postgres arm, so the forwarded path and
+// `marker: "from-postgres"` these cases asserted came only from their own DATA_API
+// stub -- METAGRAPH_RPC_USAGE_SOURCE reads "retired" in every deployed config.
+// What survives is the tool's own contract: the window argument is honoured and
+// the card is schema-stable when no tier answers.
+describe("MCP get_rpc_usage — window handling and the cold shape", () => {
+  for (const window of [undefined, "30d"] as const) {
+    const label = window ? `get_rpc_usage (window=${window})` : "get_rpc_usage";
 
-  for (const { tool, args, path } of CASES) {
-    const label = path.includes("window=30d") ? `${tool} (window=30d)` : tool;
-
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_RPC_USAGE_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: honours the window and returns a schema-stable card`, async () => {
+      const res = await callTool("get_rpc_usage", window ? { window } : {}, {
+        env: {},
+      });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
-    });
-
-    test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
-      const env = {
-        METAGRAPH_RPC_USAGE_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () => {
-            throw new Error("boom");
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
-      assert.equal(res.body.result.isError, false, label);
-      assert.equal(res.body.result.structuredContent.marker, undefined, label);
+      const card = res.body.result.structuredContent;
+      assert.equal(card.schema_version, 1, label);
+      assert.equal(card.window, window ?? "7d", label);
+      assert.equal(card.summary.total_requests, 0, label);
+      assert.deepEqual(card.endpoints, [], label);
+      assert.deepEqual(card.networks, [], label);
     });
   }
-
-  test("flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({ schema_version: 1, marker: "should-not-be-used" }),
-      },
-    };
-    for (const { tool, args } of CASES) {
-      const res = await callTool(tool, args, { env });
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        undefined,
-        `${tool} should not reach DATA_API without the flag`,
-      );
-    }
-  });
 });
 
 // get_subnet_trajectory / get_economics_trends are gated on

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -5901,35 +5901,24 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSelfHealth: flag=postgres uses Postgres data, D1 never queried", async () => {
-    const { env, captures } = dbWith({ neurons: [neuronRow()] });
-    env.METAGRAPH_SELF_HEALTH_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
-    const body = await json(
-      await handleSelfHealth(req("/api/v1/self-health"), env as unknown as Env),
-    );
-    assert.equal(body.data.marker, "pg");
-    // The lane read is EXCLUDED rather than absent, and that is the honest
-    // statement of what this test is about: #9330/#9340 makes lane_health read
-    // regardless of which tier served the card, and lane_health now lives in
-    // the same store the serving tier would have been asked, so it shows up in
-    // the same capture log. What must stay empty is the SERVING read -- the
-    // test's next-door neighbour asserts the lane read is there.
-    assert.deepEqual(servingSql(captures), []);
-  });
+  // REMOVED (#10190): "handleSelfHealth: flag=postgres uses Postgres data, D1
+  // never queried". METAGRAPH_SELF_HEALTH_SOURCE reads "retired" in every
+  // deployed config and is absent from DATA_API_FORWARD_FLAGS, so the forward it
+  // asserted never happened outside this test -- the `marker: "pg"` it checked
+  // for could only come from its own DATA_API stub. What the route actually
+  // serves from is Neon, then the lakehouse cold tier, both covered below.
 
   test("handleSelfHealth: lane verdicts ride on whichever tier answered", async () => {
     // #9330/#9340. The lanes come from lane_health, not from the tier that produced
     // the card, because the point of the change is that a lane's health stays readable
     // when the serving tier does not -- so the live-tier card above must carry them too.
     const { env } = dbWith({ neurons: [] });
-    env.METAGRAPH_SELF_HEALTH_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", components: [] }),
-    };
+    // NO SERVING TIER STUBBED (#10190). This used to force the card through
+    // METAGRAPH_SELF_HEALTH_SOURCE="postgres" and assert its stub's marker came
+    // back; that flag is retired and forwards nowhere, so the tier is whatever
+    // the route really reaches. The CLAIM under test is unchanged and is the
+    // point of #9330/#9340: the lanes come from lane_health regardless of which
+    // tier produced the card, so they must survive a tier that answered nothing.
     // A canned answer rather than a router bucket: `answers` is consulted
     // before the row set dbWith assigns, so this one statement can differ from
     // everything else the handler asks without touching the router.
@@ -5957,7 +5946,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     const body = await json(
       await handleSelfHealth(req("/api/v1/self-health"), env as unknown as Env),
     );
-    assert.equal(body.data.marker, "pg");
     // Stale first: the row an operator acts on leads.
     assert.deepEqual(
       body.data.lanes.map((l: { lane: string }) => l.lane),
@@ -6090,23 +6078,12 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
   // parsed.error guard -- the same defense-in-depth shape as every other
   // handler in this file -- is exercised too.
 
-  test("handleTopHoldersList: flag=postgres uses Postgres data, D1 never queried", async () => {
-    const { env, captures } = dbWith({});
-    env.METAGRAPH_TOP_HOLDERS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", accounts: [] }),
-    };
-    const body = await json(
-      await handleTopHoldersList(
-        req("/api/v1/accounts/top-holders"),
-        env as unknown as Env,
-        url("/api/v1/accounts/top-holders"),
-      ),
-    );
-    assert.equal(body.data.marker, "pg");
-    assert.deepEqual(captures.sql, []);
-  });
+  // REMOVED (#10190): "handleTopHoldersList: flag=postgres uses Postgres data,
+  // D1 never queried". Same reason as the self-health one above --
+  // METAGRAPH_TOP_HOLDERS_SOURCE is retired and absent from
+  // DATA_API_FORWARD_FLAGS. The live tier is the flow projection
+  // (src/top-holders-flow-tier.ts), covered by tests/top-holders-flow-tier.test.ts
+  // and by the CSV export test in tests/top-holders.test.ts.
 
   // #4832 Tier 2b: the 9 neuron_daily-history handlers (structural history,
   // concentration/performance/yield history, chain/subnet turnover, movers).

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -66,7 +66,6 @@ import {
   handleAccountPortfolio,
   handleAccountPositions,
   handleAccountsList,
-  handleTopHoldersList,
   handleSubnetConcentrationHistory,
   handleSubnetPerformanceHistory,
   handleSubnetYieldHistory,
@@ -461,19 +460,6 @@ beforeEach(() => {
   pg.control.onQuery = null;
   pg.control.db = null;
 });
-
-/**
- * The captured statements MINUS the lane-health read.
- *
- * lane_health is the one table a handler reads no matter which tier served
- * (#9330/#9340: a lane's verdict has to stay readable when the serving tier is
- * not), and it now lives in the same store as the serving tables -- so a
- * "the serving tier was never asked" assertion has to say which reads it
- * means, or it starts failing for the reason the feature exists.
- */
-function servingSql(captures: { sql: string[] }): string[] {
-  return captures.sql.filter((sql) => !/FROM lane_health/i.test(sql));
-}
 
 // A store mock that routes SQL by regex patterns (order-sensitive: specific
 // first). Named buckets let each handler test supply only the rows it needs.

--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -223,35 +223,31 @@ describe("handleRpcUsage", () => {
     assert.equal(dataApiCalled, false);
   });
 
-  test("an empty AE window falls through to the tier below", async () => {
-    const env = {
-      ...AE_ENV,
-      METAGRAPH_RPC_USAGE_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            source: "rpc-proxy",
-            summary: { total_requests: 42 },
-            endpoints: [],
-            networks: [],
-            buckets: [],
-          }),
-      },
-    };
+  // REWRITTEN (#10190). This proved the fall-through by stubbing a DATA_API
+  // response behind `METAGRAPH_RPC_USAGE_SOURCE: "postgres"` and asserting its
+  // 42 came back. That flag reads "retired" in every deployed config and is
+  // absent from DATA_API_FORWARD_FLAGS, so the arm it exercised declined on
+  // every real request -- the 42 only ever arrived in this test.
+  //
+  // The claim worth keeping is that an empty AE window is NOT published as an
+  // answer, which is #9269's bug. The cascade ORDER belongs to the composer's
+  // own suite (tests/rpc-usage-answer.test.ts); what this handler-level test
+  // uniquely proves is the wiring.
+  test("an empty AE window is not published as an answer", async () => {
     const body = await withFetch(
       aeFetch([[{ total: null }], [], [], []]),
       async () =>
         json(
           await handleRpcUsage(
             req("/api/v1/rpc/usage"),
-            env as unknown as Env,
+            AE_ENV as unknown as Env,
             url("/api/v1/rpc/usage"),
           ),
         ),
     );
-    assert.equal(body.data.summary.total_requests, 42);
+    // No lakehouse token and no live tier here, so the zeroed floor answers --
+    // and it says so, rather than an empty AE read passing for a measurement.
+    assert.equal(body.data.summary.total_requests, 0);
   });
 
   test("no AE read token means the route behaves exactly as it does today", async () => {

--- a/tests/rpc-usage-answer.test.ts
+++ b/tests/rpc-usage-answer.test.ts
@@ -133,8 +133,7 @@ function hotPayload(overrides: Row = {}): Row {
 function stubs({
   hot = null,
   cold = null,
-  postgres = null,
-}: { hot?: Row | null; cold?: Row | null; postgres?: Row | null } = {}) {
+}: { hot?: Row | null; cold?: Row | null } = {}) {
   const calls: string[] = [];
   const coldArgs: Row[] = [];
   return {
@@ -149,10 +148,6 @@ function stubs({
       coldArgs.push(options);
       return cold;
     }) as never,
-    postgresTier: (async () => {
-      calls.push("postgres");
-      return postgres;
-    }) as never,
     floor: (async (options: Row) => {
       calls.push("floor");
       return { floor: true, ...options } as Row;
@@ -161,7 +156,6 @@ function stubs({
 }
 
 const ENV = {} as unknown as Env;
-const PG_REQUEST = new Request("https://example.invalid/api/v1/rpc/usage");
 
 describe("summing two disjoint stores", () => {
   test("counts are additive, so the merged window reports the real magnitude", async () => {
@@ -394,44 +388,19 @@ describe("when the lakehouse is consulted at all", () => {
 describe("the cascade order, in one place instead of three", () => {
   test("the hot tier alone answers when the lakehouse declines", async () => {
     const s = stubs({ hot: hotPayload() });
-    const out = await answerRpcUsage(ENV, {
-      ...s,
-      now: NOW,
-      postgresRequest: PG_REQUEST,
-    });
+    const out = await answerRpcUsage(ENV, { ...s, now: NOW });
     assert.deepEqual(s.calls, ["hot", "cold"]);
     assert.equal((out.summary as Row).total_requests, 3_990);
   });
 
-  test("the Postgres tier is only reached when Analytics Engine had nothing", async () => {
-    const s = stubs({ hot: hotPayload(), cold: coldPayload() });
-    await answerRpcUsage(ENV, {
-      ...s,
-      now: NOW,
-      postgresRequest: PG_REQUEST,
-    });
-    assert.equal(s.calls.includes("postgres"), false);
-  });
-
-  test("the Postgres tier keeps its historical place ahead of the lakehouse", async () => {
-    const s = stubs({
-      cold: coldPayload(),
-      postgres: { summary: { total_requests: 42 } } as Row,
-    });
-    const out = await answerRpcUsage(ENV, {
-      ...s,
-      now: NOW,
-      postgresRequest: PG_REQUEST,
-    });
-    assert.deepEqual(s.calls, ["hot", "cold", "postgres"]);
-    assert.equal((out.summary as Row).total_requests, 42);
-  });
-
-  test("a surface with no upstream request skips the Postgres tier entirely", async () => {
-    const s = stubs({ cold: coldPayload() });
-    await answerRpcUsage(ENV, { ...s, now: NOW });
-    assert.equal(s.calls.includes("postgres"), false);
-  });
+  // THREE TESTS REMOVED HERE (#10190), all of the Postgres arm this composer no
+  // longer has: that it was only reached when Analytics Engine had nothing, that
+  // it kept its place ahead of the lakehouse, and that a surface with no upstream
+  // request skipped it. Each was correct about the code and, in production, about
+  // nothing -- METAGRAPH_RPC_USAGE_SOURCE reads "retired" in every deployed
+  // config and is absent from DATA_API_FORWARD_FLAGS, so the branch they pinned
+  // declined on every real request. A `postgres` stub was the only thing that
+  // ever made it answer.
 
   test("the zeroed floor is reached ONLY when every store declined", async () => {
     // The bug in #9269, stated as a test: this shape is correct when nothing
@@ -441,9 +410,8 @@ describe("the cascade order, in one place instead of three", () => {
       ...s,
       now: NOW,
       observedAt: "2026-08-03T00:00:00.000Z",
-      postgresRequest: PG_REQUEST,
     });
-    assert.deepEqual(s.calls, ["hot", "cold", "postgres", "floor"]);
+    assert.deepEqual(s.calls, ["hot", "cold", "floor"]);
     assert.equal(out.floor, true);
     assert.equal(out.observedAt, "2026-08-03T00:00:00.000Z");
   });

--- a/tests/top-holders.test.ts
+++ b/tests/top-holders.test.ts
@@ -437,36 +437,45 @@ describe("GET /api/v1/accounts/top-holders via the Worker", () => {
     assert.equal(Array.isArray(body.data.accounts), true);
   });
 
-  test("?format=csv exports the leaderboard rows via the Postgres tier", async () => {
+  // RE-POINTED AT THE LIVE TIER (#10190). This drove the CSV export through
+  // `METAGRAPH_TOP_HOLDERS_SOURCE: "postgres"` and a DATA_API stub -- a
+  // configuration no deployment has: the flag reads "retired" everywhere and is
+  // absent from DATA_API_FORWARD_FLAGS, so the arm it exercised declined on every
+  // real request. The CSV formatter and its formula-injection guard are worth
+  // proving, so the setup moves to the flow tier that actually answers
+  // (src/top-holders-flow-tier.ts, an R2 projection) rather than the test being
+  // deleted along with its coverage.
+  test("?format=csv exports the leaderboard rows via the live flow tier", async () => {
     const env = {
       ...createLocalArtifactEnv(),
-      METAGRAPH_TOP_HOLDERS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            sort: "total_tao",
-            limit: 20,
-            account_count: 1,
-            captured_at: new Date(1750000000000).toISOString(),
-            accounts: [
-              {
-                ss58: "5Whale1",
-                free_tao: 1000.5,
-                delegated_tao: 250.25,
-                total_tao: 1250.75,
-                net_flow_7d: -50,
-                net_flow_30d: 200,
-                net_flow_90d: 900,
-                last_updated: new Date(1750000000000).toISOString(),
-              },
-            ],
-          }),
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            json: async () => ({
+              schema_version: 1,
+              generated_at: "x",
+              row_count: 1,
+              sorts: ["net_flow_7d", "net_flow_30d", "net_flow_90d"],
+              rows: [
+                {
+                  ss58: "5Whale1",
+                  free_tao: 1000.5,
+                  delegated_tao: 250.25,
+                  total_tao: 1250.75,
+                  net_flow_7d: -50,
+                  net_flow_30d: 200,
+                  net_flow_90d: 900,
+                  last_updated: new Date(1750000000000).toISOString(),
+                },
+              ],
+            }),
+          };
+        },
       },
     };
     const res = await handleRequest(
       new Request(
-        "https://api.metagraph.sh/api/v1/accounts/top-holders?format=csv",
+        "https://api.metagraph.sh/api/v1/accounts/top-holders?format=csv&sort=net_flow_7d",
       ),
       env as unknown as Env,
       ctx,

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -1418,12 +1418,9 @@ export async function handleTopHoldersList(
 ) {
   const parsed = parseTopHoldersQuery(url);
   if ("error" in parsed) return analyticsQueryError(parsed.error);
+  // NO TIER READ (#10190): METAGRAPH_TOP_HOLDERS_SOURCE is retired and absent
+  // from DATA_API_FORWARD_FLAGS, so this arm resolved to null on every request.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_TOP_HOLDERS_SOURCE",
-    )) as ReturnType<typeof buildTopHoldersList> | null) ??
     // The LIVE leg (#9469): net_flow_7d/30d/90d, recomputed daily from
     // chain.account_events. Answers only those three sorts and declines the
     // holdings ones, so it takes precedence where it can genuinely rank and
@@ -2073,12 +2070,11 @@ export async function handleSelfHealth(
   // without one, and a missing ctx means "skip the Neon tier", not "fail".
   ctx?: { waitUntil?(promise: Promise<unknown>): void },
 ) {
+  // NO TIER READ (#10190): METAGRAPH_SELF_HEALTH_SOURCE is retired and absent
+  // from DATA_API_FORWARD_FLAGS, so this arm resolved to null on every request.
+  // Neon is the first tier that can actually answer, which is what the comment
+  // below already describes.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_SELF_HEALTH_SOURCE",
-    )) as ReturnType<typeof buildSelfHealth> | null) ??
     // Neon, where the prober writes now (#9836). Asked BEFORE the lakehouse:
     // the cold tier can only ever answer current_ok:null, and once the probe
     // lane is running there is a current reading to give.
@@ -4582,19 +4578,17 @@ export async function handleAccountEntities(
   env: Env,
   coldkey: string,
 ) {
-  const [entitiesArtifact, ownershipData] = await Promise.all([
-    readArtifact(env, ENTITY_LABELS_ARTIFACT),
-    tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_SUBNET_OWNERSHIP_SOURCE" as keyof Env,
-    ),
-  ]);
+  // NO TIER READ (#10190). METAGRAPH_SUBNET_OWNERSHIP_SOURCE is retired in every
+  // deployed config and absent from DATA_API_FORWARD_FLAGS, so this resolved to
+  // null on every request. Note the `as keyof Env` the call needed: that cast was
+  // the only thing letting a flag the helper can no longer accept be passed at
+  // all, which is exactly the blindness #10190's type narrowing removes.
+  const entitiesArtifact = await readArtifact(env, ENTITY_LABELS_ARTIFACT);
   // Through the composer (src/account-entities-answer.ts), which owns the tier
   // order and the empty floor for REST, MCP and GraphQL alike. It used to live
   // here only, which is exactly why the other two surfaces published an empty
   // ownership half. The labels join below applies identically to every tier.
-  const data = await answerAccountEntities(env, coldkey, ownershipData);
+  const data = await answerAccountEntities(env, coldkey, null);
   const artifactEntities = entitiesArtifact.ok
     ? ((entitiesArtifact.data as Record<string, unknown> | undefined)
         ?.entities as Array<Record<string, unknown>> | undefined)

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -228,10 +228,6 @@ export async function handleRpcUsage(
   const data = await answerRpcUsage(env, {
     window: label,
     observedAt: meta?.last_run_at || null,
-    // #4832 gap-closure: reuses tryPostgresTier's usual "forward the caller's
-    // request unchanged" contract (a clean 1:1 route, unlike handleCompare's
-    // embedded-helper shape). The composer decides WHEN that tier is tried.
-    postgresRequest: request,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
Eight `tryPostgresTier` call sites that resolved to `null` on **every** request, plus the eleven tests that only passed because they stubbed the tier those calls could never reach.

`METAGRAPH_TOP_HOLDERS_SOURCE` (3 sites), `METAGRAPH_SUBNET_OWNERSHIP_SOURCE` (2), `METAGRAPH_SELF_HEALTH_SOURCE` (1), `METAGRAPH_RPC_USAGE_SOURCE` (1) all read `"retired"` in every deployed config and none is in `DATA_API_FORWARD_FLAGS`. Each call was an `await` on a subrequest that could not be made, on the critical path of a live route.

**222 → 214** dead sites, and zero `tryPostgresTier` references remain for all four flags. Counts are compiler-attributed: narrow the helper's `flagName` to the forwardable set plus one flag, diff the error count.

## Three shapes, which is why #10190 is not a regex pass

| shape | n | what removal involves |
| --- | --: | --- |
| `Promise.all([readArtifact, tryPostgresTier(…)])` → composer | 3 | the result is `answerAccountEntities`'s third argument, so pass `null` and collapse to a single `await` |
| `((await tryPostgresTier(…)) as T \| null) ?? fallback` | 4 | the prefix goes, and so does the comment justifying the tier order |
| `if (postgresRequest) { … }` | 1 | cascades into two composer options, an unreferenced export, an unused import, and three callers |

One site needed `"METAGRAPH_SUBNET_OWNERSHIP_SOURCE" as keyof Env` to compile at all. That cast was the only thing letting a flag the helper can no longer accept be passed — precisely the blindness the narrowing removes.

## Eleven tests pinned branches production cannot take

This is the finding that should revise #10190's estimate: **every source removal had a test cascade.** All eleven are named for the dead tier — `flag=postgres uses Postgres data, D1 never queried`, `resolves ownership ties from the Postgres tier`, `top_holders resolves the postgres tier payload` — and passed on a `DATA_API` stub behind a flag value no deployment sets. #10223's 657-site problem in the flesh.

Handled one at a time, not wholesale:

- **Re-pointed at a live tier** where the feature deserved keeping. The `?format=csv` export (formula-injection guard included) now drives the flow projection in R2 instead of a Postgres stub. The self-health `lane verdicts ride on whichever tier answered` test keeps its #9330/#9340 claim with **no serving tier stubbed at all** — a stronger statement of it than before.
- **Rewritten to the surviving claim** where only part was real: an allowlisted sort is *accepted* rather than *forwarded*; a non-default window is *honoured* rather than *forwarded*; an empty AE window is *not published as an answer*.
- **Deleted with a pointer** where coverage genuinely lives elsewhere — ownership-tie shaping is proven against the composer's live leg in `tests/account-entities-answer.test.ts` (16 assertions, populated ties and role mapping).

Two rewrites also corrected expectations only ever true of the dead arm: a cold `rpc_usage` card's `bucket_granularity` and `source` were pinned at `null` from the malformed-Postgres path, where the zeroed floor production always reached publishes `"1h"` and `"rpc-proxy"`. No production behaviour changes — those tests were pinning a shape only a stub could produce.

## Also

`scripts/validate-api.ts` loses its `METAGRAPH_RPC_USAGE_SOURCE` case, which asserted a forward that no longer exists; count assertion 8 → 7. The `"d1"` branch #10660 added is untouched and still green.

## Verification

- `tsc --noEmit` clean, `prettier --check` clean on all 13 changed files
- Green: `validate:api`, `validate:unreferenced-exports`, `validate:unreferenced-modules`, `validate:contract-drift`, `validate:mcp`, `validate:graphql-route-parity`, `validate:tool-route-divergence`, `validate:untyped-db-reads`
- **2,962 tests pass** across every suite referencing these flags or the removed symbols
- Rebased onto `f255a810f`, then tsc + `validate:api` + 2,498 tests re-run

Net **−386 lines**.

Closes #10692
