### PR TITLE
fix(watchdog): judge lane silence by the max gap and the declared cadence

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -48,6 +48,7 @@
 // every minute, `top-holders-flow` is daily), so one shared constant could only
 // ever be wrong for most of them.
 
+import { laneSilenceCadenceMs } from "./producer-cadence.ts";
 import {
   loadLatestLaneHealth,
   staleLanes,
@@ -231,18 +232,20 @@ export const LANE_STALE_RUN_SQL = VERDICT_RUN_SQL.stale;
  */
 export const LANE_UNKNOWN_RUN_SQL = VERDICT_RUN_SQL.unknown;
 
-/**
- * Each lane's observed cadence, as a mean gap.
+/* LANE_CADENCE_SQL / laneCadenceMs / loadLaneCadence were REMOVED here (#10723).
  *
- * A mean rather than a median because it needs no window function and no sort:
- * one GROUP BY over a bounded window, where `(last - first) / (n - 1)` is the
- * mean gap by construction. A median would be more robust to a single long
- * outage, but the consumer multiplies this by three and floors it at 90
- * minutes, so that robustness would buy nothing a human could measure.
+ * They computed the MEAN gap between lane_health writes, and this file's own
+ * LANE_MAX_GAP_SQL comment already measured why that is the wrong number:
+ * `neon:account-balances` logged 6,268 rows in seven days against a six-hour
+ * producer, mean gap ONE minute. The alarm path read the mean anyway and
+ * false-alarmed four Neon lanes at 1.7-1.8h against producers running every 6h
+ * and 24h.
+ *
+ * Deleted rather than left exported. #10232 had already replaced the mean for the
+ * self-health surface and the alarm path kept using it for another eight months --
+ * a plausible-looking helper that is wrong for the only question left is how that
+ * happens twice.
  */
-export const LANE_CADENCE_SQL =
-  "SELECT lane, COUNT(*) AS n, MIN(checked_at) AS first, MAX(checked_at) AS last " +
-  "FROM lane_health WHERE checked_at > ? GROUP BY lane";
 
 /**
  * The LONGEST gap between consecutive rows, per lane (#10333).
@@ -322,18 +325,6 @@ export async function loadLaneMaxGap(
   }
 }
 
-/** Mean gap between ticks, or null when there is not enough history to say. */
-export function laneCadenceMs(sample: {
-  n: number;
-  first: number;
-  last: number;
-}): number | null {
-  if (sample.n < LANE_ALARM_MIN_CADENCE_SAMPLES) return null;
-  const span = sample.last - sample.first;
-  if (span <= 0) return null;
-  return Math.round(span / (sample.n - 1));
-}
-
 /** How long a lane may stay quiet before the silence is itself the fault. */
 export function laneSilenceThresholdMs(cadenceMs: number): number {
   return Math.max(
@@ -394,8 +385,22 @@ export interface LaneAlarmPlanInput {
   runs: LaneVerdictRuns;
   /** Current unbroken `unknown` runs, keyed by lane (#10695). */
   unknownRuns: LaneVerdictRuns;
-  /** Observed cadence per lane, keyed by lane. Null where uncalibrated. */
-  cadence: Record<string, number | null>;
+  /**
+   * Observed MAXIMUM gap per lane, keyed by lane. Null where uncalibrated.
+   *
+   * The max, not the mean (#10232, and this file's own LANE_MAX_GAP_SQL comment
+   * measures why): a container reboot fires every lane's first tick immediately,
+   * and a mirror lane writes many rows per pass -- `neon:account-balances` logged
+   * 6,268 rows in seven days against a six-hour producer, so its mean gap is ONE
+   * minute against a declared 360. Judged by that mean, every gap between passes
+   * is an outage.
+   *
+   * Resolved through `laneSilenceCadenceMs`, which floors it by the producer's
+   * declared cadence where LANE_PRODUCER names one -- the same function
+   * src/self-health.ts already judges silence by. The alarm path was the one
+   * consumer still guessing (#10723).
+   */
+  observedMaxGap: Record<string, number | null>;
   /** Lanes that already have an open alarm issue. */
   openAlarms: Record<string, number>;
   nowMs: number;
@@ -417,8 +422,19 @@ export interface LaneAlarmPlan {
  * network, so every branch below is reachable from a test.
  */
 export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
-  const { latest, runs, unknownRuns, cadence, openAlarms, nowMs, minStaleMs } =
-    input;
+  const {
+    latest,
+    runs,
+    unknownRuns,
+    observedMaxGap,
+    openAlarms,
+    nowMs,
+    minStaleMs,
+  } = input;
+  // One resolution per lane, so the stale/unknown reports and the silence bound
+  // cannot disagree about what a lane's cadence is.
+  const cadenceFor = (lane: string) =>
+    laneSilenceCadenceMs(lane, observedMaxGap[lane]);
   const qualified: LaneAlarm[] = [];
 
   const stale = staleLanes(latest);
@@ -438,7 +454,7 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
       ticks: run?.ticks ?? 1,
       detail: record.detail,
       age_ms: record.age_ms,
-      cadence_ms: cadence[record.lane] ?? null,
+      cadence_ms: cadenceFor(record.lane),
     });
   }
 
@@ -460,7 +476,7 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     // dead producer, which outranks "the producer is running but cannot
     // measure". Gating on liveness rather than de-duplicating afterwards keeps
     // the two loops mutually exclusive by construction.
-    const unknownCadenceMs = cadence[record.lane] ?? null;
+    const unknownCadenceMs = cadenceFor(record.lane);
     if (
       unknownCadenceMs !== null &&
       nowMs - record.checked_at >= laneSilenceThresholdMs(unknownCadenceMs)
@@ -477,7 +493,7 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
       ticks: run?.ticks ?? 1,
       detail: record.detail,
       age_ms: record.age_ms,
-      cadence_ms: cadence[record.lane] ?? null,
+      cadence_ms: cadenceFor(record.lane),
     });
   }
 
@@ -493,7 +509,7 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     // these lanes actually report. See LANE_SILENCE_EXEMPT for what covers
     // each one instead.
     if (record.lane in LANE_SILENCE_EXEMPT) continue;
-    const cadenceMs = cadence[record.lane] ?? null;
+    const cadenceMs = cadenceFor(record.lane);
     if (cadenceMs === null) continue;
     const quietFor = nowMs - record.checked_at;
     if (quietFor < laneSilenceThresholdMs(cadenceMs)) continue;
@@ -640,31 +656,6 @@ async function loadLaneRuns(
   }
 }
 
-/** Each lane's observed cadence, keyed by lane. Null where uncalibrated. */
-export async function loadLaneCadence(
-  db: D1Like | null | undefined,
-  sinceMs: number,
-): Promise<Record<string, number | null>> {
-  if (!db?.prepare) return {};
-  try {
-    const result = await db.prepare(LANE_CADENCE_SQL).bind(sinceMs).all?.();
-    const rows = (result?.results ?? []) as Record<string, unknown>[];
-    const out: Record<string, number | null> = {};
-    for (const row of rows) {
-      const lane = row.lane == null ? "" : String(row.lane);
-      if (!lane) continue;
-      out[lane] = laneCadenceMs({
-        n: toInt(row.n),
-        first: toInt(row.first),
-        last: toInt(row.last),
-      });
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
 /** The GitHub calls this needs, as one injectable seam. */
 export interface LaneAlarmGitHub {
   listOpen(): Promise<Record<string, number>>;
@@ -781,11 +772,17 @@ export async function runLaneAlarm(
   const minStaleMs =
     Number(env?.LANE_ALARM_MIN_STALE_MS) || LANE_ALARM_MIN_STALE_MS;
 
-  const [latest, runs, unknownRuns, cadence] = await Promise.all([
+  const [latest, runs, unknownRuns, observedMaxGap] = await Promise.all([
     loadLatestLaneHealth(db),
     loadLaneStaleRuns(db),
     loadLaneUnknownRuns(db),
-    loadLaneCadence(db, nowMs - LANE_ALARM_CADENCE_WINDOW_MS),
+    // THE MAX GAP, not the mean (#10723). This file already owned both queries
+    // and already documented why the max is the only column that survives a
+    // container reboot and a many-rows-per-pass mirror lane -- but the alarm path
+    // kept reading the mean, so `neon:account-balances` was judged against a
+    // ONE-MINUTE cadence and alarmed on every gap between its six-hourly passes.
+    // src/self-health.ts and src/self-health-mcp.ts already read it this way.
+    loadLaneMaxGap(db, nowMs - LANE_ALARM_CADENCE_WINDOW_MS),
   ]);
 
   // Read the open alarms BEFORE planning: without them every tick would open a
@@ -807,7 +804,7 @@ export async function runLaneAlarm(
     latest,
     runs,
     unknownRuns,
-    cadence,
+    observedMaxGap,
     openAlarms: openAlarms ?? {},
     nowMs,
     minStaleMs,

--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -304,9 +304,11 @@ export function withLaneHealth(
    * A single cutoff cannot work: cadences here differ by more than 100x
    * (`chain-detail` every ~30s, `hotkey-alpha` every 24h). One tight enough to
    * catch a dead 30-second lane marks every 24-hour lane absent between ticks.
-   * So the bound is the lane's OWN observed cadence, reusing the pair the
-   * alarm path already computes -- `laneCadenceMs` (span / n-1) and
-   * `laneSilenceThresholdMs` (3 intervals, floored at 90 min).
+   * So the bound is the lane's own observed MAXIMUM gap, floored by the
+   * producer's declared cadence -- `laneSilenceCadenceMs` -- and then widened by
+   * `laneSilenceThresholdMs` (3 intervals, floored at 90 min). The alarm path
+   * reads the same pair since #10723; it used to compute a MEAN gap of its own,
+   * which is what this comment described.
    *
    * OMITTING `cadences` LEAVES EVERY VERDICT ALONE, deliberately. Without a
    * sample there is no bound that is not a guess, and a guess here invents

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -21,7 +21,7 @@ import { pgMockEnv } from "./helpers/pg-mock.ts";
 // the seam; see tests/helpers/pg-mock.ts for why it is a module mock and why
 // the controller has to be built inside vi.hoisted.
 //
-// The three pure readers below (loadLaneStaleRuns, loadLaneCadence) still take
+// The pure readers below (loadLaneStaleRuns, loadLaneUnknownRuns, loadLaneMaxGap) take
 // a `db` argument, so they keep their own hand-rolled double -- injection is
 // still injection, and a module mock would say less about them than the fake
 // they are handed.
@@ -35,16 +35,15 @@ import {
   LANE_ALARM_MIN_STALE_MS,
   LANE_SILENCE_EXEMPT,
   LANE_ALARM_TITLE_PREFIX,
-  LANE_CADENCE_SQL,
+  LANE_MAX_GAP_SQL,
   LANE_STALE_RUN_SQL,
   laneAlarmGitHub,
   laneAlarmIssueBody,
   laneAlarmPlan,
   laneAlarmRecoveryComment,
   laneAlarmTitle,
-  laneCadenceMs,
   laneSilenceThresholdMs,
-  loadLaneCadence,
+  loadLaneMaxGap,
   loadLaneStaleRuns,
   runLaneAlarm,
   type LaneAlarm,
@@ -68,7 +67,7 @@ function record(over: Partial<LaneHealthRecord> = {}): LaneHealthRecord {
 
 /** A double for the `db` these two readers TAKE. They are the injectable half
  * of this module -- runLaneAlarm selects its own store, but loadLaneStaleRuns
- * and loadLaneCadence are handed one -- so a hand-rolled fake still says more
+ * and loadLaneMaxGap are handed one -- so a hand-rolled fake still says more
  * here than the module mock does. Returns rows, or throws however asked. */
 function fakeDb(rows: Record<string, unknown>[] | Error = []) {
   const calls: { sql: string; values: unknown[] }[] = [];
@@ -97,27 +96,10 @@ function fakeDb(rows: Record<string, unknown>[] | Error = []) {
   };
 }
 
-describe("laneCadenceMs", () => {
-  test("averages the gaps between ticks", () => {
-    // 5 verdicts spanning 60 minutes = 4 gaps of 15 minutes.
-    assert.equal(
-      laneCadenceMs({ n: 5, first: NOW - 60 * 60_000, last: NOW }),
-      15 * 60_000,
-    );
-  });
-
-  test("refuses to guess from too little history", () => {
-    // Two samples is one gap, and a wrong cadence produces exactly the false
-    // alarm the design is trying to avoid. Uncalibrated is the honest answer.
-    assert.equal(laneCadenceMs({ n: 2, first: NOW - 60_000, last: NOW }), null);
-  });
-
-  test("refuses a zero-width span", () => {
-    // Every verdict at the same instant: a real table state on the first tick
-    // after a deploy, and a cadence of 0 would make the silence threshold 0.
-    assert.equal(laneCadenceMs({ n: 5, first: NOW, last: NOW }), null);
-  });
-});
+// The `laneCadenceMs` describe was REMOVED (#10723) along with the function: it
+// documented a MEAN-gap computation nobody performs any more. Why the mean was the
+// wrong number is recorded in tests/lane-silence-cadence.test.ts and in
+// src/lane-alarm.ts's LANE_MAX_GAP_SQL comment.
 
 describe("laneSilenceThresholdMs", () => {
   test("three intervals for a slow lane", () => {
@@ -135,7 +117,7 @@ describe("laneAlarmPlan", () => {
     latest: {},
     runs: {},
     unknownRuns: {},
-    cadence: {},
+    observedMaxGap: {},
     openAlarms: {},
     nowMs: NOW,
     minStaleMs: LANE_ALARM_MIN_STALE_MS,
@@ -146,7 +128,7 @@ describe("laneAlarmPlan", () => {
       ...base,
       latest: { a: record({ lane: "a" }) },
       runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
-      cadence: { a: 15 * 60_000 },
+      observedMaxGap: { a: 15 * 60_000 },
     });
     assert.equal(plan.open.length, 1);
     assert.deepEqual(
@@ -181,7 +163,7 @@ describe("laneAlarmPlan", () => {
       ...base,
       latest: { a: record({ lane: "a", verdict: "unknown" }) },
       unknownRuns: { a: { since: NOW - 4 * HOUR, ticks: 4 } },
-      cadence: { a: 15 * 60_000 },
+      observedMaxGap: { a: 15 * 60_000 },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].lane, "a");
@@ -199,7 +181,7 @@ describe("laneAlarmPlan", () => {
       ...base,
       latest: { a: record({ lane: "a", verdict: "unknown" }) },
       unknownRuns: { a: { since: NOW - 60_000, ticks: 1 } },
-      cadence: { a: 15 * 60_000 },
+      observedMaxGap: { a: 15 * 60_000 },
     });
     assert.deepEqual(plan.open, []);
   });
@@ -214,7 +196,7 @@ describe("laneAlarmPlan", () => {
         a: record({ lane: "a", verdict: "unknown", checked_at: NOW - 30_000 }),
       },
       unknownRuns: { a: { since: NOW - 6 * HOUR, ticks: 6 } },
-      cadence: { a: 60_000 },
+      observedMaxGap: { a: 60_000 },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].kind, "unknown");
@@ -234,10 +216,69 @@ describe("laneAlarmPlan", () => {
         }),
       },
       unknownRuns: { a: { since: NOW - 6 * HOUR, ticks: 6 } },
-      cadence: { a: 60_000 },
+      observedMaxGap: { a: 60_000 },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].kind, "silent");
+  });
+
+  // #10723: the assertion that would have caught four false alarms.
+  //
+  // `neon:account-balances` writes a verdict per BATCH -- 6,268 rows in seven days
+  // against a six-hourly producer -- so its observed MEAN gap is one minute. Judged
+  // by that, every gap between passes is an outage, and on 2026-08-11T02:28Z four
+  // Neon lanes alarmed at 1.7-1.8h against producers running every 6h and 24h.
+  //
+  // laneSilenceCadenceMs floors the observed gap by the producer's DECLARED cadence
+  // wherever LANE_PRODUCER names one, which is what src/self-health.ts already did.
+  test("a lane with a declared producer is not alarmed inside its interval", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        "neon:account-balances": record({
+          lane: "neon:account-balances",
+          verdict: "ok",
+          // Well past the 90-minute floor, and well inside the declared 6h.
+          checked_at: NOW - 2 * HOUR,
+        }),
+      },
+      // The mean-gap number that caused the false alarms.
+      observedMaxGap: { "neon:account-balances": 60_000 },
+    });
+    assert.deepEqual(plan.open, []);
+  });
+
+  test("a lane with a declared producer still alarms past three intervals", () => {
+    // The floor must not become a mute button: three cadences of slack, then it
+    // fires. account_balances is 6h, so 20h is past 3x.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        "neon:account-balances": record({
+          lane: "neon:account-balances",
+          verdict: "ok",
+          checked_at: NOW - 20 * HOUR,
+        }),
+      },
+      observedMaxGap: { "neon:account-balances": 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].kind, "silent");
+    // The DECLARED cadence is what it reports, not the one-minute observation.
+    assert.equal(plan.open[0].cadence_ms, 6 * HOUR);
+  });
+
+  test("a lane with NO declared producer still uses its observed gap", () => {
+    // The fallback has to survive: an undeclared lane behaves exactly as before.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        z: record({ lane: "z", verdict: "ok", checked_at: NOW - 4 * HOUR }),
+      },
+      observedMaxGap: { z: 30 * 60_000 },
+    });
+    assert.equal(plan.open.length, 1);
+    assert.equal(plan.open[0].cadence_ms, 30 * 60_000);
   });
 
   test("never alarms an exempt lane for silence, however long it is quiet", () => {
@@ -252,7 +293,7 @@ describe("laneAlarmPlan", () => {
       },
       // A calibrated cadence, which is exactly the state that produced the
       // false alarm — the exemption has to hold even so.
-      cadence: { "poller-build": 12 * HOUR },
+      observedMaxGap: { "poller-build": 12 * HOUR },
     });
     assert.deepEqual(plan.open, []);
   });
@@ -267,7 +308,7 @@ describe("laneAlarmPlan", () => {
         "poller-build": record({ lane: "poller-build", verdict: "stale" }),
       },
       runs: { "poller-build": { since: NOW - 28 * HOUR, ticks: 40 } },
-      cadence: { "poller-build": 12 * HOUR },
+      observedMaxGap: { "poller-build": 12 * HOUR },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].lane, "poller-build");
@@ -286,7 +327,7 @@ describe("laneAlarmPlan", () => {
           checked_at: NOW - 30 * 24 * HOUR,
         }),
       },
-      cadence: { neurons: 12 * HOUR },
+      observedMaxGap: { neurons: 12 * HOUR },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].lane, "neurons");
@@ -347,7 +388,7 @@ describe("laneAlarmPlan", () => {
           checked_at: NOW - 6 * HOUR,
         }),
       },
-      cadence: { a: 30 * 60_000 },
+      observedMaxGap: { a: 30 * 60_000 },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].kind, "silent");
@@ -360,7 +401,7 @@ describe("laneAlarmPlan", () => {
       latest: {
         a: record({ lane: "a", verdict: "ok", checked_at: NOW - 20 * 60_000 }),
       },
-      cadence: { a: 15 * 60_000 },
+      observedMaxGap: { a: 15 * 60_000 },
     });
     assert.deepEqual(plan.open, []);
   });
@@ -375,7 +416,7 @@ describe("laneAlarmPlan", () => {
           checked_at: NOW - 40 * 24 * HOUR,
         }),
       },
-      cadence: {},
+      observedMaxGap: {},
     });
     assert.deepEqual(plan.open, []);
   });
@@ -387,7 +428,7 @@ describe("laneAlarmPlan", () => {
       ...base,
       latest: { a: record({ lane: "a", checked_at: NOW - 9 * HOUR }) },
       runs: { a: { since: NOW - 9 * HOUR, ticks: 30 } },
-      cadence: { a: 15 * 60_000 },
+      observedMaxGap: { a: 15 * 60_000 },
     });
     assert.equal(plan.open.length, 1);
     assert.equal(plan.open[0].kind, "stale");
@@ -403,7 +444,7 @@ describe("laneAlarmPlan", () => {
           checked_at: NOW - 9 * HOUR,
         }),
       },
-      cadence: { a: 15 * 60_000 },
+      observedMaxGap: { a: 15 * 60_000 },
     });
     // staleLanes() excludes `unknown`, so this cannot be a stale alarm. It is
     // 9 hours past a 15-minute cadence, though, so the silence detector still
@@ -582,7 +623,13 @@ describe("laneAlarmRecoveryComment", () => {
   });
 });
 
-describe("loadLaneStaleRuns / loadLaneCadence", () => {
+// RE-POINTED AT loadLaneMaxGap (#10723). These assertions were written against
+// loadLaneCadence -- the mean-gap loader, now deleted -- but what they actually
+// cover is the robustness contract every one of these readers shares: skip a row
+// with no lane, coerce an unreadable number, tolerate a driver that answers
+// without a `results` key, and decline to `{}` rather than throw. That contract
+// matters more on the loader the alarm actually issues.
+describe("loadLaneStaleRuns / loadLaneMaxGap", () => {
   test("read the current run and the observed cadence", async () => {
     const db = fakeDb([{ lane: "a", since: 10, ticks: 5 }]);
     assert.deepEqual(await loadLaneStaleRuns(db), {
@@ -590,14 +637,12 @@ describe("loadLaneStaleRuns / loadLaneCadence", () => {
     });
     assert.equal(db.calls[0].sql, LANE_STALE_RUN_SQL);
 
-    const cadenceDb = fakeDb([
-      { lane: "a", n: 5, first: NOW - 60 * 60_000, last: NOW },
-    ]);
-    assert.deepEqual(await loadLaneCadence(cadenceDb, NOW - 7 * 24 * HOUR), {
+    const gapDb = fakeDb([{ lane: "a", n: 5, max_gap: 15 * 60_000 }]);
+    assert.deepEqual(await loadLaneMaxGap(gapDb, NOW - 7 * 24 * HOUR), {
       a: 15 * 60_000,
     });
-    assert.equal(cadenceDb.calls[0].sql, LANE_CADENCE_SQL);
-    assert.deepEqual(cadenceDb.calls[0].values, [NOW - 7 * 24 * HOUR]);
+    assert.equal(gapDb.calls[0].sql, LANE_MAX_GAP_SQL);
+    assert.deepEqual(gapDb.calls[0].values, [NOW - 7 * 24 * HOUR]);
   });
 
   test("skip a row with no lane name rather than keying on an empty string", async () => {
@@ -605,7 +650,10 @@ describe("loadLaneStaleRuns / loadLaneCadence", () => {
       await loadLaneStaleRuns(fakeDb([{ since: 1, ticks: 1 }])),
       {},
     );
-    assert.deepEqual(await loadLaneCadence(fakeDb([{ n: 5 }]), 0), {});
+    assert.deepEqual(
+      await loadLaneMaxGap(fakeDb([{ n: 5, max_gap: 1 }]), 0),
+      {},
+    );
   });
 
   test("coerce an unreadable count to zero rather than NaN", async () => {
@@ -631,17 +679,17 @@ describe("loadLaneStaleRuns / loadLaneCadence", () => {
       }),
     };
     assert.deepEqual(await loadLaneStaleRuns(shim), {});
-    assert.deepEqual(await loadLaneCadence(shim, 0), {});
+    assert.deepEqual(await loadLaneMaxGap(shim, 0), {});
   });
 
   test("return empty on a missing binding or a failing query", async () => {
     assert.deepEqual(await loadLaneStaleRuns(null), {});
-    assert.deepEqual(await loadLaneCadence(undefined, 0), {});
+    assert.deepEqual(await loadLaneMaxGap(undefined, 0), {});
     assert.deepEqual(
       await loadLaneStaleRuns(fakeDb(new Error("no such table"))),
       {},
     );
-    assert.deepEqual(await loadLaneCadence(fakeDb(new Error("boom")), 0), {});
+    assert.deepEqual(await loadLaneMaxGap(fakeDb(new Error("boom")), 0), {});
   });
 });
 
@@ -804,7 +852,9 @@ describe("runLaneAlarm", () => {
   function healthDb(rows: {
     latest?: Record<string, unknown>[];
     runs?: Record<string, unknown>[];
-    cadence?: Record<string, unknown>[];
+    /** LANE_MAX_GAP_SQL rows: `{ lane, n, max_gap }` (#10723). The alarm reads the
+     * MAX gap now, not the mean, so this bucket answers that query's shape. */
+    maxGap?: Record<string, unknown>[];
   }) {
     const written: Record<string, unknown>[] = [];
     pg.control.queries.length = 0;
@@ -812,7 +862,7 @@ describe("runLaneAlarm", () => {
     pg.control.failNext = null;
     pg.control.answers = [
       { match: "MIN(checked_at) AS since", rows: rows.runs ?? [] },
-      { match: "COUNT(*) AS n", rows: rows.cadence ?? [] },
+      { match: "COUNT(*) AS n", rows: rows.maxGap ?? [] },
       {
         match: "SELECT lane, verdict, age_ms, detail, checked_at",
         rows: rows.latest ?? [],
@@ -841,14 +891,7 @@ describe("runLaneAlarm", () => {
         },
       ],
       runs: [{ lane: "neurons-staleness", since: NOW - 28 * HOUR, ticks: 112 }],
-      cadence: [
-        {
-          lane: "neurons-staleness",
-          n: 100,
-          first: NOW - 25 * HOUR,
-          last: NOW,
-        },
-      ],
+      maxGap: [{ lane: "neurons-staleness", n: 100, max_gap: 15 * 60_000 }],
     });
     const github = fakeGitHub();
     const out = await runLaneAlarm(
@@ -1104,9 +1147,7 @@ describe("runLaneAlarm", () => {
           checked_at: NOW - 40 * HOUR,
         },
       ],
-      cadence: [
-        { lane: "a", n: 50, first: NOW - 50 * HOUR, last: NOW - 40 * HOUR },
-      ],
+      maxGap: [{ lane: "a", n: 50, max_gap: 12 * 60_000 }],
     });
     const calls: string[] = [];
     const original = globalThis.fetch;


### PR DESCRIPTION
`lane-alarm` calibrated its silence threshold from the **mean** gap between `lane_health` writes. For a lane that writes many rows per pass that collapses to near-zero, the threshold floors at 90 minutes, and every gap *between passes* becomes an outage.

## Measured on production, 2026-08-11T02:28Z — four lanes in one tick

| alarm | producer interval | correct bound (3×) |
| --- | --- | --- |
| `neon:account-balances is silent: 1.8h` | **6h** | ~18h |
| `neon:account-balances-pass is silent: 1.8h` | **6h** | ~18h |
| `neon:hotkey-alpha is silent: 1.7h` | **24h** | ~72h |
| `neon:hotkey-alpha-pass is silent: 1.7h` | **24h** | ~72h |

Alarming a 24-hour lane after 1.7 hours is off by a factor of forty.

## The file already contained the measurement

`LANE_MAX_GAP_SQL`'s own doc comment:

```
lane                    rows  declared   mean  median   MAX
neon:account-balances   6268       360      1       0   359
```

A mean gap of **one minute** against a declared 360 — and it explains why: container reboots fire every lane's first tick immediately, and a mirror lane writes many rows per pass, so "gap between rows" is not "gap between passes".

So this file already owned both queries, already documented which one is right, already **exported** the right one — and used the wrong one for its own alarms. `src/self-health.ts` and `src/self-health-mcp.ts` have read `loadLaneMaxGap` + `laneSilenceCadenceMs` since #10232. The alarm path was the last consumer still guessing.

## The change

`laneAlarmPlan` takes `observedMaxGap` and resolves it through `laneSilenceCadenceMs`, which floors the observation by `PRODUCER_CADENCE_SECS` wherever `LANE_PRODUCER` names a producer — and it names all four of these lanes. One resolution per lane, so the stale/unknown reports and the silence bound cannot disagree about a lane's cadence.

**The mean-gap primitives are deleted, not left exported** — `LANE_CADENCE_SQL`, `laneCadenceMs`, `loadLaneCadence`. #10232 replaced the mean for the self-health surface and the alarm path kept using it anyway; a plausible-looking helper that is wrong for the only remaining question is how that happens twice.

Their loader-robustness assertions were **re-pointed at `loadLaneMaxGap`** rather than dropped — skip a row with no lane, coerce an unreadable number, tolerate a driver with no `results` key, decline to `{}` rather than throw. That contract matters more on the loader the alarm actually issues.

## Tests

Three added, the first being the assertion that would have caught this:

```
a lane with a declared producer is not alarmed inside its interval
a lane with a declared producer still alarms past three intervals
a lane with NO declared producer still uses its observed gap
```

The second exists so the floor cannot become a mute button, and asserts the alarm reports the **declared 6h** rather than the one-minute observation. The third pins the fallback so undeclared lanes behave exactly as before.

Reverting the resolution to the raw gap fails two of them.

## Why it surfaced now

#10674 gave each lane its own `$exception` fingerprint. Before that all four shared `watchdog:lane-alarm:Error`, and the storm guard dropped three of every four alarms in a tick — so this read as one lane blipping once. The first tick after that fix showed four.

## Also

Corrects `src/self-health.ts`'s comment, which still described the alarm path as computing `laneCadenceMs`.

## Verification

- `tsc --noEmit`, `npm run lint`, `npm run format:check` clean
- `validate:api`, `unreferenced-exports`, `unreferenced-modules`, `contract-drift`, `mcp` green
- **479 tests pass** across `lane-alarm`, `lane-health-silence`, `lane-silence-cadence`, `self-health`, `self-health-mcp`, `lane-health`, `request-handlers-entities`
- Rebased onto `bddf4c811`, then tsc + lint + 59 tests re-run

Closes #10723
