### PR TITLE
fix(neon): re-arm the buffer's alarm whenever a drain leaves work behind

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -15,6 +15,7 @@ import {
   BUFFER_FLUSH_LANE,
   BUFFER_ROUTE,
   countPending,
+  FLUSH_LIST_LIMIT,
   enqueueStatement,
   flushBuffer,
   NeonWriteBufferHub,
@@ -41,11 +42,19 @@ function fakeStorage(): BufferStorage & { map: Map<string, unknown> } {
     async put(entries: Record<string, unknown>) {
       for (const [key, value] of Object.entries(entries)) map.set(key, value);
     },
-    async list<T>({ prefix }: { prefix: string }) {
+    async list<T>({ prefix, limit }: { prefix: string; limit?: number }) {
       // Sorted, exactly as the platform returns it -- an unsorted fake would
       // hide the ordering bug this module's padding exists to prevent.
+      //
+      // AND BOUNDED, which this fake did NOT model until #10722. Durable Object
+      // storage caps what list() returns; the fake returned everything, so the
+      // truncation path was invisible to every test here and the production
+      // stall was the first thing to exercise it. A double that is more capable
+      // than the thing it stands in for does not simplify a test, it deletes a
+      // case.
       const out = new Map<string, T>();
       for (const key of [...map.keys()].sort()) {
+        if (limit !== undefined && out.size >= limit) break;
         if (key.startsWith(prefix)) out.set(key, map.get(key) as T);
       }
       return out;
@@ -135,7 +144,12 @@ describe("enqueueStatement", () => {
 describe("flushBuffer", () => {
   test("an empty buffer is a clean no-op", async () => {
     const out = await flushBuffer(fakeStorage(), {}, CTX, { sql: null });
-    assert.deepEqual(out, { drained: 0, undecodable: 0, ok: true });
+    assert.deepEqual(out, {
+      drained: 0,
+      undecodable: 0,
+      ok: true,
+      remaining: false,
+    });
   });
 
   test("drains every statement through ONE runner, in order", async () => {
@@ -583,5 +597,81 @@ describe("PostHog capture (#10694)", () => {
     });
     assert.ok(spy.events.length > 0);
     assert.ok(spy.events.every((e) => e.route === BUFFER_ROUTE));
+  });
+});
+
+describe("a truncated drain must come back (#10722)", () => {
+  // THE BUG THIS PINS. storage.list() is bounded, so a backlog past the limit
+  // comes back TRUNCATED -- and a flush that drained everything it LISTED still
+  // left rows behind. The alarm handler read `if (!outcome.ok)` and skipped the
+  // re-arm on that "success", while the only other path that could arm one (a
+  // later enqueue) was failing because deploys were resetting the Durable
+  // Object. The buffer stalled for 47 minutes with no alarm pending.
+
+  test("a full page reports remaining, so the caller re-arms", async () => {
+    const storage = fakeStorage();
+    for (let i = 0; i < FLUSH_LIST_LIMIT + 20; i += 1) {
+      await enqueueStatement(storage, stmt("neurons", `S${i}`), NOW);
+    }
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(out.ok, true, "the drain itself succeeded");
+    assert.equal(out.remaining, true, "but it did NOT drain everything");
+    assert.ok((await countPending(storage)) > 0, "rows are still buffered");
+  });
+
+  test("a drain that fits reports nothing remaining", async () => {
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(out.remaining, false);
+    assert.equal(await countPending(storage), 0);
+  });
+
+  test("the alarm re-arms after a SUCCESSFUL but truncated drain", async () => {
+    // The exact regression: ok === true, work left, and previously no alarm.
+    const storage = fakeStorage();
+    const state = { storage, waitUntil() {} } as unknown as DurableObjectState;
+    const h = {
+      storage,
+      do: new NeonWriteBufferHub(state, {}),
+    };
+    for (let i = 0; i < FLUSH_LIST_LIMIT + 20; i += 1) {
+      await h.do.fetch(
+        new Request("https://neon-write-buffer/enqueue", {
+          method: "POST",
+          body: JSON.stringify(stmt("neurons", `S${i}`)),
+        }),
+      );
+    }
+    // Watch setAlarm rather than getAlarm: the enqueues already armed one, so
+    // reading getAlarm afterwards cannot distinguish "the drain re-armed" from
+    // "the enqueue's alarm is still there" -- and that ambiguity is exactly
+    // what let the missing re-arm look fine.
+    let reArmed = false;
+    storage.setAlarm = async () => {
+      reArmed = true;
+    };
+    await h.do.alarm();
+    assert.equal(
+      reArmed,
+      true,
+      "a drain that left work behind MUST schedule another",
+    );
   });
 });

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -77,7 +77,38 @@ export interface FlushOutcome {
   undecodable: number;
   ok: boolean;
   reason?: string;
+  /**
+   * Whether statements were left behind -- a truncated list, or a stop on
+   * failure. THE CALLER MUST RE-ARM ON THIS. See the alarm handler.
+   */
+  remaining: boolean;
 }
+
+/**
+ * How many statement chunks one drain may list.
+ *
+ * BOUNDED BECAUSE `storage.list()` IS BOUNDED, and #10722 is what assuming
+ * otherwise cost. A drain that lists everything is not a thing the platform
+ * offers: `list()` caps its result, so a backlog past the cap comes back
+ * TRUNCATED and a flush that drains all of it still leaves rows behind.
+ * Stating the bound here makes the leftover a value the caller can act on
+ * (`remaining`) instead of an invisible remainder.
+ *
+ * Well under the platform cap so the truncation is OURS and predictable rather
+ * than the platform's and silent.
+ */
+export const FLUSH_LIST_LIMIT = 500;
+
+/**
+ * How soon to come back when a drain left work behind.
+ *
+ * SECONDS, NOT THE FULL INTERVAL. A backlog is the one state where waiting ten
+ * minutes is wrong: the rows are already late, and another full interval per
+ * batch turns a 3,000-statement backlog into an hour of latency. Ten seconds
+ * clears it at list-limit granularity while still being a wake the compute
+ * would have taken anyway.
+ */
+export const FLUSH_BACKLOG_RETRY_MS = 10_000;
 
 /** The storage surface this hub uses, narrowed so a test can supply a fake. */
 export interface BufferStorage {
@@ -163,9 +194,18 @@ export async function flushBuffer(
   const laneDb = deps.laneHealthDb ?? laneHealthStore(env);
   const capture = deps.captureException ?? recordExceptionEvent;
   const asEnv = env as unknown as Parameters<typeof recordExceptionEvent>[0];
-  const stored = await storage.list<Uint8Array>({ prefix: STATEMENT_PREFIX });
+  const stored = await storage.list<Uint8Array>({
+    prefix: STATEMENT_PREFIX,
+    limit: FLUSH_LIST_LIMIT,
+  });
   const groups = groupChunkKeys([...stored.keys()]);
-  if (groups.length === 0) return { drained: 0, undecodable: 0, ok: true };
+  // A full page back means there is almost certainly more behind it. Cheaper
+  // and more honest than a second count: the caller only needs to know whether
+  // to come back, not exactly how much is left.
+  const truncated = stored.size >= FLUSH_LIST_LIMIT;
+  if (groups.length === 0) {
+    return { drained: 0, undecodable: 0, ok: true, remaining: false };
+  }
 
   const sql =
     deps.sql ??
@@ -196,6 +236,7 @@ export async function flushBuffer(
       undecodable: 0,
       ok: false,
       reason: "hyperdrive unbound",
+      remaining: true,
     };
   }
 
@@ -251,7 +292,8 @@ export async function flushBuffer(
         detail: `drained ${drained}, stopped on ${statement.lane}: ${reason}`,
         checked_at: now(),
       });
-      return { drained, undecodable, ok: false, reason };
+      // Stopped mid-backlog: everything from here on is still stored.
+      return { drained, undecodable, ok: false, reason, remaining: true };
     }
     perLane.set(statement.lane, tally);
   }
@@ -267,7 +309,7 @@ export async function flushBuffer(
     }`,
     checked_at: now(),
   });
-  return { drained, undecodable, ok: true };
+  return { drained, undecodable, ok: true, remaining: truncated };
 }
 
 /**
@@ -378,16 +420,28 @@ export class NeonWriteBufferHub implements DurableObject {
         undecodable: 0,
         ok: false,
         reason: error instanceof Error ? error.message : String(error),
+        // The drain never ran, so assume work is still there and come back.
+        remaining: true,
       };
     }
-    // A FAILED flush is the only reason to re-arm. A successful one drained
-    // everything it listed, and the alarm has already fired and cleared -- so
-    // the next enqueue arms the next drain, which is exactly what
-    // enqueueStatement does when it finds no alarm pending. Re-arming after a
-    // clean drain would schedule a wake with nothing to do, which is the cost
-    // this whole file exists to avoid.
-    if (!outcome.ok) {
-      await storage.setAlarm(Date.now() + FLUSH_INTERVAL_MS);
+    // RE-ARM WHENEVER ANYTHING IS LEFT, not only on failure (#10722).
+    //
+    // This previously read `if (!outcome.ok)`, on the reasoning that a
+    // successful flush drained everything it listed and the next enqueue would
+    // arm the next drain. Both halves were wrong. `storage.list()` is bounded,
+    // so a backlog past the limit comes back TRUNCATED and a "successful" flush
+    // leaves rows behind; and the next enqueue only arms an alarm if it
+    // SUCCEEDS -- during a deploy the Durable Object is reset and enqueues fail
+    // ("Durable Object reset because its code was updated"), so the one path
+    // that could have recovered was failing at exactly the moment it was
+    // needed. The buffer stalled for 47 minutes on 2026-08-11 with no alarm
+    // pending and no way to arm one.
+    //
+    // A backlog comes back in SECONDS rather than the full interval: those rows
+    // are already late, and another ten minutes per batch would turn a large
+    // backlog into an hour of latency.
+    if (!outcome.ok || outcome.remaining) {
+      await storage.setAlarm(Date.now() + FLUSH_BACKLOG_RETRY_MS);
     }
   }
 }


### PR DESCRIPTION
## Incident

Buffered lanes stopped landing in Neon after **08:47** on 2026-08-11. `neon:buffer-flush` last fired
at **08:59:52** and did not fire again — ~47 minutes of `tao_usd_index` minute-ticks,
`account_balances` and `nominator_positions` sat undrained with **no alarm pending and no way to arm
one**.

`blocks-head` and `chain-detail` were unaffected — `NEVER_BUFFER_LANES` held and the block explorer
never degraded. PostHog paged correctly on the symptom via the lane-alarm watchdog.

## Root cause: two wrong assumptions that only deadlock together

**1. `storage.list()` is bounded.** The flush listed with no limit and treated the result as
*everything*. Durable Object storage caps its result, so a backlog past the cap came back
**truncated** — and a flush that drained all of it still left rows behind **while reporting `ok`**.

**2. The re-arm had been removed.** #10693 changed the condition to fire only on failure, with a
comment of mine asserting the "work remains" operand was unreachable dead code. It is reachable
exactly when (1) happens.

The stated fallback — *"the next enqueue arms the next drain"* — then failed too: deploys reset the
Durable Object three times in twenty minutes, enqueues failed with
`Durable Object reset because its code was updated`, and **a failed enqueue arms nothing**.

Either alone is survivable. Together there is no path back: work remains, no alarm is pending, and the
only thing that could arm one is failing.

## The test double hid it

`fakeStorage.list()` **ignored `limit`** and returned everything, so the truncation path was invisible
to every test in the file and production was the first thing to exercise it.

A double more capable than the thing it stands in for does not simplify a test — it deletes a case. It
now honours the bound, and the regression test asserts the exact shape that broke: `ok === true`, work
left, alarm **must** be scheduled.

## Fix

| | |
|---|---|
| `flushBuffer` | lists with an explicit `FLUSH_LIST_LIMIT`, returns `remaining` |
| `alarm()` | re-arms on `!ok` OR `remaining` |
| Backlog retry | **seconds**, not the full interval — those rows are already late |
| Storage double | honours `limit` |

## Validation

```
npx tsc --noEmit · lint · format:check    # clean
npm run validate                          # exit 0
npx vitest run <4 suites>                 # 136 passed
```

## Re-enabling

`NEON_WRITE_BUFFER_LANES` is still populated, so this deploys straight into the buffered path. I will
watch for consecutive flushes **with a backlog present** rather than declaring it fixed on one green
drain — one flush is what made the original look healthy.

Closes #10722
