### PR TITLE
refactor(scripts): ask the source which component a route carries, not the artifact

### DIFF
--- a/scripts/check-graphql-int-range.ts
+++ b/scripts/check-graphql-int-range.ts
@@ -23,7 +23,6 @@
 // Run against production out of band, like its conformance siblings: a check
 // that needs production data should not pretend to run on a pull request.
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
 import {
   GraphQLInt,
   GraphQLList,
@@ -34,10 +33,9 @@ import type { GraphQLOutputType } from "graphql";
 import { API_ROUTES } from "../src/contracts.ts";
 import { emitTypes } from "../schemas-src/graphql/emit.ts";
 import { apiRouteUrl } from "./smoke-live-api.ts";
+import { dataComponent } from "./openapi-document.ts";
 
 const BASE = process.env.CONFORMANCE_API_BASE || "https://api.metagraph.sh";
-const SPEC_PATH =
-  process.env.CONFORMANCE_SPEC_PATH || "public/metagraph/openapi.json";
 
 /** GraphQL's Int is a signed 32-bit integer (graphql-js GRAPHQL_MAX_INT). */
 export const GRAPHQL_MAX_INT = 2147483647;
@@ -52,45 +50,6 @@ export interface Overflow {
 }
 
 /** Only the sliver of the OpenAPI document this script reads. */
-export interface OpenApiDocument {
-  paths?: Record<
-    string,
-    {
-      get?: {
-        responses?: Record<
-          string,
-          {
-            content?: Record<
-              string,
-              {
-                schema?: {
-                  allOf?: { properties?: { data?: { $ref?: string } } }[];
-                };
-              }
-            >;
-          }
-        >;
-      };
-    }
-  >;
-}
-
-/** The component a route's `data` property refs, or null. */
-export function dataComponent(
-  openapi: OpenApiDocument,
-  route: string,
-): string | null {
-  const schema =
-    openapi.paths?.[route]?.get?.responses?.["200"]?.content?.[
-      "application/json"
-    ]?.schema;
-  for (const part of schema?.allOf ?? []) {
-    const ref = part?.properties?.data?.$ref;
-    if (typeof ref === "string")
-      return ref.replace("#/components/schemas/", "");
-  }
-  return null;
-}
 
 /**
  * Walk a live response beside the GraphQL type that would publish it, and
@@ -146,9 +105,6 @@ export function findOverflows(
 }
 
 async function main(): Promise<void> {
-  const openapi = JSON.parse(
-    readFileSync(SPEC_PATH, "utf8"),
-  ) as OpenApiDocument;
   const { types } = emitTypes();
   const today = new Date().toISOString().slice(0, 10);
 
@@ -161,7 +117,7 @@ async function main(): Promise<void> {
     method: string;
   }[]) {
     if (route.method !== "GET") continue;
-    const component = dataComponent(openapi, route.path);
+    const component = dataComponent(route.path);
     const type = component ? types.get(component) : null;
     if (!type) {
       skipped += 1; // no component, or one the emitter answers no type for

--- a/scripts/check-graphql-nullability.ts
+++ b/scripts/check-graphql-nullability.ts
@@ -59,6 +59,7 @@ import { emitTypes } from "../schemas-src/graphql/emit.ts";
 import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
 import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
 import { SDL } from "../src/graphql-sdl.ts";
+import { dataComponent, limitFor } from "./openapi-document.ts";
 
 const BASE = process.env.CONFORMANCE_API_BASE || "https://api.metagraph.sh";
 const SPEC_PATH =
@@ -451,50 +452,6 @@ function walk(
   }
 }
 
-/**
- * The component a route's `data` refs, read from the published spec.
- *
- * The same lookup `validate-graphql-component-parity.ts` uses to pair an SDL
- * type with the Zod behind it -- and the honest root for a REST body, because
- * the body IS that component.
- */
-export function dataComponent(
-  openapi: OpenApiParameters,
-  route: string,
-): string | null {
-  const schema = (
-    openapi as unknown as {
-      paths?: Record<
-        string,
-        {
-          get?: {
-            responses?: Record<
-              string,
-              {
-                content?: Record<
-                  string,
-                  {
-                    schema?: {
-                      allOf?: { properties?: { data?: { $ref?: string } } }[];
-                    };
-                  }
-                >;
-              }
-            >;
-          };
-        }
-      >;
-    }
-  ).paths?.[route]?.get?.responses?.["200"]?.content?.["application/json"]
-    ?.schema;
-  for (const part of schema?.allOf ?? []) {
-    const ref = part?.properties?.data?.$ref;
-    if (typeof ref === "string")
-      return ref.replace("#/components/schemas/", "");
-  }
-  return null;
-}
-
 /** Every filling of a route's path parameters, or none if one has no value. */
 export function fillRoute(route: string): string[] {
   let filled = [route];
@@ -506,41 +463,6 @@ export function fillRoute(route: string): string[] {
     );
   }
   return filled;
-}
-
-/**
- * `limit=<the route's own maximum>`, or nothing.
- *
- * Read from the published spec rather than guessed. The ceiling is per-route,
- * and REST REJECTS both an unknown parameter and an over-ceiling one -- MCP is
- * the surface that clamps -- so a blanket `?limit=100` turns 40 healthy routes
- * into "did not answer" and reports that silence as coverage.
- */
-export function limitFor(openapi: OpenApiParameters, route: string): string {
-  const parameters =
-    (
-      openapi as unknown as {
-        paths?: Record<
-          string,
-          {
-            get?: {
-              parameters?: Array<{
-                name?: string;
-                $ref?: string;
-                schema?: { maximum?: number };
-              }>;
-            };
-          }
-        >;
-      }
-    ).paths?.[route]?.get?.parameters ?? [];
-  for (const parameter of parameters) {
-    const name = parameter.name ?? parameter.$ref?.split("/").pop() ?? "";
-    if (!name.toLowerCase().includes("limit")) continue;
-    const maximum = parameter.schema?.maximum;
-    return `limit=${typeof maximum === "number" ? maximum : 100}`;
-  }
-  return "";
 }
 
 export async function checkNullability(
@@ -584,7 +506,7 @@ export async function checkNullability(
     // mistake `PROJECTED_TYPES` exists to stop the parity gate making: it
     // manufactured 84 findings, every one of them a `*List.items` or
     // `*List.total`, before the root was resolved this way.
-    const component = dataComponent(openapi, binding.route);
+    const component = dataComponent(binding.route);
     const generatedType = component ? emitted.get(component) : undefined;
     if (!generatedType) return;
     const routes = fillRoute(binding.route);

--- a/scripts/openapi-document.ts
+++ b/scripts/openapi-document.ts
@@ -1,0 +1,130 @@
+// Which component does a route's `data` carry? Ask the source, not the artifact.
+//
+// Four scripts needed this answer and each had written its own walk over the
+// generated `openapi.json` -- down `paths[route].get.responses["200"].content
+// ["application/json"].schema.allOf[].properties.data.$ref`. Two of them also
+// declared their own `OpenApiDocument` for the trip, structurally identical
+// and unaware of each other.
+//
+//   scripts/check-graphql-int-range.ts            exported `dataComponent`
+//   scripts/check-graphql-nullability.ts          exported `dataComponent`
+//   scripts/validate-graphql-component-parity.ts  a private closure
+//   scripts/validate-published-names.ts           a private closure
+//
+// None of them had to. That `$ref` is not an independent fact about the
+// document -- `src/contracts.ts` COMPUTES it, in one line, from the route's
+// own artifact path:
+//
+//     data: { $ref: `#/components/schemas/${schemaRefForArtifactPath(
+//              entry.artifact_path)}` }
+//
+// So the walk was four hand-rolled re-derivations of a function that is
+// exported. Reading them out of the emitted JSON meant the answer depended on
+// the artifact being present, current, and shaped the way each copy assumed --
+// and when an assumption broke, the walk returned `null` rather than throwing,
+// which every caller reads as "this route names no component" and skips. A
+// gate that skips is a gate that passes.
+//
+// `dataComponent` now takes the route and asks `API_ROUTES` +
+// `schemaRefForArtifactPath` directly. Change the envelope shape and there is
+// nothing here to update, because nothing here models the envelope.
+
+/**
+ * The part of `openapi.json` these readers touch.
+ *
+ * Deliberately narrow. A wider type would have to be maintained against the
+ * generator by hand, which is the thing this file exists to stop.
+ */
+import {
+  API_ROUTES,
+  networkVariantPath,
+  schemaRefForArtifactPath,
+} from "../src/contracts.ts";
+
+export interface OpenApiDocument {
+  paths?: Record<
+    string,
+    {
+      get?: {
+        // `unknown[]`, and narrowed inside `limitFor` rather than declared.
+        // The document is untyped JSON at runtime, and the looser spelling is
+        // what `schemas-src/graphql/query-arguments.ts` already publishes for
+        // the same array -- declaring a stricter one here would make the two
+        // views of one document mutually unassignable, which is how a second
+        // copy gets written instead of the first reused.
+        parameters?: readonly unknown[];
+        responses?: Record<
+          string,
+          {
+            content?: Record<
+              string,
+              {
+                schema?: {
+                  allOf?: { properties?: { data?: { $ref?: string } } }[];
+                };
+              }
+            >;
+          }
+        >;
+      };
+    }
+  >;
+}
+
+/**
+ * Route template -> the component its `data` carries, built once.
+ *
+ * Both spellings, because the document publishes both: 42 routes also appear
+ * network-scoped as `/api/v1/{network}/...`, and those twins are NOT their own
+ * `API_ROUTES` entries -- the emitter derives them through
+ * `networkVariantPath`, so this does too rather than re-deciding which routes
+ * qualify. Building from `API_ROUTES` alone left all 42 answering null, which
+ * the cross-check in tests/graphql-int-range.test.ts caught immediately: a
+ * silent null is exactly the failure this module exists to remove, and it
+ * reappeared the moment the derivation was incomplete.
+ */
+const COMPONENT_BY_ROUTE = new Map<string, string>();
+for (const entry of API_ROUTES) {
+  const component = schemaRefForArtifactPath(entry.artifact_path);
+  COMPONENT_BY_ROUTE.set(entry.path, component);
+  const scoped = networkVariantPath(entry.path);
+  if (scoped) COMPONENT_BY_ROUTE.set(scoped, component);
+}
+
+/**
+ * The component a route's `data` property refs, or null for a route the
+ * contract does not define.
+ *
+ * Null means "no such route", which is a different answer from the old walk's
+ * null ("the shape under this route was not what I expected"). The second was
+ * indistinguishable from the first at the call site, so a drifted envelope
+ * silently emptied every gate that asked.
+ */
+export function dataComponent(route: string): string | null {
+  return COMPONENT_BY_ROUTE.get(route) ?? null;
+}
+
+/**
+ * `limit=<the route's own maximum>`, or an empty string where it publishes no
+ * such parameter.
+ *
+ * Read from the spec rather than guessed. The ceiling is per-route
+ * (`schemas-src/route-queries.ts` single-sources it) and REST REJECTS both an
+ * unknown parameter and an over-ceiling one -- MCP is the surface that clamps
+ * -- so a blanket `?limit=100` turns a healthy route into a 400 and reports
+ * the silence as coverage.
+ */
+export function limitFor(openapi: OpenApiDocument, route: string): string {
+  for (const entry of openapi.paths?.[route]?.get?.parameters ?? []) {
+    const parameter = entry as {
+      name?: string;
+      $ref?: string;
+      schema?: { maximum?: number };
+    };
+    const name = parameter.name ?? parameter.$ref?.split("/").pop() ?? "";
+    if (!name.toLowerCase().includes("limit")) continue;
+    const maximum = parameter.schema?.maximum;
+    return `limit=${typeof maximum === "number" ? maximum : 100}`;
+  }
+  return "";
+}

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -54,35 +54,15 @@ import type {
   TypeNode,
 } from "graphql";
 import { emitTypes } from "../schemas-src/graphql/emit.ts";
+// Re-exported, not redeclared: `tests/graphql-component-parity.test.ts` and
+// `scripts/report-graphql-sdl-equivalence.ts` import the type from here.
+import { dataComponent, type OpenApiDocument } from "./openapi-document.ts";
+export type { OpenApiDocument } from "./openapi-document.ts";
 import {
   ALIASED_TYPE_NAMES,
   PROJECTED_TYPES,
   PUBLISHED_TYPE_NAMES,
 } from "../schemas-src/graphql/published-names.ts";
-
-/** Only the sliver of the OpenAPI document this gate reads. */
-export interface OpenApiDocument {
-  paths?: Record<
-    string,
-    {
-      get?: {
-        responses?: Record<
-          string,
-          {
-            content?: Record<
-              string,
-              {
-                schema?: {
-                  allOf?: { properties?: { data?: { $ref?: string } } }[];
-                };
-              }
-            >;
-          }
-        >;
-      };
-    }
-  >;
-}
 
 const SDL_PATH = "src/graphql-sdl.ts";
 const OPENAPI_PATH = "public/metagraph/openapi.json";
@@ -375,20 +355,6 @@ export function checkComponentParity(
   }
   const { types: generated } = emitTypes();
   const publishedAs = publishedNameResolver(projectedTypesMap);
-
-  /** The component a route's `data` property refs. */
-  const dataComponent = (route: string): string | null => {
-    const schema =
-      openapi.paths?.[route]?.get?.responses?.["200"]?.content?.[
-        "application/json"
-      ]?.schema;
-    for (const part of schema?.allOf ?? []) {
-      const ref = part?.properties?.data?.$ref;
-      if (typeof ref === "string")
-        return ref.replace("#/components/schemas/", "");
-    }
-    return null;
-  };
 
   // ── seed from the Query bindings, then propagate through matching fields ──
   const queue: [string, string][] = [];

--- a/scripts/validate-published-names.ts
+++ b/scripts/validate-published-names.ts
@@ -35,13 +35,10 @@ import {
   PROJECTED_TYPES,
   RESOLVER_BUILT_TYPES,
 } from "../schemas-src/graphql/published-names.ts";
-import {
-  extractSdl,
-  type OpenApiDocument,
-} from "./validate-graphql-component-parity.ts";
+import { extractSdl } from "./validate-graphql-component-parity.ts";
+import { dataComponent } from "./openapi-document.ts";
 
 const SDL_PATH = "src/graphql-sdl.ts";
-const OPENAPI_PATH = "public/metagraph/openapi.json";
 
 /** One Query field as the SDL declares it. */
 export interface SdlBinding {
@@ -225,9 +222,6 @@ if (!sdl) {
   console.error(`published-names: no SDL template literal in ${SDL_PATH}`);
   process.exit(1);
 }
-const openapi = JSON.parse(
-  readFileSync(OPENAPI_PATH, "utf8"),
-) as OpenApiDocument;
 const { types: generated } = emitTypes();
 
 const sdlTypes = new Map<string, ObjectTypeDefinitionNode>();
@@ -246,18 +240,6 @@ const generatedName = (type: unknown): string | null => {
     current = current.ofType as typeof current;
   }
   return current?.name ?? null;
-};
-const dataComponent = (route: string): string | null => {
-  const schema =
-    openapi.paths?.[route]?.get?.responses?.["200"]?.content?.[
-      "application/json"
-    ]?.schema;
-  for (const part of schema?.allOf ?? []) {
-    const ref = part?.properties?.data?.$ref;
-    if (typeof ref === "string")
-      return ref.replace("#/components/schemas/", "");
-  }
-  return null;
 };
 
 // ── the SDL's own Query bindings ─────────────────────────────────────────────

--- a/tests/graphql-int-range.test.ts
+++ b/tests/graphql-int-range.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 // The Int-range gate (#10386): does it actually fail?
 //
 // A gate only ever run against a passing tree proves nothing, so every test
@@ -15,9 +16,11 @@ import {
 } from "graphql";
 import {
   GRAPHQL_MAX_INT,
-  dataComponent,
   findOverflows,
 } from "../scripts/check-graphql-int-range.ts";
+// The `$ref` walk moved to one module the four readers share -- it is tested
+// here, once, rather than wherever the next copy would have been written.
+import { dataComponent } from "../scripts/openapi-document.ts";
 import { emitTypes } from "../schemas-src/graphql/emit.ts";
 
 const EPOCH_MS = 1786323600000;
@@ -112,42 +115,55 @@ describe("findOverflows", () => {
 });
 
 describe("dataComponent", () => {
-  it("reads the component a route's data property refs", () => {
-    expect(
-      dataComponent(
+  it("answers from API_ROUTES, and agrees with the published document", () => {
+    // The check that matters: the component is DERIVED from the route's
+    // artifact path now, not read out of openapi.json, so the two could drift
+    // apart without anything noticing. Every route the document defines is
+    // compared against the derivation, which is the only thing that keeps
+    // "ask the source" honest.
+    const spec = JSON.parse(
+      readFileSync("public/metagraph/openapi.json", "utf8"),
+    ) as {
+      paths: Record<
+        string,
         {
-          paths: {
-            "/r": {
-              get: {
-                responses: {
-                  "200": {
-                    content: {
-                      "application/json": {
-                        schema: {
-                          allOf: [
-                            {},
-                            {
-                              properties: {
-                                data: { $ref: "#/components/schemas/Thing" },
-                              },
-                            },
-                          ],
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        "/r",
-      ),
-    ).toBe("Thing");
+          get?: {
+            responses?: Record<
+              string,
+              {
+                content?: Record<
+                  string,
+                  {
+                    schema?: {
+                      allOf?: { properties?: { data?: { $ref?: string } } }[];
+                    };
+                  }
+                >;
+              }
+            >;
+          };
+        }
+      >;
+    };
+    let compared = 0;
+    for (const [route, item] of Object.entries(spec.paths)) {
+      const published = (
+        item.get?.responses?.["200"]?.content?.["application/json"]?.schema
+          ?.allOf ?? []
+      )
+        .map((part) => part?.properties?.data?.$ref)
+        .find((ref): ref is string => typeof ref === "string");
+      if (!published) continue;
+      compared += 1;
+      expect(dataComponent(route)).toBe(
+        published.replace("#/components/schemas/", ""),
+      );
+    }
+    expect(compared).toBeGreaterThan(150);
   });
 
-  it("answers null for a route with no data ref", () => {
-    expect(dataComponent({ paths: {} }, "/r")).toBeNull();
+  it("answers null for a route the contract does not define", () => {
+    expect(dataComponent("/api/v1/not-a-route")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #10713

Four scripts walked the generated `openapi.json` for the same answer — which
component a route's `data` carries — and each had written its own walk down
`paths[route].get.responses["200"].content["application/json"].schema.allOf[]
.properties.data.$ref`. Two also declared their own `OpenApiDocument` for the
trip, structurally identical and unaware of each other.

**None of them had to.** `src/contracts.ts` computes that `$ref`, in one line,
from the route's own artifact path:

```ts
data: { $ref: `#/components/schemas/${schemaRefForArtifactPath(entry.artifact_path)}` }
```

and `schemaRefForArtifactPath` is exported. The four walks were hand-rolled
re-derivations of a function that already existed, run against the artifact
instead of the source that generates it.

`dataComponent(route)` now reads a map built from `API_ROUTES` +
`schemaRefForArtifactPath`. Nothing in the new module models the envelope, so
changing the envelope shape cannot strand a copy.

## Why this class of duplication is worth removing

A missed copy does not throw. The walk returns `null`, every caller reads that
as "this route names no component", and the gate skips it — a gate that skips
is a gate that passes.

That is not hypothetical. Building the map from `API_ROUTES` alone left all
**42 network-scoped routes** answering null, because the `/api/v1/{network}/…`
twins are not their own entries. The cross-check below caught it on the first
run. They resolve through the emitter's own `networkVariantPath` now, rather
than through a second rule about which routes qualify.

## The check that keeps it honest

`tests/graphql-int-range.test.ts` previously fed `dataComponent` a synthetic
document it had also written — which only ever proved the walk could read its
own fixture. It now compares the derivation against **every route the published
document defines** (171 of them), so the source and the artifact cannot drift
apart without a test failing.

Two scripts stopped reading `openapi.json` altogether: it was the only reason
they opened it.

## Verification

- `typecheck` · `lint` · `format` · `validate` · `contract-drift` — clean
- `validate:published-names`, `validate:graphql-component-parity`,
  `check-graphql-int-range` — OK
- **848 test files, 19,445 tests passing**

| | before | after |
|---|---|---|
| `dataComponent` implementations | 4 | 1 |
| `OpenApiDocument` declarations | 2 | 1 |
| scripts reading `openapi.json` for this | 4 | 0 |

Net −49 lines.
