### PR TITLE
refactor(db): read rows through the generated types, not hand-rolled records (#10707)

### DIFF
--- a/src/attribution-sweep.ts
+++ b/src/attribution-sweep.ts
@@ -18,6 +18,12 @@
 // own outage into a finding about somebody else — the same conflation
 // #10566 let stand for two months.
 import { isFinneySs58Address } from "./account-balance.ts";
+// The ROW shapes come from the live schema (generated/db/types.ts), not from a
+// hand-written guess at them. That is where `swept_at: number | string` comes
+// from: node-postgres returns BIGINT as a string unless the value is exactly
+// representable, and a hand-rolled `number` would be the #9782 class of bug
+// waiting to happen.
+import type { AttributionSweeps } from "../generated/db/types.ts";
 
 /** Verdicts, matching the CHECK constraint on attribution_sweeps. */
 export type SweepVerdict =
@@ -274,7 +280,7 @@ export async function loadSweepRecord(
       )
       .bind(netuid)
       .all?.();
-    const row = (res?.results ?? [])[0] as Record<string, unknown> | undefined;
+    const row = (res?.results ?? [])[0] as AttributionSweeps | undefined;
     if (!row) return null;
     const sweptAt = Number(row.swept_at);
     return {
@@ -339,7 +345,7 @@ export async function loadSweptAt(
       .prepare(`SELECT netuid, swept_at FROM attribution_sweeps`)
       .all?.();
     for (const raw of res?.results ?? []) {
-      const row = raw as Record<string, unknown>;
+      const row = raw as AttributionSweeps;
       const netuid = Number(row.netuid);
       const at = Number(row.swept_at);
       if (Number.isInteger(netuid) && Number.isFinite(at)) out.set(netuid, at);

--- a/src/origin-reachability.ts
+++ b/src/origin-reachability.ts
@@ -39,6 +39,12 @@
 // indistinguishable from a placeholder with one observation. Under-reporting a
 // dead host is recoverable; declaring a live subnet's API gone is not.
 
+// The ROW shape comes from the live schema, not a hand-written guess:
+// `checked_at: number | string` is node-postgres returning BIGINT as a string
+// unless it is exactly representable, and typing it `number` by hand would hide
+// that.
+import type { OriginReachability } from "../generated/db/types.ts";
+
 /** What one origin's check concluded. */
 export type OriginVerdict =
   /** Answered, and answered differently for different paths. */
@@ -319,7 +325,7 @@ export async function loadDeadOrigins(
       .all?.();
     const out: OriginRecord[] = [];
     for (const raw of res?.results ?? []) {
-      const row = raw as Record<string, unknown>;
+      const row = raw as OriginReachability;
       const at = Number(row.checked_at);
       out.push({
         origin: String(row.origin ?? ""),
@@ -424,7 +430,7 @@ export async function loadOriginCheckedAt(
       .prepare(`SELECT origin, checked_at FROM origin_reachability`)
       .all?.();
     for (const raw of res?.results ?? []) {
-      const row = raw as Record<string, unknown>;
+      const row = raw as OriginReachability;
       const at = Number(row.checked_at);
       if (row.origin && Number.isFinite(at)) out.set(String(row.origin), at);
     }

--- a/src/revenue-feed.ts
+++ b/src/revenue-feed.ts
@@ -24,6 +24,10 @@ import type { FeedItem } from "./feeds.ts";
 import { subnetPageUrl } from "./contracts.ts";
 import { loadPipelineHistory } from "./emission-pipeline-history.ts";
 import { loadTaoUsdSeries } from "./tao-usd-series.ts";
+import type {
+  RevenueObservations,
+  RevenueProbeFailures,
+} from "../generated/db/types.ts";
 
 /** One row of `revenue_observations`, as the feed reads it. */
 export interface RevenueObservationRow {
@@ -341,8 +345,11 @@ export interface RevenueFeedDb {
   };
 }
 
-// Deliberately loose: rows come back from two different drivers with different
-// column typing, and a narrower type would push a cast onto every field read.
+// Deliberately loose for the SHAPING helpers below, which read rows from two
+// different drivers. The two revenue tables are typed from the live schema
+// instead -- see RevenueObservations/RevenueProbeFailures at the read sites,
+// where `observed_at: number | string` is the honest BIGINT type and the reason
+// epochMs exists at all.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
 
@@ -418,19 +425,21 @@ export async function loadRevenueFeedItems(
   ]);
   if (observationRows === null && failureRows === null) return [];
 
-  const observations: RevenueObservationRow[] = (observationRows ?? []).map(
-    (r) => ({
-      surface_id: String(r.surface_id ?? ""),
-      netuid: r.netuid == null ? null : Number(r.netuid),
-      period: String(r.period ?? ""),
-      grain: r.grain == null ? null : String(r.grain),
-      amount: Number(r.amount),
-      currency: r.currency == null ? null : String(r.currency),
-      provenance: r.provenance == null ? null : String(r.provenance),
-      observed_at: isoOrNull(r.observed_at),
-    }),
-  );
-  const failures: RevenueProbeFailureRow[] = (failureRows ?? []).map((r) => ({
+  const observations: RevenueObservationRow[] = (
+    (observationRows ?? []) as RevenueObservations[]
+  ).map((r) => ({
+    surface_id: String(r.surface_id ?? ""),
+    netuid: r.netuid == null ? null : Number(r.netuid),
+    period: String(r.period ?? ""),
+    grain: r.grain == null ? null : String(r.grain),
+    amount: Number(r.amount),
+    currency: r.currency == null ? null : String(r.currency),
+    provenance: r.provenance == null ? null : String(r.provenance),
+    observed_at: isoOrNull(r.observed_at),
+  }));
+  const failures: RevenueProbeFailureRow[] = (
+    (failureRows ?? []) as RevenueProbeFailures[]
+  ).map((r) => ({
     surface_id: String(r.surface_id ?? ""),
     netuid: r.netuid == null ? null : Number(r.netuid),
     reason: r.reason == null ? null : String(r.reason),


### PR DESCRIPTION
## Summary

Three loaders written this week read their Neon rows as `Record<string, unknown>`. `generated/db/types.ts` has a real interface for all 58 tables, derived from the live schema.

| File | Table |
| --- | --- |
| `src/attribution-sweep.ts` | `attribution_sweeps` |
| `src/origin-reachability.ts` | `origin_reachability` |
| `src/revenue-feed.ts` | `revenue_observations`, `revenue_probe_failures` |

## Why it matters concretely

The generated types spell BIGINT columns **`number | string`** — node-postgres returns BIGINT as a *string* unless the value is exactly representable, and `src/pg-sql.ts` installs a parser that preserves that. A hand-rolled `Record<string, unknown>` gives no signal; a hand-rolled `number` would be a live bug.

**That trap already bit in this exact area.** `src/revenue-feed.ts` originally parsed `observed_at` with `Date.parse(String(value))` — which is `NaN` for `"1786320000000"`. Every row would have read as undated and the feed would have served empty against a full store. A test caught it. The type would have caught it first, and now does.

## What is deliberately unchanged

The **served** shapes are already Zod in `schemas-src/` and flow to OpenAPI, generated types and the client. This is only the raw row on the way in.

`AttributionCandidates` is not imported: that table has no read site yet, only writes, and the write path is positional binds it could not type anyway. An import with no use is noise.

## Ordering note

A brand-new table cannot have a generated type until its migration has applied to Neon and the snapshot refreshed — so hand-rolling *at introduction* is unavoidable. This is the follow-up now that both tables exist (verified in #10702 / #10703, gated by #10705).

## Validation

```
npx tsc --noEmit                clean
npm run lint / format:check     clean
npm run validate                pass
npm run build                   no drift
npx vitest run                  19445 passed, 0 failed
```

No behaviour change — types only. The three affected suites (150 tests) pass unchanged, which is the point: the rows were already being read correctly, they just were not typed.

Closes #10707
