### PR TITLE
observability(neon): page on write-buffer failures instead of only recording them

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   BUFFER_FLUSH_LANE,
+  BUFFER_ROUTE,
   countPending,
   enqueueStatement,
   flushBuffer,
@@ -372,6 +373,38 @@ describe("NeonWriteBufferHub", () => {
     assert.equal(res.status, 503);
   });
 
+  test("an alarm whose flush THROWS still pages and still re-arms", async () => {
+    // flushBuffer is written not to throw, so this is storage itself breaking.
+    // Without the catch the alarm dies silently: no verdict, no capture, and
+    // no rescheduled alarm -- the buffer stops draining and nothing says why.
+    const h = hub();
+    await h.do.fetch(post(stmt("neurons", "A")));
+    const broken = Object.create(h.storage) as typeof h.storage;
+    broken.list = async () => {
+      throw new Error("storage unavailable");
+    };
+    (h.do as unknown as { state: { storage: unknown } }).state = {
+      ...h.do.state,
+      storage: broken,
+    } as never;
+    await h.do.alarm();
+    assert.notEqual(await broken.getAlarm(), null, "must re-arm");
+  });
+
+  test("and survives a non-Error throw from storage", async () => {
+    const h = hub();
+    const broken = Object.create(h.storage) as typeof h.storage;
+    broken.list = async () => {
+      throw "storage unavailable";
+    };
+    (h.do as unknown as { state: { storage: unknown } }).state = {
+      ...h.do.state,
+      storage: broken,
+    } as never;
+    await h.do.alarm();
+    assert.notEqual(await broken.getAlarm(), null, "must re-arm");
+  });
+
   test("an alarm with nothing buffered does NOT schedule another wake", async () => {
     // Re-arming after a clean drain would book a wake with no work, which is
     // the exact cost this whole file exists to remove.
@@ -443,5 +476,112 @@ describe("flushBuffer, the defensive edges", () => {
     );
     assert.equal(out.ok, false);
     assert.equal(await countPending(storage), 1, "backlog must survive");
+  });
+});
+
+describe("PostHog capture (#10694)", () => {
+  /** Collects what would have been sent to the $exception inbox. */
+  function captureSpy() {
+    const events: { errorCode?: string; route?: string; message: string }[] =
+      [];
+    return {
+      events,
+      capture: async (
+        _env: unknown,
+        e: { error: unknown; route?: string; errorCode?: string },
+      ) => {
+        events.push({
+          errorCode: e.errorCode,
+          route: e.route,
+          message: String((e.error as Error)?.message ?? e.error),
+        });
+        return true;
+      },
+    };
+  }
+
+  test("a failed flush pages, and names the lane it stopped on", async () => {
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    const spy = captureSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      captureException: spy.capture as never,
+      sql: {
+        async unsafe() {
+          throw new Error("connection reset");
+        },
+      },
+    });
+    assert.equal(spy.events.length, 1);
+    assert.equal(spy.events[0].errorCode, "flush_failed");
+    assert.equal(spy.events[0].route, BUFFER_ROUTE);
+    assert.match(spy.events[0].message, /connection reset/);
+  });
+
+  test("an unbound Hyperdrive pages -- the backlog grows with nothing else saying so", async () => {
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    const spy = captureSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      captureException: spy.capture as never,
+    });
+    assert.equal(spy.events[0].errorCode, "flush_hyperdrive_unbound");
+    assert.match(spy.events[0].message, /1 statement\(s\) held/);
+  });
+
+  test("a DISCARDED statement pages -- it is the only data loss this can cause", async () => {
+    const storage = fakeStorage();
+    storage.map.set("seq", 1);
+    storage.map.set(chunkKey(1, 0), new TextEncoder().encode("{not json"));
+    const spy = captureSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      captureException: spy.capture as never,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(spy.events[0].errorCode, "flush_undecodable_statement");
+    assert.match(spy.events[0].message, /seq 1/);
+  });
+
+  test("a clean flush pages nothing", async () => {
+    // The inbox is only useful if a healthy drain is silent.
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    const spy = captureSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      captureException: spy.capture as never,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.deepEqual(spy.events, []);
+  });
+
+  test("every capture carries the same route, so one incident is one issue", async () => {
+    // PostHog groups an inbox by (route, error type). A second spelling would
+    // split one incident into two that each look half as urgent.
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    const spy = captureSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      captureException: spy.capture as never,
+    });
+    assert.ok(spy.events.length > 0);
+    assert.ok(spy.events.every((e) => e.route === BUFFER_ROUTE));
   });
 });

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -51,9 +51,21 @@ import {
 import { createPgSql, type HyperdriveLike } from "../src/pg-sql.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "../src/lane-health.ts";
+import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 
 /** The lane the drain itself reports under. */
 export const BUFFER_FLUSH_LANE = "neon:buffer-flush";
+
+/**
+ * The route label every capture from this file carries.
+ *
+ * ONE STRING, because PostHog groups an inbox by (route, error type) and a
+ * second spelling would split one incident into two issues that each look half
+ * as urgent. The lane verdict is the durable record; this is the notification
+ * path -- see src/lane-health.ts's header for why the repo keeps both, and why
+ * PostHog is deliberately NOT the record.
+ */
+export const BUFFER_ROUTE = "neon-write-buffer";
 
 /** Where the monotonic sequence lives, outside the statement prefix. */
 const SEQ_KEY = "seq";
@@ -144,10 +156,13 @@ export async function flushBuffer(
     laneHealthDb?: LaneHealthDb | null;
     sql?: { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null;
     now?: () => number;
+    captureException?: typeof recordExceptionEvent;
   } = {},
 ): Promise<FlushOutcome> {
   const now = deps.now ?? Date.now;
   const laneDb = deps.laneHealthDb ?? laneHealthStore(env);
+  const capture = deps.captureException ?? recordExceptionEvent;
+  const asEnv = env as unknown as Parameters<typeof recordExceptionEvent>[0];
   const stored = await storage.list<Uint8Array>({ prefix: STATEMENT_PREFIX });
   const groups = groupChunkKeys([...stored.keys()]);
   if (groups.length === 0) return { drained: 0, undecodable: 0, ok: true };
@@ -166,6 +181,15 @@ export async function flushBuffer(
       age_ms: null,
       detail: `hyperdrive unbound with ${groups.length} statement(s) buffered`,
       checked_at: now(),
+    });
+    // The backlog is safe but growing, and nothing else will say so until a
+    // freshness watchdog trips two hours later.
+    await capture(asEnv, {
+      error: new Error(
+        `neon write buffer cannot flush: hyperdrive unbound, ${groups.length} statement(s) held`,
+      ),
+      route: BUFFER_ROUTE,
+      errorCode: "flush_hyperdrive_unbound",
     });
     return {
       drained: 0,
@@ -187,6 +211,16 @@ export async function flushBuffer(
       // write must not wedge the whole backlog behind it.
       undecodable += 1;
       drainedKeys.push(...group.keys);
+      // DISCARDING A STATEMENT IS DATA LOSS, and the only kind this design can
+      // produce. It must page rather than show up as a number in a detail
+      // string nobody reads.
+      await capture(asEnv, {
+        error: new Error(
+          `neon write buffer discarded an unreadable statement at seq ${group.seq}`,
+        ),
+        route: BUFFER_ROUTE,
+        errorCode: "flush_undecodable_statement",
+      });
       continue;
     }
     const tally = perLane.get(statement.lane) ?? { ok: 0, failed: 0 };
@@ -205,6 +239,11 @@ export async function flushBuffer(
       await storage.delete(drainedKeys);
       await recordFlushVerdicts(laneDb, perLane, now());
       const reason = error instanceof Error ? error.message : String(error);
+      await capture(asEnv, {
+        error,
+        route: BUFFER_ROUTE,
+        errorCode: "flush_failed",
+      });
       await recordLaneVerdict(laneDb, {
         lane: BUFFER_FLUSH_LANE,
         verdict: "stale",
@@ -293,6 +332,22 @@ export class NeonWriteBufferHub implements DurableObject {
       statement,
       Date.now(),
     );
+    if (!result.accepted) {
+      // THE BUFFER IS FULL. Producers are enqueueing faster than the flush
+      // drains, which means the flush is failing or Neon is refusing -- and
+      // from here on, capture rows are being turned away. The lane verdict
+      // says so too, but this is the path that pages.
+      await recordExceptionEvent(
+        this.env as unknown as Parameters<typeof recordExceptionEvent>[0],
+        {
+          error: new Error(
+            `neon write buffer refused a statement: ${result.reason}`,
+          ),
+          route: BUFFER_ROUTE,
+          errorCode: "buffer_full",
+        },
+      );
+    }
     // 503, not 500: the buffer being full is backpressure the producer should
     // retry against, not a bug in the request it just made.
     return result.accepted
@@ -302,10 +357,29 @@ export class NeonWriteBufferHub implements DurableObject {
 
   async alarm(): Promise<void> {
     const storage = this.state.storage as unknown as BufferStorage;
-    // `this.state` IS the WaitUntilLike the flush needs -- DurableObjectState
-    // carries waitUntil, so wrapping it would add a branch with nothing on the
-    // other side of it.
-    const outcome = await flushBuffer(storage, this.env, this.state);
+    let outcome: FlushOutcome;
+    try {
+      // `this.state` IS the WaitUntilLike the flush needs -- DurableObjectState
+      // carries waitUntil, so wrapping it would add a branch with nothing on
+      // the other side of it.
+      outcome = await flushBuffer(storage, this.env, this.state);
+    } catch (error) {
+      // flushBuffer is written not to throw, so reaching here means something
+      // outside its own error handling broke -- storage itself, most likely.
+      // WITHOUT THIS THE ALARM DIES SILENTLY: an uncaught throw in alarm()
+      // leaves no verdict, no capture, and no rescheduled alarm, so the buffer
+      // stops draining and nothing says why until a freshness watchdog trips.
+      await recordExceptionEvent(
+        this.env as unknown as Parameters<typeof recordExceptionEvent>[0],
+        { error, route: BUFFER_ROUTE, errorCode: "flush_alarm_threw" },
+      );
+      outcome = {
+        drained: 0,
+        undecodable: 0,
+        ok: false,
+        reason: error instanceof Error ? error.message : String(error),
+      };
+    }
     // A FAILED flush is the only reason to re-arm. A successful one drained
     // everything it listed, and the alarm has already fired and cleared -- so
     // the next enqueue arms the next drain, which is exactly what


### PR DESCRIPTION
## Summary

The buffer wrote lane verdicts — the durable **record** — and emitted no PostHog `$exception`, which
is the **notification**. `src/lane-health.ts`'s header draws that distinction deliberately: PostHog
can be dropped by quota so it is not the record, but a row in `lane_health` pages nobody.

Every failure mode was therefore silent until someone read the table or a freshness watchdog tripped
up to **two hours** later:

| Path | New code | Why it matters |
|---|---|---|
| Statement failed mid-drain | `flush_failed` | Backlog held and retried, but nothing says so |
| Nowhere to flush to | `flush_hyperdrive_unbound` | Backlog grows unboundedly |
| Statement unreadable | `flush_undecodable_statement` | **The only data loss this design can produce** |
| Enqueue refused | `buffer_full` | Producers outrunning the flush; capture rows turned away |
| `alarm()` threw | `flush_alarm_threw` | **Nothing drains ever again** |

The last one is the real find: `alarm()` had **no catch at all**. An uncaught throw there leaves no
verdict, no capture, and no rescheduled alarm — the buffer stops draining permanently and the only
signal is a freshness watchdog two hours later. It now catches, captures, and still re-arms.

## Design notes

**One route for all five codes.** PostHog groups an inbox by (route, error type); a second spelling
would split one incident into several that each look half as urgent.

**A clean flush pages nothing** — an inbox is only useful if the healthy path is silent. There is a
test asserting exactly that, because the failure mode of over-instrumenting is an inbox nobody reads.

**The capture seam is injectable** (`deps.captureException`), so the tests assert each code without a
live PostHog.

**Storm guard already applies:** `POSTHOG_EXCEPTION_STORM_WINDOW_MS` is 300000 on this Worker, and the
alarm fires every 10 minutes — so a persistently failing flush pages each time without spamming.

## No tracing spans, deliberately

`POSTHOG_TRACES_SAMPLE_RATE` is left unset repo-wide and only MCP opts in at 0.25, because tracing
volume is what produced the PostHog bill this project already had to unwind. The alarm fires 6×/hour;
spans would be recurring cost for failures the `$exception` path already covers. Worth revisiting only
if a flush failure ever needs per-step attribution.

## Validation

```
npx tsc --noEmit               # clean
npm run lint · format:check    # clean
npm run validate               # exit 0
npx vitest run <4 suites>      # 284 passed
```

Patch coverage by diff intersection: **zero uncovered statements, zero uncovered branches**, including
both sides of the alarm's non-Error throw.

Closes #10696