### PR TITLE
fix(watchdog): alarm a lane stuck on `unknown`, and derive the verdicts

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -53,6 +53,7 @@ import {
   staleLanes,
   type LaneHealthDb,
   type LaneHealthRecord,
+  type LaneVerdict,
 } from "./lane-health.ts";
 import { recordLaneVerdict } from "./lane-health.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
@@ -141,7 +142,10 @@ export function laneAlarmTitle(lane: string): string {
 }
 
 /** Which of the two faults an alarm is about. */
-export type LaneAlarmKind = "stale" | "silent";
+/** `stale` and `unknown` are VERDICTS the watchdog wrote; `silent` is this
+ * module's own finding -- the absence of any verdict at all -- so it is the one
+ * member not derived from the schema. */
+export type LaneAlarmKind = LaneFindingVerdict | "silent";
 
 export interface LaneAlarm {
   lane: string;
@@ -171,11 +175,61 @@ export interface LaneAlarm {
  * hypothetical: `subnet-snapshot` and `top-holders-staleness` each had zero `ok`
  * verdicts in the five days before this was written.
  */
-export const LANE_STALE_RUN_SQL =
-  "SELECT lane, MIN(checked_at) AS since, COUNT(*) AS ticks " +
-  "FROM lane_health h WHERE verdict = 'stale' AND checked_at > COALESCE(" +
-  "(SELECT MAX(checked_at) FROM lane_health x " +
-  "WHERE x.lane = h.lane AND x.verdict <> 'stale'), 0) GROUP BY lane";
+/** An unbroken run of one verdict per lane: when it started and how many ticks
+ * it has lasted. Named once rather than restated at each of the four places it
+ * appears -- the loaders, the plan input and the plan's own reads. */
+export type LaneVerdictRuns = Record<string, { since: number; ticks: number }>;
+
+/** The verdicts that are FINDINGS -- every one except `ok`. Derived from
+ * LaneVerdict (itself derived from the published self-health schema) rather than
+ * restated, for the reason lane-health.ts gives about its own type: a verdict
+ * added to the schema must not be able to appear in the API and be silently
+ * unalarmable here. */
+type LaneFindingVerdict = Exclude<LaneVerdict, "ok">;
+
+function laneRunSql(verdict: LaneFindingVerdict): string {
+  // `verdict` comes from a closed, schema-derived union, never from input --
+  // interpolated because a placeholder cannot stand where the correlated
+  // subquery needs the same value twice, and the alternative is two
+  // near-identical strings that drift.
+  return (
+    "SELECT lane, MIN(checked_at) AS since, COUNT(*) AS ticks " +
+    `FROM lane_health h WHERE verdict = '${verdict}' AND checked_at > COALESCE(` +
+    "(SELECT MAX(checked_at) FROM lane_health x " +
+    `WHERE x.lane = h.lane AND x.verdict <> '${verdict}'), 0) GROUP BY lane`
+  );
+}
+
+/**
+ * One entry per finding verdict, and `Record<LaneFindingVerdict, …>` is what
+ * makes that a CHECKED claim rather than a comment: add a verdict to
+ * LANE_VERDICTS in schemas-src/routes/self-health.ts and this object stops
+ * compiling until it has a run query too.
+ *
+ * That is the property worth having. A verdict the API can publish but this
+ * module cannot alarm on is exactly the hole #10695 fixed for `unknown` -- it
+ * existed for months because nothing anywhere forced the two sets to match.
+ */
+const VERDICT_RUN_SQL: Record<LaneFindingVerdict, string> = {
+  stale: laneRunSql("stale"),
+  unknown: laneRunSql("unknown"),
+};
+
+export const LANE_STALE_RUN_SQL = VERDICT_RUN_SQL.stale;
+
+/**
+ * The same run query for `unknown` (#10695).
+ *
+ * WHY `unknown` NEEDS ITS OWN ALARM. The close path below already refuses to
+ * treat it as recovery -- "a lane that went `unknown` has not recovered" -- and
+ * migrations/neon/0006 says the same thing about the column: collapsing
+ * `unknown` into `ok` "would report an unmeasured lane as a healthy one". The
+ * OPEN path had no `unknown` case at all, so a lane that went from `ok` straight
+ * to `unknown` and stayed there alarmed on neither loop: not stale, and not
+ * silent because it kept recording. The two halves disagreed about what the
+ * verdict means.
+ */
+export const LANE_UNKNOWN_RUN_SQL = VERDICT_RUN_SQL.unknown;
 
 /**
  * Each lane's observed cadence, as a mean gap.
@@ -337,7 +391,9 @@ export interface LaneAlarmPlanInput {
   /** Newest verdict per lane, from loadLatestLaneHealth. */
   latest: Record<string, LaneHealthRecord>;
   /** Current unbroken stale runs, keyed by lane. */
-  runs: Record<string, { since: number; ticks: number }>;
+  runs: LaneVerdictRuns;
+  /** Current unbroken `unknown` runs, keyed by lane (#10695). */
+  unknownRuns: LaneVerdictRuns;
   /** Observed cadence per lane, keyed by lane. Null where uncalibrated. */
   cadence: Record<string, number | null>;
   /** Lanes that already have an open alarm issue. */
@@ -361,7 +417,8 @@ export interface LaneAlarmPlan {
  * network, so every branch below is reachable from a test.
  */
 export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
-  const { latest, runs, cadence, openAlarms, nowMs, minStaleMs } = input;
+  const { latest, runs, unknownRuns, cadence, openAlarms, nowMs, minStaleMs } =
+    input;
   const qualified: LaneAlarm[] = [];
 
   const stale = staleLanes(latest);
@@ -385,10 +442,51 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     });
   }
 
+  // UNKNOWN, on the same bound as stale (#10695). A single `unknown` tick is
+  // ordinary -- one unreadable table, one cross-check that could not run -- so
+  // this alarms only on a run of them longer than `minStaleMs`, exactly as the
+  // stale loop does. What it ends is the state where a watchdog says "I could
+  // not evaluate this" every hour and nothing anywhere reads that as a fault.
+  //
+  // Reported as its own kind rather than folded into `stale`, because they are
+  // different findings and the message has to say which: `stale` means a breach
+  // was measured, `unknown` means the measurement itself did not happen.
+  for (const record of Object.values(latest)) {
+    if (record.verdict !== "unknown") continue;
+    if (nowMs - record.checked_at > LANE_ALARM_MAX_VERDICT_AGE_MS) continue;
+    // STILL RECORDING, or this is the silence loop's finding rather than ours.
+    // "an `unknown` verdict is never STALE, but can still go silent" was already
+    // the rule here, and it is the right one: a lane that stopped reporting is a
+    // dead producer, which outranks "the producer is running but cannot
+    // measure". Gating on liveness rather than de-duplicating afterwards keeps
+    // the two loops mutually exclusive by construction.
+    const unknownCadenceMs = cadence[record.lane] ?? null;
+    if (
+      unknownCadenceMs !== null &&
+      nowMs - record.checked_at >= laneSilenceThresholdMs(unknownCadenceMs)
+    ) {
+      continue;
+    }
+    const run = unknownRuns[record.lane];
+    const since = run?.since ?? record.checked_at;
+    if (nowMs - since < minStaleMs) continue;
+    qualified.push({
+      lane: record.lane,
+      kind: "unknown",
+      since,
+      ticks: run?.ticks ?? 1,
+      detail: record.detail,
+      age_ms: record.age_ms,
+      cadence_ms: cadence[record.lane] ?? null,
+    });
+  }
+
   for (const record of Object.values(latest)) {
     // A lane already alarming as STALE is not also alarming as SILENT. The
     // watchdog said so itself; that it then stopped saying so is the same
     // outage, and two issues for one fault is the noise this is trying to end.
+    // `unknown` needs no equivalent guard: the loop above takes only lanes that
+    // are still recording, and this one only lanes that have stopped.
     if (record.verdict === "stale") continue;
     // A lane whose silence carries no information (#10634). Checked here, in
     // the SILENT loop only, so the stale loop above still alarms on a verdict
@@ -510,14 +608,27 @@ function toInt(value: unknown): number {
 
 /** Current stale runs, keyed by lane. `{}` on any failure -- a reader that
  * throws is a reader that stops reading. */
+export async function loadLaneUnknownRuns(
+  db: D1Like | null | undefined,
+): Promise<LaneVerdictRuns> {
+  return loadLaneRuns(db, LANE_UNKNOWN_RUN_SQL);
+}
+
 export async function loadLaneStaleRuns(
   db: D1Like | null | undefined,
-): Promise<Record<string, { since: number; ticks: number }>> {
+): Promise<LaneVerdictRuns> {
+  return loadLaneRuns(db, LANE_STALE_RUN_SQL);
+}
+
+async function loadLaneRuns(
+  db: D1Like | null | undefined,
+  sql: string,
+): Promise<LaneVerdictRuns> {
   if (!db?.prepare) return {};
   try {
-    const result = await db.prepare(LANE_STALE_RUN_SQL).all?.();
+    const result = await db.prepare(sql).all?.();
     const rows = (result?.results ?? []) as Record<string, unknown>[];
-    const out: Record<string, { since: number; ticks: number }> = {};
+    const out: LaneVerdictRuns = {};
     for (const row of rows) {
       const lane = row.lane == null ? "" : String(row.lane);
       if (!lane) continue;
@@ -670,9 +781,10 @@ export async function runLaneAlarm(
   const minStaleMs =
     Number(env?.LANE_ALARM_MIN_STALE_MS) || LANE_ALARM_MIN_STALE_MS;
 
-  const [latest, runs, cadence] = await Promise.all([
+  const [latest, runs, unknownRuns, cadence] = await Promise.all([
     loadLatestLaneHealth(db),
     loadLaneStaleRuns(db),
+    loadLaneUnknownRuns(db),
     loadLaneCadence(db, nowMs - LANE_ALARM_CADENCE_WINDOW_MS),
   ]);
 
@@ -694,6 +806,7 @@ export async function runLaneAlarm(
   const plan = laneAlarmPlan({
     latest,
     runs,
+    unknownRuns,
     cadence,
     openAlarms: openAlarms ?? {},
     nowMs,

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -134,6 +134,7 @@ describe("laneAlarmPlan", () => {
   const base = {
     latest: {},
     runs: {},
+    unknownRuns: {},
     cadence: {},
     openAlarms: {},
     nowMs: NOW,
@@ -166,6 +167,79 @@ describe("laneAlarmPlan", () => {
   // poller was 31 seconds behind head and writing normally — five deploys in the
   // cadence window were enough to calibrate a "cadence" out of DEPLOY intervals,
   // after which the healthy state (no reboot) reads as an outage.
+  // #10695: the verdict the OPEN path had no case for.
+  //
+  // The close path already refused to treat `unknown` as recovery, and
+  // migrations/neon/0006 says collapsing it into `ok` "would report an unmeasured
+  // lane as a healthy one" -- but nothing opened an alarm for it. A lane that went
+  // `ok` -> `unknown` and stayed there was invisible: not stale, and not silent
+  // because it kept recording. Measured consequence: #10676 moved
+  // `table-freshness` off a `providers` breach, which left it reporting `unknown`
+  // for the stampFrom divergence (#10656) with nothing to say so.
+  test("alarms a lane stuck on `unknown` past the stale bound", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "unknown" }) },
+      unknownRuns: { a: { since: NOW - 4 * HOUR, ticks: 4 } },
+      cadence: { a: 15 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].lane, "a");
+    // Its OWN kind, not folded into stale: `stale` means a breach was measured,
+    // `unknown` means the measurement did not happen.
+    assert.equal(plan.open[0].kind, "unknown");
+    assert.equal(plan.open[0].ticks, 4);
+  });
+
+  test("one `unknown` tick is ordinary, not an alarm", () => {
+    // An unreadable table or a cross-check that could not run is a normal single
+    // tick. The bound is the same one stale uses, so this cannot become noisier
+    // than the stale path it mirrors.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", verdict: "unknown" }) },
+      unknownRuns: { a: { since: NOW - 60_000, ticks: 1 } },
+      cadence: { a: 15 * 60_000 },
+    });
+    assert.deepEqual(plan.open, []);
+  });
+
+  test("a LIVE `unknown` lane alarms once, as unknown and not as silent", () => {
+    // Two issues for one fault is the noise this design avoids. The lane is
+    // still recording, so it is the unknown loop's finding; the silence loop
+    // must not also claim it.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({ lane: "a", verdict: "unknown", checked_at: NOW - 30_000 }),
+      },
+      unknownRuns: { a: { since: NOW - 6 * HOUR, ticks: 6 } },
+      cadence: { a: 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "unknown");
+  });
+
+  test("an `unknown` lane that STOPPED recording is silent, not unknown", () => {
+    // The pre-existing rule, and the right priority: a dead producer outranks
+    // "running but cannot measure". Without the liveness gate in the unknown
+    // loop this would report the weaker finding.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({
+          lane: "a",
+          verdict: "unknown",
+          checked_at: NOW - 6 * HOUR,
+        }),
+      },
+      unknownRuns: { a: { since: NOW - 6 * HOUR, ticks: 6 } },
+      cadence: { a: 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "silent");
+  });
+
   test("never alarms an exempt lane for silence, however long it is quiet", () => {
     const plan = laneAlarmPlan({
       ...base,


### PR DESCRIPTION
`lane-alarm`'s close path refuses to treat `unknown` as recovery. Its **open** path had no `unknown` case at all. A lane going `ok` → `unknown` and staying there alarmed on **neither** loop — not stale, and not silent because it kept recording.

The schema sides with the close path. `migrations/neon/0006_lane_health.sql`:

> `unknown` is deliberately distinct from `ok`: a watchdog that could not evaluate has not observed health, and collapsing the two would report an unmeasured lane as a healthy one.

## What was actually decided, and when

The one existing test is `an \`unknown\` verdict is never STALE, but can still go silent`, added **2026-08-06** in `9ef2bab37` (#9698 — the commit that introduced this file). Its fixture is `checked_at: NOW - 9 * HOUR`: a lane that is `unknown` **and** dead. Its own comment says the quiet part out loud —

> "the watchdog cannot evaluate this lane **and has now stopped trying**"

— so what was settled is that *that combination* is caught by silence. A **live** `unknown` lane was never considered. The title reads like a policy; the test is one case.

## It was about to matter

#10676 moved `table-freshness` off its `providers` breach. The sweep still finds the `stampFrom` divergence (#10656), and a divergence produces `unknown`, not `stale`. That lane was about to go quiet carrying a real, unresolved measurement failure — #10635's fault arrived at from the other side.

## The change

A third loop mirroring stale on the same `minStaleMs` bound: one `unknown` tick is ordinary (an unreadable table, a cross-check that could not run); a run of them is a finding. Its own kind, because **`stale` means a breach was measured and `unknown` means the measurement did not happen** — the message has to say which.

**Priority preserved.** The new loop is gated on the lane still recording, so `unknown` + quiet is still SILENT: a dead producer outranks "running but cannot measure", which is what #9698 got right. Gating on liveness rather than de-duplicating afterwards keeps the two loops mutually exclusive by construction, and the pre-existing test passes **unchanged**.

## Stop hand-rolling the verdict vocabulary

`lane-health.ts` already derives `LaneVerdict` from the published schema, and says why: *"so the set of verdicts this module can persist and the set the API documents cannot drift apart."* This follows it instead of restating `"stale" | "unknown"`:

```ts
type LaneFindingVerdict = Exclude<LaneVerdict, "ok">;

const VERDICT_RUN_SQL: Record<LaneFindingVerdict, string> = {
  stale: laneRunSql("stale"),
  unknown: laneRunSql("unknown"),
};

export type LaneAlarmKind = LaneFindingVerdict | "silent";
```

`Record<LaneFindingVerdict, …>` makes the coverage claim **checked**, not commented. Verified by adding `"degraded"` to `LANE_VERDICTS` in `schemas-src/routes/self-health.ts`:

```
src/lane-alarm.ts(208,7): error TS2741: Property 'degraded' is missing in type
  '{ stale: string; unknown: string; }' but required in type 'Record<LaneFindingVerdict, string>'
```

A verdict the API can publish but this module cannot alarm on is exactly the hole above, and it survived because nothing forced the two sets to match. `silent` stays a literal — it is the one kind that is genuinely this module's own finding rather than a persisted verdict.

Also names `LaneVerdictRuns` once instead of restating `Record<string, { since: number; ticks: number }>` at six sites.

## Proven to fail

```
removed the unknown loop      → 2 failed | 57 passed
removed the liveness gate     → 2 failed | 57 passed   (the priority inverts)
```

## Verification

- `tsc --noEmit`, `npm run lint`, `npm run format:check` all clean
- **138 tests pass** across `lane-alarm`, `lane-health`, `lane-health-silence`, `lane-health-retired`, `self-health`, `self-health-mcp`
- Rebased onto `3bcbe3058`, then tsc + 59 tests re-run

Closes #10698
