### PR TITLE
fix(neon): retry an enqueue when a deploy resets the Durable Object

### DIFF
--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -338,6 +338,27 @@ export interface NeonWriteBufferNamespace {
 const RESULT_CONSUMING = /\bRETURNING\b/i;
 
 /**
+ * Errors that mean "try again", not "this write is wrong".
+ *
+ * A DEPLOY RESETS THE DURABLE OBJECT, and an enqueue in flight at that instant
+ * throws `Durable Object reset because its code was updated`. That is not a
+ * failure of the write -- the object comes back immediately on the new code --
+ * but without a retry it costs the row, and worse: a failed enqueue stores
+ * nothing, so it also arms no alarm. During the deploy churn of 2026-08-11
+ * (four deploys in twenty-five minutes) that was enough to keep the buffer
+ * from ever draining, because the one path that could have re-armed it was the
+ * path that kept failing (#10722, #10729).
+ *
+ * The other two are the ordinary Workers transients for a stub call crossing
+ * an isolate boundary.
+ */
+const TRANSIENT_STUB_ERROR =
+  /Durable Object reset|Network connection lost|internal error|cannot be reached/i;
+
+/** How many times an enqueue retries a transient stub failure. */
+export const ENQUEUE_ATTEMPTS = 3;
+
+/**
  * A `PgUnsafe` that enqueues instead of executing.
  *
  * Drop-in for `createPgSql` on the write lanes: `PgUnsafe` is a one-method
@@ -367,20 +388,40 @@ export function createBufferedPgSql(
           `neon write buffer cannot defer a statement that RETURNs rows (lane ${lane})`,
         );
       }
-      const stub = namespace.get(namespace.idFromName("global"));
-      const response = await stub.fetch(
-        new Request("https://neon-write-buffer/enqueue", {
-          method: "POST",
-          body: JSON.stringify({ lane, text, values }),
-          headers: { "content-type": "application/json" },
-        }),
-      );
-      if (!response.ok) {
-        throw new Error(
-          `neon write buffer refused the statement (${response.status})`,
-        );
+      const body = JSON.stringify({ lane, text, values });
+      let lastTransient: unknown;
+      for (let attempt = 0; attempt < ENQUEUE_ATTEMPTS; attempt += 1) {
+        // A FRESH STUB EACH ATTEMPT. Reusing one that just threw is how a
+        // retry retries the broken connection rather than the operation --
+        // idFromName is cheap and the point is to get a live object.
+        const stub = namespace.get(namespace.idFromName("global"));
+        try {
+          const response = await stub.fetch(
+            new Request("https://neon-write-buffer/enqueue", {
+              method: "POST",
+              body,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+          if (!response.ok) {
+            // A 503 is BACKPRESSURE, not a transient: the buffer is full and
+            // retrying immediately makes it fuller. It surfaces as a stale
+            // verdict and the producer's own cadence is the retry.
+            throw new Error(
+              `neon write buffer refused the statement (${response.status})`,
+            );
+          }
+          return [];
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          if (!TRANSIENT_STUB_ERROR.test(message)) throw error;
+          lastTransient = error;
+        }
       }
-      return [];
+      throw lastTransient instanceof Error
+        ? lastTransient
+        : new Error(String(lastTransient));
     },
   };
 }

--- a/tests/neon-write-buffer.test.ts
+++ b/tests/neon-write-buffer.test.ts
@@ -15,6 +15,7 @@ import {
   CHUNK_BYTES,
   createBufferedPgSql,
   decodeStatement,
+  ENQUEUE_ATTEMPTS,
   DO_VALUE_LIMIT_BYTES,
   encodeStatement,
   FLUSH_INTERVAL_MS,
@@ -452,5 +453,87 @@ describe("blocks-head can never be buffered", () => {
       "blocks-head",
       "chain-detail",
     ]);
+  });
+});
+
+describe("the enqueue retries a transient stub failure (#10729)", () => {
+  function flakyNamespace(failures: number, message: string) {
+    let calls = 0;
+    const sent: unknown[] = [];
+    return {
+      get calls() {
+        return calls;
+      },
+      sent,
+      ns: {
+        idFromName: (n: string) => n,
+        get: () => ({
+          async fetch(request: Request) {
+            calls += 1;
+            if (calls <= failures) throw new Error(message);
+            sent.push(await request.json());
+            return new Response("{}", { status: 200 });
+          },
+        }),
+      },
+    };
+  }
+
+  test("a Durable Object reset is retried, not lost", async () => {
+    // A deploy resets the DO, and an enqueue in flight throws. Without the
+    // retry that costs the row AND arms no alarm -- which is what kept the
+    // buffer from ever draining on 2026-08-11.
+    const n = flakyNamespace(
+      1,
+      "Durable Object reset because its code was updated",
+    );
+    const sql = createBufferedPgSql(n.ns, "neurons");
+    assert.deepEqual(await sql.unsafe("INSERT INTO t VALUES ($1)", [1]), []);
+    assert.equal(n.calls, 2, "it retried once");
+    assert.equal(n.sent.length, 1, "and the row landed");
+  });
+
+  test("it gives up after the attempt budget and surfaces the error", async () => {
+    // NOT unbounded: a genuinely unreachable object must still fail the write
+    // so the lane records a stale verdict and the producer retries.
+    const n = flakyNamespace(
+      99,
+      "Durable Object reset because its code was updated",
+    );
+    await assert.rejects(
+      () =>
+        createBufferedPgSql(n.ns, "neurons").unsafe("INSERT INTO t VALUES (1)"),
+      /Durable Object reset/,
+    );
+    assert.equal(n.calls, ENQUEUE_ATTEMPTS);
+  });
+
+  test("a FULL buffer is not retried -- retrying makes it fuller", async () => {
+    // 503 is backpressure, a different thing from a transient. The producer's
+    // own cadence is the retry there.
+    let calls = 0;
+    const ns = {
+      idFromName: (n: string) => n,
+      get: () => ({
+        async fetch() {
+          calls += 1;
+          return new Response("{}", { status: 503 });
+        },
+      }),
+    };
+    await assert.rejects(
+      () =>
+        createBufferedPgSql(ns, "neurons").unsafe("INSERT INTO t VALUES (1)"),
+      /refused the statement \(503\)/,
+    );
+    assert.equal(calls, 1, "exactly one attempt");
+  });
+
+  test("a non-transient error is not retried either", async () => {
+    const n = flakyNamespace(99, "TypeError: something is genuinely broken");
+    await assert.rejects(() =>
+      createBufferedPgSql(n.ns, "neurons").unsafe("INSERT INTO t VALUES (1)"),
+    );
+    assert.equal(n.calls, 1);
   });
 });

--- a/tests/neon-write-buffer.test.ts
+++ b/tests/neon-write-buffer.test.ts
@@ -537,3 +537,36 @@ describe("the enqueue retries a transient stub failure (#10729)", () => {
     assert.equal(n.calls, 1);
   });
 });
+
+describe("a non-Error throw from the stub", () => {
+  test("is still classified, retried, and surfaced as an Error", async () => {
+    // Workers RPC can reject with a bare string. Reading `.message` off that
+    // yields undefined, so the classifier would see "undefined", treat a
+    // genuine transient as fatal, and lose the row -- and the final throw
+    // would hand the caller a non-Error nothing up the stack expects.
+    let calls = 0;
+    const ns = {
+      idFromName: (n: string) => n,
+      get: () => ({
+        async fetch() {
+          calls += 1;
+          throw "Durable Object reset because its code was updated";
+        },
+      }),
+    };
+    await assert.rejects(
+      () =>
+        createBufferedPgSql(ns, "neurons").unsafe("INSERT INTO t VALUES (1)"),
+      (error: unknown) => {
+        assert.ok(error instanceof Error, "must surface as an Error");
+        assert.match(String((error as Error).message), /Durable Object reset/);
+        return true;
+      },
+    );
+    assert.equal(
+      calls,
+      ENQUEUE_ATTEMPTS,
+      "classified as transient, so retried",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`createBufferedPgSql` issued **one** `stub.fetch()` and threw on any failure. A deploy resets the
Durable Object, and an enqueue in flight throws `Durable Object reset because its code was updated`.

That is not a failure of the write — the object returns immediately on the new code — but with no
retry it costs the row, and worse: **a failed enqueue stores nothing, so it also arms no alarm.**

Measured 2026-08-11:

```
deploys        09:50   10:03   10:05   10:15:39
failure        neon:validator-nominator-counts @ 10:15:44   (5s after a deploy)
```

Across that churn the buffer never drained — the one path that could re-arm its alarm (a successful
enqueue) was the path that kept failing.

## This is the second half of #10722

#10722 fixed a drain that left work behind without re-arming. This is why nothing re-armed it from the
**enqueue** side either. **Neither alone was enough**, which is exactly why the buffer stayed stalled
after that first fix deployed — I watched it not recover and came back for the other half.

## Fix

Retry a transient stub failure up to `ENQUEUE_ATTEMPTS`, with a **fresh stub each attempt** — reusing
one that just threw retries the broken connection rather than the operation.

| Condition | Behaviour |
|---|---|
| `Durable Object reset` / `Network connection lost` / `internal error` | Retried |
| **503 (buffer full)** | **Not retried** — backpressure; retrying makes it fuller |
| Any other error | Not retried, propagates unchanged |
| Budget exhausted | Fails the write, lane records `stale`, producer retries next tick |

## Validation

```
npx tsc --noEmit · lint · format:check   # clean
npm run validate                         # exit 0
npx vitest run <4 suites>                # 140 passed
```

Four new tests: reset-is-retried-and-lands, budget-is-finite, 503-takes-exactly-one-attempt,
non-transient-takes-exactly-one-attempt.

Closes #10729
