### PR TITLE
fix(neon): cap what the write buffer may hold, and send the rest direct

### DIFF
--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -359,6 +359,35 @@ const TRANSIENT_STUB_ERROR =
 export const ENQUEUE_ATTEMPTS = 3;
 
 /**
+ * The largest statement that may be buffered. Anything bigger goes DIRECT.
+ *
+ * WHY A CAP EXISTS AT ALL (#10744). Durable Object storage rejected the bulk
+ * writes outright -- "Internal error in Durable Object storage caused object to
+ * be reset" in production on 2026-08-11 -- and no retry helps, because the
+ * platform is refusing the shape rather than failing transiently. A neuron or
+ * account-position upsert is thousands of rows and megabytes of JSON; chunking
+ * it into 96 KiB values and committing them in one put() is simply more than
+ * that store wants to hold at once.
+ *
+ * 64 KiB, AND THE NUMBER MATTERS LESS THAN THE SPLIT IT CREATES. The buffer
+ * exists to collapse FREQUENT writes -- tao_usd_index every 60s, the ledger
+ * lanes every few seconds -- and every one of those is small. The megabyte
+ * upserts are the infrequent ones: neurons every 15 minutes. Sending those
+ * direct costs one connection per quarter hour and removes the entire class of
+ * failure, while the writes that actually pin the compute still batch.
+ *
+ * MEASURED IN BYTES, not rows or characters: an SS58 address is ASCII but a
+ * subnet name need not be, and a cap counted in code units would let a
+ * multi-byte payload past it.
+ */
+export const MAX_BUFFERED_PAYLOAD_BYTES = 64 * 1024;
+
+/** UTF-8 byte length -- the unit the cap is stated in. */
+export function payloadBytes(payload: string): number {
+  return new TextEncoder().encode(payload).length;
+}
+
+/**
  * A `PgUnsafe` that enqueues instead of executing.
  *
  * Drop-in for `createPgSql` on the write lanes: `PgUnsafe` is a one-method
@@ -448,11 +477,25 @@ export function neonWriteRunner(
   lane: string,
   hyperdrive: HyperdriveLike | undefined,
 ): { unsafe(text: string, values?: unknown[]): Promise<unknown> } | null {
+  const direct =
+    hyperdrive?.connectionString && ctx ? createPgSql(hyperdrive, ctx) : null;
   const buffer = env?.NEON_WRITE_BUFFER as NeonWriteBufferNamespace | undefined;
-  if (buffer && neonWriteBufferEnabled(env, lane)) {
-    return createBufferedPgSql(buffer, lane);
-  }
-  return hyperdrive?.connectionString && ctx
-    ? createPgSql(hyperdrive, ctx)
-    : null;
+  if (!buffer || !neonWriteBufferEnabled(env, lane)) return direct;
+  const buffered = createBufferedPgSql(buffer, lane);
+  // No direct runner to fall back to: buffer everything and let an oversized
+  // statement fail loudly at the enqueue rather than be silently dropped.
+  if (!direct) return buffered;
+  return {
+    async unsafe(text: string, values: unknown[] = []): Promise<unknown> {
+      // SIZE DECIDES, PER STATEMENT. One lane issues both shapes -- the same
+      // neurons lane writes a small watermark row and a thousands-row upsert --
+      // so this cannot be a per-lane flag without either losing the batching on
+      // the small writes or keeping the failure on the big ones.
+      const size = payloadBytes(encodeStatement({ lane, text, values }));
+      if (size > MAX_BUFFERED_PAYLOAD_BYTES) {
+        return direct.unsafe(text, values);
+      }
+      return buffered.unsafe(text, values);
+    },
+  };
 }

--- a/tests/neon-write-buffer.test.ts
+++ b/tests/neon-write-buffer.test.ts
@@ -21,7 +21,9 @@ import {
   FLUSH_INTERVAL_MS,
   groupChunkKeys,
   joinPayload,
+  MAX_BUFFERED_PAYLOAD_BYTES,
   MAX_BUFFERED_STATEMENTS,
+  payloadBytes,
   NEVER_BUFFER_LANES,
   neonWriteBufferEnabled,
   neonWriteBufferLanes,
@@ -568,5 +570,81 @@ describe("a non-Error throw from the stub", () => {
       ENQUEUE_ATTEMPTS,
       "classified as transient, so retried",
     );
+  });
+});
+
+describe("oversized statements go direct, not into DO storage (#10744)", () => {
+  const HD = { connectionString: "postgresql://x" };
+  const CTX = { waitUntil: () => undefined };
+
+  function seam() {
+    const enqueued: unknown[] = [];
+    const direct: string[] = [];
+    const ns = {
+      idFromName: (n: string) => n,
+      get: () => ({
+        async fetch(request: Request) {
+          enqueued.push(await request.json());
+          return new Response("{}", { status: 200 });
+        },
+      }),
+    };
+    return { enqueued, direct, ns };
+  }
+
+  test("a SMALL statement is buffered -- that is the whole point", async () => {
+    const s = seam();
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER: s.ns, NEON_WRITE_BUFFER_LANES: "neurons" },
+      CTX,
+      "neurons",
+      HD,
+    );
+    await sql?.unsafe("INSERT INTO neurons VALUES ($1)", [1]);
+    assert.equal(s.enqueued.length, 1);
+  });
+
+  test("an OVERSIZED statement bypasses the buffer entirely", async () => {
+    // DO storage rejected these outright in production -- "Internal error in
+    // Durable Object storage caused object to be reset" -- and no retry helps,
+    // because the platform is refusing the shape rather than failing
+    // transiently. It must never reach storage at all.
+    const s = seam();
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER: s.ns, NEON_WRITE_BUFFER_LANES: "neurons" },
+      CTX,
+      "neurons",
+      HD,
+    );
+    const huge = "x".repeat(MAX_BUFFERED_PAYLOAD_BYTES + 1);
+    // The direct runner is a real createPgSql against an unusable host, so the
+    // proof is that it TRIED to connect rather than enqueueing.
+    await assert.rejects(() => sql!.unsafe(`INSERT INTO t VALUES ('${huge}')`));
+    assert.deepEqual(s.enqueued, [], "nothing may reach DO storage");
+  });
+
+  test("the cap is measured in BYTES, not code units", async () => {
+    // A multi-byte payload just under the cap in characters is over it in
+    // bytes. Counting characters would let exactly the payloads this exists to
+    // stop straight through.
+    const twoByte = "τ".repeat(MAX_BUFFERED_PAYLOAD_BYTES - 100);
+    assert.ok(payloadBytes(twoByte) > MAX_BUFFERED_PAYLOAD_BYTES);
+    assert.ok(twoByte.length < MAX_BUFFERED_PAYLOAD_BYTES);
+  });
+
+  test("with NO direct runner an oversized statement still buffers", async () => {
+    // Nothing to fall back to. Buffering and failing loudly at the enqueue
+    // beats silently dropping a capture row.
+    const s = seam();
+    const sql = neonWriteRunner(
+      { NEON_WRITE_BUFFER: s.ns, NEON_WRITE_BUFFER_LANES: "neurons" },
+      null,
+      "neurons",
+      undefined,
+    );
+    await sql?.unsafe(
+      `INSERT INTO t VALUES ('${"x".repeat(MAX_BUFFERED_PAYLOAD_BYTES + 1)}')`,
+    );
+    assert.equal(s.enqueued.length, 1);
   });
 });


### PR DESCRIPTION
## Problem

The buffer was disabled in #10734 because DO storage rejected the bulk writes outright:

```
Internal error in Durable Object storage caused object to be reset
    — nominator-positions, 10:23:40Z
```

That is the **platform refusing the shape**, not a transient. No retry helps — which is why #10722
(bounded `list()` + missing re-arm) and #10729 (enqueue retry) each fixed a real failure and neither
recovered it.

**The cause is this design's own.** A neuron or account-position upsert is thousands of rows and
megabytes of JSON; chunking that into 96 KiB values and committing them in a single `put()` is more
than that store wants to hold.

## Fix

Anything over `MAX_BUFFERED_PAYLOAD_BYTES` (64 KiB) goes **direct** and never touches DO storage.

The number matters less than the split it creates:

| | |
|---|---|
| **Small, frequent** — `tao_usd_index` 60s, ledger lanes seconds | **Buffered.** These are what pin the compute; batching them is the entire purpose. |
| **Large, infrequent** — `neurons` every 15 min | **Direct.** One connection per quarter hour, and the whole failure class disappears. |

**Per statement, not per lane.** The same `neurons` lane writes both a small watermark row and a
thousands-row upsert, so a per-lane flag would either lose the batching on the small writes or keep the
failure on the big ones.

**Byte-measured.** An SS58 address is ASCII but a subnet name need not be — a cap counted in code units
would let exactly the payloads this exists to stop straight through, and there is a test for that.

**No direct runner available?** It still buffers. Failing loudly at the enqueue beats silently dropping
a capture row.

## Validation

```
npx tsc --noEmit · lint · format:check   # clean
npm run validate                         # exit 0
npx vitest run <3 suites>                # 48 + hub + capture-state, all passing
```

Patch coverage by diff intersection: **zero uncovered statements, zero uncovered branches.**

## Re-enabling

`NEON_WRITE_BUFFER_LANES` stays **empty** in this PR. Turning it back on is a separate one-line change
so that if it misbehaves a third time, the revert is a single config commit and not entangled with the
fix. I will re-enable and verify consecutive flushes with a backlog, plus no DO storage errors in
PostHog, before calling it working.

Closes #10744
