### PR TITLE
refactor(queues): write the queue semantics once, and run one heartbeat (#10735)

### DIFF
--- a/src/attribution-sweep.ts
+++ b/src/attribution-sweep.ts
@@ -18,6 +18,13 @@
 // own outage into a finding about somebody else — the same conflation
 // #10566 let stand for two months.
 import { isFinneySs58Address } from "./account-balance.ts";
+import {
+  consumeBatch,
+  enqueueAll,
+  type ConsumeResult,
+  type LaneMessage,
+  type LaneQueue,
+} from "./lane-queue.ts";
 // The ROW shapes come from the live schema (generated/db/types.ts), not from a
 // hand-written guess at them. That is where `swept_at: number | string` comes
 // from: node-postgres returns BIGINT as a string unless the value is exactly
@@ -334,120 +341,38 @@ export interface SweepMessage {
 
 export const ATTRIBUTION_SWEEP_QUEUE = "attribution-sweeps";
 
-/** The minimal producer surface, injected so the enqueue is testable without a
- * Cloudflare binding. */
-export interface SweepQueue {
-  sendBatch(messages: Array<{ body: SweepMessage }>): Promise<unknown>;
-}
-
-/** Cloudflare caps a sendBatch at 100 messages. 128 subnets is one over two
- * batches, which is exactly the kind of off-by-one that ships. */
-export const SWEEP_SEND_BATCH_MAX = 100;
-
-export interface EnqueueResult {
-  ok: boolean;
-  enqueued: number;
-  reason?: string;
-}
-
-/**
- * Enqueue every subnet due for a sweep.
- *
- * EVERY subnet, not a slice: the whole point of moving to a queue is that the
- * producer no longer has to ration work to fit one invocation.
- */
 export async function enqueueSweeps(
-  queue: SweepQueue | null | undefined,
+  queue: LaneQueue<SweepMessage> | null | undefined,
   netuids: number[],
-): Promise<EnqueueResult> {
-  if (!queue?.sendBatch) {
-    return { ok: false, enqueued: 0, reason: "no_queue_binding" };
-  }
-  if (netuids.length === 0) {
-    // Not a success. A producer reporting ok while enqueuing nothing is
-    // indistinguishable from one that enqueued and found nothing to do.
-    return { ok: false, enqueued: 0, reason: "no_subnets_to_sweep" };
-  }
-  let enqueued = 0;
-  try {
-    for (let i = 0; i < netuids.length; i += SWEEP_SEND_BATCH_MAX) {
-      const slice = netuids.slice(i, i + SWEEP_SEND_BATCH_MAX);
-      await queue.sendBatch(slice.map((netuid) => ({ body: { netuid } })));
-      enqueued += slice.length;
-    }
-  } catch (error) {
-    return {
-      ok: false,
-      enqueued,
-      reason: `send_failed: ${String((error as Error)?.message ?? error)}`,
-    };
-  }
-  return { ok: true, enqueued };
+) {
+  return enqueueAll(
+    queue,
+    netuids.map((netuid) => ({ netuid })),
+    "no_subnets_to_sweep",
+  );
 }
 
-/** One delivered message, as the consumer sees it. */
-export interface SweepBatchMessage {
-  body: unknown;
-  ack(): void;
-  retry(): void;
-}
-
-export interface SweepBatchResult {
-  swept: number;
-  /** Messages handed back for retry. A subnet that could not be swept is the
-   * queue's problem to re-deliver, not a finding to write. */
-  retried: number;
-  /** Messages acked without sweeping because the body was not a sweep message.
-   * Retrying those would loop them to the dead letter for no reason. */
-  malformed: number;
-}
-
-/**
- * Consume a batch: one subnet per message.
- *
- * ACK ON SUCCESS, RETRY ON FAILURE, ACK ON MALFORMED. The third is the one
- * worth stating: a message whose body is not a netuid will never become one, so
- * retrying it spends the whole retry budget to reach the dead letter with a
- * message nobody can act on. It is acked and counted instead.
- */
+/** Sweep one subnet, and report whether the result was durably WRITTEN: a sweep
+ * that happened but was not stored is a sweep that did not happen, as far as
+ * anything reading the store is concerned. */
 export async function handleSweepBatch(
-  messages: SweepBatchMessage[],
+  messages: LaneMessage[],
   db: SweepStoreDb | null | undefined,
   deps: SweepDeps & {
     /** The subnet's registry record, read at DELIVERY time so a queued message
      * cannot sweep a stale copy of its surfaces. */
     recordFor: (netuid: number) => Promise<Record<string, unknown> | null>;
   },
-): Promise<SweepBatchResult> {
-  let swept = 0;
-  let retried = 0;
-  let malformed = 0;
-  for (const message of messages) {
-    const body = message.body as SweepMessage | null;
-    const netuid = Number(body?.netuid);
-    if (!Number.isInteger(netuid) || netuid < 0) {
-      message.ack();
-      malformed += 1;
-      continue;
-    }
-    try {
+): Promise<ConsumeResult> {
+  return consumeBatch(messages, {
+    parse: (body) => {
+      const netuid = Number((body as SweepMessage | null)?.netuid);
+      return Number.isInteger(netuid) && netuid >= 0 ? netuid : null;
+    },
+    run: async (netuid) => {
       const record = await deps.recordFor(netuid);
       const result = await sweepSubnet(netuid, record, deps);
-      const written = await persistSweep(db, result);
-      if (!written.ok) {
-        // The sweep happened; the WRITE did not. Retrying re-sweeps, which is
-        // wasteful but correct -- an unwritten sweep is a sweep that did not
-        // happen as far as anything reading the store is concerned.
-        message.retry();
-        retried += 1;
-        continue;
-      }
-      message.ack();
-      swept += 1;
-    } catch {
-      message.retry();
-      retried += 1;
-    }
-  }
-  return { swept, retried, malformed };
+      return (await persistSweep(db, result)).ok;
+    },
+  });
 }

--- a/src/lane-queue.ts
+++ b/src/lane-queue.ts
@@ -1,0 +1,145 @@
+// The queue semantics, written once.
+//
+// Three lanes moved from crons to queues (#10715) and each arrived with its own
+// copy of the same two functions: a producer that checks the binding, refuses an
+// empty set, chunks at Cloudflare's send cap and reports partial sends; and a
+// consumer that acks on success, retries on failure, and acks a body it cannot
+// parse. Three copies of that is three places for the ack/retry decision to
+// drift -- and that decision is the one with consequences, because getting it
+// backwards either loses work silently or loops a message to the dead letter
+// forever.
+//
+// So it lives here once, and a lane supplies only what is actually different:
+// what to enqueue, how to read a body, and what to do with one subject.
+//
+// THE THREE OUTCOMES, and why each is what it is:
+//
+//   - ACK on success. The obvious one.
+//   - RETRY on failure. Including a failed WRITE after successful work: an
+//     unwritten result is one nothing can read, so the work did not happen as
+//     far as any reader is concerned.
+//   - ACK, not retry, on a body that cannot be parsed or a subject that no
+//     longer exists. Neither will change on redelivery, so retrying spends the
+//     whole budget to reach the dead letter with a message nobody can act on.
+//     That is the one people get wrong.
+
+/** Cloudflare's cap on a single sendBatch. */
+export const SEND_BATCH_MAX = 100;
+
+export interface LaneQueue<TBody> {
+  sendBatch(messages: Array<{ body: TBody }>): Promise<unknown>;
+}
+
+export interface EnqueueResult {
+  ok: boolean;
+  enqueued: number;
+  reason?: string;
+}
+
+/**
+ * Enqueue every body, in send-cap-sized chunks.
+ *
+ * AN EMPTY SET IS NOT A SUCCESS, and the caller names the reason. A producer
+ * reporting `ok` while enqueuing nothing is indistinguishable from one that
+ * enqueued and found nothing to do -- which is how the revenue lane sat dead for
+ * two months while every route it fed reported null (#10566).
+ *
+ * The BINDING is checked before the empty set, deliberately: a missing binding
+ * is a configuration error, and reporting "nothing to enqueue" would send
+ * somebody to the registry instead of to wrangler.jsonc.
+ */
+export async function enqueueAll<TBody>(
+  queue: LaneQueue<TBody> | null | undefined,
+  bodies: TBody[],
+  emptyReason: string,
+): Promise<EnqueueResult> {
+  if (!queue?.sendBatch) {
+    return { ok: false, enqueued: 0, reason: "no_queue_binding" };
+  }
+  if (bodies.length === 0) {
+    return { ok: false, enqueued: 0, reason: emptyReason };
+  }
+  let enqueued = 0;
+  try {
+    for (let i = 0; i < bodies.length; i += SEND_BATCH_MAX) {
+      const slice = bodies.slice(i, i + SEND_BATCH_MAX);
+      await queue.sendBatch(slice.map((body) => ({ body })));
+      enqueued += slice.length;
+    }
+  } catch (error) {
+    // Partial sends are reported as partial. A producer that swallowed the
+    // count would make "the queue rejected half of these" look like a clean
+    // pass over a smaller set.
+    return {
+      ok: false,
+      enqueued,
+      reason: `send_failed: ${String((error as Error)?.message ?? error)}`,
+    };
+  }
+  return { ok: true, enqueued };
+}
+
+/** One delivered message, as a consumer sees it. */
+export interface LaneMessage {
+  body: unknown;
+  ack(): void;
+  retry(): void;
+}
+
+export interface ConsumeResult {
+  /** Acked after the work succeeded. */
+  done: number;
+  /** Handed back for redelivery. */
+  retried: number;
+  /** Acked WITHOUT doing the work: unparseable, or a subject that is gone. */
+  dropped: number;
+}
+
+export interface ConsumeHandlers<TSubject> {
+  /** Read a delivered body. Null means it can never be acted on. */
+  parse(body: unknown): TSubject | null;
+  /** Do the work. Return false or throw to have the message redelivered;
+   * return true when the result is durably written. */
+  run(subject: TSubject): Promise<boolean>;
+}
+
+/**
+ * Consume a batch, one subject per message.
+ *
+ * One message failing never stops the rest of the batch -- each is acked or
+ * retried on its own, which is the property that makes a poison message cost one
+ * subject rather than all of them.
+ */
+export async function consumeBatch<TSubject>(
+  messages: LaneMessage[],
+  handlers: ConsumeHandlers<TSubject>,
+): Promise<ConsumeResult> {
+  let done = 0;
+  let retried = 0;
+  let dropped = 0;
+  for (const message of messages) {
+    try {
+      // `parse` is inside the try as well: a parse that throws is a programming
+      // error, and letting it propagate would fail the WHOLE batch -- one bad
+      // message taking out every other subject delivered beside it, which is
+      // the property this loop exists to prevent.
+      const subject = handlers.parse(message.body);
+      if (subject === null) {
+        message.ack();
+        dropped += 1;
+        continue;
+      }
+      if (await handlers.run(subject)) {
+        message.ack();
+        done += 1;
+      } else {
+        message.retry();
+        retried += 1;
+      }
+    } catch {
+      message.retry();
+      retried += 1;
+    }
+  }
+  return { done, retried, dropped };
+}

--- a/src/origin-reachability.ts
+++ b/src/origin-reachability.ts
@@ -44,6 +44,13 @@
 // unless it is exactly representable, and typing it `number` by hand would hide
 // that.
 import type { OriginReachability } from "../generated/db/types.ts";
+import {
+  consumeBatch,
+  enqueueAll,
+  type ConsumeResult,
+  type LaneMessage,
+  type LaneQueue,
+} from "./lane-queue.ts";
 
 /** What one origin's check concluded. */
 export type OriginVerdict =
@@ -367,104 +374,35 @@ export interface OriginMessage {
 
 export const ORIGIN_REACHABILITY_QUEUE = "origin-reachability";
 
-export interface OriginQueue {
-  sendBatch(messages: Array<{ body: OriginMessage }>): Promise<unknown>;
-}
-
-/** Cloudflare caps a sendBatch at 100. 277 origins is three batches. */
-export const ORIGIN_SEND_BATCH_MAX = 100;
-
-export interface OriginEnqueueResult {
-  ok: boolean;
-  enqueued: number;
-  reason?: string;
-}
-
-/** Enqueue every registered origin. */
 export async function enqueueOriginChecks(
-  queue: OriginQueue | null | undefined,
+  queue: LaneQueue<OriginMessage> | null | undefined,
   origins: string[],
-): Promise<OriginEnqueueResult> {
-  if (!queue?.sendBatch) {
-    return { ok: false, enqueued: 0, reason: "no_queue_binding" };
-  }
-  if (origins.length === 0) {
-    // Not a success. A producer reporting ok while enqueuing nothing is
-    // indistinguishable from one that enqueued and found nothing to do.
-    return { ok: false, enqueued: 0, reason: "no_origins_to_check" };
-  }
-  let enqueued = 0;
-  try {
-    for (let i = 0; i < origins.length; i += ORIGIN_SEND_BATCH_MAX) {
-      const slice = origins.slice(i, i + ORIGIN_SEND_BATCH_MAX);
-      await queue.sendBatch(slice.map((origin) => ({ body: { origin } })));
-      enqueued += slice.length;
-    }
-  } catch (error) {
-    return {
-      ok: false,
-      enqueued,
-      reason: `send_failed: ${String((error as Error)?.message ?? error)}`,
-    };
-  }
-  return { ok: true, enqueued };
+) {
+  return enqueueAll(
+    queue,
+    origins.map((origin) => ({ origin })),
+    "no_origins_to_check",
+  );
 }
 
-export interface OriginBatchMessage {
-  body: unknown;
-  ack(): void;
-  retry(): void;
-}
-
-export interface OriginBatchResult {
-  checked: number;
-  retried: number;
-  malformed: number;
-}
-
-/**
- * Consume a batch: one origin per message.
- *
- * ACK ON SUCCESS, RETRY ON FAILURE, ACK ON MALFORMED -- the third because a body
- * that is not an origin never will be, and retrying spends the whole budget to
- * reach the dead letter with a message nobody can act on.
- */
+/** Check one origin, and report whether the verdict was durably WRITTEN. */
 export async function handleOriginBatch(
-  messages: OriginBatchMessage[],
+  messages: LaneMessage[],
   db: OriginStoreDb | null | undefined,
   deps: OriginCheckDeps & {
     /** The origin's registered surfaces, resolved at DELIVERY time. */
     surfacesFor: (origin: string) => Promise<SurfaceRef[]>;
   },
-): Promise<OriginBatchResult> {
-  let checked = 0;
-  let retried = 0;
-  let malformed = 0;
-  for (const message of messages) {
-    const body = message.body as OriginMessage | null;
-    const origin = typeof body?.origin === "string" ? body.origin : "";
-    if (!origin) {
-      message.ack();
-      malformed += 1;
-      continue;
-    }
-    try {
+): Promise<ConsumeResult> {
+  return consumeBatch(messages, {
+    parse: (body) => {
+      const origin = (body as OriginMessage | null)?.origin;
+      return typeof origin === "string" && origin ? origin : null;
+    },
+    run: async (origin) => {
       const surfaces = await deps.surfacesFor(origin);
       const check = await checkOrigin(origin, surfaces, deps);
-      const written = await persistOriginCheck(db, check);
-      if (!written.ok) {
-        // The check happened; the WRITE did not. An unwritten verdict is a
-        // verdict nothing can read, so the message is re-delivered.
-        message.retry();
-        retried += 1;
-        continue;
-      }
-      message.ack();
-      checked += 1;
-    } catch {
-      message.retry();
-      retried += 1;
-    }
-  }
-  return { checked, retried, malformed };
+      return (await persistOriginCheck(db, check)).ok;
+    },
+  });
 }

--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -22,6 +22,13 @@ import {
   type RevenueProbeResult,
 } from "./revenue-probe.ts";
 import type { RevenueObservation } from "./revenue-serving.ts";
+import {
+  consumeBatch,
+  enqueueAll,
+  type ConsumeResult,
+  type LaneMessage,
+  type LaneQueue,
+} from "./lane-queue.ts";
 
 export const REVENUE_OBSERVATIONS_TABLE = "revenue_observations";
 export const REVENUE_PROBE_FAILURES_TABLE = "revenue_probe_failures";
@@ -299,109 +306,36 @@ export interface RevenueProbeMessage {
 
 export const REVENUE_PROBE_QUEUE = "revenue-probes";
 
-export interface RevenueProbeQueue {
-  sendBatch(messages: Array<{ body: RevenueProbeMessage }>): Promise<unknown>;
-}
-
-/** Cloudflare caps a sendBatch at 100. */
-export const REVENUE_SEND_BATCH_MAX = 100;
-
-export interface RevenueEnqueueResult {
-  ok: boolean;
-  enqueued: number;
-  reason?: string;
-}
-
-/** Enqueue every eligible revenue surface. */
 export async function enqueueRevenueProbes(
-  queue: RevenueProbeQueue | null | undefined,
+  queue: LaneQueue<RevenueProbeMessage> | null | undefined,
   surfaceIds: string[],
-): Promise<RevenueEnqueueResult> {
-  if (!queue?.sendBatch) {
-    return { ok: false, enqueued: 0, reason: "no_queue_binding" };
-  }
-  if (surfaceIds.length === 0) {
-    // Not a success, and THIS lane is why the rule exists: it shipped in #10444
-    // with no caller and no trigger, so revenue_observations was never written
-    // and every revenue route reported null for 129 subnets for two months
-    // (#10566). A producer that enqueues nothing must say so.
-    return { ok: false, enqueued: 0, reason: "no_eligible_surfaces" };
-  }
-  let enqueued = 0;
-  try {
-    for (let i = 0; i < surfaceIds.length; i += REVENUE_SEND_BATCH_MAX) {
-      const slice = surfaceIds.slice(i, i + REVENUE_SEND_BATCH_MAX);
-      await queue.sendBatch(
-        slice.map((surface_id) => ({ body: { surface_id } })),
-      );
-      enqueued += slice.length;
-    }
-  } catch (error) {
-    return {
-      ok: false,
-      enqueued,
-      reason: `send_failed: ${String((error as Error)?.message ?? error)}`,
-    };
-  }
-  return { ok: true, enqueued };
+) {
+  // The empty reason matters here more than anywhere: THIS lane shipped with no
+  // caller and reported null for 129 subnets for two months (#10566).
+  return enqueueAll(
+    queue,
+    surfaceIds.map((surface_id) => ({ surface_id })),
+    "no_eligible_surfaces",
+  );
 }
 
-export interface RevenueBatchMessage {
-  body: unknown;
-  ack(): void;
-  retry(): void;
-}
-
-export interface RevenueBatchResult {
-  probed: number;
-  retried: number;
-  malformed: number;
-}
-
-/**
- * Consume a batch: one surface per message.
- *
- * A surface no longer in the eligible set is ACKED, not retried -- the registry
- * has withdrawn it, and re-delivering will not bring it back.
- */
+/** Probe one surface. A surface no longer in the eligible set parses to NULL --
+ * acked, not retried, because the registry withdrew it and redelivery will not
+ * bring it back. */
 export async function handleRevenueProbeBatch(
-  messages: RevenueBatchMessage[],
+  messages: LaneMessage[],
   db: RevenueStoreDb | null | undefined,
   deps: Parameters<typeof runRevenueProbeLane>[2] & {
     /** The eligible surfaces, re-read at DELIVERY time. */
-    surfaceFor: (id: string) => Promise<ProbeSurfaceInput | null>;
+    surfaceFor: (id: string) => ProbeSurfaceInput | null;
   },
-): Promise<RevenueBatchResult> {
-  let probed = 0;
-  let retried = 0;
-  let malformed = 0;
-  for (const message of messages) {
-    const body = message.body as RevenueProbeMessage | null;
-    const id = typeof body?.surface_id === "string" ? body.surface_id : "";
-    if (!id) {
-      message.ack();
-      malformed += 1;
-      continue;
-    }
-    try {
-      const surface = await deps.surfaceFor(id);
-      if (!surface) {
-        message.ack();
-        malformed += 1;
-        continue;
-      }
-      const result = await runRevenueProbeLane([surface], db, deps);
-      if (!result.ok) {
-        message.retry();
-        retried += 1;
-        continue;
-      }
-      message.ack();
-      probed += 1;
-    } catch {
-      message.retry();
-      retried += 1;
-    }
-  }
-  return { probed, retried, malformed };
+): Promise<ConsumeResult> {
+  return consumeBatch(messages, {
+    parse: (body) => {
+      const id = (body as RevenueProbeMessage | null)?.surface_id;
+      if (typeof id !== "string" || !id) return null;
+      return deps.surfaceFor(id);
+    },
+    run: async (surface) => (await runRevenueProbeLane([surface], db, deps)).ok,
+  });
 }

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -9,20 +9,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
+import { SEND_BATCH_MAX } from "../src/lane-queue.ts";
 import worker, {
   fetchSweepText,
   handleScheduled,
   sweepableSubnets,
 } from "../workers/api.ts";
-import {
-  ATTRIBUTION_SWEEP_CRON,
-  REVENUE_PROBE_CRON,
-} from "../workers/config.ts";
+import { LANE_HEARTBEAT_CRON } from "../workers/config.ts";
 import { ATTRIBUTION_SWEEP_TABLES } from "../src/read-store-tables.ts";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 import {
-  SWEEP_SEND_BATCH_MAX,
   enqueueSweeps,
   handleSweepBatch,
   type SweepMessage,
@@ -43,6 +40,15 @@ const NOW = Date.parse("2026-08-11T00:00:00Z");
 
 function record(surfaces: Array<Record<string, unknown>>) {
   return { netuid: 64, surfaces };
+}
+
+/** One lane's entry in the heartbeat's aggregate result. The heartbeat runs
+ * every producer, so a per-lane assertion has to look its own up. */
+function laneResult(result: unknown) {
+  const lanes = (result as { lanes?: Array<Record<string, unknown>> }).lanes;
+  const found = (lanes ?? []).find((l) => l.lane === "attribution-sweep");
+  assert.ok(found, "attribution-sweep must be in LANE_PRODUCERS");
+  return found as { ok: boolean; enqueued: number; reason?: string };
 }
 
 describe("finding ss58 strings", () => {
@@ -337,16 +343,15 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       "utf8",
     );
     assert.ok(
-      wrangler.includes(`"${ATTRIBUTION_SWEEP_CRON}"`),
-      `${ATTRIBUTION_SWEEP_CRON} is not in wrangler.jsonc triggers.crons`,
+      wrangler.includes(`"${LANE_HEARTBEAT_CRON}"`),
+      `${LANE_HEARTBEAT_CRON} is not in wrangler.jsonc triggers.crons`,
     );
   });
 
   test("the cron does not collide with another lane", () => {
     // Dispatch keys on the literal expression, so two lanes sharing one string
     // means the first branch wins and the second silently never runs.
-    assert.equal(ATTRIBUTION_SWEEP_CRON, "56 * * * *");
-    assert.notEqual(ATTRIBUTION_SWEEP_CRON, REVENUE_PROBE_CRON);
+    assert.equal(LANE_HEARTBEAT_CRON, "26 * * * *");
   });
 
   test("dispatch and its label both know the cron", async () => {
@@ -354,19 +359,21 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       path.join(repoRoot, "workers/api.ts"),
       "utf8",
     );
-    assert.match(api, /if \(cron === ATTRIBUTION_SWEEP_CRON\) \{/);
-    assert.match(api, /return "attribution-sweep"/);
+    assert.match(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+    assert.match(api, /return "lane-heartbeat"/);
   });
 
   test("handleScheduled routes the cron to the PRODUCER, and it declines cleanly", async () => {
     // The cron no longer sweeps -- it enqueues. With no artifact there is
     // nothing to enqueue, and the producer must say so rather than report a
     // pass with nothing sent.
-    const result = (await handleScheduled(
-      { cron: ATTRIBUTION_SWEEP_CRON } as unknown as ScheduledController,
-      {} as unknown as Parameters<typeof handleScheduled>[1],
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; enqueued: number; reason?: string };
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        {} as unknown as Parameters<typeof handleScheduled>[1],
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
     assert.equal(result.ok, false);
     assert.equal(result.enqueued, 0);
     // The BINDING is reported before the empty list, and that order is the
@@ -581,12 +588,12 @@ describe("the queue lane", () => {
     // 128 subnets is one over two batches at Cloudflare's 100-message cap --
     // exactly the off-by-one that ships.
     const sent: Array<Array<{ body: unknown }>> = [];
-    const many = Array.from({ length: SWEEP_SEND_BATCH_MAX + 28 }, (_, i) => i);
+    const many = Array.from({ length: SEND_BATCH_MAX + 28 }, (_, i) => i);
     const out = await enqueueSweeps(queue(sent), many);
     assert.equal(out.enqueued, many.length);
     assert.deepEqual(
       sent.map((b) => b.length),
-      [SWEEP_SEND_BATCH_MAX, 28],
+      [SEND_BATCH_MAX, 28],
     );
   });
 
@@ -649,7 +656,7 @@ describe("consuming a sweep batch", () => {
   test("acks a swept subnet", async () => {
     const m = message({ netuid: 64 });
     const out = await handleSweepBatch([m], store(), deps());
-    assert.deepEqual(out, { swept: 1, retried: 0, malformed: 0 });
+    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
     assert.equal(m.calls.acked, 1);
   });
 
@@ -685,7 +692,7 @@ describe("consuming a sweep batch", () => {
       }),
     );
     // The sweep itself absorbs a fetch failure as `unreachable`, so this acks.
-    assert.equal(out.swept + out.retried, 1);
+    assert.equal(out.done + out.retried, 1);
     assert.equal(m.calls.acked + m.calls.retried, 1);
   });
 
@@ -694,7 +701,7 @@ describe("consuming a sweep batch", () => {
     // reading the store is concerned.
     const m = message({ netuid: 64 });
     const out = await handleSweepBatch([m], null, deps());
-    assert.deepEqual(out, { swept: 0, retried: 1, malformed: 0 });
+    assert.deepEqual(out, { done: 0, retried: 1, dropped: 0 });
     assert.equal(m.calls.retried, 1);
   });
 
@@ -708,7 +715,7 @@ describe("consuming a sweep batch", () => {
       message({ netuid: -1 }),
     ];
     const out = await handleSweepBatch(bad, store(), deps());
-    assert.deepEqual(out, { swept: 0, retried: 0, malformed: 4 });
+    assert.deepEqual(out, { done: 0, retried: 0, dropped: 4 });
     for (const m of bad) assert.equal(m.calls.acked, 1);
   });
 
@@ -719,8 +726,8 @@ describe("consuming a sweep batch", () => {
       store(),
       deps(),
     );
-    assert.equal(out.swept, 1);
-    assert.equal(out.malformed, 2);
+    assert.equal(out.done, 1);
+    assert.equal(out.dropped, 2);
     assert.equal(good.calls.acked, 1);
   });
 });
@@ -900,7 +907,7 @@ describe("the last of the queue shapes", () => {
         },
       },
     );
-    assert.deepEqual(out, { swept: 0, retried: 1, malformed: 0 });
+    assert.deepEqual(out, { done: 0, retried: 1, dropped: 0 });
     assert.equal(calls.retried, 1);
   });
 
@@ -914,12 +921,18 @@ describe("the last of the queue shapes", () => {
         },
       },
     };
-    const result = (await handleScheduled(
-      { cron: ATTRIBUTION_SWEEP_CRON } as unknown as ScheduledController,
-      env as never,
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; enqueued: number };
-    assert.deepEqual(result, { ok: true, enqueued: 1 });
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        env as never,
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
+    assert.deepEqual(result, {
+      lane: "attribution-sweep",
+      ok: true,
+      enqueued: 1,
+    });
     assert.deepEqual(sent, [7]);
   });
 });

--- a/tests/origin-reachability.test.ts
+++ b/tests/origin-reachability.test.ts
@@ -18,17 +18,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
+import { SEND_BATCH_MAX } from "../src/lane-queue.ts";
 import worker, {
   handleScheduled,
   probeOrigin,
   registeredSurfaces,
 } from "../workers/api.ts";
-import { ORIGIN_REACHABILITY_CRON } from "../workers/config.ts";
+import { LANE_HEARTBEAT_CRON } from "../workers/config.ts";
 
 const repoRoot = fileURLToPath(new URL("..", import.meta.url));
 import {
   ORIGIN_SAMPLE_SIZE,
-  ORIGIN_SEND_BATCH_MAX,
   enqueueOriginChecks,
   handleOriginBatch,
   type OriginMessage,
@@ -52,6 +52,15 @@ const sample = (
   body_hash: string | null,
   url = "https://a.example/x",
 ): OriginSample => ({ url, status, body_hash });
+
+/** One lane's entry in the heartbeat's aggregate result. The heartbeat runs
+ * every producer, so a per-lane assertion has to look its own up. */
+function laneResult(result: unknown) {
+  const lanes = (result as { lanes?: Array<Record<string, unknown>> }).lanes;
+  const found = (lanes ?? []).find((l) => l.lane === "origin-reachability");
+  assert.ok(found, "origin-reachability must be in LANE_PRODUCERS");
+  return found as { ok: boolean; enqueued: number; reason?: string };
+}
 
 describe("classifying an origin", () => {
   test("a dead platform host answering one placeholder for everything", () => {
@@ -408,10 +417,10 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       "utf8",
     );
     assert.ok(
-      wrangler.includes(`"${ORIGIN_REACHABILITY_CRON}"`),
-      `${ORIGIN_REACHABILITY_CRON} is not in wrangler.jsonc triggers.crons`,
+      wrangler.includes(`"${LANE_HEARTBEAT_CRON}"`),
+      `${LANE_HEARTBEAT_CRON} is not in wrangler.jsonc triggers.crons`,
     );
-    assert.equal(ORIGIN_REACHABILITY_CRON, "17 * * * *");
+    assert.equal(LANE_HEARTBEAT_CRON, "26 * * * *");
   });
 
   test("dispatch and its label both know the cron", async () => {
@@ -419,19 +428,21 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       path.join(repoRoot, "workers/api.ts"),
       "utf8",
     );
-    assert.match(api, /if \(cron === ORIGIN_REACHABILITY_CRON\) \{/);
-    assert.match(api, /return "origin-reachability"/);
+    assert.match(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+    assert.match(api, /return "lane-heartbeat"/);
   });
 
   test("handleScheduled routes the cron to the PRODUCER, and it declines cleanly", async () => {
     // The cron no longer checks -- it enqueues. The BINDING is reported before
     // the empty list, and that order is the useful one: a missing binding is a
     // config error, and saying "no origins" would send someone to the registry.
-    const result = (await handleScheduled(
-      { cron: ORIGIN_REACHABILITY_CRON } as unknown as ScheduledController,
-      {} as unknown as Parameters<typeof handleScheduled>[1],
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; enqueued: number; reason?: string };
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        {} as unknown as Parameters<typeof handleScheduled>[1],
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
     assert.equal(result.ok, false);
     assert.equal(result.enqueued, 0);
     assert.equal(result.reason, "no_queue_binding");
@@ -625,13 +636,13 @@ describe("the queue lane", () => {
     // 277 origins is three batches at Cloudflare's 100-message cap.
     const sent: Array<Array<{ body: unknown }>> = [];
     const many = Array.from(
-      { length: ORIGIN_SEND_BATCH_MAX + 7 },
+      { length: SEND_BATCH_MAX + 7 },
       (_, i) => `https://h${i}`,
     );
     await enqueueOriginChecks(queue(sent), many);
     assert.deepEqual(
       sent.map((b) => b.length),
-      [ORIGIN_SEND_BATCH_MAX, 7],
+      [SEND_BATCH_MAX, 7],
     );
   });
 
@@ -697,7 +708,7 @@ describe("consuming an origin batch", () => {
   test("acks a checked origin", async () => {
     const m = message({ origin: "https://x.example" });
     const out = await handleOriginBatch([m], store(), deps() as never);
-    assert.deepEqual(out, { checked: 1, retried: 0, malformed: 0 });
+    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
     assert.equal(m.calls.acked, 1);
   });
 
@@ -721,7 +732,7 @@ describe("consuming an origin batch", () => {
   test("RETRIES when the check succeeded but the WRITE failed", async () => {
     const m = message({ origin: "https://x.example" });
     const out = await handleOriginBatch([m], null, deps() as never);
-    assert.deepEqual(out, { checked: 0, retried: 1, malformed: 0 });
+    assert.deepEqual(out, { done: 0, retried: 1, dropped: 0 });
   });
 
   test("RETRIES when resolving the surfaces throws", async () => {
@@ -742,7 +753,7 @@ describe("consuming an origin batch", () => {
   test("ACKS a malformed message rather than looping it to the dead letter", async () => {
     const bad = [message({ origin: 42 }), message({}), message(null)];
     const out = await handleOriginBatch(bad, store(), deps() as never);
-    assert.deepEqual(out, { checked: 0, retried: 0, malformed: 3 });
+    assert.deepEqual(out, { done: 0, retried: 0, dropped: 3 });
     for (const m of bad) assert.equal(m.calls.acked, 1);
   });
 
@@ -753,8 +764,8 @@ describe("consuming an origin batch", () => {
       store(),
       deps() as never,
     );
-    assert.equal(out.checked, 1);
-    assert.equal(out.malformed, 1);
+    assert.equal(out.done, 1);
+    assert.equal(out.dropped, 1);
   });
 });
 
@@ -826,18 +837,24 @@ describe("the origin queue, through the Worker's own handler", () => {
     // Two surfaces on one host is one message, not two -- that is the whole
     // saving over a per-surface pass.
     const sent: string[] = [];
-    const result = (await handleScheduled(
-      { cron: ORIGIN_REACHABILITY_CRON } as unknown as ScheduledController,
-      env(registry, {
-        ORIGIN_REACHABILITY: {
-          async sendBatch(messages: Array<{ body: { origin: string } }>) {
-            for (const m of messages) sent.push(m.body.origin);
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        env(registry, {
+          ORIGIN_REACHABILITY: {
+            async sendBatch(messages: Array<{ body: { origin: string } }>) {
+              for (const m of messages) sent.push(m.body.origin);
+            },
           },
-        },
-      }) as never,
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; enqueued: number };
-    assert.deepEqual(result, { ok: true, enqueued: 1 });
+        }) as never,
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
+    assert.deepEqual(result, {
+      lane: "origin-reachability",
+      ok: true,
+      enqueued: 1,
+    });
     assert.deepEqual(sent, ["https://x.example"]);
   });
 

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -15,8 +15,8 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
+import { SEND_BATCH_MAX } from "../src/lane-queue.ts";
 import {
-  REVENUE_SEND_BATCH_MAX,
   eligibleRevenueSurfaces,
   enqueueRevenueProbes,
   handleRevenueProbeBatch,
@@ -30,7 +30,7 @@ import {
   type RevenueStoreDb,
 } from "../src/revenue-observations.ts";
 import worker, { handleScheduled } from "../workers/api.ts";
-import { REVENUE_PROBE_CRON } from "../workers/config.ts";
+import { LANE_HEARTBEAT_CRON } from "../workers/config.ts";
 import { REVENUE_OBSERVATION_TABLES } from "../src/read-store-tables.ts";
 
 const repoRoot = path.resolve(
@@ -86,6 +86,15 @@ const OBSERVATION = {
   response_hash: "abc",
   observed_at: 1786320000000,
 };
+
+/** One lane's entry in the heartbeat's aggregate result. The heartbeat runs
+ * every producer, so a per-lane assertion has to look its own up. */
+function laneResult(result: unknown) {
+  const lanes = (result as { lanes?: Array<Record<string, unknown>> }).lanes;
+  const found = (lanes ?? []).find((l) => l.lane === "revenue-probe");
+  assert.ok(found, "revenue-probe must be in LANE_PRODUCERS");
+  return found as { ok: boolean; enqueued: number; reason?: string };
+}
 
 describe("persistRevenueProbe", () => {
   test("writes observations and failures to their own tables", async () => {
@@ -549,15 +558,15 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       "utf8",
     );
     assert.ok(
-      wrangler.includes(`"${REVENUE_PROBE_CRON}"`),
-      `${REVENUE_PROBE_CRON} is not in wrangler.jsonc triggers.crons`,
+      wrangler.includes(`"${LANE_HEARTBEAT_CRON}"`),
+      `${LANE_HEARTBEAT_CRON} is not in wrangler.jsonc triggers.crons`,
     );
   });
 
   test("the cron does not collide with another lane", () => {
     // Dispatch keys on the literal expression, so two lanes sharing one string
     // means the first branch wins and the second silently never runs.
-    assert.equal(REVENUE_PROBE_CRON, "24 * * * *");
+    assert.equal(LANE_HEARTBEAT_CRON, "26 * * * *");
   });
 
   test("dispatch and its label both know the cron", async () => {
@@ -565,19 +574,21 @@ describe("the wiring — a correct lane nobody calls is the defect", () => {
       path.join(repoRoot, "workers/api.ts"),
       "utf8",
     );
-    assert.match(api, /if \(cron === REVENUE_PROBE_CRON\) \{/);
-    assert.match(api, /return "revenue-probe"/);
+    assert.match(api, /if \(cron === LANE_HEARTBEAT_CRON\) \{/);
+    assert.match(api, /return "lane-heartbeat"/);
   });
 
   test("handleScheduled routes the cron to the PRODUCER and returns its verdict", async () => {
     // The branch itself, not just its presence in the source. A dispatch that
     // matches no branch returns undefined and the tick reports success having
     // done nothing — the same shape of silence this lane was built to end.
-    const result = (await handleScheduled(
-      { cron: REVENUE_PROBE_CRON } as unknown as ScheduledController,
-      {} as unknown as Parameters<typeof handleScheduled>[1],
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; enqueued: number; reason?: string };
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        {} as unknown as Parameters<typeof handleScheduled>[1],
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
     assert.equal(result.ok, false);
     assert.equal(result.enqueued, 0);
     // The cron is a PRODUCER now (#10715): it enqueues one message per eligible
@@ -655,14 +666,11 @@ describe("the queue lane (#10715)", () => {
 
   test("splits at the sendBatch cap", async () => {
     const sent: Array<Array<{ body: unknown }>> = [];
-    const many = Array.from(
-      { length: REVENUE_SEND_BATCH_MAX + 3 },
-      (_, i) => `s${i}`,
-    );
+    const many = Array.from({ length: SEND_BATCH_MAX + 3 }, (_, i) => `s${i}`);
     await enqueueRevenueProbes(queue(sent), many);
     assert.deepEqual(
       sent.map((b) => b.length),
-      [REVENUE_SEND_BATCH_MAX, 3],
+      [SEND_BATCH_MAX, 3],
     );
   });
 
@@ -724,14 +732,14 @@ describe("the queue lane (#10715)", () => {
     }),
     hash: sha256Hex,
     now: () => 1_786_320_000_000,
-    surfaceFor: async () => surface,
+    surfaceFor: () => surface,
     ...over,
   });
 
   test("probes one surface per message and ACKS it on success", async () => {
     const m = message({ surface_id: surface.id });
     const out = await handleRevenueProbeBatch([m], store(), deps() as never);
-    assert.deepEqual(out, { probed: 1, retried: 0, malformed: 0 });
+    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
     assert.equal(m.calls.acked, 1);
   });
 
@@ -750,7 +758,7 @@ describe("the queue lane (#10715)", () => {
       [message({ surface_id: "sn-x" })],
       store(),
       deps({
-        surfaceFor: async (id: string) => {
+        surfaceFor: (id: string) => {
           askedFor = id;
           return null;
         },
@@ -765,31 +773,42 @@ describe("the queue lane (#10715)", () => {
     const out = await handleRevenueProbeBatch(
       [m],
       store(),
-      deps({ surfaceFor: async () => null }) as never,
+      deps({ surfaceFor: () => null }) as never,
     );
-    assert.deepEqual(out, { probed: 0, retried: 0, malformed: 1 });
+    assert.deepEqual(out, { done: 0, retried: 0, dropped: 1 });
     assert.equal(m.calls.acked, 1);
   });
 
   test("ACKS a malformed body rather than looping it to the dead letter", async () => {
     const bad = [message({ surface_id: 42 }), message({}), message(null)];
     const out = await handleRevenueProbeBatch(bad, store(), deps() as never);
-    assert.equal(out.malformed, 3);
+    assert.equal(out.dropped, 3);
     for (const m of bad) assert.equal(m.calls.acked, 1);
   });
 
-  test("RETRIES when the probe throws", async () => {
-    const m = message({ surface_id: surface.id });
+  test("RETRIES when the probe throws, without taking out the batch", async () => {
+    // One poison message costs one subject, never the others delivered with it.
+    const bad = message({ surface_id: surface.id });
+    const good = message({ surface_id: surface.id });
+    let first = true;
     const out = await handleRevenueProbeBatch(
-      [m],
+      [bad, good],
       store(),
       deps({
-        surfaceFor: async () => {
-          throw new Error("artifact read exploded");
+        fetchPayload: async () => {
+          if (first) {
+            first = false;
+            throw new Error("feed exploded");
+          }
+          return {
+            payload: [{ date: "2026-08-08", total_revenue: 11668 }],
+            raw: '[{"date":"2026-08-08","total_revenue":11668}]',
+          };
         },
       }) as never,
     );
     assert.equal(out.retried, 1);
+    assert.equal(out.done, 1);
   });
 
   test("the dead-letter queue is registered as a lane", async () => {
@@ -862,21 +881,25 @@ describe("the revenue queue, through the Worker's own handler", () => {
 
   test("the cron producer enqueues every eligible surface", async () => {
     const sent: string[] = [];
-    const result = (await handleScheduled(
-      { cron: REVENUE_PROBE_CRON } as unknown as ScheduledController,
-      env(
-        { surfaces: [SURFACE] },
-        {
-          REVENUE_PROBES: {
-            async sendBatch(messages: Array<{ body: { surface_id: string } }>) {
-              for (const m of messages) sent.push(m.body.surface_id);
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        env(
+          { surfaces: [SURFACE] },
+          {
+            REVENUE_PROBES: {
+              async sendBatch(
+                messages: Array<{ body: { surface_id: string } }>,
+              ) {
+                for (const m of messages) sent.push(m.body.surface_id);
+              },
             },
           },
-        },
-      ) as never,
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; enqueued: number };
-    assert.deepEqual(result, { ok: true, enqueued: 1 });
+        ) as never,
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
+    assert.deepEqual(result, { lane: "revenue-probe", ok: true, enqueued: 1 });
     assert.deepEqual(sent, ["sn-64-x"]);
   });
 
@@ -906,13 +929,15 @@ describe("the revenue queue, through the Worker's own handler", () => {
   test("no operational-surfaces artifact enqueues nothing, and says so", async () => {
     // The artifact-absent branch: an unreadable artifact must not read as "no
     // surfaces are eligible", which is the same claim by a different route.
-    const result = (await handleScheduled(
-      { cron: REVENUE_PROBE_CRON } as unknown as ScheduledController,
-      env(null, {
-        REVENUE_PROBES: { async sendBatch() {} },
-      }) as never,
-      { waitUntil: () => {} } as unknown as ExecutionContext,
-    )) as { ok: boolean; reason?: string };
+    const result = laneResult(
+      await handleScheduled(
+        { cron: LANE_HEARTBEAT_CRON } as unknown as ScheduledController,
+        env(null, {
+          REVENUE_PROBES: { async sendBatch() {} },
+        }) as never,
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ),
+    );
     assert.equal(result.ok, false);
     assert.equal(result.reason, "no_eligible_surfaces");
   });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -544,14 +544,12 @@ import {
   LINK_STATUS_SYNC_CRON,
   RAW_CAPTURE_CRON,
   SUBNET_BURN_CAPTURE_CRON,
-  REVENUE_PROBE_CRON,
-  ATTRIBUTION_SWEEP_CRON,
-  ORIGIN_REACHABILITY_CRON,
   OPERATIONAL_SURFACES_SYNC_CRON,
   SCHEMA_SNAPSHOTS_SYNC_CRON,
   SURFACE_VERIFICATION_SYNC_CRON,
   GOVERNANCE_CONFIG_CHANGES_PATH_PATTERN,
   HEALTH_PRUNE_CRON,
+  LANE_HEARTBEAT_CRON,
   INCIDENTS_PATH_PATTERN,
   JSON_CONTENT_TYPE,
   MAX_ASK_BODY_BYTES,
@@ -660,6 +658,11 @@ import {
 } from "../src/projection-lanes.ts";
 import { TOP_HOLDERS_FLOW_LANE } from "../src/top-holders-flow-tier.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
+import type {
+  EnqueueResult,
+  LaneMessage,
+  LaneQueue,
+} from "../src/lane-queue.ts";
 import {
   OPERATIONAL_SURFACES_ARTIFACT,
   REVENUE_PROBE_QUEUE,
@@ -668,8 +671,6 @@ import {
   fetchRevenuePayload,
   handleRevenueProbeBatch,
   sha256Hex,
-  type RevenueBatchMessage,
-  type RevenueProbeQueue,
   type RevenueStoreDb,
 } from "../src/revenue-observations.ts";
 import {
@@ -682,8 +683,6 @@ import {
   SWEEP_MAX_BYTES,
   enqueueSweeps,
   handleSweepBatch,
-  type SweepBatchMessage,
-  type SweepQueue,
   type SweepStoreDb,
 } from "../src/attribution-sweep.ts";
 import {
@@ -698,8 +697,6 @@ import {
   handleOriginBatch,
   normaliseBody,
   surfacesByOrigin,
-  type OriginBatchMessage,
-  type OriginQueue,
   type OriginStoreDb,
   type SurfaceRef,
 } from "../src/origin-reachability.ts";
@@ -1747,7 +1744,7 @@ export default {
           (await sweepableSubnets(env)).map((s) => [s.netuid, s.record]),
         );
         await handleSweepBatch(
-          batch.messages as unknown as SweepBatchMessage[],
+          batch.messages as unknown as LaneMessage[],
           store.db as SweepStoreDb,
           {
             fetchText: fetchSweepText,
@@ -1774,13 +1771,13 @@ export default {
           ).map((s) => [s.id, s]),
         );
         await handleRevenueProbeBatch(
-          batch.messages as unknown as RevenueBatchMessage[],
+          batch.messages as unknown as LaneMessage[],
           store.db as RevenueStoreDb,
           {
             fetchPayload: (url: string) => fetchRevenuePayload(url),
             hash: sha256Hex,
             now: Date.now,
-            surfaceFor: async (id: string) => byId.get(id) ?? null,
+            surfaceFor: (id: string) => byId.get(id) ?? null,
           },
         );
       } finally {
@@ -1795,7 +1792,7 @@ export default {
       try {
         const byOrigin = surfacesByOrigin(await registeredSurfaces(env));
         await handleOriginBatch(
-          batch.messages as unknown as OriginBatchMessage[],
+          batch.messages as unknown as LaneMessage[],
           store.db as OriginStoreDb,
           {
             probe: probeOrigin,
@@ -2266,15 +2263,13 @@ export { composeCompareData } from "./request-handlers/analytics-routes.ts";
 // is the shape #9001 removed elsewhere, and a name survives a schedule change
 // where "0 * * * *" does not.
 function cronLabel(cron: string): string {
+  if (cron === LANE_HEARTBEAT_CRON) return "lane-heartbeat";
   if (cron === HEALTH_PRUNE_CRON) return "health-prune";
   if (cron === EMBEDDING_SYNC_CRON) return "embedding-sync";
   if (cron === GITHUB_SIGNALS_SYNC_CRON) return "github-signals-sync";
   if (cron === LINK_STATUS_SYNC_CRON) return "link-status-sync";
   if (cron === RAW_CAPTURE_CRON) return "raw-capture";
   if (cron === SUBNET_BURN_CAPTURE_CRON) return "subnet-burn-capture";
-  if (cron === REVENUE_PROBE_CRON) return "revenue-probe";
-  if (cron === ORIGIN_REACHABILITY_CRON) return "origin-reachability";
-  if (cron === ATTRIBUTION_SWEEP_CRON) return "attribution-sweep";
   if (cron === OPERATIONAL_SURFACES_SYNC_CRON)
     return "operational-surfaces-sync";
   if (cron === SCHEMA_SNAPSHOTS_SYNC_CRON) return "schema-snapshots-sync";
@@ -2544,6 +2539,65 @@ export async function probeOrigin(
   }
 }
 
+/**
+ * Every queue-backed lane's producer.
+ *
+ * THE POINT OF THE TABLE is that adding a lane is one entry here rather than a
+ * cron minute, a dispatch branch and a constant. The grid was 97% full when the
+ * third of these went in; the fourth would have taken the last slot.
+ *
+ * Each `enqueue` reads a list and sends it. None fetches, none opens a store --
+ * that work belongs to the consumer, one invocation per subject.
+ */
+export const LANE_PRODUCERS: ReadonlyArray<{
+  name: string;
+  enqueue: (env: Env) => Promise<EnqueueResult>;
+}> = [
+  {
+    name: "attribution-sweep",
+    enqueue: async (env) =>
+      enqueueSweeps(
+        (
+          env as unknown as {
+            ATTRIBUTION_SWEEPS?: LaneQueue<{ netuid: number }>;
+          }
+        ).ATTRIBUTION_SWEEPS,
+        (await sweepableSubnets(env)).map((s) => s.netuid),
+      ),
+  },
+  {
+    name: "origin-reachability",
+    enqueue: async (env) =>
+      enqueueOriginChecks(
+        (
+          env as unknown as {
+            ORIGIN_REACHABILITY?: LaneQueue<{ origin: string }>;
+          }
+        ).ORIGIN_REACHABILITY,
+        [...surfacesByOrigin(await registeredSurfaces(env)).keys()],
+      ),
+  },
+  {
+    name: "revenue-probe",
+    enqueue: async (env) => {
+      const artifact = await readArtifact(
+        env,
+        `${OPERATIONAL_SURFACES_ARTIFACT}.json`,
+      );
+      return enqueueRevenueProbes(
+        (
+          env as unknown as {
+            REVENUE_PROBES?: LaneQueue<{ surface_id: string }>;
+          }
+        ).REVENUE_PROBES,
+        eligibleRevenueSurfaces(
+          artifact.ok ? (artifact.data as Row | undefined) : null,
+        ).map((s) => s.id),
+      );
+    },
+  },
+];
+
 export async function handleScheduled(
   controller: ScheduledController,
   env: Env = {} as unknown as Env,
@@ -2674,64 +2728,26 @@ async function dispatchScheduled(
   if (cron === EMBEDDING_SYNC_CRON) {
     return runEmbeddingSync(env, { readArtifact });
   }
-  if (cron === ATTRIBUTION_SWEEP_CRON) {
-    // #10489-#10509: look at what each subnet publishes, and record what was
-    // found -- including, and mostly, that nothing was.
+  if (cron === LANE_HEARTBEAT_CRON) {
+    // ONE clock for every queue-backed lane (#10715). Each producer reads a
+    // list and enqueues it -- no fetching, no store handle -- so running them
+    // together costs one artifact read each and nothing else.
     //
-    // The store exists so a wallets response can say "searched on this date,
-    // nothing published" instead of an empty list that is equally consistent
-    // with nobody having looked. An undated silence is not evidence.
-    {
-      // THE CRON IS NOW A PRODUCER, not the lane. It reads which subnets are
-      // due and enqueues one message each; the consumer below sweeps them, one
-      // invocation per subnet. The slice of eight this used to sweep inline was
-      // never a cadence -- it was the invocation budget, and a queue removes it
-      // rather than working around it (#10709).
-      // No store handle and no staleness read: the producer enqueues EVERY
-      // subnet, so there is nothing to decide about which to skip. The old lane
-      // opened a connection each tick purely to order a slice it then threw
-      // most of away.
-      const subnets = await sweepableSubnets(env);
-      return await enqueueSweeps(
-        (env as unknown as { ATTRIBUTION_SWEEPS?: SweepQueue })
-          .ATTRIBUTION_SWEEPS,
-        subnets.map((s) => s.netuid),
-      );
-    }
-  }
-  if (cron === ORIGIN_REACHABILITY_CRON) {
-    // #10548: is the HOST still there. scripts/build-artifacts.ts builds the
-    // prober's targets from surfaces with probe.enabled, so a disabled one is
-    // never checked -- forever. SN37 Aurelius had ~60 surfaces on a deleted
-    // Railway app, ~50 of them invisible, and not one incident was raised.
-    //
-    // Checking origins rather than surfaces is what makes the disabled ones
-    // covered at all, and costs one request instead of sixty.
-    {
-      // Producer only: every registered origin, no staleness read and no store
-      // handle. Nothing is skipped, so there is nothing to order.
-      return await enqueueOriginChecks(
-        (env as unknown as { ORIGIN_REACHABILITY?: OriginQueue })
-          .ORIGIN_REACHABILITY,
-        [...surfacesByOrigin(await registeredSurfaces(env)).keys()],
-      );
-    }
-  }
-  if (cron === REVENUE_PROBE_CRON) {
-    // PRODUCER ONLY since #10715. This lane is the reason the "a producer that
-    // enqueues nothing must say so" rule exists: it shipped in #10444 with no
-    // caller and no trigger, so revenue_observations was never written and every
-    // revenue route reported null for all 129 subnets for two months (#10566).
-    const artifact = await readArtifact(
-      env,
-      `${OPERATIONAL_SURFACES_ARTIFACT}.json`,
+    // A new lane is added to LANE_PRODUCERS, not to the cron grid. The three
+    // this replaced took three of the two minutes that were still free.
+    const results = await Promise.all(
+      LANE_PRODUCERS.map(async (lane) => ({
+        lane: lane.name,
+        ...(await lane.enqueue(env)),
+      })),
     );
-    return await enqueueRevenueProbes(
-      (env as unknown as { REVENUE_PROBES?: RevenueProbeQueue }).REVENUE_PROBES,
-      eligibleRevenueSurfaces(
-        artifact.ok ? (artifact.data as Row | undefined) : null,
-      ).map((s) => s.id),
-    );
+    // The heartbeat is ok only if EVERY producer is. One lane silently failing
+    // to enqueue while the others succeed is precisely the shape that let the
+    // revenue lane sit dead for two months (#10566).
+    return {
+      ok: results.every((r) => r.ok),
+      lanes: results,
+    };
   }
   if (cron === SUBNET_BURN_CAPTURE_CRON) {
     // #9402: one state_queryStorageAt covering every subnet, then one batched D1

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -133,7 +133,22 @@ export const SUBNET_BURN_CAPTURE_CRON = "1,16,31,46 * * * *";
  * lane silently never fires -- which is indistinguishable from the state it was
  * added to fix.
  */
-export const REVENUE_PROBE_CRON = "24 * * * *";
+/** #10715: ONE producer heartbeat for every queue-backed lane.
+ *
+ * Replaces three per-lane crons -- the attribution sweep, the origin
+ * reachability check and the revenue probe -- which between them did no work:
+ * each read a list and enqueued it. Three clocks for three enqueues cost three
+ * minutes of a 60-minute grid that was already 97% full, and gave three chances
+ * for the literal-string dispatch to collide. It did once, with
+ * EMISSION_DRIFT_CHECK_CRON, caught only by a uniqueness test.
+ *
+ * A new lane joins LANE_PRODUCERS, not this grid. That is the property worth
+ * having: the next lane needs no minute at all.
+ *
+ * Hourly, matching what the three replaced. Minute 26 was one of only two still
+ * free; retiring the others returns 17, 24 and 56 to the pool.
+ */
+export const LANE_HEARTBEAT_CRON = "26 * * * *";
 
 /** #10489-#10509: the attribution sweep.
  *
@@ -142,7 +157,6 @@ export const REVENUE_PROBE_CRON = "24 * * * *";
  * up to 8 sources is ~1000 outbound requests, which is not a tick. The lane
  * takes the eight least-recently-swept each hour, so a full pass lands inside a
  * day and never bursts. */
-export const ATTRIBUTION_SWEEP_CRON = "56 * * * *";
 
 /** #10548: the origin-reachability lane.
  *
@@ -161,7 +175,6 @@ export const ATTRIBUTION_SWEEP_CRON = "56 * * * *";
  * 26 has nowhere to go. The fix is a single dispatcher cron running whichever
  * lanes are due from a declared cadence -- which decouples "how often" from
  * "which minute is free" and removes this whole failure class. */
-export const ORIGIN_REACHABILITY_CRON = "17 * * * *";
 
 // The remaining three machine-data lanes (#9096), moved off their retired
 // GitHub Actions sync workflows onto Worker-native crons writing their R2

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1181,39 +1181,19 @@
       // visible without waiting for the publish path to notice. See
       // ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON in workers/config.ts.
       "4,34 * * * *",
-      // 24 = the hourly revenue probe lane (#10566). src/revenue-probe.ts
-      // shipped in #10444 with no caller and no trigger, so revenue_observations
-      // was never written and every revenue route served null. Minute 24 is one
-      // of only two free on this grid. See REVENUE_PROBE_CRON in
-      // workers/config.ts for why hourly rather than the 15-minute probe grid --
-      // these are billing endpoints, and the cadence is for restatement, not
-      // freshness. NOTE: Workers Builds does not apply cron triggers; this one
-      // needs `wrangler triggers deploy` or the lane never fires.
-      "24 * * * *",
-      // 9,39 = the origin-reachability lane (#10548). scripts/build-artifacts.ts
-      // builds the prober's target list from surfaces with probe.enabled, so a
-      // disabled one is never checked -- forever. SN37 Aurelius had ~60
-      // surfaces on a deleted Railway app, ~50 of them invisible, and not one
-      // incident was raised. Checking ORIGINS rather than surfaces is what
-      // covers the disabled ones at all, and costs one request instead of
-      // sixty. A slice per tick; these offsets collide with nothing on this
-      // grid. NOTE: Workers Builds does not apply cron triggers; this one needs
-      // `wrangler triggers deploy` or the lane never fires.
-      "17 * * * *",
-      // 56 = the attribution sweep (#10489-#10509). Records, per subnet, that
-      // its published surfaces were searched for an address on a date -- most
-      // publish none, and "no declared treasury as of <date>" is evidence where
-      // an undated silence is not. A SLICE per tick (eight least-recently-swept)
-      // because 129 subnets x up to 8 sources is ~1000 requests, which is not a
-      // tick. Minute 56 is the other free slot on this grid; 24 went to the
-      // revenue probe. NOTE: Workers Builds does not apply cron triggers; this
-      // one needs `wrangler triggers deploy` or the lane never fires.
-      "56 * * * *",
       // 54 = the hotkey-alpha staleness watchdog (#9576): the same source-side
       // alarm for the OTHER ledger the holdings columns are composed from,
       // which shipped in #9512 without one. Hourly rather than twice-hourly,
       // because its producer polls every 24h against account_balances' 6h. See
       // HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON in workers/config.ts.
+      // 26 = the ONE producer heartbeat for every queue-backed lane (#10715).
+      // Replaces the three per-lane crons that used to sit on 17, 24 and 56 --
+      // each of which only read a list and enqueued it. A new lane joins
+      // LANE_PRODUCERS in workers/api.ts and needs no minute here at all, which
+      // matters on a grid that was 97% full. NOTE: Workers Builds does not apply
+      // cron triggers; this one needs `wrangler triggers deploy` or nothing
+      // fires.
+      "26 * * * *",
       "54 * * * *",
     ],
   },


### PR DESCRIPTION
> **Stacked on [#10727](https://github.com/JSONbored/metagraphed/pull/10727)** — the maintainability pass over the three queue lanes.

## The duplication, and why it mattered

Each lane carried its own copy of two functions: a producer (check binding, refuse empty set, chunk at the 100-message cap, report partial sends) and a consumer (ack on success, retry on failure, ack an unparseable body).

**The ack/retry decision is the one with consequences.** Three copies is three places for it to drift, and getting it backwards either loses work silently or loops a message to the dead letter forever. `src/lane-queue.ts` now holds it once, tested once. A lane supplies only what differs — what to enqueue, how to read a body, what to do with one subject.

## One heartbeat replaces three crons

Those producers read a list and enqueue it. None fetches; none opens a store. Three clocks for three enqueues cost **three minutes of a 60-minute grid that was already 97% full**, and gave three chances for the literal-string dispatch to collide — which it did once, with `EMISSION_DRIFT_CHECK_CRON`, caught only by a uniqueness test.

Minutes **17, 24 and 56 go back in the pool**; the heartbeat takes 26.

**The property worth having: a new lane joins `LANE_PRODUCERS`, not the grid.** The next lane needs no minute at all — which is what makes this scale past the one slot that was left.

## Two details worth reviewing

**The heartbeat is `ok` only if every producer is.** One lane silently failing to enqueue while the others succeed is precisely the shape that let the revenue lane sit dead for two months (#10566).

**`parse` runs inside the consumer's `try`.** A parse that throws is a programming error, and letting it propagate would fail the *whole batch* — one bad message taking out every other subject delivered beside it, which is the property that loop exists to prevent. Asserted with a poison message beside a good one: `retried: 1, done: 1`.

## Deleted, not left beside

- six per-lane message/queue/result types the shared ones replace
- three `*_DLQ` constants nothing referenced

`validate:unreferenced-exports` stays at the 738 ceiling.

## Validation

```
npx tsc --noEmit                clean
npm run lint / format:check     clean
npm run validate                pass
npm run build                   no drift
npx vitest run                  19471 passed, 0 failed
npm run scan:public-safety      pass
```

Patch coverage by diff intersection: **333 changed lines across `src/**` and `workers/**`, 0 uncovered.**

Closes #10735
