### PR TITLE
revert(neon): disable the write buffer -- it stalled and stopped draining

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -139,7 +139,7 @@
     //
     // Every lane below is held to `2 * HOUR` by src/table-freshness-watchdog.ts,
     // so a ten-minute flush is twelve ticks inside a bound that already exists.
-    "NEON_WRITE_BUFFER_LANES": "raw-capture-state,neurons,subnet-hyperparams,account-identity,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,tao-usd-index",
+    "NEON_WRITE_BUFFER_LANES": "",
     "UNKEY_API_ID": "api_2Dv8cVjrTSiD",
     // Tier-source flags. These are READ by this Worker -- neuronsServedFromD1()
     // and its two siblings in workers/data-api.ts gate on `!== "postgres"` --

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -74,7 +74,7 @@
     //
     // Every lane below is held to `2 * HOUR` by src/table-freshness-watchdog.ts,
     // so a ten-minute flush is twelve ticks inside a bound that already exists.
-    "NEON_WRITE_BUFFER_LANES": "raw-capture-state,neurons,subnet-hyperparams,account-identity,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,tao-usd-index",
+    "NEON_WRITE_BUFFER_LANES": "",
     "METAGRAPH_CONTRACT_VERSION": "2026-07-03.2",
     "METAGRAPH_ENABLE_RPC_PROXY": "true",
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -71,7 +71,7 @@
     //
     // Every lane below is held to `2 * HOUR` by src/table-freshness-watchdog.ts,
     // so a ten-minute flush is twelve ticks inside a bound that already exists.
-    "NEON_WRITE_BUFFER_LANES": "raw-capture-state,neurons,subnet-hyperparams,account-identity,nominator-positions,account-balances,hotkey-alpha,validator-nominator-counts,tao-usd-index",
+    "NEON_WRITE_BUFFER_LANES": "",
     // THE NEON FLAGS, and this Worker needs them because it now runs a gated
     // path (#10194's self-health probe). `vars` are per-config with no
     // inheritance, so their absence here did not read as "no opinion" -- it


### PR DESCRIPTION
## Incident

Buffered lanes stopped landing in Neon after **08:47**, and `neon:buffer-flush` last fired at
**08:59:52**. At 09:47 that was ~47 minutes of `tao_usd_index` minute-ticks, plus `account_balances`
and `nominator_positions`, sitting undrained.

**The block explorer was never affected.** `blocks-head` and `chain-detail` are in
`NEVER_BUFFER_LANES`, wrote throughout, and `blocks_head` stayed current — the exclusion did its job.

## Rollback

Emptying `NEON_WRITE_BUFFER_LANES` makes `neonWriteRunner` fall through to `createPgSql`, restoring
direct writes on every lane immediately. The buffer code stays in place and inert — **the flag is the
whole rollback, which is why it was built as a flag.**

## What is known, and what is not

Known: the Durable Object was reset repeatedly by deploys — three in twenty minutes — and enqueues
failed against a resetting object. `Durable Object reset because its code was updated` surfaced as a
stale verdict on `neon:validator-nominator-counts` at 09:33:50, and the new PostHog capture (#10696)
paged on it correctly.

**Not** known: whether that alone left the alarm unarmed, or whether the re-arm change in #10693 did.
`enqueueStatement` only arms when `getAlarm() === null`, and #10693 removed the post-flush re-arm on
the reasoning that the next enqueue would arm it — if an enqueue fails, nothing arms it, and the
buffer has no self-healing path. That is the leading hypothesis and it is mine.

This PR does not claim to fix it. It restores the data path so diagnosis is not happening while chain
price data goes unwritten.

## Follow-up

Root cause and a re-enable plan go in a separate issue. The buffer should not go back on until it has
a path that recovers from a failed enqueue without a human.