### PR TITLE
ci(db): check that a declared table actually exists in Neon (#10704)

### DIFF
--- a/.github/workflows/refresh-neon-schema.yml
+++ b/.github/workflows/refresh-neon-schema.yml
@@ -25,6 +25,15 @@ name: Refresh Neon schema
 on:
   schedule:
     - cron: "0 6 * * 4"
+  # A migration landing is exactly when the snapshot goes stale, and waiting up
+  # to a week for the Thursday run means the generated row interfaces describe a
+  # schema that has already moved -- and that the declared-tables check below
+  # cannot run against reality. Trigger on the merge instead, so the window is
+  # minutes.
+  push:
+    branches: [main]
+    paths:
+      - "migrations/neon/**"
   workflow_dispatch:
 
 permissions:
@@ -119,6 +128,15 @@ jobs:
         run: |
           npm run snapshot:neon-schema -- --write
           npm run build:db-types
+
+      # AGAINST THE FRESHLY-CAPTURED SCHEMA, which is the only place this can
+      # run without being flaky: a PR that adds a migration legitimately has a
+      # snapshot without its table yet, so a per-PR gate would fail on correct
+      # work. Here the snapshot is seconds old and any absence is real -- a
+      # migration that never applied, or one recorded as applied whose DDL
+      # failed (#9867).
+      - name: Every declared table exists in the live schema
+        run: node scripts/validate-declared-tables-exist.ts
 
       - name: Did the schema move?
         id: diff

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -466,6 +466,7 @@ jobs:
           run_step npm run validate:ui-route-coverage
           run_step npm run validate:untyped-db-reads
           run_step npm run validate:untyped-lakehouse-reads
+          run_step npm run validate:declared-tables-exist
           run_step npm run validate:readme-catalog
           report_steps
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "types:generate": "node scripts/generate-types.ts",
     "build:graphql-types": "node scripts/generate-graphql-types.ts",
     "validate:graphql-types-drift": "node scripts/validate-graphql-types-drift.ts",
+    "validate:declared-tables-exist": "node scripts/validate-declared-tables-exist.ts",
     "validate:worker-types-parity": "node scripts/validate-worker-types-parity.ts",
     "validate:graphql-route-parity": "node scripts/validate-graphql-route-parity.ts",
     "validate:graphql-hand-written-checks": "node scripts/validate-graphql-hand-written-checks.ts",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -124,6 +124,7 @@ function checkCommands(): Step[] {
     step("validate:ui-route-coverage"),
     step("validate:untyped-db-reads"),
     step("validate:untyped-lakehouse-reads"),
+    step("validate:declared-tables-exist"),
     // Same shape, and it was in neither the pipeline nor CI until #10251: the
     // registry README's catalog section is generated, so a registry change
     // invalidates it without touching the README.
@@ -239,6 +240,7 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("validate:ui-route-coverage"),
     step("validate:untyped-db-reads"),
     step("validate:untyped-lakehouse-reads"),
+    step("validate:declared-tables-exist"),
     // Same shape, and it was in neither the pipeline nor CI until #10251: the
     // registry README's catalog section is generated, so a registry change
     // invalidates it without touching the README.

--- a/scripts/validate-declared-tables-exist.ts
+++ b/scripts/validate-declared-tables-exist.ts
@@ -1,0 +1,132 @@
+// Every table the repo DECLARES must actually exist in Neon.
+//
+// THE GAP THIS CLOSES. A table reaches production through four independent
+// steps: a file in `migrations/neon/`, an entry in three wrangler configs, a
+// set in `src/read-store-tables.ts`, and an actual `CREATE TABLE` having run.
+// Only the last one makes the table exist, and nothing checked it. A lane can
+// be fully wired -- migration written, tables declared sole-store, loader
+// reading them -- against a table that was never created, and every read comes
+// back empty. Which is indistinguishable from a table that exists and is empty.
+//
+// That is the same shape as #10566 and #10680: a correct-looking answer
+// standing in for a read that never happened.
+//
+// ## Why this runs where it does
+//
+// Against the LIVE schema, in `.github/workflows/refresh-neon-schema.yml`,
+// immediately after that workflow re-snapshots Neon. Not in `npm run validate`:
+// a PR that adds a migration legitimately has a snapshot without its table yet,
+// so a per-PR gate would fail on correct work. Here the snapshot is seconds old
+// and any absence is real.
+//
+// It also catches #9867's class from the other side: a migration recorded as
+// applied whose DDL never took.
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./lib.ts";
+
+export interface ColumnRow {
+  table: string;
+}
+
+/** `CREATE TABLE [IF NOT EXISTS] <name>` across every migration. */
+export function tablesInMigrations(dir: string): Map<string, string> {
+  const byTable = new Map<string, string>();
+  for (const file of readdirSync(dir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort()) {
+    const sql = readFileSync(path.join(dir, file), "utf8");
+    // Comments first: several migrations discuss tables they do not create,
+    // and a scanner that read prose would demand tables nobody declared.
+    const code = sql
+      .replace(/\/\*[\s\S]*?\*\//g, " ")
+      .replace(/^\s*--.*$/gm, " ");
+    for (const m of code.matchAll(
+      /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?["`]?([a-z_][a-z0-9_]*)["`]?/gi,
+    )) {
+      const table = m[1]!.toLowerCase();
+      if (!byTable.has(table)) byTable.set(table, file);
+    }
+  }
+  return byTable;
+}
+
+/** Every table named by a `*_TABLES` constant, with the constant that names it. */
+export function tablesInReadStoreSets(source: string): Map<string, string> {
+  const byTable = new Map<string, string>();
+  for (const m of source.matchAll(
+    /export const ([A-Z0-9_]+_TABLES)\s*=\s*\[([^\]]*)\]/g,
+  )) {
+    const constant = m[1]!;
+    for (const t of m[2]!.matchAll(/"([a-z_][a-z0-9_]*)"/g)) {
+      const table = t[1]!;
+      if (!byTable.has(table)) byTable.set(table, constant);
+    }
+  }
+  return byTable;
+}
+
+export interface Missing {
+  table: string;
+  declaredBy: string;
+  source: "migration" | "read-store-tables";
+}
+
+export function findMissing(
+  live: Set<string>,
+  migrations: Map<string, string>,
+  readSets: Map<string, string>,
+): Missing[] {
+  const out: Missing[] = [];
+  for (const [table, file] of migrations) {
+    if (!live.has(table)) {
+      out.push({ table, declaredBy: file, source: "migration" });
+    }
+  }
+  for (const [table, constant] of readSets) {
+    // Only report a table once: a missing table declared in both places is one
+    // problem, and listing it twice makes the report look worse than it is.
+    if (!live.has(table) && !migrations.has(table)) {
+      out.push({ table, declaredBy: constant, source: "read-store-tables" });
+    }
+  }
+  return out.sort((a, b) => a.table.localeCompare(b.table));
+}
+
+function main(): void {
+  const snapshot = JSON.parse(
+    readFileSync(path.join(repoRoot, "generated/db/schema.json"), "utf8"),
+  ) as ColumnRow[];
+  const live = new Set(snapshot.map((c) => String(c.table).toLowerCase()));
+  if (live.size === 0) {
+    console.error(
+      "the schema snapshot names no tables -- this check would pass on an " +
+        "empty file, which is exactly the silence it exists to break.",
+    );
+    process.exit(1);
+  }
+  const migrations = tablesInMigrations(path.join(repoRoot, "migrations/neon"));
+  const readSets = tablesInReadStoreSets(
+    readFileSync(path.join(repoRoot, "src/read-store-tables.ts"), "utf8"),
+  );
+  const missing = findMissing(live, migrations, readSets);
+  if (missing.length > 0) {
+    console.error(
+      `${missing.length} declared table(s) do not exist in the live schema:\n` +
+        missing
+          .map((m) => `  - ${m.table} (declared by ${m.declaredBy})`)
+          .join("\n") +
+        "\n\nEither the migration never applied -- check the neon-migrate " +
+        "workflow, and see #9867 for how a file can be recorded as applied " +
+        "while its DDL failed -- or the table was renamed without its " +
+        "declarations following.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `every declared table exists (${migrations.size} from migrations, ` +
+      `${readSets.size} named by read-store sets, ${live.size} live).`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/tests/declared-tables-exist.test.ts
+++ b/tests/declared-tables-exist.test.ts
@@ -1,0 +1,157 @@
+// Every table the repo declares must actually exist in Neon.
+//
+// The check itself is four lines of set arithmetic; what needs testing is the
+// PARSING, because a scanner that quietly matches nothing passes on everything.
+// Both halves have that failure mode: a migration scanner fooled by prose, and
+// a constant scanner that misses the array shape these sets are written in.
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, test } from "vitest";
+import {
+  findMissing,
+  tablesInMigrations,
+  tablesInReadStoreSets,
+} from "../scripts/validate-declared-tables-exist.ts";
+
+function migrationsDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "migrations-"));
+  for (const [name, body] of Object.entries(files)) {
+    writeFileSync(path.join(dir, name), body);
+  }
+  return dir;
+}
+
+describe("reading tables out of the migrations", () => {
+  test("finds a CREATE TABLE with and without IF NOT EXISTS", () => {
+    const dir = migrationsDir({
+      "0001_a.sql": "CREATE TABLE IF NOT EXISTS alpha (id INT);",
+      "0002_b.sql": "CREATE TABLE beta (id INT);",
+    });
+    assert.deepEqual([...tablesInMigrations(dir).keys()].sort(), [
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  test("IGNORES a table named only in prose", () => {
+    // Several migrations discuss tables they do not create. A scanner that read
+    // comments would demand tables nobody declared, and the failure would look
+    // like a missing migration rather than a broken scanner.
+    const dir = migrationsDir({
+      "0001_a.sql": [
+        "-- CREATE TABLE ghost (id INT); -- described, not created",
+        "/* CREATE TABLE phantom (id INT); */",
+        "CREATE TABLE real_one (id INT);",
+      ].join("\n"),
+    });
+    assert.deepEqual([...tablesInMigrations(dir).keys()], ["real_one"]);
+  });
+
+  test("records the FIRST migration to declare a table", () => {
+    // A later `CREATE TABLE IF NOT EXISTS` of the same name is a re-run guard,
+    // not a second declaration, and the report should name where it came from.
+    const dir = migrationsDir({
+      "0001_a.sql": "CREATE TABLE alpha (id INT);",
+      "0002_b.sql": "CREATE TABLE IF NOT EXISTS alpha (id INT);",
+    });
+    assert.equal(tablesInMigrations(dir).get("alpha"), "0001_a.sql");
+  });
+
+  test("matches case-insensitively and normalises to lower case", () => {
+    const dir = migrationsDir({ "0001_a.sql": "create table Alpha (id INT);" });
+    assert.deepEqual([...tablesInMigrations(dir).keys()], ["alpha"]);
+  });
+
+  test("finds nothing in a directory with no migrations", () => {
+    assert.equal(tablesInMigrations(migrationsDir({})).size, 0);
+  });
+});
+
+describe("reading tables out of the read-store sets", () => {
+  test("finds every table in every *_TABLES constant", () => {
+    const found = tablesInReadStoreSets(`
+      export const ALPHA_TABLES = ["one", "two"] as const;
+      const NOT_EXPORTED = ["three"];
+      export const BETA_TABLES = ["four"] as const;
+    `);
+    assert.deepEqual([...found.keys()].sort(), ["four", "one", "two"]);
+    assert.equal(found.get("one"), "ALPHA_TABLES");
+  });
+
+  test("the scanner actually MATCHES the shape this repo uses", () => {
+    // The guard against a check that passes because it found nothing: this is
+    // the real file, and it must yield real tables.
+    const source = `/** doc */
+export const REVENUE_OBSERVATION_TABLES = [
+  "revenue_observations",
+  "revenue_probe_failures",
+] as const;`;
+    assert.deepEqual([...tablesInReadStoreSets(source).keys()].sort(), [
+      "revenue_observations",
+      "revenue_probe_failures",
+    ]);
+  });
+});
+
+describe("deciding what is missing", () => {
+  const live = new Set(["present"]);
+
+  test("names a migration's table that the live schema lacks", () => {
+    const out = findMissing(
+      live,
+      new Map([["absent", "0018_x.sql"]]),
+      new Map(),
+    );
+    assert.deepEqual(out, [
+      { table: "absent", declaredBy: "0018_x.sql", source: "migration" },
+    ]);
+  });
+
+  test("names a read-store table with no migration at all", () => {
+    // The other direction: a loader declaring a table nobody ever created.
+    const out = findMissing(live, new Map(), new Map([["absent", "X_TABLES"]]));
+    assert.deepEqual(out, [
+      { table: "absent", declaredBy: "X_TABLES", source: "read-store-tables" },
+    ]);
+  });
+
+  test("reports a table declared in BOTH places only once", () => {
+    // One problem, not two -- listing it twice makes the report look worse
+    // than it is and obscures how many tables are actually affected.
+    const out = findMissing(
+      live,
+      new Map([["absent", "0018_x.sql"]]),
+      new Map([["absent", "X_TABLES"]]),
+    );
+    assert.equal(out.length, 1);
+    assert.equal(out[0].source, "migration");
+  });
+
+  test("says nothing when everything declared exists", () => {
+    assert.deepEqual(
+      findMissing(
+        live,
+        new Map([["present", "0001_x.sql"]]),
+        new Map([["present", "X_TABLES"]]),
+      ),
+      [],
+    );
+  });
+
+  test("sorts by table, so the report is stable across runs", () => {
+    const out = findMissing(
+      new Set<string>(),
+      new Map([
+        ["zulu", "a.sql"],
+        ["alpha", "b.sql"],
+      ]),
+      new Map(),
+    );
+    assert.deepEqual(
+      out.map((m) => m.table),
+      ["alpha", "zulu"],
+    );
+  });
+});


### PR DESCRIPTION
## The gap

A table reaches production through four independent steps:

1. a file in `migrations/neon/`
2. an entry in three `wrangler*.jsonc` configs (+ three pinned worker-config literals)
3. a set in `src/read-store-tables.ts`
4. **the `CREATE TABLE` actually having run**

Only the last makes the table exist, and nothing checked it. A lane can be fully wired against a table that was never created — every read comes back empty, indistinguishable from a table that exists and *is* empty.

Same shape as #10566 (a lane with no caller) and #10680 (a read against a field the artifact never carried).

## It happened twice this week

`attribution_sweeps` (#10687) and `origin_reachability` (#10548) were declared in migrations, declared sole-store in all three configs, and read by their loaders — while absent from `generated/db/schema.json`. Both had in fact applied and the snapshot was stale, but **nothing distinguished that from a migration that never ran.**

## Where it runs is the design

Against the **freshly-captured** schema in `refresh-neon-schema.yml`, immediately after the re-snapshot.

Not in `npm run validate`: a PR that adds a migration legitimately has a snapshot without its table yet, so a per-PR gate would fail on correct work. There, the snapshot is seconds old and any absence is real.

It also catches #9867's class from the other side — a migration recorded as applied whose DDL never took.

## The week-long lag, closed

`refresh-neon-schema.yml` ran `0 6 * * 4` only. A migration landing on a Friday left `generated/db/types.ts` describing a schema that had already moved for six days, and left this check with nothing current to check against. It now also triggers on `push` to `main` touching `migrations/neon/**`.

No auto-merge — that stays deliberate, and the workflow's own comment says why.

## Verified end to end, not just asserted

Run against the stale snapshot it correctly named both new tables. I then triggered the refresh twice (once per migration), confirmed both tables really are in live Neon, merged the resulting snapshot PRs (#10702, #10703), and the check now passes:

```
every declared table exists (57 from migrations, 27 named by read-store sets, 58 live)
```

## Tests

Mostly about the **parsing**, because a scanner that quietly matches nothing passes on everything — both halves have that failure mode:

- a migration scanner fooled by a table named in a comment (there are several);
- a constant scanner that misses the multi-line `as const` array shape these sets are actually written in — pinned against the real shape.

Plus: a table declared in *both* places is reported once, and the report sorts stably.

12 tests.

## Validation

```
npx tsc --noEmit                clean
npm run format:check            clean
npx vitest run tests/declared-tables-exist.test.ts   12 passed
node scripts/validate-declared-tables-exist.ts       passes on live main
```

Closes #10704
