### PR TITLE
refactor(tiers): delete the blocks family's dead tier reads, and repoint what they hid

### DIFF
--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -15,7 +15,6 @@ import {
   readJson,
   repoRoot,
 } from "./lib.ts";
-import { buildBlockFeed } from "../src/blocks.ts";
 import { buildExtrinsicFeed } from "../src/extrinsics.ts";
 import { buildAccountEvents } from "../src/account-events.ts";
 import { buildSubnetMetagraph } from "../src/metagraph-neurons.ts";
@@ -2879,16 +2878,8 @@ for (const [route, assertion, options = {}] of checks) {
   const BLOCK_NUM = 1_000_000;
   const HASH = `0x${"a".repeat(64)}`;
 
-  const blockRow = {
-    block_number: BLOCK_NUM,
-    block_hash: HASH,
-    parent_hash: `0x${"b".repeat(64)}`,
-    author: "5AuthorExample12345678901234567890123456789012",
-    extrinsic_count: 5,
-    event_count: 20,
-    spec_version: 201,
-    observed_at: OBSERVED_AT_MS,
-  };
+  // `blockRow` went with the METAGRAPH_BLOCKS_SOURCE case (#10190) -- it was
+  // the only fixture that used it.
   const extrinsicRow = {
     block_number: BLOCK_NUM,
     extrinsic_index: 2,
@@ -2974,18 +2965,13 @@ for (const [route, assertion, options = {}] of checks) {
   }
 
   const postgresTierChecks: PostgresTierCheck[] = [
-    {
-      flag: "METAGRAPH_BLOCKS_SOURCE",
-      route: "/api/v1/blocks",
-      upstreamPath: "/api/v1/blocks",
-      data: buildBlockFeed([blockRow], {
-        limit: BLOCK_PAGINATION.defaultLimit,
-        offset: 0,
-        nextCursor: null,
-      }),
-      assertion: (body) =>
-        assert.equal(body.data.blocks[0].block_number, BLOCK_NUM),
-    },
+    // METAGRAPH_BLOCKS_SOURCE's case was REMOVED (#10190): every tryPostgresTier
+    // call under that flag is gone across REST, GraphQL and MCP, so there is no
+    // forward left to prove. The blocks family's real legs are the lakehouse
+    // cold tier (list/detail/runtime) and the archived blocks-summary
+    // projection -- covered by tests/blocks-cold-tier.test.ts,
+    // tests/runtime-versions-cold-tier.test.ts and
+    // tests/blocks-summary-artifact.test.ts.
     {
       flag: "METAGRAPH_EXTRINSICS_SOURCE",
       route: "/api/v1/extrinsics",
@@ -3041,8 +3027,8 @@ for (const [route, assertion, options = {}] of checks) {
 
   assert.equal(
     postgresTierChecks.length,
-    6,
-    "postgres-tier AJV coverage must include all 6 flags that gate a DATA_API leg",
+    5,
+    "postgres-tier AJV coverage must include all 5 flags that gate a DATA_API leg",
   );
 
   for (const {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -5958,16 +5958,9 @@ const rootValue = {
     // production, so the Postgres tier being cold is the expected steady state —
     // fall back to the same pure builder REST uses, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/blocks",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+      // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+      // on every request.
       // The blocks cold tier REST and MCP both read (#9540). Every filter is
       // forwarded, so the tier does the filtering -- the empty builder below
       // ignores them, which is why reaching it silently dropped a filtered
@@ -6005,30 +5998,22 @@ const rootValue = {
     { network }: QueryBlocks_SummaryArgs,
     context: GqlContext,
   ) {
-    // #5664: same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildBlocksSummary([])
-    // fallback contract handleBlocksSummary uses. blocks' D1 write path is retired
-    // (#4909) so a cold Postgres tier is the steady state -- the empty builder
-    // shape (block_count 0, every aggregate null) satisfies the non-null
-    // BlocksSummary! contract, never a GraphQL error.
+    // #5664: same projection -> buildBlocksSummary([]) fallback contract
+    // handleBlocksSummary uses. blocks' D1 write path is retired (#4909) and the
+    // Postgres tier that briefly replaced it is retired too (#10190), so the
+    // empty builder shape (block_count 0, every aggregate null) satisfies the
+    // non-null BlocksSummary! contract, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/blocks/summary",
-          undefined,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+      // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+      // on every request.
       // #9146: same blocks-summary projection REST and MCP read -- on the SAME
       // chain as the tier above, because a fallback that changed network would
       // answer mainnet under a testnet label (#10394).
       ((await loadBlocksSummaryFromArtifact(
         context.env,
         chainNetworkFromChainName(network),
-      )) as Row | null) ??
-      buildBlocksSummary([]);
+      )) as Row | null) ?? buildBlocksSummary([]);
     return {
       schema_version: data.schema_version ?? 1,
       block_count: data.block_count ?? 0,
@@ -6046,17 +6031,16 @@ const rootValue = {
   },
 
   async runtime(_args: unknown, context: GqlContext) {
-    // Same tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) -> buildRuntimeVersionHistory([])
-    // fallback contract GET /api/v1/runtime and the get_runtime MCP tool use; blocks'
-    // D1 write path is retired (#4909) so a cold Postgres tier is the steady state --
-    // the empty builder shape (transition_count 0, current_spec_version null) satisfies
-    // the non-null RuntimeVersionHistory! contract, never a GraphQL error.
+    // Same cold-tier -> buildRuntimeVersionHistory([]) fallback contract
+    // GET /api/v1/runtime and the get_runtime MCP tool use; blocks' D1 write
+    // path is retired (#4909) and the Postgres tier that replaced it is retired
+    // too (#10190) -- the empty builder shape (transition_count 0,
+    // current_spec_version null) satisfies the non-null RuntimeVersionHistory!
+    // contract, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/runtime"),
-        "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+      // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+      // on every request.
       // #9265: `chain.blocks` carries the same spec_version column, so the
       // non-null contract below is now satisfied with the real timeline
       // rather than only with the empty shape.
@@ -6064,8 +6048,7 @@ const rootValue = {
         context.env as unknown as Parameters<
           typeof loadRuntimeVersionHistoryColdTier
         >[0],
-      )) as Row | null) ??
-      buildRuntimeVersionHistory([]);
+      )) as Row | null) ?? buildRuntimeVersionHistory([]);
     return {
       coverage_complete: data.coverage_complete ?? null,
       coverage_gaps: data.coverage_gaps ?? null,
@@ -6081,16 +6064,9 @@ const rootValue = {
   async block({ ref, network }: QueryBlockArgs, context: GqlContext) {
     const chain = chainNetworkFromChainName(network);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/blocks/${encodeURIComponent(ref)}`,
-          undefined,
-          chain,
-        ),
-        "METAGRAPH_BLOCKS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+      // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+      // on every request.
       // The block cold tier REST and MCP both read (#9540), on the SAME chain
       // as the tier above (#10394).
       ((await loadBlockColdTier(context.env, ref, chain)) as Row | null) ??

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -6968,15 +6968,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // the schema-stable zeroed card now that blocks' D1 write path is
       // retired (#4772) and the table is dropped in production.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/blocks/summary"),
-          "METAGRAPH_BLOCKS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+        // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+        // on every request.
         // #9146: same blocks-summary projection REST reads, so the tool and
         // the route cannot report different block-production numbers.
-        (await loadBlocksSummaryFromArtifact(ctx.env)) ??
-        buildBlocksSummary([])
+        (await loadBlocksSummaryFromArtifact(ctx.env)) ?? buildBlocksSummary([])
       );
     },
   },
@@ -11111,23 +11108,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // schema-stable empty feed now that blocks' D1 write path is retired
       // (#4772) and the table is dropped in production.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/blocks", {
-            author,
-            spec_version: specVersion,
-            block_start: blockStart,
-            block_end: blockEnd,
-            from,
-            to,
-            min_extrinsics: minExtrinsics,
-            min_events: minEvents,
-            limit,
-            offset,
-            cursor,
-          }),
-          "METAGRAPH_BLOCKS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+        // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+        // on every request.
         (await loadBlockFeedColdTier(ctx.env, {
           limit,
           offset,
@@ -11164,13 +11147,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // schema-stable block:null shape now that blocks' D1 write path is
       // retired (#4772) and the table is dropped in production.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/blocks/${encodeURIComponent(ref)}`),
-          "METAGRAPH_BLOCKS_SOURCE",
-        )) ??
-        (await loadBlockColdTier(ctx.env, ref)) ??
-        buildBlock(undefined, ref)
+        // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+        // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+        // on every request.
+        (await loadBlockColdTier(ctx.env, ref)) ?? buildBlock(undefined, ref)
       );
     },
   },
@@ -11622,23 +11602,20 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     async handler(_args: unknown, ctx: McpCtx) {
       // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
       // table is dropped in production, so a D1 query here would always miss.
-      const [history, current] = await Promise.all([
-        tryPostgresTier(
-          ctx.env,
-          new Request("https://d/api/v1/runtime"),
-          "METAGRAPH_BLOCKS_SOURCE",
-        ),
-        // #8702 parity: the same `current` block the REST route serves, from
-        // the same loader, so an agent asking "is an upgrade pending" gets the
-        // answer instead of only the historical timeline.
-        loadUpgradeRadar(ctx.env),
-      ]);
+      // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every
+      // deployed config and absent from DATA_API_FORWARD_FLAGS, so the history
+      // leg of this Promise.all resolved to null on every call. The lakehouse is
+      // what has been answering.
+      //
+      // #8702 parity: the same `current` block the REST route serves, from the
+      // same loader, so an agent asking "is an upgrade pending" gets the answer
+      // instead of only the historical timeline.
+      const current = await loadUpgradeRadar(ctx.env);
       return {
-        ...((history as Record<string, unknown> | null) ??
-          // #9265: the lakehouse carries the same spec_version column, so an
-          // agent gets the real timeline instead of an empty one beside a
-          // `current` that reports a live spec version.
-          (await loadRuntimeVersionHistoryColdTier(ctx.env)) ??
+        // #9265: the lakehouse carries the same spec_version column, so an agent
+        // gets the real timeline instead of an empty one beside a `current` that
+        // reports a live spec version.
+        ...((await loadRuntimeVersionHistoryColdTier(ctx.env)) ??
           buildRuntimeVersionHistory([])),
         current,
       };

--- a/src/subnet-identity-history.ts
+++ b/src/subnet-identity-history.ts
@@ -17,8 +17,13 @@ import {
   clampOffset,
   FEED_PAGINATION,
 } from "../workers/request-params.ts";
-import { tryPostgresTier } from "../workers/postgres-tier.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
+import { d1All } from "./analytics-live.ts";
+import { readStore } from "./read-store.ts";
+
+/** The one table latestBlockNumber reads. Declared so readStore can refuse when
+ * Neon does not own it, rather than reading a store that has no such table. */
+const BLOCKS_HEAD_TABLES = ["blocks_head"] as const;
 
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -206,29 +211,37 @@ async function latestIdentityHashes(): Promise<Map<number, unknown>> {
   return new Map<number, unknown>();
 }
 
-// D1 retirement (2026-07-16, item 10 of the D1->Postgres cleanup): D1's own
-// `blocks` table was fully dropped in an earlier migration (#4772), so a
-// `SELECT MAX(block_number) FROM blocks` against D1 always threw and this
-// function always returned null -- silently, forever, not intermittently.
-// Postgres's own `blocks` table is the live source now (already the
-// flipped/current tier for the public /api/v1/blocks route via
-// METAGRAPH_BLOCKS_SOURCE); this synthesizes an internal request the same
-// "no client request to forward" way /api/v1/internal/compare-health does,
-// since this call site is a cron-triggered internal helper, not a route.
-// There is no D1 fallback left to attempt for this specific query -- the
-// table it would have queried no longer exists in D1 at all -- so this
-// simply returns null when Postgres is unavailable or the flag is off,
-// same degrade as before, but now for a real reason instead of a guaranteed
-// D1 miss.
+/**
+ * The newest captured block, read from `blocks_head` (#10190).
+ *
+ * WAS A DEAD TIER READ. This forwarded an internal
+ * /api/v1/internal/latest-block-number request under METAGRAPH_BLOCKS_SOURCE --
+ * a flag that reads "retired" in every deployed config and is absent from
+ * DATA_API_FORWARD_FLAGS -- so it resolved to null on every call, and every
+ * identity-change record has carried `block_number: null` since the flag was
+ * retired. The tests said so out loud ("no METAGRAPH_BLOCKS_SOURCE tier
+ * configured on this env, so block_number degrades to null") without anyone
+ * noticing that production has no such tier either.
+ *
+ * `blocks_head` is the right source and needed no new plumbing: it is in
+ * NEON_SOLE_STORE_TABLES, carries one row per block with the firehose filling it
+ * (`neon:blocks-head` writes every ~30s), and is already watched by
+ * TABLE_FRESHNESS. It was WRITE-ONLY until now -- src/capture-state-neon-write.ts
+ * inserts it and nothing in src/ or workers/ read it.
+ *
+ * Still degrades to null rather than throwing: no Hyperdrive binding, an
+ * undeclared table or an unreadable query all mean "no block number to stamp",
+ * which is the state that existed before.
+ */
 async function latestBlockNumber(env: Env): Promise<number | null> {
-  const pg = await tryPostgresTier(
-    env,
-    new Request("https://api.metagraph.sh/api/v1/internal/latest-block-number"),
-    "METAGRAPH_BLOCKS_SOURCE",
+  const rows = await d1All(
+    readStore(env, BLOCKS_HEAD_TABLES) as never,
+    "SELECT MAX(block_number) AS block_number FROM blocks_head",
+    [],
   );
-  const blockNumber = pg?.block_number as number | undefined;
-  return Number.isSafeInteger(blockNumber) && (blockNumber as number) > 0
-    ? (blockNumber as number)
+  const blockNumber = Number(rows[0]?.block_number);
+  return Number.isSafeInteger(blockNumber) && blockNumber > 0
+    ? blockNumber
     : null;
 }
 

--- a/tests/graphql-network-scoping.test.ts
+++ b/tests/graphql-network-scoping.test.ts
@@ -15,7 +15,48 @@ import {
   DEFAULT_CHAIN_NETWORK,
   networkScopedRoute,
 } from "../src/chain-network.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { chainTable } from "../src/chain-network.ts";
 import type { Row } from "./row-type.ts";
+
+/**
+ * A lakehouse transport double that records the SQL each leg issued.
+ *
+ * The blocks fields no longer read the Postgres tier at all (#10190 -- the flag
+ * is retired in every deployed config), so the cold tier IS the read, and the
+ * network reaches it through the TABLE NAME `chainTable` resolves rather than
+ * through a request path. Asserting the path a dead tier is asked for would pass
+ * on a resolver that dropped the argument from the leg that actually answers.
+ */
+function recordingLakehouse(rows: unknown[] = []) {
+  const queries: string[] = [];
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    queries.push(JSON.parse(String(init.body)).query as string);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return queries;
+}
+
+/** An archive double that records the projection keys it is asked for. */
+function recordingArchive(body: unknown) {
+  const keys: string[] = [];
+  return {
+    keys,
+    binding: {
+      get: async (key: string) => {
+        keys.push(key);
+        return body === undefined ? null : { json: async () => body };
+      },
+    },
+  };
+}
+
+/** Enough env for the lakehouse leg to be attempted at all. */
+const LAKEHOUSE_ENV = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 
 /** A DATA_API double that records every path it is asked for. */
 function recordingDataApi(payload: Row) {
@@ -77,23 +118,25 @@ describe("networkScopedRoute", () => {
 });
 
 describe("the resolvers ask the twin path", () => {
-  test("blocks(network: test) reads /api/v1/test/blocks", async () => {
-    const api = recordingDataApi({ blocks: [], block_count: 0 });
+  test("blocks(network: test) reads the testnet lakehouse table", async () => {
+    const queries = recordingLakehouse();
     const { status } = await query(
       "{ blocks(limit: 1, network: test) { total } }",
-      { METAGRAPH_BLOCKS_SOURCE: "postgres", DATA_API: api.binding },
+      LAKEHOUSE_ENV,
     );
     assert.equal(status, 200);
-    assert.deepEqual(api.paths, ["/api/v1/test/blocks"]);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0], new RegExp(chainTable("blocks", "testnet")));
   });
 
-  test("blocks() with no network still reads the base path", async () => {
-    const api = recordingDataApi({ blocks: [], block_count: 0 });
-    await query("{ blocks(limit: 1) { total } }", {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: api.binding,
-    });
-    assert.deepEqual(api.paths, ["/api/v1/blocks"]);
+  test("blocks() with no network still reads the mainnet table", async () => {
+    const queries = recordingLakehouse();
+    await query("{ blocks(limit: 1) { total } }", LAKEHOUSE_ENV);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0], new RegExp(chainTable("blocks")));
+    // Same read, different chain -- the two tables must not be the same string,
+    // or the assertion above would hold for a resolver that ignored `network`.
+    assert.notEqual(chainTable("blocks"), chainTable("blocks", "testnet"));
   });
 
   test("a chain rollup forwards it too", async () => {
@@ -106,12 +149,10 @@ describe("the resolvers ask the twin path", () => {
   });
 
   test("a per-block read forwards it", async () => {
-    const api = recordingDataApi({ schema_version: 1, ref: "9", block: null });
-    await query('{ block(ref: "9", network: test) { ref } }', {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: api.binding,
-    });
-    assert.deepEqual(api.paths, ["/api/v1/test/blocks/9"]);
+    const queries = recordingLakehouse();
+    await query('{ block(ref: "9", network: test) { ref } }', LAKEHOUSE_ENV);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0], new RegExp(chainTable("blocks", "testnet")));
   });
 
   test("a block-detail cascade forwards it to the hot/cold decision", async () => {
@@ -191,12 +232,21 @@ describe("the resolvers ask the twin path", () => {
     assert.equal(events.status, 200);
   });
 
-  test("blocks_summary forwards it", async () => {
-    const api = recordingDataApi({ schema_version: 1, block_count: 0 });
+  test("blocks_summary forwards it to the projection key", async () => {
+    // This one's cold read is the archived projection, not the lakehouse, so
+    // the network arrives in the OBJECT KEY (#9412).
+    const archive = recordingArchive({ schema_version: 1, summary: {} });
     await query("{ blocks_summary(network: test) { block_count } }", {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: api.binding,
+      METAGRAPH_ARCHIVE: archive.binding,
     });
-    assert.deepEqual(api.paths, ["/api/v1/test/blocks/summary"]);
+    assert.equal(archive.keys.length, 1);
+    assert.match(archive.keys[0], /testnet/);
+
+    const mainnet = recordingArchive({ schema_version: 1, summary: {} });
+    await query("{ blocks_summary { block_count } }", {
+      METAGRAPH_ARCHIVE: mainnet.binding,
+    });
+    assert.equal(mainnet.keys.length, 1);
+    assert.doesNotMatch(mainnet.keys[0], /testnet/);
   });
 });

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -5564,9 +5564,45 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
   });
 });
 
-describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
+// #10190: METAGRAPH_BLOCKS_SOURCE is retired in every deployed config and absent
+// from DATA_API_FORWARD_FLAGS, so these fields never read the Postgres tier --
+// the lakehouse is what answers, and the filters that used to be asserted as
+// query params on the tier's URL are SQL predicates now.
+describe("graphql — blocks / block (#5575, lakehouse feed)", () => {
+  /** Stub the lakehouse transport; captures every SQL the cold tier issued. */
+  function lakehouse(rows: Row[] = []) {
+    const original = globalThis.fetch;
+    const queries: string[] = [];
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      queries.push(String(JSON.parse(String(init.body)).query));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { queries, restore: () => (globalThis.fetch = original) };
+  }
+
+  /** Enough env for the lakehouse leg to be attempted at all. */
+  const COLD = { R2_SQL_TOKEN: "cfut_test" } as unknown as Env;
+
+  // A real SS58: safeAuthorLiteral rejects anything else, and the cold tier
+  // declines the whole query rather than widening an unexpressible filter.
+  const AUTHOR = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+  function blockRow(overrides: Row = {}) {
+    return {
+      block_number: 123,
+      block_hash: `0x${"b".repeat(64)}`,
+      parent_hash: `0x${"a".repeat(64)}`,
+      author: "5Author",
+      extrinsic_count: 3,
+      event_count: 7,
+      spec_version: 200,
+      observed_at: 1_752_451_200_000,
+      ...overrides,
+    };
   }
 
   test("blocks: cold/no-tier store returns a schema-stable empty page (fallback builder, production steady state)", async () => {
@@ -5581,141 +5617,85 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     });
   });
 
-  test("blocks: resolves Postgres-tier rows into the block feed", async () => {
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          block_count: 1,
-          limit: 20,
-          offset: 0,
-          next_cursor: "cursor-1",
-          blocks: [
-            {
-              block_number: 123,
-              block_hash: `0x${"b".repeat(64)}`,
-              parent_hash: `0x${"a".repeat(64)}`,
-              author: "5Author",
-              extrinsic_count: 3,
-              event_count: 7,
-              spec_version: 200,
-              observed_at: "2026-07-14T00:00:00.000Z",
-            },
-          ],
-        }),
-      ),
-    };
-    const { status, body } = await gql(
-      "{ blocks { items { block_number block_hash extrinsic_count event_count } total next_cursor } }",
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    assert.equal(body.data.blocks.total, 1);
-    assert.equal(body.data.blocks.next_cursor, "cursor-1");
-    const item = body.data.blocks.items[0];
-    assert.equal(item.block_number, 123);
-    assert.equal(item.extrinsic_count, 3);
-    assert.equal(item.event_count, 7);
+  test("blocks: resolves lakehouse rows into the block feed", async () => {
+    const lake = lakehouse([blockRow()]);
+    try {
+      const { status, body } = await gql(
+        "{ blocks { items { block_number block_hash extrinsic_count event_count } total next_cursor } }",
+        COLD,
+      );
+      assert.equal(status, 200);
+      assert.equal(body.data.blocks.total, 1);
+      const item = body.data.blocks.items[0];
+      assert.equal(item.block_number, 123);
+      assert.equal(item.extrinsic_count, 3);
+      assert.equal(item.event_count, 7);
+    } finally {
+      lake.restore();
+    }
   });
 
-  test("blocks: limit/offset/cursor are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            block_count: 0,
-            limit: 5,
-            offset: 10,
-            next_cursor: null,
-            blocks: [],
-          });
-        },
-      },
-    };
-    await gql(
-      `{ blocks(limit: 5, offset: 10, cursor: "abc123") { total } }`,
-      env as unknown as Env,
-    );
-    assert.equal(capturedUrl!.pathname, "/api/v1/blocks");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
+  test("blocks: limit/offset reach the lakehouse query", async () => {
+    const lake = lakehouse();
+    try {
+      await gql(`{ blocks(limit: 5, offset: 10) { total } }`, COLD);
+      // OFFSET is emulated by over-fetching then slicing (see
+      // OFFSET_EMULATION_CAP), so limit+offset is the LIMIT that goes out.
+      assert.match(lake.queries[0], /LIMIT 15$/);
+      assert.match(lake.queries[0], /FROM chain\.blocks/);
+    } finally {
+      lake.restore();
+    }
   });
 
-  test("blocks: the REST-parity filters are all forwarded as query params to the Postgres tier (#7870)", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            block_count: 0,
-            limit: 50,
-            offset: 0,
-            next_cursor: null,
-            blocks: [],
-          });
-        },
-      },
-    };
-    await gql(
-      `{ blocks(
-          author: "5Author"
-          spec_version: 200
-          block_start: 100
-          block_end: 500
-          from: "1750000000000"
-          to: "1760000000000"
-          min_extrinsics: 2
-          min_events: 3
-        ) { total } }`,
-      env as unknown as Env,
-    );
-    assert.equal(capturedUrl!.pathname, "/api/v1/blocks");
-    assert.equal(capturedUrl!.searchParams.get("author"), "5Author");
-    assert.equal(capturedUrl!.searchParams.get("spec_version"), "200");
-    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
-    assert.equal(capturedUrl!.searchParams.get("block_end"), "500");
-    assert.equal(capturedUrl!.searchParams.get("from"), "1750000000000");
-    assert.equal(capturedUrl!.searchParams.get("to"), "1760000000000");
-    assert.equal(capturedUrl!.searchParams.get("min_extrinsics"), "2");
-    assert.equal(capturedUrl!.searchParams.get("min_events"), "3");
+  test("blocks: the REST-parity filters all become lakehouse predicates (#7870)", async () => {
+    const lake = lakehouse();
+    try {
+      await gql(
+        `{ blocks(
+            author: "${AUTHOR}"
+            spec_version: 200
+            block_start: 100
+            block_end: 500
+            from: "1750000000000"
+            to: "1760000000000"
+            min_extrinsics: 2
+            min_events: 3
+          ) { total } }`,
+        COLD,
+      );
+      const sql = lake.queries[0];
+      assert.match(sql, new RegExp(`author = '${AUTHOR}'`));
+      assert.match(sql, /spec_version = 200/);
+      assert.match(sql, /block_number >= 100/);
+      assert.match(sql, /block_number <= 500/);
+      assert.match(sql, /observed_at >= 1750000000000/);
+      assert.match(sql, /observed_at <= 1760000000000/);
+      assert.match(sql, /extrinsic_count >= 2/);
+      assert.match(sql, /event_count >= 3/);
+    } finally {
+      lake.restore();
+    }
   });
 
-  test("blocks: a single filter is forwarded and the unset filters are omitted (#7870)", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            block_count: 0,
-            limit: 50,
-            offset: 0,
-            next_cursor: null,
-            blocks: [],
-          });
-        },
-      },
-    };
-    await gql(`{ blocks(author: "5Solo") { total } }`, env as unknown as Env);
-    assert.equal(capturedUrl!.searchParams.get("author"), "5Solo");
-    assert.equal(capturedUrl!.searchParams.has("spec_version"), false);
-    assert.equal(capturedUrl!.searchParams.has("block_start"), false);
-    assert.equal(capturedUrl!.searchParams.has("block_end"), false);
-    assert.equal(capturedUrl!.searchParams.has("from"), false);
-    assert.equal(capturedUrl!.searchParams.has("to"), false);
-    assert.equal(capturedUrl!.searchParams.has("min_extrinsics"), false);
-    assert.equal(capturedUrl!.searchParams.has("min_events"), false);
+  test("blocks: a single filter is applied and the unset filters are omitted (#7870)", async () => {
+    const lake = lakehouse();
+    try {
+      await gql(`{ blocks(author: "${AUTHOR}") { total } }`, COLD);
+      // One predicate and nothing else between WHERE and ORDER BY: the unset
+      // filters are omitted rather than sent as a widening default.
+      const sql = lake.queries[0];
+      // The seam ceiling is always present -- it is what keeps this leg from
+      // reading a range the head leg owns. Nothing else is.
+      assert.match(
+        sql,
+        new RegExp(
+          `WHERE author = '${AUTHOR}' AND block_number < \\d+ ORDER BY`,
+        ),
+      );
+    } finally {
+      lake.restore();
+    }
   });
 
   test("introspection: blocks exposes the new REST-parity filter args with the right scalar types (#7870)", async () => {
@@ -5774,76 +5754,39 @@ describe("graphql — blocks / block (#5575, Postgres-tier feed)", () => {
     });
   });
 
-  test("block: resolves a Postgres-tier row by numeric height, with chain-walk nav", async () => {
-    const ref = "123";
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ref,
-          block: {
-            block_number: 123,
-            block_hash: `0x${"b".repeat(64)}`,
-            parent_hash: `0x${"a".repeat(64)}`,
-            author: "5Author",
-            extrinsic_count: 3,
-            event_count: 7,
-            spec_version: 200,
-            observed_at: "2026-07-14T00:00:00.000Z",
-          },
-          prev_block_number: 122,
-          next_block_number: 124,
-        }),
-      ),
-    };
-    const { status, body } = await gql(
-      `{ block(ref: "${ref}") { ref block { block_number spec_version } prev_block_number next_block_number } }`,
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    assert.equal(body.data.block.ref, ref);
-    assert.equal(body.data.block.block.block_number, 123);
-    assert.equal(body.data.block.block.spec_version, 200);
-    assert.equal(body.data.block.prev_block_number, 122);
-    assert.equal(body.data.block.next_block_number, 124);
+  test("block: resolves a lakehouse row by numeric height", async () => {
+    // Below the seam, so the lakehouse is the source (above it the head leg
+    // owns the height and the lakehouse is not consulted at all).
+    const lake = lakehouse([blockRow()]);
+    try {
+      const { status, body } = await gql(
+        `{ block(ref: "123") { ref block { block_number spec_version } } }`,
+        COLD,
+      );
+      assert.equal(status, 200);
+      assert.equal(body.data.block.ref, "123");
+      assert.equal(body.data.block.block.block_number, 123);
+      assert.equal(body.data.block.block.spec_version, 200);
+      assert.match(lake.queries[0], /block_number = 123/);
+    } finally {
+      lake.restore();
+    }
   });
 
-  test("block: resolves a Postgres-tier row by 0x block hash", async () => {
+  test("block: resolves a lakehouse row by 0x block hash", async () => {
     const ref = `0x${"b".repeat(64)}`;
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            ref,
-            block: {
-              block_number: 123,
-              block_hash: ref,
-              parent_hash: null,
-              author: null,
-              extrinsic_count: 0,
-              event_count: 0,
-              spec_version: 200,
-              observed_at: "2026-07-14T00:00:00.000Z",
-            },
-            prev_block_number: null,
-            next_block_number: null,
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(
-      `{ block(ref: "${ref}") { ref block { block_number block_hash } } }`,
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, `/api/v1/blocks/${ref}`);
-    assert.equal(body.data.block.block.block_number, 123);
-    assert.equal(body.data.block.block.block_hash, ref);
+    const lake = lakehouse([blockRow({ block_hash: ref })]);
+    try {
+      const { status, body } = await gql(
+        `{ block(ref: "${ref}") { ref block { block_number block_hash } } }`,
+        COLD,
+      );
+      assert.equal(status, 200);
+      assert.equal(body.data.block.block.block_hash, ref);
+      assert.match(lake.queries[0], new RegExp(`block_hash = '${ref}'`));
+    } finally {
+      lake.restore();
+    }
   });
 
   test("block: unresolved ref returns block:null, never a GraphQL error", async () => {
@@ -9059,9 +9002,15 @@ function asPlainJson(value: unknown) {
   return JSON.parse(JSON.stringify(value));
 }
 
-describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
+describe("graphql — blocks_summary (#5664, archived projection)", () => {
+  /** The artifact envelope the blocks-summary lane writes. */
+  function summaryProjection(summary: Row) {
+    return { schema_version: 1, summary };
+  }
+
+  /** An archive binding that answers every key with the same body. */
+  function archive(body: unknown) {
+    return { get: async () => ({ json: async () => body }) };
   }
 
   test("cold store: no Postgres flag returns a schema-stable empty summary, never null", async () => {
@@ -9091,12 +9040,12 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
     });
   });
 
-  test("resolves the Postgres-tier summary, including nested time/throughput/concentration", async () => {
+  test("resolves the projected summary, including nested time/throughput/concentration", async () => {
     const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
+      // #10190: the retired tier is gone; #9146's blocks-summary projection is
+      // what serves this card, read from the archive by network-scoped key.
+      METAGRAPH_ARCHIVE: archive(
+        summaryProjection({
           block_count: 3,
           first_block: 100,
           last_block: 102,
@@ -9163,27 +9112,25 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
     assert.equal(s.author_concentration.top_1pct_share, 0.67);
   });
 
-  test("forwards to /api/v1/blocks/summary with no query params", async () => {
-    let capturedUrl: URL | undefined;
+  test("reads the mainnet projection key, and asks for nothing else", async () => {
+    const keys: string[] = [];
     const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({ schema_version: 1, block_count: 0 });
+      METAGRAPH_ARCHIVE: {
+        get: async (key: string) => {
+          keys.push(key);
+          return { json: async () => summaryProjection({ block_count: 0 }) };
         },
       },
     };
     await gql("{ blocks_summary { block_count } }", env);
-    assert.equal(capturedUrl!.pathname, "/api/v1/blocks/summary");
-    assert.equal(capturedUrl!.search, "");
+    assert.equal(keys.length, 1);
+    assert.doesNotMatch(keys[0], /testnet/);
   });
 
-  test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
+  test("a partial projection body degrades to the schema-stable defaults, never null", async () => {
     const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
       // Every field absent -- the resolver's own ?? defaults must fill them in.
-      DATA_API: dataApi(Response.json({})),
+      METAGRAPH_ARCHIVE: archive(summaryProjection({})),
     };
     const { status, body } = await gql(
       `{ blocks_summary {
@@ -9209,10 +9156,36 @@ describe("graphql — blocks_summary (#5664, Postgres-tier + retired-D1 fallback
   });
 });
 
-describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + retired-D1 fallback)", () => {
+describe("graphql — runtime (#5898, lakehouse spec-version timeline)", () => {
   function dataApi(response: Row) {
     return { fetch: async () => response };
   }
+
+  /**
+   * Stub the lakehouse transport for the two queries the runtime cold tier
+   * issues: the GROUP BY timeline, and the separately-queried head block that
+   * current_spec_version has to come from (a rollback would make the last
+   * transition the wrong answer).
+   */
+  function lakehouse(transitions: Row[]) {
+    const original = globalThis.fetch;
+    const queries: string[] = [];
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init.body)).query);
+      queries.push(sql);
+      const rows = sql.includes("ORDER BY block_number DESC")
+        ? transitions.slice(-1)
+        : transitions;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { queries, restore: () => (globalThis.fetch = original) };
+  }
+
+  const COLD = { R2_SQL_TOKEN: "cfut_test" } as unknown as Env;
 
   test("cold store: no Postgres flag returns a schema-stable empty timeline, never null", async () => {
     const { status, body } = await gql(
@@ -9233,75 +9206,72 @@ describe("graphql — runtime (#5898, Postgres-tier spec-version timeline + reti
     });
   });
 
-  test("resolves the Postgres-tier spec-version transition timeline", async () => {
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          transitions: [
-            {
-              spec_version: 200,
-              block_number: 100,
-              observed_at: "2026-06-25T00:00:00.000Z",
-            },
-            {
-              spec_version: 201,
-              block_number: 500,
-              observed_at: "2026-07-01T00:00:00.000Z",
-            },
-          ],
-          transition_count: 2,
-          current_spec_version: 201,
-          coverage_from_block: 100,
-          coverage_from_at: "2026-06-25T00:00:00.000Z",
-        }),
-      ),
-    };
-    const { status, body } = await gql(
-      `{ runtime {
-          schema_version transition_count current_spec_version
-          coverage_from_block coverage_from_at
-          transitions { spec_version block_number observed_at }
-        } }`,
-      env as unknown as Env,
-    );
-    assert.equal(status, 200);
-    assert.deepEqual(body.data.runtime, {
-      schema_version: 1,
-      transition_count: 2,
-      current_spec_version: 201,
-      coverage_from_block: 100,
-      coverage_from_at: "2026-06-25T00:00:00.000Z",
-      transitions: [
-        {
-          spec_version: 200,
-          block_number: 100,
-          observed_at: "2026-06-25T00:00:00.000Z",
-        },
-        {
-          spec_version: 201,
-          block_number: 500,
-          observed_at: "2026-07-01T00:00:00.000Z",
-        },
-      ],
-    });
+  test("resolves the lakehouse spec-version transition timeline", async () => {
+    // observed_at is epoch ms because that is the lakehouse column's type; the
+    // ISO strings below are the builder's formatting.
+    const lake = lakehouse([
+      {
+        spec_version: 200,
+        block_number: 100,
+        observed_at: Date.parse("2026-06-25T00:00:00.000Z"),
+      },
+      {
+        spec_version: 201,
+        block_number: 500,
+        observed_at: Date.parse("2026-07-01T00:00:00.000Z"),
+      },
+    ]);
+    try {
+      const { status, body } = await gql(
+        `{ runtime {
+            schema_version transition_count current_spec_version
+            coverage_from_block coverage_from_at
+            transitions { spec_version block_number observed_at }
+          } }`,
+        COLD,
+      );
+      assert.equal(status, 200);
+      assert.deepEqual(body.data.runtime, {
+        schema_version: 1,
+        transition_count: 2,
+        current_spec_version: 201,
+        coverage_from_block: 100,
+        coverage_from_at: "2026-06-25T00:00:00.000Z",
+        transitions: [
+          {
+            spec_version: 200,
+            block_number: 100,
+            observed_at: "2026-06-25T00:00:00.000Z",
+          },
+          {
+            spec_version: 201,
+            block_number: 500,
+            observed_at: "2026-07-01T00:00:00.000Z",
+          },
+        ],
+      });
+    } finally {
+      lake.restore();
+    }
   });
 
-  test("forwards to /api/v1/runtime with no query params", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({ schema_version: 1, transition_count: 0 });
-        },
-      },
-    };
-    await gql("{ runtime { transition_count } }", env);
-    assert.equal(capturedUrl!.pathname, "/api/v1/runtime");
-    assert.equal(capturedUrl!.search, "");
+  test("asks the lakehouse for the timeline AND the head block, separately", async () => {
+    // Two queries, not one: current_spec_version must not be read off the last
+    // transition, because GROUP BY collapses each version to its EARLIEST
+    // block and a rollback would then report the superseded version.
+    const lake = lakehouse([
+      { spec_version: 200, block_number: 100, observed_at: 1 },
+    ]);
+    try {
+      await gql("{ runtime { transition_count } }", COLD);
+      assert.equal(lake.queries.length, 2);
+      assert.ok(lake.queries.some((q) => q.includes("GROUP BY spec_version")));
+      assert.ok(
+        lake.queries.some((q) => q.includes("ORDER BY block_number DESC")),
+      );
+    } finally {
+      lake.restore();
+    }
   });
 
   test("a partial Postgres-tier body degrades to the schema-stable defaults, never null", async () => {
@@ -25093,7 +25063,6 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
     }) as unknown as Env;
   const neurons = { METAGRAPH_NEURONS_SOURCE: "postgres" };
   const events = { METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres" };
-  const blocks = { METAGRAPH_BLOCKS_SOURCE: "postgres" };
   const health = { METAGRAPH_HEALTH_SOURCE: "postgres" };
   const SS58 = "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL";
 
@@ -25128,34 +25097,54 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
     ]);
   });
 
-  test("runtime forwards the coverage completeness marker and its gaps", async () => {
-    const { body } = await gql(
-      `{ runtime {
-          coverage_complete
-          coverage_gaps { after_spec_version before_spec_version after_block before_block block_span }
-        } }`,
-      api(
-        {
-          schema_version: 1,
-          transitions: [],
-          transition_count: 0,
-          coverage_complete: false,
-          coverage_gaps: [
-            {
-              after_spec_version: 200,
-              before_spec_version: 205,
-              after_block: 100,
-              before_block: 900,
-              block_span: 800,
-            },
-          ],
-        },
-        blocks,
-      ),
-    );
-    assert.equal(body.errors, undefined);
-    assert.equal(body.data.runtime.coverage_complete, false);
-    assert.equal(body.data.runtime.coverage_gaps[0].block_span, 800);
+  test("runtime publishes the coverage completeness marker and its gaps", async () => {
+    // #10190: the tier that used to hand these fields over pre-built is retired,
+    // so they are DERIVED from the lakehouse timeline now. Two transitions five
+    // spec versions apart is the gap -- feeding the gap in ready-made would no
+    // longer exercise anything the resolver does.
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init.body)).query);
+      // Non-consecutive versions AND a span over
+      // MAX_PLAUSIBLE_TRANSITION_BLOCK_SPAN: both are required, because a long
+      // quiet stretch under one runtime is a fact about the chain, not a hole.
+      const rows = [
+        { spec_version: 200, block_number: 100, observed_at: 1 },
+        { spec_version: 205, block_number: 1_000_100, observed_at: 2 },
+      ];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          result: {
+            rows: sql.includes("ORDER BY block_number DESC")
+              ? rows.slice(-1)
+              : rows,
+          },
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      const { body } = await gql(
+        `{ runtime {
+            coverage_complete
+            coverage_gaps { after_spec_version before_spec_version after_block before_block block_span }
+          } }`,
+        { R2_SQL_TOKEN: "cfut_test" } as unknown as Env,
+      );
+      assert.equal(body.errors, undefined);
+      assert.equal(body.data.runtime.coverage_complete, false);
+      assert.deepEqual(body.data.runtime.coverage_gaps[0], {
+        after_spec_version: 200,
+        before_spec_version: 205,
+        after_block: 100,
+        before_block: 1_000_100,
+        block_span: 1_000_000,
+      });
+    } finally {
+      globalThis.fetch = original;
+    }
   });
 
   test("subnet_weight_setters forwards tempo and the overdue counters", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -96,7 +96,6 @@ import {
   buildExtrinsicFeed,
   buildBlockExtrinsics,
 } from "../src/extrinsics.ts";
-import { buildBlock, buildBlockFeed } from "../src/blocks.ts";
 import { DOMAIN_TAGS } from "../src/domain-tags.ts";
 import { EVM_PRECOMPILE_BY_ADDRESS } from "../src/evm-precompiles.ts";
 import {
@@ -11881,17 +11880,21 @@ describe("MCP economics + metagraph data tools", () => {
   // the same bug one step later.
   describe("degraded-tier marker (#9120)", () => {
     // Tier flags on with no DATA_API bound: every tier read degrades.
+    //
+    // METAGRAPH_BLOCKS_SOURCE is deliberately NOT here: it is retired, so the
+    // blocks tools read no tier and have no tier miss to mark (#10190). Listing
+    // it would assert a marker on a read that cannot happen.
     const degradedEnv = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       METAGRAPH_NEURONS_SOURCE: "postgres",
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
     };
 
     test("a tier miss is marked, whichever tool it happened in", async () => {
       const unmarked: string[] = [];
       for (const [name, args] of [
         ["get_subnet_metagraph", { netuid: 7 }],
-        ["list_blocks", { limit: 1 }],
+        ["get_chain_transfers", { window: "7d" }],
         ["get_chain_calls", { window: "7d" }],
       ] as [string, Row][]) {
         const res = await callTool(name, args, { env: degradedEnv });
@@ -17770,40 +17773,14 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
     // builders directly, so the mocked response is byte-identical to what
     // production would actually serve -- mirrors chainTransfersPostgresEnv
     // above.
+    //
+    // list_blocks and get_block are the exception: their flag is retired
+    // (#10190) and no tier read remains, so they are validated against the
+    // cold-tier shape their own fallback builds. The point of the loop is the
+    // published SCHEMA, which holds either way.
     const cases = [
-      [
-        "list_blocks",
-        {
-          METAGRAPH_BLOCKS_SOURCE: "postgres",
-          DATA_API: {
-            fetch: async () =>
-              Response.json(
-                buildBlockFeed([BLOCK_ROW], {
-                  limit: 50,
-                  offset: 0,
-                  nextCursor: null,
-                }),
-              ),
-          },
-        },
-        {},
-      ],
-      [
-        "get_block",
-        {
-          METAGRAPH_BLOCKS_SOURCE: "postgres",
-          DATA_API: {
-            fetch: async () =>
-              Response.json(
-                buildBlock(BLOCK_ROW, "4200000", {
-                  prev: 4199999,
-                  next: 4200001,
-                }),
-              ),
-          },
-        },
-        { ref: "4200000" },
-      ],
+      ["list_blocks", {}, {}],
+      ["get_block", {}, { ref: "4200000" }],
       [
         "list_block_extrinsics",
         {
@@ -22616,27 +22593,41 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     assert.equal(out.coverage_from_block, null);
   });
 
-  test("get_runtime: flag=postgres uses Postgres data", async () => {
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          assert.equal(new URL(req.url).pathname, "/api/v1/runtime");
-          return Response.json({
-            schema_version: 1,
-            transition_count: 1,
-            current_spec_version: 300,
-            coverage_from_block: 100,
-            coverage_from_at: null,
-            transitions: [
-              { spec_version: 300, block_number: 100, observed_at: null },
-            ],
-          });
+  test("get_runtime resolves the lakehouse timeline, not the retired tier", async () => {
+    // #10190: METAGRAPH_BLOCKS_SOURCE is retired, so the tier leg of this tool
+    // was always null and `chain.blocks`'s spec_version column is the source.
+    const tierPaths: string[] = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      const rows = [{ spec_version: 300, block_number: 100, observed_at: 1 }];
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      const res = await callTool(
+        "get_runtime",
+        {},
+        {
+          env: {
+            R2_SQL_TOKEN: "cfut_test",
+            METAGRAPH_BLOCKS_SOURCE: "postgres",
+            DATA_API: {
+              fetch: async (req: Request) => {
+                tierPaths.push(new URL(req.url).pathname);
+                return Response.json({ schema_version: 1 });
+              },
+            },
+          },
         },
-      },
-    };
-    const res = await callTool("get_runtime", {}, { env });
-    assert.equal(res.body.result.structuredContent.current_spec_version, 300);
+      );
+      assert.deepEqual(tierPaths, []);
+      assert.equal(res.body.result.structuredContent.current_spec_version, 300);
+    } finally {
+      globalThis.fetch = original;
+    }
   });
 
   test("get_runtime carries the #8702 upgrade radar alongside the timeline", async () => {
@@ -23365,18 +23356,17 @@ describe("MCP extrinsics-tier chain analytics tools — Postgres tier wiring", (
   });
 });
 
-// list_blocks / get_blocks_summary / get_block are gated on
-// METAGRAPH_BLOCKS_SOURCE, not METAGRAPH_NEURONS_SOURCE or
-// METAGRAPH_EXTRINSICS_SOURCE, so they don't fit either shared CASES loop
-// above -- same two-test-per-tool contract, just with the correct flag name
-// and its own CASES array.
-describe("MCP blocks-tier chain-explorer tools — Postgres tier wiring", () => {
+// list_blocks / get_blocks_summary / get_block USED to be gated on
+// METAGRAPH_BLOCKS_SOURCE. That flag is retired in every deployed config and
+// absent from DATA_API_FORWARD_FLAGS, so the tier read resolved to null on every
+// call and the cold tier has been the answer all along (#10190).
+//
+// These pin the retirement rather than the wiring: flag set, DATA_API bound and
+// answering, and nothing asks it. That is what stops the dead read from being
+// reintroduced by a future edit that "restores parity" with the other families.
+describe("MCP blocks-tier chain-explorer tools — no tier read (#10190)", () => {
   const CASES = [
-    {
-      tool: "list_blocks",
-      args: {},
-      path: "/api/v1/blocks?limit=50&offset=0",
-    },
+    { tool: "list_blocks", args: {} },
     {
       tool: "list_blocks",
       args: {
@@ -23392,82 +23382,46 @@ describe("MCP blocks-tier chain-explorer tools — Postgres tier wiring", () => 
         offset: 5,
         cursor: "abc123",
       },
-      path:
-        "/api/v1/blocks?author=5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" +
-        "&spec_version=300&block_start=100&block_end=200&from=1000&to=2000" +
-        "&min_extrinsics=1&min_events=2&limit=10&offset=5&cursor=abc123",
+      label: "list_blocks (filtered)",
     },
-    {
-      tool: "get_blocks_summary",
-      args: {},
-      path: "/api/v1/blocks/summary",
-    },
-    {
-      tool: "get_block",
-      args: { ref: "4200000" },
-      path: "/api/v1/blocks/4200000",
-    },
+    { tool: "get_blocks_summary", args: {} },
+    { tool: "get_block", args: { ref: "4200000" } },
   ];
 
-  for (const { tool, args, path } of CASES) {
-    const label = path.includes("author=") ? `${tool} (filtered)` : tool;
-
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_BLOCKS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
+  /** A DATA_API that records every path it is asked for. */
+  function recordingDataApi() {
+    const paths: string[] = [];
+    return {
+      paths,
+      binding: {
+        fetch: async (req: Request) => {
+          paths.push(new URL(req.url).pathname);
+          return Response.json({ schema_version: 1, marker: "from-postgres" });
         },
-      };
-      const res = await callTool(tool, args, { env });
+      },
+    };
+  }
+
+  for (const { tool, args, label = tool } of CASES) {
+    test(`${label}: the retired flag is not consulted even when set`, async () => {
+      const tier = recordingDataApi();
+      const res = await callTool(tool, args, {
+        env: {
+          METAGRAPH_BLOCKS_SOURCE: "postgres",
+          DATA_API: tier.binding,
+        },
+      });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
+      assert.deepEqual(tier.paths, [], label);
+      assert.equal(res.body.result.structuredContent.marker, undefined, label);
     });
 
-    test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
-      const env = {
-        METAGRAPH_BLOCKS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async () => {
-            throw new Error("boom");
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: a cold store still yields the schema-stable empty shape`, async () => {
+      const res = await callTool(tool, args, { env: {} });
       assert.equal(res.body.result.isError, false, label);
       assert.equal(res.body.result.structuredContent.marker, undefined, label);
     });
   }
-
-  test("flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({ schema_version: 1, marker: "should-not-be-used" }),
-      },
-    };
-    for (const { tool, args } of CASES) {
-      const res = await callTool(tool, args, { env });
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        undefined,
-        `${tool} should not reach DATA_API without the flag`,
-      );
-    }
-  });
 });
 
 // get_subnet_hyperparams / get_subnet_hyperparams_history are gated on

--- a/tests/postgres-tier.test.ts
+++ b/tests/postgres-tier.test.ts
@@ -12,25 +12,31 @@ import {
 } from "../workers/postgres-tier.ts";
 import { mockEnv, type AnyFn } from "./row-type.ts";
 
+// The flag these branch tests pass is a stand-in -- only its membership in
+// DATA_API_FORWARD_FLAGS matters, not which family it names. METAGRAPH_HEALTH_SOURCE
+// is the durable choice: #10660 pins "HEALTH is never a forward flag" as a CI
+// invariant (src/health-status-live.ts documents why), so it cannot drift into the
+// set and silently invert the "returns null" branch below.
+
 function dataApi(handler: AnyFn) {
   return { fetch: handler };
 }
 
 function req() {
-  return new Request("https://api.metagraph.sh/api/v1/blocks");
+  return new Request("https://api.metagraph.sh/api/v1/health");
 }
 
 test("tryPostgresTier: flag not set to 'postgres' returns null without touching DATA_API or bumping the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   let called = false;
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "d1",
+    METAGRAPH_HEALTH_SOURCE: "d1",
     DATA_API: dataApi(async () => {
       called = true;
       return Response.json({});
     }),
   });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.equal(result, null);
   assert.equal(called, false);
   assert.equal(currentPostgresTierFallbackGeneration(), before);
@@ -133,8 +139,8 @@ test("tryPostgresTier: 'retired' on the neurons flag short-circuits too", async 
 
 test("tryPostgresTier: no DATA_API binding falls back and bumps the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
-  const env = mockEnv({ METAGRAPH_BLOCKS_SOURCE: "postgres" });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const env = mockEnv({ METAGRAPH_HEALTH_SOURCE: "postgres" });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.equal(result, null);
   assert.equal(currentPostgresTierFallbackGeneration(), before + 1);
 });
@@ -142,12 +148,12 @@ test("tryPostgresTier: no DATA_API binding falls back and bumps the fallback gen
 test("tryPostgresTier: DATA_API.fetch throwing falls back and bumps the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "postgres",
+    METAGRAPH_HEALTH_SOURCE: "postgres",
     DATA_API: dataApi(async () => {
       throw new Error("network down");
     }),
   });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.equal(result, null);
   assert.equal(currentPostgresTierFallbackGeneration(), before + 1);
 });
@@ -155,10 +161,10 @@ test("tryPostgresTier: DATA_API.fetch throwing falls back and bumps the fallback
 test("tryPostgresTier: a non-2xx DATA_API response falls back and bumps the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "postgres",
+    METAGRAPH_HEALTH_SOURCE: "postgres",
     DATA_API: dataApi(async () => new Response(null, { status: 502 })),
   });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.equal(result, null);
   assert.equal(currentPostgresTierFallbackGeneration(), before + 1);
 });
@@ -166,7 +172,7 @@ test("tryPostgresTier: a non-2xx DATA_API response falls back and bumps the fall
 test("tryPostgresTier: an unparseable response body falls back and bumps the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "postgres",
+    METAGRAPH_HEALTH_SOURCE: "postgres",
     DATA_API: dataApi(
       async () =>
         new Response("not json", {
@@ -175,7 +181,7 @@ test("tryPostgresTier: an unparseable response body falls back and bumps the fal
         }),
     ),
   });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.equal(result, null);
   assert.equal(currentPostgresTierFallbackGeneration(), before + 1);
 });
@@ -183,10 +189,10 @@ test("tryPostgresTier: an unparseable response body falls back and bumps the fal
 test("tryPostgresTier: a JSON body that isn't an object (a bare string) falls back and bumps the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "postgres",
+    METAGRAPH_HEALTH_SOURCE: "postgres",
     DATA_API: dataApi(async () => Response.json("unexpected")),
   });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.equal(result, null);
   assert.equal(currentPostgresTierFallbackGeneration(), before + 1);
 });
@@ -194,12 +200,12 @@ test("tryPostgresTier: a JSON body that isn't an object (a bare string) falls ba
 test("tryPostgresTier: a successful JSON object response is returned as-is without bumping the fallback generation", async () => {
   const before = currentPostgresTierFallbackGeneration();
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "postgres",
+    METAGRAPH_HEALTH_SOURCE: "postgres",
     DATA_API: dataApi(async () =>
       Response.json({ schema_version: 1, block_count: 5 }),
     ),
   });
-  const result = await tryPostgresTier(env, req(), "METAGRAPH_BLOCKS_SOURCE");
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
   assert.deepEqual(result, { schema_version: 1, block_count: 5 });
   assert.equal(currentPostgresTierFallbackGeneration(), before);
 });
@@ -207,7 +213,7 @@ test("tryPostgresTier: a successful JSON object response is returned as-is witho
 test("tryPostgresTier: rewrites a HEAD request to GET before forwarding to DATA_API", async () => {
   let receivedMethod: string | undefined;
   const env = mockEnv({
-    METAGRAPH_BLOCKS_SOURCE: "postgres",
+    METAGRAPH_HEALTH_SOURCE: "postgres",
     DATA_API: dataApi(async (request: Request) => {
       receivedMethod = request.method;
       return Response.json({ ok: true });
@@ -215,8 +221,8 @@ test("tryPostgresTier: rewrites a HEAD request to GET before forwarding to DATA_
   });
   await tryPostgresTier(
     env,
-    new Request("https://api.metagraph.sh/api/v1/blocks", { method: "HEAD" }),
-    "METAGRAPH_BLOCKS_SOURCE",
+    new Request("https://api.metagraph.sh/api/v1/health", { method: "HEAD" }),
+    "METAGRAPH_HEALTH_SOURCE",
   );
   assert.equal(receivedMethod, "GET");
 });

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -851,9 +851,9 @@ describe("withEdgeCache", () => {
       "blocks-summary",
       async () => {
         await tryPostgresTier(
-          { METAGRAPH_BLOCKS_SOURCE: "postgres" } as unknown as Env,
+          { METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres" } as unknown as Env,
           req("/api/v1/blocks/summary"),
-          "METAGRAPH_BLOCKS_SOURCE",
+          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
         );
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       },

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -4363,44 +4363,90 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     return { fetch: async () => response };
   }
 
-  test("flag=postgres + DATA_API succeeds: Postgres data wins, D1 never queried", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+  /**
+   * A DATA_API that fails the test if it is ever consulted.
+   *
+   * The blocks family's flag (METAGRAPH_BLOCKS_SOURCE) is retired in every
+   * deployed config and absent from DATA_API_FORWARD_FLAGS, so its handlers no
+   * longer read the tier at all (#10190). These use it as the ASSERTION: set the
+   * flag to "postgres", bind a DATA_API that would answer, and prove nothing
+   * asks it -- which is what stops a dead tier read from being reintroduced.
+   */
+  function forbiddenDataApi() {
+    const calls: string[] = [];
+    return {
+      calls,
+      binding: {
+        fetch: async (request: Request) => {
+          calls.push(new URL(request.url).pathname);
+          return Response.json({ schema_version: 1, marker: "tier" });
+        },
+      },
+    };
+  }
+
+  /** Stub the lakehouse transport; answers each cold-tier query by SQL prefix. */
+  function lakehouse(answer: (sql: string) => unknown[]) {
+    const original = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      const sql = String(JSON.parse(String(init.body)).query);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: answer(sql) } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return () => {
+      globalThis.fetch = original;
+    };
+  }
+
+  const LAKEHOUSE_TOKEN = { R2_SQL_TOKEN: "cfut_test" };
+
+  test("handleBlocks: the retired blocks flag is not consulted even when set", async () => {
+    // No head-leg fixture: the lakehouse is then the only leg that can answer,
+    // so the marker below identifies the source unambiguously.
+    const { env } = dbWith({});
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = dataApi(
-      Response.json({ schema_version: 1, block_count: 99, blocks: [] }),
-    );
-    const body = await json(
-      await handleBlocks(
-        req("/api/v1/blocks"),
-        env as unknown as Env,
-        url("/api/v1/blocks"),
-      ),
-    );
-    assert.equal(body.data.block_count, 99); // the Postgres fixture, not D1's
-    assert.deepEqual(captures.sql, []); // D1 was never touched
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.binding;
+    Object.assign(env, LAKEHOUSE_TOKEN);
+    const restore = lakehouse(() => [blockRow({ author: "cold-tier" })]);
+    try {
+      const body = await json(
+        await handleBlocks(
+          req("/api/v1/blocks"),
+          env as unknown as Env,
+          url("/api/v1/blocks"),
+        ),
+      );
+      assert.deepEqual(tier.calls, []); // the dead tier read is gone
+      assert.equal(body.data.blocks[0].author, "cold-tier"); // the lakehouse did
+    } finally {
+      restore();
+    }
   });
 
-  test("handleBlock: flag=postgres uses Postgres data over the D1 fixture", async () => {
-    const { env, captures } = dbWith({ blockDetail: blockRow() });
+  test("handleBlock: the retired blocks flag is not consulted even when set", async () => {
+    const { env } = dbWith({ blockDetail: blockRow() });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = dataApi(
-      Response.json({
-        schema_version: 1,
-        ref: String(BLOCK_NUM),
-        block: { ...blockRow(), author: "postgres-author" },
-        prev_block_number: null,
-        next_block_number: null,
-      }),
-    );
-    const body = await json(
-      await handleBlock(
-        req(`/api/v1/blocks/${BLOCK_NUM}`),
-        env as unknown as Env,
-        String(BLOCK_NUM),
-      ),
-    );
-    assert.equal(body.data.block.author, "postgres-author");
-    assert.deepEqual(captures.sql, []);
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.binding;
+    Object.assign(env, LAKEHOUSE_TOKEN);
+    const restore = lakehouse(() => [{ ...blockRow(), author: "lakehouse" }]);
+    try {
+      const body = await json(
+        await handleBlock(
+          req(`/api/v1/blocks/${BLOCK_NUM}`),
+          env as unknown as Env,
+          String(BLOCK_NUM),
+        ),
+      );
+      assert.deepEqual(tier.calls, []);
+      assert.equal(body.data.block.author, "lakehouse");
+    } finally {
+      restore();
+    }
   });
 
   test("handleExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -5365,12 +5411,19 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleBlocksSummary: flag=postgres uses Postgres data, D1 never queried", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+  test("handleBlocksSummary: the retired flag is not consulted; the projection answers", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", block_count: 0 }),
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.binding;
+    // #9146: the blocks-summary projection is what serves this card now.
+    env.METAGRAPH_ARCHIVE = {
+      get: async () => ({
+        json: async () => ({
+          schema_version: 1,
+          summary: { marker: "projection", block_count: 7 },
+        }),
+      }),
     };
     const body = await json(
       await handleBlocksSummary(
@@ -5379,8 +5432,8 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url("/api/v1/blocks/summary"),
       ),
     );
-    assert.equal(body.data.marker, "pg");
-    assert.deepEqual(captures.sql, []);
+    assert.deepEqual(tier.calls, []);
+    assert.equal(body.data.marker, "projection");
   });
 
   test("handleAccountExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -5442,62 +5495,77 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleRuntime: flag=postgres uses Postgres data, D1 never queried", async () => {
-    const { env, captures } = dbWith({ blocksFeed: [blockRow()] });
+  test("handleRuntime: the retired flag is not consulted; the lakehouse answers", async () => {
+    const { env } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", transitions: [] }),
-    };
-    const body = await json(
-      await handleRuntime(
-        req("/api/v1/runtime"),
-        env as unknown as Env,
-        url("/api/v1/runtime"),
-      ),
-    );
-    assert.equal(body.data.marker, "pg");
-    assert.deepEqual(captures.sql, []);
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.binding;
+    Object.assign(env, LAKEHOUSE_TOKEN);
+    // #9265: `chain.blocks` carries spec_version, so the timeline is real.
+    const restore = lakehouse(() => [
+      { spec_version: 423, block_number: 8_000_000, observed_at: 1 },
+    ]);
+    try {
+      const body = await json(
+        await handleRuntime(
+          req("/api/v1/runtime"),
+          env as unknown as Env,
+          url("/api/v1/runtime"),
+        ),
+      );
+      assert.deepEqual(tier.calls, []);
+      assert.equal(body.data.current_spec_version, 423);
+    } finally {
+      restore();
+    }
   });
 
   // #6392: /runtime was the one Explorer list page with no CSV export, because
   // the route rejected every query param -- ?format=csv 400'd before it could
   // reach the handler.
   describe("handleRuntime CSV export (#6392)", () => {
-    function pgEnv(transitions: Row[]) {
+    // The transitions arrive from the lakehouse now, not the retired tier
+    // (#10190), so the fixture is injected as ROWS and the builder derives the
+    // envelope -- which is closer to what the route actually does than handing
+    // it a pre-built envelope ever was.
+    function coldTierEnv(transitions: Row[]) {
       const { env } = dbWith({ blocksFeed: [blockRow()] });
-      env.METAGRAPH_BLOCKS_SOURCE = "postgres";
-      env.DATA_API = {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            transitions,
-            transition_count: transitions.length,
-            current_spec_version: transitions.at(-1)?.spec_version ?? null,
-            coverage_from_block: transitions[0]?.block_number ?? null,
-            coverage_from_at: transitions[0]?.observed_at ?? null,
-          }),
-      };
+      Object.assign(env, LAKEHOUSE_TOKEN);
+      restoreFetch = lakehouse((sql) =>
+        // LATEST_SQL asks for the head block; TRANSITIONS_SQL for the timeline.
+        sql.includes("ORDER BY block_number DESC")
+          ? transitions.slice(-1)
+          : transitions,
+      );
       return env;
     }
 
+    let restoreFetch: (() => void) | undefined;
+    afterEach(() => {
+      restoreFetch?.();
+      restoreFetch = undefined;
+    });
+
     const ROWS = [
+      // observed_at is epoch ms here because that is the lakehouse column's own
+      // type -- the ISO string in the CSV assertion below is the builder's
+      // formatting, which the pre-built tier envelope used to bypass.
       {
         spec_version: 423,
         block_number: 8000000,
-        observed_at: "2026-06-25T00:00:00.000Z",
+        observed_at: Date.parse("2026-06-25T00:00:00.000Z"),
       },
       {
         spec_version: 424,
         block_number: 8100000,
-        observed_at: "2026-07-01T00:00:00.000Z",
+        observed_at: Date.parse("2026-07-01T00:00:00.000Z"),
       },
     ];
 
     test("?format=csv exports the transition timeline with the on-screen columns", async () => {
       const res = await handleRuntime(
         req("/api/v1/runtime?format=csv"),
-        pgEnv(ROWS) as unknown as Env,
+        coldTierEnv(ROWS) as unknown as Env,
         url("/api/v1/runtime?format=csv"),
       );
       assert.equal(res.status, 200);
@@ -5516,7 +5584,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     test("the default response is still the JSON envelope", async () => {
       const res = await handleRuntime(
         req("/api/v1/runtime"),
-        pgEnv(ROWS) as unknown as Env,
+        coldTierEnv(ROWS) as unknown as Env,
         url("/api/v1/runtime"),
       );
       assert.match(res.headers.get("content-type") || "", /application\/json/);
@@ -5529,7 +5597,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     test("?format=json is accepted and keeps the envelope", async () => {
       const res = await handleRuntime(
         req("/api/v1/runtime?format=json"),
-        pgEnv(ROWS) as unknown as Env,
+        coldTierEnv(ROWS) as unknown as Env,
         url("/api/v1/runtime?format=json"),
       );
       assert.equal(res.status, 200);
@@ -5539,7 +5607,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     test("a cold store yields a header-only CSV, never an error", async () => {
       const res = await handleRuntime(
         req("/api/v1/runtime?format=csv"),
-        pgEnv([]) as unknown as Env,
+        coldTierEnv([]) as unknown as Env,
         url("/api/v1/runtime?format=csv"),
       );
       assert.equal(res.status, 200);
@@ -5552,7 +5620,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     test("an unsupported format is still rejected", async () => {
       const res = await handleRuntime(
         req("/api/v1/runtime?format=bogus"),
-        pgEnv(ROWS) as unknown as Env,
+        coldTierEnv(ROWS) as unknown as Env,
         url("/api/v1/runtime?format=bogus"),
       );
       assert.equal(res.status, 400);

--- a/tests/runtime-versions-cold-tier.test.ts
+++ b/tests/runtime-versions-cold-tier.test.ts
@@ -5,7 +5,8 @@
 // from a live chain read -- the same payload claiming, in one breath, that the
 // network runs runtime 440 and that it has never upgraded. All three surfaces
 // ran `tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) ?? buildRuntimeVersionHistory([])`
-// and the Postgres tier is gone.
+// and the Postgres tier is gone -- the dead call has since been removed
+// outright (#10190), leaving this reader as the only source.
 //
 // The trap this file pins: `coverage_complete` is computed as "no gaps found",
 // and an EMPTY timeline has no gaps in it. The dead route was therefore

--- a/tests/subnet-identity-history.test.ts
+++ b/tests/subnet-identity-history.test.ts
@@ -1,6 +1,15 @@
-import { describe, test } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
 import assert from "node:assert/strict";
 
+// latestBlockNumber reads `blocks_head` through src/read-store.ts, which
+// constructs its own `new Client(...)` -- there is no seam a caller can inject,
+// so the module is the mock. See tests/helpers/pg-mock.ts.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
 import {
   buildSubnetIdentityHistory,
   deriveNetuidGroupedAliases,
@@ -483,9 +492,8 @@ describe("recordSubnetIdentityChanges", () => {
     assert.equal(result.recorded, true);
     assert.equal(result.rows, 1);
     assert.equal(result.observed_at, 1_700_000_000_000);
-    // No METAGRAPH_BLOCKS_SOURCE tier configured on this env, so block_number
-    // degrades to null -- see the "latestBlockNumber via Postgres" tests
-    // below for the populated case.
+    // No store bound on this env, so block_number degrades to null -- see the
+    // "latestBlockNumber reads blocks_head" tests below for the populated case.
     assert.equal(result.block_number, null);
   });
 
@@ -606,68 +614,72 @@ describe("recordSubnetIdentityChanges", () => {
     assert.equal(result.rows, 1);
   });
 
-  // D1's own `blocks` table was fully dropped (#4772) -- latestBlockNumber
-  // (item 10 of the D1->Postgres cleanup) now queries Postgres via
-  // tryPostgresTier(METAGRAPH_BLOCKS_SOURCE) against a synthesized internal
-  // request, with no D1 fallback left to attempt (the table it would have
-  // queried doesn't exist in D1 at all). Exercised indirectly through
-  // recordSubnetIdentityChanges's own `block_number` field, same style the
-  // retired D1-based tests used.
-  describe("latestBlockNumber via Postgres (item 10)", () => {
+  // D1's own `blocks` table was fully dropped (#4772), and the tier that
+  // replaced it (METAGRAPH_BLOCKS_SOURCE) is retired in every deployed config
+  // and absent from DATA_API_FORWARD_FLAGS -- so it stamped null on every real
+  // call (#10190). The source is `blocks_head` now: one row per block, written
+  // by the firehose every ~30s and already watched by TABLE_FRESHNESS.
+  //
+  // Exercised indirectly through recordSubnetIdentityChanges's own
+  // `block_number` field, same style the retired tier tests used.
+  describe("latestBlockNumber reads blocks_head", () => {
     const profiles = [{ netuid: 7, native_identity: { subnet_name: "First" } }];
 
-    test("reports the Postgres-served block_number", async () => {
-      const env = {
-        DATA_API: {
-          fetch: async () =>
-            new Response(JSON.stringify({ block_number: 8_404_076 }), {
-              status: 200,
-            }),
-        },
-        METAGRAPH_BLOCKS_SOURCE: "postgres",
-      } as unknown as Env;
-      const result = await recordSubnetIdentityChanges(env, { profiles });
+    beforeEach(() => {
+      pg.control.queries.length = 0;
+      pg.control.answers = [];
+      pg.control.rows = null;
+      pg.control.failNext = null;
+    });
+
+    test("reports the head block from blocks_head", async () => {
+      pg.control.answers = [
+        { match: "FROM blocks_head", rows: [{ block_number: 8_404_076 }] },
+      ];
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles },
+      );
       assert.equal(result.block_number, 8_404_076);
+      assert.match(pg.control.queries[0].text, /MAX\(block_number\)/);
     });
 
-    test("degrades to null block_number when the flag is off", async () => {
-      const env = {
-        DATA_API: {
-          fetch: async () =>
-            new Response(JSON.stringify({ block_number: 8_404_076 }), {
-              status: 200,
-            }),
-        },
-        // METAGRAPH_BLOCKS_SOURCE not "postgres" -- tryPostgresTier no-ops.
-      } as unknown as Env;
+    test("degrades to null when the store is unbound", async () => {
+      // No HYPERDRIVE: readStore has nothing to open, so nothing is queried.
+      const result = await recordSubnetIdentityChanges({} as unknown as Env, {
+        profiles,
+      });
+      assert.equal(result.block_number, null);
+      assert.deepEqual(pg.control.queries, []);
+    });
+
+    test("degrades to null when blocks_head is not declared Neon's", async () => {
+      // readStore is all-or-nothing: an undeclared table means no store at all,
+      // not a store that answers the other tables.
+      const env = pgMockEnv(["subnets"]) as unknown as Env;
       const result = await recordSubnetIdentityChanges(env, { profiles });
+      assert.equal(result.block_number, null);
+      assert.deepEqual(pg.control.queries, []);
+    });
+
+    test("degrades to null when the query fails", async () => {
+      pg.control.failNext = new Error("connection reset");
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles },
+      );
       assert.equal(result.block_number, null);
     });
 
-    test("degrades to null block_number when the Postgres fetch fails", async () => {
-      const env = {
-        DATA_API: {
-          fetch: async () => {
-            throw new Error("network down");
-          },
-        },
-        METAGRAPH_BLOCKS_SOURCE: "postgres",
-      } as unknown as Env;
-      const result = await recordSubnetIdentityChanges(env, { profiles });
-      assert.equal(result.block_number, null);
-    });
-
-    test("degrades to null block_number on a non-positive/non-integer value", async () => {
-      const env = {
-        DATA_API: {
-          fetch: async () =>
-            new Response(JSON.stringify({ block_number: null }), {
-              status: 200,
-            }),
-        },
-        METAGRAPH_BLOCKS_SOURCE: "postgres",
-      } as unknown as Env;
-      const result = await recordSubnetIdentityChanges(env, { profiles });
+    test("degrades to null on a non-positive/non-integer value", async () => {
+      // MAX() over an empty table is NULL, which must not become 0.
+      pg.control.answers = [
+        { match: "FROM blocks_head", rows: [{ block_number: null }] },
+      ];
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles },
+      );
       assert.equal(result.block_number, null);
     });
   });

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -6331,11 +6331,9 @@ export async function handleBlocks(
   // one of them -- see src/blocks-cold-tier.ts. All tiers feed the SAME
   // buildBlockFeed formatter, so the payload is identical whichever answered.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_BLOCKS_SOURCE",
-    )) as ReturnType<typeof buildBlockFeed> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+    // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // on every request.
     (await loadBlockFeedColdTier(
       env,
       {
@@ -6364,8 +6362,7 @@ export async function handleBlocks(
         minEvents: routeInt(url, "min_events"),
       } as never,
       network,
-    )) ??
-    buildBlockFeed([], { limit, offset, nextCursor: null });
+    )) ?? buildBlockFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       data.blocks as unknown[],
@@ -6403,12 +6400,14 @@ export async function handleBlocksSummary(
   /** Which chain's projection to serve (#9412). */
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ) {
-  const pgData = await tryPostgresTier(env, request, "METAGRAPH_BLOCKS_SOURCE");
-  // #9146: on a tier miss, serve the precomputed card from the blocks-summary
-  // projection rather than a zeroed one. The reader declines (null) when it
-  // cannot answer faithfully, which keeps buildBlocksSummary([]) as the floor.
-  const projected =
-    pgData ?? (await loadBlocksSummaryFromArtifact(env, network));
+  // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+  // config and absent from DATA_API_FORWARD_FLAGS, so `pgData` was always null
+  // and the projection below always the answer.
+  //
+  // #9146: serve the precomputed card from the blocks-summary projection rather
+  // than a zeroed one. The reader declines (null) when it cannot answer
+  // faithfully, which keeps buildBlocksSummary([]) as the floor.
+  const projected = await loadBlocksSummaryFromArtifact(env, network);
   const data = projected ?? buildBlocksSummary([]);
   const response = await envelopeResponse(
     request,
@@ -6441,13 +6440,10 @@ export async function handleBlock(
   // #9115: same lakehouse fallback as the feed above; buildBlock is shared, so
   // a block served from R2 is byte-identical to one served from Postgres.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_BLOCKS_SOURCE",
-    )) as ReturnType<typeof buildBlock> | null) ??
-    (await loadBlockColdTier(env, ref, network)) ??
-    buildBlock(undefined, ref);
+    // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+    // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // on every request.
+    (await loadBlockColdTier(env, ref, network)) ?? buildBlock(undefined, ref);
   // Finalized block detail is immutable once resolved; a cold/unknown ref stays
   // on the short profile so clients re-check when the block lands.
   const cacheProfile = data.block ? "static" : "short";
@@ -6900,18 +6896,15 @@ export async function handleRuntime(request: Request, env: Env, url: URL) {
   // #4909 D1 retirement: blocks' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
   const history =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_BLOCKS_SOURCE",
-    )) as ReturnType<typeof buildRuntimeVersionHistory> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_BLOCKS_SOURCE is retired in every deployed
+    // config and absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // on every request.
     // The same spec_version column, from the tier that actually has it
     // (#9265). Through the shared reader so MCP and GraphQL get the timeline
     // too rather than being wired one surface at a time.
     (await loadRuntimeVersionHistoryColdTier(
       env as unknown as Parameters<typeof loadRuntimeVersionHistoryColdTier>[0],
-    )) ??
-    buildRuntimeVersionHistory([]);
+    )) ?? buildRuntimeVersionHistory([]);
   // #8702: the forward-looking half of the same question. `transitions` is
   // where the runtime has BEEN (first-party block observations); `current` is
   // where it IS and what is queued behind it (live chain reads + the captured


### PR DESCRIPTION
Closes #10737.

`METAGRAPH_BLOCKS_SOURCE` reads `"retired"` in `wrangler.jsonc` and is absent from
`DATA_API_FORWARD_FLAGS`, so `tryPostgresTier` returned null for it before
touching `DATA_API`. Twelve call sites were gated on it — four each in GraphQL,
MCP and REST — and every one was `tier ?? <the read that actually answers>`.
Deleted all twelve; the surviving arm is now the read.

## The site that was not merely dead

`latestBlockNumber` (`src/subnet-identity-history.ts`) had **no** fallback arm, so
every identity-change record written since the flag was retired carries
`block_number: null`. It reads `blocks_head` now — one row per block, written by
the firehose every ~30s, already in `NEON_SOLE_STORE_TABLES`, already watched by
`TABLE_FRESHNESS`, and read by nothing until this change. It still degrades to
null rather than throwing: no Hyperdrive, an undeclared table, or a failed query
all mean "no block number to stamp", which is the state that existed before.

## The tests are the larger half of the diff

A passing test asserting a dead read is what let the family sit dead — the old
`subnet-identity-history` test said so out loud (*"No METAGRAPH_BLOCKS_SOURCE
tier configured on this env, so block_number degrades to null"*). So they are
repointed at the leg that answers, not deleted:

| test | was | now |
| --- | --- | --- |
| `graphql-network-scoping` ×4 | the path a dead tier is asked for | the testnet table `chainTable` resolves, and the network-scoped projection key |
| `graphql` filters (#7870) | tier query params | lakehouse SQL predicates |
| `graphql` runtime | a pre-built envelope | rows, so `detectRuntimeCoverageGaps` derives the gap |
| `mcp-server` blocks tools ×8 | tier wiring | flag set, `DATA_API` bound and answering, nothing asks it |
| `request-handlers-entities` ×6 | tier fixture | cold-tier fixture, plus the same retirement pin |
| `subnet-identity-history` ×5 | a `DATA_API` double | the `pg` module double against `blocks_head` |
| `postgres-tier` ×16 | `METAGRAPH_BLOCKS_SOURCE` as the stand-in flag | `METAGRAPH_HEALTH_SOURCE`, the one flag #10660 guarantees can never enter `DATA_API_FORWARD_FLAGS` |

The four network-scoping tests were verified to **fail** when the resolver drops
`network` (mutation-tested locally on `loadBlockFeedColdTier`,
`loadBlockColdTier` and `projectionKey`) — the previous versions passed on a
resolver that ignored the argument entirely, which is what #10394 exists to
prevent.

`validate-api`'s postgres-tier coverage drops 6 → 5, with the reason recorded
beside the four earlier removals.

## Verification

- `tsc --noEmit` clean; `eslint` clean; `prettier --check` clean
- `npm run validate:api` — 5 tier routes at `postgres`, 3 forwarding + 2
  non-forwarding at `d1`, 210 routes validated
- 3,165 tests across the 11 affected suites pass
- dead-site count (compiler-attributed, narrowing `flagName` to a union) drops
  199 → 186 for this family

Remaining under #10190: `ACCOUNT_EVENTS`, `EXTRINSICS`, `HEALTH`.
