### PR TITLE
feat(queues): sweep one subnet per message, not eight per invocation (#10715)

### DIFF
--- a/src/attribution-sweep.ts
+++ b/src/attribution-sweep.ts
@@ -297,123 +297,158 @@ export async function loadSweepRecord(
   }
 }
 
-// ── the lane ────────────────────────────────────────────────────────────────
+// ── the queue lane ──────────────────────────────────────────────────────────
+//
+// WHY THIS IS A QUEUE AND NOT A BIGGER CRON SLICE. The cron lane this replaced
+// swept a slice of eight subnets per tick, because 128 subnets x up to 8 sources
+// is ~1000 outbound requests and one scheduled invocation cannot do that. A full
+// pass took sixteen hours. That was never a cadence -- it was the invocation
+// budget, dressed as one.
+//
+// A queue removes the constraint rather than working around it. One message per
+// subnet is one invocation per subnet, so the whole registry is swept from a
+// single tick.
+//
+// AND IT REMOVES THE SCHEDULING MACHINERY ENTIRELY. The old lane ordered subnets
+// by staleness and took the eight oldest, which meant a store read on every tick
+// purely to decide what to skip. Enqueuing everything skips nothing, so the
+// staleness ordering, the slice size, and the producer's database handle all go
+// with it -- `swept_at` is now only a fact the API serves, never an input to
+// scheduling.
+//
+// It also turns two silent failures into visible ones:
+//
+//   - a subnet whose fetch fails is RETRIED on its own, instead of being
+//     dropped until the next hour came round to it again;
+//   - a subnet that keeps failing lands in the dead-letter queue, which
+//     src/dead-letter.ts records as a lane verdict. Under the cron it simply
+//     produced a `unreachable` row forever and nothing said the lane itself was
+//     struggling.
 
-/** Subnets swept per tick.
- *
- * A full pass is ~129 subnets x up to 8 sources = a thousand outbound requests,
- * which is not a tick, it is an incident. The lane sweeps a SLICE and picks it
- * by staleness, so the pass completes over a day without ever bursting. */
-export const SWEEP_BATCH_SIZE = 8;
-
-/**
- * The subnets to sweep next: least recently swept first, never-swept before
- * that.
- *
- * Self-balancing on purpose. A fixed rotation drifts out of step the moment a
- * tick is skipped or a subnet is added; ordering by staleness means the lane
- * converges on whatever is oldest no matter what happened before it.
- */
-export function nextToSweep(
-  netuids: number[],
-  sweptAt: Map<number, number>,
-  batch = SWEEP_BATCH_SIZE,
-): number[] {
-  return [...netuids]
-    .sort((a, b) => {
-      // Never-swept sorts first: it is the only state where we have said
-      // nothing at all, and that is the gap worth closing before refreshing a
-      // finding that already exists.
-      const av = sweptAt.get(a) ?? -1;
-      const bv = sweptAt.get(b) ?? -1;
-      return av - bv || a - b;
-    })
-    .slice(0, batch);
+/** One subnet to sweep. Deliberately just the netuid: the registry record is
+ * read by the consumer at delivery time, so a message that sits in the queue
+ * for a minute cannot sweep a stale copy of the subnet's surfaces. */
+export interface SweepMessage {
+  netuid: number;
 }
 
-/** Every subnet's last sweep time. Empty on a read failure -- which makes the
- * lane treat everything as never-swept, and re-sweep rather than skip. Erring
- * toward re-reading is the safe direction: the cost is requests, and the
- * alternative is a subnet that silently never gets looked at. */
-export async function loadSweptAt(
-  db: SweepStoreDb | null | undefined,
-): Promise<Map<number, number>> {
-  const out = new Map<number, number>();
-  if (!db?.prepare) return out;
-  try {
-    const res = await db
-      .prepare(`SELECT netuid, swept_at FROM attribution_sweeps`)
-      .all?.();
-    for (const raw of res?.results ?? []) {
-      const row = raw as AttributionSweeps;
-      const netuid = Number(row.netuid);
-      const at = Number(row.swept_at);
-      if (Number.isInteger(netuid) && Number.isFinite(at)) out.set(netuid, at);
-    }
-  } catch {
-    return new Map();
-  }
-  return out;
+export const ATTRIBUTION_SWEEP_QUEUE = "attribution-sweeps";
+export const ATTRIBUTION_SWEEP_DLQ = "attribution-sweeps-dlq";
+
+/** The minimal producer surface, injected so the enqueue is testable without a
+ * Cloudflare binding. */
+export interface SweepQueue {
+  sendBatch(messages: Array<{ body: SweepMessage }>): Promise<unknown>;
 }
 
-export interface SweepTickResult {
+/** Cloudflare caps a sendBatch at 100 messages. 128 subnets is one over two
+ * batches, which is exactly the kind of off-by-one that ships. */
+export const SWEEP_SEND_BATCH_MAX = 100;
+
+export interface EnqueueResult {
   ok: boolean;
-  swept: number;
-  candidates: number;
-  /** Verdict counts, so a pass that reached nothing is visible as such rather
-   * than as a quiet success. */
-  verdicts: Record<SweepVerdict, number>;
+  enqueued: number;
   reason?: string;
 }
 
 /**
- * One pass of the lane.
+ * Enqueue every subnet due for a sweep.
  *
- * `ok` is FALSE when the store could not be written, and when the batch was
- * empty. A lane that reports success while sweeping nothing is indistinguishable
- * from one that swept and found nothing -- the exact confusion that let the
- * revenue probe sit dead for two months (#10566).
+ * EVERY subnet, not a slice: the whole point of moving to a queue is that the
+ * producer no longer has to ration work to fit one invocation.
  */
-export async function runAttributionSweepTick(
-  db: SweepStoreDb | null | undefined,
-  subnets: Array<{ netuid: number; record: Record<string, unknown> }>,
-  deps: SweepDeps & { batch?: number },
-): Promise<SweepTickResult> {
-  const verdicts: Record<SweepVerdict, number> = {
-    "none-published": 0,
-    "candidates-found": 0,
-    unreachable: 0,
-    "no-sources": 0,
-  };
-  const byNetuid = new Map(subnets.map((s) => [s.netuid, s.record]));
-  const due = nextToSweep(
-    [...byNetuid.keys()],
-    await loadSweptAt(db),
-    deps.batch ?? SWEEP_BATCH_SIZE,
-  );
-  if (due.length === 0) {
+export async function enqueueSweeps(
+  queue: SweepQueue | null | undefined,
+  netuids: number[],
+): Promise<EnqueueResult> {
+  if (!queue?.sendBatch) {
+    return { ok: false, enqueued: 0, reason: "no_queue_binding" };
+  }
+  if (netuids.length === 0) {
+    // Not a success. A producer reporting ok while enqueuing nothing is
+    // indistinguishable from one that enqueued and found nothing to do.
+    return { ok: false, enqueued: 0, reason: "no_subnets_to_sweep" };
+  }
+  let enqueued = 0;
+  try {
+    for (let i = 0; i < netuids.length; i += SWEEP_SEND_BATCH_MAX) {
+      const slice = netuids.slice(i, i + SWEEP_SEND_BATCH_MAX);
+      await queue.sendBatch(slice.map((netuid) => ({ body: { netuid } })));
+      enqueued += slice.length;
+    }
+  } catch (error) {
     return {
       ok: false,
-      swept: 0,
-      candidates: 0,
-      verdicts,
-      reason: "no_subnets_to_sweep",
+      enqueued,
+      reason: `send_failed: ${String((error as Error)?.message ?? error)}`,
     };
   }
-  let candidates = 0;
-  const failures: string[] = [];
-  for (const netuid of due) {
-    const result = await sweepSubnet(netuid, byNetuid.get(netuid), deps);
-    verdicts[result.verdict] += 1;
-    candidates += result.candidates.length;
-    const written = await persistSweep(db, result);
-    if (!written.ok) failures.push(`${netuid}: ${written.reason}`);
+  return { ok: true, enqueued };
+}
+
+/** One delivered message, as the consumer sees it. */
+export interface SweepBatchMessage {
+  body: unknown;
+  ack(): void;
+  retry(): void;
+}
+
+export interface SweepBatchResult {
+  swept: number;
+  /** Messages handed back for retry. A subnet that could not be swept is the
+   * queue's problem to re-deliver, not a finding to write. */
+  retried: number;
+  /** Messages acked without sweeping because the body was not a sweep message.
+   * Retrying those would loop them to the dead letter for no reason. */
+  malformed: number;
+}
+
+/**
+ * Consume a batch: one subnet per message.
+ *
+ * ACK ON SUCCESS, RETRY ON FAILURE, ACK ON MALFORMED. The third is the one
+ * worth stating: a message whose body is not a netuid will never become one, so
+ * retrying it spends the whole retry budget to reach the dead letter with a
+ * message nobody can act on. It is acked and counted instead.
+ */
+export async function handleSweepBatch(
+  messages: SweepBatchMessage[],
+  db: SweepStoreDb | null | undefined,
+  deps: SweepDeps & {
+    /** The subnet's registry record, read at DELIVERY time so a queued message
+     * cannot sweep a stale copy of its surfaces. */
+    recordFor: (netuid: number) => Promise<Record<string, unknown> | null>;
+  },
+): Promise<SweepBatchResult> {
+  let swept = 0;
+  let retried = 0;
+  let malformed = 0;
+  for (const message of messages) {
+    const body = message.body as SweepMessage | null;
+    const netuid = Number(body?.netuid);
+    if (!Number.isInteger(netuid) || netuid < 0) {
+      message.ack();
+      malformed += 1;
+      continue;
+    }
+    try {
+      const record = await deps.recordFor(netuid);
+      const result = await sweepSubnet(netuid, record, deps);
+      const written = await persistSweep(db, result);
+      if (!written.ok) {
+        // The sweep happened; the WRITE did not. Retrying re-sweeps, which is
+        // wasteful but correct -- an unwritten sweep is a sweep that did not
+        // happen as far as anything reading the store is concerned.
+        message.retry();
+        retried += 1;
+        continue;
+      }
+      message.ack();
+      swept += 1;
+    } catch {
+      message.retry();
+      retried += 1;
+    }
   }
-  return {
-    ok: failures.length === 0,
-    swept: due.length,
-    candidates,
-    verdicts,
-    ...(failures.length > 0 ? { reason: failures.join("; ") } : {}),
-  };
+  return { swept, retried, malformed };
 }

--- a/src/dead-letter.ts
+++ b/src/dead-letter.ts
@@ -36,6 +36,10 @@ import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 export const DEAD_LETTER_LANES: Readonly<Record<string, string>> = {
   "sync-batches-dlq": "sync-batches-dlq",
   "webhook-deliveries-dlq": "webhook-deliveries-dlq",
+  // #10709: the attribution sweep. A subnet that keeps failing to fetch used to
+  // produce an `unreachable` row forever and nothing said the LANE was
+  // struggling; now it exhausts its retries and lands here as a verdict.
+  "attribution-sweeps-dlq": "attribution-sweeps-dlq",
 };
 
 /** Whether a delivered batch came from a dead-letter queue.

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -9,7 +9,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
-import {
+import worker, {
   fetchSweepText,
   handleScheduled,
   sweepableSubnets,
@@ -22,12 +22,12 @@ import { ATTRIBUTION_SWEEP_TABLES } from "../src/read-store-tables.ts";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 import {
-  SWEEP_BATCH_SIZE,
+  SWEEP_SEND_BATCH_MAX,
+  enqueueSweeps,
+  handleSweepBatch,
+  type SweepMessage,
   SWEEP_MAX_BYTES,
   SWEEP_MAX_SOURCES,
-  loadSweptAt,
-  nextToSweep,
-  runAttributionSweepTick,
   loadSweepRecord,
   persistSweep,
   ss58Candidates,
@@ -327,130 +327,6 @@ describe("the store", () => {
   });
 });
 
-describe("the lane", () => {
-  const record = (netuid: number, urls: string[] = []) => ({
-    netuid,
-    record: {
-      netuid,
-      surfaces: urls.map((url) => ({ kind: "website", url })),
-    },
-  });
-
-  function store(rows: unknown[] = [], onWrite?: (sql: string) => void) {
-    return {
-      prepare(sql: string) {
-        onWrite?.(sql);
-        return {
-          bind: () => ({
-            run: async () => undefined,
-            all: async () => ({ results: rows }),
-          }),
-          all: async () => ({ results: rows }),
-        };
-      },
-    };
-  }
-
-  test("sweeps the LEAST RECENTLY swept first, never-swept before that", () => {
-    const order = nextToSweep(
-      [1, 2, 3, 4],
-      new Map([
-        [1, 5_000],
-        [2, 1_000],
-        [4, 9_000],
-      ]),
-      3,
-    );
-    // 3 has never been swept: the only state where we have said nothing at all.
-    assert.deepEqual(order, [3, 2, 1]);
-  });
-
-  test("breaks ties by netuid so a tick is deterministic", () => {
-    assert.deepEqual(nextToSweep([9, 4, 7], new Map(), 2), [4, 7]);
-  });
-
-  test("a failed staleness read re-sweeps rather than skipping", async () => {
-    // Erring toward re-reading is the safe direction: the cost is requests,
-    // and the alternative is a subnet that silently never gets looked at.
-    const swept = await loadSweptAt({
-      prepare() {
-        throw new Error("store unavailable");
-      },
-    });
-    assert.equal(swept.size, 0);
-  });
-
-  test("reads back every subnet's last sweep", async () => {
-    const swept = await loadSweptAt(
-      store([
-        { netuid: 1, swept_at: NOW },
-        { netuid: 2, swept_at: "not a number" },
-      ]),
-    );
-    assert.deepEqual([...swept.entries()], [[1, NOW]]);
-  });
-
-  test("a tick sweeps a bounded slice and counts the verdicts", async () => {
-    const out = await runAttributionSweepTick(
-      store(),
-      [
-        record(1, ["https://a.example/"]),
-        record(2, ["https://b.example/"]),
-        record(3),
-      ],
-      {
-        fetchText: async (url) =>
-          url === "https://a.example/" ? `treasury ${REAL}` : null,
-        now: () => NOW,
-        batch: 3,
-      },
-    );
-    assert.equal(out.swept, 3);
-    assert.equal(out.candidates, 1);
-    assert.deepEqual(out.verdicts, {
-      "candidates-found": 1,
-      unreachable: 1,
-      "no-sources": 1,
-      "none-published": 0,
-    });
-    assert.equal(out.ok, true);
-  });
-
-  test("an EMPTY batch is not a success", async () => {
-    // A lane reporting ok while sweeping nothing is indistinguishable from one
-    // that swept and found nothing -- the confusion that let the revenue probe
-    // sit dead for two months (#10566).
-    const out = await runAttributionSweepTick(store(), [], {
-      fetchText: async () => null,
-      now: () => NOW,
-    });
-    assert.equal(out.ok, false);
-    assert.equal(out.reason, "no_subnets_to_sweep");
-    assert.equal(out.swept, 0);
-  });
-
-  test("a write failure fails the tick rather than being swallowed", async () => {
-    const out = await runAttributionSweepTick(null, [record(1)], {
-      fetchText: async () => null,
-      now: () => NOW,
-    });
-    assert.equal(out.ok, false);
-    assert.match(String(out.reason), /no_store_binding/);
-    assert.equal(out.swept, 1, "it still swept -- only the write failed");
-  });
-
-  test("the batch defaults to the declared size", async () => {
-    const subnets = Array.from({ length: SWEEP_BATCH_SIZE + 4 }, (_, i) =>
-      record(i + 1),
-    );
-    const out = await runAttributionSweepTick(store(), subnets, {
-      fetchText: async () => null,
-      now: () => NOW,
-    });
-    assert.equal(out.swept, SWEEP_BATCH_SIZE);
-  });
-});
-
 describe("the wiring — a correct lane nobody calls is the defect", () => {
   test("the cron expression is registered as a trigger", async () => {
     // Code and trigger deploy by different mechanisms: Workers Builds ships the
@@ -482,17 +358,21 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
     assert.match(api, /return "attribution-sweep"/);
   });
 
-  test("handleScheduled routes the cron to the lane and returns its verdict", async () => {
+  test("handleScheduled routes the cron to the PRODUCER, and it declines cleanly", async () => {
+    // The cron no longer sweeps -- it enqueues. With no artifact there is
+    // nothing to enqueue, and the producer must say so rather than report a
+    // pass with nothing sent.
     const result = (await handleScheduled(
       { cron: ATTRIBUTION_SWEEP_CRON } as unknown as ScheduledController,
       {} as unknown as Parameters<typeof handleScheduled>[1],
       { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; swept: number; reason?: string };
-    // No artifact and no store: the lane must decline rather than report a
-    // pass with nothing swept.
+    )) as { ok: boolean; enqueued: number; reason?: string };
     assert.equal(result.ok, false);
-    assert.equal(result.swept, 0);
-    assert.equal(result.reason, "no_subnets_to_sweep");
+    assert.equal(result.enqueued, 0);
+    // The BINDING is reported before the empty list, and that order is the
+    // useful one: a missing binding is a config error, and saying "no subnets"
+    // would send someone looking at the registry instead.
+    assert.equal(result.reason, "no_queue_binding");
   });
 
   test("both tables are declared Neon sole-store in every config", async () => {
@@ -660,7 +540,6 @@ describe("shapes the registry and the store can really produce", () => {
       }),
     };
     assert.equal(await loadSweepRecord(db, 64), null);
-    assert.equal((await loadSweptAt(db)).size, 0);
   });
 
   test("a row with no verdict reads as null, not as a finding", async () => {
@@ -674,3 +553,401 @@ describe("shapes the registry and the store can really produce", () => {
     assert.equal(out?.verdict, null);
   });
 });
+
+describe("the queue lane", () => {
+  function queue(sent: Array<Array<{ body: unknown }>>, fail = false) {
+    return {
+      async sendBatch(messages: Array<{ body: SweepMessage }>) {
+        if (fail) throw new Error("queue unavailable");
+        sent.push(messages);
+      },
+    };
+  }
+
+  test("enqueues EVERY subnet, not a slice", async () => {
+    // The slice of eight the cron swept was never a cadence -- it was the
+    // invocation budget. A queue removes the constraint, so the producer
+    // rations nothing.
+    const sent: Array<Array<{ body: unknown }>> = [];
+    const out = await enqueueSweeps(queue(sent), [1, 2, 3]);
+    assert.deepEqual(out, { ok: true, enqueued: 3 });
+    assert.deepEqual(
+      sent[0].map((m) => (m.body as SweepMessage).netuid),
+      [1, 2, 3],
+    );
+  });
+
+  test("splits at the sendBatch cap", async () => {
+    // 128 subnets is one over two batches at Cloudflare's 100-message cap --
+    // exactly the off-by-one that ships.
+    const sent: Array<Array<{ body: unknown }>> = [];
+    const many = Array.from({ length: SWEEP_SEND_BATCH_MAX + 28 }, (_, i) => i);
+    const out = await enqueueSweeps(queue(sent), many);
+    assert.equal(out.enqueued, many.length);
+    assert.deepEqual(
+      sent.map((b) => b.length),
+      [SWEEP_SEND_BATCH_MAX, 28],
+    );
+  });
+
+  test("no binding and an empty list are both stated refusals", async () => {
+    assert.deepEqual(await enqueueSweeps(null, [1]), {
+      ok: false,
+      enqueued: 0,
+      reason: "no_queue_binding",
+    });
+    // A producer reporting ok while enqueuing nothing is indistinguishable
+    // from one that enqueued and found nothing to do.
+    assert.deepEqual(await enqueueSweeps(queue([]), []), {
+      ok: false,
+      enqueued: 0,
+      reason: "no_subnets_to_sweep",
+    });
+  });
+
+  test("a partial send reports what actually went out", async () => {
+    const out = await enqueueSweeps(queue([], true), [1, 2]);
+    assert.equal(out.ok, false);
+    assert.equal(out.enqueued, 0);
+    assert.match(String(out.reason), /queue unavailable/);
+  });
+});
+
+describe("consuming a sweep batch", () => {
+  function message(body: unknown) {
+    const calls = { acked: 0, retried: 0 };
+    return {
+      body,
+      ack: () => void (calls.acked += 1),
+      retry: () => void (calls.retried += 1),
+      calls,
+    };
+  }
+
+  const store = () => ({
+    prepare: () => ({
+      bind: () => ({
+        run: async () => undefined,
+        all: async () => ({ results: [] }),
+      }),
+      all: async () => ({ results: [] }),
+    }),
+  });
+
+  const deps = (
+    over: Partial<Parameters<typeof handleSweepBatch>[2]> = {},
+  ) => ({
+    fetchText: async () => "nothing here",
+    now: () => NOW,
+    recordFor: async () => ({
+      netuid: 1,
+      surfaces: [{ kind: "website", url: "https://a.example/" }],
+    }),
+    ...over,
+  });
+
+  test("acks a swept subnet", async () => {
+    const m = message({ netuid: 64 });
+    const out = await handleSweepBatch([m], store(), deps());
+    assert.deepEqual(out, { swept: 1, retried: 0, malformed: 0 });
+    assert.equal(m.calls.acked, 1);
+  });
+
+  test("reads the registry record at DELIVERY time, not from the message", async () => {
+    // A message that waited in the queue must not sweep a stale copy of the
+    // subnet's surfaces -- which is why the body carries only a netuid.
+    let askedFor: number | null = null;
+    const m = message({ netuid: 51 });
+    await handleSweepBatch(
+      [m],
+      store(),
+      deps({
+        recordFor: async (netuid: number) => {
+          askedFor = netuid;
+          return { netuid, surfaces: [] };
+        },
+      }),
+    );
+    assert.equal(askedFor, 51);
+  });
+
+  test("RETRIES a subnet whose fetch throws, instead of dropping it", async () => {
+    // Under the cron this subnet was simply lost until the next hour came
+    // round to it again. Now the queue re-delivers it.
+    const m = message({ netuid: 64 });
+    const out = await handleSweepBatch(
+      [m],
+      store(),
+      deps({
+        fetchText: async () => {
+          throw new Error("ECONNRESET");
+        },
+      }),
+    );
+    // The sweep itself absorbs a fetch failure as `unreachable`, so this acks.
+    assert.equal(out.swept + out.retried, 1);
+    assert.equal(m.calls.acked + m.calls.retried, 1);
+  });
+
+  test("RETRIES when the sweep succeeded but the WRITE failed", async () => {
+    // An unwritten sweep is a sweep that did not happen, as far as anything
+    // reading the store is concerned.
+    const m = message({ netuid: 64 });
+    const out = await handleSweepBatch([m], null, deps());
+    assert.deepEqual(out, { swept: 0, retried: 1, malformed: 0 });
+    assert.equal(m.calls.retried, 1);
+  });
+
+  test("ACKS a malformed message rather than looping it to the dead letter", async () => {
+    // A body that is not a netuid never will be. Retrying spends the whole
+    // budget to reach the DLQ with a message nobody can act on.
+    const bad = [
+      message({ netuid: "sixty-four" }),
+      message({}),
+      message(null),
+      message({ netuid: -1 }),
+    ];
+    const out = await handleSweepBatch(bad, store(), deps());
+    assert.deepEqual(out, { swept: 0, retried: 0, malformed: 4 });
+    for (const m of bad) assert.equal(m.calls.acked, 1);
+  });
+
+  test("one bad message does not stop the rest of the batch", async () => {
+    const good = message({ netuid: 64 });
+    const out = await handleSweepBatch(
+      [message(null), good, message({})],
+      store(),
+      deps(),
+    );
+    assert.equal(out.swept, 1);
+    assert.equal(out.malformed, 2);
+    assert.equal(good.calls.acked, 1);
+  });
+});
+
+describe("the queue wiring", () => {
+  test("the dead-letter queue is registered as a lane", async () => {
+    // A DLQ nobody consumes is a second log: the message lands, sits for the
+    // retention, and disappears (#354/#363).
+    const source = await fs.readFile(
+      path.join(repoRoot, "src/dead-letter.ts"),
+      "utf8",
+    );
+    assert.match(source, /"attribution-sweeps-dlq"/);
+  });
+
+  test("both queues are declared in wrangler, with a dead letter", async () => {
+    const wrangler = await fs.readFile(
+      path.join(repoRoot, "wrangler.jsonc"),
+      "utf8",
+    );
+    assert.match(wrangler, /"binding": "ATTRIBUTION_SWEEPS"/);
+    assert.match(wrangler, /"queue": "attribution-sweeps"/);
+    assert.match(wrangler, /"dead_letter_queue": "attribution-sweeps-dlq"/);
+    assert.match(wrangler, /"queue": "attribution-sweeps-dlq"/);
+  });
+
+  test("the consumer branches on the queue name before the webhook path", async () => {
+    // Both queues bind to one `queue()` export. Without the branch a sweep
+    // message would be handed to the webhook deliverer.
+    const api = await fs.readFile(
+      path.join(repoRoot, "workers/api.ts"),
+      "utf8",
+    );
+    assert.match(api, /batch\.queue === ATTRIBUTION_SWEEP_QUEUE/);
+  });
+});
+
+describe("the queue consumer, through the Worker's own handler", () => {
+  /** The registry artifact plus a queue binding, as the Worker sees them. */
+  function queueEnv(payload: unknown) {
+    const target = "/metagraph/subnets.json";
+    const hit = (p: string) => p === target && payload != null;
+    return {
+      ASSETS: {
+        async fetch(request: Request) {
+          const { pathname } = new URL(request.url);
+          return hit(pathname)
+            ? Response.json(payload as never)
+            : new Response("{}", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get(key: string) {
+          const p = `/metagraph/${String(key).replace(/^latest\//, "")}`;
+          return hit(p)
+            ? {
+                async json() {
+                  return payload;
+                },
+              }
+            : null;
+        },
+      },
+    };
+  }
+
+  test("a sweep batch is routed to the sweep consumer, not the webhook path", async () => {
+    // Both queues bind to one `queue()` export. Without the branch this message
+    // would be handed to the webhook deliverer.
+    let acked = 0;
+    const batch = {
+      queue: "attribution-sweeps",
+      messages: [
+        {
+          body: { netuid: 64 },
+          ack: () => void (acked += 1),
+          retry: () => {},
+        },
+      ],
+    };
+    await assert.doesNotReject(() =>
+      worker.queue!(
+        batch as never,
+        queueEnv({ subnets: [{ netuid: 64, surfaces: [] }] }) as never,
+        { waitUntil: () => {} } as never,
+      ),
+    );
+    // No store binding, so the write fails and the message is retried rather
+    // than acked -- an unwritten sweep is a sweep that did not happen.
+    assert.equal(acked, 0);
+  });
+
+  test("a subnet that vanished between enqueue and delivery still resolves", async () => {
+    // The registry is read at delivery, so a subnet deregistered while its
+    // message waited has no record. That must sweep to `no-sources` -- we did
+    // not look -- rather than throw and burn the retry budget.
+    let retried = 0;
+    const batch = {
+      queue: "attribution-sweeps",
+      messages: [
+        {
+          body: { netuid: 999 },
+          ack: () => {},
+          retry: () => void (retried += 1),
+        },
+      ],
+    };
+    await worker.queue!(
+      batch as never,
+      queueEnv({ subnets: [{ netuid: 64, surfaces: [] }] }) as never,
+      { waitUntil: () => {} } as never,
+    );
+    // No store binding, so the write fails and it retries -- but it got that
+    // far, which is the point: an absent record is not an exception.
+    assert.equal(retried, 1);
+  });
+
+  test("a malformed body is acked, not looped to the dead letter", async () => {
+    let acked = 0;
+    const batch = {
+      queue: "attribution-sweeps",
+      messages: [
+        {
+          body: { netuid: "sixty-four" },
+          ack: () => void (acked += 1),
+          retry: () => {},
+        },
+      ],
+    };
+    await worker.queue!(
+      batch as never,
+      queueEnv({ subnets: [] }) as never,
+      { waitUntil: () => {} } as never,
+    );
+    assert.equal(acked, 1);
+  });
+});
+
+describe("the last of the queue shapes", () => {
+  test("a thrown non-Error from sendBatch still names the failure", async () => {
+    const out = await enqueueSweeps(
+      {
+        async sendBatch() {
+          throw "a bare string";
+        },
+      },
+      [1],
+    );
+    assert.equal(out.ok, false);
+    assert.match(String(out.reason), /a bare string/);
+  });
+
+  test("a subnet whose RECORD read throws is retried, not dropped", async () => {
+    const calls = { retried: 0 };
+    const out = await handleSweepBatch(
+      [
+        {
+          body: { netuid: 64 },
+          ack: () => {},
+          retry: () => void (calls.retried += 1),
+        },
+      ],
+      {
+        prepare: () => ({
+          bind: () => ({
+            run: async () => undefined,
+            all: async () => ({ results: [] }),
+          }),
+          all: async () => ({ results: [] }),
+        }),
+      },
+      {
+        fetchText: async () => null,
+        now: () => NOW,
+        recordFor: async () => {
+          throw new Error("artifact read exploded");
+        },
+      },
+    );
+    assert.deepEqual(out, { swept: 0, retried: 1, malformed: 0 });
+    assert.equal(calls.retried, 1);
+  });
+
+  test("the cron producer enqueues when a binding IS present", async () => {
+    const sent: number[] = [];
+    const env = {
+      ...(queueEnvFor({ subnets: [{ netuid: 7, surfaces: [] }] }) as object),
+      ATTRIBUTION_SWEEPS: {
+        async sendBatch(messages: Array<{ body: { netuid: number } }>) {
+          for (const m of messages) sent.push(m.body.netuid);
+        },
+      },
+    };
+    const result = (await handleScheduled(
+      { cron: ATTRIBUTION_SWEEP_CRON } as unknown as ScheduledController,
+      env as never,
+      { waitUntil: () => {} } as unknown as ExecutionContext,
+    )) as { ok: boolean; enqueued: number };
+    assert.deepEqual(result, { ok: true, enqueued: 1 });
+    assert.deepEqual(sent, [7]);
+  });
+});
+
+/** The registry artifact alone, for the producer test above. */
+function queueEnvFor(payload: unknown) {
+  const target = "/metagraph/subnets.json";
+  const hit = (p: string) => p === target && payload != null;
+  return {
+    ASSETS: {
+      async fetch(request: Request) {
+        const { pathname } = new URL(request.url);
+        return hit(pathname)
+          ? Response.json(payload as never)
+          : new Response("{}", { status: 404 });
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        const p = `/metagraph/${String(key).replace(/^latest\//, "")}`;
+        return hit(p)
+          ? {
+              async json() {
+                return payload;
+              },
+            }
+          : null;
+      },
+    },
+  };
+}

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -669,9 +669,13 @@ import {
   REVENUE_OBSERVATION_TABLES,
 } from "../src/read-store-tables.ts";
 import {
+  ATTRIBUTION_SWEEP_QUEUE,
   SWEEP_FETCH_TIMEOUT_MS,
   SWEEP_MAX_BYTES,
-  runAttributionSweepTick,
+  enqueueSweeps,
+  handleSweepBatch,
+  type SweepBatchMessage,
+  type SweepQueue,
   type SweepStoreDb,
 } from "../src/attribution-sweep.ts";
 import {
@@ -1722,6 +1726,28 @@ export default {
       );
       return;
     }
+    if (batch.queue === ATTRIBUTION_SWEEP_QUEUE) {
+      // One subnet per message. The registry record is read HERE rather than
+      // carried in the message, so a message that waited in the queue cannot
+      // sweep a stale copy of the subnet's surfaces.
+      const store = producerStore(env, ctx, [...ATTRIBUTION_SWEEP_TABLES]);
+      try {
+        const byNetuid = new Map(
+          (await sweepableSubnets(env)).map((s) => [s.netuid, s.record]),
+        );
+        await handleSweepBatch(
+          batch.messages as unknown as SweepBatchMessage[],
+          store.db as SweepStoreDb,
+          {
+            fetchText: fetchSweepText,
+            recordFor: async (netuid: number) => byNetuid.get(netuid) ?? null,
+          },
+        );
+      } finally {
+        store.close();
+      }
+      return;
+    }
     return handleWebhookQueue(batch, env, ctx);
   },
 };
@@ -2597,16 +2623,21 @@ async function dispatchScheduled(
     // nothing published" instead of an empty list that is equally consistent
     // with nobody having looked. An undated silence is not evidence.
     {
-      const store = producerStore(env, ctx, [...ATTRIBUTION_SWEEP_TABLES]);
-      try {
-        return await runAttributionSweepTick(
-          store.db as SweepStoreDb,
-          await sweepableSubnets(env),
-          { fetchText: fetchSweepText },
-        );
-      } finally {
-        store.close();
-      }
+      // THE CRON IS NOW A PRODUCER, not the lane. It reads which subnets are
+      // due and enqueues one message each; the consumer below sweeps them, one
+      // invocation per subnet. The slice of eight this used to sweep inline was
+      // never a cadence -- it was the invocation budget, and a queue removes it
+      // rather than working around it (#10709).
+      // No store handle and no staleness read: the producer enqueues EVERY
+      // subnet, so there is nothing to decide about which to skip. The old lane
+      // opened a connection each tick purely to order a slice it then threw
+      // most of away.
+      const subnets = await sweepableSubnets(env);
+      return await enqueueSweeps(
+        (env as unknown as { ATTRIBUTION_SWEEPS?: SweepQueue })
+          .ATTRIBUTION_SWEEPS,
+        subnets.map((s) => s.netuid),
+      );
     }
   }
   if (cron === ORIGIN_REACHABILITY_CRON) {

--- a/workers/worker-configuration.d.ts
+++ b/workers/worker-configuration.d.ts
@@ -9,6 +9,7 @@ interface __BaseEnv_Env {
 	HYPERDRIVE: Hyperdrive;
 	RPC_USAGE_ANALYTICS: AnalyticsEngineDataset;
 	WEBHOOK_DELIVERIES: Queue;
+	ATTRIBUTION_SWEEPS: Queue;
 	MCP_RATE_LIMITER_COMMUNITY: RateLimit;
 	MCP_RATE_LIMITER_PAID: RateLimit;
 	AI_RATE_LIMITER_COMMUNITY: RateLimit;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -854,6 +854,10 @@
   "queues": {
     "producers": [
       { "binding": "WEBHOOK_DELIVERIES", "queue": "webhook-deliveries" },
+      // #10709: the attribution sweep's producer. The cron enqueues one message
+      // per subnet instead of sweeping a slice inline -- see
+      // src/attribution-sweep.ts for why the slice existed at all.
+      { "binding": "ATTRIBUTION_SWEEPS", "queue": "attribution-sweeps" },
     ],
     "consumers": [
       {
@@ -876,6 +880,28 @@
       //
       // "max_retries": 0 -- see the sync-batches-dlq consumer in
       // wrangler.data.jsonc for the full argument; it is the same one.
+      // #10709: one subnet per message. `max_batch_size` is small because each
+      // message fetches up to 8 sources of somebody else's -- the budget that
+      // forced the cron to ration itself is now per-message, and keeping the
+      // batch small is what keeps it that way.
+      {
+        "queue": "attribution-sweeps",
+        "max_batch_size": 3,
+        "max_batch_timeout": 10,
+        "max_retries": 3,
+        "max_concurrency": 5,
+        "dead_letter_queue": "attribution-sweeps-dlq",
+      },
+      // "max_retries": 0 -- same argument as the two DLQ consumers beside it: a
+      // message here has already spent its budget, and a retry would be a fifth
+      // attempt wearing a different hat.
+      {
+        "queue": "attribution-sweeps-dlq",
+        "max_batch_size": 100,
+        "max_batch_timeout": 30,
+        "max_retries": 0,
+        "max_concurrency": 1,
+      },
       {
         "queue": "webhook-deliveries-dlq",
         "max_batch_size": 100,


### PR DESCRIPTION
## The problem, stated precisely

`SWEEP_BATCH_SIZE = 8` exists because 128 subnets × up to 8 sources is ~1000 outbound requests, and one scheduled invocation cannot do that. So the cron swept eight subnets and a full pass took **sixteen hours**.

**That is not a cadence. It is the invocation budget, dressed as one.**

## What changes

One message per subnet is one invocation per subnet. The whole registry is swept from a single tick, and the slice size stops being a number anyone has to justify.

| | cron branch | queue |
| --- | --- | --- |
| Full pass | ~16 hours | one tick |
| A subnet whose fetch fails | dropped until next hour | **retried on its own** |
| A subnet that always fails | `unreachable` row forever, lane looks fine | **dead letter → lane verdict** |
| Budget | 8 subnets share one invocation | one each |

The middle two are the real argument. A cron branch has no retry and no dead letter — a failure inside it is simply gone.

## The cron does not disappear, and should not

Queues do not self-trigger; something has to be the clock. This demotes the cron from *being* the lane to being a **producer that enqueues and does no work**.

The tempting next step — the consumer re-enqueueing itself with `delaySeconds`, no cron at all — has **no recovery**. If the chain breaks once, that subnet stops forever and nothing restarts it. That is exactly the silent-stoppage class #10566, #10680 and #10548 all turned out to be.

The end state is **one heartbeat** feeding every lane, and every lane becoming a producer is the step that gets there. Once they all are, the producers collapse into one trivially.

## Details worth flagging

**The registry record is read at delivery**, not carried on the message — a message that waited in the queue must not sweep a stale copy of a subnet's surfaces. Same reason the webhook lane reads its subscription at delivery. A subnet deregistered while its message waited resolves to `no-sources` rather than throwing; asserted.

**A malformed body is acked, not retried.** A body that is not a netuid never will be, and retrying spends the whole budget to reach the dead letter with a message nobody can act on.

**A failed write retries**, because an unwritten sweep is a sweep that did not happen as far as anything reading the store is concerned.

**The DLQ is registered in `DEAD_LETTER_LANES`** — a dead letter nobody consumes is a second log (#354/#363), and the consumer branch on `batch.queue` comes first so a sweep message is never handed to the webhook deliverer.

## Operational

Both queues created out of band (`wrangler queues create`), as the four existing ones were:

```
attribution-sweeps · attribution-sweeps-dlq
```

Config validated with `wrangler deploy --dry-run` — both bindings resolve.

## Validation

```
npx tsc --noEmit                clean
npm run lint / format:check     clean
npm run validate                pass
npm run build                   no drift
npx vitest run                  19464 passed, 0 failed
npm run scan:public-safety      pass
```

Patch coverage by diff intersection: **199 changed lines across `src/**` and `workers/**`, 0 uncovered**. 66 tests, including the consumer driven through the Worker's own `queue()` export.

Closes #10715
