### PR TITLE
fix(emission-gate): pin a sample to one finalized block, and rotate whole samples (#10742)

### DIFF
--- a/src/emission-gate-sampler.ts
+++ b/src/emission-gate-sampler.ts
@@ -43,6 +43,24 @@ export const SUBNET_EMISSION_ENABLED_PREFIX =
 export const SUBNET_EMA_TAO_FLOW_PREFIX =
   "0x658faa385070e074c85bf6b568cf05559f25bd6b257310b72a9310520b27a626";
 
+/**
+ * The archive endpoints a sample may run against, in preference order.
+ *
+ * BOTH SERVE ARCHIVE STATE, which is what this lane needs -- the lite and
+ * entrypoint endpoints prune, and a pruned node cannot answer a finalized-block
+ * read that is more than a few blocks old.
+ *
+ * ROTATION IS PER SAMPLE, NEVER PER CALL, and that distinction is the whole
+ * lesson of #10742. A sample is a dozen RPC calls that must agree on one block;
+ * spreading those calls across two nodes is precisely how one node ends up
+ * asked about a block the other one reported. Rotating the WHOLE sample gets
+ * the load spreading without ever splitting a sample's reads.
+ */
+export const EMISSION_SAMPLER_ARCHIVE_URLS = [
+  "https://archive.chain.opentensor.ai",
+  "https://bittensor-finney.api.onfinality.io/public",
+] as const;
+
 export interface EmissionGateSamplerOptions {
   rpcUrl: string;
   fetchImpl?: typeof fetch;
@@ -111,14 +129,25 @@ export async function sampleEmissionGate(
     return body.result as T;
   }
 
-  async function keysPaged(prefix: string): Promise<string[]> {
+  async function keysPaged(prefix: string, at: string): Promise<string[]> {
     const keys: string[] = [];
     let startKey: string | undefined;
     for (;;) {
+      // THE PREFIX IS THE FIRST PAGE'S startKey, and that is not a trick for
+      // its own sake. `at` is params[3], so params[2] has to be occupied to
+      // reach it -- and it cannot be `null`, which 400s the RPC proxy (the
+      // constraint this module's header already records, and which the old
+      // conditional spread existed to honour).
+      //
+      // The prefix is a strict prefix of every key under it, so it sorts
+      // BEFORE all of them: `state_getKeysPaged` returns keys strictly greater
+      // than startKey, which is exactly the full set. It is the one value that
+      // is both a legal key-shaped argument and guaranteed to skip nothing.
       const page = await rpc<string[]>("state_getKeysPaged", [
         prefix,
         500,
-        ...(startKey ? [startKey] : []),
+        startKey ?? prefix,
+        at,
       ]);
       if (!page?.length) break;
       keys.push(...page);
@@ -144,13 +173,14 @@ export async function sampleEmissionGate(
    */
   async function queryStorage(
     keys: string[],
+    at: string,
   ): Promise<Map<string, string | null>> {
     const values = new Map<string, string | null>();
     for (let i = 0; i < keys.length; i += STORAGE_BATCH_SIZE) {
       const chunk = keys.slice(i, i + STORAGE_BATCH_SIZE);
       const pages = await rpc<{ changes?: [string, string | null][] }[] | null>(
         "state_queryStorageAt",
-        [chunk],
+        [chunk, at],
       );
       for (const page of pages ?? []) {
         for (const [key, value] of page?.changes ?? []) {
@@ -176,16 +206,36 @@ export async function sampleEmissionGate(
     return bits === null ? null : u64f64U128ToFloat(bits);
   }
 
-  const header = await rpc<{ number: string }>("chain_getHeader", []);
+  // THE WHOLE SAMPLE IS PINNED TO ONE FINALIZED BLOCK, and both halves of that
+  // matter.
+  //
+  // ONE: a sample is a dozen RPC calls. Unpinned, each resolves "best block"
+  // independently, so `block_number` came from one call's head and the storage
+  // values from another's -- and this lane's entire job is to say WHEN a
+  // governance parameter changed. Attributing a change to a block it was not
+  // read at is a wrong answer in the one field the lane exists to produce.
+  //
+  // TWO: the public archive endpoints are a rotating pool. Two calls in one
+  // sample can land on different nodes, and a node that has not yet imported
+  // the head another node just reported answers
+  // "UnknownBlock: Header was not found in the database" -- which is exactly
+  // what production was throwing (#10742). FINALIZED rather than best head is
+  // what makes the hash safe to hand to any node in the pool: a finalized block
+  // does not reorg and every node has it.
+  const at = await rpc<string>("chain_getFinalizedHead", []);
+  const header = await rpc<{ number: string }>("chain_getHeader", [at]);
   const blockNumber = parseInt(header.number, 16);
   const observedAt = now();
 
-  const paramValues = await queryStorage([
-    EMISSION_GATE_BAR_STORAGE_KEY,
-    EMISSION_BAR_QUANTILE_STORAGE_KEY,
-    EMISSION_GATE_EXPONENT_STORAGE_KEY,
-    TOTAL_ISSUANCE_STORAGE_KEY,
-  ]);
+  const paramValues = await queryStorage(
+    [
+      EMISSION_GATE_BAR_STORAGE_KEY,
+      EMISSION_BAR_QUANTILE_STORAGE_KEY,
+      EMISSION_GATE_EXPONENT_STORAGE_KEY,
+      TOTAL_ISSUANCE_STORAGE_KEY,
+    ],
+    at,
+  );
   const bar = u64f64At(paramValues, EMISSION_GATE_BAR_STORAGE_KEY);
   const quantile = u64f64At(paramValues, EMISSION_BAR_QUANTILE_STORAGE_KEY);
   const exponent = u64f64At(paramValues, EMISSION_GATE_EXPONENT_STORAGE_KEY);
@@ -207,8 +257,8 @@ export async function sampleEmissionGate(
     block_emission_halvings: halvings,
   };
 
-  const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX);
-  const enabledValues = await queryStorage(enabledKeys);
+  const enabledKeys = await keysPaged(SUBNET_EMISSION_ENABLED_PREFIX, at);
+  const enabledValues = await queryStorage(enabledKeys, at);
   const currentEnabled = new Map<number, boolean>();
   for (const key of enabledKeys) {
     const netuid = netuidFromKey(key, SUBNET_EMISSION_ENABLED_PREFIX);
@@ -222,13 +272,16 @@ export async function sampleEmissionGate(
     FlowParamItem,
     string,
   ][];
-  const flowValues = await queryStorage(flowEntries.map(([, key]) => key));
+  const flowValues = await queryStorage(
+    flowEntries.map(([, key]) => key),
+    at,
+  );
   const flowObservations: FlowParamObservation[] = flowEntries.map(
     ([item, key]) => ({ item, raw: flowValues.get(key) ?? null }),
   );
 
-  const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX);
-  const emaValues = await queryStorage(emaKeys);
+  const emaKeys = await keysPaged(SUBNET_EMA_TAO_FLOW_PREFIX, at);
+  const emaValues = await queryStorage(emaKeys, at);
   const currentEma = new Map<number, { block: number } | null>();
   for (const key of emaKeys) {
     const netuid = netuidFromKey(key, SUBNET_EMA_TAO_FLOW_PREFIX);
@@ -244,4 +297,47 @@ export async function sampleEmissionGate(
     flow_observations: flowObservations,
     current_ema: [...currentEma],
   };
+}
+
+/**
+ * Sample against the archive pool, rotating the ENDPOINT and failing over.
+ *
+ * The rotation offset is the caller's, not this module's: a Worker isolate that
+ * kept its own counter would restart at zero on every cold start and hammer the
+ * first endpoint, which is the opposite of spreading load. Ticks are what
+ * actually alternate, so the tick supplies the offset.
+ *
+ * FAILOVER RE-RUNS THE WHOLE SAMPLE, never a single call. A half-sample from one
+ * node completed against another is the split this lane just stopped doing.
+ */
+export async function sampleEmissionGateWithFailover(
+  options: Omit<EmissionGateSamplerOptions, "rpcUrl"> & {
+    urls?: readonly string[];
+    /** Which endpoint to start from; any integer, including a tick counter. */
+    offset?: number;
+  } = {},
+): Promise<EmissionGateSample> {
+  const urls = options.urls?.length
+    ? options.urls
+    : EMISSION_SAMPLER_ARCHIVE_URLS;
+  const start = Number.isFinite(options.offset)
+    ? Math.abs(Math.trunc(options.offset as number))
+    : 0;
+  let lastError: unknown;
+  for (let i = 0; i < urls.length; i += 1) {
+    const rpcUrl = urls[(start + i) % urls.length]!;
+    try {
+      return await sampleEmissionGate({ ...options, rpcUrl });
+    } catch (error) {
+      // Kept, not swallowed: if every endpoint fails the caller needs the last
+      // reason, and a lane that reported a generic failure over a specific one
+      // is how #10742 hid behind a stale issue title for a week.
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(
+        `emission-gate sample failed on all ${urls.length} endpoint(s)`,
+      );
 }

--- a/tests/emission-gate-sampler.test.ts
+++ b/tests/emission-gate-sampler.test.ts
@@ -5,9 +5,16 @@
 // own comment at the assertion).
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { handleScheduled } from "../workers/api.ts";
+import {
+  EMISSION_GATE_SAMPLE_CRON,
+  EMISSION_GATE_SAMPLE_INTERVAL_MS,
+} from "../workers/config.ts";
 import {
   netuidFromKey,
+  EMISSION_SAMPLER_ARCHIVE_URLS,
   sampleEmissionGate,
+  sampleEmissionGateWithFailover,
   STORAGE_BATCH_SIZE,
   SUBNET_EMA_TAO_FLOW_PREFIX,
   SUBNET_EMISSION_ENABLED_PREFIX,
@@ -68,9 +75,14 @@ function changesFor(
   return [{ changes: keys.map((key) => [key, value(key)]) }];
 }
 
-/** The minimal healthy chain: header, null gate params, one enabled subnet,
- * flow params unset, one EMA entry. */
+/** The finalized block every call in a sample must be pinned to. */
+const FINALIZED_HASH =
+  "0xe37c081adf43c0e284d4fb7ee3c21b58e057bf50548d8821d340f631f91ba244";
+
+/** The minimal healthy chain: finalized head, header, null gate params, one
+ * enabled subnet, flow params unset, one EMA entry. */
 function healthyAnswer(method: string, params: unknown[]): unknown {
+  if (method === "chain_getFinalizedHead") return FINALIZED_HASH;
   if (method === "chain_getHeader") return { number: "0x85a1c8" };
   if (method === "state_getKeysPaged") {
     const prefix = params[0];
@@ -161,15 +173,47 @@ describe("sampleEmissionGate", () => {
     assert.deepEqual(sample.current_enabled, [[7, true]]);
   });
 
-  test("state_getKeysPaged omits params[2] on the first page — null 400s the proxy", async () => {
+  test("state_getKeysPaged never passes null for params[2] — it 400s the proxy", async () => {
+    // The block hash is params[3], so params[2] must be occupied to reach it,
+    // and `null` is the one value the RPC proxy rejects. The PREFIX is used
+    // instead: it sorts before every key under it, so it skips nothing.
     const { impl, calls } = rpcFetch(healthyAnswer);
     await sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl });
     const firstPaged = calls.find((c) => c.method === "state_getKeysPaged")!;
+    assert.notEqual(firstPaged.params[2], null, "null 400s the proxy");
     assert.equal(
-      firstPaged.params.length,
-      2,
-      "third param must be ABSENT, not null",
+      firstPaged.params[2],
+      firstPaged.params[0],
+      "the prefix is the first page's startKey",
     );
+    assert.equal(firstPaged.params[3], FINALIZED_HASH);
+  });
+
+  test("EVERY read is pinned to the one finalized block", async () => {
+    // A sample is a dozen calls. Unpinned, each resolves "best block" on
+    // whichever archive node the rotation handed it, so block_number could come
+    // from one block and the values from another -- and this lane's whole job is
+    // to say WHEN a parameter changed. It is also what threw UnknownBlock in
+    // production (#10742): a node that had not imported another node's head.
+    const { impl, calls } = rpcFetch(healthyAnswer);
+    await sampleEmissionGate({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+
+    assert.equal(
+      calls.filter((c) => c.method === "chain_getFinalizedHead").length,
+      1,
+      "the block is resolved ONCE, then reused",
+    );
+    assert.deepEqual(
+      calls.find((c) => c.method === "chain_getHeader")!.params,
+      [FINALIZED_HASH],
+      "the header is read AT that block, not at the head",
+    );
+    for (const c of calls.filter((x) => x.method === "state_queryStorageAt")) {
+      assert.equal(c.params[1], FINALIZED_HASH, "storage read off-block");
+    }
+    for (const c of calls.filter((x) => x.method === "state_getKeysPaged")) {
+      assert.equal(c.params[3], FINALIZED_HASH, "keys read off-block");
+    }
   });
 
   test("paginates keysPaged past a full page, passing the last key", async () => {
@@ -373,5 +417,198 @@ describe("sampleEmissionGate", () => {
       fetchImpl: impl,
     });
     assert.equal(sample.current.emission_gate_bar, 1);
+  });
+});
+
+describe("rotating the archive pool", () => {
+  test("both declared endpoints serve ARCHIVE state", () => {
+    // The lite and entrypoint endpoints prune, and a pruned node cannot answer
+    // a finalized-block read that is more than a few blocks old.
+    assert.deepEqual(EMISSION_SAMPLER_ARCHIVE_URLS, [
+      "https://archive.chain.opentensor.ai",
+      "https://bittensor-finney.api.onfinality.io/public",
+    ]);
+  });
+
+  test("the offset picks the endpoint, so consecutive ticks alternate", async () => {
+    // One sample is a dozen fetches to the SAME endpoint, so what is asserted
+    // is the endpoint each sample ran on -- not the call count.
+    const perSample: string[] = [];
+    async function runAt(offset: number) {
+      const seen = new Set<string>();
+      const impl = (async (url: string, init?: RequestInit) => {
+        seen.add(String(url));
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          method: string;
+          params: unknown[];
+        };
+        return {
+          ok: true,
+          json: async () => ({
+            result: healthyAnswer(body.method, body.params),
+          }),
+        } as unknown as Response;
+      }) as unknown as typeof fetch;
+      await sampleEmissionGateWithFailover({ offset, fetchImpl: impl });
+      assert.equal(seen.size, 1, "a sample must not split across endpoints");
+      perSample.push([...seen][0]!);
+    }
+    for (const offset of [0, 1, 2, 3]) await runAt(offset);
+    assert.deepEqual(perSample, [
+      EMISSION_SAMPLER_ARCHIVE_URLS[0],
+      EMISSION_SAMPLER_ARCHIVE_URLS[1],
+      EMISSION_SAMPLER_ARCHIVE_URLS[0],
+      EMISSION_SAMPLER_ARCHIVE_URLS[1],
+    ]);
+  });
+
+  test("a failing endpoint fails the WHOLE sample over, not one call", async () => {
+    // Completing a half-sample from one node against another is the split this
+    // lane exists to stop making.
+    const seen: string[] = [];
+    const impl = (async (url: string, init?: RequestInit) => {
+      const host = String(url);
+      seen.push(host);
+      if (host === EMISSION_SAMPLER_ARCHIVE_URLS[0]) {
+        throw new Error("archive unreachable");
+      }
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        method: string;
+        params: unknown[];
+      };
+      return {
+        ok: true,
+        json: async () => ({
+          result: healthyAnswer(body.method, body.params),
+        }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const sample = await sampleEmissionGateWithFailover({
+      offset: 0,
+      fetchImpl: impl,
+    });
+    assert.equal(sample.block_number, 0x85a1c8);
+    assert.equal(seen[0], EMISSION_SAMPLER_ARCHIVE_URLS[0], "tried first");
+    assert.ok(
+      seen.slice(1).every((u) => u === EMISSION_SAMPLER_ARCHIVE_URLS[1]),
+      "every call after the failover ran on the SECOND endpoint",
+    );
+  });
+
+  test("all endpoints failing throws the LAST reason, not a generic one", async () => {
+    // A lane reporting a generic failure over a specific one is how #10742 hid
+    // behind a stale issue title for a week.
+    const impl = (async (url: string) => {
+      throw new Error(
+        `down: ${String(url).includes("onfinality") ? "b" : "a"}`,
+      );
+    }) as unknown as typeof fetch;
+    await assert.rejects(
+      () => sampleEmissionGateWithFailover({ offset: 0, fetchImpl: impl }),
+      /down: b/,
+    );
+  });
+
+  test("an explicit override runs alone, with no failover", async () => {
+    const used: string[] = [];
+    const impl = (async (url: string) => {
+      used.push(String(url));
+      throw new Error("nope");
+    }) as unknown as typeof fetch;
+    await assert.rejects(() =>
+      sampleEmissionGateWithFailover({
+        urls: ["https://operator.example"],
+        fetchImpl: impl,
+      }),
+    );
+    assert.deepEqual(used, ["https://operator.example"]);
+  });
+});
+
+describe("the cron branch", () => {
+  test("no sync secret declines before any chain read", async () => {
+    let fetched = 0;
+    const original = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetched += 1;
+      return new Response("{}");
+    }) as typeof fetch;
+    try {
+      const out = (await handleScheduled(
+        { cron: EMISSION_GATE_SAMPLE_CRON } as unknown as ScheduledController,
+        {} as unknown as Parameters<typeof handleScheduled>[1],
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      )) as { ok: boolean; skipped?: boolean; reason?: string };
+      assert.equal(out.ok, false);
+      assert.equal(out.skipped, true);
+      assert.equal(fetched, 0, "a lane that cannot persist must not read");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("an operator's override runs alone; otherwise the pool rotates", async () => {
+    // The branch's own decision, asserted through the URLs the sample reaches.
+    const original = globalThis.fetch;
+    async function hostsFor(env: Record<string, unknown>) {
+      const seen = new Set<string>();
+      globalThis.fetch = (async (url: string, init?: RequestInit) => {
+        const href = String(url);
+        if (href.includes("internal.metagraph.sh")) {
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }
+        seen.add(new URL(href).origin);
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          method: string;
+          params: unknown[];
+        };
+        return new Response(
+          JSON.stringify({ result: healthyAnswer(body.method, body.params) }),
+        );
+      }) as typeof fetch;
+      await handleScheduled(
+        { cron: EMISSION_GATE_SAMPLE_CRON } as unknown as ScheduledController,
+        { EMISSION_GATE_SYNC_SECRET: "s", ...env } as never,
+        { waitUntil: () => {} } as unknown as ExecutionContext,
+      ).catch(() => {});
+      return [...seen];
+    }
+    try {
+      assert.deepEqual(
+        await hostsFor({
+          EMISSION_SAMPLER_RPC_URL: "https://operator.example",
+        }),
+        ["https://operator.example"],
+        "an explicit endpoint means THAT endpoint",
+      );
+      const rotated = await hostsFor({});
+      assert.equal(rotated.length, 1, "one sample, one endpoint");
+      assert.ok(
+        (EMISSION_SAMPLER_ARCHIVE_URLS as readonly string[]).some((u) =>
+          u.startsWith(rotated[0]!),
+        ),
+        "absent an override it comes from the archive pool",
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test("the interval is the cron's cadence, which is what rotates the pool", () => {
+    // A wrong constant here would not fail anything loudly -- it would just
+    // stop alternating, and quietly pin every sample to one endpoint.
+    assert.equal(EMISSION_GATE_SAMPLE_INTERVAL_MS, 10 * 60 * 1000);
+    assert.equal(EMISSION_GATE_SAMPLE_CRON, "3,13,23,33,43,53 * * * *");
+  });
+
+  test("a non-Error thrown by every endpoint still yields an Error", async () => {
+    const impl = (async () => {
+      throw "a bare string";
+    }) as unknown as typeof fetch;
+    await assert.rejects(
+      () => sampleEmissionGateWithFailover({ offset: 0, fetchImpl: impl }),
+      /failed on all 2 endpoint\(s\)/,
+    );
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -421,7 +421,7 @@ import { handleBadgeRequest } from "../src/badge.ts";
 import { handleOgImage } from "../src/og-image.ts";
 import { handleIconProxy } from "../src/icon-proxy.ts";
 import { maskRouteParams } from "../src/route-label.ts";
-import { sampleEmissionGate } from "../src/emission-gate-sampler.ts";
+import { sampleEmissionGateWithFailover } from "../src/emission-gate-sampler.ts";
 import { checkEmissionDrift } from "../src/emission-drift-check.ts";
 import { refreshLiveEconomics } from "../src/live-economics-refresh.ts";
 import { runNeuronsStalenessWatchdog } from "../src/neurons-staleness-watchdog.ts";
@@ -516,6 +516,7 @@ import {
   LAKEHOUSE_SEAM_CRON,
   SAFE_MODE_WATCHDOG_CRON,
   EMISSION_GATE_SAMPLE_CRON,
+  EMISSION_GATE_SAMPLE_INTERVAL_MS,
   EMISSION_DRIFT_CHECK_CRON,
   NEURONS_STALENESS_WATCHDOG_CRON,
   NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
@@ -2904,11 +2905,18 @@ async function dispatchScheduled(
         reason: "EMISSION_GATE_SYNC_SECRET not configured",
       };
     }
-    const sample = await sampleEmissionGate({
-      rpcUrl:
-        env.EMISSION_SAMPLER_RPC_URL ||
-        env.CHAIN_HEAD_RPC_URL ||
-        "https://archive.chain.opentensor.ai",
+    // An explicit override still wins and runs alone -- an operator naming one
+    // endpoint means that endpoint, not "start there and fail over elsewhere".
+    // Absent one, the sample rotates across the archive pool, a WHOLE sample per
+    // endpoint (#10742).
+    //
+    // The offset is derived from the tick rather than kept in module state: an
+    // isolate-local counter restarts at zero on every cold start, so it would
+    // pin nearly every sample to the first endpoint and spread nothing.
+    const override = env.EMISSION_SAMPLER_RPC_URL || env.CHAIN_HEAD_RPC_URL;
+    const sample = await sampleEmissionGateWithFailover({
+      urls: override ? [override] : undefined,
+      offset: Math.floor(Date.now() / EMISSION_GATE_SAMPLE_INTERVAL_MS),
     });
     const response = await handleEmissionGateSync(
       new Request(

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -247,6 +247,14 @@ export const SAFE_MODE_WATCHDOG_CRON = "41 * * * *";
 // itself. Same 10-minute cadence the box timer and the Actions schedule
 // used. Must match a wrangler.jsonc cron entry.
 export const EMISSION_GATE_SAMPLE_CRON = "3,13,23,33,43,53 * * * *";
+
+/** The sampler's cadence, as milliseconds.
+ *
+ * Derived from the cron above rather than restated: it is what turns wall-clock
+ * time into a tick ordinal, which is what rotates the archive endpoint across
+ * ticks (#10742). An isolate-local counter cannot do that job -- it restarts at
+ * zero on every cold start. */
+export const EMISSION_GATE_SAMPLE_INTERVAL_MS = 10 * 60 * 1000;
 // #8749: the live emission-drift check, formerly the 30-minute Actions
 // schedule -- the same reconstruction CI pins against a fixture, held against
 // live chain state. Reads and alerts, writes nothing; a divergence throws so


### PR DESCRIPTION
## The error, and why nobody saw it

Production was throwing:

```
state_queryStorageAt: Cannot resolve a block range ['"0xe37c081a…"' … '"Some(0xe37c081a…)"'].
UnknownBlock: Header was not found in the database
```

It landed in a PostHog issue **titled `state_getStorage: HTTP 429`**, because the fingerprint is `cron:<lane>:Error` — lane-scoped, so everything this lane throws groups under whatever it threw first, on 2026-08-03. An operator reading that title would add backoff and see nothing improve. That's why it sat a week.

## The cause

**A sample is a dozen RPC calls, and not one of them named a block.** Each resolved "best block" independently. Against a rotating pool of public archive endpoints that's two different questions to two different nodes — and a node that hasn't yet imported the head another node just reported answers exactly that error.

## The correctness bug underneath it

Independent of the error: `block_number` came from `chain_getHeader`'s block, and the storage values from whatever block each later call happened to resolve.

**This lane's entire job is to say *when* a governance parameter changed** — and it was free to attribute a change to a block it wasn't read at.

## The fix

Resolve `chain_getFinalizedHead` **once**, pass that hash to every read.

**Finalized, not best head** — that's what makes the hash safe to hand to any node in a pool: a finalized block doesn't reorg, and every node has it.

`state_getKeysPaged` needed care. The hash is `params[3]`, so `params[2]` must be occupied to reach it — and `null` is the one value the RPC proxy 400s (a constraint this module's header already recorded, and which the old conditional spread existed to honour). The **prefix** is passed instead: it's a strict prefix of every key beneath it, so it sorts before all of them and skips nothing.

## Rotation — per sample, never per call

Spreading a sample's calls across two nodes is *precisely* how one node gets asked about another's block. `sampleEmissionGateWithFailover` runs a **whole sample** against one endpoint and fails the whole thing over.

| Endpoint | |
| --- | --- |
| `archive.chain.opentensor.ai` | official Opentensor public archive |
| `bittensor-finney.api.onfinality.io/public` | OnFinality public |

Both serve **archive** state — the `lite` and `entrypoint` endpoints prune and can't answer an older finalized read.

The offset comes from the **tick**, not module state: an isolate-local counter restarts at zero on every cold start, so it would pin nearly every sample to the first endpoint and spread nothing.

An explicit `EMISSION_SAMPLER_RPC_URL` still wins and runs **alone** — an operator naming one endpoint means that endpoint, not "start there and wander".

When every endpoint fails, the **last** reason is thrown rather than a generic one. A lane reporting a generic failure over a specific one is how this hid behind a stale title in the first place.

## Tests

22 passing, including:

- **every read is pinned** — `chain_getFinalizedHead` called exactly once, and every `state_queryStorageAt` / `state_getKeysPaged` carries that hash
- **`params[2]` is never `null`**, and is the prefix
- **a sample never splits across endpoints** (asserted as `seen.size === 1`)
- failover moves the *whole* sample; the last reason survives; an override runs alone

Closes #10742
