### PR TITLE
feat(graphql): publish the 50 fields that promised nothing, and measure them where JSON hid them

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -721,8 +721,23 @@ export type Adapter = {
   schema_version: Scalars['Int']['output'];
   slug: Scalars['String']['output'];
   /** Captured adapter metrics payload; shape is adapter-specific. */
-  snapshot?: Maybe<Scalars['JSON']['output']>;
+  snapshot?: Maybe<AdapterArtifactSnapshot>;
   subnet?: Maybe<Scalars['String']['output']>;
+};
+
+export type AdapterArtifactSnapshot = {
+  __typename?: 'AdapterArtifactSnapshot';
+  adapter_kind?: Maybe<Scalars['String']['output']>;
+  contract_version?: Maybe<Scalars['String']['output']>;
+  dimensions?: Maybe<Scalars['JSON']['output']>;
+  excluded_dimensions?: Maybe<Array<Scalars['String']['output']>>;
+  generated_at?: Maybe<Scalars['String']['output']>;
+  netuid?: Maybe<Scalars['Int']['output']>;
+  notes?: Maybe<Scalars['JSON']['output']>;
+  schema_version?: Maybe<Scalars['Int']['output']>;
+  slug?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
+  status?: Maybe<Scalars['String']['output']>;
 };
 
 /** Provenance for the USD fields: RECONSTRUCTED, never measured. The product of a measured alpha price and a measured TAO/USD index is our arithmetic, and a null storage says there is no single chain read behind it. */
@@ -744,13 +759,28 @@ export type Block = {
   spec_version?: Maybe<Scalars['Int']['output']>;
 };
 
-/** One block's raw all-events-tier events (#6977) -- every pallet.method event, distinct from the curated block_events stream. Rows are opaque JSON. */
+/** One block's raw all-events-tier events (#6977) -- every pallet.method event, distinct from the curated block_events stream. Rows carry the raw pallet-level shape (pallet, method, args, phase, summary), not the curated AccountEvent. */
 export type BlockChainEvents = {
   __typename?: 'BlockChainEvents';
   block_number?: Maybe<Scalars['Int']['output']>;
   event_count: Scalars['Int']['output'];
-  events: Array<Scalars['JSON']['output']>;
+  events: Array<BlockChainEventsArtifactEvents>;
   schema_version?: Maybe<Scalars['Int']['output']>;
+};
+
+/** One raw pallet-level chain event from the all-events tier (distinct from the curated AccountEvent and from Subscription's ChainEvent firehose payload). */
+export type BlockChainEventsArtifactEvents = {
+  __typename?: 'BlockChainEventsArtifactEvents';
+  args?: Maybe<Scalars['JSON']['output']>;
+  block_number?: Maybe<Scalars['Int']['output']>;
+  event_index?: Maybe<Scalars['Int']['output']>;
+  extrinsic_index?: Maybe<Scalars['Int']['output']>;
+  method?: Maybe<Scalars['String']['output']>;
+  observed_at?: Maybe<Scalars['Float']['output']>;
+  pallet?: Maybe<Scalars['String']['output']>;
+  phase?: Maybe<Scalars['String']['output']>;
+  /** Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525). */
+  summary?: Maybe<Scalars['String']['output']>;
 };
 
 export type BlockDetail = {
@@ -781,11 +811,27 @@ export type BlockExtrinsics = {
   __typename?: 'BlockExtrinsics';
   block_number?: Maybe<Scalars['Int']['output']>;
   extrinsic_count: Scalars['Int']['output'];
-  extrinsics: Array<Scalars['JSON']['output']>;
+  extrinsics?: Maybe<Array<BlockExtrinsicsArtifactExtrinsics>>;
   limit?: Maybe<Scalars['Int']['output']>;
   offset?: Maybe<Scalars['Int']['output']>;
   ref?: Maybe<Scalars['String']['output']>;
   schema_version?: Maybe<Scalars['Int']['output']>;
+};
+
+export type BlockExtrinsicsArtifactExtrinsics = {
+  __typename?: 'BlockExtrinsicsArtifactExtrinsics';
+  block_number?: Maybe<Scalars['Int']['output']>;
+  call_args?: Maybe<Scalars['JSON']['output']>;
+  call_function?: Maybe<Scalars['String']['output']>;
+  call_module?: Maybe<Scalars['String']['output']>;
+  extrinsic_hash?: Maybe<Scalars['String']['output']>;
+  extrinsic_index?: Maybe<Scalars['Int']['output']>;
+  fee_tao?: Maybe<Scalars['Float']['output']>;
+  observed_at?: Maybe<Scalars['String']['output']>;
+  signer?: Maybe<Scalars['String']['output']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
+  summary?: Maybe<Scalars['String']['output']>;
+  tip_tao?: Maybe<Scalars['Float']['output']>;
 };
 
 export type BlockList = {
@@ -852,14 +898,14 @@ export type BuildPublicContract = {
 export type BuildSummary = {
   __typename?: 'BuildSummary';
   adapter_count?: Maybe<Scalars['Int']['output']>;
-  artifact_budget_summary?: Maybe<Scalars['JSON']['output']>;
+  artifact_budget_summary?: Maybe<BuildSummaryArtifactArtifactBudgetSummary>;
   artifact_budgets?: Maybe<Array<BuildArtifactBudget>>;
   artifact_count: Scalars['Int']['output'];
   artifact_size_bytes?: Maybe<Scalars['Int']['output']>;
-  artifacts?: Maybe<Scalars['JSON']['output']>;
+  artifacts?: Maybe<Array<BuildSummaryArtifactArtifacts>>;
   candidate_count?: Maybe<Scalars['Int']['output']>;
   contract_version?: Maybe<Scalars['String']['output']>;
-  coverage?: Maybe<Scalars['JSON']['output']>;
+  coverage?: Maybe<CoverageArtifact>;
   endpoint_count?: Maybe<Scalars['Int']['output']>;
   full_artifact_count?: Maybe<Scalars['Int']['output']>;
   full_artifact_size_bytes?: Maybe<Scalars['Int']['output']>;
@@ -874,6 +920,21 @@ export type BuildSummary = {
   storage_tier_size_bytes?: Maybe<Scalars['JSON']['output']>;
   subnet_count?: Maybe<Scalars['Int']['output']>;
   surface_count?: Maybe<Scalars['Int']['output']>;
+};
+
+export type BuildSummaryArtifactArtifactBudgetSummary = {
+  __typename?: 'BuildSummaryArtifactArtifactBudgetSummary';
+  fail_count: Scalars['Int']['output'];
+  ok_count: Scalars['Int']['output'];
+  warn_count: Scalars['Int']['output'];
+};
+
+export type BuildSummaryArtifactArtifacts = {
+  __typename?: 'BuildSummaryArtifactArtifacts';
+  path: Scalars['String']['output'];
+  sha256?: Maybe<Scalars['String']['output']>;
+  size_bytes?: Maybe<Scalars['Int']['output']>;
+  storage_tier?: Maybe<Scalars['String']['output']>;
 };
 
 /** Per-UTC-day network activity series (blocks, extrinsics, events, signers) over the window, newest day first. Mirrors GET /api/v1/chain/activity's data envelope. */
@@ -1093,19 +1154,31 @@ export type ChainConcentrationHistoryPoint = {
   /** Which definition of the metrics produced this point. */
   builder_version?: Maybe<Scalars['Int']['output']>;
   day: Scalars['String']['output'];
-  emission?: Maybe<Scalars['JSON']['output']>;
+  emission?: Maybe<ChainConcentrationScorecard>;
   entity_count?: Maybe<Scalars['Int']['output']>;
-  entity_emission?: Maybe<Scalars['JSON']['output']>;
-  entity_stake?: Maybe<Scalars['JSON']['output']>;
+  entity_emission?: Maybe<ChainConcentrationScorecard>;
+  entity_stake?: Maybe<ChainConcentrationScorecard>;
   /** The shape of the day the card was computed over -- a point across half the network is not comparable to one across all of it. */
   neuron_count?: Maybe<Scalars['Int']['output']>;
   /** WHEN the network looked like this, as distinct from when it was computed. */
   source_captured_at?: Maybe<Scalars['String']['output']>;
   /** NULL means no measurable distribution, NOT missing. */
-  stake?: Maybe<Scalars['JSON']['output']>;
+  stake?: Maybe<ChainConcentrationScorecard>;
   subnet_count?: Maybe<Scalars['Int']['output']>;
   uids_per_entity?: Maybe<Scalars['Float']['output']>;
-  validator_stake?: Maybe<Scalars['JSON']['output']>;
+  validator_stake?: Maybe<ChainConcentrationScorecard>;
+};
+
+export type ChainConcentrationScorecard = {
+  __typename?: 'ChainConcentrationScorecard';
+  entropy?: Maybe<Scalars['Float']['output']>;
+  entropy_normalized?: Maybe<Scalars['Float']['output']>;
+  gini?: Maybe<Scalars['Float']['output']>;
+  hhi?: Maybe<Scalars['Float']['output']>;
+  hhi_normalized?: Maybe<Scalars['Float']['output']>;
+  holders: Scalars['Int']['output'];
+  nakamoto_coefficient?: Maybe<Scalars['Int']['output']>;
+  total: Scalars['Float']['output'];
 };
 
 export type ChainDeregistrations = {
@@ -1803,15 +1876,61 @@ export type ChainYield = {
 
 export type Changelog = {
   __typename?: 'Changelog';
-  artifacts?: Maybe<Scalars['JSON']['output']>;
+  artifacts?: Maybe<ChangelogArtifactArtifacts>;
   contract_version?: Maybe<Scalars['String']['output']>;
   coverage_delta?: Maybe<Scalars['JSON']['output']>;
   generated_at?: Maybe<Scalars['String']['output']>;
   notes?: Maybe<Scalars['JSON']['output']>;
   schema_version?: Maybe<Scalars['Int']['output']>;
   source?: Maybe<Scalars['String']['output']>;
-  subnets?: Maybe<Scalars['JSON']['output']>;
-  summary?: Maybe<Scalars['JSON']['output']>;
+  subnets?: Maybe<ChangelogArtifactSubnets>;
+  summary?: Maybe<ChangelogArtifactSummary>;
+};
+
+export type ChangelogArtifactArtifacts = {
+  __typename?: 'ChangelogArtifactArtifacts';
+  added: Array<Scalars['JSON']['output']>;
+  modified: Array<Scalars['JSON']['output']>;
+  removed: Array<Scalars['JSON']['output']>;
+};
+
+export type ChangelogArtifactSubnets = {
+  __typename?: 'ChangelogArtifactSubnets';
+  added: Array<ChangelogArtifactSubnetsAdded>;
+  removed: Array<ChangelogArtifactSubnetsRemoved>;
+  renamed: Array<ChangelogArtifactSubnetsRenamed>;
+};
+
+export type ChangelogArtifactSubnetsAdded = {
+  __typename?: 'ChangelogArtifactSubnetsAdded';
+  name?: Maybe<Scalars['String']['output']>;
+  netuid: Scalars['Int']['output'];
+  slug?: Maybe<Scalars['String']['output']>;
+};
+
+export type ChangelogArtifactSubnetsRemoved = {
+  __typename?: 'ChangelogArtifactSubnetsRemoved';
+  name?: Maybe<Scalars['String']['output']>;
+  netuid: Scalars['Int']['output'];
+  slug?: Maybe<Scalars['String']['output']>;
+};
+
+export type ChangelogArtifactSubnetsRenamed = {
+  __typename?: 'ChangelogArtifactSubnetsRenamed';
+  after?: Maybe<Scalars['String']['output']>;
+  before?: Maybe<Scalars['String']['output']>;
+  netuid: Scalars['Int']['output'];
+};
+
+export type ChangelogArtifactSummary = {
+  __typename?: 'ChangelogArtifactSummary';
+  artifact_added_count: Scalars['Int']['output'];
+  artifact_modified_count: Scalars['Int']['output'];
+  artifact_removed_count: Scalars['Int']['output'];
+  coverage_delta?: Maybe<Scalars['JSON']['output']>;
+  netuid_added_count: Scalars['Int']['output'];
+  netuid_removed_count: Scalars['Int']['output'];
+  netuid_renamed_count: Scalars['Int']['output'];
 };
 
 export type Compare = {
@@ -1862,6 +1981,44 @@ export type CompareSubnet = {
   structure?: Maybe<CompareStructure>;
 };
 
+/** Self-reported on-chain identity (SubtensorModule::set_identity) for a `coldkey`. */
+export type CompareValidatorsArtifactValidatorsColdkeyIdentity = {
+  __typename?: 'CompareValidatorsArtifactValidatorsColdkeyIdentity';
+  additional?: Maybe<Scalars['String']['output']>;
+  captured_at?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  discord?: Maybe<Scalars['String']['output']>;
+  github?: Maybe<Scalars['String']['output']>;
+  has_identity: Scalars['Boolean']['output'];
+  image?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  url?: Maybe<Scalars['String']['output']>;
+};
+
+export type CompareValidatorsArtifactValidatorsSubnetContext = {
+  __typename?: 'CompareValidatorsArtifactValidatorsSubnetContext';
+  active: Scalars['Boolean']['output'];
+  axon?: Maybe<Scalars['String']['output']>;
+  coldkey?: Maybe<Scalars['String']['output']>;
+  consensus?: Maybe<Scalars['Float']['output']>;
+  dividends?: Maybe<Scalars['Float']['output']>;
+  /** This row's emission on the subnet named by the sibling `netuid`. ALPHA for non-root subnets, genuine TAO on root (#2550). Renamed from `emission_tao` in #10514, because the entry's own `total_stake_tao` IS priced TAO and a shared `_tao` suffix across different units is a trap no description undoes. */
+  emission_alpha?: Maybe<Scalars['Float']['output']>;
+  hotkey?: Maybe<Scalars['String']['output']>;
+  incentive?: Maybe<Scalars['Float']['output']>;
+  is_immunity_period: Scalars['Boolean']['output'];
+  netuid: Scalars['Int']['output'];
+  rank?: Maybe<Scalars['Float']['output']>;
+  registered_at_block?: Maybe<Scalars['Int']['output']>;
+  /** This row's stake on the subnet named by the sibling `netuid`. ALPHA for non-root subnets, genuine TAO on root (#2550). Renamed from `stake_tao` in #10514 -- see the sibling emission field. Never summable across subnets; the entry's priced total already did that conversion. */
+  stake_alpha?: Maybe<Scalars['Float']['output']>;
+  take?: Maybe<Scalars['Float']['output']>;
+  trust?: Maybe<Scalars['Float']['output']>;
+  uid: Scalars['Int']['output'];
+  validator_permit: Scalars['Boolean']['output'];
+  validator_trust?: Maybe<Scalars['Float']['output']>;
+};
+
 export type ComparedValidator = {
   __typename?: 'ComparedValidator';
   apy_estimate?: Maybe<Scalars['Float']['output']>;
@@ -1869,12 +2026,12 @@ export type ComparedValidator = {
   avg_validator_trust?: Maybe<Scalars['Float']['output']>;
   coldkey?: Maybe<Scalars['String']['output']>;
   /** The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape. */
-  coldkey_identity?: Maybe<Scalars['JSON']['output']>;
+  coldkey_identity?: Maybe<CompareValidatorsArtifactValidatorsColdkeyIdentity>;
   hotkey: Scalars['String']['output'];
   max_validator_trust?: Maybe<Scalars['Float']['output']>;
   nominator_count?: Maybe<Scalars['Int']['output']>;
   /** This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape. */
-  subnet_context?: Maybe<Scalars['JSON']['output']>;
+  subnet_context?: Maybe<CompareValidatorsArtifactValidatorsSubnetContext>;
   subnet_count: Scalars['Int']['output'];
   take?: Maybe<Scalars['Float']['output']>;
   total_emission_tao: Scalars['Float']['output'];
@@ -1900,7 +2057,7 @@ export type ConcentrationMetrics = {
 
 export type Contracts = {
   __typename?: 'Contracts';
-  artifacts: Array<Scalars['JSON']['output']>;
+  artifacts?: Maybe<Array<ContractsArtifactArtifacts>>;
   base_path?: Maybe<Scalars['String']['output']>;
   contract_version?: Maybe<Scalars['String']['output']>;
   generated_at?: Maybe<Scalars['String']['output']>;
@@ -1912,10 +2069,97 @@ export type Contracts = {
   type_definitions_url?: Maybe<Scalars['String']['output']>;
 };
 
+export type ContractsArtifactArtifacts = {
+  __typename?: 'ContractsArtifactArtifacts';
+  content_type?: Maybe<Scalars['String']['output']>;
+  contract_version: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  path: Scalars['String']['output'];
+  retirement?: Maybe<ContractsArtifactArtifactsRetirement>;
+  schema_ref?: Maybe<Scalars['String']['output']>;
+  status: Scalars['String']['output'];
+  storage_tier: Scalars['String']['output'];
+};
+
+export type ContractsArtifactArtifactsRetirement = {
+  __typename?: 'ContractsArtifactArtifactsRetirement';
+  code: Scalars['String']['output'];
+  http_status: Scalars['Int']['output'];
+  message: Scalars['String']['output'];
+};
+
+export type CoverageArtifact = {
+  __typename?: 'CoverageArtifact';
+  application_subnet_count: Scalars['Int']['output'];
+  candidate_count: Scalars['Int']['output'];
+  candidate_subnet_count: Scalars['Int']['output'];
+  chain_subnet_count: Scalars['Int']['output'];
+  completeness?: Maybe<CoverageCompleteness>;
+  contract_version?: Maybe<Scalars['String']['output']>;
+  curated_overlay_count: Scalars['Int']['output'];
+  curation_level_counts: Scalars['JSON']['output'];
+  domain_coverage: Scalars['JSON']['output'];
+  first_party_subnet_count: Scalars['Int']['output'];
+  generated_at: Scalars['String']['output'];
+  manifested_count: Scalars['Int']['output'];
+  native_only_count: Scalars['Int']['output'];
+  native_only_with_candidates: Scalars['Int']['output'];
+  native_only_without_candidates: Scalars['Int']['output'];
+  native_snapshot_captured_at: Scalars['String']['output'];
+  network: Scalars['String']['output'];
+  /** Public-safe notes; may be a string or a string list depending on the adapter. */
+  notes?: Maybe<Scalars['JSON']['output']>;
+  official_surface_count: Scalars['Int']['output'];
+  probed_count: Scalars['Int']['output'];
+  probed_surface_count: Scalars['Int']['output'];
+  registry_observed_surface_count: Scalars['Int']['output'];
+  root_subnet_count: Scalars['Int']['output'];
+  schema_version: Scalars['Int']['output'];
+  source: CoverageArtifactSource;
+  subnets_without_official_surface: Scalars['Int']['output'];
+  surface_count: Scalars['Int']['output'];
+};
+
+export type CoverageArtifactSource = {
+  __typename?: 'CoverageArtifactSource';
+  candidates: Scalars['String']['output'];
+  native: Scalars['JSON']['output'];
+  overlays: Scalars['String']['output'];
+};
+
+export type CoverageCompleteness = {
+  __typename?: 'CoverageCompleteness';
+  average_score?: Maybe<Scalars['Int']['output']>;
+  dimension_coverage?: Maybe<Scalars['JSON']['output']>;
+  fully_complete_count?: Maybe<Scalars['Int']['output']>;
+  fully_complete_pct?: Maybe<Scalars['Int']['output']>;
+  median_score?: Maybe<Scalars['Int']['output']>;
+  methodology?: Maybe<Scalars['String']['output']>;
+  score_distribution?: Maybe<Scalars['JSON']['output']>;
+  scored_subnet_count?: Maybe<Scalars['Int']['output']>;
+};
+
+export type CurationArtifactCuration = {
+  __typename?: 'CurationArtifactCuration';
+  candidate_count: Scalars['Int']['output'];
+  coverage_level: Scalars['String']['output'];
+  curation: CurationMetadata;
+  curation_level?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  gap_count?: Maybe<Scalars['Int']['output']>;
+  gaps: Gaps;
+  lifecycle?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  slug: Scalars['String']['output'];
+  surface_count: Scalars['Int']['output'];
+};
+
 /** Per-subnet curation state (coverage level, curation level, source counts). Mirrors GET /api/v1/curation (and MCP list_curation). */
 export type CurationList = {
   __typename?: 'CurationList';
-  curation: Array<Scalars['JSON']['output']>;
+  curation?: Maybe<Array<CurationArtifactCuration>>;
   cursor: Scalars['Int']['output'];
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
@@ -1926,6 +2170,16 @@ export type CurationList = {
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
+};
+
+export type CurationMetadata = {
+  __typename?: 'CurationMetadata';
+  gap_notes?: Maybe<Array<Scalars['String']['output']>>;
+  level: Scalars['String']['output'];
+  review_state: Scalars['String']['output'];
+  reviewed_at?: Maybe<Scalars['String']['output']>;
+  source_count?: Maybe<Scalars['Int']['output']>;
+  verified_at?: Maybe<Scalars['String']['output']>;
 };
 
 /** A field's own statement that its zero is not a measurement (#9307): the stream it reads is uncurated or was never emitted, or the derivation behind it could not answer this request. Absent on every trustworthy answer. */
@@ -2228,6 +2482,17 @@ export type EndpointIncidentWindow = {
   started_at: Scalars['Float']['output'];
 };
 
+export type EndpointIncidentsArtifactSummary = {
+  __typename?: 'EndpointIncidentsArtifactSummary';
+  active_count: Scalars['Int']['output'];
+  by_kind: Scalars['JSON']['output'];
+  by_layer: Scalars['JSON']['output'];
+  by_provider: Scalars['JSON']['output'];
+  by_severity: Scalars['JSON']['output'];
+  by_status: Scalars['JSON']['output'];
+  incident_count: Scalars['Int']['output'];
+};
+
 export type EndpointList = {
   __typename?: 'EndpointList';
   items: Array<Endpoint>;
@@ -2244,16 +2509,43 @@ export type EndpointPoolList = {
   next_cursor?: Maybe<Scalars['Int']['output']>;
   notes?: Maybe<Scalars['JSON']['output']>;
   order?: Maybe<Scalars['String']['output']>;
-  pools: Array<Scalars['JSON']['output']>;
+  pools?: Maybe<Array<RpcPool>>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   source?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
 };
 
+export type EndpointScoreReason = {
+  __typename?: 'EndpointScoreReason';
+  points: Scalars['Int']['output'];
+  reason: Scalars['String']['output'];
+};
+
+export type EvidenceClaim = {
+  __typename?: 'EvidenceClaim';
+  claim: Scalars['String']['output'];
+  confidence: Scalars['String']['output'];
+  limits: Scalars['String']['output'];
+  source_tier: Scalars['String']['output'];
+  source_type: Scalars['String']['output'];
+  source_url: Scalars['String']['output'];
+  subject: Scalars['String']['output'];
+  support_summary: Scalars['String']['output'];
+  verified_at?: Maybe<Scalars['String']['output']>;
+};
+
+export type EvidenceLedgerArtifactSummary = {
+  __typename?: 'EvidenceLedgerArtifactSummary';
+  candidate_claim_count: Scalars['Int']['output'];
+  claim_count: Scalars['Int']['output'];
+  subnet_claim_count: Scalars['Int']['output'];
+  surface_claim_count: Scalars['Int']['output'];
+};
+
 export type EvidenceList = {
   __typename?: 'EvidenceList';
-  claims: Array<Scalars['JSON']['output']>;
+  claims?: Maybe<Array<EvidenceClaim>>;
   cursor: Scalars['Int']['output'];
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
@@ -2262,7 +2554,7 @@ export type EvidenceList = {
   returned: Scalars['Int']['output'];
   schema_version?: Maybe<Scalars['Int']['output']>;
   sort?: Maybe<Scalars['String']['output']>;
-  summary?: Maybe<Scalars['JSON']['output']>;
+  summary?: Maybe<EvidenceLedgerArtifactSummary>;
   total: Scalars['Int']['output'];
 };
 
@@ -2351,11 +2643,32 @@ export type FailureReasonsDay = {
   total_checks: Scalars['Int']['output'];
 };
 
+export type Gaps = {
+  __typename?: 'Gaps';
+  gap_notes: Array<Scalars['String']['output']>;
+  missing_kinds: Array<Scalars['String']['output']>;
+  moving_target_surfaces?: Maybe<Array<Scalars['String']['output']>>;
+  supported_kinds: Array<Scalars['String']['output']>;
+};
+
+export type GapsArtifactGaps = {
+  __typename?: 'GapsArtifactGaps';
+  coverage_level: Scalars['String']['output'];
+  curation_level: Scalars['String']['output'];
+  gap_count?: Maybe<Scalars['Int']['output']>;
+  gap_priority?: Maybe<Scalars['Int']['output']>;
+  gap_severity?: Maybe<Scalars['String']['output']>;
+  gaps: Gaps;
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  slug: Scalars['String']['output'];
+};
+
 /** Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps). */
 export type GapsList = {
   __typename?: 'GapsList';
   cursor: Scalars['Int']['output'];
-  gaps: Array<Scalars['JSON']['output']>;
+  gaps?: Maybe<Array<GapsArtifactGaps>>;
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
@@ -2416,12 +2729,19 @@ export type GlobalIncidents = {
   sort?: Maybe<Scalars['String']['output']>;
   source?: Maybe<Scalars['String']['output']>;
   /** Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape. */
-  summary?: Maybe<Scalars['JSON']['output']>;
+  summary?: Maybe<GlobalIncidentsArtifactSummary>;
   /** Per-surface incident summaries -- NOT endpoint incidents. Published as [EndpointIncident!]! until #10214: those rows carry surface_id/netuid/incident_count/downtime_ms and answered null for all 18 of that type's own fields, on every one of 232 sampled. */
   surfaces: Array<GlobalIncidentSurface>;
   /** Surfaces matching the filters before paging (#7875). Equals the surfaces length when no limit/cursor is supplied. */
   total: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
+};
+
+/** Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape. */
+export type GlobalIncidentsArtifactSummary = {
+  __typename?: 'GlobalIncidentsArtifactSummary';
+  affected_surface_count: Scalars['Int']['output'];
+  incident_count: Scalars['Int']['output'];
 };
 
 export type HealthHistory = {
@@ -2433,9 +2753,69 @@ export type HealthHistory = {
   order?: Maybe<Scalars['String']['output']>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
-  summary?: Maybe<Scalars['JSON']['output']>;
-  surfaces: Array<Scalars['JSON']['output']>;
+  summary?: Maybe<HealthProbeSummary>;
+  surfaces?: Maybe<Array<HealthHistoryArtifactSurfaces>>;
   total: Scalars['Int']['output'];
+};
+
+export type HealthHistoryArtifactSurfaces = {
+  __typename?: 'HealthHistoryArtifactSurfaces';
+  classification: Scalars['String']['output'];
+  error_class?: Maybe<Scalars['String']['output']>;
+  kind: Scalars['String']['output'];
+  last_checked?: Maybe<Scalars['String']['output']>;
+  last_ok?: Maybe<Scalars['String']['output']>;
+  latency_ms?: Maybe<Scalars['Int']['output']>;
+  netuid: Scalars['Int']['output'];
+  provider: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  status_code?: Maybe<Scalars['Int']['output']>;
+  surface_id: Scalars['String']['output'];
+  verified_at?: Maybe<Scalars['String']['output']>;
+};
+
+export type HealthIncidentsArtifactSurfaces = {
+  __typename?: 'HealthIncidentsArtifactSurfaces';
+  downtime_ms: Scalars['Int']['output'];
+  incident_count: Scalars['Int']['output'];
+  incidents: Array<HealthIncidentsArtifactSurfacesIncidents>;
+  samples: Scalars['Int']['output'];
+  surface_id: Scalars['String']['output'];
+  transient_failed_samples: Scalars['Int']['output'];
+  transient_failure_count: Scalars['Int']['output'];
+  uptime_ratio?: Maybe<Scalars['Float']['output']>;
+};
+
+export type HealthIncidentsArtifactSurfacesIncidents = {
+  __typename?: 'HealthIncidentsArtifactSurfacesIncidents';
+  duration_ms: Scalars['Int']['output'];
+  ended_at: Scalars['Float']['output'];
+  failed_samples: Scalars['Int']['output'];
+  started_at: Scalars['Float']['output'];
+};
+
+export type HealthPercentilesArtifactSurfaces = {
+  __typename?: 'HealthPercentilesArtifactSurfaces';
+  latency_ms: HealthPercentilesArtifactSurfacesLatencyMs;
+  samples: Scalars['Int']['output'];
+  surface_id: Scalars['String']['output'];
+};
+
+export type HealthPercentilesArtifactSurfacesLatencyMs = {
+  __typename?: 'HealthPercentilesArtifactSurfacesLatencyMs';
+  avg?: Maybe<Scalars['Int']['output']>;
+  max?: Maybe<Scalars['Int']['output']>;
+  min?: Maybe<Scalars['Int']['output']>;
+  p50?: Maybe<Scalars['Int']['output']>;
+  p95?: Maybe<Scalars['Int']['output']>;
+  p99?: Maybe<Scalars['Int']['output']>;
+};
+
+export type HealthProbeSummary = {
+  __typename?: 'HealthProbeSummary';
+  classification_counts: Scalars['JSON']['output'];
+  status_counts: Scalars['JSON']['output'];
+  surface_count: Scalars['Int']['output'];
 };
 
 /** All-subnet 7d/30d daily uptime + latency trend matrix from the live health-probe history. Mirrors GET /api/v1/health/trends' data envelope. */
@@ -2520,7 +2900,7 @@ export type IncidentList = {
   order?: Maybe<Scalars['String']['output']>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
-  summary?: Maybe<Scalars['JSON']['output']>;
+  summary?: Maybe<EndpointIncidentsArtifactSummary>;
   total: Scalars['Int']['output'];
 };
 
@@ -2562,6 +2942,28 @@ export type IndexerLagWindow = {
   newest_observed_at?: Maybe<Scalars['String']['output']>;
   oldest_block?: Maybe<Scalars['Int']['output']>;
   oldest_observed_at?: Maybe<Scalars['String']['output']>;
+};
+
+export type IntegrationReadiness = {
+  __typename?: 'IntegrationReadiness';
+  components: IntegrationReadinessComponents;
+  readiness_tier: Scalars['String']['output'];
+  readiness_verified?: Maybe<Scalars['Boolean']['output']>;
+  readiness_version: Scalars['Int']['output'];
+  score: Scalars['Int']['output'];
+};
+
+export type IntegrationReadinessComponents = {
+  __typename?: 'IntegrationReadinessComponents';
+  active_lifecycle?: Maybe<Scalars['Boolean']['output']>;
+  auth_clarity?: Maybe<Scalars['Boolean']['output']>;
+  callable_now?: Maybe<Scalars['Boolean']['output']>;
+  documented?: Maybe<Scalars['Boolean']['output']>;
+  has_callable_api?: Maybe<Scalars['Boolean']['output']>;
+  has_candidate_api?: Maybe<Scalars['Boolean']['output']>;
+  has_public_docs?: Maybe<Scalars['Boolean']['output']>;
+  has_source_repo?: Maybe<Scalars['Boolean']['output']>;
+  profile_complete?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Spread of per-subnet update intensity (WeightsSet events per validator) across every subnet that set weights in the window. */
@@ -2807,7 +3209,7 @@ export type PoolList = {
   notes?: Maybe<Scalars['JSON']['output']>;
   operational_observed_at?: Maybe<Scalars['String']['output']>;
   order?: Maybe<Scalars['String']['output']>;
-  pools: Array<Scalars['JSON']['output']>;
+  pools?: Maybe<Array<RpcPool>>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   source?: Maybe<Scalars['String']['output']>;
@@ -2822,7 +3224,7 @@ export type ProfileList = {
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
   order?: Maybe<Scalars['String']['output']>;
-  profiles: Array<Scalars['JSON']['output']>;
+  profiles?: Maybe<Array<SubnetProfile>>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
@@ -3823,7 +4225,6 @@ export type QueryEndpointsArgs = {
 
 export type QueryEvidenceArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
   q?: InputMaybe<Scalars['String']['input']>;
@@ -3901,7 +4302,6 @@ export type QueryGapsArgs = {
 
 export type QueryGlobal_IncidentsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -3928,7 +4328,6 @@ export type QueryHealth_HistoryArgs = {
   classification?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['Int']['input']>;
   date: Scalars['String']['input'];
-  fields?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
@@ -3948,7 +4347,6 @@ export type QueryHealth_TrendsArgs = {
 
 export type QueryIncidentsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -3989,7 +4387,6 @@ export type QueryProfilesArgs = {
   confidence?: InputMaybe<Scalars['String']['input']>;
   curation_level?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4068,7 +4465,6 @@ export type QueryReview_Enrichment_EvidenceArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
   direct_submission_kinds?: InputMaybe<Scalars['String']['input']>;
   evidence_action?: InputMaybe<Scalars['String']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   lane?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   missing_kinds?: InputMaybe<Scalars['String']['input']>;
@@ -4084,7 +4480,6 @@ export type QueryReview_Enrichment_QueueArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
   direct_submission_kinds?: InputMaybe<Scalars['String']['input']>;
   evidence_action?: InputMaybe<Scalars['String']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   identity_level?: InputMaybe<Scalars['String']['input']>;
   lane?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
@@ -4104,7 +4499,6 @@ export type QueryReview_Enrichment_TargetsArgs = {
   auto_review_candidate?: InputMaybe<Scalars['String']['input']>;
   cursor?: InputMaybe<Scalars['Int']['input']>;
   evidence_action?: InputMaybe<Scalars['String']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   identity_level?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   lane?: InputMaybe<Scalars['String']['input']>;
@@ -4199,7 +4593,6 @@ export type QuerySaved_QueryArgs = {
 
 export type QuerySearchArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4211,7 +4604,6 @@ export type QuerySearchArgs = {
 
 export type QuerySearch_IndexArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4223,7 +4615,6 @@ export type QuerySearch_IndexArgs = {
 
 export type QuerySource_SnapshotsArgs = {
   cursor?: InputMaybe<Scalars['Int']['input']>;
-  fields?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
   q?: InputMaybe<Scalars['String']['input']>;
@@ -4817,9 +5208,27 @@ export type RevenueVerificationCheck = {
   ok: Scalars['Boolean']['output'];
 };
 
+export type ReviewAdapterCandidate = {
+  __typename?: 'ReviewAdapterCandidate';
+  candidate_api_count: Scalars['Int']['output'];
+  candidate_api_ids: Array<Scalars['String']['output']>;
+  candidate_api_kinds: Array<Scalars['String']['output']>;
+  curation_level: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  operational_kinds: Array<Scalars['String']['output']>;
+  operational_surface_count: Scalars['Int']['output'];
+  operational_surface_ids: Array<Scalars['String']['output']>;
+  priority_score: Scalars['Int']['output'];
+  reason_codes: Array<Scalars['String']['output']>;
+  recommended_adapter_kind: Scalars['String']['output'];
+  slug: Scalars['String']['output'];
+  suggested_next_action: Scalars['String']['output'];
+};
+
 export type ReviewAdapterCandidateList = {
   __typename?: 'ReviewAdapterCandidateList';
-  candidates: Array<Scalars['JSON']['output']>;
+  candidates?: Maybe<Array<ReviewAdapterCandidate>>;
   cursor: Scalars['Int']['output'];
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
@@ -4831,18 +5240,94 @@ export type ReviewAdapterCandidateList = {
   total: Scalars['Int']['output'];
 };
 
+export type ReviewEnrichmentEvidenceArtifactEntries = {
+  __typename?: 'ReviewEnrichmentEvidenceArtifactEntries';
+  candidate_evidence_by_kind: Scalars['JSON']['output'];
+  candidate_evidence_summary: ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary;
+  direct_submission_kinds: Array<Scalars['String']['output']>;
+  evidence_action: Scalars['String']['output'];
+  lane: Scalars['String']['output'];
+  missing_kinds: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  priority_score: Scalars['Int']['output'];
+  slug: Scalars['String']['output'];
+};
+
+export type ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary = {
+  __typename?: 'ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary';
+  candidate_count: Scalars['Int']['output'];
+  kinds_with_candidates: Array<Scalars['String']['output']>;
+  live_kinds: Array<Scalars['String']['output']>;
+  live_or_redirected_count: Scalars['Int']['output'];
+  reviewable_count: Scalars['Int']['output'];
+  stale_kinds: Array<Scalars['String']['output']>;
+  stale_or_failed_count: Scalars['Int']['output'];
+  unverified_count: Scalars['Int']['output'];
+  unverified_kinds: Array<Scalars['String']['output']>;
+};
+
 export type ReviewEnrichmentEvidenceList = {
   __typename?: 'ReviewEnrichmentEvidenceList';
   cursor: Scalars['Int']['output'];
-  entries: Array<Scalars['JSON']['output']>;
+  entries?: Maybe<Array<ReviewEnrichmentEvidenceArtifactEntries>>;
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
-  notes?: Maybe<Scalars['JSON']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
   order?: Maybe<Scalars['String']['output']>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
+};
+
+export type ReviewEnrichmentQueueArtifactQueue = {
+  __typename?: 'ReviewEnrichmentQueueArtifactQueue';
+  adapter_score: Scalars['Int']['output'];
+  candidate_count: Scalars['Int']['output'];
+  candidate_evidence_summary: ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary;
+  completeness_score: Scalars['Int']['output'];
+  contribution_hint: Scalars['String']['output'];
+  curation_level: Scalars['String']['output'];
+  direct_submission_kinds: Array<Scalars['String']['output']>;
+  endpoint_count: Scalars['Int']['output'];
+  evidence_action: Scalars['String']['output'];
+  identity_level: Scalars['String']['output'];
+  identity_surface_count: Scalars['Int']['output'];
+  lane: Scalars['String']['output'];
+  manual_review_required: Scalars['Boolean']['output'];
+  missing_identity: Array<Scalars['String']['output']>;
+  missing_kinds: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  operational_interface_count: Scalars['Int']['output'];
+  priority_score: Scalars['Int']['output'];
+  profile_level: Scalars['String']['output'];
+  reason_codes: Array<Scalars['String']['output']>;
+  recommended_action: Scalars['String']['output'];
+  review_state: Scalars['String']['output'];
+  sample_candidate_ids: Array<Scalars['String']['output']>;
+  sample_live_candidate_ids: Array<Scalars['String']['output']>;
+  sample_stale_candidate_ids: Array<Scalars['String']['output']>;
+  sample_target_candidate_ids: Array<Scalars['String']['output']>;
+  slug: Scalars['String']['output'];
+  source_urls: Array<Scalars['String']['output']>;
+  stale_candidate_count: Scalars['Int']['output'];
+  surface_count: Scalars['Int']['output'];
+  verified_candidate_count: Scalars['Int']['output'];
+};
+
+export type ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary = {
+  __typename?: 'ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary';
+  candidate_count: Scalars['Int']['output'];
+  kinds_with_candidates: Array<Scalars['String']['output']>;
+  live_kinds: Array<Scalars['String']['output']>;
+  live_or_redirected_count: Scalars['Int']['output'];
+  reviewable_count: Scalars['Int']['output'];
+  stale_kinds: Array<Scalars['String']['output']>;
+  stale_or_failed_count: Scalars['Int']['output'];
+  unverified_count: Scalars['Int']['output'];
+  unverified_kinds: Array<Scalars['String']['output']>;
 };
 
 export type ReviewEnrichmentQueueList = {
@@ -4851,9 +5336,9 @@ export type ReviewEnrichmentQueueList = {
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
-  notes?: Maybe<Scalars['JSON']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
   order?: Maybe<Scalars['String']['output']>;
-  queue: Array<Scalars['JSON']['output']>;
+  queue?: Maybe<Array<ReviewEnrichmentQueueArtifactQueue>>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
@@ -4865,12 +5350,87 @@ export type ReviewEnrichmentTargetList = {
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
-  notes?: Maybe<Scalars['JSON']['output']>;
+  notes?: Maybe<Scalars['String']['output']>;
   order?: Maybe<Scalars['String']['output']>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
-  targets: Array<Scalars['JSON']['output']>;
+  targets?: Maybe<Array<ReviewEnrichmentTargetsArtifactTargets>>;
   total: Scalars['Int']['output'];
+};
+
+export type ReviewEnrichmentTargetsArtifactTargets = {
+  __typename?: 'ReviewEnrichmentTargetsArtifactTargets';
+  auto_review_candidate: Scalars['Boolean']['output'];
+  candidate_command?: Maybe<Scalars['String']['output']>;
+  candidate_evidence?: Maybe<ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence>;
+  contribution_prompt: Scalars['String']['output'];
+  evidence_action: Scalars['String']['output'];
+  identity_level: Scalars['String']['output'];
+  kind?: Maybe<Scalars['String']['output']>;
+  lane: Scalars['String']['output'];
+  manual_review_required: Scalars['Boolean']['output'];
+  missing_kinds: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  priority_score: Scalars['Int']['output'];
+  profile_level: Scalars['String']['output'];
+  queue_context: ReviewEnrichmentTargetsArtifactTargetsQueueContext;
+  reason_codes: Array<Scalars['String']['output']>;
+  recommended_action: Scalars['String']['output'];
+  sample_live_candidate_ids: Array<Scalars['String']['output']>;
+  sample_stale_candidate_ids: Array<Scalars['String']['output']>;
+  sample_target_candidate_ids: Array<Scalars['String']['output']>;
+  slug: Scalars['String']['output'];
+  source_requirements: Array<Scalars['String']['output']>;
+  source_urls: Array<Scalars['String']['output']>;
+  submission_route: Scalars['String']['output'];
+  target_action: Scalars['String']['output'];
+  target_id: Scalars['String']['output'];
+  target_type: Scalars['String']['output'];
+};
+
+export type ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence = {
+  __typename?: 'ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence';
+  candidate_count: Scalars['Int']['output'];
+  classifications: Scalars['JSON']['output'];
+  live_or_redirected_count: Scalars['Int']['output'];
+  reviewable_count: Scalars['Int']['output'];
+  sample_candidate_ids: Array<Scalars['String']['output']>;
+  stale_or_failed_count: Scalars['Int']['output'];
+  unverified_count: Scalars['Int']['output'];
+};
+
+export type ReviewEnrichmentTargetsArtifactTargetsQueueContext = {
+  __typename?: 'ReviewEnrichmentTargetsArtifactTargetsQueueContext';
+  adapter_score: Scalars['Int']['output'];
+  candidate_count: Scalars['Int']['output'];
+  completeness_score: Scalars['Int']['output'];
+  curation_level: Scalars['String']['output'];
+  direct_submission_kind_count: Scalars['Int']['output'];
+  endpoint_count: Scalars['Int']['output'];
+  identity_surface_count: Scalars['Int']['output'];
+  operational_interface_count: Scalars['Int']['output'];
+  profile_level: Scalars['String']['output'];
+  review_state: Scalars['String']['output'];
+  source_url_count: Scalars['Int']['output'];
+  stale_candidate_count: Scalars['Int']['output'];
+  surface_count: Scalars['Int']['output'];
+  verified_candidate_count: Scalars['Int']['output'];
+};
+
+export type ReviewGapPriority = {
+  __typename?: 'ReviewGapPriority';
+  candidate_count: Scalars['Int']['output'];
+  curation_level: Scalars['String']['output'];
+  missing_kinds: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  priority_score: Scalars['Int']['output'];
+  review_state: Scalars['String']['output'];
+  slug: Scalars['String']['output'];
+  suggested_next_action: Scalars['String']['output'];
+  surface_count: Scalars['Int']['output'];
+  verified_candidate_count: Scalars['Int']['output'];
 };
 
 export type ReviewGapPriorityList = {
@@ -4881,10 +5441,57 @@ export type ReviewGapPriorityList = {
   next_cursor?: Maybe<Scalars['Int']['output']>;
   notes?: Maybe<Scalars['JSON']['output']>;
   order?: Maybe<Scalars['String']['output']>;
-  priorities: Array<Scalars['JSON']['output']>;
+  priorities?: Maybe<Array<ReviewGapPriority>>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
+};
+
+export type ReviewProfileCompletenessArtifactProfiles = {
+  __typename?: 'ReviewProfileCompletenessArtifactProfiles';
+  candidate_count: Scalars['Int']['output'];
+  completeness_score: Scalars['Int']['output'];
+  confidence: Scalars['String']['output'];
+  curation_level: Scalars['String']['output'];
+  gap_reasons: Array<Scalars['String']['output']>;
+  identity_evidence: SubnetProfileIdentityEvidence;
+  identity_level: Scalars['String']['output'];
+  identity_promotion_kind_count: Scalars['Int']['output'];
+  identity_promotion_kinds: Array<Scalars['String']['output']>;
+  identity_surface_count: Scalars['Int']['output'];
+  live_identity_candidate_kind_count: Scalars['Int']['output'];
+  missing_critical_count: Scalars['Int']['output'];
+  missing_identity: Array<Scalars['String']['output']>;
+  missing_operational: Array<Scalars['String']['output']>;
+  missing_required: Array<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  native_identity_signal_count: Scalars['Int']['output'];
+  native_name_quality: Scalars['String']['output'];
+  netuid: Scalars['Int']['output'];
+  operational_interface_count: Scalars['Int']['output'];
+  priority_score: Scalars['Int']['output'];
+  profile_level: Scalars['String']['output'];
+  review_state: Scalars['String']['output'];
+  slug: Scalars['String']['output'];
+  source_count: Scalars['Int']['output'];
+  stale_identity_candidate_kind_count: Scalars['Int']['output'];
+  suggested_next_action: Scalars['String']['output'];
+  supported_interface_kinds: Array<Scalars['String']['output']>;
+};
+
+export type ReviewProfileCompletenessArtifactSummary = {
+  __typename?: 'ReviewProfileCompletenessArtifactSummary';
+  average_completeness_score: Scalars['Int']['output'];
+  by_confidence: Scalars['JSON']['output'];
+  by_identity_level: Scalars['JSON']['output'];
+  by_profile_level: Scalars['JSON']['output'];
+  critical_gap_counts: Scalars['JSON']['output'];
+  identity_promotion_candidate_count: Scalars['Int']['output'];
+  native_identity_count: Scalars['Int']['output'];
+  native_identity_unpromoted_count: Scalars['Int']['output'];
+  needs_identity_count: Scalars['Int']['output'];
+  needs_operational_count: Scalars['Int']['output'];
+  profile_count: Scalars['Int']['output'];
 };
 
 export type ReviewProfileCompletenessList = {
@@ -4895,10 +5502,10 @@ export type ReviewProfileCompletenessList = {
   next_cursor?: Maybe<Scalars['Int']['output']>;
   notes?: Maybe<Scalars['JSON']['output']>;
   order?: Maybe<Scalars['String']['output']>;
-  profiles: Array<Scalars['JSON']['output']>;
+  profiles?: Maybe<Array<ReviewProfileCompletenessArtifactProfiles>>;
   returned: Scalars['Int']['output'];
   sort?: Maybe<Scalars['String']['output']>;
-  summary?: Maybe<Scalars['JSON']['output']>;
+  summary?: Maybe<ReviewProfileCompletenessArtifactSummary>;
   total: Scalars['Int']['output'];
 };
 
@@ -4923,6 +5530,43 @@ export type RootClaimType = {
   __typename?: 'RootClaimType';
   kind: Scalars['String']['output'];
   subnets?: Maybe<Array<Scalars['Int']['output']>>;
+};
+
+export type RpcPool = {
+  __typename?: 'RpcPool';
+  best_endpoint_id?: Maybe<Scalars['String']['output']>;
+  eligible_count: Scalars['Int']['output'];
+  endpoint_count: Scalars['Int']['output'];
+  endpoints: Array<RpcPoolEndpoints>;
+  id: Scalars['String']['output'];
+  kind: Scalars['String']['output'];
+};
+
+export type RpcPoolEndpoints = {
+  __typename?: 'RpcPoolEndpoints';
+  archive_support?: Maybe<Scalars['Boolean']['output']>;
+  auth_required?: Maybe<Scalars['Boolean']['output']>;
+  health_source: Scalars['String']['output'];
+  health_stale: Scalars['Boolean']['output'];
+  id: Scalars['String']['output'];
+  kind?: Maybe<Scalars['String']['output']>;
+  last_ok?: Maybe<Scalars['String']['output']>;
+  latency_ms?: Maybe<Scalars['Int']['output']>;
+  latest_block?: Maybe<Scalars['Int']['output']>;
+  layer?: Maybe<Scalars['String']['output']>;
+  observed_at?: Maybe<Scalars['String']['output']>;
+  pool_eligibility_reasons?: Maybe<Array<Scalars['String']['output']>>;
+  pool_eligible: Scalars['Boolean']['output'];
+  provider: Scalars['String']['output'];
+  public_safe?: Maybe<Scalars['Boolean']['output']>;
+  reliability_grade?: Maybe<Scalars['String']['output']>;
+  reliability_score?: Maybe<Scalars['Int']['output']>;
+  score: Scalars['Int']['output'];
+  score_reasons?: Maybe<Array<EndpointScoreReason>>;
+  status: Scalars['String']['output'];
+  surface_id?: Maybe<Scalars['String']['output']>;
+  surface_key?: Maybe<Scalars['String']['output']>;
+  url: Scalars['String']['output'];
 };
 
 /** RPC reverse-proxy usage analytics over a 7d/30d window. Mirrors GET /api/v1/rpc/usage's data envelope. */
@@ -5078,19 +5722,48 @@ export type ScoreDistribution = {
   p90?: Maybe<Scalars['Float']['output']>;
 };
 
+export type SearchArtifactDocuments = {
+  __typename?: 'SearchArtifactDocuments';
+  artifact_path: Scalars['String']['output'];
+  categories?: Maybe<Array<Scalars['String']['output']>>;
+  id: Scalars['String']['output'];
+  netuid?: Maybe<Scalars['Int']['output']>;
+  service_kinds?: Maybe<Array<Scalars['String']['output']>>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+  tokens: Array<Scalars['String']['output']>;
+  type: Scalars['String']['output'];
+  url?: Maybe<Scalars['String']['output']>;
+};
+
 export type SearchDocumentList = {
   __typename?: 'SearchDocumentList';
   /** Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON. */
-  documents: Array<Scalars['JSON']['output']>;
+  documents?: Maybe<Array<SearchArtifactDocuments>>;
   next_cursor?: Maybe<Scalars['String']['output']>;
   total: Scalars['Int']['output'];
+};
+
+export type SearchIndexArtifactDocuments = {
+  __typename?: 'SearchIndexArtifactDocuments';
+  artifact_path: Scalars['String']['output'];
+  categories?: Maybe<Array<Scalars['String']['output']>>;
+  id: Scalars['String']['output'];
+  netuid?: Maybe<Scalars['Int']['output']>;
+  service_kinds?: Maybe<Array<Scalars['String']['output']>>;
+  slug?: Maybe<Scalars['String']['output']>;
+  subtitle?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+  url?: Maybe<Scalars['String']['output']>;
 };
 
 /** Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index). */
 export type SearchIndexList = {
   __typename?: 'SearchIndexList';
   cursor: Scalars['Int']['output'];
-  documents: Array<Scalars['JSON']['output']>;
+  documents?: Maybe<Array<SearchIndexArtifactDocuments>>;
   generated_at?: Maybe<Scalars['String']['output']>;
   limit: Scalars['Int']['output'];
   next_cursor?: Maybe<Scalars['Int']['output']>;
@@ -5175,9 +5848,29 @@ export type SourceSnapshotList = {
   returned: Scalars['Int']['output'];
   schema_version?: Maybe<Scalars['Int']['output']>;
   sort?: Maybe<Scalars['String']['output']>;
-  sources: Array<Scalars['JSON']['output']>;
-  summary?: Maybe<Scalars['JSON']['output']>;
+  sources?: Maybe<Array<SourceSnapshotsArtifactSources>>;
+  summary?: Maybe<SourceSnapshotsArtifactSummary>;
   total: Scalars['Int']['output'];
+};
+
+export type SourceSnapshotsArtifactSources = {
+  __typename?: 'SourceSnapshotsArtifactSources';
+  captured_at: Scalars['String']['output'];
+  hash: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  kind: Scalars['String']['output'];
+  path: Scalars['String']['output'];
+  record_count: Scalars['Int']['output'];
+};
+
+export type SourceSnapshotsArtifactSummary = {
+  __typename?: 'SourceSnapshotsArtifactSummary';
+  adapter_snapshot_count: Scalars['Int']['output'];
+  candidate_count: Scalars['Int']['output'];
+  overlay_count: Scalars['Int']['output'];
+  provider_count: Scalars['Int']['output'];
+  source_count: Scalars['Int']['output'];
+  verification_result_count: Scalars['Int']['output'];
 };
 
 export type Subnet = {
@@ -5338,12 +6031,20 @@ export type SubnetConviction = {
   /** Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
   field_sources?: Maybe<Scalars['JSON']['output']>;
   king?: Maybe<Scalars['String']['output']>;
-  leaderboard: Array<Scalars['JSON']['output']>;
+  leaderboard?: Maybe<Array<SubnetConvictionArtifactLeaderboard>>;
   maturity_rate?: Maybe<Scalars['Float']['output']>;
   netuid: Scalars['Int']['output'];
   queried_at_block?: Maybe<Scalars['Int']['output']>;
   schema_version: Scalars['Int']['output'];
   unlock_rate?: Maybe<Scalars['Float']['output']>;
+};
+
+export type SubnetConvictionArtifactLeaderboard = {
+  __typename?: 'SubnetConvictionArtifactLeaderboard';
+  conviction?: Maybe<Scalars['Float']['output']>;
+  hotkey?: Maybe<Scalars['String']['output']>;
+  is_owner?: Maybe<Scalars['Boolean']['output']>;
+  locked_mass?: Maybe<Scalars['Float']['output']>;
 };
 
 export type SubnetDeregistrationEvent = {
@@ -5460,10 +6161,10 @@ export type SubnetEmissionDecomposition = {
 export type SubnetEventSummary = {
   __typename?: 'SubnetEventSummary';
   /** Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape. */
-  categories: Scalars['JSON']['output'];
+  categories?: Maybe<Array<SubnetEventSummaryArtifactCategories>>;
   category_count: Scalars['Int']['output'];
   /** Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim. */
-  event_kinds: Scalars['JSON']['output'];
+  event_kinds?: Maybe<Array<SubnetEventSummaryArtifactEventKinds>>;
   kind_count: Scalars['Int']['output'];
   /** The resolved recent-event cap actually applied (1-50, default 10). */
   limit: Scalars['Int']['output'];
@@ -5476,6 +6177,34 @@ export type SubnetEventSummary = {
   total_events: Scalars['Int']['output'];
   /** The resolved window label (7d/30d/90d). */
   window?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetEventSummaryArtifactCategories = {
+  __typename?: 'SubnetEventSummaryArtifactCategories';
+  alpha_amount: Scalars['Float']['output'];
+  amount_tao: Scalars['Float']['output'];
+  category: Scalars['String']['output'];
+  event_count: Scalars['Int']['output'];
+  first_block?: Maybe<Scalars['Int']['output']>;
+  first_observed_at?: Maybe<Scalars['String']['output']>;
+  kind_count: Scalars['Int']['output'];
+  last_block?: Maybe<Scalars['Int']['output']>;
+  last_observed_at?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetEventSummaryArtifactEventKinds = {
+  __typename?: 'SubnetEventSummaryArtifactEventKinds';
+  alpha_amount: Scalars['Float']['output'];
+  amount_tao: Scalars['Float']['output'];
+  category: Scalars['String']['output'];
+  coldkey_count: Scalars['Int']['output'];
+  event_count: Scalars['Int']['output'];
+  event_kind: Scalars['String']['output'];
+  first_block?: Maybe<Scalars['Int']['output']>;
+  first_observed_at?: Maybe<Scalars['String']['output']>;
+  hotkey_count: Scalars['Int']['output'];
+  last_block?: Maybe<Scalars['Int']['output']>;
+  last_observed_at?: Maybe<Scalars['String']['output']>;
 };
 
 /** One subnet's paginated first-party chain-event feed (#7172), newest first, offset-paginated. event_count is the page count, not a grand total. Each item is an AccountEvent. Empty feed on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/events' data envelope. */
@@ -5516,7 +6245,7 @@ export type SubnetHealthIncidents = {
   schema_version: Scalars['Int']['output'];
   source?: Maybe<Scalars['String']['output']>;
   /** Per operational surface: its sample count, uptime_ratio, incident_count, total downtime_ms, and gap-island incident list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). Opaque JSON passed through verbatim, matching the get_subnet_health_incidents MCP/REST shape (like SubnetHealthTrends.windows). */
-  surfaces: Scalars['JSON']['output'];
+  surfaces?: Maybe<Array<HealthIncidentsArtifactSurfaces>>;
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -5528,7 +6257,7 @@ export type SubnetHealthPercentiles = {
   schema_version: Scalars['Int']['output'];
   source?: Maybe<Scalars['String']['output']>;
   /** Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces). */
-  surfaces: Scalars['JSON']['output'];
+  surfaces?: Maybe<Array<HealthPercentilesArtifactSurfaces>>;
   window?: Maybe<Scalars['String']['output']>;
 };
 
@@ -5667,11 +6396,24 @@ export type SubnetLease = {
   __typename?: 'SubnetLease';
   /** Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
   field_sources?: Maybe<Scalars['JSON']['output']>;
-  lease?: Maybe<Scalars['JSON']['output']>;
+  lease?: Maybe<SubnetLeaseArtifactLease>;
   leased?: Maybe<Scalars['Boolean']['output']>;
   netuid: Scalars['Int']['output'];
   queried_at?: Maybe<Scalars['String']['output']>;
   schema_version: Scalars['Int']['output'];
+};
+
+export type SubnetLeaseArtifactLease = {
+  __typename?: 'SubnetLeaseArtifactLease';
+  accumulated_dividends_alpha?: Maybe<Scalars['Float']['output']>;
+  beneficiary: Scalars['String']['output'];
+  coldkey: Scalars['String']['output'];
+  cost_tao?: Maybe<Scalars['Float']['output']>;
+  emissions_share_percent?: Maybe<Scalars['Int']['output']>;
+  end_block?: Maybe<Scalars['Int']['output']>;
+  hotkey: Scalars['String']['output'];
+  lease_id: Scalars['Int']['output'];
+  netuid: Scalars['Int']['output'];
 };
 
 /** Every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had, decoded from the account_events stream. Mirrors GET /api/v1/subnets/{netuid}/lease/history. */
@@ -5680,9 +6422,17 @@ export type SubnetLeaseHistory = {
   count: Scalars['Int']['output'];
   event_kinds?: Maybe<Array<Scalars['String']['output']>>;
   event_pallet?: Maybe<Scalars['String']['output']>;
-  lease_events: Array<Scalars['JSON']['output']>;
+  lease_events?: Maybe<Array<SubnetLeaseHistoryArtifactLeaseEvents>>;
   netuid: Scalars['Int']['output'];
   schema_version: Scalars['Int']['output'];
+};
+
+export type SubnetLeaseHistoryArtifactLeaseEvents = {
+  __typename?: 'SubnetLeaseHistoryArtifactLeaseEvents';
+  beneficiary?: Maybe<Scalars['String']['output']>;
+  block_number?: Maybe<Scalars['Int']['output']>;
+  event_kind?: Maybe<Scalars['String']['output']>;
+  observed_at?: Maybe<Scalars['String']['output']>;
 };
 
 export type SubnetLifecycle = {
@@ -5823,8 +6573,18 @@ export type SubnetOwnershipHistory = {
   /** The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read. */
   observed_through?: Maybe<Scalars['String']['output']>;
   /** Each record carries a source: chain-event (announced on chain, block-stamped) or owner-observation (inferred from two consecutive owner captures, so observed_at is when the change was NOTICED and block_number is null). */
-  ownership_changes: Array<Scalars['JSON']['output']>;
+  ownership_changes?: Maybe<Array<SubnetOwnershipHistoryArtifactOwnershipChanges>>;
   schema_version: Scalars['Int']['output'];
+};
+
+export type SubnetOwnershipHistoryArtifactOwnershipChanges = {
+  __typename?: 'SubnetOwnershipHistoryArtifactOwnershipChanges';
+  block_number?: Maybe<Scalars['Int']['output']>;
+  netuid?: Maybe<Scalars['Int']['output']>;
+  new_coldkey?: Maybe<Scalars['String']['output']>;
+  observed_at?: Maybe<Scalars['String']['output']>;
+  old_coldkey?: Maybe<Scalars['String']['output']>;
+  source?: Maybe<Scalars['String']['output']>;
 };
 
 /** Per-subnet reward-distribution & score-spread card (#5714). Metric blocks are null on a cold/empty subnet. Mirrors GET /api/v1/subnets/{netuid}/performance. */
@@ -5896,6 +6656,160 @@ export type SubnetPipelineHistory = {
   points: Array<PipelineHistoryPoint>;
   schema_version: Scalars['Int']['output'];
   window?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetProfile = {
+  __typename?: 'SubnetProfile';
+  candidate_count: Scalars['Int']['output'];
+  categories: Array<Scalars['String']['output']>;
+  completeness: SubnetProfileCompleteness;
+  completeness_score: Scalars['Int']['output'];
+  confidence: Scalars['String']['output'];
+  curation_level: Scalars['String']['output'];
+  derived_categories: Array<Scalars['String']['output']>;
+  derived_description?: Maybe<Scalars['String']['output']>;
+  endpoint_count: Scalars['Int']['output'];
+  gap_reasons: Array<Scalars['String']['output']>;
+  github_commits_weekly?: Maybe<Array<SubnetProfileGithubCommitsWeekly>>;
+  github_languages?: Maybe<Scalars['JSON']['output']>;
+  github_last_push_at?: Maybe<Scalars['String']['output']>;
+  github_releases?: Maybe<Array<SubnetProfileGithubReleases>>;
+  github_stars?: Maybe<Scalars['Int']['output']>;
+  github_unreachable?: Maybe<Scalars['Boolean']['output']>;
+  identity_evidence: SubnetProfileIdentityEvidence;
+  identity_level: Scalars['String']['output'];
+  identity_surface_count: Scalars['Int']['output'];
+  injection_scrubbed?: Maybe<Scalars['Boolean']['output']>;
+  integration_readiness?: Maybe<Scalars['Int']['output']>;
+  interface_count?: Maybe<Scalars['Int']['output']>;
+  lineage?: Maybe<SubnetProfileLineage>;
+  missing_critical_count: Scalars['Int']['output'];
+  missing_identity: Array<Scalars['String']['output']>;
+  missing_operational: Array<Scalars['String']['output']>;
+  missing_required: Array<Scalars['String']['output']>;
+  monitored_endpoint_count: Scalars['Int']['output'];
+  name: Scalars['String']['output'];
+  native_identity?: Maybe<SubnetProfileNativeIdentity>;
+  native_name?: Maybe<Scalars['String']['output']>;
+  native_name_quality?: Maybe<Scalars['String']['output']>;
+  netuid: Scalars['Int']['output'];
+  operational_interface_count?: Maybe<Scalars['Int']['output']>;
+  operational_interface_kinds: Array<Scalars['String']['output']>;
+  primary_app_surface?: Maybe<SubnetProfilePrimaryAppSurface>;
+  primary_links: SubnetProfilePrimaryLinks;
+  profile_level: Scalars['String']['output'];
+  project_name: Scalars['String']['output'];
+  provenance: SubnetProfileProvenance;
+  readiness?: Maybe<IntegrationReadiness>;
+  review_state: Scalars['String']['output'];
+  slug: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  subnet_type: Scalars['String']['output'];
+  suggested_submission_kinds: Array<Scalars['String']['output']>;
+  supported_interface_kinds: Array<Scalars['String']['output']>;
+  surface_count: Scalars['Int']['output'];
+  symbol?: Maybe<Scalars['String']['output']>;
+  team?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetProfileCompleteness = {
+  __typename?: 'SubnetProfileCompleteness';
+  confidence: Scalars['String']['output'];
+  gap_reasons: Array<Scalars['String']['output']>;
+  identity_level: Scalars['String']['output'];
+  identity_surface_count: Scalars['Int']['output'];
+  missing_critical_count: Scalars['Int']['output'];
+  missing_identity: Array<Scalars['String']['output']>;
+  missing_operational: Array<Scalars['String']['output']>;
+  missing_required: Array<Scalars['String']['output']>;
+  profile_level: Scalars['String']['output'];
+  score: Scalars['Int']['output'];
+};
+
+export type SubnetProfileGithubCommitsWeekly = {
+  __typename?: 'SubnetProfileGithubCommitsWeekly';
+  count: Scalars['Int']['output'];
+  week: Scalars['String']['output'];
+};
+
+export type SubnetProfileGithubReleases = {
+  __typename?: 'SubnetProfileGithubReleases';
+  name?: Maybe<Scalars['String']['output']>;
+  prerelease: Scalars['Boolean']['output'];
+  published_at: Scalars['String']['output'];
+  tag: Scalars['String']['output'];
+  url: Scalars['String']['output'];
+};
+
+export type SubnetProfileIdentityEvidence = {
+  __typename?: 'SubnetProfileIdentityEvidence';
+  candidate_identity_count: Scalars['Int']['output'];
+  curated_identity_count: Scalars['Int']['output'];
+  curated_identity_kinds: Array<Scalars['String']['output']>;
+  live_candidate_identity_kinds: Array<Scalars['String']['output']>;
+  native_contact_present: Scalars['Boolean']['output'];
+  native_description_present: Scalars['Boolean']['output'];
+  native_identity_count: Scalars['Int']['output'];
+  native_identity_kinds: Array<Scalars['String']['output']>;
+  needs_promotion_kinds: Array<Scalars['String']['output']>;
+  stale_candidate_identity_kinds: Array<Scalars['String']['output']>;
+  unverified_candidate_identity_kinds: Array<Scalars['String']['output']>;
+};
+
+export type SubnetProfileLineage = {
+  __typename?: 'SubnetProfileLineage';
+  also_on?: Maybe<Array<SubnetProfileLineageAlsoOn>>;
+  graduated_from_testnet?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type SubnetProfileLineageAlsoOn = {
+  __typename?: 'SubnetProfileLineageAlsoOn';
+  matched_by?: Maybe<Scalars['String']['output']>;
+  name?: Maybe<Scalars['String']['output']>;
+  netuid?: Maybe<Scalars['Int']['output']>;
+  network?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetProfileNativeIdentity = {
+  __typename?: 'SubnetProfileNativeIdentity';
+  additional?: Maybe<Scalars['String']['output']>;
+  contact_present: Scalars['Boolean']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  discord?: Maybe<Scalars['String']['output']>;
+  discord_url?: Maybe<Scalars['String']['output']>;
+  github_url?: Maybe<Scalars['String']['output']>;
+  logo_url?: Maybe<Scalars['String']['output']>;
+  source: Scalars['String']['output'];
+  subnet_name?: Maybe<Scalars['String']['output']>;
+  website_url?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetProfilePrimaryAppSurface = {
+  __typename?: 'SubnetProfilePrimaryAppSurface';
+  id: Scalars['String']['output'];
+  key?: Maybe<Scalars['String']['output']>;
+  kind: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  provider: Scalars['String']['output'];
+  url: Scalars['String']['output'];
+};
+
+export type SubnetProfilePrimaryLinks = {
+  __typename?: 'SubnetProfilePrimaryLinks';
+  dashboard_url?: Maybe<Scalars['String']['output']>;
+  docs_url?: Maybe<Scalars['String']['output']>;
+  source_repo?: Maybe<Scalars['String']['output']>;
+  website_url?: Maybe<Scalars['String']['output']>;
+};
+
+export type SubnetProfileProvenance = {
+  __typename?: 'SubnetProfileProvenance';
+  curation_level: Scalars['String']['output'];
+  identity_source: Scalars['String']['output'];
+  interface_source_count: Scalars['Int']['output'];
+  review_state: Scalars['String']['output'];
+  reviewed_at?: Maybe<Scalars['String']['output']>;
+  source_urls: Array<Scalars['String']['output']>;
 };
 
 /** Per-subnet Prometheus-endpoint serving activity (#7172) over a 7d/30d window. Zeroed card on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/prometheus. */
@@ -6870,12 +7784,15 @@ export type ResolversTypes = ResolversObject<{
   AccountWeightSetters: ResolverTypeWrapper<AccountWeightSetters>;
   AccountWeightSettersSubnet: ResolverTypeWrapper<AccountWeightSettersSubnet>;
   Adapter: ResolverTypeWrapper<Adapter>;
+  AdapterArtifactSnapshot: ResolverTypeWrapper<AdapterArtifactSnapshot>;
   AlphaUsdFieldSource: ResolverTypeWrapper<AlphaUsdFieldSource>;
   Block: ResolverTypeWrapper<Block>;
   BlockChainEvents: ResolverTypeWrapper<BlockChainEvents>;
+  BlockChainEventsArtifactEvents: ResolverTypeWrapper<BlockChainEventsArtifactEvents>;
   BlockDetail: ResolverTypeWrapper<BlockDetail>;
   BlockEvents: ResolverTypeWrapper<BlockEvents>;
   BlockExtrinsics: ResolverTypeWrapper<BlockExtrinsics>;
+  BlockExtrinsicsArtifactExtrinsics: ResolverTypeWrapper<BlockExtrinsicsArtifactExtrinsics>;
   BlockList: ResolverTypeWrapper<BlockList>;
   BlockTimeDistribution: ResolverTypeWrapper<BlockTimeDistribution>;
   BlocksSummary: ResolverTypeWrapper<BlocksSummary>;
@@ -6884,6 +7801,8 @@ export type ResolversTypes = ResolversObject<{
   BuildArtifactBudget: ResolverTypeWrapper<BuildArtifactBudget>;
   BuildPublicContract: ResolverTypeWrapper<BuildPublicContract>;
   BuildSummary: ResolverTypeWrapper<BuildSummary>;
+  BuildSummaryArtifactArtifactBudgetSummary: ResolverTypeWrapper<BuildSummaryArtifactArtifactBudgetSummary>;
+  BuildSummaryArtifactArtifacts: ResolverTypeWrapper<BuildSummaryArtifactArtifacts>;
   ChainActivity: ResolverTypeWrapper<ChainActivity>;
   ChainActivityDay: ResolverTypeWrapper<ChainActivityDay>;
   ChainAlphaVolume: ResolverTypeWrapper<ChainAlphaVolume>;
@@ -6899,6 +7818,7 @@ export type ResolversTypes = ResolversObject<{
   ChainConcentration: ResolverTypeWrapper<ChainConcentration>;
   ChainConcentrationHistory: ResolverTypeWrapper<ChainConcentrationHistory>;
   ChainConcentrationHistoryPoint: ResolverTypeWrapper<ChainConcentrationHistoryPoint>;
+  ChainConcentrationScorecard: ResolverTypeWrapper<ChainConcentrationScorecard>;
   ChainDeregistrations: ResolverTypeWrapper<ChainDeregistrations>;
   ChainDeregistrationsNetwork: ResolverTypeWrapper<ChainDeregistrationsNetwork>;
   ChainDeregistrationsSubnet: ResolverTypeWrapper<ChainDeregistrationsSubnet>;
@@ -6957,15 +7877,30 @@ export type ResolversTypes = ResolversObject<{
   ChainWeightsSubnet: ResolverTypeWrapper<ChainWeightsSubnet>;
   ChainYield: ResolverTypeWrapper<ChainYield>;
   Changelog: ResolverTypeWrapper<Changelog>;
+  ChangelogArtifactArtifacts: ResolverTypeWrapper<ChangelogArtifactArtifacts>;
+  ChangelogArtifactSubnets: ResolverTypeWrapper<ChangelogArtifactSubnets>;
+  ChangelogArtifactSubnetsAdded: ResolverTypeWrapper<ChangelogArtifactSubnetsAdded>;
+  ChangelogArtifactSubnetsRemoved: ResolverTypeWrapper<ChangelogArtifactSubnetsRemoved>;
+  ChangelogArtifactSubnetsRenamed: ResolverTypeWrapper<ChangelogArtifactSubnetsRenamed>;
+  ChangelogArtifactSummary: ResolverTypeWrapper<ChangelogArtifactSummary>;
   Compare: ResolverTypeWrapper<Compare>;
   CompareEconomics: ResolverTypeWrapper<CompareEconomics>;
   CompareHealth: ResolverTypeWrapper<CompareHealth>;
   CompareStructure: ResolverTypeWrapper<CompareStructure>;
   CompareSubnet: ResolverTypeWrapper<CompareSubnet>;
+  CompareValidatorsArtifactValidatorsColdkeyIdentity: ResolverTypeWrapper<CompareValidatorsArtifactValidatorsColdkeyIdentity>;
+  CompareValidatorsArtifactValidatorsSubnetContext: ResolverTypeWrapper<CompareValidatorsArtifactValidatorsSubnetContext>;
   ComparedValidator: ResolverTypeWrapper<ComparedValidator>;
   ConcentrationMetrics: ResolverTypeWrapper<ConcentrationMetrics>;
   Contracts: ResolverTypeWrapper<Contracts>;
+  ContractsArtifactArtifacts: ResolverTypeWrapper<ContractsArtifactArtifacts>;
+  ContractsArtifactArtifactsRetirement: ResolverTypeWrapper<ContractsArtifactArtifactsRetirement>;
+  CoverageArtifact: ResolverTypeWrapper<CoverageArtifact>;
+  CoverageArtifactSource: ResolverTypeWrapper<CoverageArtifactSource>;
+  CoverageCompleteness: ResolverTypeWrapper<CoverageCompleteness>;
+  CurationArtifactCuration: ResolverTypeWrapper<CurationArtifactCuration>;
   CurationList: ResolverTypeWrapper<CurationList>;
+  CurationMetadata: ResolverTypeWrapper<CurationMetadata>;
   DegradedInfo: ResolverTypeWrapper<DegradedInfo>;
   DeregistrationDerivation: ResolverTypeWrapper<DeregistrationDerivation>;
   DeregistrationTenure: ResolverTypeWrapper<DeregistrationTenure>;
@@ -6985,8 +7920,12 @@ export type ResolversTypes = ResolversObject<{
   Endpoint: ResolverTypeWrapper<Endpoint>;
   EndpointIncident: ResolverTypeWrapper<EndpointIncident>;
   EndpointIncidentWindow: ResolverTypeWrapper<EndpointIncidentWindow>;
+  EndpointIncidentsArtifactSummary: ResolverTypeWrapper<EndpointIncidentsArtifactSummary>;
   EndpointList: ResolverTypeWrapper<EndpointList>;
   EndpointPoolList: ResolverTypeWrapper<EndpointPoolList>;
+  EndpointScoreReason: ResolverTypeWrapper<EndpointScoreReason>;
+  EvidenceClaim: ResolverTypeWrapper<EvidenceClaim>;
+  EvidenceLedgerArtifactSummary: ResolverTypeWrapper<EvidenceLedgerArtifactSummary>;
   EvidenceList: ResolverTypeWrapper<EvidenceList>;
   EvmAddressMapping: ResolverTypeWrapper<EvmAddressMapping>;
   Extrinsic: ResolverTypeWrapper<Extrinsic>;
@@ -6996,11 +7935,20 @@ export type ResolversTypes = ResolversObject<{
   FailureReasons: ResolverTypeWrapper<FailureReasons>;
   FailureReasonsDay: ResolverTypeWrapper<FailureReasonsDay>;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
+  Gaps: ResolverTypeWrapper<Gaps>;
+  GapsArtifactGaps: ResolverTypeWrapper<GapsArtifactGaps>;
   GapsList: ResolverTypeWrapper<GapsList>;
   GlobalHealth: ResolverTypeWrapper<GlobalHealth>;
   GlobalIncidentSurface: ResolverTypeWrapper<GlobalIncidentSurface>;
   GlobalIncidents: ResolverTypeWrapper<GlobalIncidents>;
+  GlobalIncidentsArtifactSummary: ResolverTypeWrapper<GlobalIncidentsArtifactSummary>;
   HealthHistory: ResolverTypeWrapper<HealthHistory>;
+  HealthHistoryArtifactSurfaces: ResolverTypeWrapper<HealthHistoryArtifactSurfaces>;
+  HealthIncidentsArtifactSurfaces: ResolverTypeWrapper<HealthIncidentsArtifactSurfaces>;
+  HealthIncidentsArtifactSurfacesIncidents: ResolverTypeWrapper<HealthIncidentsArtifactSurfacesIncidents>;
+  HealthPercentilesArtifactSurfaces: ResolverTypeWrapper<HealthPercentilesArtifactSurfaces>;
+  HealthPercentilesArtifactSurfacesLatencyMs: ResolverTypeWrapper<HealthPercentilesArtifactSurfacesLatencyMs>;
+  HealthProbeSummary: ResolverTypeWrapper<HealthProbeSummary>;
   HealthTrends: ResolverTypeWrapper<HealthTrends>;
   Hyperparameters: ResolverTypeWrapper<Hyperparameters>;
   HyperparamsHistoryEntry: ResolverTypeWrapper<HyperparamsHistoryEntry>;
@@ -7011,6 +7959,8 @@ export type ResolversTypes = ResolversObject<{
   IndexerLagLatency: ResolverTypeWrapper<IndexerLagLatency>;
   IndexerLagWindow: ResolverTypeWrapper<IndexerLagWindow>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
+  IntegrationReadiness: ResolverTypeWrapper<IntegrationReadiness>;
+  IntegrationReadinessComponents: ResolverTypeWrapper<IntegrationReadinessComponents>;
   IntensityDistribution: ResolverTypeWrapper<IntensityDistribution>;
   JSON: ResolverTypeWrapper<Scalars['JSON']['output']>;
   Network: ResolverTypeWrapper<Network>;
@@ -7038,15 +7988,28 @@ export type ResolversTypes = ResolversObject<{
   RevenueSource: ResolverTypeWrapper<RevenueSource>;
   RevenueVerification: ResolverTypeWrapper<RevenueVerification>;
   RevenueVerificationCheck: ResolverTypeWrapper<RevenueVerificationCheck>;
+  ReviewAdapterCandidate: ResolverTypeWrapper<ReviewAdapterCandidate>;
   ReviewAdapterCandidateList: ResolverTypeWrapper<ReviewAdapterCandidateList>;
+  ReviewEnrichmentEvidenceArtifactEntries: ResolverTypeWrapper<ReviewEnrichmentEvidenceArtifactEntries>;
+  ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary: ResolverTypeWrapper<ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary>;
   ReviewEnrichmentEvidenceList: ResolverTypeWrapper<ReviewEnrichmentEvidenceList>;
+  ReviewEnrichmentQueueArtifactQueue: ResolverTypeWrapper<ReviewEnrichmentQueueArtifactQueue>;
+  ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary: ResolverTypeWrapper<ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary>;
   ReviewEnrichmentQueueList: ResolverTypeWrapper<ReviewEnrichmentQueueList>;
   ReviewEnrichmentTargetList: ResolverTypeWrapper<ReviewEnrichmentTargetList>;
+  ReviewEnrichmentTargetsArtifactTargets: ResolverTypeWrapper<ReviewEnrichmentTargetsArtifactTargets>;
+  ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence: ResolverTypeWrapper<ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence>;
+  ReviewEnrichmentTargetsArtifactTargetsQueueContext: ResolverTypeWrapper<ReviewEnrichmentTargetsArtifactTargetsQueueContext>;
+  ReviewGapPriority: ResolverTypeWrapper<ReviewGapPriority>;
   ReviewGapPriorityList: ResolverTypeWrapper<ReviewGapPriorityList>;
+  ReviewProfileCompletenessArtifactProfiles: ResolverTypeWrapper<ReviewProfileCompletenessArtifactProfiles>;
+  ReviewProfileCompletenessArtifactSummary: ResolverTypeWrapper<ReviewProfileCompletenessArtifactSummary>;
   ReviewProfileCompletenessList: ResolverTypeWrapper<ReviewProfileCompletenessList>;
   RootClaimEntry: ResolverTypeWrapper<RootClaimEntry>;
   RootClaimHotkey: ResolverTypeWrapper<RootClaimHotkey>;
   RootClaimType: ResolverTypeWrapper<RootClaimType>;
+  RpcPool: ResolverTypeWrapper<RpcPool>;
+  RpcPoolEndpoints: ResolverTypeWrapper<RpcPoolEndpoints>;
   RpcUsage: ResolverTypeWrapper<RpcUsage>;
   RpcUsageBucket: ResolverTypeWrapper<RpcUsageBucket>;
   RpcUsageCoverage: ResolverTypeWrapper<RpcUsageCoverage>;
@@ -7060,13 +8023,17 @@ export type ResolversTypes = ResolversObject<{
   RuntimeTransition: ResolverTypeWrapper<RuntimeTransition>;
   RuntimeVersionHistory: ResolverTypeWrapper<RuntimeVersionHistory>;
   ScoreDistribution: ResolverTypeWrapper<ScoreDistribution>;
+  SearchArtifactDocuments: ResolverTypeWrapper<SearchArtifactDocuments>;
   SearchDocumentList: ResolverTypeWrapper<SearchDocumentList>;
+  SearchIndexArtifactDocuments: ResolverTypeWrapper<SearchIndexArtifactDocuments>;
   SearchIndexList: ResolverTypeWrapper<SearchIndexList>;
   SelfHealth: ResolverTypeWrapper<SelfHealth>;
   SelfHealthComponentView: ResolverTypeWrapper<SelfHealthComponentView>;
   SelfHealthDay: ResolverTypeWrapper<SelfHealthDay>;
   SelfHealthLane: ResolverTypeWrapper<SelfHealthLane>;
   SourceSnapshotList: ResolverTypeWrapper<SourceSnapshotList>;
+  SourceSnapshotsArtifactSources: ResolverTypeWrapper<SourceSnapshotsArtifactSources>;
+  SourceSnapshotsArtifactSummary: ResolverTypeWrapper<SourceSnapshotsArtifactSummary>;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   Subnet: ResolverTypeWrapper<Subnet>;
   SubnetAxonRemovals: ResolverTypeWrapper<SubnetAxonRemovals>;
@@ -7077,11 +8044,14 @@ export type ResolversTypes = ResolversObject<{
   SubnetConcentrationHistory: ResolverTypeWrapper<SubnetConcentrationHistory>;
   SubnetConcentrationHistoryPoint: ResolverTypeWrapper<SubnetConcentrationHistoryPoint>;
   SubnetConviction: ResolverTypeWrapper<SubnetConviction>;
+  SubnetConvictionArtifactLeaderboard: ResolverTypeWrapper<SubnetConvictionArtifactLeaderboard>;
   SubnetDeregistrationEvent: ResolverTypeWrapper<SubnetDeregistrationEvent>;
   SubnetDeregistrations: ResolverTypeWrapper<SubnetDeregistrations>;
   SubnetEconomics: ResolverTypeWrapper<SubnetEconomics>;
   SubnetEmissionDecomposition: ResolverTypeWrapper<SubnetEmissionDecomposition>;
   SubnetEventSummary: ResolverTypeWrapper<SubnetEventSummary>;
+  SubnetEventSummaryArtifactCategories: ResolverTypeWrapper<SubnetEventSummaryArtifactCategories>;
+  SubnetEventSummaryArtifactEventKinds: ResolverTypeWrapper<SubnetEventSummaryArtifactEventKinds>;
   SubnetEvents: ResolverTypeWrapper<SubnetEvents>;
   SubnetHealth: ResolverTypeWrapper<SubnetHealth>;
   SubnetHealthIncidents: ResolverTypeWrapper<SubnetHealthIncidents>;
@@ -7098,7 +8068,9 @@ export type ResolversTypes = ResolversObject<{
   SubnetIdentityHistoryEntry: ResolverTypeWrapper<SubnetIdentityHistoryEntry>;
   SubnetIdleStake: ResolverTypeWrapper<SubnetIdleStake>;
   SubnetLease: ResolverTypeWrapper<SubnetLease>;
+  SubnetLeaseArtifactLease: ResolverTypeWrapper<SubnetLeaseArtifactLease>;
   SubnetLeaseHistory: ResolverTypeWrapper<SubnetLeaseHistory>;
+  SubnetLeaseHistoryArtifactLeaseEvents: ResolverTypeWrapper<SubnetLeaseHistoryArtifactLeaseEvents>;
   SubnetLifecycle: ResolverTypeWrapper<SubnetLifecycle>;
   SubnetLifecycleEntry: ResolverTypeWrapper<SubnetLifecycleEntry>;
   SubnetList: ResolverTypeWrapper<SubnetList>;
@@ -7108,10 +8080,22 @@ export type ResolversTypes = ResolversObject<{
   SubnetOhlc: ResolverTypeWrapper<SubnetOhlc>;
   SubnetOhlcCandle: ResolverTypeWrapper<SubnetOhlcCandle>;
   SubnetOwnershipHistory: ResolverTypeWrapper<SubnetOwnershipHistory>;
+  SubnetOwnershipHistoryArtifactOwnershipChanges: ResolverTypeWrapper<SubnetOwnershipHistoryArtifactOwnershipChanges>;
   SubnetPerformance: ResolverTypeWrapper<SubnetPerformance>;
   SubnetPerformanceHistory: ResolverTypeWrapper<SubnetPerformanceHistory>;
   SubnetPerformanceHistoryPoint: ResolverTypeWrapper<SubnetPerformanceHistoryPoint>;
   SubnetPipelineHistory: ResolverTypeWrapper<SubnetPipelineHistory>;
+  SubnetProfile: ResolverTypeWrapper<SubnetProfile>;
+  SubnetProfileCompleteness: ResolverTypeWrapper<SubnetProfileCompleteness>;
+  SubnetProfileGithubCommitsWeekly: ResolverTypeWrapper<SubnetProfileGithubCommitsWeekly>;
+  SubnetProfileGithubReleases: ResolverTypeWrapper<SubnetProfileGithubReleases>;
+  SubnetProfileIdentityEvidence: ResolverTypeWrapper<SubnetProfileIdentityEvidence>;
+  SubnetProfileLineage: ResolverTypeWrapper<SubnetProfileLineage>;
+  SubnetProfileLineageAlsoOn: ResolverTypeWrapper<SubnetProfileLineageAlsoOn>;
+  SubnetProfileNativeIdentity: ResolverTypeWrapper<SubnetProfileNativeIdentity>;
+  SubnetProfilePrimaryAppSurface: ResolverTypeWrapper<SubnetProfilePrimaryAppSurface>;
+  SubnetProfilePrimaryLinks: ResolverTypeWrapper<SubnetProfilePrimaryLinks>;
+  SubnetProfileProvenance: ResolverTypeWrapper<SubnetProfileProvenance>;
   SubnetPrometheus: ResolverTypeWrapper<SubnetPrometheus>;
   SubnetRecycled: ResolverTypeWrapper<SubnetRecycled>;
   SubnetRegistrations: ResolverTypeWrapper<SubnetRegistrations>;
@@ -7231,12 +8215,15 @@ export type ResolversParentTypes = ResolversObject<{
   AccountWeightSetters: AccountWeightSetters;
   AccountWeightSettersSubnet: AccountWeightSettersSubnet;
   Adapter: Adapter;
+  AdapterArtifactSnapshot: AdapterArtifactSnapshot;
   AlphaUsdFieldSource: AlphaUsdFieldSource;
   Block: Block;
   BlockChainEvents: BlockChainEvents;
+  BlockChainEventsArtifactEvents: BlockChainEventsArtifactEvents;
   BlockDetail: BlockDetail;
   BlockEvents: BlockEvents;
   BlockExtrinsics: BlockExtrinsics;
+  BlockExtrinsicsArtifactExtrinsics: BlockExtrinsicsArtifactExtrinsics;
   BlockList: BlockList;
   BlockTimeDistribution: BlockTimeDistribution;
   BlocksSummary: BlocksSummary;
@@ -7245,6 +8232,8 @@ export type ResolversParentTypes = ResolversObject<{
   BuildArtifactBudget: BuildArtifactBudget;
   BuildPublicContract: BuildPublicContract;
   BuildSummary: BuildSummary;
+  BuildSummaryArtifactArtifactBudgetSummary: BuildSummaryArtifactArtifactBudgetSummary;
+  BuildSummaryArtifactArtifacts: BuildSummaryArtifactArtifacts;
   ChainActivity: ChainActivity;
   ChainActivityDay: ChainActivityDay;
   ChainAlphaVolume: ChainAlphaVolume;
@@ -7260,6 +8249,7 @@ export type ResolversParentTypes = ResolversObject<{
   ChainConcentration: ChainConcentration;
   ChainConcentrationHistory: ChainConcentrationHistory;
   ChainConcentrationHistoryPoint: ChainConcentrationHistoryPoint;
+  ChainConcentrationScorecard: ChainConcentrationScorecard;
   ChainDeregistrations: ChainDeregistrations;
   ChainDeregistrationsNetwork: ChainDeregistrationsNetwork;
   ChainDeregistrationsSubnet: ChainDeregistrationsSubnet;
@@ -7317,15 +8307,30 @@ export type ResolversParentTypes = ResolversObject<{
   ChainWeightsSubnet: ChainWeightsSubnet;
   ChainYield: ChainYield;
   Changelog: Changelog;
+  ChangelogArtifactArtifacts: ChangelogArtifactArtifacts;
+  ChangelogArtifactSubnets: ChangelogArtifactSubnets;
+  ChangelogArtifactSubnetsAdded: ChangelogArtifactSubnetsAdded;
+  ChangelogArtifactSubnetsRemoved: ChangelogArtifactSubnetsRemoved;
+  ChangelogArtifactSubnetsRenamed: ChangelogArtifactSubnetsRenamed;
+  ChangelogArtifactSummary: ChangelogArtifactSummary;
   Compare: Compare;
   CompareEconomics: CompareEconomics;
   CompareHealth: CompareHealth;
   CompareStructure: CompareStructure;
   CompareSubnet: CompareSubnet;
+  CompareValidatorsArtifactValidatorsColdkeyIdentity: CompareValidatorsArtifactValidatorsColdkeyIdentity;
+  CompareValidatorsArtifactValidatorsSubnetContext: CompareValidatorsArtifactValidatorsSubnetContext;
   ComparedValidator: ComparedValidator;
   ConcentrationMetrics: ConcentrationMetrics;
   Contracts: Contracts;
+  ContractsArtifactArtifacts: ContractsArtifactArtifacts;
+  ContractsArtifactArtifactsRetirement: ContractsArtifactArtifactsRetirement;
+  CoverageArtifact: CoverageArtifact;
+  CoverageArtifactSource: CoverageArtifactSource;
+  CoverageCompleteness: CoverageCompleteness;
+  CurationArtifactCuration: CurationArtifactCuration;
   CurationList: CurationList;
+  CurationMetadata: CurationMetadata;
   DegradedInfo: DegradedInfo;
   DeregistrationDerivation: DeregistrationDerivation;
   DeregistrationTenure: DeregistrationTenure;
@@ -7345,8 +8350,12 @@ export type ResolversParentTypes = ResolversObject<{
   Endpoint: Endpoint;
   EndpointIncident: EndpointIncident;
   EndpointIncidentWindow: EndpointIncidentWindow;
+  EndpointIncidentsArtifactSummary: EndpointIncidentsArtifactSummary;
   EndpointList: EndpointList;
   EndpointPoolList: EndpointPoolList;
+  EndpointScoreReason: EndpointScoreReason;
+  EvidenceClaim: EvidenceClaim;
+  EvidenceLedgerArtifactSummary: EvidenceLedgerArtifactSummary;
   EvidenceList: EvidenceList;
   EvmAddressMapping: EvmAddressMapping;
   Extrinsic: Extrinsic;
@@ -7356,11 +8365,20 @@ export type ResolversParentTypes = ResolversObject<{
   FailureReasons: FailureReasons;
   FailureReasonsDay: FailureReasonsDay;
   Float: Scalars['Float']['output'];
+  Gaps: Gaps;
+  GapsArtifactGaps: GapsArtifactGaps;
   GapsList: GapsList;
   GlobalHealth: GlobalHealth;
   GlobalIncidentSurface: GlobalIncidentSurface;
   GlobalIncidents: GlobalIncidents;
+  GlobalIncidentsArtifactSummary: GlobalIncidentsArtifactSummary;
   HealthHistory: HealthHistory;
+  HealthHistoryArtifactSurfaces: HealthHistoryArtifactSurfaces;
+  HealthIncidentsArtifactSurfaces: HealthIncidentsArtifactSurfaces;
+  HealthIncidentsArtifactSurfacesIncidents: HealthIncidentsArtifactSurfacesIncidents;
+  HealthPercentilesArtifactSurfaces: HealthPercentilesArtifactSurfaces;
+  HealthPercentilesArtifactSurfacesLatencyMs: HealthPercentilesArtifactSurfacesLatencyMs;
+  HealthProbeSummary: HealthProbeSummary;
   HealthTrends: HealthTrends;
   Hyperparameters: Hyperparameters;
   HyperparamsHistoryEntry: HyperparamsHistoryEntry;
@@ -7371,6 +8389,8 @@ export type ResolversParentTypes = ResolversObject<{
   IndexerLagLatency: IndexerLagLatency;
   IndexerLagWindow: IndexerLagWindow;
   Int: Scalars['Int']['output'];
+  IntegrationReadiness: IntegrationReadiness;
+  IntegrationReadinessComponents: IntegrationReadinessComponents;
   IntensityDistribution: IntensityDistribution;
   JSON: Scalars['JSON']['output'];
   NetworkParameters: NetworkParameters;
@@ -7397,15 +8417,28 @@ export type ResolversParentTypes = ResolversObject<{
   RevenueSource: RevenueSource;
   RevenueVerification: RevenueVerification;
   RevenueVerificationCheck: RevenueVerificationCheck;
+  ReviewAdapterCandidate: ReviewAdapterCandidate;
   ReviewAdapterCandidateList: ReviewAdapterCandidateList;
+  ReviewEnrichmentEvidenceArtifactEntries: ReviewEnrichmentEvidenceArtifactEntries;
+  ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary: ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary;
   ReviewEnrichmentEvidenceList: ReviewEnrichmentEvidenceList;
+  ReviewEnrichmentQueueArtifactQueue: ReviewEnrichmentQueueArtifactQueue;
+  ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary: ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary;
   ReviewEnrichmentQueueList: ReviewEnrichmentQueueList;
   ReviewEnrichmentTargetList: ReviewEnrichmentTargetList;
+  ReviewEnrichmentTargetsArtifactTargets: ReviewEnrichmentTargetsArtifactTargets;
+  ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence: ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence;
+  ReviewEnrichmentTargetsArtifactTargetsQueueContext: ReviewEnrichmentTargetsArtifactTargetsQueueContext;
+  ReviewGapPriority: ReviewGapPriority;
   ReviewGapPriorityList: ReviewGapPriorityList;
+  ReviewProfileCompletenessArtifactProfiles: ReviewProfileCompletenessArtifactProfiles;
+  ReviewProfileCompletenessArtifactSummary: ReviewProfileCompletenessArtifactSummary;
   ReviewProfileCompletenessList: ReviewProfileCompletenessList;
   RootClaimEntry: RootClaimEntry;
   RootClaimHotkey: RootClaimHotkey;
   RootClaimType: RootClaimType;
+  RpcPool: RpcPool;
+  RpcPoolEndpoints: RpcPoolEndpoints;
   RpcUsage: RpcUsage;
   RpcUsageBucket: RpcUsageBucket;
   RpcUsageCoverage: RpcUsageCoverage;
@@ -7419,13 +8452,17 @@ export type ResolversParentTypes = ResolversObject<{
   RuntimeTransition: RuntimeTransition;
   RuntimeVersionHistory: RuntimeVersionHistory;
   ScoreDistribution: ScoreDistribution;
+  SearchArtifactDocuments: SearchArtifactDocuments;
   SearchDocumentList: SearchDocumentList;
+  SearchIndexArtifactDocuments: SearchIndexArtifactDocuments;
   SearchIndexList: SearchIndexList;
   SelfHealth: SelfHealth;
   SelfHealthComponentView: SelfHealthComponentView;
   SelfHealthDay: SelfHealthDay;
   SelfHealthLane: SelfHealthLane;
   SourceSnapshotList: SourceSnapshotList;
+  SourceSnapshotsArtifactSources: SourceSnapshotsArtifactSources;
+  SourceSnapshotsArtifactSummary: SourceSnapshotsArtifactSummary;
   String: Scalars['String']['output'];
   Subnet: Subnet;
   SubnetAxonRemovals: SubnetAxonRemovals;
@@ -7436,11 +8473,14 @@ export type ResolversParentTypes = ResolversObject<{
   SubnetConcentrationHistory: SubnetConcentrationHistory;
   SubnetConcentrationHistoryPoint: SubnetConcentrationHistoryPoint;
   SubnetConviction: SubnetConviction;
+  SubnetConvictionArtifactLeaderboard: SubnetConvictionArtifactLeaderboard;
   SubnetDeregistrationEvent: SubnetDeregistrationEvent;
   SubnetDeregistrations: SubnetDeregistrations;
   SubnetEconomics: SubnetEconomics;
   SubnetEmissionDecomposition: SubnetEmissionDecomposition;
   SubnetEventSummary: SubnetEventSummary;
+  SubnetEventSummaryArtifactCategories: SubnetEventSummaryArtifactCategories;
+  SubnetEventSummaryArtifactEventKinds: SubnetEventSummaryArtifactEventKinds;
   SubnetEvents: SubnetEvents;
   SubnetHealth: SubnetHealth;
   SubnetHealthIncidents: SubnetHealthIncidents;
@@ -7457,7 +8497,9 @@ export type ResolversParentTypes = ResolversObject<{
   SubnetIdentityHistoryEntry: SubnetIdentityHistoryEntry;
   SubnetIdleStake: SubnetIdleStake;
   SubnetLease: SubnetLease;
+  SubnetLeaseArtifactLease: SubnetLeaseArtifactLease;
   SubnetLeaseHistory: SubnetLeaseHistory;
+  SubnetLeaseHistoryArtifactLeaseEvents: SubnetLeaseHistoryArtifactLeaseEvents;
   SubnetLifecycle: SubnetLifecycle;
   SubnetLifecycleEntry: SubnetLifecycleEntry;
   SubnetList: SubnetList;
@@ -7467,10 +8509,22 @@ export type ResolversParentTypes = ResolversObject<{
   SubnetOhlc: SubnetOhlc;
   SubnetOhlcCandle: SubnetOhlcCandle;
   SubnetOwnershipHistory: SubnetOwnershipHistory;
+  SubnetOwnershipHistoryArtifactOwnershipChanges: SubnetOwnershipHistoryArtifactOwnershipChanges;
   SubnetPerformance: SubnetPerformance;
   SubnetPerformanceHistory: SubnetPerformanceHistory;
   SubnetPerformanceHistoryPoint: SubnetPerformanceHistoryPoint;
   SubnetPipelineHistory: SubnetPipelineHistory;
+  SubnetProfile: SubnetProfile;
+  SubnetProfileCompleteness: SubnetProfileCompleteness;
+  SubnetProfileGithubCommitsWeekly: SubnetProfileGithubCommitsWeekly;
+  SubnetProfileGithubReleases: SubnetProfileGithubReleases;
+  SubnetProfileIdentityEvidence: SubnetProfileIdentityEvidence;
+  SubnetProfileLineage: SubnetProfileLineage;
+  SubnetProfileLineageAlsoOn: SubnetProfileLineageAlsoOn;
+  SubnetProfileNativeIdentity: SubnetProfileNativeIdentity;
+  SubnetProfilePrimaryAppSurface: SubnetProfilePrimaryAppSurface;
+  SubnetProfilePrimaryLinks: SubnetProfilePrimaryLinks;
+  SubnetProfileProvenance: SubnetProfileProvenance;
   SubnetPrometheus: SubnetPrometheus;
   SubnetRecycled: SubnetRecycled;
   SubnetRegistrations: SubnetRegistrations;
@@ -8101,8 +9155,22 @@ export type AdapterResolvers<ContextType = GqlContext, ParentType extends Resolv
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  snapshot?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  snapshot?: Resolver<Maybe<ResolversTypes['AdapterArtifactSnapshot']>, ParentType, ContextType>;
   subnet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type AdapterArtifactSnapshotResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AdapterArtifactSnapshot'] = ResolversParentTypes['AdapterArtifactSnapshot']> = ResolversObject<{
+  adapter_kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  contract_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  dimensions?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  excluded_dimensions?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type AlphaUsdFieldSourceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['AlphaUsdFieldSource'] = ResolversParentTypes['AlphaUsdFieldSource']> = ResolversObject<{
@@ -8124,8 +9192,20 @@ export type BlockResolvers<ContextType = GqlContext, ParentType extends Resolver
 export type BlockChainEventsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockChainEvents'] = ResolversParentTypes['BlockChainEvents']> = ResolversObject<{
   block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   event_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  events?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  events?: Resolver<Array<ResolversTypes['BlockChainEventsArtifactEvents']>, ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+}>;
+
+export type BlockChainEventsArtifactEventsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockChainEventsArtifactEvents'] = ResolversParentTypes['BlockChainEventsArtifactEvents']> = ResolversObject<{
+  args?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  event_index?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  extrinsic_index?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  method?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  pallet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  phase?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type BlockDetailResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockDetail'] = ResolversParentTypes['BlockDetail']> = ResolversObject<{
@@ -8149,11 +9229,26 @@ export type BlockEventsResolvers<ContextType = GqlContext, ParentType extends Re
 export type BlockExtrinsicsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockExtrinsics'] = ResolversParentTypes['BlockExtrinsics']> = ResolversObject<{
   block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   extrinsic_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  extrinsics?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  extrinsics?: Resolver<Maybe<Array<ResolversTypes['BlockExtrinsicsArtifactExtrinsics']>>, ParentType, ContextType>;
   limit?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   offset?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   ref?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+}>;
+
+export type BlockExtrinsicsArtifactExtrinsicsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockExtrinsicsArtifactExtrinsics'] = ResolversParentTypes['BlockExtrinsicsArtifactExtrinsics']> = ResolversObject<{
+  block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  call_args?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  call_function?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  call_module?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  extrinsic_hash?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  extrinsic_index?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  fee_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  signer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  success?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tip_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type BlockListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BlockList'] = ResolversParentTypes['BlockList']> = ResolversObject<{
@@ -8209,14 +9304,14 @@ export type BuildPublicContractResolvers<ContextType = GqlContext, ParentType ex
 
 export type BuildSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BuildSummary'] = ResolversParentTypes['BuildSummary']> = ResolversObject<{
   adapter_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  artifact_budget_summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  artifact_budget_summary?: Resolver<Maybe<ResolversTypes['BuildSummaryArtifactArtifactBudgetSummary']>, ParentType, ContextType>;
   artifact_budgets?: Resolver<Maybe<Array<ResolversTypes['BuildArtifactBudget']>>, ParentType, ContextType>;
   artifact_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   artifact_size_bytes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  artifacts?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  artifacts?: Resolver<Maybe<Array<ResolversTypes['BuildSummaryArtifactArtifacts']>>, ParentType, ContextType>;
   candidate_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   contract_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  coverage?: Resolver<Maybe<ResolversTypes['CoverageArtifact']>, ParentType, ContextType>;
   endpoint_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   full_artifact_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   full_artifact_size_bytes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -8231,6 +9326,19 @@ export type BuildSummaryResolvers<ContextType = GqlContext, ParentType extends R
   storage_tier_size_bytes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   surface_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+}>;
+
+export type BuildSummaryArtifactArtifactBudgetSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BuildSummaryArtifactArtifactBudgetSummary'] = ResolversParentTypes['BuildSummaryArtifactArtifactBudgetSummary']> = ResolversObject<{
+  fail_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  ok_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  warn_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type BuildSummaryArtifactArtifactsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['BuildSummaryArtifactArtifacts'] = ResolversParentTypes['BuildSummaryArtifactArtifacts']> = ResolversObject<{
+  path?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sha256?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  size_bytes?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  storage_tier?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type ChainActivityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainActivity'] = ResolversParentTypes['ChainActivity']> = ResolversObject<{
@@ -8393,16 +9501,27 @@ export type ChainConcentrationHistoryResolvers<ContextType = GqlContext, ParentT
 export type ChainConcentrationHistoryPointResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainConcentrationHistoryPoint'] = ResolversParentTypes['ChainConcentrationHistoryPoint']> = ResolversObject<{
   builder_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   day?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  emission?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  emission?: Resolver<Maybe<ResolversTypes['ChainConcentrationScorecard']>, ParentType, ContextType>;
   entity_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  entity_emission?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  entity_stake?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  entity_emission?: Resolver<Maybe<ResolversTypes['ChainConcentrationScorecard']>, ParentType, ContextType>;
+  entity_stake?: Resolver<Maybe<ResolversTypes['ChainConcentrationScorecard']>, ParentType, ContextType>;
   neuron_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   source_captured_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  stake?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  stake?: Resolver<Maybe<ResolversTypes['ChainConcentrationScorecard']>, ParentType, ContextType>;
   subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   uids_per_entity?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
-  validator_stake?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  validator_stake?: Resolver<Maybe<ResolversTypes['ChainConcentrationScorecard']>, ParentType, ContextType>;
+}>;
+
+export type ChainConcentrationScorecardResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainConcentrationScorecard'] = ResolversParentTypes['ChainConcentrationScorecard']> = ResolversObject<{
+  entropy?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  entropy_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  gini?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hhi?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hhi_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  holders?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  nakamoto_coefficient?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  total?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
 export type ChainDeregistrationsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainDeregistrations'] = ResolversParentTypes['ChainDeregistrations']> = ResolversObject<{
@@ -8933,15 +10052,55 @@ export type ChainYieldResolvers<ContextType = GqlContext, ParentType extends Res
 }>;
 
 export type ChangelogResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Changelog'] = ResolversParentTypes['Changelog']> = ResolversObject<{
-  artifacts?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  artifacts?: Resolver<Maybe<ResolversTypes['ChangelogArtifactArtifacts']>, ParentType, ContextType>;
   contract_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   coverage_delta?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  subnets?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  subnets?: Resolver<Maybe<ResolversTypes['ChangelogArtifactSubnets']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['ChangelogArtifactSummary']>, ParentType, ContextType>;
+}>;
+
+export type ChangelogArtifactArtifactsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChangelogArtifactArtifacts'] = ResolversParentTypes['ChangelogArtifactArtifacts']> = ResolversObject<{
+  added?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  modified?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  removed?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+}>;
+
+export type ChangelogArtifactSubnetsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChangelogArtifactSubnets'] = ResolversParentTypes['ChangelogArtifactSubnets']> = ResolversObject<{
+  added?: Resolver<Array<ResolversTypes['ChangelogArtifactSubnetsAdded']>, ParentType, ContextType>;
+  removed?: Resolver<Array<ResolversTypes['ChangelogArtifactSubnetsRemoved']>, ParentType, ContextType>;
+  renamed?: Resolver<Array<ResolversTypes['ChangelogArtifactSubnetsRenamed']>, ParentType, ContextType>;
+}>;
+
+export type ChangelogArtifactSubnetsAddedResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChangelogArtifactSubnetsAdded'] = ResolversParentTypes['ChangelogArtifactSubnetsAdded']> = ResolversObject<{
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type ChangelogArtifactSubnetsRemovedResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChangelogArtifactSubnetsRemoved'] = ResolversParentTypes['ChangelogArtifactSubnetsRemoved']> = ResolversObject<{
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type ChangelogArtifactSubnetsRenamedResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChangelogArtifactSubnetsRenamed'] = ResolversParentTypes['ChangelogArtifactSubnetsRenamed']> = ResolversObject<{
+  after?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  before?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ChangelogArtifactSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChangelogArtifactSummary'] = ResolversParentTypes['ChangelogArtifactSummary']> = ResolversObject<{
+  artifact_added_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  artifact_modified_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  artifact_removed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  coverage_delta?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  netuid_added_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  netuid_removed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  netuid_renamed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type CompareResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Compare'] = ResolversParentTypes['Compare']> = ResolversObject<{
@@ -8987,16 +10146,49 @@ export type CompareSubnetResolvers<ContextType = GqlContext, ParentType extends 
   structure?: Resolver<Maybe<ResolversTypes['CompareStructure']>, ParentType, ContextType>;
 }>;
 
+export type CompareValidatorsArtifactValidatorsColdkeyIdentityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CompareValidatorsArtifactValidatorsColdkeyIdentity'] = ResolversParentTypes['CompareValidatorsArtifactValidatorsColdkeyIdentity']> = ResolversObject<{
+  additional?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  captured_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  discord?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  github?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  has_identity?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  image?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type CompareValidatorsArtifactValidatorsSubnetContextResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CompareValidatorsArtifactValidatorsSubnetContext'] = ResolversParentTypes['CompareValidatorsArtifactValidatorsSubnetContext']> = ResolversObject<{
+  active?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  axon?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  consensus?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  dividends?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emission_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hotkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  incentive?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  is_immunity_period?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  rank?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  registered_at_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  stake_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  take?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  trust?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  uid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  validator_permit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  validator_trust?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
 export type ComparedValidatorResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ComparedValidator'] = ResolversParentTypes['ComparedValidator']> = ResolversObject<{
   apy_estimate?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   apy_estimate_eligible_subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   avg_validator_trust?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  coldkey_identity?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  coldkey_identity?: Resolver<Maybe<ResolversTypes['CompareValidatorsArtifactValidatorsColdkeyIdentity']>, ParentType, ContextType>;
   hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   max_validator_trust?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   nominator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  subnet_context?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  subnet_context?: Resolver<Maybe<ResolversTypes['CompareValidatorsArtifactValidatorsSubnetContext']>, ParentType, ContextType>;
   subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   take?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   total_emission_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
@@ -9019,7 +10211,7 @@ export type ConcentrationMetricsResolvers<ContextType = GqlContext, ParentType e
 }>;
 
 export type ContractsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Contracts'] = ResolversParentTypes['Contracts']> = ResolversObject<{
-  artifacts?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  artifacts?: Resolver<Maybe<Array<ResolversTypes['ContractsArtifactArtifacts']>>, ParentType, ContextType>;
   base_path?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   contract_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -9031,8 +10223,88 @@ export type ContractsResolvers<ContextType = GqlContext, ParentType extends Reso
   type_definitions_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
+export type ContractsArtifactArtifactsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ContractsArtifactArtifacts'] = ResolversParentTypes['ContractsArtifactArtifacts']> = ResolversObject<{
+  content_type?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  contract_version?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  path?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  retirement?: Resolver<Maybe<ResolversTypes['ContractsArtifactArtifactsRetirement']>, ParentType, ContextType>;
+  schema_ref?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  storage_tier?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type ContractsArtifactArtifactsRetirementResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ContractsArtifactArtifactsRetirement'] = ResolversParentTypes['ContractsArtifactArtifactsRetirement']> = ResolversObject<{
+  code?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  http_status?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  message?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type CoverageArtifactResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CoverageArtifact'] = ResolversParentTypes['CoverageArtifact']> = ResolversObject<{
+  application_subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  chain_subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  completeness?: Resolver<Maybe<ResolversTypes['CoverageCompleteness']>, ParentType, ContextType>;
+  contract_version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  curated_overlay_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  curation_level_counts?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  domain_coverage?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  first_party_subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  generated_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  manifested_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_only_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_only_with_candidates?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_only_without_candidates?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_snapshot_captured_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  network?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  official_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  probed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  probed_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  registry_observed_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  root_subnet_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  source?: Resolver<ResolversTypes['CoverageArtifactSource'], ParentType, ContextType>;
+  subnets_without_official_surface?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type CoverageArtifactSourceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CoverageArtifactSource'] = ResolversParentTypes['CoverageArtifactSource']> = ResolversObject<{
+  candidates?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  native?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  overlays?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type CoverageCompletenessResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CoverageCompleteness'] = ResolversParentTypes['CoverageCompleteness']> = ResolversObject<{
+  average_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  dimension_coverage?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  fully_complete_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  fully_complete_pct?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  median_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  methodology?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  score_distribution?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  scored_subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+}>;
+
+export type CurationArtifactCurationResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CurationArtifactCuration'] = ResolversParentTypes['CurationArtifactCuration']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  coverage_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  curation?: Resolver<ResolversTypes['CurationMetadata'], ParentType, ContextType>;
+  curation_level?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  gap_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  gaps?: Resolver<ResolversTypes['Gaps'], ParentType, ContextType>;
+  lifecycle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type CurationListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CurationList'] = ResolversParentTypes['CurationList']> = ResolversObject<{
-  curation?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  curation?: Resolver<Maybe<Array<ResolversTypes['CurationArtifactCuration']>>, ParentType, ContextType>;
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9042,6 +10314,15 @@ export type CurationListResolvers<ContextType = GqlContext, ParentType extends R
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type CurationMetadataResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['CurationMetadata'] = ResolversParentTypes['CurationMetadata']> = ResolversObject<{
+  gap_notes?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  reviewed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  verified_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type DegradedInfoResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['DegradedInfo'] = ResolversParentTypes['DegradedInfo']> = ResolversObject<{
@@ -9268,6 +10549,16 @@ export type EndpointIncidentWindowResolvers<ContextType = GqlContext, ParentType
   started_at?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
 }>;
 
+export type EndpointIncidentsArtifactSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointIncidentsArtifactSummary'] = ResolversParentTypes['EndpointIncidentsArtifactSummary']> = ResolversObject<{
+  active_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  by_kind?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  by_layer?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  by_provider?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  by_severity?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  by_status?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  incident_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type EndpointListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointList'] = ResolversParentTypes['EndpointList']> = ResolversObject<{
   items?: Resolver<Array<ResolversTypes['Endpoint']>, ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -9281,15 +10572,39 @@ export type EndpointPoolListResolvers<ContextType = GqlContext, ParentType exten
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  pools?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  pools?: Resolver<Maybe<Array<ResolversTypes['RpcPool']>>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type EndpointScoreReasonResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointScoreReason'] = ResolversParentTypes['EndpointScoreReason']> = ResolversObject<{
+  points?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  reason?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type EvidenceClaimResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EvidenceClaim'] = ResolversParentTypes['EvidenceClaim']> = ResolversObject<{
+  claim?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  confidence?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  limits?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_tier?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  subject?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  support_summary?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  verified_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type EvidenceLedgerArtifactSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EvidenceLedgerArtifactSummary'] = ResolversParentTypes['EvidenceLedgerArtifactSummary']> = ResolversObject<{
+  candidate_claim_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  claim_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  subnet_claim_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_claim_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type EvidenceListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EvidenceList'] = ResolversParentTypes['EvidenceList']> = ResolversObject<{
-  claims?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  claims?: Resolver<Maybe<Array<ResolversTypes['EvidenceClaim']>>, ParentType, ContextType>;
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9298,7 +10613,7 @@ export type EvidenceListResolvers<ContextType = GqlContext, ParentType extends R
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['EvidenceLedgerArtifactSummary']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -9368,9 +10683,28 @@ export type FailureReasonsDayResolvers<ContextType = GqlContext, ParentType exte
   total_checks?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type GapsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Gaps'] = ResolversParentTypes['Gaps']> = ResolversObject<{
+  gap_notes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  moving_target_surfaces?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  supported_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type GapsArtifactGapsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GapsArtifactGaps'] = ResolversParentTypes['GapsArtifactGaps']> = ResolversObject<{
+  coverage_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  gap_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  gap_priority?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  gap_severity?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  gaps?: Resolver<ResolversTypes['Gaps'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type GapsListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GapsList'] = ResolversParentTypes['GapsList']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  gaps?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  gaps?: Resolver<Maybe<Array<ResolversTypes['GapsArtifactGaps']>>, ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -9419,10 +10753,15 @@ export type GlobalIncidentsResolvers<ContextType = GqlContext, ParentType extend
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['GlobalIncidentsArtifactSummary']>, ParentType, ContextType>;
   surfaces?: Resolver<Array<ResolversTypes['GlobalIncidentSurface']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type GlobalIncidentsArtifactSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GlobalIncidentsArtifactSummary'] = ResolversParentTypes['GlobalIncidentsArtifactSummary']> = ResolversObject<{
+  affected_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  incident_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type HealthHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthHistory'] = ResolversParentTypes['HealthHistory']> = ResolversObject<{
@@ -9433,9 +10772,63 @@ export type HealthHistoryResolvers<ContextType = GqlContext, ParentType extends 
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  surfaces?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['HealthProbeSummary']>, ParentType, ContextType>;
+  surfaces?: Resolver<Maybe<Array<ResolversTypes['HealthHistoryArtifactSurfaces']>>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type HealthHistoryArtifactSurfacesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthHistoryArtifactSurfaces'] = ResolversParentTypes['HealthHistoryArtifactSurfaces']> = ResolversObject<{
+  classification?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  error_class?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  last_checked?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  last_ok?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  latency_ms?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  provider?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status_code?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  surface_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  verified_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type HealthIncidentsArtifactSurfacesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthIncidentsArtifactSurfaces'] = ResolversParentTypes['HealthIncidentsArtifactSurfaces']> = ResolversObject<{
+  downtime_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  incident_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  incidents?: Resolver<Array<ResolversTypes['HealthIncidentsArtifactSurfacesIncidents']>, ParentType, ContextType>;
+  samples?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  transient_failed_samples?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  transient_failure_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  uptime_ratio?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type HealthIncidentsArtifactSurfacesIncidentsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthIncidentsArtifactSurfacesIncidents'] = ResolversParentTypes['HealthIncidentsArtifactSurfacesIncidents']> = ResolversObject<{
+  duration_ms?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  ended_at?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  failed_samples?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  started_at?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+}>;
+
+export type HealthPercentilesArtifactSurfacesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthPercentilesArtifactSurfaces'] = ResolversParentTypes['HealthPercentilesArtifactSurfaces']> = ResolversObject<{
+  latency_ms?: Resolver<ResolversTypes['HealthPercentilesArtifactSurfacesLatencyMs'], ParentType, ContextType>;
+  samples?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type HealthPercentilesArtifactSurfacesLatencyMsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthPercentilesArtifactSurfacesLatencyMs'] = ResolversParentTypes['HealthPercentilesArtifactSurfacesLatencyMs']> = ResolversObject<{
+  avg?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  max?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  min?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  p50?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  p95?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  p99?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+}>;
+
+export type HealthProbeSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthProbeSummary'] = ResolversParentTypes['HealthProbeSummary']> = ResolversObject<{
+  classification_counts?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  status_counts?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type HealthTrendsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['HealthTrends'] = ResolversParentTypes['HealthTrends']> = ResolversObject<{
@@ -9510,7 +10903,7 @@ export type IncidentListResolvers<ContextType = GqlContext, ParentType extends R
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['EndpointIncidentsArtifactSummary']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -9543,6 +10936,26 @@ export type IndexerLagWindowResolvers<ContextType = GqlContext, ParentType exten
   newest_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   oldest_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   oldest_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type IntegrationReadinessResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['IntegrationReadiness'] = ResolversParentTypes['IntegrationReadiness']> = ResolversObject<{
+  components?: Resolver<ResolversTypes['IntegrationReadinessComponents'], ParentType, ContextType>;
+  readiness_tier?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  readiness_verified?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  readiness_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type IntegrationReadinessComponentsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['IntegrationReadinessComponents'] = ResolversParentTypes['IntegrationReadinessComponents']> = ResolversObject<{
+  active_lifecycle?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  auth_clarity?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  callable_now?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  documented?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  has_callable_api?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  has_candidate_api?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  has_public_docs?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  has_source_repo?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  profile_complete?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
 export type IntensityDistributionResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['IntensityDistribution'] = ResolversParentTypes['IntensityDistribution']> = ResolversObject<{
@@ -9741,7 +11154,7 @@ export type PoolListResolvers<ContextType = GqlContext, ParentType extends Resol
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   operational_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  pools?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  pools?: Resolver<Maybe<Array<ResolversTypes['RpcPool']>>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -9754,7 +11167,7 @@ export type ProfileListResolvers<ContextType = GqlContext, ParentType extends Re
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  profiles?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  profiles?: Resolver<Maybe<Array<ResolversTypes['SubnetProfile']>>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10038,8 +11451,25 @@ export type RevenueVerificationCheckResolvers<ContextType = GqlContext, ParentTy
   ok?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
 }>;
 
+export type ReviewAdapterCandidateResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewAdapterCandidate'] = ResolversParentTypes['ReviewAdapterCandidate']> = ResolversObject<{
+  candidate_api_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_api_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  candidate_api_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  operational_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  operational_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  operational_surface_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  priority_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  reason_codes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  recommended_adapter_kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  suggested_next_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
 export type ReviewAdapterCandidateListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewAdapterCandidateList'] = ResolversParentTypes['ReviewAdapterCandidateList']> = ResolversObject<{
-  candidates?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  candidates?: Resolver<Maybe<Array<ResolversTypes['ReviewAdapterCandidate']>>, ParentType, ContextType>;
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10051,17 +11481,89 @@ export type ReviewAdapterCandidateListResolvers<ContextType = GqlContext, Parent
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type ReviewEnrichmentEvidenceArtifactEntriesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentEvidenceArtifactEntries'] = ResolversParentTypes['ReviewEnrichmentEvidenceArtifactEntries']> = ResolversObject<{
+  candidate_evidence_by_kind?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  candidate_evidence_summary?: Resolver<ResolversTypes['ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary'], ParentType, ContextType>;
+  direct_submission_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  evidence_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  lane?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  missing_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priority_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary'] = ResolversParentTypes['ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  kinds_with_candidates?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  live_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  live_or_redirected_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  reviewable_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stale_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  stale_or_failed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  unverified_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  unverified_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
 export type ReviewEnrichmentEvidenceListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentEvidenceList'] = ResolversParentTypes['ReviewEnrichmentEvidenceList']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  entries?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  entries?: Resolver<Maybe<Array<ResolversTypes['ReviewEnrichmentEvidenceArtifactEntries']>>, ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ReviewEnrichmentQueueArtifactQueueResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentQueueArtifactQueue'] = ResolversParentTypes['ReviewEnrichmentQueueArtifactQueue']> = ResolversObject<{
+  adapter_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_evidence_summary?: Resolver<ResolversTypes['ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary'], ParentType, ContextType>;
+  completeness_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  contribution_hint?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  direct_submission_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  endpoint_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  evidence_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  lane?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  manual_review_required?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  missing_identity?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  operational_interface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priority_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  profile_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  reason_codes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  recommended_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sample_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  sample_live_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  sample_stale_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  sample_target_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_urls?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  stale_candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  verified_candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary'] = ResolversParentTypes['ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  kinds_with_candidates?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  live_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  live_or_redirected_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  reviewable_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stale_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  stale_or_failed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  unverified_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  unverified_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type ReviewEnrichmentQueueListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentQueueList'] = ResolversParentTypes['ReviewEnrichmentQueueList']> = ResolversObject<{
@@ -10069,9 +11571,9 @@ export type ReviewEnrichmentQueueListResolvers<ContextType = GqlContext, ParentT
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  queue?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  queue?: Resolver<Maybe<Array<ResolversTypes['ReviewEnrichmentQueueArtifactQueue']>>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10082,12 +11584,83 @@ export type ReviewEnrichmentTargetListResolvers<ContextType = GqlContext, Parent
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  targets?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  targets?: Resolver<Maybe<Array<ResolversTypes['ReviewEnrichmentTargetsArtifactTargets']>>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ReviewEnrichmentTargetsArtifactTargetsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentTargetsArtifactTargets'] = ResolversParentTypes['ReviewEnrichmentTargetsArtifactTargets']> = ResolversObject<{
+  auto_review_candidate?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  candidate_command?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  candidate_evidence?: Resolver<Maybe<ResolversTypes['ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence']>, ParentType, ContextType>;
+  contribution_prompt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  evidence_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  lane?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  manual_review_required?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  missing_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priority_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  profile_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  queue_context?: Resolver<ResolversTypes['ReviewEnrichmentTargetsArtifactTargetsQueueContext'], ParentType, ContextType>;
+  reason_codes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  recommended_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  sample_live_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  sample_stale_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  sample_target_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_requirements?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  source_urls?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  submission_route?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  target_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  target_id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  target_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type ReviewEnrichmentTargetsArtifactTargetsCandidateEvidenceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence'] = ResolversParentTypes['ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  classifications?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  live_or_redirected_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  reviewable_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  sample_candidate_ids?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  stale_or_failed_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  unverified_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ReviewEnrichmentTargetsArtifactTargetsQueueContextResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewEnrichmentTargetsArtifactTargetsQueueContext'] = ResolversParentTypes['ReviewEnrichmentTargetsArtifactTargetsQueueContext']> = ResolversObject<{
+  adapter_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  completeness_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  direct_submission_kind_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  endpoint_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  identity_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  operational_interface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  profile_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_url_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stale_candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  verified_candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ReviewGapPriorityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewGapPriority'] = ResolversParentTypes['ReviewGapPriority']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  missing_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priority_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  suggested_next_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  verified_candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type ReviewGapPriorityListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewGapPriorityList'] = ResolversParentTypes['ReviewGapPriorityList']> = ResolversObject<{
@@ -10097,10 +11670,55 @@ export type ReviewGapPriorityListResolvers<ContextType = GqlContext, ParentType 
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  priorities?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  priorities?: Resolver<Maybe<Array<ResolversTypes['ReviewGapPriority']>>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type ReviewProfileCompletenessArtifactProfilesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewProfileCompletenessArtifactProfiles'] = ResolversParentTypes['ReviewProfileCompletenessArtifactProfiles']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  completeness_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  confidence?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  gap_reasons?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  identity_evidence?: Resolver<ResolversTypes['SubnetProfileIdentityEvidence'], ParentType, ContextType>;
+  identity_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_promotion_kind_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  identity_promotion_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  identity_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  live_identity_candidate_kind_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  missing_critical_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  missing_identity?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_operational?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_required?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  native_identity_signal_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_name_quality?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  operational_interface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  priority_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  profile_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  source_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  stale_identity_candidate_kind_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  suggested_next_action?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  supported_interface_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type ReviewProfileCompletenessArtifactSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewProfileCompletenessArtifactSummary'] = ResolversParentTypes['ReviewProfileCompletenessArtifactSummary']> = ResolversObject<{
+  average_completeness_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  by_confidence?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  by_identity_level?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  by_profile_level?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  critical_gap_counts?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  identity_promotion_candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_identity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_identity_unpromoted_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  needs_identity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  needs_operational_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  profile_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type ReviewProfileCompletenessListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ReviewProfileCompletenessList'] = ResolversParentTypes['ReviewProfileCompletenessList']> = ResolversObject<{
@@ -10110,10 +11728,10 @@ export type ReviewProfileCompletenessListResolvers<ContextType = GqlContext, Par
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  profiles?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  profiles?: Resolver<Maybe<Array<ResolversTypes['ReviewProfileCompletenessArtifactProfiles']>>, ParentType, ContextType>;
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['ReviewProfileCompletenessArtifactSummary']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
@@ -10132,6 +11750,41 @@ export type RootClaimHotkeyResolvers<ContextType = GqlContext, ParentType extend
 export type RootClaimTypeResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RootClaimType'] = ResolversParentTypes['RootClaimType']> = ResolversObject<{
   kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   subnets?: Resolver<Maybe<Array<ResolversTypes['Int']>>, ParentType, ContextType>;
+}>;
+
+export type RpcPoolResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RpcPool'] = ResolversParentTypes['RpcPool']> = ResolversObject<{
+  best_endpoint_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  eligible_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  endpoint_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  endpoints?: Resolver<Array<ResolversTypes['RpcPoolEndpoints']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type RpcPoolEndpointsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RpcPoolEndpoints'] = ResolversParentTypes['RpcPoolEndpoints']> = ResolversObject<{
+  archive_support?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  auth_required?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  health_source?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  health_stale?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  last_ok?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  latency_ms?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  latest_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  layer?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  pool_eligibility_reasons?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  pool_eligible?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  provider?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  public_safe?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  reliability_grade?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  reliability_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  score_reasons?: Resolver<Maybe<Array<ResolversTypes['EndpointScoreReason']>>, ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  surface_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  surface_key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
 }>;
 
 export type RpcUsageResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RpcUsage'] = ResolversParentTypes['RpcUsage']> = ResolversObject<{
@@ -10244,15 +11897,42 @@ export type ScoreDistributionResolvers<ContextType = GqlContext, ParentType exte
   p90?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
+export type SearchArtifactDocumentsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SearchArtifactDocuments'] = ResolversParentTypes['SearchArtifactDocuments']> = ResolversObject<{
+  artifact_path?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  categories?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  service_kinds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  subtitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tokens?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
 export type SearchDocumentListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SearchDocumentList'] = ResolversParentTypes['SearchDocumentList']> = ResolversObject<{
-  documents?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  documents?: Resolver<Maybe<Array<ResolversTypes['SearchArtifactDocuments']>>, ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type SearchIndexArtifactDocumentsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SearchIndexArtifactDocuments'] = ResolversParentTypes['SearchIndexArtifactDocuments']> = ResolversObject<{
+  artifact_path?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  categories?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  service_kinds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
+  slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  subtitle?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
 export type SearchIndexListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SearchIndexList'] = ResolversParentTypes['SearchIndexList']> = ResolversObject<{
   cursor?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  documents?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  documents?: Resolver<Maybe<Array<ResolversTypes['SearchIndexArtifactDocuments']>>, ParentType, ContextType>;
   generated_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   next_cursor?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -10307,9 +11987,27 @@ export type SourceSnapshotListResolvers<ContextType = GqlContext, ParentType ext
   returned?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   sort?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  sources?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
-  summary?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  sources?: Resolver<Maybe<Array<ResolversTypes['SourceSnapshotsArtifactSources']>>, ParentType, ContextType>;
+  summary?: Resolver<Maybe<ResolversTypes['SourceSnapshotsArtifactSummary']>, ParentType, ContextType>;
   total?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SourceSnapshotsArtifactSourcesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SourceSnapshotsArtifactSources'] = ResolversParentTypes['SourceSnapshotsArtifactSources']> = ResolversObject<{
+  captured_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hash?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  path?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  record_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SourceSnapshotsArtifactSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SourceSnapshotsArtifactSummary'] = ResolversParentTypes['SourceSnapshotsArtifactSummary']> = ResolversObject<{
+  adapter_snapshot_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  overlay_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  provider_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  source_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  verification_result_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type SubnetResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['Subnet'] = ResolversParentTypes['Subnet']> = ResolversObject<{
@@ -10411,12 +12109,19 @@ export type SubnetConvictionResolvers<ContextType = GqlContext, ParentType exten
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
   king?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  leaderboard?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  leaderboard?: Resolver<Maybe<Array<ResolversTypes['SubnetConvictionArtifactLeaderboard']>>, ParentType, ContextType>;
   maturity_rate?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   queried_at_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   unlock_rate?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type SubnetConvictionArtifactLeaderboardResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetConvictionArtifactLeaderboard'] = ResolversParentTypes['SubnetConvictionArtifactLeaderboard']> = ResolversObject<{
+  conviction?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hotkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  is_owner?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  locked_mass?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type SubnetDeregistrationEventResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetDeregistrationEvent'] = ResolversParentTypes['SubnetDeregistrationEvent']> = ResolversObject<{
@@ -10506,9 +12211,9 @@ export type SubnetEmissionDecompositionResolvers<ContextType = GqlContext, Paren
 }>;
 
 export type SubnetEventSummaryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEventSummary'] = ResolversParentTypes['SubnetEventSummary']> = ResolversObject<{
-  categories?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  categories?: Resolver<Maybe<Array<ResolversTypes['SubnetEventSummaryArtifactCategories']>>, ParentType, ContextType>;
   category_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  event_kinds?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  event_kinds?: Resolver<Maybe<Array<ResolversTypes['SubnetEventSummaryArtifactEventKinds']>>, ParentType, ContextType>;
   kind_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   limit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10518,6 +12223,32 @@ export type SubnetEventSummaryResolvers<ContextType = GqlContext, ParentType ext
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   total_events?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetEventSummaryArtifactCategoriesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEventSummaryArtifactCategories'] = ResolversParentTypes['SubnetEventSummaryArtifactCategories']> = ResolversObject<{
+  alpha_amount?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  amount_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  category?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  event_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  first_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  first_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  kind_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  last_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  last_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetEventSummaryArtifactEventKindsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEventSummaryArtifactEventKinds'] = ResolversParentTypes['SubnetEventSummaryArtifactEventKinds']> = ResolversObject<{
+  alpha_amount?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  amount_tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  category?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  coldkey_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  event_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  event_kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  first_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  first_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  hotkey_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  last_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  last_observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type SubnetEventsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEvents'] = ResolversParentTypes['SubnetEvents']> = ResolversObject<{
@@ -10552,7 +12283,7 @@ export type SubnetHealthIncidentsResolvers<ContextType = GqlContext, ParentType 
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  surfaces?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  surfaces?: Resolver<Maybe<Array<ResolversTypes['HealthIncidentsArtifactSurfaces']>>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
@@ -10561,7 +12292,7 @@ export type SubnetHealthPercentilesResolvers<ContextType = GqlContext, ParentTyp
   observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  surfaces?: Resolver<ResolversTypes['JSON'], ParentType, ContextType>;
+  surfaces?: Resolver<Maybe<Array<ResolversTypes['HealthPercentilesArtifactSurfaces']>>, ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
@@ -10668,20 +12399,39 @@ export type SubnetIdleStakeResolvers<ContextType = GqlContext, ParentType extend
 
 export type SubnetLeaseResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetLease'] = ResolversParentTypes['SubnetLease']> = ResolversObject<{
   field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
-  lease?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  lease?: Resolver<Maybe<ResolversTypes['SubnetLeaseArtifactLease']>, ParentType, ContextType>;
   leased?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   queried_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
+export type SubnetLeaseArtifactLeaseResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetLeaseArtifactLease'] = ResolversParentTypes['SubnetLeaseArtifactLease']> = ResolversObject<{
+  accumulated_dividends_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  beneficiary?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  coldkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  cost_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  emissions_share_percent?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  end_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  hotkey?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  lease_id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
 export type SubnetLeaseHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetLeaseHistory'] = ResolversParentTypes['SubnetLeaseHistory']> = ResolversObject<{
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   event_kinds?: Resolver<Maybe<Array<ResolversTypes['String']>>, ParentType, ContextType>;
   event_pallet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  lease_events?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  lease_events?: Resolver<Maybe<Array<ResolversTypes['SubnetLeaseHistoryArtifactLeaseEvents']>>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SubnetLeaseHistoryArtifactLeaseEventsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetLeaseHistoryArtifactLeaseEvents'] = ResolversParentTypes['SubnetLeaseHistoryArtifactLeaseEvents']> = ResolversObject<{
+  beneficiary?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  event_kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type SubnetLifecycleResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetLifecycle'] = ResolversParentTypes['SubnetLifecycle']> = ResolversObject<{
@@ -10792,8 +12542,17 @@ export type SubnetOwnershipHistoryResolvers<ContextType = GqlContext, ParentType
   event_pallet?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   observed_through?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  ownership_changes?: Resolver<Array<ResolversTypes['JSON']>, ParentType, ContextType>;
+  ownership_changes?: Resolver<Maybe<Array<ResolversTypes['SubnetOwnershipHistoryArtifactOwnershipChanges']>>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SubnetOwnershipHistoryArtifactOwnershipChangesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetOwnershipHistoryArtifactOwnershipChanges'] = ResolversParentTypes['SubnetOwnershipHistoryArtifactOwnershipChanges']> = ResolversObject<{
+  block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  new_coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  observed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  old_coldkey?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type SubnetPerformanceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetPerformance'] = ResolversParentTypes['SubnetPerformance']> = ResolversObject<{
@@ -10848,6 +12607,149 @@ export type SubnetPipelineHistoryResolvers<ContextType = GqlContext, ParentType 
   points?: Resolver<Array<ResolversTypes['PipelineHistoryPoint']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   window?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfileResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfile'] = ResolversParentTypes['SubnetProfile']> = ResolversObject<{
+  candidate_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  categories?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  completeness?: Resolver<ResolversTypes['SubnetProfileCompleteness'], ParentType, ContextType>;
+  completeness_score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  confidence?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  derived_categories?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  derived_description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  endpoint_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  gap_reasons?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  github_commits_weekly?: Resolver<Maybe<Array<ResolversTypes['SubnetProfileGithubCommitsWeekly']>>, ParentType, ContextType>;
+  github_languages?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  github_last_push_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  github_releases?: Resolver<Maybe<Array<ResolversTypes['SubnetProfileGithubReleases']>>, ParentType, ContextType>;
+  github_stars?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  github_unreachable?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  identity_evidence?: Resolver<ResolversTypes['SubnetProfileIdentityEvidence'], ParentType, ContextType>;
+  identity_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  injection_scrubbed?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  integration_readiness?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  interface_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  lineage?: Resolver<Maybe<ResolversTypes['SubnetProfileLineage']>, ParentType, ContextType>;
+  missing_critical_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  missing_identity?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_operational?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_required?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  monitored_endpoint_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  native_identity?: Resolver<Maybe<ResolversTypes['SubnetProfileNativeIdentity']>, ParentType, ContextType>;
+  native_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  native_name_quality?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  operational_interface_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  operational_interface_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  primary_app_surface?: Resolver<Maybe<ResolversTypes['SubnetProfilePrimaryAppSurface']>, ParentType, ContextType>;
+  primary_links?: Resolver<ResolversTypes['SubnetProfilePrimaryLinks'], ParentType, ContextType>;
+  profile_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  project_name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  provenance?: Resolver<ResolversTypes['SubnetProfileProvenance'], ParentType, ContextType>;
+  readiness?: Resolver<Maybe<ResolversTypes['IntegrationReadiness']>, ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  subnet_type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  suggested_submission_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  supported_interface_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  symbol?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  team?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfileCompletenessResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileCompleteness'] = ResolversParentTypes['SubnetProfileCompleteness']> = ResolversObject<{
+  confidence?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  gap_reasons?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  identity_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  missing_critical_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  missing_identity?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_operational?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  missing_required?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  profile_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  score?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+}>;
+
+export type SubnetProfileGithubCommitsWeeklyResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileGithubCommitsWeekly'] = ResolversParentTypes['SubnetProfileGithubCommitsWeekly']> = ResolversObject<{
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  week?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type SubnetProfileGithubReleasesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileGithubReleases'] = ResolversParentTypes['SubnetProfileGithubReleases']> = ResolversObject<{
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  prerelease?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  published_at?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tag?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type SubnetProfileIdentityEvidenceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileIdentityEvidence'] = ResolversParentTypes['SubnetProfileIdentityEvidence']> = ResolversObject<{
+  candidate_identity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  curated_identity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  curated_identity_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  live_candidate_identity_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  native_contact_present?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  native_description_present?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  native_identity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  native_identity_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  needs_promotion_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  stale_candidate_identity_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  unverified_candidate_identity_kinds?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfileLineageResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileLineage'] = ResolversParentTypes['SubnetProfileLineage']> = ResolversObject<{
+  also_on?: Resolver<Maybe<Array<ResolversTypes['SubnetProfileLineageAlsoOn']>>, ParentType, ContextType>;
+  graduated_from_testnet?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfileLineageAlsoOnResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileLineageAlsoOn'] = ResolversParentTypes['SubnetProfileLineageAlsoOn']> = ResolversObject<{
+  matched_by?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  netuid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  network?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfileNativeIdentityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileNativeIdentity'] = ResolversParentTypes['SubnetProfileNativeIdentity']> = ResolversObject<{
+  additional?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  contact_present?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  discord?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  discord_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  github_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  logo_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  subnet_name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  website_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfilePrimaryAppSurfaceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfilePrimaryAppSurface'] = ResolversParentTypes['SubnetProfilePrimaryAppSurface']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  provider?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type SubnetProfilePrimaryLinksResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfilePrimaryLinks'] = ResolversParentTypes['SubnetProfilePrimaryLinks']> = ResolversObject<{
+  dashboard_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  docs_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source_repo?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  website_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+}>;
+
+export type SubnetProfileProvenanceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetProfileProvenance'] = ResolversParentTypes['SubnetProfileProvenance']> = ResolversObject<{
+  curation_level?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identity_source?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  interface_source_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  review_state?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  reviewed_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  source_urls?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
 export type SubnetPrometheusResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetPrometheus'] = ResolversParentTypes['SubnetPrometheus']> = ResolversObject<{
@@ -11568,12 +13470,15 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   AccountWeightSetters?: AccountWeightSettersResolvers<ContextType>;
   AccountWeightSettersSubnet?: AccountWeightSettersSubnetResolvers<ContextType>;
   Adapter?: AdapterResolvers<ContextType>;
+  AdapterArtifactSnapshot?: AdapterArtifactSnapshotResolvers<ContextType>;
   AlphaUsdFieldSource?: AlphaUsdFieldSourceResolvers<ContextType>;
   Block?: BlockResolvers<ContextType>;
   BlockChainEvents?: BlockChainEventsResolvers<ContextType>;
+  BlockChainEventsArtifactEvents?: BlockChainEventsArtifactEventsResolvers<ContextType>;
   BlockDetail?: BlockDetailResolvers<ContextType>;
   BlockEvents?: BlockEventsResolvers<ContextType>;
   BlockExtrinsics?: BlockExtrinsicsResolvers<ContextType>;
+  BlockExtrinsicsArtifactExtrinsics?: BlockExtrinsicsArtifactExtrinsicsResolvers<ContextType>;
   BlockList?: BlockListResolvers<ContextType>;
   BlockTimeDistribution?: BlockTimeDistributionResolvers<ContextType>;
   BlocksSummary?: BlocksSummaryResolvers<ContextType>;
@@ -11581,6 +13486,8 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   BuildArtifactBudget?: BuildArtifactBudgetResolvers<ContextType>;
   BuildPublicContract?: BuildPublicContractResolvers<ContextType>;
   BuildSummary?: BuildSummaryResolvers<ContextType>;
+  BuildSummaryArtifactArtifactBudgetSummary?: BuildSummaryArtifactArtifactBudgetSummaryResolvers<ContextType>;
+  BuildSummaryArtifactArtifacts?: BuildSummaryArtifactArtifactsResolvers<ContextType>;
   ChainActivity?: ChainActivityResolvers<ContextType>;
   ChainActivityDay?: ChainActivityDayResolvers<ContextType>;
   ChainAlphaVolume?: ChainAlphaVolumeResolvers<ContextType>;
@@ -11596,6 +13503,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   ChainConcentration?: ChainConcentrationResolvers<ContextType>;
   ChainConcentrationHistory?: ChainConcentrationHistoryResolvers<ContextType>;
   ChainConcentrationHistoryPoint?: ChainConcentrationHistoryPointResolvers<ContextType>;
+  ChainConcentrationScorecard?: ChainConcentrationScorecardResolvers<ContextType>;
   ChainDeregistrations?: ChainDeregistrationsResolvers<ContextType>;
   ChainDeregistrationsNetwork?: ChainDeregistrationsNetworkResolvers<ContextType>;
   ChainDeregistrationsSubnet?: ChainDeregistrationsSubnetResolvers<ContextType>;
@@ -11653,15 +13561,30 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   ChainWeightsSubnet?: ChainWeightsSubnetResolvers<ContextType>;
   ChainYield?: ChainYieldResolvers<ContextType>;
   Changelog?: ChangelogResolvers<ContextType>;
+  ChangelogArtifactArtifacts?: ChangelogArtifactArtifactsResolvers<ContextType>;
+  ChangelogArtifactSubnets?: ChangelogArtifactSubnetsResolvers<ContextType>;
+  ChangelogArtifactSubnetsAdded?: ChangelogArtifactSubnetsAddedResolvers<ContextType>;
+  ChangelogArtifactSubnetsRemoved?: ChangelogArtifactSubnetsRemovedResolvers<ContextType>;
+  ChangelogArtifactSubnetsRenamed?: ChangelogArtifactSubnetsRenamedResolvers<ContextType>;
+  ChangelogArtifactSummary?: ChangelogArtifactSummaryResolvers<ContextType>;
   Compare?: CompareResolvers<ContextType>;
   CompareEconomics?: CompareEconomicsResolvers<ContextType>;
   CompareHealth?: CompareHealthResolvers<ContextType>;
   CompareStructure?: CompareStructureResolvers<ContextType>;
   CompareSubnet?: CompareSubnetResolvers<ContextType>;
+  CompareValidatorsArtifactValidatorsColdkeyIdentity?: CompareValidatorsArtifactValidatorsColdkeyIdentityResolvers<ContextType>;
+  CompareValidatorsArtifactValidatorsSubnetContext?: CompareValidatorsArtifactValidatorsSubnetContextResolvers<ContextType>;
   ComparedValidator?: ComparedValidatorResolvers<ContextType>;
   ConcentrationMetrics?: ConcentrationMetricsResolvers<ContextType>;
   Contracts?: ContractsResolvers<ContextType>;
+  ContractsArtifactArtifacts?: ContractsArtifactArtifactsResolvers<ContextType>;
+  ContractsArtifactArtifactsRetirement?: ContractsArtifactArtifactsRetirementResolvers<ContextType>;
+  CoverageArtifact?: CoverageArtifactResolvers<ContextType>;
+  CoverageArtifactSource?: CoverageArtifactSourceResolvers<ContextType>;
+  CoverageCompleteness?: CoverageCompletenessResolvers<ContextType>;
+  CurationArtifactCuration?: CurationArtifactCurationResolvers<ContextType>;
   CurationList?: CurationListResolvers<ContextType>;
+  CurationMetadata?: CurationMetadataResolvers<ContextType>;
   DegradedInfo?: DegradedInfoResolvers<ContextType>;
   DeregistrationDerivation?: DeregistrationDerivationResolvers<ContextType>;
   DeregistrationTenure?: DeregistrationTenureResolvers<ContextType>;
@@ -11681,8 +13604,12 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   Endpoint?: EndpointResolvers<ContextType>;
   EndpointIncident?: EndpointIncidentResolvers<ContextType>;
   EndpointIncidentWindow?: EndpointIncidentWindowResolvers<ContextType>;
+  EndpointIncidentsArtifactSummary?: EndpointIncidentsArtifactSummaryResolvers<ContextType>;
   EndpointList?: EndpointListResolvers<ContextType>;
   EndpointPoolList?: EndpointPoolListResolvers<ContextType>;
+  EndpointScoreReason?: EndpointScoreReasonResolvers<ContextType>;
+  EvidenceClaim?: EvidenceClaimResolvers<ContextType>;
+  EvidenceLedgerArtifactSummary?: EvidenceLedgerArtifactSummaryResolvers<ContextType>;
   EvidenceList?: EvidenceListResolvers<ContextType>;
   EvmAddressMapping?: EvmAddressMappingResolvers<ContextType>;
   Extrinsic?: ExtrinsicResolvers<ContextType>;
@@ -11691,11 +13618,20 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   FailureReason?: FailureReasonResolvers<ContextType>;
   FailureReasons?: FailureReasonsResolvers<ContextType>;
   FailureReasonsDay?: FailureReasonsDayResolvers<ContextType>;
+  Gaps?: GapsResolvers<ContextType>;
+  GapsArtifactGaps?: GapsArtifactGapsResolvers<ContextType>;
   GapsList?: GapsListResolvers<ContextType>;
   GlobalHealth?: GlobalHealthResolvers<ContextType>;
   GlobalIncidentSurface?: GlobalIncidentSurfaceResolvers<ContextType>;
   GlobalIncidents?: GlobalIncidentsResolvers<ContextType>;
+  GlobalIncidentsArtifactSummary?: GlobalIncidentsArtifactSummaryResolvers<ContextType>;
   HealthHistory?: HealthHistoryResolvers<ContextType>;
+  HealthHistoryArtifactSurfaces?: HealthHistoryArtifactSurfacesResolvers<ContextType>;
+  HealthIncidentsArtifactSurfaces?: HealthIncidentsArtifactSurfacesResolvers<ContextType>;
+  HealthIncidentsArtifactSurfacesIncidents?: HealthIncidentsArtifactSurfacesIncidentsResolvers<ContextType>;
+  HealthPercentilesArtifactSurfaces?: HealthPercentilesArtifactSurfacesResolvers<ContextType>;
+  HealthPercentilesArtifactSurfacesLatencyMs?: HealthPercentilesArtifactSurfacesLatencyMsResolvers<ContextType>;
+  HealthProbeSummary?: HealthProbeSummaryResolvers<ContextType>;
   HealthTrends?: HealthTrendsResolvers<ContextType>;
   Hyperparameters?: HyperparametersResolvers<ContextType>;
   HyperparamsHistoryEntry?: HyperparamsHistoryEntryResolvers<ContextType>;
@@ -11705,6 +13641,8 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   IndexerLagDegraded?: IndexerLagDegradedResolvers<ContextType>;
   IndexerLagLatency?: IndexerLagLatencyResolvers<ContextType>;
   IndexerLagWindow?: IndexerLagWindowResolvers<ContextType>;
+  IntegrationReadiness?: IntegrationReadinessResolvers<ContextType>;
+  IntegrationReadinessComponents?: IntegrationReadinessComponentsResolvers<ContextType>;
   IntensityDistribution?: IntensityDistributionResolvers<ContextType>;
   JSON?: GraphQLScalarType;
   NetworkParameters?: NetworkParametersResolvers<ContextType>;
@@ -11731,15 +13669,28 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   RevenueSource?: RevenueSourceResolvers<ContextType>;
   RevenueVerification?: RevenueVerificationResolvers<ContextType>;
   RevenueVerificationCheck?: RevenueVerificationCheckResolvers<ContextType>;
+  ReviewAdapterCandidate?: ReviewAdapterCandidateResolvers<ContextType>;
   ReviewAdapterCandidateList?: ReviewAdapterCandidateListResolvers<ContextType>;
+  ReviewEnrichmentEvidenceArtifactEntries?: ReviewEnrichmentEvidenceArtifactEntriesResolvers<ContextType>;
+  ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary?: ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummaryResolvers<ContextType>;
   ReviewEnrichmentEvidenceList?: ReviewEnrichmentEvidenceListResolvers<ContextType>;
+  ReviewEnrichmentQueueArtifactQueue?: ReviewEnrichmentQueueArtifactQueueResolvers<ContextType>;
+  ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary?: ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummaryResolvers<ContextType>;
   ReviewEnrichmentQueueList?: ReviewEnrichmentQueueListResolvers<ContextType>;
   ReviewEnrichmentTargetList?: ReviewEnrichmentTargetListResolvers<ContextType>;
+  ReviewEnrichmentTargetsArtifactTargets?: ReviewEnrichmentTargetsArtifactTargetsResolvers<ContextType>;
+  ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence?: ReviewEnrichmentTargetsArtifactTargetsCandidateEvidenceResolvers<ContextType>;
+  ReviewEnrichmentTargetsArtifactTargetsQueueContext?: ReviewEnrichmentTargetsArtifactTargetsQueueContextResolvers<ContextType>;
+  ReviewGapPriority?: ReviewGapPriorityResolvers<ContextType>;
   ReviewGapPriorityList?: ReviewGapPriorityListResolvers<ContextType>;
+  ReviewProfileCompletenessArtifactProfiles?: ReviewProfileCompletenessArtifactProfilesResolvers<ContextType>;
+  ReviewProfileCompletenessArtifactSummary?: ReviewProfileCompletenessArtifactSummaryResolvers<ContextType>;
   ReviewProfileCompletenessList?: ReviewProfileCompletenessListResolvers<ContextType>;
   RootClaimEntry?: RootClaimEntryResolvers<ContextType>;
   RootClaimHotkey?: RootClaimHotkeyResolvers<ContextType>;
   RootClaimType?: RootClaimTypeResolvers<ContextType>;
+  RpcPool?: RpcPoolResolvers<ContextType>;
+  RpcPoolEndpoints?: RpcPoolEndpointsResolvers<ContextType>;
   RpcUsage?: RpcUsageResolvers<ContextType>;
   RpcUsageBucket?: RpcUsageBucketResolvers<ContextType>;
   RpcUsageCoverage?: RpcUsageCoverageResolvers<ContextType>;
@@ -11753,13 +13704,17 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   RuntimeTransition?: RuntimeTransitionResolvers<ContextType>;
   RuntimeVersionHistory?: RuntimeVersionHistoryResolvers<ContextType>;
   ScoreDistribution?: ScoreDistributionResolvers<ContextType>;
+  SearchArtifactDocuments?: SearchArtifactDocumentsResolvers<ContextType>;
   SearchDocumentList?: SearchDocumentListResolvers<ContextType>;
+  SearchIndexArtifactDocuments?: SearchIndexArtifactDocumentsResolvers<ContextType>;
   SearchIndexList?: SearchIndexListResolvers<ContextType>;
   SelfHealth?: SelfHealthResolvers<ContextType>;
   SelfHealthComponentView?: SelfHealthComponentViewResolvers<ContextType>;
   SelfHealthDay?: SelfHealthDayResolvers<ContextType>;
   SelfHealthLane?: SelfHealthLaneResolvers<ContextType>;
   SourceSnapshotList?: SourceSnapshotListResolvers<ContextType>;
+  SourceSnapshotsArtifactSources?: SourceSnapshotsArtifactSourcesResolvers<ContextType>;
+  SourceSnapshotsArtifactSummary?: SourceSnapshotsArtifactSummaryResolvers<ContextType>;
   Subnet?: SubnetResolvers<ContextType>;
   SubnetAxonRemovals?: SubnetAxonRemovalsResolvers<ContextType>;
   SubnetBurn?: SubnetBurnResolvers<ContextType>;
@@ -11769,11 +13724,14 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SubnetConcentrationHistory?: SubnetConcentrationHistoryResolvers<ContextType>;
   SubnetConcentrationHistoryPoint?: SubnetConcentrationHistoryPointResolvers<ContextType>;
   SubnetConviction?: SubnetConvictionResolvers<ContextType>;
+  SubnetConvictionArtifactLeaderboard?: SubnetConvictionArtifactLeaderboardResolvers<ContextType>;
   SubnetDeregistrationEvent?: SubnetDeregistrationEventResolvers<ContextType>;
   SubnetDeregistrations?: SubnetDeregistrationsResolvers<ContextType>;
   SubnetEconomics?: SubnetEconomicsResolvers<ContextType>;
   SubnetEmissionDecomposition?: SubnetEmissionDecompositionResolvers<ContextType>;
   SubnetEventSummary?: SubnetEventSummaryResolvers<ContextType>;
+  SubnetEventSummaryArtifactCategories?: SubnetEventSummaryArtifactCategoriesResolvers<ContextType>;
+  SubnetEventSummaryArtifactEventKinds?: SubnetEventSummaryArtifactEventKindsResolvers<ContextType>;
   SubnetEvents?: SubnetEventsResolvers<ContextType>;
   SubnetHealth?: SubnetHealthResolvers<ContextType>;
   SubnetHealthIncidents?: SubnetHealthIncidentsResolvers<ContextType>;
@@ -11790,7 +13748,9 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SubnetIdentityHistoryEntry?: SubnetIdentityHistoryEntryResolvers<ContextType>;
   SubnetIdleStake?: SubnetIdleStakeResolvers<ContextType>;
   SubnetLease?: SubnetLeaseResolvers<ContextType>;
+  SubnetLeaseArtifactLease?: SubnetLeaseArtifactLeaseResolvers<ContextType>;
   SubnetLeaseHistory?: SubnetLeaseHistoryResolvers<ContextType>;
+  SubnetLeaseHistoryArtifactLeaseEvents?: SubnetLeaseHistoryArtifactLeaseEventsResolvers<ContextType>;
   SubnetLifecycle?: SubnetLifecycleResolvers<ContextType>;
   SubnetLifecycleEntry?: SubnetLifecycleEntryResolvers<ContextType>;
   SubnetList?: SubnetListResolvers<ContextType>;
@@ -11800,10 +13760,22 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SubnetOhlc?: SubnetOhlcResolvers<ContextType>;
   SubnetOhlcCandle?: SubnetOhlcCandleResolvers<ContextType>;
   SubnetOwnershipHistory?: SubnetOwnershipHistoryResolvers<ContextType>;
+  SubnetOwnershipHistoryArtifactOwnershipChanges?: SubnetOwnershipHistoryArtifactOwnershipChangesResolvers<ContextType>;
   SubnetPerformance?: SubnetPerformanceResolvers<ContextType>;
   SubnetPerformanceHistory?: SubnetPerformanceHistoryResolvers<ContextType>;
   SubnetPerformanceHistoryPoint?: SubnetPerformanceHistoryPointResolvers<ContextType>;
   SubnetPipelineHistory?: SubnetPipelineHistoryResolvers<ContextType>;
+  SubnetProfile?: SubnetProfileResolvers<ContextType>;
+  SubnetProfileCompleteness?: SubnetProfileCompletenessResolvers<ContextType>;
+  SubnetProfileGithubCommitsWeekly?: SubnetProfileGithubCommitsWeeklyResolvers<ContextType>;
+  SubnetProfileGithubReleases?: SubnetProfileGithubReleasesResolvers<ContextType>;
+  SubnetProfileIdentityEvidence?: SubnetProfileIdentityEvidenceResolvers<ContextType>;
+  SubnetProfileLineage?: SubnetProfileLineageResolvers<ContextType>;
+  SubnetProfileLineageAlsoOn?: SubnetProfileLineageAlsoOnResolvers<ContextType>;
+  SubnetProfileNativeIdentity?: SubnetProfileNativeIdentityResolvers<ContextType>;
+  SubnetProfilePrimaryAppSurface?: SubnetProfilePrimaryAppSurfaceResolvers<ContextType>;
+  SubnetProfilePrimaryLinks?: SubnetProfilePrimaryLinksResolvers<ContextType>;
+  SubnetProfileProvenance?: SubnetProfileProvenanceResolvers<ContextType>;
   SubnetPrometheus?: SubnetPrometheusResolvers<ContextType>;
   SubnetRecycled?: SubnetRecycledResolvers<ContextType>;
   SubnetRegistrations?: SubnetRegistrationsResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7573,6 +7573,8 @@ export interface components {
             contract_version?: string;
             curated_overlay_count: number;
             curation_level_counts: components["schemas"]["CountMap"];
+            domain_coverage: components["schemas"]["CountMap"];
+            first_party_subnet_count: number;
             generated_at: string;
             manifested_count: number;
             native_only_count: number;
@@ -7582,8 +7584,10 @@ export interface components {
             network: components["schemas"]["BittensorNetwork"];
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            official_surface_count: number;
             probed_count: number;
             probed_surface_count: number;
+            registry_observed_surface_count: number;
             root_subnet_count: number;
             /** @constant */
             schema_version: 1;
@@ -7601,6 +7605,7 @@ export interface components {
                 });
                 overlays: string;
             };
+            subnets_without_official_surface: number;
             surface_count: number;
         } & {
             [key: string]: unknown;
@@ -16935,6 +16940,10 @@ export interface operations {
                      *         "curation_level_counts": {
                      *           "example": 1
                      *         },
+                     *         "domain_coverage": {
+                     *           "example": 1
+                     *         },
+                     *         "first_party_subnet_count": 1,
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "manifested_count": 1,
                      *         "native_only_count": 1,
@@ -16943,8 +16952,10 @@ export interface operations {
                      *         "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "finney",
                      *         "notes": "Example description.",
+                     *         "official_surface_count": 1,
                      *         "probed_count": 1,
                      *         "probed_surface_count": 1,
+                     *         "registry_observed_surface_count": 1,
                      *         "root_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "source": {
@@ -16952,6 +16963,7 @@ export interface operations {
                      *           "native": "example",
                      *           "overlays": "example"
                      *         },
+                     *         "subnets_without_official_surface": 1,
                      *         "surface_count": 1
                      *       },
                      *       "meta": {
@@ -24324,6 +24336,8 @@ export interface operations {
                      *           "contract_version": "2026-06-29.1",
                      *           "curated_overlay_count": 1,
                      *           "curation_level_counts": {},
+                     *           "domain_coverage": {},
+                     *           "first_party_subnet_count": 1,
                      *           "generated_at": "2026-06-01T00:00:00.000Z",
                      *           "manifested_count": 1,
                      *           "native_only_count": 1,
@@ -24332,8 +24346,10 @@ export interface operations {
                      *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
                      *           "network": "finney",
                      *           "notes": "Example description.",
+                     *           "official_surface_count": 1,
                      *           "probed_count": 1,
                      *           "probed_surface_count": 1,
+                     *           "registry_observed_surface_count": 1,
                      *           "root_subnet_count": 1,
                      *           "schema_version": 1,
                      *           "source": {
@@ -24341,6 +24357,7 @@ export interface operations {
                      *             "native": "example",
                      *             "overlays": "example"
                      *           },
+                     *           "subnets_without_official_surface": 1,
                      *           "surface_count": 1
                      *         },
                      *         "endpoint_count": 1,
@@ -30022,6 +30039,10 @@ export interface operations {
                      *         "curation_level_counts": {
                      *           "example": 1
                      *         },
+                     *         "domain_coverage": {
+                     *           "example": 1
+                     *         },
+                     *         "first_party_subnet_count": 1,
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "manifested_count": 1,
                      *         "native_only_count": 1,
@@ -30030,8 +30051,10 @@ export interface operations {
                      *         "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "finney",
                      *         "notes": "Example description.",
+                     *         "official_surface_count": 1,
                      *         "probed_count": 1,
                      *         "probed_surface_count": 1,
+                     *         "registry_observed_surface_count": 1,
                      *         "root_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "source": {
@@ -30039,6 +30062,7 @@ export interface operations {
                      *           "native": "example",
                      *           "overlays": "example"
                      *         },
+                     *         "subnets_without_official_surface": 1,
                      *         "surface_count": 1
                      *       },
                      *       "meta": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2100,6 +2100,8 @@
               "contract_version": "2026-06-29.1",
               "curated_overlay_count": 1,
               "curation_level_counts": {},
+              "domain_coverage": {},
+              "first_party_subnet_count": 1,
               "generated_at": "2026-06-01T00:00:00.000Z",
               "manifested_count": 1,
               "native_only_count": 1,
@@ -2108,8 +2110,10 @@
               "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
               "network": "finney",
               "notes": "Example description.",
+              "official_surface_count": 1,
               "probed_count": 1,
               "probed_surface_count": 1,
+              "registry_observed_surface_count": 1,
               "root_subnet_count": 1,
               "schema_version": 1,
               "source": {
@@ -2117,6 +2121,7 @@
                 "native": "example",
                 "overlays": "example"
               },
+              "subnets_without_official_surface": 1,
               "surface_count": 1
             },
             "endpoint_count": 1,
@@ -4521,6 +4526,10 @@
             "curation_level_counts": {
               "example": 1
             },
+            "domain_coverage": {
+              "example": 1
+            },
+            "first_party_subnet_count": 1,
             "generated_at": "2026-06-01T00:00:00.000Z",
             "manifested_count": 1,
             "native_only_count": 1,
@@ -4529,8 +4538,10 @@
             "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
             "network": "finney",
             "notes": "Example description.",
+            "official_surface_count": 1,
             "probed_count": 1,
             "probed_surface_count": 1,
+            "registry_observed_surface_count": 1,
             "root_subnet_count": 1,
             "schema_version": 1,
             "source": {
@@ -4538,6 +4549,7 @@
               "native": "example",
               "overlays": "example"
             },
+            "subnets_without_official_surface": 1,
             "surface_count": 1
           },
           "meta": {
@@ -27412,6 +27424,14 @@
           "curation_level_counts": {
             "$ref": "#/components/schemas/CountMap"
           },
+          "domain_coverage": {
+            "$ref": "#/components/schemas/CountMap"
+          },
+          "first_party_subnet_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "generated_at": {
             "type": "string"
           },
@@ -27455,12 +27475,22 @@
             ],
             "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
+          "official_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "probed_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
           },
           "probed_surface_count": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "registry_observed_surface_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
@@ -27564,6 +27594,11 @@
             ],
             "type": "object"
           },
+          "subnets_without_official_surface": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "surface_count": {
             "maximum": 9007199254740991,
             "minimum": 0,
@@ -27579,6 +27614,8 @@
           "chain_subnet_count",
           "curated_overlay_count",
           "curation_level_counts",
+          "domain_coverage",
+          "first_party_subnet_count",
           "manifested_count",
           "native_only_count",
           "native_only_with_candidates",
@@ -27587,8 +27624,11 @@
           "network",
           "probed_count",
           "probed_surface_count",
+          "official_surface_count",
+          "registry_observed_surface_count",
           "root_subnet_count",
           "source",
+          "subnets_without_official_surface",
           "surface_count"
         ],
         "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7573,6 +7573,8 @@ export interface components {
             contract_version?: string;
             curated_overlay_count: number;
             curation_level_counts: components["schemas"]["CountMap"];
+            domain_coverage: components["schemas"]["CountMap"];
+            first_party_subnet_count: number;
             generated_at: string;
             manifested_count: number;
             native_only_count: number;
@@ -7582,8 +7584,10 @@ export interface components {
             network: components["schemas"]["BittensorNetwork"];
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            official_surface_count: number;
             probed_count: number;
             probed_surface_count: number;
+            registry_observed_surface_count: number;
             root_subnet_count: number;
             /** @constant */
             schema_version: 1;
@@ -7601,6 +7605,7 @@ export interface components {
                 });
                 overlays: string;
             };
+            subnets_without_official_surface: number;
             surface_count: number;
         } & {
             [key: string]: unknown;
@@ -16935,6 +16940,10 @@ export interface operations {
                      *         "curation_level_counts": {
                      *           "example": 1
                      *         },
+                     *         "domain_coverage": {
+                     *           "example": 1
+                     *         },
+                     *         "first_party_subnet_count": 1,
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "manifested_count": 1,
                      *         "native_only_count": 1,
@@ -16943,8 +16952,10 @@ export interface operations {
                      *         "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "finney",
                      *         "notes": "Example description.",
+                     *         "official_surface_count": 1,
                      *         "probed_count": 1,
                      *         "probed_surface_count": 1,
+                     *         "registry_observed_surface_count": 1,
                      *         "root_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "source": {
@@ -16952,6 +16963,7 @@ export interface operations {
                      *           "native": "example",
                      *           "overlays": "example"
                      *         },
+                     *         "subnets_without_official_surface": 1,
                      *         "surface_count": 1
                      *       },
                      *       "meta": {
@@ -24324,6 +24336,8 @@ export interface operations {
                      *           "contract_version": "2026-06-29.1",
                      *           "curated_overlay_count": 1,
                      *           "curation_level_counts": {},
+                     *           "domain_coverage": {},
+                     *           "first_party_subnet_count": 1,
                      *           "generated_at": "2026-06-01T00:00:00.000Z",
                      *           "manifested_count": 1,
                      *           "native_only_count": 1,
@@ -24332,8 +24346,10 @@ export interface operations {
                      *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
                      *           "network": "finney",
                      *           "notes": "Example description.",
+                     *           "official_surface_count": 1,
                      *           "probed_count": 1,
                      *           "probed_surface_count": 1,
+                     *           "registry_observed_surface_count": 1,
                      *           "root_subnet_count": 1,
                      *           "schema_version": 1,
                      *           "source": {
@@ -24341,6 +24357,7 @@ export interface operations {
                      *             "native": "example",
                      *             "overlays": "example"
                      *           },
+                     *           "subnets_without_official_surface": 1,
                      *           "surface_count": 1
                      *         },
                      *         "endpoint_count": 1,
@@ -30022,6 +30039,10 @@ export interface operations {
                      *         "curation_level_counts": {
                      *           "example": 1
                      *         },
+                     *         "domain_coverage": {
+                     *           "example": 1
+                     *         },
+                     *         "first_party_subnet_count": 1,
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "manifested_count": 1,
                      *         "native_only_count": 1,
@@ -30030,8 +30051,10 @@ export interface operations {
                      *         "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
                      *         "network": "finney",
                      *         "notes": "Example description.",
+                     *         "official_surface_count": 1,
                      *         "probed_count": 1,
                      *         "probed_surface_count": 1,
+                     *         "registry_observed_surface_count": 1,
                      *         "root_subnet_count": 1,
                      *         "schema_version": 1,
                      *         "source": {
@@ -30039,6 +30062,7 @@ export interface operations {
                      *           "native": "example",
                      *           "overlays": "example"
                      *         },
+                     *         "subnets_without_official_surface": 1,
                      *         "surface_count": 1
                      *       },
                      *       "meta": {

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -464,6 +464,105 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   ValidatorPermitModelAgreement: "ValidatorPermitModelAgreement",
   ValidatorSetComposition: "ValidatorSetComposition",
   ValidatorTakeDistribution: "ValidatorTakeDistribution",
+  // ── the 69 types #10214 stopped publishing as opaque JSON ─────────────────
+  //
+  // Every one is an IDENTITY entry, and that is the point rather than an
+  // omission. The 50 fields these back were `JSON` in the hand-written SDL --
+  // a caller could read them, but nothing said what was inside, so nothing
+  // checked. They are emitted from their Zod components now, and a component
+  // that has never had a published name has no name to preserve: the component
+  // id IS the contract, first published here.
+  //
+  // The renamed entries above exist because the hand-written SDL chose a name
+  // before the component did (`SubnetIndexEntry` -> `Subnet`). There was no
+  // such choice to honour here -- inventing one would mint a public name no
+  // caller has ever seen, and it can still be chosen later, in the issue that
+  // wants it, without this diff having pre-empted it.
+  AdapterArtifactSnapshot: "AdapterArtifactSnapshot",
+  BlockChainEventsArtifactEvents: "BlockChainEventsArtifactEvents",
+  BlockExtrinsicsArtifactExtrinsics: "BlockExtrinsicsArtifactExtrinsics",
+  BuildSummaryArtifactArtifactBudgetSummary:
+    "BuildSummaryArtifactArtifactBudgetSummary",
+  BuildSummaryArtifactArtifacts: "BuildSummaryArtifactArtifacts",
+  ChainConcentrationScorecard: "ChainConcentrationScorecard",
+  ChangelogArtifactArtifacts: "ChangelogArtifactArtifacts",
+  ChangelogArtifactSubnets: "ChangelogArtifactSubnets",
+  ChangelogArtifactSubnetsAdded: "ChangelogArtifactSubnetsAdded",
+  ChangelogArtifactSubnetsRemoved: "ChangelogArtifactSubnetsRemoved",
+  ChangelogArtifactSubnetsRenamed: "ChangelogArtifactSubnetsRenamed",
+  ChangelogArtifactSummary: "ChangelogArtifactSummary",
+  CompareValidatorsArtifactValidatorsColdkeyIdentity:
+    "CompareValidatorsArtifactValidatorsColdkeyIdentity",
+  CompareValidatorsArtifactValidatorsSubnetContext:
+    "CompareValidatorsArtifactValidatorsSubnetContext",
+  ContractsArtifactArtifacts: "ContractsArtifactArtifacts",
+  ContractsArtifactArtifactsRetirement: "ContractsArtifactArtifactsRetirement",
+  CoverageArtifact: "CoverageArtifact",
+  CoverageArtifactSource: "CoverageArtifactSource",
+  CoverageCompleteness: "CoverageCompleteness",
+  CurationArtifactCuration: "CurationArtifactCuration",
+  CurationMetadata: "CurationMetadata",
+  EndpointIncidentsArtifactSummary: "EndpointIncidentsArtifactSummary",
+  EndpointScoreReason: "EndpointScoreReason",
+  EvidenceClaim: "EvidenceClaim",
+  EvidenceLedgerArtifactSummary: "EvidenceLedgerArtifactSummary",
+  Gaps: "Gaps",
+  GapsArtifactGaps: "GapsArtifactGaps",
+  GlobalIncidentsArtifactSummary: "GlobalIncidentsArtifactSummary",
+  HealthHistoryArtifactSurfaces: "HealthHistoryArtifactSurfaces",
+  HealthIncidentsArtifactSurfaces: "HealthIncidentsArtifactSurfaces",
+  HealthIncidentsArtifactSurfacesIncidents:
+    "HealthIncidentsArtifactSurfacesIncidents",
+  HealthPercentilesArtifactSurfaces: "HealthPercentilesArtifactSurfaces",
+  HealthPercentilesArtifactSurfacesLatencyMs:
+    "HealthPercentilesArtifactSurfacesLatencyMs",
+  HealthProbeSummary: "HealthProbeSummary",
+  IntegrationReadiness: "IntegrationReadiness",
+  IntegrationReadinessComponents: "IntegrationReadinessComponents",
+  ReviewAdapterCandidate: "ReviewAdapterCandidate",
+  ReviewEnrichmentEvidenceArtifactEntries:
+    "ReviewEnrichmentEvidenceArtifactEntries",
+  ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary:
+    "ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary",
+  ReviewEnrichmentQueueArtifactQueue: "ReviewEnrichmentQueueArtifactQueue",
+  ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary:
+    "ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary",
+  ReviewEnrichmentTargetsArtifactTargets:
+    "ReviewEnrichmentTargetsArtifactTargets",
+  ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence:
+    "ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence",
+  ReviewEnrichmentTargetsArtifactTargetsQueueContext:
+    "ReviewEnrichmentTargetsArtifactTargetsQueueContext",
+  ReviewGapPriority: "ReviewGapPriority",
+  ReviewProfileCompletenessArtifactProfiles:
+    "ReviewProfileCompletenessArtifactProfiles",
+  ReviewProfileCompletenessArtifactSummary:
+    "ReviewProfileCompletenessArtifactSummary",
+  RpcPool: "RpcPool",
+  RpcPoolEndpoints: "RpcPoolEndpoints",
+  SearchArtifactDocuments: "SearchArtifactDocuments",
+  SearchIndexArtifactDocuments: "SearchIndexArtifactDocuments",
+  SourceSnapshotsArtifactSources: "SourceSnapshotsArtifactSources",
+  SourceSnapshotsArtifactSummary: "SourceSnapshotsArtifactSummary",
+  SubnetConvictionArtifactLeaderboard: "SubnetConvictionArtifactLeaderboard",
+  SubnetEventSummaryArtifactCategories: "SubnetEventSummaryArtifactCategories",
+  SubnetEventSummaryArtifactEventKinds: "SubnetEventSummaryArtifactEventKinds",
+  SubnetLeaseArtifactLease: "SubnetLeaseArtifactLease",
+  SubnetLeaseHistoryArtifactLeaseEvents:
+    "SubnetLeaseHistoryArtifactLeaseEvents",
+  SubnetOwnershipHistoryArtifactOwnershipChanges:
+    "SubnetOwnershipHistoryArtifactOwnershipChanges",
+  SubnetProfile: "SubnetProfile",
+  SubnetProfileCompleteness: "SubnetProfileCompleteness",
+  SubnetProfileGithubCommitsWeekly: "SubnetProfileGithubCommitsWeekly",
+  SubnetProfileGithubReleases: "SubnetProfileGithubReleases",
+  SubnetProfileIdentityEvidence: "SubnetProfileIdentityEvidence",
+  SubnetProfileLineage: "SubnetProfileLineage",
+  SubnetProfileLineageAlsoOn: "SubnetProfileLineageAlsoOn",
+  SubnetProfileNativeIdentity: "SubnetProfileNativeIdentity",
+  SubnetProfilePrimaryAppSurface: "SubnetProfilePrimaryAppSurface",
+  SubnetProfilePrimaryLinks: "SubnetProfilePrimaryLinks",
+  SubnetProfileProvenance: "SubnetProfileProvenance",
 };
 
 /**
@@ -2135,10 +2234,35 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
     added: {},
     dropped: ["schema_version", "events"],
   },
+  // Was declared over `BlockEventsArtifact` -- the component behind the OTHER
+  // block route, /api/v1/blocks/{ref}/events, whose `events` are curated
+  // `AccountEvent` rows. This field mirrors /api/v1/blocks/{ref}/chain-events,
+  // and openapi.json says so: its `data` refs `BlockChainEventsArtifact`.
+  //
+  // Measured against production, the two payloads are not the same shape:
+  //
+  //   /blocks/{ref}/chain-events   {block_number, count, events[...]}
+  //   /blocks/{ref}/events         {block_number, event_count, events[...],
+  //                                 limit, offset, ref, schema_version}
+  //
+  // and their rows differ entirely -- raw pallet-level `{pallet, method, args,
+  // phase, summary}` here against the curated `{event_kind, hotkey, coldkey,
+  // netuid, amount_tao}` there. The component's own comment says as much:
+  // "distinct from the curated AccountEvent".
+  //
+  // It cost nothing while `events` was published as `[JSON!]!`, because JSON
+  // serialises whatever it is handed. It stops being free the moment the field
+  // is TYPED (#10214): every row would be checked against AccountEvent, match
+  // none of its fields, and serve `event_kind: null, hotkey: null, ...` for
+  // data that is sitting right there.
+  //
+  // `schema_version` and `event_count` are resolver-added: the artifact carries
+  // `count`, and the resolver renames it and stamps a version, which is what
+  // this route's GraphQL card has always published.
   BlockChainEvents: {
-    component: "BlockEventsArtifact",
-    added: {},
-    dropped: ["ref", "limit", "offset"],
+    component: "BlockChainEventsArtifact",
+    added: { schema_version: "Int", event_count: "Int!" },
+    dropped: ["count"],
   },
   AccountEntry: { component: "AccountsListArtifactAccounts", added: {} },
   // ── the three that had NO component until #10409 ─────────────────────────

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -74,6 +74,13 @@ export const CoverageArtifactSchema = ArtifactBaseSchema.extend({
   completeness: CoverageCompletenessSchema,
   curated_overlay_count: z.int().min(0),
   curation_level_counts: CountMapSchema,
+  // #10214: served by /api/v1/build and /api/v1/coverage all along, declared
+  // nowhere. The artifact is `.passthrough()`, so they reached a caller while
+  // the contract said nothing about them -- invisible until this component was
+  // published as a GraphQL type and the emitted shape could be compared
+  // field-for-field against what production returns.
+  domain_coverage: CountMapSchema,
+  first_party_subnet_count: z.int().min(0),
   manifested_count: z.int().min(0),
   native_only_count: z.int().min(0),
   native_only_with_candidates: z.int().min(0),
@@ -82,8 +89,11 @@ export const CoverageArtifactSchema = ArtifactBaseSchema.extend({
   network: BittensorNetworkSchema,
   probed_count: z.int().min(0),
   probed_surface_count: z.int().min(0),
+  official_surface_count: z.int().min(0),
+  registry_observed_surface_count: z.int().min(0),
   root_subnet_count: z.int().min(0),
   source: CoverageSourceSchema,
+  subnets_without_official_surface: z.int().min(0),
   surface_count: z.int().min(0),
 }).passthrough();
 export type CoverageArtifact = z.infer<typeof CoverageArtifactSchema>;

--- a/scripts/check-graphql-nullability.ts
+++ b/scripts/check-graphql-nullability.ts
@@ -18,6 +18,20 @@
 // that found it, so the fix is either the Zod (the producer really can answer
 // null) or nothing (the field is safe to tighten).
 //
+// TWO SOURCES, ONE QUESTION (#10214). Asking through GraphQL is the direct
+// measurement, and it is BLIND by construction on any field the published
+// schema serves as `JSON`: a probe that selects into one gets back `Field
+// "profiles" must not have a selection since type "[JSON!]!" has no subfields`
+// and the field is skipped entirely. That was every type #10214 published --
+// so the check could not see precisely the fields whose promises were new.
+// The same rows are also read off each binding's mirrored REST route, where
+// the shape is visible whatever GraphQL says about it, and both feed ONE set
+// of counts. Kept in one script rather than a sibling because it is one
+// question with two transports: split across two files the shared rule --
+// what counts as a violation -- gets decided twice and drifts, which it had
+// already started to do (a missing key was fatal in one reading and skipped
+// in the other).
+//
 // Out of band, like its conformance siblings: a check that needs production
 // data should not pretend to run on a pull request.
 //
@@ -41,6 +55,7 @@ import type {
   GraphQLOutputType,
 } from "graphql";
 import { buildGeneratedSchema } from "../schemas-src/graphql/build-schema.ts";
+import { emitTypes } from "../schemas-src/graphql/emit.ts";
 import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
 import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
 import { SDL } from "../src/graphql-sdl.ts";
@@ -75,6 +90,62 @@ const ARGUMENTS: Readonly<Record<string, string>> = {
   amount: "1.0",
 };
 
+/**
+ * Path-parameter values for the REST half, SEVERAL per parameter.
+ *
+ * One subject silently decides which types get measured: netuid 1 has 3
+ * monitored surfaces and no health incidents, so probing only it leaves
+ * `HealthIncidentsArtifactSurfacesIncidents` unobserved and reads that silence
+ * as coverage. netuid 64 has 34 surfaces and live incidents. Every value is
+ * tried and the observations pool into the same counts.
+ *
+ * Derived from `ARGUMENTS` where they overlap rather than restated, so the two
+ * halves cannot come to disagree about which account or block is known-good.
+ */
+const REST_PATH_VALUES: Readonly<Record<string, readonly string[]>> = {
+  netuid: ["1", "64", "4"],
+  hotkey: [ARGUMENTS.hotkey.replaceAll('"', "")],
+  coldkey: [ARGUMENTS.coldkey.replaceAll('"', "")],
+  ss58: [ARGUMENTS.ss58.replaceAll('"', "")],
+  address: [ARGUMENTS.address.replaceAll('"', "")],
+  slug: [ARGUMENTS.slug.replaceAll('"', "")],
+  block_number: [ARGUMENTS.block_number],
+  ref: [ARGUMENTS.ref.replaceAll('"', "")],
+  id: [ARGUMENTS.id.replaceAll('"', "")],
+  // Computed, not pinned: the archive is a rolling window, so a date literal
+  // would pass today and 404 in a month with nothing saying why.
+  date: [new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)],
+};
+
+/**
+ * Query arguments a route needs before it answers with anything to walk.
+ *
+ * `/api/v1/compare/validators` returns 200 with a null `subnet_context` on
+ * every row unless it is given a `netuid` -- an empty answer measures nothing,
+ * which is how a type inside a healthy route stays unobserved.
+ */
+const REST_REQUIRED_QUERY: Readonly<Record<string, string>> = {
+  "/api/v1/compare/validators": `hotkeys=${ARGUMENTS.hotkey.replaceAll('"', "")}&netuid=1`,
+};
+
+/**
+ * Where an observation came from, because the two see different things.
+ *
+ * GRAPHQL asks production for exactly the non-null leaves it wants and reads
+ * the answer. It is the direct measurement -- the same execution that will
+ * enforce the promise -- and it is the authority wherever it can reach.
+ *
+ * REST reads the same rows off the mirrored route. It exists because the
+ * GraphQL side is BLIND by construction on any field the published schema
+ * serves as `JSON`: a probe selecting into one gets `Field "profiles" must not
+ * have a selection since type "[JSON!]!" has no subfields` and the whole field
+ * is skipped. That was every type #10214 published, which is to say the
+ * measurement mattered most exactly where this check could not make it. The
+ * loader is shared, so the row REST returns IS the row the resolver hands
+ * graphql-js; only the promise attached to it differs.
+ */
+export type Source = "graphql" | "rest";
+
 export interface NullabilityFinding {
   /** `Type.field`, as the generated schema names it. */
   field: string;
@@ -88,6 +159,14 @@ export interface NullabilityFinding {
 export interface NullabilityReport {
   /** Query fields the probe could build and send. */
   probed: number;
+  /**
+   * Bindings the REST half read, which is a DIFFERENT number from `probed`.
+   *
+   * Printed separately rather than summed: a field GraphQL skipped and REST
+   * reached is measured, and one both reached is measured twice as thoroughly.
+   * One combined figure would make those indistinguishable.
+   */
+  restProbed: number;
   /** Query fields skipped entirely, with the reason -- 0 evidence for each. */
   skipped: string[];
   /**
@@ -289,6 +368,36 @@ function renderArguments(field: GraphQLField<unknown, unknown>): string | null {
  * So: the published type drives the walk, and a field is only judged when the
  * generated type has it too.
  */
+/**
+ * Walk one answer, counting what the generated schema promises non-null.
+ *
+ * A NULL counts. An ABSENT key does NOT, from either source, and the reason is
+ * worth stating because the opposite is tempting: graphql-js treats a missing
+ * property exactly like an explicit null, so absence looks like the same
+ * defect.
+ *
+ * It is not, because an absent key is not one fact but several, and this check
+ * cannot tell them apart. Over GraphQL, a key missing from the answer usually
+ * means the probe did not ask for it. Over REST, production serves whatever
+ * build is deployed, against a contract generated from THIS tree -- so a key
+ * the contract declares and the payload lacks may be a defect, or may simply
+ * be a field the deployed producer does not compute yet.
+ *
+ * `stake_tao`/`emission_tao` are the live example, and they are worth spelling
+ * out because the obvious reading of them is wrong. They are NOT a rename of
+ * the `stake_alpha`/`emission_alpha` the surface answers with: alpha and TAO
+ * are DIFFERENT TOKENS. A non-root subnet's stake is denominated in that
+ * subnet's own alpha, and #9058/#9066 made the `_tao` fields mean TAO by
+ * PRICING alpha through each subnet's alpha price -- a derived quantity, not
+ * the same number under a new name. So the deployed producer emitting the raw
+ * alpha figure and not the priced one is a gap in the producer, not a Zod that
+ * overstates it, and counting it here produced eight findings whose only
+ * available "fix" was loosening four correct components to match.
+ *
+ * What remains is the question this check was written to ask, and both sources
+ * can answer it: does the producer ever ANSWER null where the generated schema
+ * promises it cannot.
+ */
 function walk(
   value: unknown,
   publishedOn: GraphQLOutputType,
@@ -342,12 +451,105 @@ function walk(
   }
 }
 
+/**
+ * The component a route's `data` refs, read from the published spec.
+ *
+ * The same lookup `validate-graphql-component-parity.ts` uses to pair an SDL
+ * type with the Zod behind it -- and the honest root for a REST body, because
+ * the body IS that component.
+ */
+export function dataComponent(
+  openapi: OpenApiParameters,
+  route: string,
+): string | null {
+  const schema = (
+    openapi as unknown as {
+      paths?: Record<
+        string,
+        {
+          get?: {
+            responses?: Record<
+              string,
+              {
+                content?: Record<
+                  string,
+                  {
+                    schema?: {
+                      allOf?: { properties?: { data?: { $ref?: string } } }[];
+                    };
+                  }
+                >;
+              }
+            >;
+          };
+        }
+      >;
+    }
+  ).paths?.[route]?.get?.responses?.["200"]?.content?.["application/json"]
+    ?.schema;
+  for (const part of schema?.allOf ?? []) {
+    const ref = part?.properties?.data?.$ref;
+    if (typeof ref === "string")
+      return ref.replace("#/components/schemas/", "");
+  }
+  return null;
+}
+
+/** Every filling of a route's path parameters, or none if one has no value. */
+export function fillRoute(route: string): string[] {
+  let filled = [route];
+  for (const match of route.matchAll(/\{([^}]+)\}/g)) {
+    const values = REST_PATH_VALUES[match[1]];
+    if (values === undefined) return [];
+    filled = filled.flatMap((one) =>
+      values.map((value) => one.replace(match[0], encodeURIComponent(value))),
+    );
+  }
+  return filled;
+}
+
+/**
+ * `limit=<the route's own maximum>`, or nothing.
+ *
+ * Read from the published spec rather than guessed. The ceiling is per-route,
+ * and REST REJECTS both an unknown parameter and an over-ceiling one -- MCP is
+ * the surface that clamps -- so a blanket `?limit=100` turns 40 healthy routes
+ * into "did not answer" and reports that silence as coverage.
+ */
+export function limitFor(openapi: OpenApiParameters, route: string): string {
+  const parameters =
+    (
+      openapi as unknown as {
+        paths?: Record<
+          string,
+          {
+            get?: {
+              parameters?: Array<{
+                name?: string;
+                $ref?: string;
+                schema?: { maximum?: number };
+              }>;
+            };
+          }
+        >;
+      }
+    ).paths?.[route]?.get?.parameters ?? [];
+  for (const parameter of parameters) {
+    const name = parameter.name ?? parameter.$ref?.split("/").pop() ?? "";
+    if (!name.toLowerCase().includes("limit")) continue;
+    const maximum = parameter.schema?.maximum;
+    return `limit=${typeof maximum === "number" ? maximum : 100}`;
+  }
+  return "";
+}
+
 export async function checkNullability(
   openapi: OpenApiParameters,
   fetchImpl: typeof fetch = fetch,
 ): Promise<NullabilityReport> {
   const { schema: generated } = buildGeneratedSchema(openapi);
   const published = buildSchema(SDL);
+  const { types: emitted } = emitTypes();
   const root = generated.getQueryType()!;
   const counts = new Map<
     string,
@@ -356,7 +558,69 @@ export async function checkNullability(
   const skipped: string[] = [];
   const partial: string[] = [];
   const allLeaves = new Set<string>();
+  /** Bindings the REST half read, which is separate from what GraphQL probed. */
+  const restProbed = new Set<string>();
   let probed = 0;
+
+  /**
+   * The REST half, run for every binding that names a route -- including the
+   * ones the GraphQL probe handled.
+   *
+   * Not a fallback. Where both can see a field they agree (the loader is
+   * shared), and pooling both is what makes a field null on 1 row in 400 show
+   * up at all -- the GraphQL probe reads one answer per field, REST reads up
+   * to the route's whole page.
+   */
+  const probeRest = async (
+    binding: (typeof QUERY_BINDINGS)[number],
+  ): Promise<void> => {
+    if (!binding.route) return;
+    // The root to walk REST's `data` against is the route's COMPONENT, never
+    // the Query field's return type. For ~40 bindings the resolver returns a
+    // PROJECTION it builds -- `EndpointList {items, total, cursor, limit,
+    // returned}` over an `EndpointsArtifact {endpoints, summary, ...}` -- and
+    // walking a REST body against one reports every projection field as
+    // missing. That is a view compared to its source, which is the same
+    // mistake `PROJECTED_TYPES` exists to stop the parity gate making: it
+    // manufactured 84 findings, every one of them a `*List.items` or
+    // `*List.total`, before the root was resolved this way.
+    const component = dataComponent(openapi, binding.route);
+    const generatedType = component ? emitted.get(component) : undefined;
+    if (!generatedType) return;
+    const routes = fillRoute(binding.route);
+    if (routes.length === 0) return;
+    const query = [
+      limitFor(openapi, binding.route),
+      REST_REQUIRED_QUERY[binding.route] ?? "",
+    ].filter(Boolean);
+    for (const route of routes) {
+      const url = `${BASE}${route}${query.length ? `?${query.join("&")}` : ""}`;
+      let data: unknown;
+      try {
+        const res = await fetchImpl(url, {
+          headers: { accept: "application/json" },
+        });
+        if (!res.ok) continue;
+        data = ((await res.json()) as { data?: unknown })?.data ?? null;
+      } catch {
+        continue;
+      }
+      if (data === null || data === undefined) continue;
+      // The generated type is passed as BOTH sides: a REST row is the
+      // component's own shape, so the published GraphQL type has no say here
+      // -- and it is precisely the side that is blind, since the fields this
+      // reaches are the ones it publishes as opaque JSON.
+      walk(
+        data,
+        generatedType,
+        generatedType,
+        binding.field,
+        counts,
+        `${binding.field} (REST)`,
+      );
+      restProbed.add(binding.field);
+    }
+  };
 
   for (const binding of QUERY_BINDINGS) {
     const field = root.getFields()[binding.field];
@@ -364,6 +628,10 @@ export async function checkNullability(
       skipped.push(`${binding.field} -- the generated root has no such field`);
       continue;
     }
+    // Before any GraphQL reasoning, so a binding the probe SKIPS still gets
+    // measured. That is the whole point of consolidating the two: the fields
+    // GraphQL cannot ask about are exactly the ones worth asking about.
+    await probeRest(binding);
     const publishedField = published.getQueryType()?.getFields()[binding.field];
     if (!publishedField) {
       skipped.push(`${binding.field} -- the served root has no such field`);
@@ -481,6 +749,7 @@ export async function checkNullability(
   }
   return {
     probed,
+    restProbed: restProbed.size,
     skipped,
     partial,
     observed: [...counts.values()].filter((c) => c.seen > 0).length,
@@ -501,7 +770,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   // across every run is the one that decides the cutover: how many answered
   // null.
   console.log(
-    `graphql-nullability: probed ${report.probed} Query field(s) against ${BASE}; ` +
+    `graphql-nullability: probed ${report.probed} Query field(s) over GraphQL ` +
+      `and ${report.restProbed} over REST against ${BASE}; ` +
       `${report.observed} of ${report.observed + report.unobserved.length} ` +
       `generated non-null field(s) observed, ` +
       `${report.findings.length} answered NULL.`,

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -158,69 +158,16 @@ export const DECLARED: Record<string, string> = {
  * had only ever run on the MIRRORS, and 27 of these sit on a projection or a
  * paginated view, where nothing had compared a type to a type. The debt did
  * not grow -- half of it had simply never been counted.
+ *
+ * EMPTY as of #10214. The 50 that remained are published types now, emitted
+ * from the same components this gate compares against. The map stays because
+ * the RULE is what stops the next one: an under-typed field with no entry is
+ * still a violation, so a field cannot quietly become `JSON` again. Reaching
+ * zero removes the debt, not the check that kept it counted -- and an empty
+ * declaration list is the only shape in which "the list only shrinks" has
+ * nothing left to shrink.
  */
-const JSON_UNDERTYPED: Record<string, string> = {
-  "Adapter.snapshot": "AdapterArtifactSnapshot",
-  "BlockChainEvents.events": "[AccountEvent!]",
-  "BlockExtrinsics.extrinsics": "[BlockExtrinsicsArtifactExtrinsics!]",
-  "BuildSummary.artifact_budget_summary":
-    "BuildSummaryArtifactArtifactBudgetSummary",
-  "BuildSummary.artifacts": "[BuildSummaryArtifactArtifacts!]",
-  "BuildSummary.coverage": "CoverageArtifact",
-  "ChainConcentrationHistoryPoint.emission": "ChainConcentrationScorecard",
-  "ChainConcentrationHistoryPoint.entity_emission":
-    "ChainConcentrationScorecard",
-  "ChainConcentrationHistoryPoint.entity_stake": "ChainConcentrationScorecard",
-  "ChainConcentrationHistoryPoint.stake": "ChainConcentrationScorecard",
-  "ChainConcentrationHistoryPoint.validator_stake":
-    "ChainConcentrationScorecard",
-  "Changelog.artifacts": "ChangelogArtifactArtifacts",
-  "Changelog.subnets": "ChangelogArtifactSubnets",
-  "Changelog.summary": "ChangelogArtifactSummary",
-  "ComparedValidator.coldkey_identity":
-    "CompareValidatorsArtifactValidatorsColdkeyIdentity",
-  "ComparedValidator.subnet_context":
-    "CompareValidatorsArtifactValidatorsSubnetContext",
-  "Contracts.artifacts": "[ContractsArtifactArtifacts!]",
-  "CurationList.curation": "[CurationArtifactCuration!]",
-  "EndpointPoolList.pools": "[RpcPool!]",
-  "EvidenceList.claims": "[EvidenceClaim!]",
-  "EvidenceList.summary": "EvidenceLedgerArtifactSummary",
-  "GapsList.gaps": "[GapsArtifactGaps!]",
-  "GlobalIncidents.summary": "GlobalIncidentsArtifactSummary",
-  "HealthHistory.summary": "HealthProbeSummary",
-  "HealthHistory.surfaces": "[HealthHistoryArtifactSurfaces!]",
-  "IncidentList.summary": "EndpointIncidentsArtifactSummary",
-  "PoolList.pools": "[RpcPool!]",
-  "ProfileList.profiles": "[SubnetProfile!]",
-  "ReviewAdapterCandidateList.candidates": "[ReviewAdapterCandidate!]",
-  "ReviewEnrichmentEvidenceList.entries":
-    "[ReviewEnrichmentEvidenceArtifactEntries!]",
-  "ReviewEnrichmentEvidenceList.notes": "String",
-  "ReviewEnrichmentQueueList.notes": "String",
-  "ReviewEnrichmentQueueList.queue": "[ReviewEnrichmentQueueArtifactQueue!]",
-  "ReviewEnrichmentTargetList.notes": "String",
-  "ReviewEnrichmentTargetList.targets":
-    "[ReviewEnrichmentTargetsArtifactTargets!]",
-  "ReviewGapPriorityList.priorities": "[ReviewGapPriority!]",
-  "ReviewProfileCompletenessList.profiles":
-    "[ReviewProfileCompletenessArtifactProfiles!]",
-  "ReviewProfileCompletenessList.summary":
-    "ReviewProfileCompletenessArtifactSummary",
-  "SearchDocumentList.documents": "[SearchArtifactDocuments!]",
-  "SearchIndexList.documents": "[SearchIndexArtifactDocuments!]",
-  "SourceSnapshotList.sources": "[SourceSnapshotsArtifactSources!]",
-  "SourceSnapshotList.summary": "SourceSnapshotsArtifactSummary",
-  "SubnetConviction.leaderboard": "[SubnetConvictionArtifactLeaderboard!]",
-  "SubnetEventSummary.categories": "[SubnetEventSummaryArtifactCategories!]",
-  "SubnetEventSummary.event_kinds": "[SubnetEventSummaryArtifactEventKinds!]",
-  "SubnetHealthIncidents.surfaces": "[HealthIncidentsArtifactSurfaces!]",
-  "SubnetHealthPercentiles.surfaces": "[HealthPercentilesArtifactSurfaces!]",
-  "SubnetLease.lease": "SubnetLeaseArtifactLease",
-  "SubnetLeaseHistory.lease_events": "[SubnetLeaseHistoryArtifactLeaseEvents!]",
-  "SubnetOwnershipHistory.ownership_changes":
-    "[SubnetOwnershipHistoryArtifactOwnershipChanges!]",
-};
+const JSON_UNDERTYPED: Record<string, string> = {};
 
 export interface ParityReport {
   violations: string[];
@@ -416,6 +363,11 @@ export function checkComponentParity(
   projectedTypesMap: Readonly<
     Record<string, (typeof PROJECTED_TYPES)[string]>
   > = PROJECTED_TYPES,
+  // Injectable for the same reason `declared` is, and newly load-bearing:
+  // `JSON_UNDERTYPED` is empty now, so the shrink-only rule has no live entry
+  // to demonstrate on. A rule provable only while something violates it is a
+  // rule that stops being tested the moment it works.
+  undertypedMap: Readonly<Record<string, string>> = JSON_UNDERTYPED,
 ): ParityReport {
   const sdlTypes = new Map<string, ObjectTypeDefinitionNode>();
   for (const def of parse(sdl).definitions) {
@@ -571,7 +523,7 @@ export function checkComponentParity(
               // because closing one means publishing a new named type, and
               // that is the generator's job (#10214). The list only SHRINKS:
               // an entry that stops being under-typed fails below.
-              if (JSON_UNDERTYPED[key] === wanted) undertypedMatched.add(key);
+              if (undertypedMap[key] === wanted) undertypedMatched.add(key);
               else
                 violations.push(
                   `${key} -- the SDL declares JSON, ${componentName} emits ` +
@@ -701,7 +653,7 @@ export function checkComponentParity(
       if (divergence) {
         const { published, wanted } = divergence;
         if (published.replace(/[![\]]/g, "") === "JSON") {
-          if (JSON_UNDERTYPED[key] === wanted) undertypedMatched.add(key);
+          if (undertypedMap[key] === wanted) undertypedMatched.add(key);
           else
             violations.push(
               `${key} -- the SDL declares JSON, ${projection.component} ` +
@@ -766,7 +718,7 @@ export function checkComponentParity(
     violations,
     stale: [
       ...Object.keys(declared).filter((key) => !matched.has(key)),
-      ...Object.keys(JSON_UNDERTYPED).filter(
+      ...Object.keys(undertypedMap).filter(
         (key) => !undertypedMatched.has(key),
       ),
     ],

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -172,7 +172,6 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
-      fields: String
     ): SearchDocumentList!
     "The slim search index -- the same documents as search without the per-document token blobs, for fast browser typeahead and listing. Filter by type/netuid/q, sort with sort/order, and page with limit/cursor. An invalid filter/sort/limit/cursor is a GraphQL error. Mirrors GET /api/v1/search-index."
     search_index(
@@ -183,7 +182,6 @@ export const SDL = /* GraphQL */ `
       order: String
       limit: Int
       cursor: Int
-      fields: String
     ): SearchIndexList!
     "The per-domain rollup overview: every tag in the fixed 14-tag capability taxonomy with its member subnet count, total stake, total emission share, and within-domain emission concentration. Computed live from the subnets index + economics tier. Mirrors GET /api/v1/domains."
     domains: DomainOverview!
@@ -523,7 +521,6 @@ export const SDL = /* GraphQL */ `
       q: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): SourceSnapshotList!
@@ -543,7 +540,6 @@ export const SDL = /* GraphQL */ `
       q: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): EvidenceList!
@@ -558,7 +554,6 @@ export const SDL = /* GraphQL */ `
       q: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): ProfileList!
@@ -586,7 +581,6 @@ export const SDL = /* GraphQL */ `
       missing_kinds: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): ReviewEnrichmentEvidenceList!
@@ -606,7 +600,6 @@ export const SDL = /* GraphQL */ `
       review_state: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): ReviewEnrichmentQueueList!
@@ -628,7 +621,6 @@ export const SDL = /* GraphQL */ `
       reason_codes: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): ReviewEnrichmentTargetList!
@@ -709,7 +701,6 @@ export const SDL = /* GraphQL */ `
       classification: String
       sort: String
       order: String
-      fields: String
       limit: Int
       cursor: Int
     ): HealthHistory!
@@ -723,7 +714,6 @@ export const SDL = /* GraphQL */ `
     incidents(
       window: String
       netuid: Int
-      fields: String
       sort: String
       order: String
       limit: Int
@@ -733,7 +723,6 @@ export const SDL = /* GraphQL */ `
     global_incidents(
       window: String
       netuid: Int
-      fields: String
       sort: String
       order: String
       limit: Int
@@ -1207,7 +1196,7 @@ export const SDL = /* GraphQL */ `
     "Public-safe notes; may be a string or a string list depending on the adapter."
     notes: JSON
     "Captured adapter metrics payload; shape is adapter-specific."
-    snapshot: JSON
+    snapshot: AdapterArtifactSnapshot
     "Per-adapter extension metadata keyed by provider id; each value's shape is adapter-specific."
     extensions: JSON
   }
@@ -2434,7 +2423,7 @@ export const SDL = /* GraphQL */ `
     generated_at: String
     notes: JSON
     source: String
-    pools: [JSON!]!
+    pools: [RpcPool!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2450,7 +2439,7 @@ export const SDL = /* GraphQL */ `
     notes: JSON
     source: String
     operational_observed_at: String
-    pools: [JSON!]!
+    pools: [RpcPool!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2463,7 +2452,7 @@ export const SDL = /* GraphQL */ `
   type IncidentList {
     generated_at: String
     notes: JSON
-    summary: JSON
+    summary: EndpointIncidentsArtifactSummary
     incidents: [EndpointIncident!]!
     total: Int!
     returned: Int!
@@ -2477,8 +2466,8 @@ export const SDL = /* GraphQL */ `
   type SourceSnapshotList {
     generated_at: String
     schema_version: Int
-    summary: JSON
-    sources: [JSON!]!
+    summary: SourceSnapshotsArtifactSummary
+    sources: [SourceSnapshotsArtifactSources!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2492,7 +2481,7 @@ export const SDL = /* GraphQL */ `
   type GapsList {
     generated_at: String
     notes: JSON
-    gaps: [JSON!]!
+    gaps: [GapsArtifactGaps!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2507,7 +2496,7 @@ export const SDL = /* GraphQL */ `
     generated_at: String
     "A string or a list of strings, depending on the producer -- /api/v1/endpoints serves three. Declared String until #10409, which nulls the whole row on a list: graphql-js' String serializer throws on a non-scalar."
     notes: JSON
-    curation: [JSON!]!
+    curation: [CurationArtifactCuration!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2520,8 +2509,8 @@ export const SDL = /* GraphQL */ `
   type EvidenceList {
     generated_at: String
     schema_version: Int
-    summary: JSON
-    claims: [JSON!]!
+    summary: EvidenceLedgerArtifactSummary
+    claims: [EvidenceClaim!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2570,7 +2559,7 @@ export const SDL = /* GraphQL */ `
   type ProfileList {
     "When the profile rows were gathered. Sourced from the artifact's generated_at, which is the only stamp it carries -- profile rows are derived at build time, so there is no separate capture event (#9892)."
     captured_at: String
-    profiles: [JSON!]!
+    profiles: [SubnetProfile!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2584,9 +2573,9 @@ export const SDL = /* GraphQL */ `
     generated_at: String
     source: String
     notes: JSON
-    summary: JSON
-    artifacts: JSON
-    subnets: JSON
+    summary: ChangelogArtifactSummary
+    artifacts: ChangelogArtifactArtifacts
+    subnets: ChangelogArtifactSubnets
     coverage_delta: JSON
     contract_version: String
     schema_version: Int
@@ -2602,7 +2591,7 @@ export const SDL = /* GraphQL */ `
     openapi_url: String
     type_definitions_url: String
     notes: JSON
-    artifacts: [JSON!]!
+    artifacts: [ContractsArtifactArtifacts!]
   }
 
   type BuildSummary {
@@ -2616,9 +2605,9 @@ export const SDL = /* GraphQL */ `
     subnet_count: Int
     surface_count: Int
     provider_count: Int
-    artifacts: JSON
-    coverage: JSON
-    artifact_budget_summary: JSON
+    artifacts: [BuildSummaryArtifactArtifacts!]
+    coverage: CoverageArtifact
+    artifact_budget_summary: BuildSummaryArtifactArtifactBudgetSummary
     notes: JSON
     full_artifact_count: Int
     full_artifact_size_bytes: Int
@@ -2671,8 +2660,8 @@ export const SDL = /* GraphQL */ `
 
   type HealthHistory {
     date: String
-    summary: JSON
-    surfaces: [JSON!]!
+    summary: HealthProbeSummary
+    surfaces: [HealthHistoryArtifactSurfaces!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2685,7 +2674,7 @@ export const SDL = /* GraphQL */ `
   type ReviewAdapterCandidateList {
     generated_at: String
     notes: JSON
-    candidates: [JSON!]!
+    candidates: [ReviewAdapterCandidate!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2697,8 +2686,8 @@ export const SDL = /* GraphQL */ `
 
   type ReviewEnrichmentEvidenceList {
     generated_at: String
-    notes: JSON
-    entries: [JSON!]!
+    notes: String
+    entries: [ReviewEnrichmentEvidenceArtifactEntries!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2710,8 +2699,8 @@ export const SDL = /* GraphQL */ `
 
   type ReviewEnrichmentQueueList {
     generated_at: String
-    notes: JSON
-    queue: [JSON!]!
+    notes: String
+    queue: [ReviewEnrichmentQueueArtifactQueue!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2723,8 +2712,8 @@ export const SDL = /* GraphQL */ `
 
   type ReviewEnrichmentTargetList {
     generated_at: String
-    notes: JSON
-    targets: [JSON!]!
+    notes: String
+    targets: [ReviewEnrichmentTargetsArtifactTargets!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2737,7 +2726,7 @@ export const SDL = /* GraphQL */ `
   type ReviewGapPriorityList {
     generated_at: String
     notes: JSON
-    priorities: [JSON!]!
+    priorities: [ReviewGapPriority!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -2750,8 +2739,8 @@ export const SDL = /* GraphQL */ `
   type ReviewProfileCompletenessList {
     generated_at: String
     notes: JSON
-    summary: JSON
-    profiles: [JSON!]!
+    summary: ReviewProfileCompletenessArtifactSummary
+    profiles: [ReviewProfileCompletenessArtifactProfiles!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -3291,11 +3280,11 @@ export const SDL = /* GraphQL */ `
     builder_version: Int
     uids_per_entity: Float
     "NULL means no measurable distribution, NOT missing."
-    stake: JSON
-    emission: JSON
-    entity_stake: JSON
-    entity_emission: JSON
-    validator_stake: JSON
+    stake: ChainConcentrationScorecard
+    emission: ChainConcentrationScorecard
+    entity_stake: ChainConcentrationScorecard
+    entity_emission: ChainConcentrationScorecard
+    validator_stake: ChainConcentrationScorecard
   }
 
   type ChainConcentrationHistory {
@@ -3790,7 +3779,7 @@ export const SDL = /* GraphQL */ `
     observed_at: String
     source: String
     "Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape."
-    summary: JSON
+    summary: GlobalIncidentsArtifactSummary
     "Per-surface incident summaries -- NOT endpoint incidents. Published as [EndpointIncident!]! until #10214: those rows carry surface_id/netuid/incident_count/downtime_ms and answered null for all 18 of that type's own fields, on every one of 232 sampled."
     surfaces: [GlobalIncidentSurface!]!
     "Surfaces matching the filters before paging (#7875). Equals the surfaces length when no limit/cursor is supplied."
@@ -3852,20 +3841,20 @@ export const SDL = /* GraphQL */ `
     observed_at: String
     source: String
     "Per operational surface: its sample count, uptime_ratio, incident_count, total downtime_ms, and gap-island incident list (started_at/ended_at/duration_ms/failed_samples, epoch-ms). Opaque JSON passed through verbatim, matching the get_subnet_health_incidents MCP/REST shape (like SubnetHealthTrends.windows)."
-    surfaces: JSON!
+    surfaces: [HealthIncidentsArtifactSurfaces!]
     min_incident_samples: Int
   }
 
   type SearchDocumentList {
     "Heterogeneous per-type documents (subnet/surface/provider/doc), passed through verbatim as opaque JSON."
-    documents: [JSON!]!
+    documents: [SearchArtifactDocuments!]
     total: Int!
     next_cursor: String
   }
 
   "Filtered and paginated search-index documents with full REST list-query pagination metadata (#7877). Mirrors GET /api/v1/search-index (and MCP list_search_index)."
   type SearchIndexList {
-    documents: [JSON!]!
+    documents: [SearchIndexArtifactDocuments!]
     total: Int!
     returned: Int!
     limit: Int!
@@ -3900,7 +3889,7 @@ export const SDL = /* GraphQL */ `
     hotkey: String!
     coldkey: String
     "The coldkey's self-declared on-chain identity; opaque JSON, matching the REST/MCP shape."
-    coldkey_identity: JSON
+    coldkey_identity: CompareValidatorsArtifactValidatorsColdkeyIdentity
     take: Float
     apy_estimate: Float
     apy_estimate_eligible_subnet_count: Int!
@@ -3911,7 +3900,7 @@ export const SDL = /* GraphQL */ `
     max_validator_trust: Float
     subnet_count: Int!
     "This validator's membership row in the requested netuid; null when netuid was omitted or it has no permit there. Opaque JSON, matching the REST/MCP shape."
-    subnet_context: JSON
+    subnet_context: CompareValidatorsArtifactValidatorsSubnetContext
   }
 
   "Several validators placed side by side (#6989). Mirrors GET /api/v1/compare/validators."
@@ -4157,7 +4146,7 @@ export const SDL = /* GraphQL */ `
     observed_at: String
     source: String
     "Per operational surface: its success-only latency sample count and p50/p90/p95/p99 latency percentiles in ms. Opaque JSON passed through verbatim, matching the get_subnet_health_percentiles MCP/REST shape (like SubnetHealthIncidents.surfaces)."
-    surfaces: JSON!
+    surfaces: [HealthPercentilesArtifactSurfaces!]
   }
 
   "One subnet's chain-event activity summary over a window (#6980). Mirrors GET /api/v1/subnets/{netuid}/event-summary' data envelope."
@@ -4174,9 +4163,9 @@ export const SDL = /* GraphQL */ `
     "The resolved recent-event cap actually applied (1-50, default 10)."
     limit: Int!
     "Per event category: its kind list and rolled-up counts. Opaque JSON passed through verbatim, matching the get_subnet_event_summary MCP/REST shape."
-    categories: JSON!
+    categories: [SubnetEventSummaryArtifactCategories!]
     "Per event kind: event_count, hotkey/coldkey participation counts, TAO/alpha amounts, and first/last block + observed_at. Opaque JSON passed through verbatim."
-    event_kinds: JSON!
+    event_kinds: [SubnetEventSummaryArtifactEventKinds!]
     "The bounded newest-first recent-event list. Opaque JSON passed through verbatim."
     recent_events: [AccountEvent!]!
   }
@@ -4374,7 +4363,7 @@ export const SDL = /* GraphQL */ `
     event_method: String
     count: Int!
     "Each record carries a source: chain-event (announced on chain, block-stamped) or owner-observation (inferred from two consecutive owner captures, so observed_at is when the change was NOTICED and block_number is null)."
-    ownership_changes: [JSON!]!
+    ownership_changes: [SubnetOwnershipHistoryArtifactOwnershipChanges!]
     "The newest owner observation for this subnet, ISO-8601 -- how far the observation source covers it at all, so watched-but-never-changed-hands is distinguishable from not-watched-since. Null when no observations were read."
     observed_through: String
   }
@@ -4388,7 +4377,7 @@ export const SDL = /* GraphQL */ `
     maturity_rate: Float
     king: String
     count: Int!
-    leaderboard: [JSON!]!
+    leaderboard: [SubnetConvictionArtifactLeaderboard!]
     """
     Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.
     """
@@ -4400,7 +4389,7 @@ export const SDL = /* GraphQL */ `
     schema_version: Int!
     netuid: Int!
     count: Int!
-    lease_events: [JSON!]!
+    lease_events: [SubnetLeaseHistoryArtifactLeaseEvents!]
     event_pallet: String
     event_kinds: [String!]
   }
@@ -4410,7 +4399,7 @@ export const SDL = /* GraphQL */ `
     schema_version: Int!
     netuid: Int!
     leased: Boolean
-    lease: JSON
+    lease: SubnetLeaseArtifactLease
     queried_at: String
     """
     Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.
@@ -4645,7 +4634,7 @@ export const SDL = /* GraphQL */ `
     extrinsic_count: Int!
     limit: Int
     offset: Int
-    extrinsics: [JSON!]!
+    extrinsics: [BlockExtrinsicsArtifactExtrinsics!]
   }
 
   "One block's decoded, account-attributed events list (#6977). Rows are opaque JSON; block_number is null for an unknown ref."
@@ -4659,12 +4648,12 @@ export const SDL = /* GraphQL */ `
     events: [AccountEvent!]!
   }
 
-  "One block's raw all-events-tier events (#6977) -- every pallet.method event, distinct from the curated block_events stream. Rows are opaque JSON."
+  "One block's raw all-events-tier events (#6977) -- every pallet.method event, distinct from the curated block_events stream. Rows carry the raw pallet-level shape (pallet, method, args, phase, summary), not the curated AccountEvent."
   type BlockChainEvents {
     schema_version: Int
     block_number: Int
     event_count: Int!
-    events: [JSON!]!
+    events: [BlockChainEventsArtifactEvents!]!
   }
 
   type BlockDetail {
@@ -5616,5 +5605,887 @@ export const SDL = /* GraphQL */ `
     min_blocks: Int
     max_blocks: Int
     censored: Boolean!
+  }
+
+  # ── Types the mirrors above stopped under-typing as JSON (#10214) ──────────
+  #
+  # Emitted verbatim from the Zod components -- printType over the same
+  # emitTypes() the parity gate compares against -- so each is the component's
+  # own shape rather than a hand-read of it. That is the point: a field
+  # published as JSON promised nothing, and a hand-written replacement would
+  # have promised whatever its author believed instead of what the producer
+  # actually returns.
+
+  type AdapterArtifactSnapshot {
+    schema_version: Int
+    contract_version: String
+    generated_at: String
+    slug: String
+    netuid: Int
+    source: String
+    status: String
+    notes: JSON
+    adapter_kind: String
+    excluded_dimensions: [String!]
+    dimensions: JSON
+  }
+
+  """
+  One raw pallet-level chain event from the all-events tier (distinct from the curated AccountEvent and from Subscription's ChainEvent firehose payload).
+  """
+  type BlockChainEventsArtifactEvents {
+    block_number: Int
+    event_index: Int
+    pallet: String
+    method: String
+    args: JSON
+    phase: String
+    extrinsic_index: Int
+    observed_at: Float
+
+    """
+    Deterministic human-readable action sentence for this event's pallet.method, or null when no template matches (#8525).
+    """
+    summary: String
+  }
+
+  type BlockExtrinsicsArtifactExtrinsics {
+    block_number: Int
+    extrinsic_index: Int
+    extrinsic_hash: String
+    signer: String
+    call_module: String
+    call_function: String
+    call_args: JSON
+    success: Boolean
+    fee_tao: Float
+    tip_tao: Float
+    observed_at: String
+    summary: String
+  }
+
+  type BuildSummaryArtifactArtifactBudgetSummary {
+    fail_count: Int!
+    ok_count: Int!
+    warn_count: Int!
+  }
+
+  type BuildSummaryArtifactArtifacts {
+    path: String!
+    sha256: String
+    size_bytes: Int
+    storage_tier: String
+  }
+
+  type ChainConcentrationScorecard {
+    holders: Int!
+    total: Float!
+    gini: Float
+    hhi: Float
+    hhi_normalized: Float
+    nakamoto_coefficient: Int
+    entropy: Float
+    entropy_normalized: Float
+  }
+
+  type ChangelogArtifactArtifacts {
+    added: [JSON!]!
+    modified: [JSON!]!
+    removed: [JSON!]!
+  }
+
+  type ChangelogArtifactSubnets {
+    added: [ChangelogArtifactSubnetsAdded!]!
+    removed: [ChangelogArtifactSubnetsRemoved!]!
+    renamed: [ChangelogArtifactSubnetsRenamed!]!
+  }
+
+  type ChangelogArtifactSubnetsAdded {
+    netuid: Int!
+    name: String
+    slug: String
+  }
+
+  type ChangelogArtifactSubnetsRemoved {
+    netuid: Int!
+    name: String
+    slug: String
+  }
+
+  type ChangelogArtifactSubnetsRenamed {
+    netuid: Int!
+    before: String
+    after: String
+  }
+
+  type ChangelogArtifactSummary {
+    artifact_added_count: Int!
+    artifact_modified_count: Int!
+    artifact_removed_count: Int!
+    coverage_delta: JSON
+    netuid_added_count: Int!
+    netuid_removed_count: Int!
+    netuid_renamed_count: Int!
+  }
+
+  """
+  Self-reported on-chain identity (SubtensorModule::set_identity) for a \`coldkey\`.
+  """
+  type CompareValidatorsArtifactValidatorsColdkeyIdentity {
+    has_identity: Boolean!
+    name: String
+    url: String
+    github: String
+    image: String
+    discord: String
+    description: String
+    additional: String
+    captured_at: String
+  }
+
+  type CompareValidatorsArtifactValidatorsSubnetContext {
+    netuid: Int!
+    uid: Int!
+    hotkey: String
+    coldkey: String
+    active: Boolean!
+    validator_permit: Boolean!
+    rank: Float
+    trust: Float
+    validator_trust: Float
+    consensus: Float
+    incentive: Float
+    dividends: Float
+
+    """
+    This row's emission on the subnet named by the sibling \`netuid\`. ALPHA for non-root subnets, genuine TAO on root (#2550). Renamed from \`emission_tao\` in #10514, because the entry's own \`total_stake_tao\` IS priced TAO and a shared \`_tao\` suffix across different units is a trap no description undoes.
+    """
+    emission_alpha: Float
+
+    """
+    This row's stake on the subnet named by the sibling \`netuid\`. ALPHA for non-root subnets, genuine TAO on root (#2550). Renamed from \`stake_tao\` in #10514 -- see the sibling emission field. Never summable across subnets; the entry's priced total already did that conversion.
+    """
+    stake_alpha: Float
+    registered_at_block: Int
+    is_immunity_period: Boolean!
+    axon: String
+    take: Float
+  }
+
+  type ContractsArtifactArtifacts {
+    content_type: String
+    retirement: ContractsArtifactArtifactsRetirement
+    status: String!
+    contract_version: String!
+    description: String
+    id: String!
+    path: String!
+    schema_ref: String
+    storage_tier: String!
+  }
+
+  type ContractsArtifactArtifactsRetirement {
+    code: String!
+    http_status: Int!
+    message: String!
+  }
+
+  type CoverageArtifact {
+    contract_version: String
+    generated_at: String!
+
+    """
+    Public-safe notes; may be a string or a string list depending on the adapter.
+    """
+    notes: JSON
+    schema_version: Int!
+    application_subnet_count: Int!
+    candidate_count: Int!
+    candidate_subnet_count: Int!
+    chain_subnet_count: Int!
+    completeness: CoverageCompleteness
+    curated_overlay_count: Int!
+    curation_level_counts: JSON!
+    domain_coverage: JSON!
+    first_party_subnet_count: Int!
+    manifested_count: Int!
+    native_only_count: Int!
+    native_only_with_candidates: Int!
+    native_only_without_candidates: Int!
+    native_snapshot_captured_at: String!
+    network: String!
+    probed_count: Int!
+    probed_surface_count: Int!
+    official_surface_count: Int!
+    registry_observed_surface_count: Int!
+    root_subnet_count: Int!
+    source: CoverageArtifactSource!
+    subnets_without_official_surface: Int!
+    surface_count: Int!
+  }
+
+  type CoverageArtifactSource {
+    candidates: String!
+    native: JSON!
+    overlays: String!
+  }
+
+  type CoverageCompleteness {
+    scored_subnet_count: Int
+    average_score: Int
+    median_score: Int
+    fully_complete_count: Int
+    fully_complete_pct: Int
+    score_distribution: JSON
+    dimension_coverage: JSON
+    methodology: String
+  }
+
+  type CurationArtifactCuration {
+    netuid: Int!
+    slug: String!
+    name: String!
+    coverage_level: String!
+    curation_level: String
+    surface_count: Int!
+    candidate_count: Int!
+    gap_count: Int
+    description: String
+    lifecycle: String
+    curation: CurationMetadata!
+    gaps: Gaps!
+  }
+
+  type CurationMetadata {
+    gap_notes: [String!]
+    level: String!
+    review_state: String!
+    reviewed_at: String
+    source_count: Int
+    verified_at: String
+  }
+
+  type EndpointIncidentsArtifactSummary {
+    incident_count: Int!
+    active_count: Int!
+    by_kind: JSON!
+    by_layer: JSON!
+    by_provider: JSON!
+    by_severity: JSON!
+    by_status: JSON!
+  }
+
+  type EndpointScoreReason {
+    points: Int!
+    reason: String!
+  }
+
+  type EvidenceClaim {
+    claim: String!
+    subject: String!
+    source_url: String!
+    source_type: String!
+    source_tier: String!
+    confidence: String!
+    support_summary: String!
+    limits: String!
+    verified_at: String
+  }
+
+  type EvidenceLedgerArtifactSummary {
+    candidate_claim_count: Int!
+    claim_count: Int!
+    subnet_claim_count: Int!
+    surface_claim_count: Int!
+  }
+
+  type Gaps {
+    gap_notes: [String!]!
+    missing_kinds: [String!]!
+    moving_target_surfaces: [String!]
+    supported_kinds: [String!]!
+  }
+
+  type GapsArtifactGaps {
+    netuid: Int!
+    slug: String!
+    name: String!
+    coverage_level: String!
+    curation_level: String!
+    gap_count: Int
+    gaps: Gaps!
+    gap_severity: String
+    gap_priority: Int
+  }
+
+  """
+  Aggregate counts -- incident_count, active_count, and by_kind/by_layer/by_provider/by_severity/by_status maps. Opaque JSON: the by_* maps are dynamic-keyed, matching the MCP get_global_incidents summary shape.
+  """
+  type GlobalIncidentsArtifactSummary {
+    incident_count: Int!
+    affected_surface_count: Int!
+  }
+
+  type HealthHistoryArtifactSurfaces {
+    surface_id: String!
+    netuid: Int!
+    kind: String!
+    provider: String!
+    status: String!
+    classification: String!
+    latency_ms: Int
+    status_code: Int
+    last_checked: String
+    last_ok: String
+    verified_at: String
+    error_class: String
+  }
+
+  type HealthIncidentsArtifactSurfaces {
+    surface_id: String!
+    samples: Int!
+    uptime_ratio: Float
+    incident_count: Int!
+    downtime_ms: Int!
+    transient_failure_count: Int!
+    transient_failed_samples: Int!
+    incidents: [HealthIncidentsArtifactSurfacesIncidents!]!
+  }
+
+  type HealthIncidentsArtifactSurfacesIncidents {
+    started_at: Float!
+    ended_at: Float!
+    duration_ms: Int!
+    failed_samples: Int!
+  }
+
+  type HealthPercentilesArtifactSurfaces {
+    surface_id: String!
+    samples: Int!
+    latency_ms: HealthPercentilesArtifactSurfacesLatencyMs!
+  }
+
+  type HealthPercentilesArtifactSurfacesLatencyMs {
+    p50: Int
+    p95: Int
+    p99: Int
+    avg: Int
+    min: Int
+    max: Int
+  }
+
+  type HealthProbeSummary {
+    surface_count: Int!
+    status_counts: JSON!
+    classification_counts: JSON!
+  }
+
+  type IntegrationReadiness {
+    score: Int!
+    readiness_tier: String!
+    readiness_version: Int!
+    readiness_verified: Boolean
+    components: IntegrationReadinessComponents!
+  }
+
+  type IntegrationReadinessComponents {
+    has_callable_api: Boolean
+    documented: Boolean
+    auth_clarity: Boolean
+    callable_now: Boolean
+    active_lifecycle: Boolean
+    profile_complete: Boolean
+    has_source_repo: Boolean
+    has_public_docs: Boolean
+    has_candidate_api: Boolean
+  }
+
+  type ReviewAdapterCandidate {
+    candidate_api_count: Int!
+    candidate_api_ids: [String!]!
+    candidate_api_kinds: [String!]!
+    curation_level: String!
+    name: String!
+    netuid: Int!
+    operational_kinds: [String!]!
+    operational_surface_count: Int!
+    operational_surface_ids: [String!]!
+    priority_score: Int!
+    reason_codes: [String!]!
+    recommended_adapter_kind: String!
+    suggested_next_action: String!
+    slug: String!
+  }
+
+  type ReviewEnrichmentEvidenceArtifactEntries {
+    candidate_evidence_by_kind: JSON!
+    candidate_evidence_summary: ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary!
+    direct_submission_kinds: [String!]!
+    evidence_action: String!
+    lane: String!
+    missing_kinds: [String!]!
+    name: String!
+    netuid: Int!
+    priority_score: Int!
+    slug: String!
+  }
+
+  type ReviewEnrichmentEvidenceArtifactEntriesCandidateEvidenceSummary {
+    candidate_count: Int!
+    kinds_with_candidates: [String!]!
+    live_kinds: [String!]!
+    live_or_redirected_count: Int!
+    reviewable_count: Int!
+    stale_kinds: [String!]!
+    stale_or_failed_count: Int!
+    unverified_count: Int!
+    unverified_kinds: [String!]!
+  }
+
+  type ReviewEnrichmentQueueArtifactQueue {
+    adapter_score: Int!
+    candidate_count: Int!
+    candidate_evidence_summary: ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary!
+    completeness_score: Int!
+    contribution_hint: String!
+    curation_level: String!
+    direct_submission_kinds: [String!]!
+    endpoint_count: Int!
+    evidence_action: String!
+    identity_level: String!
+    identity_surface_count: Int!
+    lane: String!
+    manual_review_required: Boolean!
+    missing_kinds: [String!]!
+    missing_identity: [String!]!
+    name: String!
+    netuid: Int!
+    operational_interface_count: Int!
+    priority_score: Int!
+    profile_level: String!
+    reason_codes: [String!]!
+    recommended_action: String!
+    review_state: String!
+    sample_candidate_ids: [String!]!
+    sample_live_candidate_ids: [String!]!
+    sample_stale_candidate_ids: [String!]!
+    sample_target_candidate_ids: [String!]!
+    slug: String!
+    source_urls: [String!]!
+    stale_candidate_count: Int!
+    surface_count: Int!
+    verified_candidate_count: Int!
+  }
+
+  type ReviewEnrichmentQueueArtifactQueueCandidateEvidenceSummary {
+    candidate_count: Int!
+    kinds_with_candidates: [String!]!
+    live_kinds: [String!]!
+    live_or_redirected_count: Int!
+    reviewable_count: Int!
+    stale_kinds: [String!]!
+    stale_or_failed_count: Int!
+    unverified_count: Int!
+    unverified_kinds: [String!]!
+  }
+
+  type ReviewEnrichmentTargetsArtifactTargets {
+    auto_review_candidate: Boolean!
+    candidate_command: String
+    candidate_evidence: ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence
+    contribution_prompt: String!
+    evidence_action: String!
+    identity_level: String!
+    kind: String
+    lane: String!
+    manual_review_required: Boolean!
+    missing_kinds: [String!]!
+    name: String!
+    netuid: Int!
+    priority_score: Int!
+    profile_level: String!
+    queue_context: ReviewEnrichmentTargetsArtifactTargetsQueueContext!
+    reason_codes: [String!]!
+    recommended_action: String!
+    sample_live_candidate_ids: [String!]!
+    sample_stale_candidate_ids: [String!]!
+    sample_target_candidate_ids: [String!]!
+    slug: String!
+    source_requirements: [String!]!
+    source_urls: [String!]!
+    submission_route: String!
+    target_action: String!
+    target_id: String!
+    target_type: String!
+  }
+
+  type ReviewEnrichmentTargetsArtifactTargetsCandidateEvidence {
+    candidate_count: Int!
+    classifications: JSON!
+    live_or_redirected_count: Int!
+    reviewable_count: Int!
+    sample_candidate_ids: [String!]!
+    stale_or_failed_count: Int!
+    unverified_count: Int!
+  }
+
+  type ReviewEnrichmentTargetsArtifactTargetsQueueContext {
+    adapter_score: Int!
+    candidate_count: Int!
+    completeness_score: Int!
+    curation_level: String!
+    direct_submission_kind_count: Int!
+    endpoint_count: Int!
+    identity_surface_count: Int!
+    operational_interface_count: Int!
+    profile_level: String!
+    review_state: String!
+    source_url_count: Int!
+    stale_candidate_count: Int!
+    surface_count: Int!
+    verified_candidate_count: Int!
+  }
+
+  type ReviewGapPriority {
+    candidate_count: Int!
+    curation_level: String!
+    missing_kinds: [String!]!
+    name: String!
+    netuid: Int!
+    priority_score: Int!
+    review_state: String!
+    slug: String!
+    suggested_next_action: String!
+    surface_count: Int!
+    verified_candidate_count: Int!
+  }
+
+  type ReviewProfileCompletenessArtifactProfiles {
+    candidate_count: Int!
+    completeness_score: Int!
+    confidence: String!
+    curation_level: String!
+    gap_reasons: [String!]!
+    identity_level: String!
+    identity_evidence: SubnetProfileIdentityEvidence!
+    identity_promotion_kind_count: Int!
+    identity_promotion_kinds: [String!]!
+    identity_surface_count: Int!
+    live_identity_candidate_kind_count: Int!
+    missing_critical_count: Int!
+    missing_identity: [String!]!
+    missing_operational: [String!]!
+    missing_required: [String!]!
+    name: String!
+    native_name_quality: String!
+    native_identity_signal_count: Int!
+    netuid: Int!
+    operational_interface_count: Int!
+    priority_score: Int!
+    profile_level: String!
+    review_state: String!
+    slug: String!
+    source_count: Int!
+    stale_identity_candidate_kind_count: Int!
+    supported_interface_kinds: [String!]!
+    suggested_next_action: String!
+  }
+
+  type ReviewProfileCompletenessArtifactSummary {
+    profile_count: Int!
+    needs_identity_count: Int!
+    needs_operational_count: Int!
+    average_completeness_score: Int!
+    native_identity_count: Int!
+    identity_promotion_candidate_count: Int!
+    native_identity_unpromoted_count: Int!
+    by_identity_level: JSON!
+    by_profile_level: JSON!
+    by_confidence: JSON!
+    critical_gap_counts: JSON!
+  }
+
+  type RpcPool {
+    id: String!
+    kind: String!
+    best_endpoint_id: String
+    endpoint_count: Int!
+    eligible_count: Int!
+    endpoints: [RpcPoolEndpoints!]!
+  }
+
+  type RpcPoolEndpoints {
+    id: String!
+    surface_id: String
+    surface_key: String
+    kind: String
+    layer: String
+    url: String!
+    provider: String!
+    auth_required: Boolean
+    public_safe: Boolean
+    status: String!
+    score: Int!
+    score_reasons: [EndpointScoreReason!]
+    pool_eligible: Boolean!
+    pool_eligibility_reasons: [String!]
+    reliability_score: Int
+    reliability_grade: String
+    archive_support: Boolean
+    latency_ms: Int
+    observed_at: String
+    health_source: String!
+    health_stale: Boolean!
+    last_ok: String
+    latest_block: Int
+  }
+
+  type SearchArtifactDocuments {
+    id: String!
+    type: String!
+    netuid: Int
+    slug: String
+    title: String!
+    subtitle: String
+    url: String
+    artifact_path: String!
+    tokens: [String!]!
+    categories: [String!]
+    service_kinds: [String!]
+  }
+
+  type SearchIndexArtifactDocuments {
+    id: String!
+    type: String!
+    netuid: Int
+    slug: String
+    title: String!
+    subtitle: String
+    url: String
+    artifact_path: String!
+    categories: [String!]
+    service_kinds: [String!]
+  }
+
+  type SourceSnapshotsArtifactSources {
+    captured_at: String!
+    hash: String!
+    id: String!
+    kind: String!
+    path: String!
+    record_count: Int!
+  }
+
+  type SourceSnapshotsArtifactSummary {
+    adapter_snapshot_count: Int!
+    candidate_count: Int!
+    overlay_count: Int!
+    provider_count: Int!
+    source_count: Int!
+    verification_result_count: Int!
+  }
+
+  type SubnetConvictionArtifactLeaderboard {
+    hotkey: String
+    is_owner: Boolean
+    locked_mass: Float
+    conviction: Float
+  }
+
+  type SubnetEventSummaryArtifactCategories {
+    category: String!
+    event_count: Int!
+    kind_count: Int!
+    amount_tao: Float!
+    alpha_amount: Float!
+    first_block: Int
+    last_block: Int
+    first_observed_at: String
+    last_observed_at: String
+  }
+
+  type SubnetEventSummaryArtifactEventKinds {
+    event_kind: String!
+    category: String!
+    event_count: Int!
+    hotkey_count: Int!
+    coldkey_count: Int!
+    amount_tao: Float!
+    alpha_amount: Float!
+    first_block: Int
+    last_block: Int
+    first_observed_at: String
+    last_observed_at: String
+  }
+
+  type SubnetLeaseArtifactLease {
+    lease_id: Int!
+    beneficiary: String!
+    coldkey: String!
+    hotkey: String!
+    emissions_share_percent: Int
+    end_block: Int
+    netuid: Int!
+    cost_tao: Float
+    accumulated_dividends_alpha: Float
+  }
+
+  type SubnetLeaseHistoryArtifactLeaseEvents {
+    event_kind: String
+    beneficiary: String
+    block_number: Int
+    observed_at: String
+  }
+
+  type SubnetOwnershipHistoryArtifactOwnershipChanges {
+    netuid: Int
+    old_coldkey: String
+    new_coldkey: String
+    block_number: Int
+    observed_at: String
+    source: String
+  }
+
+  type SubnetProfile {
+    netuid: Int!
+    slug: String!
+    name: String!
+    native_name: String
+    native_name_quality: String
+    native_identity: SubnetProfileNativeIdentity
+    injection_scrubbed: Boolean
+    subnet_type: String!
+    status: String!
+    symbol: String
+    github_languages: JSON
+    github_last_push_at: String
+    github_stars: Int
+    github_commits_weekly: [SubnetProfileGithubCommitsWeekly!]
+    github_releases: [SubnetProfileGithubReleases!]
+    github_unreachable: Boolean
+    project_name: String!
+    team: String
+    categories: [String!]!
+    derived_categories: [String!]!
+    derived_description: String
+    lineage: SubnetProfileLineage
+    primary_links: SubnetProfilePrimaryLinks!
+    primary_app_surface: SubnetProfilePrimaryAppSurface
+    supported_interface_kinds: [String!]!
+    operational_interface_kinds: [String!]!
+    surface_count: Int!
+    endpoint_count: Int!
+    monitored_endpoint_count: Int!
+    candidate_count: Int!
+    identity_evidence: SubnetProfileIdentityEvidence!
+    interface_count: Int
+    operational_interface_count: Int
+    completeness: SubnetProfileCompleteness!
+    provenance: SubnetProfileProvenance!
+    curation_level: String!
+    review_state: String!
+    confidence: String!
+    profile_level: String!
+    identity_level: String!
+    identity_surface_count: Int!
+    completeness_score: Int!
+    missing_identity: [String!]!
+    missing_required: [String!]!
+    missing_operational: [String!]!
+    missing_critical_count: Int!
+    gap_reasons: [String!]!
+    suggested_submission_kinds: [String!]!
+    integration_readiness: Int
+    readiness: IntegrationReadiness
+  }
+
+  type SubnetProfileCompleteness {
+    score: Int!
+    profile_level: String!
+    identity_level: String!
+    identity_surface_count: Int!
+    confidence: String!
+    missing_identity: [String!]!
+    missing_required: [String!]!
+    missing_operational: [String!]!
+    missing_critical_count: Int!
+    gap_reasons: [String!]!
+  }
+
+  type SubnetProfileGithubCommitsWeekly {
+    week: String!
+    count: Int!
+  }
+
+  type SubnetProfileGithubReleases {
+    tag: String!
+    name: String
+    published_at: String!
+    url: String!
+    prerelease: Boolean!
+  }
+
+  type SubnetProfileIdentityEvidence {
+    candidate_identity_count: Int!
+    curated_identity_count: Int!
+    curated_identity_kinds: [String!]!
+    live_candidate_identity_kinds: [String!]!
+    native_contact_present: Boolean!
+    native_description_present: Boolean!
+    native_identity_count: Int!
+    native_identity_kinds: [String!]!
+    needs_promotion_kinds: [String!]!
+    stale_candidate_identity_kinds: [String!]!
+    unverified_candidate_identity_kinds: [String!]!
+  }
+
+  type SubnetProfileLineage {
+    graduated_from_testnet: Boolean
+    also_on: [SubnetProfileLineageAlsoOn!]
+  }
+
+  type SubnetProfileLineageAlsoOn {
+    network: String
+    netuid: Int
+    name: String
+    matched_by: String
+  }
+
+  type SubnetProfileNativeIdentity {
+    source: String!
+    subnet_name: String
+    description: String
+    additional: String
+    website_url: String
+    github_url: String
+    discord: String
+    discord_url: String
+    logo_url: String
+    contact_present: Boolean!
+  }
+
+  type SubnetProfilePrimaryAppSurface {
+    id: String!
+    key: String
+    kind: String!
+    name: String!
+    provider: String!
+    url: String!
+  }
+
+  type SubnetProfilePrimaryLinks {
+    website_url: String
+    docs_url: String
+    source_repo: String
+    dashboard_url: String
+  }
+
+  type SubnetProfileProvenance {
+    identity_source: String!
+    interface_source_count: Int!
+    review_state: String!
+    curation_level: String!
+    reviewed_at: String
+    source_urls: [String!]!
   }
 `;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -4679,7 +4679,7 @@ const rootValue = {
   },
 
   async incidents(
-    { window, netuid, fields, sort, order, limit, cursor }: QueryIncidentsArgs,
+    { window, netuid, sort, order, limit, cursor }: QueryIncidentsArgs,
     context: GqlContext,
   ) {
     // Checked against the window enum the ROUTE publishes, not against
@@ -4723,10 +4723,11 @@ const rootValue = {
     const queryUrl = new URL("https://graphql.internal/incidents");
     for (const [name, value] of [
       ["netuid", netuid],
-      // #10065: the rows are opaque JSON here, so a selection set cannot
-      // project them and `fields` is the caller's only narrowing. Validated by
-      // the shared engine, the same one REST and MCP run.
-      ["fields", fields],
+      // `fields` was here while the rows were opaque JSON and a selection set
+      // could not project them (#10065). #10214 gave them a named type, so the
+      // selection set IS the projection now and the argument was removed from
+      // the SDL -- the rule that `fields` belongs only where the return type
+      // carries a JSON member, applied in the direction that retires one.
       ["sort", sort],
       ["order", order],
       ["limit", limit],

--- a/tests/chain-detail-serving.test.ts
+++ b/tests/chain-detail-serving.test.ts
@@ -412,7 +412,7 @@ describe("GraphQL runs the same cascade", () => {
     // field actually publishes, so this reads as the asymmetry it is.
     const body = await gql(
       `{ block_extrinsics(ref: "${RECENT}") ` +
-        `{ block_number extrinsic_count extrinsics } }`,
+        `{ block_number extrinsic_count extrinsics { call_function } } }`,
       envWith({ covered: [RECENT] }),
     );
     assert.equal(body.errors, undefined);

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -273,11 +273,14 @@ describe("declared projections (#10214)", () => {
 // `JSON` read as agreement, so an emitter that retyped 348 fields as JSON
 // would have passed every gate in the repo.
 describe("scalar identity", () => {
-  test("every JSON under-typing is declared, and all of them are live", () => {
+  test("no field is published as JSON over a component that has a shape", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.undertyped, 50);
+    // Was 50, and 24 before #10409 counted the projections. Zero is the whole
+    // point of #10214: every one of them is a published type now, so there is
+    // no field left that a caller can reach but not select into.
+    assert.equal(report.undertyped, 0);
   });
 
   test("it FAILS when a field is retyped to a different scalar", () => {
@@ -317,22 +320,54 @@ describe("scalar identity", () => {
     );
   });
 
-  test("a CLOSED under-typing makes its declaration stale, so the list shrinks", () => {
-    // `Adapter.snapshot` is one of the 50 still open. Publishing the shape its
-    // component already describes has to make the declaration stale, or the
-    // list would keep an entry for a gap that no longer exists.
-    const fixed = inType(
-      sdl,
-      "Adapter",
-      /^ {4}snapshot: JSON\n/m,
-      "    snapshot: AdapterArtifactSnapshot\n",
-    );
-    const report = checkComponentParity(fixed, openapi);
-    assert.ok(
-      report.stale.includes("Adapter.snapshot"),
-      `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
-    );
-    assert.equal(report.undertyped, 49);
+  // The shrink-only rule, proven on an INJECTED declaration rather than a live
+  // one. `JSON_UNDERTYPED` is empty as of #10214, and a rule that can only be
+  // demonstrated while something still violates it is a rule that stops being
+  // tested on the day it finally works -- which is this day. `Adapter.snapshot`
+  // is the field the old fixture used, when it was one of the 50.
+  describe("the shrink-only rule, on an injected declaration", () => {
+    test("a declared under-typing that is still live is accepted, not a violation", () => {
+      const undertyped = inType(
+        sdl,
+        "Adapter",
+        /^ {4}snapshot: AdapterArtifactSnapshot\n/m,
+        "    snapshot: JSON\n",
+      );
+      const report = checkComponentParity(
+        undertyped,
+        openapi,
+        DECLARED,
+        PROJECTED_TYPES,
+        {
+          "Adapter.snapshot": "AdapterArtifactSnapshot",
+        },
+      );
+      assert.deepEqual(report.stale, []);
+      assert.equal(report.undertyped, 1);
+      assert.ok(
+        !report.violations.some((v) => v.startsWith("Adapter.snapshot")),
+        `a declared under-typing must not also be a violation, got: ${report.violations.join("; ")}`,
+      );
+    });
+
+    test("a CLOSED under-typing makes its declaration stale, so the list shrinks", () => {
+      // The SDL as committed already publishes the shape, which is what closing
+      // it means -- so the declaration below names a gap that no longer exists.
+      const report = checkComponentParity(
+        sdl,
+        openapi,
+        DECLARED,
+        PROJECTED_TYPES,
+        {
+          "Adapter.snapshot": "AdapterArtifactSnapshot",
+        },
+      );
+      assert.ok(
+        report.stale.includes("Adapter.snapshot"),
+        `expected the closed under-typing to be reported stale, got: ${report.stale.join("; ")}`,
+      );
+      assert.equal(report.undertyped, 0);
+    });
   });
 
   test("a Float over an Int component field is a WIDENING and stays allowed", () => {
@@ -366,7 +401,15 @@ describe("paginated views", () => {
     // verification until #10476 models it as its own SDL type. This number is
     // a completeness pin rather than a shrink-only ceiling, so it moves with a
     // deliberate drop; it moving WITHOUT one is the failure it exists to catch.
-    assert.equal(report.droppedFields, 195);
+    //
+    // 195 -> 193 (#10214): BlockChainEvents was declared over the WRONG
+    // component -- `BlockEventsArtifact`, the other block route -- and dropped
+    // its three unused envelope fields (ref/limit/offset). Pointed at the
+    // component openapi.json actually names for /blocks/{ref}/chain-events, it
+    // drops one instead (`count`, which the resolver republishes as
+    // `event_count`). Net -2, and the two it stopped dropping were fields that
+    // never existed on this payload.
+    assert.equal(report.droppedFields, 193);
   });
 
   test("it FAILS when a component field is neither published nor declared dropped", () => {

--- a/tests/graphql-document-paging.test.ts
+++ b/tests/graphql-document-paging.test.ts
@@ -55,7 +55,7 @@ describe("document-shaped collections page over GraphQL", () => {
 
   test("contracts takes limit and returns at most that many artifacts", async () => {
     const paged = dataOf(
-      await query("{ contracts(limit: 2) { artifacts } }"),
+      await query("{ contracts(limit: 2) { artifacts { id } } }"),
       "contracts",
     );
     assert.ok((paged.artifacts as Row[]).length <= 2);

--- a/tests/graphql-generated-schema.test.ts
+++ b/tests/graphql-generated-schema.test.ts
@@ -231,10 +231,33 @@ describe("the schema diff", () => {
     const report = diffSchemas(sdl, openapi);
     assert.ok(report.identical > 200, `only ${report.identical} identical`);
     assert.ok(report.tightened.length > 0, "no tightenings found");
-    assert.ok(report.newlyNamed.length > 0, "no newly-named types found");
+    // ZERO as of #10214, and measured rather than asserted away: this class is
+    // exactly "a type the generator builds that the schema publishes as an
+    // opaque JSON", which is the debt that issue closed. The class stays
+    // reported -- the fixture below proves it still populates -- because the
+    // number going back up is the regression it exists to name.
+    assert.deepEqual(report.newlyNamed, []);
     for (const line of report.tightened) {
       assert.match(line, / -- .+ becomes .+!$/);
     }
+  });
+
+  test("a type the schema under-types as JSON is reported newly-named", () => {
+    // Put `Adapter.snapshot` back the way it was before #10214 -- JSON over a
+    // component with a shape, and the named type deleted from the schema. A
+    // class that only ever reads zero is a class nobody would notice breaking.
+    const withoutType = sdl
+      .replace(/^ {2}type AdapterArtifactSnapshot \{[^}]*\}\n\n/m, "")
+      .replace(
+        /^ {4}snapshot: AdapterArtifactSnapshot$/m,
+        "    snapshot: JSON",
+      );
+    assert.notEqual(withoutType, sdl, "the fixture type must exist");
+    const report = diffSchemas(withoutType, openapi);
+    assert.ok(
+      report.newlyNamed.includes("AdapterArtifactSnapshot"),
+      `expected the under-typed type to be reported, got: ${report.newlyNamed.join("; ")}`,
+    );
   });
 
   test("a field the generator cannot build is reported, not silently equal", () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1933,7 +1933,15 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
   const INCIDENTS_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["probe-derived only"],
-    summary: { incident_count: 2, active_count: 2 },
+    summary: {
+      incident_count: 2,
+      active_count: 2,
+      by_kind: { "subnet-api": 2 },
+      by_layer: { "subnet-app": 2 },
+      by_provider: { allways: 2 },
+      by_severity: { critical: 1, warning: 1 },
+      by_status: { failed: 2 },
+    },
     incidents: [
       {
         id: "incident-a",
@@ -1992,7 +2000,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
   test("endpoint_pools filters by kind and paginates", async () => {
     const env = fixtureEnv({ "/metagraph/endpoint-pools.json": POOLS_BLOB });
     const filtered = await gql(
-      '{ endpoint_pools(kind: "archive") { pools total } }',
+      '{ endpoint_pools(kind: "archive") { pools { id kind best_endpoint_id endpoint_count eligible_count } total } }',
       env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
@@ -2003,7 +2011,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
     );
 
     const paged = await gql(
-      "{ endpoint_pools(limit: 1) { pools total returned next_cursor } }",
+      "{ endpoint_pools(limit: 1) { pools { id kind best_endpoint_id endpoint_count eligible_count } total returned next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(paged.body.data.endpoint_pools.pools.length, 1);
@@ -2030,7 +2038,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
   test("rpc_pools returns the same pools[] row shape via its own artifact", async () => {
     const env = fixtureEnv({ "/metagraph/rpc/pools.json": POOLS_BLOB });
     const { status, body } = await gql(
-      '{ rpc_pools(sort: "eligible_count", order: "desc") { pools total } }',
+      '{ rpc_pools(sort: "eligible_count", order: "desc") { pools { id kind best_endpoint_id endpoint_count eligible_count } total } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2076,7 +2084,7 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
       "/metagraph/endpoint-incidents.json": INCIDENTS_BLOB,
     });
     const { status, body } = await gql(
-      '{ endpoint_incidents(severity: "critical") { incidents { id severity } total summary } }',
+      '{ endpoint_incidents(severity: "critical") { incidents { id severity } total summary { incident_count active_count by_kind by_layer by_provider by_severity by_status } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2121,24 +2129,38 @@ describe("graphql — endpoint_pools / rpc_pools / endpoint_incidents", () => {
 // own loader unchanged (same filter/sort/page + error behavior as REST and
 // MCP) rather than a GraphQL-only reimplementation.
 describe("graphql — source_snapshots", () => {
+  // Complete rows, not a sketch: `sources` and `summary` are published types
+  // now (#10214), so a row missing a field the component requires is a null in
+  // a non-null position -- graphql-js nulls the whole row and attaches an
+  // error. `hash` rather than `input_hash` is what /api/v1/source-snapshots
+  // actually serves; the old spelling here was never a key the producer had.
   const SNAPSHOTS_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     schema_version: 1,
-    summary: { source_count: 2 },
+    summary: {
+      adapter_snapshot_count: 0,
+      candidate_count: 0,
+      overlay_count: 0,
+      provider_count: 0,
+      source_count: 2,
+      verification_result_count: 0,
+    },
     sources: [
       {
+        captured_at: "2026-07-01T00:00:00.000Z",
+        hash: "abc",
         id: "chain-events",
         kind: "db",
         path: "chain_events",
         record_count: 100,
-        input_hash: "abc",
       },
       {
+        captured_at: "2026-07-01T00:00:00.000Z",
+        hash: "def",
         id: "economics",
         kind: "kv",
         path: "economics.json",
         record_count: 50,
-        input_hash: "def",
       },
     ],
   };
@@ -2148,7 +2170,7 @@ describe("graphql — source_snapshots", () => {
       "/metagraph/source-snapshots.json": SNAPSHOTS_BLOB,
     });
     const filtered = await gql(
-      '{ source_snapshots(q: "chain") { sources total generated_at } }',
+      '{ source_snapshots(q: "chain") { sources { captured_at hash id kind path record_count } total generated_at } }',
       env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
@@ -2163,7 +2185,7 @@ describe("graphql — source_snapshots", () => {
     );
 
     const paged = await gql(
-      "{ source_snapshots(limit: 1) { sources total returned next_cursor } }",
+      "{ source_snapshots(limit: 1) { sources { captured_at hash id kind path record_count } total returned next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(paged.body.data.source_snapshots.sources.length, 1);
@@ -2177,7 +2199,7 @@ describe("graphql — source_snapshots", () => {
       "/metagraph/source-snapshots.json": SNAPSHOTS_BLOB,
     });
     const { status, body } = await gql(
-      '{ source_snapshots(sort: "record_count", order: "desc") { sources summary schema_version } }',
+      '{ source_snapshots(sort: "record_count", order: "desc") { sources { captured_at hash id kind path record_count } summary { adapter_snapshot_count candidate_count overlay_count provider_count source_count verification_result_count } schema_version } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2248,16 +2270,32 @@ describe("graphql — changelog", () => {
     generated_at: "2026-07-01T00:00:00.000Z",
     source: "publish",
     notes: ["one", "two"],
-    summary: { artifacts_changed: 3, subnets_changed: 1 },
+    summary: {
+      artifacts_changed: 3,
+      subnets_changed: 1,
+      artifact_added_count: 1,
+      artifact_modified_count: 0,
+      artifact_removed_count: 0,
+      netuid_added_count: 0,
+      netuid_removed_count: 0,
+      netuid_renamed_count: 1,
+    },
     artifacts: { added: ["adapters.json"], modified: [], removed: [] },
-    subnets: { added: [], removed: [], renamed: ["sn-7"] },
+    // `renamed` carries ROWS, not names -- verified against production, where
+    // each is `{after, before, netuid}`. It read as a string list only while
+    // `subnets` was opaque JSON and nothing could contradict it.
+    subnets: {
+      added: [],
+      removed: [],
+      renamed: [{ netuid: 7, before: "sn-7", after: "sn-seven" }],
+    },
     coverage_delta: { surfaces: 4 },
   };
 
   test("serves the baked changelog artifact verbatim", async () => {
     const env = fixtureEnv({ "/metagraph/changelog.json": CHANGELOG_BLOB });
     const { status, body } = await gql(
-      "{ changelog { generated_at source notes summary artifacts subnets coverage_delta } }",
+      "{ changelog { generated_at source notes summary { artifact_added_count artifact_modified_count artifact_removed_count coverage_delta netuid_added_count netuid_removed_count netuid_renamed_count } artifacts { added modified removed } subnets { added { netuid } removed { netuid } renamed { netuid before after } } coverage_delta } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2265,9 +2303,16 @@ describe("graphql — changelog", () => {
     assert.equal(changelog.generated_at, "2026-07-01T00:00:00.000Z");
     assert.equal(changelog.source, "publish");
     assert.deepEqual(changelog.notes, ["one", "two"]);
-    assert.equal(changelog.summary.artifacts_changed, 3);
+    // `artifacts_changed` is NOT a field the summary component declares --
+    // production does not serve it, and asserting it here passed only because
+    // the whole summary was an opaque blob echoed back. The six counts it does
+    // declare are asserted instead.
+    assert.equal(changelog.summary.artifact_added_count, 1);
+    assert.equal(changelog.summary.netuid_renamed_count, 1);
     assert.deepEqual(changelog.artifacts.added, ["adapters.json"]);
-    assert.deepEqual(changelog.subnets.renamed, ["sn-7"]);
+    assert.deepEqual(changelog.subnets.renamed, [
+      { netuid: 7, before: "sn-7", after: "sn-seven" },
+    ]);
     assert.equal(changelog.coverage_delta.surfaces, 4);
   });
 
@@ -2281,6 +2326,14 @@ describe("graphql — changelog", () => {
       generated_at: "2026-07-01T00:00:00.000Z",
       summary: {
         artifacts_changed: 3,
+        // The six counts the component declares non-null. They were absent
+        // while `summary` was opaque JSON, which typed nothing.
+        artifact_added_count: 1,
+        artifact_modified_count: 0,
+        artifact_removed_count: 0,
+        netuid_added_count: 0,
+        netuid_removed_count: 0,
+        netuid_renamed_count: 0,
         coverage_delta: {
           surface_count: { before: 3493, after: 3496, delta: 3 },
         },
@@ -2288,7 +2341,7 @@ describe("graphql — changelog", () => {
     };
     const env = fixtureEnv({ "/metagraph/changelog.json": nested });
     const { status, body } = await gql(
-      "{ changelog { coverage_delta summary } }",
+      "{ changelog { coverage_delta summary { artifact_added_count artifact_modified_count artifact_removed_count coverage_delta netuid_added_count netuid_removed_count netuid_renamed_count } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2324,12 +2377,25 @@ describe("graphql — contracts", () => {
     openapi_url: "https://api.metagraph.sh/openapi.json",
     type_definitions_url: "https://api.metagraph.sh/types.d.ts",
     notes: ["read-only"],
+    // `tier` was never a key /api/v1/contracts serves -- it is `storage_tier`,
+    // alongside the id/status/contract_version the component requires. The
+    // misspelling survived because `artifacts` was opaque JSON.
     artifacts: [
-      { path: "/metagraph/subnets.json", tier: "r2", schema_ref: "subnets" },
       {
+        id: "subnets",
+        path: "/metagraph/subnets.json",
+        storage_tier: "r2",
+        schema_ref: "subnets",
+        status: "live",
+        contract_version: "abc123",
+      },
+      {
+        id: "changelog",
         path: "/metagraph/changelog.json",
-        tier: "r2",
+        storage_tier: "r2",
         schema_ref: "changelog",
+        status: "live",
+        contract_version: "abc123",
       },
     ],
   };
@@ -2337,7 +2403,7 @@ describe("graphql — contracts", () => {
   test("serves the baked contracts artifact verbatim", async () => {
     const env = fixtureEnv({ "/metagraph/contracts.json": CONTRACTS_BLOB });
     const { status, body } = await gql(
-      "{ contracts { schema_version contract_version generated_at name base_path primary_domain openapi_url type_definitions_url notes artifacts } }",
+      "{ contracts { schema_version contract_version generated_at name base_path primary_domain openapi_url type_definitions_url notes artifacts { content_type status contract_version description id path schema_ref storage_tier } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2381,14 +2447,44 @@ describe("graphql — build", () => {
     surface_count: 400,
     provider_count: 50,
     artifacts: [{ path: "/metagraph/subnets.json", size_bytes: 1000 }],
-    coverage: { surfaces: 10 },
-    artifact_budget_summary: { ok: 1, warn: 0, fail: 0 },
+    // The whole coverage card, because that is what /api/v1/build embeds --
+    // `{surfaces: 10}` is not a shape the artifact has ever had, and it stood
+    // only while `coverage` was opaque JSON echoed straight back.
+    coverage: {
+      schema_version: 1,
+      generated_at: "2026-07-01T00:00:00.000Z",
+      application_subnet_count: 1,
+      candidate_count: 1,
+      candidate_subnet_count: 1,
+      chain_subnet_count: 1,
+      curated_overlay_count: 1,
+      curation_level_counts: { curated: 1 },
+      domain_coverage: { "example.com": 1 },
+      first_party_subnet_count: 1,
+      manifested_count: 1,
+      native_only_count: 1,
+      native_only_with_candidates: 1,
+      native_only_without_candidates: 0,
+      native_snapshot_captured_at: "2026-07-01T00:00:00.000Z",
+      network: "finney",
+      probed_count: 1,
+      probed_surface_count: 10,
+      official_surface_count: 1,
+      registry_observed_surface_count: 1,
+      root_subnet_count: 1,
+      source: { candidates: "registry", native: {}, overlays: "registry" },
+      subnets_without_official_surface: 0,
+      surface_count: 10,
+    },
+    // `{ok, warn, fail}` were never the producer's key names -- production
+    // serves `{fail_count, ok_count, warn_count}`.
+    artifact_budget_summary: { fail_count: 0, ok_count: 1, warn_count: 0 },
   };
 
   test("serves the baked build-summary artifact verbatim", async () => {
     const env = fixtureEnv({ "/metagraph/build-summary.json": BUILD_BLOB });
     const { status, body } = await gql(
-      "{ build { schema_version contract_version generated_at published_at artifact_count artifact_size_bytes subnet_count surface_count provider_count artifacts coverage artifact_budget_summary } }",
+      "{ build { schema_version contract_version generated_at published_at artifact_count artifact_size_bytes subnet_count surface_count provider_count artifacts { path sha256 size_bytes storage_tier } coverage { contract_version generated_at notes schema_version application_subnet_count candidate_count candidate_subnet_count chain_subnet_count curated_overlay_count curation_level_counts manifested_count native_only_count native_only_with_candidates native_only_without_candidates native_snapshot_captured_at network probed_count probed_surface_count root_subnet_count surface_count } artifact_budget_summary { fail_count ok_count warn_count } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2400,8 +2496,30 @@ describe("graphql — build", () => {
     assert.equal(build.artifact_count, 99);
     assert.equal(build.subnet_count, 129);
     assert.deepEqual(build.artifacts[0].path, "/metagraph/subnets.json");
-    assert.equal(build.coverage.surfaces, 10);
-    assert.equal(build.artifact_budget_summary.ok, 1);
+    assert.equal(build.coverage.surface_count, 10);
+    assert.equal(build.artifact_budget_summary.ok_count, 1);
+  });
+
+  // Its own query rather than more fields on the one above: that one already
+  // costs 50 of the published complexity limit's 50, so adding to it makes the
+  // test fail as COMPLEXITY_LIMIT_EXCEEDED rather than on what it asserts.
+  test("the coverage card carries the five fields it served but never declared (#10214)", async () => {
+    const env = fixtureEnv({ "/metagraph/build-summary.json": BUILD_BLOB });
+    const { status, body } = await gql(
+      "{ build { coverage { domain_coverage first_party_subnet_count official_surface_count registry_observed_surface_count subnets_without_official_surface source { candidates native overlays } } } }",
+      env as unknown as Env,
+    );
+    assert.equal(status, 200);
+    const coverage = body.data.build.coverage;
+    // Served by /api/v1/build and /api/v1/coverage all along, declared
+    // nowhere -- the artifact is `.passthrough()`, so they reached callers
+    // while the contract said nothing about them.
+    assert.deepEqual(coverage.domain_coverage, { "example.com": 1 });
+    assert.equal(coverage.first_party_subnet_count, 1);
+    assert.equal(coverage.official_surface_count, 1);
+    assert.equal(coverage.registry_observed_surface_count, 1);
+    assert.equal(coverage.subnets_without_official_surface, 0);
+    assert.equal(coverage.source.candidates, "registry");
   });
 
   test("surfaces a cold/missing artifact as a GraphQL error, matching REST/MCP", async () => {
@@ -2482,7 +2600,14 @@ describe("graphql — health_history", () => {
   };
   const HISTORY_BLOB = {
     date: "2026-07-01",
-    summary: { incident_count: 0, surface_count: 2 },
+    // `status_counts`/`classification_counts` are what the snapshot actually
+    // summarises -- checked against production, which serves those two beside
+    // `surface_count` and has no `incident_count` at all.
+    summary: {
+      surface_count: 2,
+      status_counts: { ok: 2 },
+      classification_counts: { live: 2 },
+    },
     surfaces: [
       SURFACE_ROW,
       {
@@ -2499,7 +2624,7 @@ describe("graphql — health_history", () => {
       "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
     });
     const { status, body } = await gql(
-      '{ health_history(date: "2026-07-01") { date summary surfaces total returned limit cursor next_cursor } }',
+      '{ health_history(date: "2026-07-01") { date summary { surface_count status_counts classification_counts } surfaces { surface_id netuid kind provider status classification latency_ms status_code last_checked last_ok verified_at error_class } total returned limit cursor next_cursor } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2510,7 +2635,7 @@ describe("graphql — health_history", () => {
     assert.equal(history.surfaces.length, 2);
 
     const paged = await gql(
-      '{ health_history(date: "2026-07-01", limit: 1) { surfaces total returned next_cursor } }',
+      '{ health_history(date: "2026-07-01", limit: 1) { surfaces { surface_id netuid kind provider status classification latency_ms status_code last_checked last_ok verified_at error_class } total returned next_cursor } }',
       env as unknown as Env,
     );
     assert.equal(paged.body.data.health_history.surfaces.length, 1);
@@ -2524,7 +2649,7 @@ describe("graphql — health_history", () => {
       "/metagraph/health/history/2026-07-01.json": HISTORY_BLOB,
     });
     const filtered = await gql(
-      '{ health_history(date: "2026-07-01", netuid: 1) { total surfaces } }',
+      '{ health_history(date: "2026-07-01", netuid: 1) { total surfaces { surface_id netuid kind provider status classification latency_ms status_code last_checked last_ok verified_at error_class } } }',
       env as unknown as Env,
     );
     assert.equal(filtered.body.data.health_history.total, 1);
@@ -2534,7 +2659,7 @@ describe("graphql — health_history", () => {
     );
 
     const sorted = await gql(
-      '{ health_history(date: "2026-07-01", sort: "latency_ms", order: "desc") { surfaces sort order } }',
+      '{ health_history(date: "2026-07-01", sort: "latency_ms", order: "desc") { surfaces { surface_id netuid kind provider status classification latency_ms status_code last_checked last_ok verified_at error_class } sort order } }',
       env as unknown as Env,
     );
     assert.equal(sorted.body.data.health_history.surfaces[0].netuid, 1);
@@ -2586,15 +2711,98 @@ describe("graphql — health_history", () => {
 // unchanged (same filter/sort/page + error behavior as REST and MCP) rather
 // than a GraphQL-only reimplementation.
 describe("graphql — profiles", () => {
+  // Every field SubnetProfile declares non-null -- 31 of them -- taken from a
+  // real /api/v1/profiles row rather than invented, so what the resolver sees
+  // here is the shape it sees in production. A short row was fine while the
+  // type was opaque JSON; now a single missing key nulls the whole profile
+  // and every assertion below it reads as a paging bug instead.
   const PROFILE_ROW = {
-    netuid: 7,
-    slug: "allways",
-    name: "Allways",
+    candidate_count: 1,
+    categories: ["baseline-augmented", "chain-rpc", "root", "system"],
+    completeness: {
+      confidence: "high",
+      gap_reasons: ["stale-subtensor-rpc"],
+      identity_level: "complete",
+      identity_surface_count: 3,
+      missing_critical_count: 0,
+      missing_identity: [],
+      missing_operational: [],
+      missing_required: [],
+      profile_level: "operational",
+      score: 90,
+    },
     completeness_score: 82,
-    curation_level: "machine-verified",
-    review_state: "verified",
     confidence: "high",
+    curation_level: "machine-verified",
+    derived_categories: [],
+    endpoint_count: 17,
+    gap_reasons: ["stale-subtensor-rpc"],
+    identity_evidence: {
+      candidate_identity_count: 0,
+      curated_identity_count: 3,
+      curated_identity_kinds: ["docs", "source-repo", "website"],
+      live_candidate_identity_kinds: [],
+      native_contact_present: false,
+      native_description_present: false,
+      native_identity_count: 0,
+      native_identity_kinds: [],
+      needs_promotion_kinds: [],
+      stale_candidate_identity_kinds: [],
+      unverified_candidate_identity_kinds: [],
+    },
+    identity_level: "complete",
+    identity_surface_count: 3,
+    missing_critical_count: 0,
+    missing_identity: [],
+    missing_operational: [],
+    missing_required: [],
+    monitored_endpoint_count: 16,
+    name: "Allways",
+    netuid: 7,
+    operational_interface_kinds: ["archive", "subtensor-rpc", "subtensor-wss"],
+    primary_links: {
+      dashboard_url: "https://taomarketcap.com/subnets/0",
+      docs_url: "https://docs.learnbittensor.org/concepts/bittensor-networks",
+      source_repo: "https://github.com/opentensor/subtensor",
+      website_url: "https://bittensor.com",
+    },
     profile_level: "operational",
+    project_name: "root",
+    provenance: {
+      curation_level: "maintainer-reviewed",
+      identity_source: "curated-overlay",
+      interface_source_count: 12,
+      review_state: "maintainer-reviewed",
+      reviewed_at: "2026-06-06T00:00:00.000Z",
+      source_urls: [
+        "https://api.taomarketcap.com/public/v1/subnets/0",
+        "https://backprop.finance/dtao/subnets/0-root",
+        "https://bittensor.com",
+        "https://docs.learnbittensor.org/concepts/bittensor-networks",
+        "https://docs.learnbittensor.org/subtensor-nodes/subtensor-node-requirements",
+        "https://docs.nodies.app/rpc-services/public-endpoints",
+        "https://github.com/opentensor/subtensor",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/0/subnet.json",
+        "https://onfinality.io/en/networks/bittensor-finney",
+        "https://subnetradar.com/subnet/0",
+        "https://taomarketcap.com/subnets/0",
+        "https://www.comparenodes.com/library/public-endpoints/bittensor/",
+      ],
+    },
+    review_state: "verified",
+    slug: "allways",
+    status: "active",
+    subnet_type: "root",
+    suggested_submission_kinds: [],
+    supported_interface_kinds: [
+      "archive",
+      "dashboard",
+      "docs",
+      "source-repo",
+      "subtensor-rpc",
+      "subtensor-wss",
+      "website",
+    ],
     surface_count: 5,
   };
 
@@ -2636,7 +2844,7 @@ describe("graphql — profiles", () => {
   test("filters by netuid and paginates", async () => {
     const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
     const filtered = await gql(
-      "{ profiles(netuid: 7) { profiles total captured_at } }",
+      "{ profiles(netuid: 7) { profiles { netuid slug name subnet_type status categories surface_count endpoint_count curation_level review_state confidence profile_level completeness_score gap_reasons } total captured_at } }",
       env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
@@ -2648,7 +2856,7 @@ describe("graphql — profiles", () => {
     );
 
     const paged = await gql(
-      "{ profiles(limit: 1) { profiles total returned next_cursor } }",
+      "{ profiles(limit: 1) { profiles { netuid slug name subnet_type status categories surface_count endpoint_count curation_level review_state confidence profile_level completeness_score gap_reasons } total returned next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(paged.body.data.profiles.profiles.length, 1);
@@ -2660,14 +2868,14 @@ describe("graphql — profiles", () => {
   test("searches by q and sorts by completeness_score", async () => {
     const env = fixtureEnv({ "/metagraph/profiles.json": PROFILES_BLOB });
     const searched = await gql(
-      '{ profiles(q: "alpha") { profiles total } }',
+      '{ profiles(q: "alpha") { profiles { netuid slug name subnet_type status categories surface_count endpoint_count curation_level review_state confidence profile_level completeness_score gap_reasons } total } }',
       env as unknown as Env,
     );
     assert.equal(searched.body.data.profiles.total, 1);
     assert.equal(searched.body.data.profiles.profiles[0].slug, "alpha");
 
     const sorted = await gql(
-      '{ profiles(sort: "completeness_score", order: "desc") { profiles } }',
+      '{ profiles(sort: "completeness_score", order: "desc") { profiles { netuid slug name subnet_type status categories surface_count endpoint_count curation_level review_state confidence profile_level completeness_score gap_reasons } } }',
       env as unknown as Env,
     );
     assert.equal(sorted.body.data.profiles.profiles[0].slug, "allways");
@@ -2702,7 +2910,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
 
   test("block_extrinsics: cold store returns a schema-stable empty list, never an error", async () => {
     const { status, body } = await gql(
-      '{ block_extrinsics(ref: "9") { block_number extrinsic_count extrinsics } }',
+      '{ block_extrinsics(ref: "9") { block_number extrinsic_count extrinsics { block_number extrinsic_index extrinsic_hash signer call_module call_function call_args success fee_tao tip_tao observed_at summary } } }',
     );
     assert.equal(status, 200);
     assert.equal(body.data.block_extrinsics.block_number, null);
@@ -2736,7 +2944,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
       ),
     };
     const { status, body } = await gql(
-      '{ block_extrinsics(ref: "9", limit: 10, offset: 2) { block_number extrinsic_count extrinsics } }',
+      '{ block_extrinsics(ref: "9", limit: 10, offset: 2) { block_number extrinsic_count extrinsics { block_number extrinsic_index extrinsic_hash signer call_module call_function call_args success fee_tao tip_tao observed_at summary } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -2839,14 +3047,18 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
     resetDecodeWatermarkCache();
     const env = { [R2_SQL_TOKEN_ENV]: "cfut_test" } as unknown as Env;
     const { status, body } = await gql(
-      "{ block_chain_events(block_number: 9) { block_number event_count events } }",
+      "{ block_chain_events(block_number: 9) { block_number event_count events { block_number event_index pallet method args phase extrinsic_index observed_at summary } } }",
       env,
     );
     assert.ok(queries.length > 0, "the lakehouse was never queried");
     assert.equal(status, 200);
     assert.equal(body.data.block_chain_events.block_number, 9);
     assert.equal(body.data.block_chain_events.event_count, 2);
+    // The RAW pallet-level row this tier serves -- not the curated AccountEvent
+    // the projection used to name. Selecting `event_kind`/`hotkey` here returned
+    // null for every row while the rows carried pallet/method all along.
     assert.equal(body.data.block_chain_events.events[1].method, "Transfer");
+    assert.equal(body.data.block_chain_events.events[1].pallet, "Balances");
   });
 
   test("block_chain_events: an absent all-events tier is a GraphQL error, not null-degrade", async () => {
@@ -2880,20 +3092,94 @@ describe("graphql — review_* contributor-review family", () => {
   const ADAPTER_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["adapter shortlist"],
+    // Rows taken from the live review artifact and filtered to the fields the
+    // type requires, then re-keyed to the two subjects these filter tests use.
+    // A four-key sketch was enough while these were opaque JSON; each is a
+    // published type now, so a missing required key nulls the whole row.
     candidates: [
       {
-        netuid: 7,
+        candidate_api_count: 5,
+        candidate_api_ids: [
+          "sn-51-website-common-health",
+          "sn-51-website-common-openapi-json",
+          "sn-51-website-common-swagger",
+          "sn-51-website-common-swagger-json",
+          "sn-51-website-link-lium-io-subnet-api-9",
+        ],
+        candidate_api_kinds: ["openapi", "subnet-api"],
+        curation_level: "maintainer-reviewed",
         name: "Allways",
-        priority_score: 88,
-        curation_level: "candidate-discovered",
+        netuid: 7,
+        operational_kinds: ["data-artifact", "openapi", "subnet-api"],
+        operational_surface_count: 151,
+        operational_surface_ids: [
+          "sn-51-lium-admin-banned-machines",
+          "sn-51-lium-admin-banned-machines-ban-id",
+          "sn-51-lium-admin-custom-referral-links",
+          "sn-51-lium-admin-custom-referral-links-link-id",
+          "sn-51-lium-admin-custom-referral-links-stats",
+          "sn-51-lium-admin-custom-referral-links-validate-code",
+          "sn-51-lium-admin-expiring-credit-grants",
+          "sn-51-lium-auth-github-login",
+          "sn-51-lium-auth-github-login-complete",
+          "sn-51-lium-auth-google-login",
+          "sn-51-lium-auth-google-login-complete",
+          "sn-51-lium-auth-logout",
+        ],
+        priority_score: 91,
+        reason_codes: [
+          "candidate-api-evidence",
+          "data-artifact-surface",
+          "multiple-operational-kinds",
+          "openapi-surface",
+          "subnet-api-surface",
+        ],
         recommended_adapter_kind: "generic-openapi-or-custom",
+        slug: "allways",
+        suggested_next_action:
+          "snapshot schema shape and consider normalized metrics from stable read-only operations",
       },
       {
-        netuid: 12,
-        name: "Compute",
-        priority_score: 72,
+        candidate_api_count: 5,
+        candidate_api_ids: [
+          "sn-51-website-common-health",
+          "sn-51-website-common-openapi-json",
+          "sn-51-website-common-swagger",
+          "sn-51-website-common-swagger-json",
+          "sn-51-website-link-lium-io-subnet-api-9",
+        ],
+        candidate_api_kinds: ["openapi", "subnet-api"],
         curation_level: "maintainer-reviewed",
-        recommended_adapter_kind: "custom-adapter",
+        name: "Compute",
+        netuid: 12,
+        operational_kinds: ["data-artifact", "openapi", "subnet-api"],
+        operational_surface_count: 151,
+        operational_surface_ids: [
+          "sn-51-lium-admin-banned-machines",
+          "sn-51-lium-admin-banned-machines-ban-id",
+          "sn-51-lium-admin-custom-referral-links",
+          "sn-51-lium-admin-custom-referral-links-link-id",
+          "sn-51-lium-admin-custom-referral-links-stats",
+          "sn-51-lium-admin-custom-referral-links-validate-code",
+          "sn-51-lium-admin-expiring-credit-grants",
+          "sn-51-lium-auth-github-login",
+          "sn-51-lium-auth-github-login-complete",
+          "sn-51-lium-auth-google-login",
+          "sn-51-lium-auth-google-login-complete",
+          "sn-51-lium-auth-logout",
+        ],
+        priority_score: 55,
+        reason_codes: [
+          "candidate-api-evidence",
+          "data-artifact-surface",
+          "multiple-operational-kinds",
+          "openapi-surface",
+          "subnet-api-surface",
+        ],
+        recommended_adapter_kind: "generic-openapi-or-custom",
+        slug: "compute",
+        suggested_next_action:
+          "snapshot schema shape and consider normalized metrics from stable read-only operations",
       },
     ],
   };
@@ -2901,20 +3187,74 @@ describe("graphql — review_* contributor-review family", () => {
   const EVIDENCE_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["evidence"],
+    // Rows taken from the live review artifact and filtered to the fields the
+    // type requires, then re-keyed to the two subjects these filter tests use.
+    // A four-key sketch was enough while these were opaque JSON; each is a
+    // published type now, so a missing required key nulls the whole row.
     entries: [
       {
-        netuid: 7,
-        name: "Allways",
-        priority_score: 90,
+        candidate_evidence_by_kind: {
+          sse: {
+            candidate_count: 0,
+            classifications: {},
+            live_or_redirected_count: 0,
+            reviewable_count: 0,
+            sample_candidate_ids: [],
+            stale_or_failed_count: 0,
+            unverified_count: 0,
+          },
+        },
+        candidate_evidence_summary: {
+          candidate_count: 0,
+          kinds_with_candidates: [],
+          live_kinds: [],
+          live_or_redirected_count: 0,
+          reviewable_count: 0,
+          stale_kinds: [],
+          stale_or_failed_count: 0,
+          unverified_count: 0,
+          unverified_kinds: [],
+        },
+        direct_submission_kinds: [],
+        evidence_action: "maintainer-review-existing-evidence",
         lane: "direct-submission",
-        evidence_action: "submit-new-evidence",
+        missing_kinds: ["sse"],
+        name: "Allways",
+        netuid: 7,
+        priority_score: 91,
+        slug: "allways",
       },
       {
-        netuid: 12,
-        name: "Compute",
-        priority_score: 40,
+        candidate_evidence_by_kind: {
+          sse: {
+            candidate_count: 0,
+            classifications: {},
+            live_or_redirected_count: 0,
+            reviewable_count: 0,
+            sample_candidate_ids: [],
+            stale_or_failed_count: 0,
+            unverified_count: 0,
+          },
+        },
+        candidate_evidence_summary: {
+          candidate_count: 0,
+          kinds_with_candidates: [],
+          live_kinds: [],
+          live_or_redirected_count: 0,
+          reviewable_count: 0,
+          stale_kinds: [],
+          stale_or_failed_count: 0,
+          unverified_count: 0,
+          unverified_kinds: [],
+        },
+        direct_submission_kinds: [],
+        evidence_action: "maintainer-review-existing-evidence",
         lane: "monitoring-followup",
-        evidence_action: "monitor",
+        missing_kinds: ["sse"],
+        name: "Compute",
+        netuid: 12,
+        priority_score: 55,
+        slug: "compute",
       },
     ],
   };
@@ -2922,20 +3262,132 @@ describe("graphql — review_* contributor-review family", () => {
   const QUEUE_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["queue"],
+    // Rows taken from the live review artifact and filtered to the fields the
+    // type requires, then re-keyed to the two subjects these filter tests use.
+    // A four-key sketch was enough while these were opaque JSON; each is a
+    // published type now, so a missing required key nulls the whole row.
     queue: [
       {
-        netuid: 7,
-        name: "Allways",
-        priority_score: 95,
-        lane: "direct-submission",
+        adapter_score: 3181,
+        candidate_count: 14,
+        candidate_evidence_summary: {
+          candidate_count: 0,
+          kinds_with_candidates: [],
+          live_kinds: [],
+          live_or_redirected_count: 0,
+          reviewable_count: 0,
+          stale_kinds: [],
+          stale_or_failed_count: 0,
+          unverified_count: 0,
+          unverified_kinds: [],
+        },
+        completeness_score: 93,
+        contribution_hint:
+          "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
         curation_level: "candidate-discovered",
+        direct_submission_kinds: [],
+        endpoint_count: 161,
+        evidence_action: "maintainer-review-existing-evidence",
+        identity_level: "complete",
+        identity_surface_count: 3,
+        lane: "adapter-candidate",
+        manual_review_required: true,
+        missing_identity: [],
+        missing_kinds: ["sse"],
+        name: "Allways",
+        netuid: 7,
+        operational_interface_count: 3,
+        priority_score: 91,
+        profile_level: "operational",
+        reason_codes: ["adapter-candidate"],
+        recommended_action:
+          "evaluate adapter support for data-artifact, openapi, subnet-api",
+        review_state: "maintainer-reviewed",
+        sample_candidate_ids: [
+          "sn-51-taostats-metagraph",
+          "sn-51-website-common-docs",
+          "sn-51-website-common-health",
+          "sn-51-website-common-openapi-json",
+          "sn-51-website-common-swagger",
+        ],
+        sample_live_candidate_ids: [],
+        sample_stale_candidate_ids: [],
+        sample_target_candidate_ids: [],
+        slug: "allways",
+        source_urls: [
+          "https://api.taomarketcap.com/public/v1/subnets/51",
+          "https://backprop.finance/dtao/subnets/51-lium-io",
+          "https://docs.lium.io/bittensor-subnet/overview",
+          "https://github.com/Datura-ai/lium-io",
+          "https://github.com/Datura-ai/lium-io/blob/main/README.md",
+          "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
+          "https://lium.io/",
+        ],
+        stale_candidate_count: 0,
+        surface_count: 161,
+        verified_candidate_count: 8,
       },
       {
-        netuid: 12,
-        name: "Compute",
-        priority_score: 50,
-        lane: "baseline-monitoring",
+        adapter_score: 3181,
+        candidate_count: 14,
+        candidate_evidence_summary: {
+          candidate_count: 0,
+          kinds_with_candidates: [],
+          live_kinds: [],
+          live_or_redirected_count: 0,
+          reviewable_count: 0,
+          stale_kinds: [],
+          stale_or_failed_count: 0,
+          unverified_count: 0,
+          unverified_kinds: [],
+        },
+        completeness_score: 93,
+        contribution_hint:
+          "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
         curation_level: "maintainer-reviewed",
+        direct_submission_kinds: [],
+        endpoint_count: 161,
+        evidence_action: "maintainer-review-existing-evidence",
+        identity_level: "complete",
+        identity_surface_count: 3,
+        lane: "adapter-candidate",
+        manual_review_required: true,
+        missing_identity: [],
+        missing_kinds: ["sse"],
+        name: "Compute",
+        netuid: 12,
+        operational_interface_count: 3,
+        priority_score: 55,
+        profile_level: "operational",
+        reason_codes: ["adapter-candidate"],
+        recommended_action:
+          "evaluate adapter support for data-artifact, openapi, subnet-api",
+        review_state: "maintainer-reviewed",
+        sample_candidate_ids: [
+          "sn-51-taostats-metagraph",
+          "sn-51-website-common-docs",
+          "sn-51-website-common-health",
+          "sn-51-website-common-openapi-json",
+          "sn-51-website-common-swagger",
+        ],
+        sample_live_candidate_ids: [],
+        sample_stale_candidate_ids: [],
+        sample_target_candidate_ids: [],
+        slug: "compute",
+        source_urls: [
+          "https://api.taomarketcap.com/public/v1/subnets/51",
+          "https://backprop.finance/dtao/subnets/51-lium-io",
+          "https://docs.lium.io/bittensor-subnet/overview",
+          "https://github.com/Datura-ai/lium-io",
+          "https://github.com/Datura-ai/lium-io/blob/main/README.md",
+          "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
+          "https://lium.io/",
+        ],
+        stale_candidate_count: 0,
+        surface_count: 161,
+        verified_candidate_count: 8,
       },
     ],
   };
@@ -2943,20 +3395,110 @@ describe("graphql — review_* contributor-review family", () => {
   const TARGETS_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["targets"],
+    // Rows taken from the live review artifact and filtered to the fields the
+    // type requires, then re-keyed to the two subjects these filter tests use.
+    // A four-key sketch was enough while these were opaque JSON; each is a
+    // published type now, so a missing required key nulls the whole row.
     targets: [
       {
-        netuid: 7,
-        name: "Allways",
-        priority_score: 91,
-        target_type: "surface-candidate",
+        auto_review_candidate: false,
+        contribution_prompt:
+          "Review whether the existing public API/schema/data surfaces justify a subnet-specific adapter. Adapter requests route to manual review.",
+        evidence_action: "maintainer-review-existing-evidence",
+        identity_level: "complete",
         lane: "direct-submission",
+        manual_review_required: true,
+        missing_kinds: ["sse"],
+        name: "Allways",
+        netuid: 7,
+        priority_score: 91,
+        profile_level: "operational",
+        queue_context: {
+          adapter_score: 3181,
+          candidate_count: 14,
+          completeness_score: 93,
+          curation_level: "maintainer-reviewed",
+          direct_submission_kind_count: 0,
+          endpoint_count: 161,
+          identity_surface_count: 3,
+          operational_interface_count: 3,
+          profile_level: "operational",
+          review_state: "maintainer-reviewed",
+          source_url_count: 8,
+          stale_candidate_count: 0,
+          surface_count: 161,
+          verified_candidate_count: 8,
+        },
+        reason_codes: ["adapter-candidate"],
+        recommended_action:
+          "evaluate adapter support for data-artifact, openapi, subnet-api",
+        sample_live_candidate_ids: [],
+        sample_stale_candidate_ids: [],
+        sample_target_candidate_ids: [],
+        slug: "allways",
+        source_requirements: [
+          "Existing public API/schema/data evidence should be stable enough to normalize.",
+          "Adapter work requires maintainer review before publication.",
+        ],
+        source_urls: [
+          "https://api.taomarketcap.com/public/v1/subnets/51",
+          "https://backprop.finance/dtao/subnets/51-lium-io",
+          "https://docs.lium.io/bittensor-subnet/overview",
+        ],
+        submission_route: "adapter-request",
+        target_action: "adapter-review",
+        target_id: "sn-51-adapter-review-adapter-candidate",
+        target_type: "surface-candidate",
       },
       {
-        netuid: 12,
-        name: "Compute",
-        priority_score: 55,
-        target_type: "monitoring-followup",
+        auto_review_candidate: false,
+        contribution_prompt:
+          "Review whether the existing public API/schema/data surfaces justify a subnet-specific adapter. Adapter requests route to manual review.",
+        evidence_action: "maintainer-review-existing-evidence",
+        identity_level: "complete",
         lane: "monitoring-followup",
+        manual_review_required: true,
+        missing_kinds: ["sse"],
+        name: "Compute",
+        netuid: 12,
+        priority_score: 55,
+        profile_level: "operational",
+        queue_context: {
+          adapter_score: 3181,
+          candidate_count: 14,
+          completeness_score: 93,
+          curation_level: "maintainer-reviewed",
+          direct_submission_kind_count: 0,
+          endpoint_count: 161,
+          identity_surface_count: 3,
+          operational_interface_count: 3,
+          profile_level: "operational",
+          review_state: "maintainer-reviewed",
+          source_url_count: 8,
+          stale_candidate_count: 0,
+          surface_count: 161,
+          verified_candidate_count: 8,
+        },
+        reason_codes: ["adapter-candidate"],
+        recommended_action:
+          "evaluate adapter support for data-artifact, openapi, subnet-api",
+        sample_live_candidate_ids: [],
+        sample_stale_candidate_ids: [],
+        sample_target_candidate_ids: [],
+        slug: "compute",
+        source_requirements: [
+          "Existing public API/schema/data evidence should be stable enough to normalize.",
+          "Adapter work requires maintainer review before publication.",
+        ],
+        source_urls: [
+          "https://api.taomarketcap.com/public/v1/subnets/51",
+          "https://backprop.finance/dtao/subnets/51-lium-io",
+          "https://docs.lium.io/bittensor-subnet/overview",
+        ],
+        submission_route: "adapter-request",
+        target_action: "adapter-review",
+        target_id: "sn-51-adapter-review-adapter-candidate",
+        target_type: "monitoring-followup",
       },
     ],
   };
@@ -2964,20 +3506,36 @@ describe("graphql — review_* contributor-review family", () => {
   const GAPS_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["gaps"],
+    // Rows taken from the live review artifact and filtered to the fields the
+    // type requires, then re-keyed to the two subjects these filter tests use.
+    // A four-key sketch was enough while these were opaque JSON; each is a
+    // published type now, so a missing required key nulls the whole row.
     priorities: [
       {
-        netuid: 7,
-        name: "Allways",
-        priority_score: 88,
+        candidate_count: 14,
         curation_level: "candidate-discovered",
         missing_kinds: ["openapi"],
+        name: "Allways",
+        netuid: 7,
+        priority_score: 88,
+        review_state: "maintainer-reviewed",
+        slug: "allways",
+        suggested_next_action: "evaluate for subnet-specific adapter",
+        surface_count: 161,
+        verified_candidate_count: 8,
       },
       {
-        netuid: 12,
-        name: "Compute",
-        priority_score: 72,
+        candidate_count: 14,
         curation_level: "maintainer-reviewed",
         missing_kinds: ["website"],
+        name: "Compute",
+        netuid: 12,
+        priority_score: 72,
+        review_state: "maintainer-reviewed",
+        slug: "compute",
+        suggested_next_action: "evaluate for subnet-specific adapter",
+        surface_count: 161,
+        verified_candidate_count: 8,
       },
     ],
   };
@@ -2985,23 +3543,147 @@ describe("graphql — review_* contributor-review family", () => {
   const PROFILE_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     notes: ["profile gaps"],
-    summary: { profile_count: 2 },
+    summary: {
+      average_completeness_score: 81,
+      by_confidence: {
+        high: 126,
+        low: 3,
+      },
+      by_identity_level: {
+        complete: 120,
+        partial: 9,
+      },
+      by_profile_level: {
+        "adapter-backed": 2,
+        "identity-complete": 1,
+        "identity-partial": 1,
+        operational: 125,
+      },
+      critical_gap_counts: {
+        "missing-data-artifact": 9,
+        "missing-openapi": 62,
+        "missing-source-repo": 6,
+        "missing-sse": 123,
+        "missing-subnet-api": 7,
+        "missing-website": 7,
+        "stale-data-artifact": 8,
+        "stale-openapi": 7,
+        "stale-subnet-api": 26,
+        "stale-subtensor-rpc": 1,
+      },
+      identity_promotion_candidate_count: 0,
+      native_identity_count: 124,
+      native_identity_unpromoted_count: 0,
+      needs_identity_count: 9,
+      needs_operational_count: 2,
+      // Two, because the fixture has two rows -- the shape is production\'s,
+      // the counts are this test\'s.
+      profile_count: 2,
+    },
+    // Rows taken from the live review artifact and filtered to the fields the
+    // type requires, then re-keyed to the two subjects these filter tests use.
+    // A four-key sketch was enough while these were opaque JSON; each is a
+    // published type now, so a missing required key nulls the whole row.
     profiles: [
       {
-        netuid: 7,
+        candidate_count: 1,
+        completeness_score: 25,
+        confidence: "medium",
+        curation_level: "maintainer-reviewed",
+        gap_reasons: [
+          "missing-source-repo",
+          "missing-website",
+          "missing-openapi",
+          "missing-subnet-api",
+          "missing-sse",
+          "missing-data-artifact",
+        ],
+        identity_evidence: {
+          candidate_identity_count: 0,
+          curated_identity_count: 1,
+          curated_identity_kinds: ["docs"],
+          live_candidate_identity_kinds: [],
+          native_contact_present: false,
+          native_description_present: true,
+          native_identity_count: 0,
+          native_identity_kinds: [],
+          needs_promotion_kinds: [],
+          stale_candidate_identity_kinds: [],
+          unverified_candidate_identity_kinds: [],
+        },
+        identity_level: "partial",
+        identity_promotion_kind_count: 0,
+        identity_promotion_kinds: [],
+        identity_surface_count: 1,
+        live_identity_candidate_kind_count: 0,
+        missing_critical_count: 6,
+        missing_identity: ["source-repo", "website"],
+        missing_operational: ["openapi", "subnet-api", "sse", "data-artifact"],
+        missing_required: ["source-repo", "website"],
         name: "Allways",
+        native_identity_signal_count: 0,
+        native_name_quality: "chain",
+        netuid: 7,
+        operational_interface_count: 0,
         priority_score: 80,
         profile_level: "identity-partial",
-        identity_level: "partial",
-        confidence: "medium",
+        review_state: "maintainer-reviewed",
+        slug: "allways",
+        source_count: 5,
+        stale_identity_candidate_kind_count: 0,
+        suggested_next_action:
+          "submit official docs, website, or source repository evidence",
+        supported_interface_kinds: ["dashboard", "docs"],
       },
       {
-        netuid: 12,
+        candidate_count: 1,
+        completeness_score: 25,
+        confidence: "low",
+        curation_level: "maintainer-reviewed",
+        gap_reasons: [
+          "missing-source-repo",
+          "missing-website",
+          "missing-openapi",
+          "missing-subnet-api",
+          "missing-sse",
+          "missing-data-artifact",
+        ],
+        identity_evidence: {
+          candidate_identity_count: 0,
+          curated_identity_count: 1,
+          curated_identity_kinds: ["docs"],
+          live_candidate_identity_kinds: [],
+          native_contact_present: false,
+          native_description_present: true,
+          native_identity_count: 0,
+          native_identity_kinds: [],
+          needs_promotion_kinds: [],
+          stale_candidate_identity_kinds: [],
+          unverified_candidate_identity_kinds: [],
+        },
+        identity_level: "none",
+        identity_promotion_kind_count: 0,
+        identity_promotion_kinds: [],
+        identity_surface_count: 1,
+        live_identity_candidate_kind_count: 0,
+        missing_critical_count: 6,
+        missing_identity: ["source-repo", "website"],
+        missing_operational: ["openapi", "subnet-api", "sse", "data-artifact"],
+        missing_required: ["source-repo", "website"],
         name: "Compute",
+        native_identity_signal_count: 0,
+        native_name_quality: "chain",
+        netuid: 12,
+        operational_interface_count: 0,
         priority_score: 40,
         profile_level: "directory-only",
-        identity_level: "none",
-        confidence: "low",
+        review_state: "maintainer-reviewed",
+        slug: "compute",
+        source_count: 5,
+        stale_identity_candidate_kind_count: 0,
+        suggested_next_action:
+          "submit official docs, website, or source repository evidence",
+        supported_interface_kinds: ["dashboard", "docs"],
       },
     ],
   };
@@ -3019,7 +3701,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("review_adapter_candidates filters by netuid and paginates", async () => {
     const env = reviewEnv();
     const filtered = await gql(
-      "{ review_adapter_candidates(netuid: 7) { candidates total generated_at } }",
+      "{ review_adapter_candidates(netuid: 7) { candidates { candidate_api_count candidate_api_ids candidate_api_kinds curation_level name netuid operational_kinds operational_surface_count operational_surface_ids priority_score reason_codes recommended_adapter_kind suggested_next_action slug } total generated_at } }",
       env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
@@ -3034,7 +3716,7 @@ describe("graphql — review_* contributor-review family", () => {
     );
 
     const paged = await gql(
-      "{ review_adapter_candidates(limit: 1) { candidates total returned next_cursor } }",
+      "{ review_adapter_candidates(limit: 1) { candidates { candidate_api_count candidate_api_ids candidate_api_kinds curation_level name netuid operational_kinds operational_surface_count operational_surface_ids priority_score reason_codes recommended_adapter_kind suggested_next_action slug } total returned next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(
@@ -3049,7 +3731,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("review_enrichment_evidence filters by lane and sorts", async () => {
     const env = reviewEnv();
     const filtered = await gql(
-      '{ review_enrichment_evidence(lane: "direct-submission") { entries total } }',
+      '{ review_enrichment_evidence(lane: "direct-submission") { entries { candidate_evidence_by_kind direct_submission_kinds evidence_action lane missing_kinds name netuid priority_score slug } total } }',
       env as unknown as Env,
     );
     assert.equal(filtered.body.data.review_enrichment_evidence.total, 1);
@@ -3059,7 +3741,7 @@ describe("graphql — review_* contributor-review family", () => {
     );
 
     const sorted = await gql(
-      '{ review_enrichment_evidence(sort: "priority_score", order: "asc") { entries } }',
+      '{ review_enrichment_evidence(sort: "priority_score", order: "asc") { entries { candidate_evidence_by_kind direct_submission_kinds evidence_action lane missing_kinds name netuid priority_score slug } } }',
       env as unknown as Env,
     );
     assert.equal(
@@ -3071,7 +3753,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("review_enrichment_queue filters by curation_level", async () => {
     const env = reviewEnv();
     const { body } = await gql(
-      '{ review_enrichment_queue(curation_level: "maintainer-reviewed") { queue total } }',
+      '{ review_enrichment_queue(curation_level: "maintainer-reviewed") { queue { adapter_score candidate_count completeness_score contribution_hint curation_level direct_submission_kinds endpoint_count evidence_action identity_level identity_surface_count lane manual_review_required missing_kinds missing_identity name netuid operational_interface_count priority_score profile_level reason_codes recommended_action review_state sample_candidate_ids sample_live_candidate_ids sample_stale_candidate_ids sample_target_candidate_ids slug source_urls stale_candidate_count surface_count verified_candidate_count } total } }',
       env as unknown as Env,
     );
     assert.equal(body.data.review_enrichment_queue.total, 1);
@@ -3081,7 +3763,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("review_enrichment_targets filters by target_type", async () => {
     const env = reviewEnv();
     const { body } = await gql(
-      '{ review_enrichment_targets(target_type: "surface-candidate") { targets total } }',
+      '{ review_enrichment_targets(target_type: "surface-candidate") { targets { auto_review_candidate candidate_command contribution_prompt evidence_action identity_level kind lane manual_review_required missing_kinds name netuid priority_score profile_level reason_codes recommended_action sample_live_candidate_ids sample_stale_candidate_ids sample_target_candidate_ids slug source_requirements source_urls submission_route target_action target_id target_type } total } }',
       env as unknown as Env,
     );
     assert.equal(body.data.review_enrichment_targets.total, 1);
@@ -3091,7 +3773,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("review_gaps filters by missing_kinds", async () => {
     const env = reviewEnv();
     const { body } = await gql(
-      '{ review_gaps(missing_kinds: "openapi") { priorities total } }',
+      '{ review_gaps(missing_kinds: "openapi") { priorities { candidate_count curation_level missing_kinds name netuid priority_score review_state slug suggested_next_action surface_count verified_candidate_count } total } }',
       env as unknown as Env,
     );
     assert.equal(body.data.review_gaps.total, 1);
@@ -3101,7 +3783,7 @@ describe("graphql — review_* contributor-review family", () => {
   test("review_profile_completeness filters by identity_level and exposes summary", async () => {
     const env = reviewEnv();
     const { body } = await gql(
-      '{ review_profile_completeness(identity_level: "partial") { profiles total summary } }',
+      '{ review_profile_completeness(identity_level: "partial") { profiles { candidate_count completeness_score confidence curation_level gap_reasons identity_level identity_promotion_kind_count identity_promotion_kinds identity_surface_count live_identity_candidate_kind_count missing_critical_count missing_identity missing_operational missing_required name native_name_quality native_identity_signal_count netuid operational_interface_count priority_score profile_level review_state slug source_count stale_identity_candidate_kind_count supported_interface_kinds suggested_next_action } total summary { profile_count needs_identity_count needs_operational_count average_completeness_score native_identity_count identity_promotion_candidate_count native_identity_unpromoted_count by_identity_level by_profile_level by_confidence critical_gap_counts } } }',
       env as unknown as Env,
     );
     assert.equal(body.data.review_profile_completeness.total, 1);
@@ -6041,7 +6723,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       ),
     };
     const { status, body } = await gql(
-      "{ subnet_ownership_history(netuid: 7) { schema_version netuid count ownership_changes } }",
+      "{ subnet_ownership_history(netuid: 7) { schema_version netuid count ownership_changes { netuid old_coldkey new_coldkey block_number observed_at source } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -6081,7 +6763,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       ),
     };
     const { status, body } = await gql(
-      "{ subnet_conviction(netuid: 7) { schema_version netuid queried_at_block unlock_rate maturity_rate king count leaderboard } }",
+      "{ subnet_conviction(netuid: 7) { schema_version netuid queried_at_block unlock_rate maturity_rate king count leaderboard { hotkey is_owner locked_mass conviction } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -6112,7 +6794,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       ),
     };
     const { status, body } = await gql(
-      "{ subnet_lease_history(netuid: 9) { schema_version netuid count lease_events } }",
+      "{ subnet_lease_history(netuid: 9) { schema_version netuid count lease_events { event_kind beneficiary block_number observed_at } } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -6135,7 +6817,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
       ),
     };
     const { body } = await gql(
-      "{ subnet_ownership_history(netuid: 4) { count ownership_changes } }",
+      "{ subnet_ownership_history(netuid: 4) { count ownership_changes { netuid old_coldkey new_coldkey block_number observed_at source } } }",
       env as unknown as Env,
     );
     assert.equal(body.data.subnet_ownership_history.count, 0);
@@ -6149,7 +6831,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     const env = { DATA_API: { fetch: async () => Response.json({}) } };
 
     const ownership = await gql(
-      "{ subnet_ownership_history(netuid: 4) { schema_version netuid count ownership_changes } }",
+      "{ subnet_ownership_history(netuid: 4) { schema_version netuid count ownership_changes { netuid old_coldkey new_coldkey block_number observed_at source } } }",
       env as unknown as Env,
     );
     assert.deepEqual(ownership.body.data.subnet_ownership_history, {
@@ -6160,7 +6842,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     });
 
     const conviction = await gql(
-      "{ subnet_conviction(netuid: 4) { schema_version netuid queried_at_block unlock_rate maturity_rate king count leaderboard } }",
+      "{ subnet_conviction(netuid: 4) { schema_version netuid queried_at_block unlock_rate maturity_rate king count leaderboard { hotkey is_owner locked_mass conviction } } }",
       env as unknown as Env,
     );
     assert.deepEqual(conviction.body.data.subnet_conviction, {
@@ -6175,7 +6857,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
     });
 
     const leaseHistory = await gql(
-      "{ subnet_lease_history(netuid: 4) { schema_version netuid count lease_events } }",
+      "{ subnet_lease_history(netuid: 4) { schema_version netuid count lease_events { event_kind beneficiary block_number observed_at } } }",
       env as unknown as Env,
     );
     assert.deepEqual(leaseHistory.body.data.subnet_lease_history, {
@@ -6252,7 +6934,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
           DATA_API: dataApi(new Response("err", { status: 502 })),
         };
         const { status, body } = await gql(
-          "{ subnet_ownership_history(netuid: 7) { netuid count ownership_changes } }",
+          "{ subnet_ownership_history(netuid: 7) { netuid count ownership_changes { netuid old_coldkey new_coldkey block_number observed_at source } } }",
           env as unknown as Env,
         );
         assert.equal(status, 200);
@@ -6283,7 +6965,7 @@ describe("graphql — subnet_ownership_history / subnet_conviction / subnet_leas
           DATA_API: dataApi(new Response("err", { status: 502 })),
         };
         const { body } = await gql(
-          "{ subnet_ownership_history(netuid: 18) { count ownership_changes } }",
+          "{ subnet_ownership_history(netuid: 18) { count ownership_changes { netuid old_coldkey new_coldkey block_number observed_at source } } }",
           env as unknown as Env,
         );
         assert.equal(body.errors, undefined);
@@ -6461,7 +7143,7 @@ describe("graphql — subnet_lease (#6719, live chain RPC via subnet-lease.ts)",
       }),
       async () => {
         const { status, body } = await gql(
-          "{ subnet_lease(netuid: 7) { schema_version netuid leased lease queried_at } }",
+          "{ subnet_lease(netuid: 7) { schema_version netuid leased lease { lease_id beneficiary coldkey hotkey emissions_share_percent end_block netuid cost_tao accumulated_dividends_alpha } queried_at } }",
         );
         assert.equal(status, 200);
         assert.equal(body.errors, undefined);
@@ -8794,12 +9476,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
           source: "postgres",
           summary: {
             incident_count: 2,
-            active_count: 1,
-            by_status: { down: 1, warn: 1 },
-            by_severity: { high: 1, medium: 1 },
-            by_kind: {},
-            by_layer: {},
-            by_provider: { acme: 2 },
+            affected_surface_count: 1,
           },
           surfaces: [
             {
@@ -8817,7 +9494,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
     const { status, body } = await gql(
       `{ incidents(window: "30d") {
           schema_version window observed_at source
-          summary
+          summary { incident_count affected_surface_count }
           surfaces { surface_id netuid incident_count downtime_ms transient_failure_count transient_failed_samples }
         } }`,
       env as unknown as Env,
@@ -8826,11 +9503,13 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
     const inc = body.data.incidents;
     assert.equal(inc.window, "30d");
     assert.equal(inc.observed_at, "2026-07-01T00:00:00.000Z");
-    // JSON scalar passes the dynamic-keyed summary through as-is.
+    // The summary is a TYPE now, not a JSON blob (#10214): it declares
+    // incident_count and affected_surface_count and nothing else, so the
+    // by_status/by_provider maps this used to echo back are not part of the
+    // contract and cannot be selected. Asserting them proved only that a blob
+    // round-trips.
     assert.equal(inc.summary.incident_count, 2);
-    assert.equal(inc.summary.active_count, 1);
-    assert.deepEqual(inc.summary.by_status, { down: 1, warn: 1 });
-    assert.deepEqual(inc.summary.by_provider, { acme: 2 });
+    assert.equal(inc.summary.affected_surface_count, 1);
     assert.equal(inc.surfaces.length, 1);
     // A per-surface ROLLUP, not an endpoint incident. The row was published as
     // `EndpointIncident` until #10214, and this test selected eleven of that
@@ -8846,7 +9525,7 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
       DATA_API: dataApi(Response.json({})),
     };
     const { status, body } = await gql(
-      '{ incidents(window: "30d") { schema_version window observed_at source summary surfaces { surface_id } } }',
+      '{ incidents(window: "30d") { schema_version window observed_at source summary { incident_count affected_surface_count } surfaces { surface_id } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -8893,8 +9572,7 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
         source: "postgres",
         summary: {
           incident_count: 1,
-          active_count: 1,
-          by_status: { down: 1 },
+          affected_surface_count: 1,
         },
         surfaces: [
           {
@@ -8912,7 +9590,8 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
     // the complexity budget -- both fields carry the fan-out weight); dataApi
     // serves each resolver a fresh Response, so the envelopes must be identical.
     const selection = `{
-        schema_version window observed_at source summary
+        schema_version window observed_at source
+        summary { incident_count affected_surface_count }
         surfaces { surface_id netuid incident_count downtime_ms }
       }`;
     const { status, body } = await gql(
@@ -9723,13 +10402,25 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     const env = fixtureEnv({
       "/metagraph/search.json": {
         documents: [
-          { id: "subnet:1", type: "subnet", title: "Alpha", tokens: "a b" },
-          { id: "subnet:2", type: "subnet", title: "Beta", tokens: "c d" },
+          {
+            id: "subnet:1",
+            type: "subnet",
+            title: "Alpha",
+            tokens: ["a", "b"],
+            artifact_path: "/metagraph/subnets/1.json",
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            title: "Beta",
+            tokens: ["c", "d"],
+            artifact_path: "/metagraph/subnets/1.json",
+          },
         ],
       },
     });
     const { status, body } = await gql(
-      "{ search(limit: 1) { documents total next_cursor } }",
+      "{ search(limit: 1) { documents { id type netuid slug title subtitle url artifact_path tokens categories service_kinds } total next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -9738,8 +10429,10 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     assert.equal(s.total, 2);
     assert.equal(s.documents.length, 1);
     assert.equal(s.documents[0].id, "subnet:1");
-    // The full index keeps the per-document token blob.
-    assert.equal(s.documents[0].tokens, "a b");
+    // The full index keeps the per-document tokens -- a LIST, which is what
+    // /api/v1/search serves; the string here typechecked against nothing while
+    // `documents` was opaque JSON.
+    assert.deepEqual(s.documents[0].tokens, ["a", "b"]);
     assert.ok(s.next_cursor);
   });
 
@@ -9747,13 +10440,25 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     const env = fixtureEnv({
       "/metagraph/search-index.json": {
         documents: [
-          { id: "subnet:1", type: "subnet", title: "Alpha" },
-          { id: "subnet:2", type: "subnet", title: "Beta" },
+          {
+            id: "subnet:1",
+            type: "subnet",
+            title: "Alpha",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            title: "Beta",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
         ],
       },
     });
     const { status, body } = await gql(
-      "{ search_index(limit: 1) { documents total next_cursor } }",
+      "{ search_index(limit: 1) { documents { id type netuid slug title subtitle url artifact_path categories service_kinds } total next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -9770,13 +10475,25 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     const env = fixtureEnv({
       "/metagraph/search-index.json": {
         documents: [
-          { id: "subnet:1", type: "subnet", title: "Alpha network" },
-          { id: "subnet:2", type: "subnet", title: "Beta protocol" },
+          {
+            id: "subnet:1",
+            type: "subnet",
+            title: "Alpha network",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            title: "Beta protocol",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
         ],
       },
     });
     const { status, body } = await gql(
-      '{ search_index(q: "Alpha") { documents total returned } }',
+      '{ search_index(q: "Alpha") { documents { id type netuid slug title subtitle url artifact_path categories service_kinds } total returned } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -9790,14 +10507,34 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     const env = fixtureEnv({
       "/metagraph/search-index.json": {
         documents: [
-          { id: "subnet:1", type: "subnet", netuid: 1, title: "Alpha" },
-          { id: "subnet:2", type: "subnet", netuid: 2, title: "Beta" },
-          { id: "provider:datura", type: "provider", title: "Datura" },
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "Alpha",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            netuid: 2,
+            title: "Beta",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
+          {
+            id: "provider:datura",
+            type: "provider",
+            title: "Datura",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
         ],
       },
     });
     const { status, body } = await gql(
-      '{ search_index(type: "subnet", netuid: 1) { documents total returned } }',
+      '{ search_index(type: "subnet", netuid: 1) { documents { id type netuid slug title subtitle url artifact_path categories service_kinds } total returned } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -9811,7 +10548,9 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     // MCP list_search use -- so a cold/absent artifact is a GraphQL error exactly
     // as REST returns not_found, not the empty-page degradation the old listPage
     // path uniquely produced. Matches the source_snapshots/evidence convention.
-    const { body } = await gql("{ search { documents total } }");
+    const { body } = await gql(
+      "{ search { documents { id type netuid slug title subtitle url artifact_path tokens categories service_kinds } total } }",
+    );
     assert.ok(
       body.errors,
       "expected a GraphQL error when the search artifact is cold",
@@ -9828,27 +10567,30 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
             type: "subnet",
             netuid: 1,
             title: "Alpha",
-            tokens: "alpha vision",
+            tokens: ["alpha", "vision"],
+            artifact_path: "/metagraph/subnets/1.json",
           },
           {
             id: "surface:2",
             type: "surface",
             netuid: 2,
             title: "Beta",
-            tokens: "beta audio",
+            tokens: ["beta", "audio"],
+            artifact_path: "/metagraph/subnets/1.json",
           },
           {
             id: "provider:3",
             type: "provider",
             netuid: 3,
             title: "Gamma",
-            tokens: "gamma data",
+            tokens: ["gamma", "data"],
+            artifact_path: "/metagraph/subnets/1.json",
           },
         ],
       },
     });
     const { status, body } = await gql(
-      '{ search(q: "beta") { documents total } }',
+      '{ search(q: "beta") { documents { id type netuid slug title subtitle url artifact_path tokens categories service_kinds } total } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -9863,19 +10605,35 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     const env = fixtureEnv({
       "/metagraph/search.json": {
         documents: [
-          { id: "subnet:1", type: "subnet", netuid: 1, title: "Alpha" },
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "Alpha",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
           {
             id: "surface:1",
             type: "surface",
             netuid: 1,
             title: "Alpha surface",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
           },
-          { id: "subnet:2", type: "subnet", netuid: 2, title: "Beta" },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            netuid: 2,
+            title: "Beta",
+            artifact_path: "/metagraph/subnets/1.json",
+            tokens: ["t"],
+          },
         ],
       },
     });
     const { status, body } = await gql(
-      '{ search(type: "subnet", netuid: 1) { documents total } }',
+      '{ search(type: "subnet", netuid: 1) { documents { id type netuid slug title subtitle url artifact_path tokens categories service_kinds } total } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -9987,7 +10745,7 @@ describe("graphql — discovery parity (#6989, search/domains/compare_validators
     const { status, body } = await gql(
       `{ compare_validators(hotkeys: ["${HOTKEY_A}", "${HOTKEY_B}"]) {
           schema_version netuid validator_count
-          validators { hotkey total_stake_tao subnet_count subnet_context }
+          validators { hotkey total_stake_tao subnet_count subnet_context { netuid uid hotkey coldkey active validator_permit rank trust validator_trust consensus incentive dividends emission_alpha stake_alpha registered_at_block is_immunity_period axon take } }
         } }`,
     );
     assert.equal(status, 200);
@@ -11518,7 +12276,7 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
   test("cold store: no Postgres flag returns a schema-stable empty surfaces list, never null", async () => {
     const { status, body } = await gql(
       `{ subnet_health_percentiles(netuid: 5) {
-          schema_version netuid window surfaces
+          schema_version netuid window surfaces { surface_id samples }
         } }`,
     );
     assert.equal(status, 200);
@@ -11540,21 +12298,29 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
           window: "30d",
           observed_at: "2026-07-19T00:00:00.000Z",
           source: "live-cron-prober",
+          // The shape /api/v1/subnets/{netuid}/health/percentiles actually
+          // serves: the percentiles nest under `latency_ms`. The flat
+          // `p95_ms`/`latency_sample_count` keys here were never the
+          // producer's, and nothing could say so while `surfaces` was JSON.
           surfaces: [
             {
-              surface: "api",
-              latency_sample_count: 120,
-              p50_ms: 88,
-              p90_ms: 210,
-              p95_ms: 280,
-              p99_ms: 640,
+              surface_id: "s1",
+              samples: 120,
+              latency_ms: {
+                p50: 88,
+                p95: 280,
+                p99: 640,
+                avg: 120,
+                min: 40,
+                max: 900,
+              },
             },
           ],
         }),
       ),
     };
     const { status, body } = await gql(
-      '{ subnet_health_percentiles(netuid: 7, window: "30d") { netuid window observed_at source surfaces } }',
+      '{ subnet_health_percentiles(netuid: 7, window: "30d") { netuid window observed_at source surfaces { surface_id samples latency_ms { p50 p95 p99 avg min max } } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -11563,7 +12329,7 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
     assert.equal(p.netuid, 7);
     assert.equal(p.window, "30d");
     assert.equal(p.source, "live-cron-prober");
-    assert.equal(p.surfaces[0].p95_ms, 280);
+    assert.equal(p.surfaces[0].latency_ms.p95, 280);
   });
 
   test("forwards the window to the health/percentiles Postgres path", async () => {
@@ -11607,7 +12373,7 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
     const { status, body } = await gql(
       `{ subnet_event_summary(netuid: 5) {
           schema_version netuid window total_events kind_count category_count
-          recent_event_count limit categories event_kinds
+          recent_event_count limit categories { category event_count kind_count amount_tao alpha_amount first_block last_block first_observed_at last_observed_at } event_kinds { event_kind category event_count hotkey_count coldkey_count amount_tao alpha_amount first_block last_block first_observed_at last_observed_at }
           recent_events { block_number event_kind }
         } }`,
     );
@@ -11642,14 +12408,33 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
           category_count: 2,
           recent_event_count: 2,
           limit: 10,
-          categories: [{ category: "stake", event_count: 30 }],
-          event_kinds: [{ event_kind: "StakeAdded", event_count: 30 }],
+          categories: [
+            {
+              category: "stake",
+              event_count: 30,
+              // Non-null on the component; absent while this was opaque JSON.
+              kind_count: 1,
+              amount_tao: 0,
+              alpha_amount: 0,
+            },
+          ],
+          event_kinds: [
+            {
+              event_kind: "StakeAdded",
+              event_count: 30,
+              category: "stake",
+              hotkey_count: 1,
+              coldkey_count: 1,
+              amount_tao: 0,
+              alpha_amount: 0,
+            },
+          ],
           recent_events: [{ event_kind: "StakeAdded", block_number: 91 }],
         }),
       ),
     };
     const { status, body } = await gql(
-      '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories event_kinds recent_events { block_number event_kind } } }',
+      '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories { category event_count kind_count amount_tao alpha_amount first_block last_block first_observed_at last_observed_at } event_kinds { event_kind category event_count hotkey_count coldkey_count amount_tao alpha_amount first_block last_block first_observed_at last_observed_at } recent_events { block_number event_kind } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -11883,6 +12668,10 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
             source_url: "https://alpha.example.com/openapi.json",
             support_summary: "probe returned 200",
             verified_at: "2026-06-01T00:00:00.000Z",
+            source_type: "docs",
+            source_tier: "official",
+            confidence: "high",
+            limits: "none",
           },
           {
             subject: "beta-docs",
@@ -11890,6 +12679,10 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
             source_url: "https://beta.example.com/docs",
             support_summary: "manual review",
             verified_at: "2026-06-02T00:00:00.000Z",
+            source_type: "docs",
+            source_tier: "official",
+            confidence: "high",
+            limits: "none",
           },
           {
             subject: "gamma-api",
@@ -11897,6 +12690,10 @@ describe("graphql — subnet_gaps / subnet_evidence (#6980, baked review artifac
             source_url: "https://gamma.example.com/openapi.json",
             support_summary: "openapi lint clean",
             verified_at: "2026-06-03T00:00:00.000Z",
+            source_type: "docs",
+            source_tier: "official",
+            confidence: "high",
+            limits: "none",
           },
         ],
       },
@@ -14186,9 +14983,16 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
 describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fallback)", () => {
   const NETUID = 3;
 
+  // `surfaces` carries a type now (#10214), so it needs a selection -- asking
+  // for it as a leaf is a 400 before any resolver runs.
   function incidentsQuery(argsClause: string) {
     return `{ subnet_health_incidents${argsClause} {
-      schema_version netuid window observed_at source surfaces
+      schema_version netuid window observed_at source
+      surfaces {
+        surface_id samples uptime_ratio incident_count downtime_ms
+        transient_failure_count transient_failed_samples
+        incidents { started_at ended_at duration_ms failed_samples }
+      }
     } }`;
   }
 
@@ -14224,6 +15028,8 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
                 uptime_ratio: 0.98,
                 incident_count: 1,
                 downtime_ms: 60000,
+                transient_failure_count: 0,
+                transient_failed_samples: 0,
                 incidents: [
                   {
                     started_at: 1000,
@@ -23385,7 +24191,7 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
 
   const query = `{ adapter(slug: "gittensor") {
     schema_version contract_version generated_at slug subnet netuid
-    notes snapshot extensions
+    notes snapshot { schema_version contract_version generated_at slug netuid source status notes adapter_kind excluded_dimensions dimensions } extensions
   } }`;
 
   test("resolves a baked adapter artifact via loadAdapter", async () => {
@@ -23393,7 +24199,25 @@ describe("graphql — adapter (#6984, reuses loadAdapter / MCP get_adapter)", ()
     const { status, body } = await gql(query, env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.deepEqual(body.data.adapter, SAMPLE);
+    const adapter = body.data.adapter;
+    // Field by field rather than deepEqual against SAMPLE: `snapshot` is a
+    // TYPE now (#10214), so the answer carries every field the selection asks
+    // for -- null for the ones this fixture omits -- while SAMPLE carries only
+    // the two it sets. Comparing whole objects would compare a selection to a
+    // fixture and fail on the difference between "absent" and "selected, null".
+    assert.equal(adapter.schema_version, SAMPLE.schema_version);
+    assert.equal(adapter.contract_version, SAMPLE.contract_version);
+    assert.equal(adapter.generated_at, SAMPLE.generated_at);
+    assert.equal(adapter.slug, SAMPLE.slug);
+    assert.equal(adapter.subnet, SAMPLE.subnet);
+    assert.equal(adapter.netuid, SAMPLE.netuid);
+    assert.deepEqual(adapter.notes, SAMPLE.notes);
+    assert.deepEqual(adapter.extensions, SAMPLE.extensions);
+    // The two the fixture sets are carried through the new type, and a field
+    // it does not set reads null rather than being missing.
+    assert.equal(adapter.snapshot.status, "captured");
+    assert.equal(adapter.snapshot.adapter_kind, "gittensor");
+    assert.equal(adapter.snapshot.source, null);
   });
 
   test("a missing slug resolves to null (schema-stable), never a GraphQL error", async () => {
@@ -23494,7 +24318,7 @@ describe("graphql — gaps", () => {
   test("filters by netuid and paginates", async () => {
     const env = fixtureEnv({ "/metagraph/gaps.json": GAPS_BLOB });
     const filtered = await gql(
-      "{ gaps(netuid: 7) { gaps total generated_at } }",
+      "{ gaps(netuid: 7) { gaps { netuid slug name coverage_level curation_level gap_count gap_severity gap_priority } total generated_at } }",
       env as unknown as Env,
     );
     assert.equal(filtered.status, 200);
@@ -23507,7 +24331,7 @@ describe("graphql — gaps", () => {
     );
 
     const paged = await gql(
-      "{ gaps(limit: 1) { gaps total returned next_cursor } }",
+      "{ gaps(limit: 1) { gaps { netuid slug name coverage_level curation_level gap_count gap_severity gap_priority } total returned next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(paged.body.data.gaps.gaps.length, 1);
@@ -23519,7 +24343,7 @@ describe("graphql — gaps", () => {
   test("sorts by gap_count and filters coverage_level", async () => {
     const env = fixtureEnv({ "/metagraph/gaps.json": GAPS_BLOB });
     const { status, body } = await gql(
-      '{ gaps(sort: "gap_count", order: "desc", coverage_level: "manifested") { gaps total } }',
+      '{ gaps(sort: "gap_count", order: "desc", coverage_level: "manifested") { gaps { netuid slug name coverage_level curation_level gap_count gap_severity gap_priority } total } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -23549,7 +24373,12 @@ describe("graphql — evidence", () => {
   const EVIDENCE_BLOB = {
     generated_at: "2026-07-01T00:00:00.000Z",
     schema_version: 1,
-    summary: { claim_count: 2 },
+    summary: {
+      claim_count: 2,
+      candidate_claim_count: 0,
+      subnet_claim_count: 2,
+      surface_claim_count: 0,
+    },
     claims: [
       {
         subject: "sn-7",
@@ -23557,6 +24386,10 @@ describe("graphql — evidence", () => {
         source_url: "https://example.org/a",
         support_summary: "README documents the API",
         verified_at: "2026-06-01T00:00:00.000Z",
+        source_type: "docs",
+        source_tier: "official",
+        confidence: "high",
+        limits: "none",
       },
       {
         subject: "sn-31",
@@ -23564,6 +24397,10 @@ describe("graphql — evidence", () => {
         source_url: "https://example.org/b",
         support_summary: "operator site links it",
         verified_at: null,
+        source_type: "docs",
+        source_tier: "official",
+        confidence: "high",
+        limits: "none",
       },
     ],
   };
@@ -23573,7 +24410,7 @@ describe("graphql — evidence", () => {
       "/metagraph/evidence-ledger.json": EVIDENCE_BLOB,
     });
     const searched = await gql(
-      '{ evidence(q: "OpenAPI") { claims total generated_at summary } }',
+      '{ evidence(q: "OpenAPI") { claims { claim subject source_url source_type source_tier confidence support_summary limits verified_at } total generated_at summary { candidate_claim_count claim_count subnet_claim_count surface_claim_count } } }',
       env as unknown as Env,
     );
     assert.equal(searched.status, 200);
@@ -23583,7 +24420,7 @@ describe("graphql — evidence", () => {
     assert.equal(searched.body.data.evidence.summary.claim_count, 2);
 
     const paged = await gql(
-      "{ evidence(limit: 1) { claims total returned next_cursor } }",
+      "{ evidence(limit: 1) { claims { claim subject source_url source_type source_tier confidence support_summary limits verified_at } total returned next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(paged.body.data.evidence.claims.length, 1);
@@ -23596,7 +24433,7 @@ describe("graphql — evidence", () => {
       "/metagraph/evidence-ledger.json": EVIDENCE_BLOB,
     });
     const { status, body } = await gql(
-      '{ evidence(sort: "subject", order: "desc") { claims schema_version } }',
+      '{ evidence(sort: "subject", order: "desc") { claims { claim subject source_url source_type source_tier confidence support_summary limits verified_at } schema_version } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
@@ -24081,16 +24918,34 @@ describe("graphql — curation parity (#6982, #8550)", () => {
             netuid: 1,
             coverage_level: "probed",
             curation_level: "maintainer-reviewed",
+            slug: "sn",
+            name: "SN",
+            surface_count: 0,
+            candidate_count: 0,
+            curation: {},
+            gaps: {},
           },
           {
             netuid: 2,
             coverage_level: "manifested",
             curation_level: "adapter-backed",
+            slug: "sn",
+            name: "SN",
+            surface_count: 0,
+            candidate_count: 0,
+            curation: {},
+            gaps: {},
           },
           {
             netuid: 3,
             coverage_level: "probed",
             curation_level: "adapter-backed",
+            slug: "sn",
+            name: "SN",
+            surface_count: 0,
+            candidate_count: 0,
+            curation: {},
+            gaps: {},
           },
         ],
       },
@@ -24098,7 +24953,7 @@ describe("graphql — curation parity (#6982, #8550)", () => {
 
   test("curation resolves the baked artifact as a CurationList envelope (#8550)", async () => {
     const { status, body } = await gql(
-      "{ curation { curation total next_cursor } }",
+      "{ curation { curation { netuid slug name coverage_level curation_level surface_count candidate_count gap_count description lifecycle } total next_cursor } }",
       env(),
     );
     assert.equal(status, 200);
@@ -24109,7 +24964,7 @@ describe("graphql — curation parity (#6982, #8550)", () => {
 
   test("curation filters by netuid/coverage_level/curation_level and sorts, at parity with REST/MCP (#8550)", async () => {
     const byNetuid = await gql(
-      "{ curation(netuid: 2) { curation total } }",
+      "{ curation(netuid: 2) { curation { netuid slug name coverage_level curation_level surface_count candidate_count gap_count description lifecycle } total } }",
       env(),
     );
     assert.equal(byNetuid.body.errors, undefined);
@@ -24129,7 +24984,7 @@ describe("graphql — curation parity (#6982, #8550)", () => {
     assert.equal(byLevel.body.data.curation.total, 2);
 
     const sorted = await gql(
-      '{ curation(sort: "netuid", order: "desc") { curation } }',
+      '{ curation(sort: "netuid", order: "desc") { curation { netuid slug name coverage_level curation_level surface_count candidate_count gap_count description lifecycle } } }',
       env(),
     );
     assert.equal(sorted.body.errors, undefined);

--- a/tests/subnet-ownership-surface-parity.test.ts
+++ b/tests/subnet-ownership-surface-parity.test.ts
@@ -162,7 +162,7 @@ async function graphqlOwnership(): Promise<Row> {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
-        query: `{ subnet_ownership_history(netuid: ${NETUID}) { schema_version netuid event_pallet event_method count observed_through ownership_changes } }`,
+        query: `{ subnet_ownership_history(netuid: ${NETUID}) { schema_version netuid event_pallet event_method count observed_through ownership_changes { netuid old_coldkey new_coldkey block_number observed_at source } } }`,
       }),
     }),
     mockEnv({ [R2_SQL_TOKEN_ENV]: "cfut_test", DATA_API: DEGRADED_DATA_API }),


### PR DESCRIPTION
Closes #10691

`validate:graphql-component-parity` counted 50 fields the published SDL served
as `JSON` over a Zod component that has a real shape. Nothing was broken at
runtime — `JSON` serialises anything — but a caller could receive `profiles`,
`queue`, `targets`, `curation`, `search.documents` or `endpoint_pools.pools`
and not read a single field of them.

Each is published from the component that already described it, emitted through
the same `emitTypes()` the gate compares against rather than hand-read. 70 types,
each registered under its component id — the first public name any of them has
had, so there was no earlier name to preserve.

    graphql-component-parity: 417 mirror types, 3295 fields compared,
                              0 JSON under-typing(s) left to close.

## The measurement this unblocks

`conformance:graphql-nullability` asks whether the generated schema's non-nulls
hold on the live surface. It probes **through GraphQL**, so a field published as
`JSON` came back as `must not have a selection since type "[JSON!]!" has no
subfields` and was skipped — it was blind to exactly the fields whose promises
are new.

It now reads the same rows off each binding's REST route as a second source,
feeding one set of counts:

| | GraphQL | REST | non-nulls observed | answered NULL |
|---|---|---|---|---|
| before | 147 | — | 1094 of 1745 | 0 |
| after | 152 | 179 | **3052 of 3368** | **0** |

Nearly three times the coverage, and nothing the emitted schema promises is null
on the live surface. Kept in one script rather than a sibling: it is one question
with two transports, and split across two files the shared rule — what counts as
a violation — gets decided twice and drifts. It already had, which is how the
next part surfaced.

**An absent key is deliberately not counted.** It looks like the same defect
(graphql-js treats a missing property exactly like null), but neither source can
tell a producer that omits a key from a deployment that predates it.
`stake_tao`/`emission_tao` are the live example and the obvious reading is wrong:
they are *not* a rename of the `stake_alpha`/`emission_alpha` the surface answers
with — alpha and TAO are different tokens, and #9058 made the `_tao` fields mean
TAO by pricing alpha through each subnet's alpha price. Counting absence produced
eight findings whose only available fix was loosening four correct components.

## Two contract defects the typing exposed

**`BlockChainEvents` was declared over the wrong component** — `BlockEventsArtifact`,
the component behind the *other* block route, whose rows are curated `AccountEvent`s.
This field mirrors `/blocks/{ref}/chain-events`, and `openapi.json` says so. Measured
against production the payloads are not the same shape:

    /blocks/{ref}/chain-events   {block_number, count, events[...]}
    /blocks/{ref}/events         {block_number, event_count, events[...], limit,
                                  offset, ref, schema_version}

and their rows differ entirely — raw `{pallet, method, args, phase}` here against
curated `{event_kind, hotkey, coldkey}` there. Free while `events` was `[JSON!]!`;
typing it would have served `event_kind: null` for data sitting right there.

**`CoverageArtifact` served five fields it declared nowhere** — `domain_coverage`,
`first_party_subnet_count`, `official_surface_count`,
`registry_observed_surface_count`, `subnets_without_official_surface`. The artifact
is `.passthrough()`, so they reached callers while the contract said nothing about
them.

## Fixtures

The fixtures standing in for these blobs were sketches, which was fine while nothing
typed them. Completed from live rows — each of these was a key the producer has never
had:

| fixture said | producer serves |
|---|---|
| `input_hash` | `hash` |
| `tier` | `storage_tier` |
| `tokens: "a b"` | `tokens: ["a", "b"]` |
| `renamed: ["sn-7"]` | `renamed: [{netuid, before, after}]` |
| `p95_ms` (flat) | `latency_ms: {p50, p95, p99, …}` |
| `{ok, warn, fail}` | `{fail_count, ok_count, warn_count}` |

`SubnetProfile`'s 31 non-null fields were verified present on all 100 production
rows before the fixture was built from one.

The shrink-only rule is now proven on an **injected** declaration rather than a live
one: with `JSON_UNDERTYPED` empty, a rule demonstrable only while something violates
it stops being tested on the day it works.

## Verification

- `typecheck` · `lint` · `format` · `validate` — clean
- `contract-drift` · `route-parity` · `query-arguments` · `types-drift` ·
  `hand-written-checks` · `published-names` · `unreferenced-exports` — OK
- **846 test files, 19,345 tests passing**
- `conformance:graphql-nullability` against production — 0 findings

No UI change: the only GraphQL consumer in `apps/ui` is the interactive GraphiQL
explorer, which loads the schema live and whose default query touches none of the
changed fields.
