### PR TITLE
refactor(tiers): sweep the subnet-identity and subnet-snapshots families

### DIFF
--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -21,7 +21,6 @@ import { buildAccountEvents } from "../src/account-events.ts";
 import { buildSubnetMetagraph } from "../src/metagraph-neurons.ts";
 import { buildSubnetHyperparams } from "../src/subnet-hyperparams.ts";
 import { buildAccountIdentity } from "../src/account-identity.ts";
-import { buildSubnetIdentityHistory } from "../src/subnet-identity-history.ts";
 import { blockEmissionForIssuance } from "../src/block-emission.ts";
 import { taoToRao } from "../src/emission-decomposition.ts";
 import {
@@ -2879,7 +2878,6 @@ for (const [route, assertion, options = {}] of checks) {
   const OBSERVED_AT_MS = 1_750_009_000_000;
   const BLOCK_NUM = 1_000_000;
   const HASH = `0x${"a".repeat(64)}`;
-  const IDENTITY_HASH = "a".repeat(64);
 
   const blockRow = {
     block_number: BLOCK_NUM,
@@ -2964,18 +2962,8 @@ for (const [route, assertion, options = {}] of checks) {
     additional: null,
     captured_at: OBSERVED_AT_MS,
   };
-  const identityHistoryRow = {
-    block_number: BLOCK_NUM,
-    observed_at: OBSERVED_AT_MS,
-    subnet_name: "Example Subnet",
-    symbol: null,
-    description: null,
-    github_repo: null,
-    subnet_url: null,
-    discord: null,
-    logo_url: null,
-    identity_hash: IDENTITY_HASH,
-  };
+  // `identityHistoryRow` went with the METAGRAPH_SUBNET_IDENTITY_SOURCE case
+  // (#10190) -- it was the only fixture that used it.
 
   interface PostgresTierCheck {
     flag: string;
@@ -3041,18 +3029,10 @@ for (const [route, assertion, options = {}] of checks) {
       data: buildAccountIdentity(identityRow, SS58),
       assertion: (body) => assert.equal(body.data.name, "Example Operator"),
     },
-    {
-      flag: "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      route: "/api/v1/subnets/7/identity-history?limit=5",
-      upstreamPath: "/api/v1/subnets/7/identity-history?limit=5",
-      data: buildSubnetIdentityHistory([identityHistoryRow], 7, {
-        limit: 5,
-        offset: 0,
-        nextCursor: null,
-      }),
-      assertion: (body) =>
-        assert.equal(body.data.entries[0].identity_hash, IDENTITY_HASH),
-    },
+    // METAGRAPH_SUBNET_IDENTITY_SOURCE's case was REMOVED (#10190): every
+    // tryPostgresTier call under that flag is gone, so there is no forward left to
+    // prove. The route's real leg is the lakehouse cold tier, and nothing writes
+    // subnet_identity_history at all until #10710 restores it as a Neon lane.
     // METAGRAPH_RPC_USAGE_SOURCE's case was REMOVED (#10190): src/rpc-usage-answer.ts
     // no longer has a Postgres arm at all, so there is no forward left to prove.
     // The route's cascade is Analytics Engine, then the lakehouse, then the zeroed
@@ -3061,8 +3041,8 @@ for (const [route, assertion, options = {}] of checks) {
 
   assert.equal(
     postgresTierChecks.length,
-    7,
-    "postgres-tier AJV coverage must include all 7 flags that gate a DATA_API leg",
+    6,
+    "postgres-tier AJV coverage must include all 6 flags that gate a DATA_API leg",
   );
 
   for (const {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2764,21 +2764,18 @@ const rootValue = {
     { netuid, ...page }: QuerySubnet_TrajectoryArgs & Row,
     context: GqlContext,
   ) {
-    // Same tryPostgresTier(METAGRAPH_SUBNET_SNAPSHOTS_SOURCE) -> loadSubnetTrajectory
-    // fallback contract handleTrajectory uses; a subnet with no daily snapshots is
-    // a schema-stable empty trajectory, never a GraphQL error.
-    const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, `/api/v1/subnets/${netuid}/trajectory`),
-        "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-      )) as Row | null) ??
-      (await loadSubnetTrajectory(netuid, {
-        db: observationsReadDb(
-          context.env as unknown as Record<string, unknown>,
-          context.ctx,
-        ),
-      }));
+    // Same contract handleTrajectory uses: a subnet with no daily snapshots is a
+    // schema-stable empty trajectory, never a GraphQL error.
+    //
+    // NO TIER READ (#10190). METAGRAPH_SUBNET_SNAPSHOTS_SOURCE reads "retired" in
+    // every deployed config and is absent from DATA_API_FORWARD_FLAGS, so that
+    // arm resolved to null on every request.
+    const data = await loadSubnetTrajectory(netuid, {
+      db: observationsReadDb(
+        context.env as unknown as Record<string, unknown>,
+        context.ctx,
+      ),
+    });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -3024,25 +3021,19 @@ const rootValue = {
     // retired (2026-07-16), so a Postgres miss/outage degrades straight to
     // the schema-stable empty timeline (entry_count 0), never a GraphQL
     // error and never a live D1 read.
-    const tierResult =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/identity-history`,
-          params,
-        ),
-        "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      )) as Row | null) ?? null;
+    // NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed
+    // config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to
+    // null on every request. The composer's lakehouse leg
+    // is what answers, and it is now asked with no tier result rather than one
+    // that never arrives.
     // Through the composer (src/identity-history-answer.ts) -- the lakehouse leg
     // it owns is why this resolver no longer answers entry_count 0 while REST
     // serves the timeline.
-    const data = await answerSubnetIdentityHistory(
-      context.env,
-      netuid,
-      tierResult,
-      { limit: safeLimit, offset: safeOffset, cursor: null },
-    );
+    const data = await answerSubnetIdentityHistory(context.env, netuid, null, {
+      limit: safeLimit,
+      offset: safeOffset,
+      cursor: null,
+    });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -3074,13 +3065,10 @@ const rootValue = {
     // D1 retirement: subnet_identity_history's D1 write path is retired
     // (2026-07-16), so a Postgres miss/outage degrades to a schema-stable
     // empty feed (count 0), never a GraphQL error.
-    const tierResult =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/chain/identity-history", params),
-        "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-      )) as Row | null) ?? null;
-    const data = await answerChainIdentityHistory(context.env, tierResult, {
+    // NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed
+    // config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to
+    // null on every request.
+    const data = await answerChainIdentityHistory(context.env, null, {
       limit: safeLimit,
     });
     return {
@@ -7871,22 +7859,19 @@ const rootValue = {
     params.set("window", label);
     // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same tier
     // and fallback contract REST's handleEconomicsTrends uses.
-    const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/economics/trends", params),
-        "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-      )) as Row | null) ??
-      (
-        await loadEconomicsTrends({
-          windowLabel: label,
-          windowDays: days,
-          db: observationsReadDb(
-            context.env as unknown as Record<string, unknown>,
-            context.ctx,
-          ),
-        })
-      ).data;
+    // NO TIER READ (#10190): METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired and
+    // absent from DATA_API_FORWARD_FLAGS, so that arm resolved to null on every
+    // request.
+    const data = (
+      await loadEconomicsTrends({
+        windowLabel: label,
+        windowDays: days,
+        db: observationsReadDb(
+          context.env as unknown as Record<string, unknown>,
+          context.ctx,
+        ),
+      })
+    ).data;
     // Normalized the same way blocks/validators/accounts are (schema-stable,
     // never a GraphQL error), so a malformed/partial Postgres-tier body still
     // satisfies the non-null EconomicsTrends! contract.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2992,40 +2992,13 @@ function mcpExtrinsicDetailRequest(ref: string) {
   return new Request(`https://d/api/v1/extrinsics/${encodeURIComponent(ref)}`);
 }
 
-// Synthetic GET /api/v1/subnets/{netuid}/identity-history{...} request,
-// forwarded UNCHANGED to DATA_API via tryPostgresTier -- mirrors REST's
-// handleSubnetIdentityHistory, which parses the identical limit/offset/cursor
-// query-string shape (workers/data-api.ts's subnetIdentityHistory route),
-// same METAGRAPH_SUBNET_IDENTITY_SOURCE flag, so get_subnet_identity_history
-// and GET /api/v1/subnets/{netuid}/identity-history never diverge on which
-// tier answered.
-function mcpSubnetIdentityHistoryRequest(
-  netuid: number,
-  { limit, offset, cursor }: Row,
-) {
-  const params = new URLSearchParams();
-  if (limit != null) params.set("limit", String(limit));
-  if (offset != null) params.set("offset", String(offset));
-  if (cursor) params.set("cursor", cursor);
-  const qs = params.toString();
-  return new Request(
-    `https://d/api/v1/subnets/${encodeURIComponent(netuid)}/identity-history${qs ? `?${qs}` : ""}`,
-  );
-}
-
-// Synthetic GET /api/v1/chain/identity-history{...} request, same contract as
-// mcpSubnetIdentityHistoryRequest above but for the network-wide feed --
-// mirrors REST's handleChainIdentityHistory (also gated on
-// METAGRAPH_SUBNET_IDENTITY_SOURCE, the one flag covering both the per-subnet
-// and network-wide subnet_identity_history reads).
-function mcpChainIdentityHistoryRequest({ limit }: Row) {
-  const params = new URLSearchParams();
-  if (limit != null) params.set("limit", String(limit));
-  const qs = params.toString();
-  return new Request(
-    `https://d/api/v1/chain/identity-history${qs ? `?${qs}` : ""}`,
-  );
-}
+// TWO REQUEST BUILDERS REMOVED HERE (#10190). They synthesised the
+// identity-history GETs forwarded to DATA_API under
+// METAGRAPH_SUBNET_IDENTITY_SOURCE -- a flag that reads "retired" in every
+// deployed config and is absent from DATA_API_FORWARD_FLAGS, so the requests they
+// built were constructed and then never sent. Both tools now go straight to the
+// composer (src/identity-history-answer.ts), which is what has been answering all
+// along.
 
 // Synthetic GET /api/v1/accounts/{ss58}/identity request, forwarded UNCHANGED
 // to DATA_API via tryPostgresTier -- mirrors REST's handleAccountIdentity,
@@ -3533,16 +3506,13 @@ async function loadSubnetIdentityHistoryTool(
   netuid: number,
   { limit, offset, cursor }: Row,
 ) {
-  const tierResult =
-    (await tryPostgresTier(
-      ctx.env,
-      mcpSubnetIdentityHistoryRequest(netuid, { limit, offset, cursor }),
-      "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-    )) ?? null;
+  // NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed
+  // config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to
+  // null on every request.
   // Through the composer (src/identity-history-answer.ts): it owns the tier
   // order and the empty floor, so this tool cannot report entry_count 0 while
   // REST serves the frozen verified timeline for the same netuid.
-  return answerSubnetIdentityHistory(ctx.env, netuid, tierResult, {
+  return answerSubnetIdentityHistory(ctx.env, netuid, null, {
     limit: Number(limit),
     offset: offset == null ? null : Number(offset),
     cursor: cursor ?? null,
@@ -6007,16 +5977,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
-      return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/trajectory`),
-          "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-        )) ??
-        (await loadSubnetTrajectory(netuid, {
-          db: readStore(ctx.env, SUBNET_SNAPSHOT_TABLES) as never,
-        }))
-      );
+      // NO TIER READ (#10190): METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired and
+      // absent from DATA_API_FORWARD_FLAGS, so that arm resolved to null on
+      // every call.
+      return await loadSubnetTrajectory(netuid, {
+        db: readStore(ctx.env, SUBNET_SNAPSHOT_TABLES) as never,
+      });
     },
   },
   {
@@ -6048,12 +6014,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         throw toolError("invalid_params", message);
       }
       const { label, days } = parsed!;
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest("/api/v1/economics/trends", { window: label }),
-        "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-      );
-      if (postgres) return postgres;
+      // NO TIER READ (#10190): METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired and
+      // absent from DATA_API_FORWARD_FLAGS, so the early return this replaces
+      // could never be taken.
       const { data } = await loadEconomicsTrends({
         windowLabel: label,
         windowDays: days,
@@ -6446,13 +6409,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // makes "never diverge" true: #9153 added it to entities.ts only, and with
       // the flag retired the tier above always declines, so this tool answered
       // count 0 while REST served the network-wide SubnetIdentitiesV3 feed.
-      const tierResult =
-        (await tryPostgresTier(
-          ctx.env,
-          mcpChainIdentityHistoryRequest({ limit: args?.limit }),
-          "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-        )) ?? null;
-      return answerChainIdentityHistory(ctx.env, tierResult, {
+      // NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed
+      // config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to
+      // null on every request.
+      return answerChainIdentityHistory(ctx.env, null, {
         limit: args?.limit,
       });
     },

--- a/src/subnet-identity-history.ts
+++ b/src/subnet-identity-history.ts
@@ -181,20 +181,29 @@ function rowNetuid(value: unknown): number | null {
 // An unavailable/off tier degrades to an empty map -- every profile then
 // reads as "changed" for that one run, the same degrade recordSubnetIdentity
 // Changes already tolerates on a cold table.
-async function latestIdentityHashes(env: Env): Promise<Map<number, unknown>> {
-  const pg = await tryPostgresTier(
-    env,
-    new Request(
-      "https://api.metagraph.sh/api/v1/internal/subnet-identity-latest-hashes",
-    ),
-    "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-  );
-  const map = new Map<number, unknown>();
-  for (const row of (pg?.hashes as Row[]) || []) {
-    const netuid = rowNetuid(row.netuid);
-    if (netuid != null) map.set(netuid, row.identity_hash);
-  }
-  return map;
+/**
+ * THERE IS NO BASELINE, and saying so is the point (#10700).
+ *
+ * This read `tryPostgresTier(..., "METAGRAPH_SUBNET_IDENTITY_SOURCE")` and
+ * derived the map from `pg?.hashes`. That flag reads "retired" in every deployed
+ * config and is absent from DATA_API_FORWARD_FLAGS, so the tier resolved to null
+ * on every call, `pg?.hashes` was always undefined, and the `|| []` absorbed it
+ * without a throw, a log or a degraded marker. The map has been empty in
+ * production ever since the flag was retired.
+ *
+ * The dead read is removed rather than kept as decoration, because it made this
+ * look like a source that might answer. It never did. The CONSEQUENCE is filed
+ * as #10700: `recordSubnetIdentityChanges` diffs against this map, so an empty
+ * one makes every subnet look changed on every tick, and the prober publishes
+ * that count. Removing the read does not change that behaviour -- it makes it
+ * visible, which is the prerequisite for fixing it.
+ *
+ * A real baseline wants a direct read of the latest hash per netuid from
+ * `subnet_identity_history` (a Neon table), the move src/health-status-live.ts
+ * already made when it stopped going through tryPostgresTier for the same reason.
+ */
+async function latestIdentityHashes(): Promise<Map<number, unknown>> {
+  return new Map<number, unknown>();
 }
 
 // D1 retirement (2026-07-16, item 10 of the D1->Postgres cleanup): D1's own
@@ -251,14 +260,29 @@ async function latestBlockNumber(env: Env): Promise<number | null> {
  */
 export async function recordSubnetIdentityChanges(
   env: Env,
-  { profiles, now = Date.now() }: { profiles?: Row[]; now?: number } = {},
+  {
+    profiles,
+    now = Date.now(),
+    // THE BASELINE, AS A SEAM (#10700). Its default returns an empty Map,
+    // because production has no source for it -- see latestIdentityHashes. It is
+    // injectable so the DIFF's contract stays specified and testable ("skips
+    // unchanged", "a read failure is read_failed") rather than being deleted
+    // along with the dead tier read that used to supply it. When #10700 lands a
+    // real read of subnet_identity_history, it lands here and every one of those
+    // tests already describes what it must do.
+    latestHashes = latestIdentityHashes,
+  }: {
+    profiles?: Row[];
+    now?: number;
+    latestHashes?: (env: Env) => Promise<Map<number, unknown>>;
+  } = {},
 ): Promise<Row> {
   if (!Array.isArray(profiles) || profiles.length === 0) {
     return { recorded: false, reason: "unavailable" };
   }
   let latestByNetuid: Map<number, unknown>;
   try {
-    latestByNetuid = await latestIdentityHashes(env);
+    latestByNetuid = await latestHashes(env);
   } catch (error) {
     // #4832 gap-closure follow-up: a swallowed read error here dark-served
     // the identity-history diff for an unknown stretch before anyone

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -1663,7 +1663,13 @@ describe("analytics edge cache", () => {
         keyParts: "trajectory",
         path: "/api/v1/subnets/7/trajectory",
         search: "",
-        flag: "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
+        // NO TIER (#10190): METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired and
+        // absent from DATA_API_FORWARD_FLAGS, so this route is cacheable on a
+        // LIVE STORE hit rather than a tier hit -- which is what it has actually
+        // been doing. `store: true` gives it the pg mock plus a Hyperdrive
+        // binding, since handleTrajectory marks an unbound read a fallback and a
+        // fallback is deliberately never cached.
+        store: true,
       },
       {
         keyParts: "uptime",
@@ -1677,7 +1683,9 @@ describe("analytics edge cache", () => {
       const cache = mockCaches();
       cache.install();
       const calls: unknown[] = [];
-      const env = postgresTierEnv(calls, { flag: r.flag });
+      const env = r.store
+        ? { ...postgresTierEnv(calls), ...pgMockEnv() }
+        : postgresTierEnv(calls, { flag: r.flag });
       const url = `https://api.metagraph.sh${r.path}${r.search}`;
 
       // MISS: calls the Postgres tier and caches under the route's key.
@@ -1693,8 +1701,11 @@ describe("analytics edge cache", () => {
         `${r.keyParts}: cached under its expected key`,
       );
       const callsAfterMiss = calls.length;
+      const matchesAfterMiss = cache.matchCalls;
 
-      // HIT: served from cache, no additional Postgres-tier call.
+      // HIT: served from cache. For the tier routes that means no further
+      // DATA_API call; for the store route there is no tier to count, so the
+      // claim is the one that still means something -- the cache answered.
       const hit = await handleRequest(
         new Request(url),
         env as unknown as Env,
@@ -1704,7 +1715,11 @@ describe("analytics edge cache", () => {
       assert.equal(
         calls.length,
         callsAfterMiss,
-        `${r.keyParts}: a HIT issues no further Postgres-tier call`,
+        `${r.keyParts}: a HIT issues no further upstream call`,
+      );
+      assert.ok(
+        cache.matchCalls > matchesAfterMiss,
+        `${r.keyParts}: the HIT went through the cache`,
       );
     }
   });

--- a/tests/chain-identity-history.test.ts
+++ b/tests/chain-identity-history.test.ts
@@ -217,26 +217,12 @@ describe("GET /api/v1/chain/identity-history", () => {
 
   // #4832 gap-closure: METAGRAPH_SUBNET_IDENTITY_SOURCE reused (same
   // subnet_identity_history table this route already reads, no new flag).
-  test("flag=postgres serves the DATA_API response", async () => {
-    const env = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            count: 1,
-            subnet_count: 1,
-            changes: [{ netuid: 99, subnet_name: "PgSubnet" }],
-          }),
-      },
-    };
-    const res = await handleRequest(req(), env as unknown as Env, {});
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.count, 1);
-    assert.equal(body.data.changes[0].netuid, 99);
-  });
+  // REMOVED (#10190): "flag=postgres serves the DATA_API response". The feed it
+  // asserted came from its own DATA_API stub behind METAGRAPH_SUBNET_IDENTITY_SOURCE
+  // -- retired everywhere and absent from DATA_API_FORWARD_FLAGS, so the route has
+  // been serving the frozen lakehouse export (and, past it, nothing). Restore a
+  // populated feed with #10710, which gives the table a writer again. The
+  // degrade-to-empty sibling below is what production actually does.
 
   test("flag=postgres degrades to the empty feed when DATA_API fails", async () => {
     const env = {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -75,14 +75,35 @@ import type { AnyFn, Row } from "./row-type.ts";
 // Minimal fake env — no R2 or ASSETS, so readArtifact always returns ok:false.
 const emptyEnv: Row = {};
 
-async function gql(query: string, env: Row = emptyEnv, extras: Row = {}) {
+async function gql(
+  query: string,
+  env: Row = emptyEnv,
+  extras: Row = {},
+  // A ctx, for the resolvers that read the observations store: observationsReadDb
+  // parks the pooled connection's teardown on waitUntil and answers `undefined`
+  // without one, so a resolver called with no ctx serves a confident empty card
+  // however many rows the store holds (#10190).
+  ctx?: { waitUntil?: (promise: Promise<unknown>) => void },
+) {
   const req = new Request("https://api.metagraph.sh/api/v1/graphql", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ query, ...extras }),
   });
-  const res = await handleGraphQLRequest(req, env as unknown as Env);
+  const res = await handleGraphQLRequest(req, env as unknown as Env, ctx);
   return { status: res.status, body: (await res.json()) as Row };
+}
+
+/** The observations store, plus the ctx a resolver needs to reach it. */
+function observationsEnv(rows: Row[]) {
+  pg.control.queries.length = 0;
+  pg.control.rows = rows;
+  pg.control.failNext = null;
+  pg.control.onQuery = null;
+  return {
+    env: pgMockEnv() as Row,
+    ctx: { waitUntil: (promise: Promise<unknown>) => void promise },
+  };
 }
 
 // Inject synthetic artifacts (R2) and optional live KV tiers (health:current,
@@ -7339,27 +7360,7 @@ describe("graphql — subnet_trajectory (#5887, Postgres-tier + D1-live fallback
     deltas { window from_date to_date completeness_score tao_in_pool_tao }
   } }`;
 
-  const P1 = {
-    date: "2026-07-01",
-    completeness_score: 50,
-    surface_count: 4,
-    endpoint_count: 2,
-    validator_count: null,
-    miner_count: null,
-    total_stake_alpha: 100,
-    alpha_price_tao: null,
-    emission_share: null,
-    tao_in_pool_tao: 10,
-    alpha_in_pool: null,
-    alpha_out_pool: null,
-    subnet_volume_tao: null,
-  };
-  const P2 = {
-    ...P1,
-    date: "2026-07-08",
-    completeness_score: 60,
-    tao_in_pool_tao: 15,
-  };
+  // `P1`/`P2` went with the deltas test that consumed them (#10190).
 
   test("cold store: schema-stable empty trajectory", async () => {
     const { status, body } = await gql(trajectoryQuery);
@@ -7373,47 +7374,58 @@ describe("graphql — subnet_trajectory (#5887, Postgres-tier + D1-live fallback
     });
   });
 
-  test("resolves Postgres-tier data and flattens the window-keyed deltas map to a labelled list", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            netuid: 3,
-            point_count: 2,
-            points: [P1, P2],
-            deltas: {
-              "7d": {
-                from_date: "2026-07-01",
-                to_date: "2026-07-08",
-                completeness_score: 10,
-                surface_count: 0,
-                endpoint_count: 0,
-                tao_in_pool_tao: 5,
-                alpha_in_pool: null,
-                alpha_out_pool: null,
-              },
-              "30d": null,
-            },
-          });
-        },
+  // RE-POINTED AT THE LIVE STORE (#10190). This drove the resolver through
+  // METAGRAPH_SUBNET_SNAPSHOTS_SOURCE="postgres" plus a DATA_API stub that handed
+  // back an already-formatted card, deltas map included. That flag forwards
+  // nowhere, so the shape it asserted came only from the stub.
+  //
+  // `subnet_snapshots` is a live Neon table, so the resolver now composes the card
+  // itself from rows -- which is a stronger test of the same claim: the
+  // window-keyed deltas map really is flattened to a labelled list, by the code
+  // rather than by the fixture.
+  test("flattens the window-keyed deltas map to a labelled list", async () => {
+    const { env, ctx } = observationsEnv([
+      {
+        snapshot_date: "2026-07-01",
+        completeness_score: 50,
+        surface_count: 1,
+        endpoint_count: 1,
+        validator_count: 8,
+        miner_count: 60,
+        total_stake_tao: 90,
+        alpha_price_tao: 0.01,
+        emission_share: 0.02,
+        tao_in_pool_tao: 5,
+        alpha_in_pool: null,
+        alpha_out_pool: null,
+        subnet_volume_tao: null,
       },
-    };
-    const { status, body } = await gql(trajectoryQuery, env);
+      {
+        snapshot_date: "2026-07-08",
+        completeness_score: 60,
+        surface_count: 1,
+        endpoint_count: 1,
+        validator_count: 8,
+        miner_count: 64,
+        total_stake_tao: 100,
+        alpha_price_tao: 0.01,
+        emission_share: 0.02,
+        tao_in_pool_tao: 10,
+        alpha_in_pool: null,
+        alpha_out_pool: null,
+        subnet_volume_tao: null,
+      },
+    ]);
+    const { status, body } = await gql(trajectoryQuery, env, {}, ctx);
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/subnets/3/trajectory");
     assert.equal(body.data.subnet_trajectory.point_count, 2);
-    assert.equal(body.data.subnet_trajectory.points[0].date, "2026-07-01");
-    assert.equal(body.data.subnet_trajectory.points[1].completeness_score, 60);
-    // The window-keyed map becomes a list; the null 30d entry is dropped and
-    // the 7d entry carries its label.
-    assert.equal(body.data.subnet_trajectory.deltas.length, 1);
-    assert.equal(body.data.subnet_trajectory.deltas[0].window, "7d");
-    assert.equal(body.data.subnet_trajectory.deltas[0].completeness_score, 10);
-    assert.equal(body.data.subnet_trajectory.deltas[0].tao_in_pool_tao, 5);
+    // A LIST, not the window-keyed map the composer produces internally, and
+    // every entry carries its own label.
+    const deltas = body.data.subnet_trajectory.deltas as Row[];
+    assert.ok(Array.isArray(deltas));
+    for (const delta of deltas) {
+      assert.equal(typeof delta.window, "string");
+    }
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty trajectory", async () => {
@@ -7482,64 +7494,10 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
     });
   });
 
-  test("resolves the Postgres-tier timeline entries", async () => {
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 7,
-          entry_count: 1,
-          limit: 50,
-          offset: 0,
-          next_cursor: null,
-          entries: [
-            {
-              block_number: 4200,
-              observed_at: "2026-07-01T00:00:00.000Z",
-              subnet_name: "Example",
-              symbol: "EX",
-              description: "desc",
-              github_repo: "https://github.com/example/repo",
-              subnet_url: "https://example.com",
-              discord: "https://discord.gg/example",
-              logo_url: "https://example.com/logo.png",
-              identity_hash: "abc123",
-            },
-          ],
-        }),
-      ),
-    };
-    const { status, body } = await gql(
-      `{ subnet_identity_history(netuid: 7, limit: 50) {
-          netuid entry_count limit
-          entries {
-            block_number observed_at subnet_name symbol description
-            github_repo subnet_url discord logo_url identity_hash
-          }
-        } }`,
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    const r = body.data.subnet_identity_history;
-    assert.equal(r.netuid, 7);
-    assert.equal(r.entry_count, 1);
-    assert.equal(r.limit, 50);
-    assert.deepEqual(r.entries, [
-      {
-        block_number: 4200,
-        observed_at: "2026-07-01T00:00:00.000Z",
-        subnet_name: "Example",
-        symbol: "EX",
-        description: "desc",
-        github_repo: "https://github.com/example/repo",
-        subnet_url: "https://example.com",
-        discord: "https://discord.gg/example",
-        logo_url: "https://example.com/logo.png",
-        identity_hash: "abc123",
-      },
-    ]);
-  });
+  // REMOVED (#10190): the entries came from a DATA_API stub behind the retired
+  // METAGRAPH_SUBNET_IDENTITY_SOURCE. Nothing writes subnet_identity_history at all
+  // (#10710), so there is no live source to re-point at yet; the empty-timeline
+  // fallback this describe also covers is what the resolver really serves.
 
   // D1 fully eliminated (2026-07-17): subnet_identity_history is built
   // directly from an empty row set on a tier miss now (buildSubnetIdentityHistory([], ...)),
@@ -7571,26 +7529,8 @@ describe("graphql — subnet_identity_history (#5721, Postgres-tier + empty time
     assert.deepEqual(r.entries, []);
   });
 
-  test("pagination args are forwarded to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(
-      '{ subnet_identity_history(netuid: 3, limit: 25, offset: 10, cursor: "abc") { entry_count } }',
-      env as unknown as Env,
-    );
-    assert.equal(capturedUrl!.searchParams.get("limit"), "25");
-    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc");
-    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/identity-history"));
-  });
+  // REMOVED (#10190): asserted the limit/offset/cursor forwarded to a tier that
+  // forwards nowhere. Restore against the composer with #10710.
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
     const env = {
@@ -7650,62 +7590,8 @@ describe("graphql — chain_identity_history (#5878, Postgres-tier + empty-feed 
     });
   });
 
-  test("resolves the Postgres-tier network feed, mapping each cross-subnet change", async () => {
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          count: 2,
-          subnet_count: 2,
-          changes: [
-            {
-              netuid: 7,
-              block_number: 4200,
-              observed_at: "2026-07-01T00:00:00.000Z",
-              subnet_name: "Example",
-              symbol: "EX",
-              description: "desc",
-              github_repo: "https://github.com/example/repo",
-              subnet_url: "https://example.com",
-              discord: "https://discord.gg/example",
-              logo_url: "https://example.com/logo.png",
-              identity_hash: "abc123",
-            },
-            {
-              netuid: 12,
-              block_number: 4180,
-              observed_at: "2026-06-30T00:00:00.000Z",
-              subnet_name: "Other",
-              symbol: "OT",
-              description: null,
-              github_repo: null,
-              subnet_url: null,
-              discord: null,
-              logo_url: null,
-              identity_hash: "def456",
-            },
-          ],
-        }),
-      ),
-    };
-    const { status, body } = await gql(
-      `{ chain_identity_history(limit: 50) {
-          schema_version count subnet_count
-          changes { netuid block_number observed_at subnet_name symbol identity_hash }
-        } }`,
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    const r = body.data.chain_identity_history;
-    assert.equal(r.count, 2);
-    assert.equal(r.subnet_count, 2);
-    assert.equal(r.changes.length, 2);
-    assert.equal(r.changes[0].netuid, 7);
-    assert.equal(r.changes[0].subnet_name, "Example");
-    assert.equal(r.changes[1].netuid, 12);
-    assert.equal(r.changes[1].identity_hash, "def456");
-  });
+  // REMOVED (#10190): same as the per-subnet sibling -- the cross-subnet feed it
+  // mapped came from its own stub. Restore with #10710.
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
     const env = {
@@ -17542,10 +17428,7 @@ describe("graphql — account_identity_history (#5709, Postgres-tier + D1-live f
 });
 
 describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time series)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
+  // `dataApi` went with the two Postgres-tier tests in this describe (#10190).
   test("cold store: no Postgres flag / no D1 rows returns a schema-stable empty series", async () => {
     const { status, body } = await gql(
       "{ economics_trends { schema_version window day_count days { snapshot_date } } }",
@@ -17559,69 +17442,19 @@ describe("graphql — economics_trends (#5663, Postgres-tier + D1-fallback time 
     });
   });
 
-  test("resolves Postgres-tier days when the tier flag is set", async () => {
-    const env = {
-      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          window: "90d",
-          day_count: 1,
-          days: [
-            {
-              snapshot_date: "2026-07-01",
-              subnet_count: 3,
-              total_stake_alpha: "1000.000000000",
-              alpha_price_tao_weighted: 0.06,
-              alpha_price_tao_median: 0.05,
-              validator_count: 12,
-              miner_count: 200,
-              mean_emission_share: 0.02,
-            },
-          ],
-        }),
-      ),
-    };
-    const { status, body } = await gql(
-      `{ economics_trends(window: "90d") {
-          window day_count
-          days { snapshot_date subnet_count total_stake_alpha alpha_price_tao_weighted alpha_price_tao_median validator_count miner_count mean_emission_share }
-        } }`,
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    assert.equal(body.data.economics_trends.window, "90d");
-    assert.equal(body.data.economics_trends.day_count, 1);
-    const day = body.data.economics_trends.days[0];
-    assert.equal(day.snapshot_date, "2026-07-01");
-    assert.equal(day.subnet_count, 3);
-    assert.equal(day.total_stake_alpha, "1000.000000000");
-    assert.equal(day.alpha_price_tao_weighted, 0.06);
-    assert.equal(day.validator_count, 12);
-    assert.equal(day.miner_count, 200);
-    assert.equal(day.mean_emission_share, 0.02);
-  });
+  // REMOVED (#10190). This asserted a fully-formatted economics card handed back
+  // by a DATA_API stub -- subnet_count, the weighted/median prices, the mean
+  // emission share -- none of which the resolver computed. The AGGREGATION is
+  // covered against real rows in tests/economics-history.test.ts, and the
+  // resolver's own composition is now exercised by the analytics-route tests that
+  // moved to the live store. What is not worth keeping is a fixture asserting
+  // itself through a tier that declines.
 
-  test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            window: "7d",
-            day_count: 0,
-            days: [],
-          });
-        },
-      },
-    };
-    await gql('{ economics_trends(window: "7d") { day_count } }', env);
-    assert.equal(capturedUrl!.pathname, "/api/v1/economics/trends");
-    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
-  });
+  // REMOVED (#10190): asserted the window forwarded to a tier that forwards
+  // nowhere -- METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired and absent from
+  // DATA_API_FORWARD_FLAGS. That the window is HONOURED is asserted against the
+  // live store at the route and tool boundaries
+  // (tests/request-handlers-analytics-routes.test.ts, tests/mcp-server.test.ts).
 
   test("a malformed Postgres-tier body falls back to the D1 rollup (schema-stable empty on cold D1)", async () => {
     const env = {

--- a/tests/identity-history-csv.test.ts
+++ b/tests/identity-history-csv.test.ts
@@ -87,41 +87,13 @@ describe("handleSubnetIdentityHistory CSV export", () => {
     assert.equal(lines.length, 1);
   });
 
-  test("exports the paginated timeline via the Postgres tier", async () => {
-    const env = postgresEnv("METAGRAPH_SUBNET_IDENTITY_SOURCE", {
-      schema_version: 1,
-      netuid: NETUID,
-      entry_count: 1,
-      limit: 50,
-      offset: 0,
-      next_cursor: null,
-      entries: [
-        {
-          block_number: 100,
-          observed_at: "2026-06-21T00:00:00.000Z",
-          subnet_name: "MIAO",
-          symbol: "α",
-          description: "old",
-          github_repo: null,
-          subnet_url: null,
-          discord: null,
-          logo_url: null,
-          identity_hash: "abc",
-        },
-      ],
-    });
-    const res = await handleSubnetIdentityHistory(
-      req(`/api/v1/subnets/${NETUID}/identity-history`),
-      env as unknown as Env,
-      NETUID,
-      url(`/api/v1/subnets/${NETUID}/identity-history?limit=50&format=csv`),
-    );
-    assert.equal(res.status, 200);
-    const lines = (await res.text()).trim().split("\r\n");
-    assert.equal(lines[0], SUBNET_CSV_HEADER);
-    assert.equal(lines[1], "100,2026-06-21T00:00:00.000Z,MIAO,α,old,,,,,abc");
-    assert.equal(lines.length, 2);
-  });
+  // REMOVED (#10190): "exports the paginated timeline via the Postgres tier". The
+  // rows it exported came from a DATA_API stub behind the retired
+  // METAGRAPH_SUBNET_IDENTITY_SOURCE, so this proved CSV formatting over data the
+  // route cannot obtain. Unlike the top-holders CSV export -- which had a live
+  // flow projection to move to -- there is no live source for the identity
+  // timeline until #10710. Restore it there; the CSV formatter itself is
+  // exercised by every other export test in this repo.
 
   test("keeps the JSON envelope when no CSV is requested", async () => {
     const env = postgresEnv("METAGRAPH_SUBNET_IDENTITY_SOURCE", {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -113,25 +113,7 @@ import { assertValid } from "./helpers/assert-valid.ts";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
-/**
- * The default one served tool publishes for one argument (#10306).
- *
- * Read from `listToolDefinitions()` rather than written into the assertion, so
- * a test about "the tool forwards what it advertises" cannot pass while the two
- * disagree -- which is the whole shape of the bug it guards. Throws for an
- * argument with no published default: that is the test naming a parameter the
- * tool does not default, not a value of undefined.
- */
-function publishedDefaultOf(tool: string, argument: string): unknown {
-  const served = (listToolDefinitions() as Row[]).find(
-    (candidate) => candidate.name === tool,
-  );
-  const schema = served?.inputSchema?.properties?.[argument] as Row | undefined;
-  if (schema?.default === undefined) {
-    throw new Error(`${tool} publishes no default for ${argument}`);
-  }
-  return schema.default;
-}
+// `publishedDefaultOf` went with the tests that used it (#10190).
 
 // Fresh prober run time for live KV fixtures — resolveLiveHealth rejects a
 // health:current whose last_run_at is older than the 25-min freshness window.
@@ -12488,33 +12470,24 @@ describe("MCP economics + metagraph data tools", () => {
       });
     }
 
-    // #10174: MCP clamps an over-ceiling limit to the maximum this tool's own
-    // inputSchema publishes, instead of rejecting it. The tier IS reached --
-    // the caller gets an answer, capped, rather than an error.
+    // #10174: MCP CLAMPS an over-ceiling limit to the maximum this tool's own
+    // inputSchema publishes, instead of rejecting it -- the caller gets an
+    // answer, capped, rather than an error. That acceptance is the contract and
+    // is what these assert.
+    //
+    // They used to prove the clamp by reading `limit` off the URL forwarded to
+    // DATA_API under METAGRAPH_SUBNET_IDENTITY_SOURCE="postgres" (#10190). That
+    // flag forwards nowhere and the request builder is gone, so the clamped VALUE
+    // is not observable at this boundary until subnet_identity_history has a live
+    // source again (#10710) -- at which point the forwarded-limit assertion
+    // belongs on the composer, not on a tier stub.
     for (const limit of [201, 500]) {
-      test(`clamps limit=${limit} to the published 200`, async () => {
-        let seenLimit: string | null = null;
-        const env = {
-          METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-          DATA_API: {
-            fetch: async (request: Request) => {
-              seenLimit = new URL(request.url).searchParams.get("limit");
-              return Response.json({
-                schema_version: 1,
-                count: 0,
-                subnet_count: 0,
-                changes: [],
-              });
-            },
-          },
-        };
-        const res = await callTool(
-          "get_chain_identity_history",
-          { limit },
-          { env },
-        );
+      test(`accepts limit=${limit} by clamping, not by rejecting`, async () => {
+        const res = await callTool("get_chain_identity_history", { limit });
         assert.equal(res.body.result.isError, false);
-        assert.equal(seenLimit, "200");
+        // Contrast with the invalid_params cases above: 0/-1/1.5/"abc" are
+        // rejected, an over-ceiling integer is not.
+        assert.equal(res.body.result.structuredContent.count, 0);
       });
     }
 
@@ -12525,76 +12498,21 @@ describe("MCP economics + metagraph data tools", () => {
     });
 
     test("accepts limit=1 and limit=200", async () => {
+      // The `fetched` assertion went with the tier (#10190): there is no
+      // DATA_API leg to observe being reached. Both ceiling edges are still
+      // accepted, which is what the boundary owes.
       for (const limit of [1, 200]) {
-        let fetched = false;
-        const env = {
-          METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-          DATA_API: {
-            fetch: async () => {
-              fetched = true;
-              return Response.json({
-                schema_version: 1,
-                count: 0,
-                subnet_count: 0,
-                changes: [],
-              });
-            },
-          },
-        };
-        const res = await callTool(
-          "get_chain_identity_history",
-          { limit },
-          { env },
-        );
+        const res = await callTool("get_chain_identity_history", { limit });
         assert.equal(res.body.result.isError, false);
-        assert.equal(fetched, true);
         assert.equal(res.body.result.structuredContent.count, 0);
       }
     });
   });
 
-  test("get_chain_identity_history summarizes recent changes across subnets", async () => {
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            count: 2,
-            subnet_count: 2,
-            changes: [
-              {
-                netuid: 12,
-                block_number: 200,
-                observed_at: new Date(1_700_000_000_000).toISOString(),
-                subnet_name: "Beta",
-                symbol: "β",
-                identity_hash: "h2",
-              },
-              {
-                netuid: 7,
-                block_number: 100,
-                observed_at: new Date(1_600_000_000_000).toISOString(),
-                subnet_name: "Alpha",
-                symbol: "α",
-                identity_hash: "h1",
-              },
-            ],
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_chain_identity_history",
-      { limit: 2 },
-      { env },
-    );
-    const out = res.body.result.structuredContent;
-    assert.equal(out.count, 2);
-    assert.equal(out.subnet_count, 2); // spans netuids 12 and 7
-    assert.equal(out.changes[0].netuid, 12);
-    assert.equal(out.changes[0].subnet_name, "Beta");
-    assert.equal(out.changes[1].netuid, 7);
-  });
+  // REMOVED (#10190): "summarizes recent changes across subnets". The summary it
+  // asserted was computed from rows its own DATA_API stub supplied, behind a flag
+  // that forwards nowhere -- so the tool has been summarising an empty feed in
+  // production. Restore with #10710, which is what gives it rows.
 
   // #4832 gap-closure: get_chain_identity_history mirrors REST's
   // handleChainIdentityHistory tier-selection exactly (same
@@ -12603,118 +12521,11 @@ describe("MCP economics + metagraph data tools", () => {
   // in tests/request-handlers-entities.test.ts. D1 fully eliminated
   // (2026-07-16): a Postgres miss/outage now degrades straight to the
   // schema-stable empty feed, never a live D1 read.
-  describe("get_chain_identity_history Postgres tier", () => {
-    const ALPHA_ROW = {
-      netuid: 7,
-      block_number: 100,
-      observed_at: new Date(1_600_000_000_000).toISOString(),
-      subnet_name: "Alpha",
-      symbol: "α",
-      identity_hash: "h1",
-    };
-
-    test("flag=postgres uses Postgres data", async () => {
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () =>
-            Response.json({
-              schema_version: 1,
-              count: 1,
-              subnet_count: 1,
-              changes: [{ netuid: 99, subnet_name: "pg-only" }],
-            }),
-        },
-      };
-      const res = await callTool("get_chain_identity_history", {}, { env });
-      const out = res.body.result.structuredContent;
-      assert.equal(out.changes[0].subnet_name, "pg-only");
-    });
-
-    test("flag=postgres degrades to the empty feed on failure", async () => {
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () => {
-            throw new Error("boom");
-          },
-        },
-      };
-      const res = await callTool("get_chain_identity_history", {}, { env });
-      const out = res.body.result.structuredContent;
-      assert.equal(out.count, 0);
-      assert.deepEqual(out.changes, []);
-    });
-
-    test("flag absent yields the empty feed even when DATA_API is bound (unflipped)", async () => {
-      const env = {
-        DATA_API: {
-          fetch: async () =>
-            Response.json({
-              schema_version: 1,
-              count: 1,
-              subnet_count: 1,
-              changes: [ALPHA_ROW],
-            }),
-        },
-      };
-      const res = await callTool("get_chain_identity_history", {}, { env });
-      const out = res.body.result.structuredContent;
-      assert.equal(out.count, 0);
-      assert.deepEqual(out.changes, []);
-    });
-
-    test("flag=postgres forwards limit as a REST-equivalent query param", async () => {
-      let seenUrl: URL | undefined;
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            seenUrl = new URL(request.url);
-            return Response.json({
-              schema_version: 1,
-              count: 0,
-              subnet_count: 0,
-              changes: [],
-            });
-          },
-        },
-      };
-      await callTool("get_chain_identity_history", { limit: 25 }, { env });
-      assert.equal(seenUrl!.pathname, "/api/v1/chain/identity-history");
-      assert.equal(seenUrl!.searchParams.get("limit"), "25");
-    });
-
-    // Was "omits the limit param when not supplied", which pinned the #10306
-    // bug: the tool published a `limit` default and forwarded nothing, so the
-    // page a caller got was whatever the route re-derived rather than the one
-    // the tool advertised. The expected value is READ from the served schema
-    // rather than written here, so this cannot drift from what the tool
-    // publishes.
-    test("flag=postgres forwards the limit default the tool publishes", async () => {
-      let seenUrl: URL | undefined;
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            seenUrl = new URL(request.url);
-            return Response.json({
-              schema_version: 1,
-              count: 0,
-              subnet_count: 0,
-              changes: [],
-            });
-          },
-        },
-      };
-      await callTool("get_chain_identity_history", {}, { env });
-      assert.equal(seenUrl!.pathname, "/api/v1/chain/identity-history");
-      assert.equal(
-        seenUrl!.searchParams.get("limit"),
-        String(publishedDefaultOf("get_chain_identity_history", "limit")),
-      );
-    });
-  });
+  // DESCRIBE REMOVED (#10190): "get_chain_identity_history Postgres tier" -- three
+  // tests asserting the flag=postgres forward, the REST-equivalent query param and
+  // the published limit default. METAGRAPH_SUBNET_IDENTITY_SOURCE forwards nowhere
+  // and the request builder is gone. Restore against a live source once
+  // subnet_identity_history is a Neon lane (#10710).
 
   test("get_chain_yield returns schema-stable null blocks on cold D1", async () => {
     const res = await callTool("get_chain_yield", {});
@@ -18550,142 +18361,10 @@ describe("MCP parity tools — subnet history / events (D1-backed)", () => {
   // which this block mirrors. Also mirrors list_extrinsics/get_extrinsic's own
   // "D1 -> Postgres serving cutover (#4694)" block in the block-explorer
   // describe above.
-  describe("get_subnet_identity_history D1 -> Postgres serving cutover", () => {
-    test("flag=postgres uses Postgres data, D1 never queried", async () => {
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () =>
-            Response.json({
-              schema_version: 1,
-              netuid: 86,
-              entry_count: 1,
-              limit: null,
-              offset: null,
-              next_cursor: null,
-              entries: [{ identity_hash: "pg-hash" }],
-            }),
-        },
-      };
-      const res = await callTool(
-        "get_subnet_identity_history",
-        { netuid: 86 },
-        { env },
-      );
-      const out = res.body.result.structuredContent;
-      assert.equal(out.entries[0].identity_hash, "pg-hash");
-    });
-
-    // D1 fully eliminated (2026-07-17): a Postgres-tier failure/miss no
-    // longer falls back to D1 -- it resolves to the schema-stable empty
-    // shape (buildSubnetIdentityHistory([], netuid, {...})), same as the
-    // flag-absent case below. A D1 mock, if bound, is never queried.
-    test("flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () => {
-            throw new Error("boom");
-          },
-        },
-      };
-      const res = await callTool(
-        "get_subnet_identity_history",
-        { netuid: 86 },
-        { env },
-      );
-      const out = res.body.result.structuredContent;
-      assert.equal(res.body.result.isError, false);
-      assert.equal(out.entry_count, 0);
-      assert.deepEqual(out.entries, []);
-    });
-
-    test("flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-      const env = {
-        DATA_API: {
-          fetch: async () =>
-            Response.json({
-              schema_version: 1,
-              netuid: 86,
-              entry_count: 0,
-              entries: [],
-            }),
-        },
-      };
-      const res = await callTool(
-        "get_subnet_identity_history",
-        { netuid: 86 },
-        { env },
-      );
-      const out = res.body.result.structuredContent;
-      assert.equal(out.entry_count, 0);
-      assert.deepEqual(out.entries, []);
-    });
-
-    test("flag=postgres forwards netuid + limit/offset/cursor as a REST-equivalent request", async () => {
-      let seenUrl: URL | undefined;
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            seenUrl = new URL(request.url);
-            return Response.json({
-              schema_version: 1,
-              netuid: 86,
-              entry_count: 0,
-              entries: [],
-            });
-          },
-        },
-      };
-      await callTool(
-        "get_subnet_identity_history",
-        { netuid: 86, limit: 10, offset: 5, cursor: "abc" },
-        { env },
-      );
-      assert.equal(seenUrl!.pathname, "/api/v1/subnets/86/identity-history");
-      assert.equal(seenUrl!.searchParams.get("limit"), "10");
-      assert.equal(seenUrl!.searchParams.get("offset"), "5");
-      assert.equal(seenUrl!.searchParams.get("cursor"), "abc");
-    });
-
-    // THE tool #10306 was filed for. This test used to assert
-    // `searchParams.has("limit") === false`, which is precisely the defect:
-    // the tool advertised "1-1000, default 100", forwarded no limit, and the
-    // read came back empty -- `entry_count: 0` for a subnet that had changed
-    // its identity, with no degraded marker to say otherwise.
-    //
-    // `cursor` still has no default and must stay absent, which is what keeps
-    // this from being a blanket "everything is forwarded now" assertion.
-    test("flag=postgres forwards the pagination defaults the tool publishes", async () => {
-      let seenUrl: URL | undefined;
-      const env = {
-        METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            seenUrl = new URL(request.url);
-            return Response.json({
-              schema_version: 1,
-              netuid: 86,
-              entry_count: 0,
-              entries: [],
-            });
-          },
-        },
-      };
-      await callTool("get_subnet_identity_history", { netuid: 86 }, { env });
-      assert.equal(seenUrl!.pathname, "/api/v1/subnets/86/identity-history");
-      assert.equal(
-        seenUrl!.searchParams.get("limit"),
-        String(publishedDefaultOf("get_subnet_identity_history", "limit")),
-      );
-      assert.equal(
-        seenUrl!.searchParams.get("offset"),
-        String(publishedDefaultOf("get_subnet_identity_history", "offset")),
-      );
-      assert.equal(seenUrl!.searchParams.has("cursor"), false);
-    });
-  });
+  // DESCRIBE REMOVED (#10190): "get_subnet_identity_history D1 -> Postgres serving
+  // cutover" -- three tests on a cutover between two stores that no longer exist,
+  // asserting a forward that never happened and a D1 that was never queried
+  // because there is no D1. Restore against a live source with #10710.
 
   // neuron_daily's D1 write path is retired (#4772) and the table is dropped
   // in production, so get_neuron_history always returns the schema-stable
@@ -23499,7 +23178,15 @@ describe("MCP get_rpc_usage — window handling and the cold shape", () => {
 // don't fit the shared CASES loop above (which hardcodes the neurons-tier
 // flag) -- same two-test-per-tool contract, just with the correct flag name
 // and its own CASES array.
-describe("MCP subnet-snapshots-tier analytics tools — Postgres tier wiring", () => {
+// REWRITTEN (#10190): was "MCP subnet-snapshots-tier analytics tools — Postgres
+// tier wiring". METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired everywhere and absent
+// from DATA_API_FORWARD_FLAGS, so the forwarded path and `marker: "from-postgres"`
+// these cases asserted came only from their own DATA_API stub.
+//
+// Unlike the identity tools, these two have a LIVE source -- `subnet_snapshots` is
+// a Neon table -- so what they owe is the tools' own contract: the window argument
+// is honoured, and the card is schema-stable when the store is empty.
+describe("MCP subnet-snapshots-tier analytics tools", () => {
   const CASES = [
     {
       tool: "get_subnet_trajectory",
@@ -23521,43 +23208,20 @@ describe("MCP subnet-snapshots-tier analytics tools — Postgres tier wiring", (
   for (const { tool, args, path } of CASES) {
     const label = path.includes("window=7d") ? `${tool} (window=7d)` : tool;
 
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: honours its arguments and returns a schema-stable card`, async () => {
+      const res = await callTool(tool, args, { env: {} });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
-    });
-
-    test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
-      const env = {
-        METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () => {
-            throw new Error("boom");
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
-      assert.equal(res.body.result.isError, false, label);
-      assert.equal(res.body.result.structuredContent.marker, undefined, label);
+      const card = res.body.result.structuredContent;
+      assert.equal(card.schema_version, 1, label);
+      // The window/netuid the args asked for, echoed back rather than reset --
+      // `path` is kept as the REST equivalent this tool must stay aligned with.
+      if (tool === "get_subnet_trajectory") {
+        assert.equal(card.netuid, 7, label);
+      } else {
+        assert.equal(card.window, path.includes("7d") ? "7d" : "30d", label);
+      }
+      // No store bound here, so the card is the schema-stable empty one.
+      assert.equal(card.marker, undefined, label);
     });
   }
 

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -6,6 +6,8 @@ import assert from "node:assert/strict";
 import { handleRequest } from "../workers/api.ts";
 import { describe, test, beforeEach, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
+// The generated row type, so these fixtures cannot drift from the schema.
+import type { SubnetSnapshots } from "../generated/db/types.ts";
 
 // The store these handlers read is Postgres now (#10086/#10179), reached
 // through `new Client(...)` inside src/pg-sql.ts. observationsReadDb builds
@@ -105,39 +107,25 @@ async function errorJson(res: Response, status = 400): Promise<Row> {
   return body;
 }
 
-// D1 fully eliminated (2026-07-17): every tier miss below falls straight
-// through to the schema-stable empty payload, never a live D1 query. These
-// helpers build a Postgres-tier hit (flag + DATA_API mock) so the handlers'
-// serve/CSV/format-negotiation logic can still be exercised with real data.
-function postgresTrajectoryEnv(points: Row[]): Env {
-  return {
-    METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          netuid: NETUID,
-          points,
-          point_count: points.length,
-          deltas: { "7d": null, "30d": null },
-        }),
-    },
-  } as unknown as Env;
-}
+// THE LIVE STORE, NOT A TIER STUB (#10190).
+//
+// These used to build a Postgres-tier hit -- METAGRAPH_SUBNET_SNAPSHOTS_SOURCE
+// set to "postgres" plus a DATA_API mock -- so the handlers' serve/CSV/
+// format-negotiation logic could be exercised with real data. That flag reads
+// "retired" in every deployed config and is absent from DATA_API_FORWARD_FLAGS,
+// so the arm they drove declined on every real request: the logic was proven
+// against a path production never takes.
+//
+// It is proven against `subnet_snapshots` instead, through the same pg mock the
+// rest of this file uses. The fixtures are DB rows now rather than formatted
+// output, and typed against the GENERATED row type -- so a column rename in
+// schemas breaks these tests instead of silently making them describe a shape
+// the loader no longer reads.
+type SnapshotFixture = Partial<SubnetSnapshots> &
+  Pick<SubnetSnapshots, "snapshot_date">;
 
-function postgresEconomicsTrendsEnv(days: Row[], window = "30d"): Env {
-  return {
-    METAGRAPH_SUBNET_SNAPSHOTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window,
-          day_count: days.length,
-          days,
-        }),
-    },
-  } as unknown as Env;
+function snapshotStoreEnv(rows: SnapshotFixture[]) {
+  return storeEnv(rows as unknown as Row[]);
 }
 
 function postgresUptimeEnv(surfaces: Row[], window = "90d"): Env {
@@ -171,15 +159,15 @@ describe("handleTrajectory", () => {
   // and tests/economics-history.test.ts -- these handler tests only need to
   // prove the Postgres-tier response is served/CSV-formatted as-is.
   test("returns CSV response when ?format=csv is present", async () => {
-    const env = postgresTrajectoryEnv([
+    const { env, ctx } = snapshotStoreEnv([
       {
-        date: "2026-06-01",
+        snapshot_date: "2026-06-01",
         completeness_score: 35,
         surface_count: 1,
         endpoint_count: 1,
         validator_count: 8,
         miner_count: 60,
-        total_stake_alpha: 90,
+        total_stake_tao: 90,
         alpha_price_tao: 0.01,
         emission_share: 0.02,
         tao_in_pool_tao: null,
@@ -188,13 +176,13 @@ describe("handleTrajectory", () => {
         subnet_volume_tao: null,
       },
       {
-        date: "2026-06-02",
+        snapshot_date: "2026-06-02",
         completeness_score: 40,
         surface_count: 2,
         endpoint_count: 1,
         validator_count: 8,
         miner_count: 64,
-        total_stake_alpha: 100,
+        total_stake_tao: 100,
         alpha_price_tao: 0.01,
         emission_share: 0.02,
         tao_in_pool_tao: null,
@@ -208,6 +196,7 @@ describe("handleTrajectory", () => {
       env,
       NETUID,
       url("/?format=csv"),
+      ctx,
     );
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
@@ -227,15 +216,15 @@ describe("handleTrajectory", () => {
   });
 
   test("returns CSV response when Accept: text/csv header is present", async () => {
-    const env = postgresTrajectoryEnv([
+    const { env, ctx } = snapshotStoreEnv([
       {
-        date: "2026-06-01",
+        snapshot_date: "2026-06-01",
         completeness_score: 35,
         surface_count: 1,
         endpoint_count: 1,
         validator_count: 8,
         miner_count: 60,
-        total_stake_alpha: 90,
+        total_stake_tao: 90,
         alpha_price_tao: 0.01,
         emission_share: 0.02,
         tao_in_pool_tao: null,
@@ -247,7 +236,7 @@ describe("handleTrajectory", () => {
     const request = new Request("https://api.metagraph.sh/", {
       headers: { accept: "text/csv" },
     });
-    const res = await handleTrajectory(request, env, NETUID, url("/"));
+    const res = await handleTrajectory(request, env, NETUID, url("/"), ctx);
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
     const text = await res.text();
@@ -289,15 +278,15 @@ describe("handleTrajectory", () => {
   });
 
   test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
-    const env = postgresTrajectoryEnv([
+    const { env, ctx } = snapshotStoreEnv([
       {
-        date: "2026-06-01",
+        snapshot_date: "2026-06-01",
         completeness_score: 35,
         surface_count: 1,
         endpoint_count: 1,
         validator_count: 8,
         miner_count: 60,
-        total_stake_alpha: 90,
+        total_stake_tao: 90,
         alpha_price_tao: 0.01,
         emission_share: 0.02,
         tao_in_pool_tao: null,
@@ -314,6 +303,7 @@ describe("handleTrajectory", () => {
       env,
       NETUID,
       url("/?format=json"),
+      ctx,
     );
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type")!, /application\/json/);
@@ -321,17 +311,18 @@ describe("handleTrajectory", () => {
     assert.equal(body.data.point_count, 1);
   });
 
-  // #4832 gap-closure: METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is a NEW flag,
-  // deliberately left unset in wrangler.jsonc (no historical backfill --
-  // see handleTrajectory's own header comment) -- these tests only prove
-  // the wiring, not a live flip.
-  test("flag=postgres serves the DATA_API response", async () => {
-    const env = postgresTrajectoryEnv([]);
+  // RENAMED (#10190): was "flag=postgres serves the DATA_API response", which is
+  // no longer what it does -- the flag forwards nowhere and this drives the live
+  // store. An EMPTY store is the case worth keeping: the card must still be
+  // schema-stable rather than a 404 or an error.
+  test("an empty store still yields a schema-stable card", async () => {
+    const { env, ctx } = snapshotStoreEnv([]);
     const res = await handleTrajectory(
       req(`/api/v1/subnets/${NETUID}/trajectory`),
       env,
       NETUID,
       url(`/api/v1/subnets/${NETUID}/trajectory`),
+      ctx,
     );
     assert.equal(res.status, 200);
     const body = (await res.json()) as Row;
@@ -384,22 +375,22 @@ describe("handleEconomicsTrends", () => {
   // in tests/neuron-history.test.ts -- these handler tests only need to prove
   // the Postgres-tier response is served/CSV-formatted as-is.
   test("returns CSV response when ?format=csv is requested", async () => {
-    const env = postgresEconomicsTrendsEnv(
-      [
-        {
-          snapshot_date: "2026-06-02",
-          subnet_count: 1,
-          total_stake_alpha: "300.000000000",
-          alpha_price_tao_weighted: 0.02,
-          alpha_price_tao_median: 0.02,
-          validator_count: 8,
-          miner_count: 50,
-          mean_emission_share: 0.04,
-        },
-      ],
-      "30d",
+    const { env, ctx } = snapshotStoreEnv([
+      {
+        snapshot_date: "2026-06-02",
+        total_stake_tao: 300.0,
+        alpha_price_tao: 0.02,
+        validator_count: 8,
+        miner_count: 50,
+        emission_share: 0.04,
+      },
+    ]);
+    const res = await handleEconomicsTrends(
+      req("/"),
+      env,
+      url("/?format=csv"),
+      ctx,
     );
-    const res = await handleEconomicsTrends(req("/"), env, url("/?format=csv"));
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
     assert.ok(
@@ -422,22 +413,20 @@ describe("handleEconomicsTrends", () => {
   });
 
   test("returns CSV response when Accept: text/csv header is present", async () => {
-    const env = postgresEconomicsTrendsEnv([
+    const { env, ctx } = snapshotStoreEnv([
       {
         snapshot_date: "2026-06-02",
-        subnet_count: 1,
-        total_stake_alpha: "300.000000000",
-        alpha_price_tao_weighted: 0.02,
-        alpha_price_tao_median: 0.02,
+        total_stake_tao: 300.0,
+        alpha_price_tao: 0.02,
         validator_count: 8,
         miner_count: 50,
-        mean_emission_share: 0.04,
+        emission_share: 0.04,
       },
     ]);
     const request = new Request("https://api.metagraph.sh/", {
       headers: { accept: "text/csv" },
     });
-    const res = await handleEconomicsTrends(request, env, url("/"));
+    const res = await handleEconomicsTrends(request, env, url("/"), ctx);
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
     const text = await res.text();
@@ -481,36 +470,39 @@ describe("handleEconomicsTrends", () => {
   });
 
   test("?format=json keeps the JSON envelope even when Accept asks for CSV", async () => {
-    const env = postgresEconomicsTrendsEnv([
+    const { env, ctx } = snapshotStoreEnv([
       {
         snapshot_date: "2026-06-02",
-        subnet_count: 1,
-        total_stake_alpha: "300.000000000",
-        alpha_price_tao_weighted: 0.02,
-        alpha_price_tao_median: 0.02,
+        total_stake_tao: 300.0,
+        alpha_price_tao: 0.02,
         validator_count: 8,
         miner_count: 50,
-        mean_emission_share: 0.04,
+        emission_share: 0.04,
       },
     ]);
     const request = new Request("https://api.metagraph.sh/", {
       headers: { accept: "text/csv" },
     });
-    const res = await handleEconomicsTrends(request, env, url("/?format=json"));
+    const res = await handleEconomicsTrends(
+      request,
+      env,
+      url("/?format=json"),
+      ctx,
+    );
     assert.equal(res.status, 200);
     assert.match(res.headers.get("content-type")!, /application\/json/);
     const body = (await res.json()) as Row;
     assert.equal(body.data.day_count, 1);
   });
 
-  // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same table
-  // and same deliberately-unflipped rationale as handleTrajectory above.
-  test("flag=postgres serves the DATA_API response", async () => {
-    const env = postgresEconomicsTrendsEnv([]);
+  // RENAMED (#10190), same reason as the trajectory one above.
+  test("an empty store still yields a schema-stable card", async () => {
+    const { env, ctx } = snapshotStoreEnv([]);
     const res = await handleEconomicsTrends(
       req("/api/v1/economics/trends"),
       env,
       url("/api/v1/economics/trends"),
+      ctx,
     );
     assert.equal(res.status, 200);
     const body = (await res.json()) as Row;
@@ -1113,7 +1105,6 @@ describe("handleCompareValidators", () => {
           schema_version: 1,
           hotkey: reqUrl.pathname.split("/").pop(),
           coldkey: "coldkey-1",
-          subnet_count: 1,
           subnets: [{ netuid: 7, uid: 3, stake_tao: 100 }],
         });
       },

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -334,22 +334,7 @@ function accountDayRow(overrides = {}) {
   };
 }
 
-function identityHistoryRow(overrides = {}) {
-  return {
-    id: 10,
-    block_number: 100,
-    observed_at: OBSERVED_AT,
-    subnet_name: "MIAO",
-    symbol: "α",
-    description: "old",
-    github_repo: null,
-    subnet_url: null,
-    discord: null,
-    logo_url: null,
-    identity_hash: "abc",
-    ...overrides,
-  };
-}
+// `identityHistoryRow` went with the tests that used it (#10190).
 
 function hyperparamsRow(overrides = {}) {
   return {
@@ -1397,34 +1382,11 @@ describe("handleSubnetIdentityHistory", () => {
     assert.deepEqual(body.data.entries, []);
   });
 
-  test("happy path returns identity timeline rows", async () => {
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            netuid: NETUID,
-            entry_count: 1,
-            limit: 20,
-            offset: null,
-            next_cursor: null,
-            entries: [{ subnet_name: "MIAO", identity_hash: "abc" }],
-          }),
-      },
-    };
-    const body = await json(
-      await handleSubnetIdentityHistory(
-        req(`/api/v1/subnets/${NETUID}/identity-history`),
-        env as unknown as Env,
-        NETUID,
-        url(`/api/v1/subnets/${NETUID}/identity-history?limit=20`),
-      ),
-    );
-    assert.equal(body.data.entry_count, 1);
-    assert.equal(body.data.entries[0].subnet_name, "MIAO");
-    assert.equal(body.data.limit, 20);
-  });
+  // REMOVED (#10190): "happy path returns identity timeline rows". The rows came
+  // from a DATA_API stub behind the retired METAGRAPH_SUBNET_IDENTITY_SOURCE, so
+  // the "happy path" it described is one production never takes -- nothing writes
+  // subnet_identity_history at all (#10710). The cold/empty shape this route really
+  // serves is asserted by its siblings; restore a populated timeline with #10710.
 });
 
 describe("handleSubnetHyperparams", () => {
@@ -4774,34 +4736,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
   // dedicated flag (METAGRAPH_SUBNET_IDENTITY_SOURCE). Written from the main
   // Worker's own hourly cron (writeSubnetSnapshot), not an external GitHub
   // Actions workflow -- but served the same way as every other tier here.
-  test("handleSubnetIdentityHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
-    const { env, captures } = dbWith({
-      subnetIdentityHistory: [identityHistoryRow()],
-    });
-    env.METAGRAPH_SUBNET_IDENTITY_SOURCE = "postgres";
-    env.DATA_API = dataApi(
-      Response.json({
-        schema_version: 1,
-        netuid: NETUID,
-        entry_count: 1,
-        limit: null,
-        offset: null,
-        next_cursor: null,
-        entries: [{ identity_hash: "pg-hash" }],
-      }),
-    );
-    const path = `/api/v1/subnets/${NETUID}/identity-history`;
-    const body = await json(
-      await handleSubnetIdentityHistory(
-        req(path),
-        env as unknown as Env,
-        NETUID,
-        url(path),
-      ),
-    );
-    assert.equal(body.data.entries[0].identity_hash, "pg-hash");
-    assert.deepEqual(captures.sql, []);
-  });
+  // REMOVED (#10190): "handleSubnetIdentityHistory: flag=postgres uses Postgres
+  // data, D1 never queried". Both halves are moot -- METAGRAPH_SUBNET_IDENTITY_SOURCE
+  // forwards nowhere, and there is no D1 left to leave unqueried.
 
   test("handleSubnetIdentityHistory: flag=postgres falls back to schema-stable empty on failure (D1 retired)", async () => {
     const env: Row = {};

--- a/tests/subnet-identity-history-api.test.ts
+++ b/tests/subnet-identity-history-api.test.ts
@@ -12,34 +12,14 @@ function req(path: string) {
 // path is fully retired -- handleSubnetIdentityHistory now goes
 // tryPostgresTier -> buildSubnetIdentityHistory([], ...) on any miss/outage,
 // never a live D1 read.
-test("GET /subnets/{netuid}/identity-history returns the identity timeline (#1647)", async () => {
-  const env = {
-    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          netuid: 86,
-          entry_count: 1,
-          limit: null,
-          offset: null,
-          next_cursor: null,
-          entries: [{ subnet_name: "MIAO", identity_hash: "hash-1" }],
-        }),
-    },
-  };
-  const res = await handleRequest(
-    req("/api/v1/subnets/86/identity-history"),
-    env as unknown as Env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.ok, true);
-  assert.equal(body.data.netuid, 86);
-  assert.equal(body.data.entry_count, 1);
-  assert.equal(body.data.entries[0].subnet_name, "MIAO");
-});
+// REMOVED (#10190): "returns the identity timeline (#1647)". It served the
+// timeline by stubbing DATA_API behind METAGRAPH_SUBNET_IDENTITY_SOURCE
+// ="postgres" -- retired everywhere and absent from DATA_API_FORWARD_FLAGS, so
+// that arm declined on every real request and the MIAO row it asserted existed
+// only in this test. The route's real leg is the lakehouse cold tier through
+// src/identity-history-answer.ts; the schema-stable cold shape is pinned by the
+// test below, and a populated timeline becomes assertable again when
+// subnet_identity_history is restored as a Neon lane (#10706's sibling work).
 
 test("GET /subnets/{netuid}/identity-history rejects an unsupported query param", async () => {
   const res = await handleRequest(
@@ -63,25 +43,24 @@ test("GET /subnets/{netuid}/identity-history is schema-stable when cold (no Post
   assert.deepEqual(body.data.entries, []);
 });
 
-// D1 fully eliminated (2026-07-16): loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids
-// (the D1-querying loaders workers/api.ts's overlay wrappers used to fall back
-// to) are gone -- these overlays only ever populate previously_known_as when
-// the Postgres tier flag is on now (see the "flag=postgres" tests below);
-// without it, the overlay is simply absent (schema-stable), never sourced
-// from a live D1 read.
-function postgresAliasesEnv(rows: Row[]) {
-  return {
-    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-    DATA_API: { fetch: async () => Response.json({ rows }) },
-  };
-}
+// previously_known_as HAS NO SOURCE (#10706), and these tests now say so.
+//
+// They populated the overlay by stubbing DATA_API behind
+// METAGRAPH_SUBNET_IDENTITY_SOURCE="postgres". That flag is retired everywhere
+// and absent from DATA_API_FORWARD_FLAGS, so the alias read declined on every
+// real request -- the field has been empty in production since the flag was
+// retired, on all three routes that publish it. Nothing writes
+// subnet_identity_history at all: D1 was its primary writer and the Postgres
+// mirror went through this same flag.
+//
+// So these assert the honest current behaviour. The SHAPING logic they used to
+// demonstrate is covered directly, with 17 assertions over
+// derivePreviouslyKnownAs / deriveNetuidGroupedAliases / overlayPreviouslyKnownAs
+// in tests/subnet-identity-history.test.ts. When the Neon lane lands, these are
+// the tests to restore to a populated overlay.
 
-test("GET /subnets/{netuid} overlays previously_known_as on the subnet detail", async () => {
-  const env = createLocalArtifactEnv({
-    ...postgresAliasesEnv([
-      { netuid: 7, subnet_name: "Old Allways", observed_at: 2 },
-    ]),
-  });
+test("GET /subnets/{netuid} publishes no previously_known_as overlay on the subnet detail (#10706)", async () => {
+  const env = createLocalArtifactEnv({});
   const res = await handleRequest(
     req("/api/v1/subnets/7"),
     env as unknown as Env,
@@ -89,14 +68,12 @@ test("GET /subnets/{netuid} overlays previously_known_as on the subnet detail", 
   );
   assert.equal(res.status, 200);
   const body = await res.json();
-  assert.deepEqual(body.data.subnet?.previously_known_as, ["Old Allways"]);
+  // No source, so no overlay (#10706).
+  assert.equal(body.data.subnet?.previously_known_as, undefined);
 });
 
-test("GET /subnets/{netuid} overlays previously_known_as on flat subnet detail", async () => {
+test("GET /subnets/{netuid} publishes no previously_known_as overlay on flat subnet detail (#10706)", async () => {
   const env = createLocalArtifactEnv({
-    ...postgresAliasesEnv([
-      { netuid: 7, subnet_name: "Old Allways", observed_at: 2 },
-    ]),
     METAGRAPH_ARCHIVE: {
       async get(key: string) {
         if (!String(key).includes("subnets/7.json")) return null;
@@ -130,16 +107,13 @@ test("GET /subnets/{netuid} overlays previously_known_as on flat subnet detail",
   );
   assert.equal(res.status, 200);
   const body = await res.json();
-  assert.deepEqual(body.data.previously_known_as, ["Old Allways"]);
+  // No source, so no overlay (#10706).
+  assert.equal(body.data.previously_known_as, undefined);
   assert.equal(body.data.subnet, undefined);
 });
 
-test("GET /agent-catalog overlays previously_known_as on index entries", async () => {
-  const env = createLocalArtifactEnv({
-    ...postgresAliasesEnv([
-      { netuid: 7, subnet_name: "Old Allways", observed_at: 2 },
-    ]),
-  });
+test("GET /agent-catalog publishes no previously_known_as overlay on index entries (#10706)", async () => {
+  const env = createLocalArtifactEnv({});
   const res = await handleRequest(
     req("/api/v1/agent-catalog"),
     env as unknown as Env,
@@ -151,15 +125,12 @@ test("GET /agent-catalog overlays previously_known_as on index entries", async (
     (entry) => entry.netuid === 7,
   );
   assert.ok(subnet);
-  assert.deepEqual(subnet.previously_known_as, ["Old Allways"]);
+  // No source, so no overlay (#10706).
+  assert.equal(subnet.previously_known_as, undefined);
 });
 
-test("GET /agent-catalog/{netuid} overlays previously_known_as on the detail entry", async () => {
-  const env = createLocalArtifactEnv({
-    ...postgresAliasesEnv([
-      { netuid: 7, subnet_name: "Old Allways", observed_at: 2 },
-    ]),
-  });
+test("GET /agent-catalog/{netuid} publishes no previously_known_as overlay on the detail entry (#10706)", async () => {
+  const env = createLocalArtifactEnv({});
   const res = await handleRequest(
     req("/api/v1/agent-catalog/7"),
     env as unknown as Env,
@@ -167,109 +138,17 @@ test("GET /agent-catalog/{netuid} overlays previously_known_as on the detail ent
   );
   assert.equal(res.status, 200);
   const body = await res.json();
-  assert.deepEqual(body.data.previously_known_as, ["Old Allways"]);
-});
-
-// #4832 gap-closure: loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids are
-// D1-fetch helpers embedded in these overlay call sites (no standalone route),
-// so tryPostgresTier can't forward the caller's own request -- api.ts
-// synthesizes an internal request instead. These tests prove that wiring,
-// reusing METAGRAPH_SUBNET_IDENTITY_SOURCE (already flipped in production).
-// Only the alias query itself must be skipped when Postgres serves it -- the
-// same request also runs the unrelated live-health overlay (surface_status),
-// which stays D1-backed here since only METAGRAPH_SUBNET_IDENTITY_SOURCE is
-// flipped in these tests.
-function identityAliasesMustNotBeQueried() {
-  let called = false;
-  return {
-    get called() {
-      return called;
-    },
-    db: {
-      prepare(sql: string) {
-        if (/subnet_identity_history/.test(sql)) {
-          called = true;
-          throw new Error(
-            "D1 must not be queried when Postgres serves the request",
-          );
-        }
-        return {
-          bind: () => ({
-            async all() {
-              return { results: [] };
-            },
-          }),
-        };
-      },
-    },
-  };
-}
-
-test("GET /agent-catalog/{netuid}: flag=postgres serves the DATA_API response, D1 never queried", async () => {
-  const tracker = identityAliasesMustNotBeQueried();
-  const env = createLocalArtifactEnv({
-    METAGRAPH_HEALTH_DB: tracker.db,
-    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          rows: [{ netuid: 7, subnet_name: "Old Allways", observed_at: 2 }],
-        }),
-    },
-  });
-  const res = await handleRequest(
-    req("/api/v1/agent-catalog/7"),
-    env as unknown as Env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.deepEqual(body.data.previously_known_as, ["Old Allways"]);
-  assert.equal(tracker.called, false);
-});
-
-test("GET /agent-catalog/{netuid}: flag=postgres degrades to no overlay when DATA_API fails", async () => {
-  const env = createLocalArtifactEnv({
-    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    },
-  });
-  const res = await handleRequest(
-    req("/api/v1/agent-catalog/7"),
-    env as unknown as Env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
+  // No source, so no overlay (#10706).
   assert.equal(body.data.previously_known_as, undefined);
 });
 
-test("GET /agent-catalog: flag=postgres serves the bulk DATA_API response, D1 never queried", async () => {
-  const tracker = identityAliasesMustNotBeQueried();
-  const env = createLocalArtifactEnv({
-    METAGRAPH_HEALTH_DB: tracker.db,
-    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          rows: [{ netuid: 7, subnet_name: "Old Allways", observed_at: 2 }],
-        }),
-    },
-  });
-  const res = await handleRequest(
-    req("/api/v1/agent-catalog"),
-    env as unknown as Env,
-    {},
-  );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  const subnet = (body.data.subnets as Row[]).find(
-    (entry) => entry.netuid === 7,
-  );
-  assert.ok(subnet);
-  assert.deepEqual(subnet.previously_known_as, ["Old Allways"]);
-  assert.equal(tracker.called, false);
-});
+// The D1 alias-query tracker went with the three tests that used it (#10190):
+// there is no D1 to assert was left unqueried.
+
+// THREE TESTS REMOVED HERE (#10190/#10706). All three drove the alias overlay
+// through METAGRAPH_SUBNET_IDENTITY_SOURCE="postgres" plus a DATA_API stub: two
+// asserting it "serves the DATA_API response, D1 never queried", one asserting it
+// degrades when that stub fails. The flag forwards nowhere, there is no D1 left to
+// leave unqueried, and the degrade case is now simply the only case -- asserted by
+// the four overlay tests above. Restore them against a real source when
+// subnet_identity_history becomes a Neon lane.

--- a/tests/subnet-identity-history-error-capture.test.ts
+++ b/tests/subnet-identity-history-error-capture.test.ts
@@ -21,28 +21,27 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-// latestIdentityHashes only throws when Postgres hands back a truthy but
-// non-iterable `hashes` payload (tryPostgresTier itself never throws) --
-// see the sibling "returns read_failed" test in
-// tests/subnet-identity-history.test.ts for the same trigger.
-function pgEnvWithBadPayload(extra: Row = {}): Env {
-  return {
-    METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        new Response(JSON.stringify({ hashes: { not: "an array" } }), {
-          status: 200,
-        }),
-    },
-    ...extra,
-  } as unknown as Env;
+// THE BASELINE READER, INJECTED (#10190/#10700). This used to trigger the failure
+// by stubbing DATA_API behind METAGRAPH_SUBNET_IDENTITY_SOURCE="postgres" and
+// returning a truthy-but-non-iterable `hashes` payload. That flag is retired and
+// absent from DATA_API_FORWARD_FLAGS, so the read never happened in production and
+// the payload never existed to be malformed. What this file is about is unchanged:
+// a baseline read that FAILS must be reported, not swallowed.
+function envWith(extra: Row = {}): Env {
+  return { ...extra } as unknown as Env;
 }
+
+/** A baseline reader that fails the way an unreadable baseline does. */
+const failingBaseline = async () => {
+  throw new TypeError("hashes is not iterable");
+};
 
 const profiles = [{ netuid: 7, native_identity: { subnet_name: "X" } }];
 
 test("a genuine read failure returns recorded:false, reason:read_failed", async () => {
-  const result = await recordSubnetIdentityChanges(pgEnvWithBadPayload(), {
+  const result = await recordSubnetIdentityChanges(envWith(), {
     profiles,
+    latestHashes: failingBaseline,
   });
   assert.deepEqual(result, { recorded: false, reason: "read_failed" });
 });
@@ -50,12 +49,11 @@ test("a genuine read failure returns recorded:false, reason:read_failed", async 
 test("a genuine read failure reaches PostHog as $exception, tagged error_code read_failed", async () => {
   const original = globalThis.fetch;
   const posted: Row[] = [];
-  const env = pgEnvWithBadPayload({
+  const env = envWith({
     [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
   });
-  // env.DATA_API.fetch above only intercepts the internal latest-hashes
-  // lookup; globalThis.fetch is what recordExceptionEvent posts $exception
-  // through, so both must be stubbed independently.
+  // globalThis.fetch is what recordExceptionEvent posts $exception through, so it
+  // is stubbed independently of the injected baseline reader.
   globalThis.fetch = (async (
     url: string | URL | Request,
     init?: RequestInit,
@@ -64,7 +62,10 @@ test("a genuine read failure reaches PostHog as $exception, tagged error_code re
     return { ok: true };
   }) as unknown as typeof fetch;
   try {
-    await recordSubnetIdentityChanges(env, { profiles });
+    await recordSubnetIdentityChanges(env, {
+      profiles,
+      latestHashes: failingBaseline,
+    });
     assert.equal(posted.length, 1);
     assert.equal(posted[0].body.event, "$exception");
     assert.equal(
@@ -88,14 +89,9 @@ test("an unchanged-identity run (no read failure) never reaches PostHog", async 
     return { ok: true };
   }) as unknown as typeof fetch;
   try {
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          new Response(JSON.stringify({ hashes: [] }), { status: 200 }),
-      },
-      [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
-    } as unknown as Env;
+    const env = envWith({ [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token" });
+    // An EMPTY baseline, which is what production actually has (#10700) -- and it
+    // is not a failure, so nothing may be captured.
     const result = await recordSubnetIdentityChanges(env, { profiles });
     assert.equal(result.recorded, true);
     assert.equal(posted.length, 0);

--- a/tests/subnet-identity-history.test.ts
+++ b/tests/subnet-identity-history.test.ts
@@ -442,17 +442,29 @@ describe("recordSubnetIdentityChanges", () => {
   // netuid via tryPostgresTier against /api/v1/internal/subnet-identity-
   // latest-hashes, instead of querying D1 directly. Mock env.DATA_API.fetch
   // instead of a `db` binding.
-  function pgEnv(hashes: unknown): Env {
-    return {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          new Response(JSON.stringify({ hashes }), { status: 200 }),
-      },
-    } as unknown as Env;
+  // THE BASELINE, INJECTED (#10190/#10700). These tests used to build it by
+  // stubbing DATA_API behind METAGRAPH_SUBNET_IDENTITY_SOURCE="postgres" -- a
+  // flag value no deployment sets, gating an arm absent from
+  // DATA_API_FORWARD_FLAGS, so the baseline they exercised never existed in
+  // production. The dead read is gone; the DIFF's contract is what these tests
+  // are actually about, so they now hand it a baseline directly.
+  const ENV = {} as unknown as Env;
+
+  /** A baseline reader over the rows the old DATA_API stub would have returned. */
+  function baselineOf(rows: unknown) {
+    return async () => {
+      const map = new Map<number, unknown>();
+      for (const row of rows as {
+        netuid?: unknown;
+        identity_hash?: unknown;
+      }[]) {
+        const netuid = Number(row?.netuid);
+        if (Number.isInteger(netuid)) map.set(netuid, row?.identity_hash);
+      }
+      return map;
+    };
   }
   test("counts a changed identity without writing anything", async () => {
-    const env = pgEnv([{ netuid: 86, identity_hash: "old-hash" }]);
     const profiles = [
       {
         netuid: 86,
@@ -463,9 +475,10 @@ describe("recordSubnetIdentityChanges", () => {
         },
       },
     ];
-    const result = await recordSubnetIdentityChanges(env, {
+    const result = await recordSubnetIdentityChanges(ENV, {
       profiles,
       now: 1_700_000_000_000,
+      latestHashes: baselineOf([{ netuid: 86, identity_hash: "old-hash" }]),
     });
     assert.equal(result.recorded, true);
     assert.equal(result.rows, 1);
@@ -490,8 +503,8 @@ describe("recordSubnetIdentityChanges", () => {
       },
     });
     const hash = await identityHash(snapshot);
-    const env = pgEnv([{ netuid: 7, identity_hash: hash }]);
-    const result = await recordSubnetIdentityChanges(env, {
+    const result = await recordSubnetIdentityChanges(ENV, {
+      latestHashes: baselineOf([{ netuid: 7, identity_hash: hash }]),
       profiles: [
         {
           netuid: 7,
@@ -521,11 +534,11 @@ describe("recordSubnetIdentityChanges", () => {
       native_identity: { subnet_name: "Subnet" },
     });
     const hash = await identityHash(snapshot);
-    const env = pgEnv([
-      { netuid: "", identity_hash: "junk" }, // blank → ignored
-      { netuid: "7", identity_hash: hash }, // string netuid → key on 7
-    ]);
-    const result = await recordSubnetIdentityChanges(env, {
+    const result = await recordSubnetIdentityChanges(ENV, {
+      latestHashes: baselineOf([
+        { netuid: "", identity_hash: "junk" }, // blank → ignored
+        { netuid: "7", identity_hash: hash }, // string netuid → key on 7
+      ]),
       profiles: [
         {
           netuid: 7,
@@ -551,18 +564,17 @@ describe("recordSubnetIdentityChanges", () => {
   // internally and degrades to null), so the only way latestIdentityHashes
   // can still throw is a malformed-but-truthy `hashes` payload that isn't
   // iterable -- e.g. an object instead of an array.
-  test("returns read_failed when the hashes payload isn't iterable", async () => {
-    const env = {
-      METAGRAPH_SUBNET_IDENTITY_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          new Response(JSON.stringify({ hashes: { not: "an array" } }), {
-            status: 200,
-          }),
-      },
-    } as unknown as Env;
+  // The baseline READER throwing, rather than a malformed DATA_API body: with the
+  // dead tier read gone there is no body to malform, and what this test is
+  // actually about is that a baseline this function cannot obtain is reported as
+  // `read_failed` instead of being silently treated as "nothing has changed"
+  // (which is the #10700 behaviour, and is why the distinction matters).
+  test("returns read_failed when the baseline cannot be read", async () => {
     assert.deepEqual(
-      await recordSubnetIdentityChanges(env, {
+      await recordSubnetIdentityChanges(ENV, {
+        latestHashes: async () => {
+          throw new TypeError("hashes is not iterable");
+        },
         profiles: [
           {
             netuid: 7,

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -390,7 +390,6 @@ import {
   derivePreviouslyKnownAs,
   overlayPreviouslyKnownAs,
 } from "../src/subnet-identity-history.ts";
-import { tryPostgresTier } from "./postgres-tier.ts";
 import { chainEventsQueryError } from "../src/chain-events-cold-tier.ts";
 import {
   type ColdTierAnswer,
@@ -8027,54 +8026,28 @@ async function lookupSubnetNetuid(
   return Number.isInteger(netuid) ? netuid : null;
 }
 
-// loadPreviouslyKnownAs/loadPreviouslyKnownAsForNetuids (src/subnet-identity-
-// history.mjs) are Postgres-fetch helpers embedded in 3 overlay call sites
-// below rather than standalone routes, so there is no single client request
-// for tryPostgresTier to forward unchanged -- these two wrappers synthesize
-// their own internal /api/v1/internal/subnet-identity-aliases request
-// instead, mirroring composeCompareData's health-dimension wiring (#4832
-// gap-closure). Reuses METAGRAPH_SUBNET_IDENTITY_SOURCE, already flipped to
-// postgres for /identity-history. D1 fully eliminated (2026-07-16): a tier
-// miss/outage now returns an empty alias list rather than falling back to
-// D1's frozen copy, same degrade every other route reusing this flag already
-// tolerates.
-async function loadPreviouslyKnownAsTiered(
-  env: Env,
+// THE ALIAS OVERLAY HAS NO SOURCE (#10190), and these two wrappers now say so.
+//
+// They synthesised an internal /api/v1/internal/subnet-identity-aliases request
+// and forwarded it under METAGRAPH_SUBNET_IDENTITY_SOURCE. That flag reads
+// "retired" in every deployed config and is absent from DATA_API_FORWARD_FLAGS,
+// so the request was built, the tier declined, and `?? []` supplied the answer --
+// every time. The URL construction goes with the read: building a request nobody
+// sends is the part that made this look like a live tier.
+//
+// The alias list is therefore empty, which is exactly what it has published since
+// the flag was retired. The derive helpers stay because they own the shape, and
+// because a real source (a direct read of subnet_identity_history's earlier
+// names) drops straight into them.
+function loadPreviouslyKnownAsTiered(
   netuid: number,
   currentName: string | null,
 ) {
-  const pgUrl = new URL(
-    "https://data-api.internal/api/v1/internal/subnet-identity-aliases",
-  );
-  pgUrl.searchParams.set("netuids", String(netuid));
-  const pgData = await tryPostgresTier(
-    env,
-    new Request(pgUrl),
-    "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-  );
-  return derivePreviouslyKnownAs(
-    (pgData?.rows as Row[] | undefined) ?? [],
-    currentName,
-  );
+  return derivePreviouslyKnownAs([], currentName);
 }
 
-async function loadPreviouslyKnownAsForNetuidsTiered(env: Env, entries: Row[]) {
-  const netuids = entries
-    .map((entry) => entry?.netuid)
-    .filter((netuid) => Number.isInteger(netuid));
-  const pgUrl = new URL(
-    "https://data-api.internal/api/v1/internal/subnet-identity-aliases",
-  );
-  pgUrl.searchParams.set("netuids", netuids.join(","));
-  const pgData = await tryPostgresTier(
-    env,
-    new Request(pgUrl),
-    "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-  );
-  return deriveNetuidGroupedAliases(
-    (pgData?.rows as Row[] | undefined) ?? [],
-    entries,
-  );
+function loadPreviouslyKnownAsForNetuidsTiered(entries: Row[]) {
+  return deriveNetuidGroupedAliases([], entries);
 }
 
 async function handleApiRequest(
@@ -8261,8 +8234,7 @@ async function handleApiRequest(
       baseData.subnet && typeof baseData.subnet === "object"
         ? baseData.subnet
         : baseData;
-    const aliasNames = await loadPreviouslyKnownAsTiered(
-      env,
+    const aliasNames = loadPreviouslyKnownAsTiered(
       Number(matched.params.netuid),
       aliasTarget.native_name ?? aliasTarget.name,
     );
@@ -8283,8 +8255,7 @@ async function handleApiRequest(
     baseData &&
     typeof baseData === "object"
   ) {
-    const aliasNames = await loadPreviouslyKnownAsTiered(
-      env,
+    const aliasNames = loadPreviouslyKnownAsTiered(
       Number(matched.params.netuid),
       baseData.name,
     );
@@ -8295,10 +8266,7 @@ async function handleApiRequest(
     matched.id === "agent-catalog" &&
     baseData?.subnets?.length
   ) {
-    const aliasMap = await loadPreviouslyKnownAsForNetuidsTiered(
-      env,
-      baseData.subnets,
-    );
+    const aliasMap = loadPreviouslyKnownAsForNetuidsTiered(baseData.subnets);
     baseData = {
       ...baseData,
       subnets: baseData.subnets.map((entry: Row) =>

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -272,24 +272,21 @@ export async function handleTrajectory(
   // "postgres" in wrangler.jsonc (D1 retirement, 2026-07-16). D1 fully
   // eliminated (2026-07-17): a tier miss now always falls through to the
   // schema-stable empty payload (never a live D1 query).
-  let isFallback = false;
-  let data = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-  )) as ReturnType<typeof formatTrajectory> | null;
-  if (!data) {
-    // Cacheable when D1-served — only an empty payload (no binding, or a D1
-    // read failure mid-load) is barred from the edge cache (see
-    // handleHealthTrends in analytics.ts).
-    const d1Generation = currentD1ReadFailureGeneration();
-    data = (await loadSubnetTrajectory(netuid, {
-      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-    })) as ReturnType<typeof formatTrajectory>;
-    isFallback =
-      !env.HYPERDRIVE?.connectionString ||
-      currentD1ReadFailureGeneration() !== d1Generation;
-  }
+  // NO TIER READ (#10190). METAGRAPH_SUBNET_SNAPSHOTS_SOURCE reads "retired" in
+  // every deployed config and is absent from DATA_API_FORWARD_FLAGS, so the tier
+  // resolved to null on every request and this branch was the only path.
+  // Flattened rather than left as a permanently-true guard.
+  //
+  // Cacheability is unchanged: only an empty payload (no binding, or a read
+  // failure mid-load) is barred from the edge cache -- see handleHealthTrends in
+  // analytics.ts.
+  const readFailureGeneration = currentD1ReadFailureGeneration();
+  const data = (await loadSubnetTrajectory(netuid, {
+    db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+  })) as ReturnType<typeof formatTrajectory>;
+  const isFallback =
+    !env.HYPERDRIVE?.connectionString ||
+    currentD1ReadFailureGeneration() !== readFailureGeneration;
   if (csvRequested(url, request)) {
     const csvRes = await csvResponse(
       data.points as unknown[],
@@ -330,25 +327,19 @@ export async function handleEconomicsTrends(
   const { label, days } = historyWindow(url);
   // #4832 gap-closure: reuses METAGRAPH_SUBNET_SNAPSHOTS_SOURCE, same table
   // and same flip as handleTrajectory above. D1 reads resurrected 2026-08-02.
-  let isFallback = false;
-  let data = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_SUBNET_SNAPSHOTS_SOURCE",
-  )) as Awaited<ReturnType<typeof loadEconomicsTrends>>["data"] | null;
-  if (!data) {
-    // Cacheable when D1-served — see handleTrajectory above.
-    const d1Generation = currentD1ReadFailureGeneration();
-    const loaded = await loadEconomicsTrends({
-      windowLabel: label,
-      windowDays: days,
-      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-    });
-    data = loaded.data;
-    isFallback =
-      !env.HYPERDRIVE?.connectionString ||
-      currentD1ReadFailureGeneration() !== d1Generation;
-  }
+  // NO TIER READ (#10190), same as handleTrajectory above: the flag is retired
+  // and absent from DATA_API_FORWARD_FLAGS, so this branch was the only path.
+  const readFailureGeneration = currentD1ReadFailureGeneration();
+  const loaded = await loadEconomicsTrends({
+    windowLabel: label,
+    windowDays: days,
+    db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+  });
+  // `let`, not `const`: the USD overlay below reassigns it (#10382).
+  let data = loaded.data;
+  const isFallback =
+    !env.HYPERDRIVE?.connectionString ||
+    currentD1ReadFailureGeneration() !== readFailureGeneration;
   // USD per day (#10382), overlaid BEFORE the CSV branch so both formats carry
   // the same answer. Each day is priced by a reading from inside that UTC day;
   // a day older than the index carries null rather than today's rate applied

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -1740,16 +1740,13 @@ export async function handleSubnetIdentityHistory(
   if (validationError) return analyticsQueryError(validationError);
   const page = resolvePage(url);
   const { limit, offset } = page;
-  const identityTier =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-    )) as Record<string, unknown> | null) ?? null;
+  // NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed
+  // config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to
+  // null on every request.
   // Through the composer (src/identity-history-answer.ts): same formatter and
   // data-api's exact cursor token, so a page started on one tier finishes
   // correctly on the other -- and MCP/GraphQL now reach it by the same route.
-  const data = (await answerSubnetIdentityHistory(env, netuid, identityTier, {
+  const data = (await answerSubnetIdentityHistory(env, netuid, null, {
     limit,
     offset,
     cursor: routeText(url, "cursor"),
@@ -2022,16 +2019,13 @@ export async function handleChainIdentityHistory(
   // (2026-07-16, syncSubnetIdentityToPostgres is the sole writer now), so a
   // Postgres miss/outage degrades to a schema-stable empty feed, never a
   // live D1 read.
-  const chainIdentityTier =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_SUBNET_IDENTITY_SOURCE",
-    )) as Record<string, unknown> | null) ?? null;
+  // NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed
+  // config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to
+  // null on every request.
   // Through the composer (src/identity-history-answer.ts): the frozen verified
   // history through the SAME formatter as the Postgres tier, for all three
   // surfaces rather than this one.
-  const data = (await answerChainIdentityHistory(env, chainIdentityTier, {
+  const data = (await answerChainIdentityHistory(env, null, {
     limit,
   })) as unknown as ReturnType<typeof buildChainIdentityHistory>;
   return envelopeResponse(


### PR DESCRIPTION
15 more `tryPostgresTier` call sites that resolved to `null` on **every** request, and the **36 test cascades** they carried. **214 → 199** dead sites.

`METAGRAPH_SUBNET_IDENTITY_SOURCE` (9) and `METAGRAPH_SUBNET_SNAPSHOTS_SOURCE` (6) both read `"retired"` in every deployed config, and neither is in `DATA_API_FORWARD_FLAGS`.

## Five shapes, where #10692 had three

| shape | n | removal |
| --- | --: | --- |
| `const tierResult = (…) ?? null` → composer | 6 | pass `null` |
| `((await …) as T \| null) ?? fallback` | 2 | drop the prefix |
| bare `return (… ?? fallback)` | 1 | return the fallback |
| `const x = await …; if (x) return x;` | 1 | unreachable early return |
| `let data = …; if (!data) { … }` | 2 | permanently-true guard, flattened, `isFallback` recomputed |
| `pgUrl` built then forwarded | 2 | the URL construction goes too |
| a function whose only source was the tier | 1 | see #10710 |

Building a request nobody sends is what made the last shape look like a live tier, so it goes with the read.

## Re-pointed rather than dropped, where a live source exists

**`request-handlers-analytics-routes`** — trajectory and economics-trends read `subnet_snapshots`, a real Neon table. The CSV and format-negotiation tests now drive the pg mock with DB rows **typed against the generated `SubnetSnapshots` row type**, so a column rename in `schemas` breaks the fixture instead of leaving it describing a shape the loader stopped reading. The `ctx` matters too: `observationsReadDb` answers `undefined` without a `waitUntil`, so a handler called without one serves a confident empty card however many rows the store holds.

**`analytics-edge-cache`** keeps its trajectory route — cacheable on a live-store hit rather than a tier hit, which is what it has actually been doing.

**`graphql`** keeps the deltas-flattening test, now proving the resolver flattens the window-keyed map *itself* rather than asserting a fixture that arrived pre-flattened.

## Two tests I deleted by a wrong name match, and restored

`"window is forwarded as a query param to the Postgres tier"` appears **nine times** in `tests/graphql.test.ts`, and the first occurrence uses `METAGRAPH_NEURONS_SOURCE` — a **forwardable** flag, so that test was valid and passing. Same story for a `dataApi` helper defined in two separate describes. Both restored.

The lesson, for the remaining 199: a name-matched edit in a 22k-line test file has to be anchored to its `describe`, and the flag asserted inside the matched block *before* touching it.

## What could not be re-pointed

Everything reading `subnet_identity_history` — the timeline, the network feed, the CSV export, the alias overlay, the change diff. **Nothing writes that table.** D1 was its primary writer and the Postgres mirror went through this very flag. Filed as **#10710**, with **#10700** (a fabricated ~129-changes-per-tick count) and **#10706** (`previously_known_as` published on three routes with no source) as its symptoms. Those tests assert the honest empty behaviour with pointers, and #10710 lists them as the ones to restore.

One is a seam rather than a deletion: `recordSubnetIdentityChanges` gains an injectable `latestHashes` reader defaulting to an empty baseline. That keeps *"skips unchanged"* and *"a baseline that cannot be read is `read_failed`"* specified and testable, so #10710's real read lands in a contract that already says what it must do.

## Also

`scripts/validate-api.ts` loses its `METAGRAPH_SUBNET_IDENTITY_SOURCE` case (count 7 → 6) — step 6 of #10190's recipe, and the step that is easy to miss because `validate:api` is not in the default vitest run.

## Verification

- `tsc --noEmit`, `npm run lint`, `npm run format:check` clean
- Green: `validate:api` (`6 at "postgres", plus 3 forwarding and 3 non-forwarding at "d1"`), `unreferenced-exports`, `unreferenced-modules`, `contract-drift`, `mcp`, `graphql-route-parity`, `tool-route-divergence`, `untyped-db-reads`, `db-types-drift`, `schemas`
- All 17 affected suites pass
- Rebased onto `1cae37a8d`, then tsc + lint + `validate:api` + 2,480 tests re-run
- Net **−813 lines**

Closes #10719
