### PR TITLE
fix(r2-sql): break on a repeated upstream 5xx, so one outage costs one exception (#10741)

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -115,10 +115,51 @@ let r2SqlFailureGeneration = 0;
  */
 let r2SqlRateLimitedUntilMs = 0;
 
+/**
+ * How many CONSECUTIVE upstream 5xx open the outage breaker.
+ *
+ * Two, not one, and the difference is the whole point: a lone 500 is a blip
+ * worth an exception, because it might be the first sign of a query this repo
+ * needs to fix. Two in a row is an upstream that is down, and the 1,546 that
+ * followed the first on 2026-08-03..10 said nothing the first had not (#10741).
+ */
+export const R2_SQL_OUTAGE_STREAK = 2;
+
+/** Shorter than the rate-limit cooldown deliberately. A 429 has a budget that
+ * genuinely needs a minute to refill; an upstream fault has no budget, so the
+ * only thing this cooldown buys is not re-reporting -- and holding a whole tier
+ * dark for a minute to save log lines is the wrong trade. */
+export const R2_SQL_OUTAGE_COOLDOWN_MS = 15_000;
+
+/** The status floor this module treats as "the far side broke, not us". */
+const SERVER_ERROR_FLOOR = 500;
+
+/**
+ * When the upstream-outage cooldown expires; 0 when closed.
+ *
+ * A SEPARATE breaker from the rate-limit one, not a widened version of it. They
+ * mean different things and must be able to be open at once: 429 says the
+ * ACCOUNT budget is spent and backing off refills it, 5xx says R2 SQL itself is
+ * failing and backing off changes nothing upstream. Collapsing them would let a
+ * 15s outage cooldown clear a 60s rate-limit cooldown early.
+ */
+let r2SqlOutageUntilMs = 0;
+
+/** Consecutive 5xx seen. Reset by ANY response that is not a 5xx -- including a
+ * rejection, because a 429 or a 422 both prove the far side is answering. */
+let r2SqlServerErrorStreak = 0;
+
 registerModuleStateReset("src/r2-sql.ts", () => {
   r2SqlFailureGeneration = 0;
   r2SqlRateLimitedUntilMs = 0;
+  r2SqlOutageUntilMs = 0;
+  r2SqlServerErrorStreak = 0;
 });
+
+/** Milliseconds remaining on the upstream-outage cooldown, or 0 when closed. */
+export function r2SqlOutageRemainingMs(nowMs: number = Date.now()): number {
+  return Math.max(0, r2SqlOutageUntilMs - nowMs);
+}
 
 // Same contract as usage-telemetry's storm window: wrangler vars arrive as
 // strings, and stating the shape once as a schema beats a typeof/isFinite
@@ -314,6 +355,13 @@ function failureClassification(
  */
 const RATE_LIMITED_CODE = "rate_limited";
 
+/** The `error_code` a query suppressed by the OUTAGE breaker reports.
+ *
+ * Distinct from `rate_limited` so a reader can tell which breaker declined:
+ * "the account budget is spent" and "the engine is failing" call for different
+ * responses, and one label for both would hide that. */
+const UPSTREAM_DOWN_CODE = "upstream_down";
+
 /**
  * The failure codes that are CAPACITY, not correctness (#9900).
  *
@@ -336,6 +384,11 @@ const EXPECTED_FAILURE_CODES: ReadonlySet<string> = new Set([
   "timeout",
   "http_429",
   RATE_LIMITED_CODE,
+  // The query the OUTAGE breaker never sent. The 5xx responses themselves stay
+  // OFF this list on purpose: a first 500 must still reach the inbox, because
+  // it is the only thing that would tell us a query in this repo started
+  // breaking the engine. It is the suppressed follow-ups that carry nothing.
+  UPSTREAM_DOWN_CODE,
 ]);
 
 /** Whether a classified r2-sql failure is an expected capacity condition. */
@@ -381,6 +434,22 @@ export async function r2SqlQuery<Row = Record<string, unknown>>(
     return null;
   }
   const now = deps.now ?? Date.now;
+  const outage = r2SqlOutageRemainingMs(now());
+  if (outage > 0) {
+    // The engine is failing, so this query cannot succeed. Decline WITHOUT the
+    // exception hop, for the same reason the rate-limit branch below does: the
+    // 5xx that opened this breaker already recorded one, and 1,546 identical
+    // follow-ups said nothing it had not (#10741).
+    r2SqlFailureGeneration += 1;
+    const detail = `r2 sql: upstream unavailable, ${outage}ms of cooldown remaining`;
+    console.error("[r2-sql]", UPSTREAM_DOWN_CODE, r2SqlQueryKind(sql), detail);
+    try {
+      deps.onError?.(detail);
+    } catch {
+      // A caller's own reporting must never turn a declined query into a thrown one.
+    }
+    return null;
+  }
   const remaining = r2SqlRateLimitRemainingMs(now());
   if (remaining > 0) {
     // The account budget is known-exhausted, so this query cannot succeed and
@@ -433,6 +502,19 @@ export async function r2SqlQuery<Row = Record<string, unknown>>(
     } as RequestInit);
     if (!res?.ok) {
       thrownCode = `http_${res?.status}`;
+      if ((res?.status ?? 0) >= SERVER_ERROR_FLOOR) {
+        // Opened BEFORE the throw, exactly as the rate-limit branch is, so this
+        // rejection records one exception and the callers behind it are
+        // declined rather than each paying for their own.
+        r2SqlServerErrorStreak += 1;
+        if (r2SqlServerErrorStreak >= R2_SQL_OUTAGE_STREAK) {
+          r2SqlOutageUntilMs = now() + R2_SQL_OUTAGE_COOLDOWN_MS;
+        }
+      } else {
+        // ANY non-5xx response proves the far side is answering, so the streak
+        // is not merely paused -- it is over.
+        r2SqlServerErrorStreak = 0;
+      }
       if (res?.status === RATE_LIMIT_STATUS) {
         // Opened BEFORE the throw, so the catch below records exactly one
         // exception for this rejection and every caller behind it is suppressed
@@ -444,6 +526,7 @@ export async function r2SqlQuery<Row = Record<string, unknown>>(
         `r2 sql: HTTP ${res?.status}${await rejectionDetail(res)}`,
       );
     }
+    r2SqlServerErrorStreak = 0;
     const body = (await res.json()) as R2SqlBody;
     if (body?.success !== true) {
       const first = body?.errors?.[0];

--- a/tests/cross-view-agreement.test.ts
+++ b/tests/cross-view-agreement.test.ts
@@ -16,7 +16,8 @@
 // A view is allowed to DECLINE (503). What it may not do is claim a tier
 // answered and hand back nothing while its twin hands back rows.
 import assert from "node:assert/strict";
-import { beforeEach, describe, test, vi } from "vitest";
+import { beforeEach, describe, test, vi, afterEach } from "vitest";
+import { resetModuleState } from "../src/module-state-registry.ts";
 
 // The hot tier is Postgres now (#10179), reached through `new Client(...)`
 // inside src/read-store.ts -- and every view here is entered through
@@ -36,6 +37,12 @@ import { resetDecodeWatermarkCache } from "../src/decode-watermark.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 import { jsonBody } from "./row-type.ts";
+
+// r2-sql's breakers are module-global by design (an account rate limit and an
+// upstream outage are both account-wide facts). Tests here deliberately fail a
+// tier read, and the global setup resets per FILE -- too coarse when one test's
+// opened breaker would decline the next test's query.
+afterEach(() => resetModuleState());
 
 const SEAM = DEFAULT_BLOCKS_SEAM; // 8_759_336
 /** A block in the ~8.76M-block range that answered `events: []` for all of

--- a/tests/projection-lanes.test.ts
+++ b/tests/projection-lanes.test.ts
@@ -5,6 +5,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { afterEach, describe, test, vi } from "vitest";
+import { resetModuleState } from "../src/module-state-registry.ts";
 import {
   PROJECTION_LANES,
   PROJECTION_NETWORKS,
@@ -128,6 +129,13 @@ const realFetch = globalThis.fetch;
 afterEach(() => {
   globalThis.fetch = realFetch;
   vi.useRealTimers();
+  // Several tests here deliberately fail their lakehouse query, and r2-sql's
+  // breakers are module-global by design (the account rate limit and the
+  // upstream outage are both account-wide facts, not per-caller ones). The
+  // global setup file resets per FILE, which is the right granularity for
+  // `isolate: false` but too coarse here: a test that opens a breaker would
+  // otherwise decline every later test's query in this file.
+  resetModuleState();
 });
 
 const LAKE_ENV = { R2_SQL_TOKEN: "cfut_test" };

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -7,7 +7,10 @@ import assert from "node:assert/strict";
 import { afterEach, describe, test } from "vitest";
 import {
   currentR2SqlFailureGeneration,
+  R2_SQL_OUTAGE_COOLDOWN_MS,
+  R2_SQL_OUTAGE_STREAK,
   isExpectedR2SqlFailure,
+  r2SqlOutageRemainingMs,
   isR2SqlConfigured,
   r2SqlQuery,
   r2SqlQueryKind,
@@ -975,5 +978,130 @@ describe("r2SqlQuery marks capacity failures expected (#9900)", () => {
     });
     assert.equal(captured[0]?.expected, false);
     assert.equal(captured[0]?.errorCode, "http_422");
+  });
+});
+
+describe("the upstream-outage breaker (#10741)", () => {
+  const SQL = "SELECT 1";
+  function res(status: number) {
+    return {
+      ok: status < 400,
+      status,
+      json: async () => ({ result: [], success: true }),
+      text: async () => "",
+    } as unknown as Response;
+  }
+
+  test("a FIRST 500 still throws — it may be our query that broke the engine", async () => {
+    const clock = 1_000;
+    let calls = 0;
+    const out = await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: (async () => {
+        calls += 1;
+        return res(500);
+      }) as unknown as typeof fetch,
+      now: () => clock,
+    });
+    assert.equal(out, null);
+    assert.equal(calls, 1, "the first 5xx is SENT, not suppressed");
+    assert.equal(r2SqlOutageRemainingMs(clock), 0, "one 500 is a blip");
+  });
+
+  test("a SECOND consecutive 500 opens the breaker", async () => {
+    const clock = 1_000;
+    const fetchImpl = (async () => res(500)) as unknown as typeof fetch;
+    await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: fetchImpl,
+      now: () => clock,
+    });
+    await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: fetchImpl,
+      now: () => clock,
+    });
+    assert.equal(r2SqlOutageRemainingMs(clock), R2_SQL_OUTAGE_COOLDOWN_MS);
+  });
+
+  test("queries behind the open breaker are NOT sent, and do not throw", async () => {
+    // The 1,546 that followed the first said nothing it had not.
+    const clock = 1_000;
+    let sent = 0;
+    const fetchImpl = (async () => {
+      sent += 1;
+      return res(500);
+    }) as unknown as typeof fetch;
+    for (let i = 0; i < 5; i += 1) {
+      await r2SqlQuery(mockEnv(TOKEN), SQL, {
+        fetch: fetchImpl,
+        now: () => clock,
+      });
+    }
+    assert.equal(
+      sent,
+      R2_SQL_OUTAGE_STREAK,
+      "only the streak reached upstream",
+    );
+  });
+
+  test("the breaker reopens the tier once the cooldown passes", async () => {
+    let clock = 1_000;
+    const fetchImpl = (async () => res(500)) as unknown as typeof fetch;
+    await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: fetchImpl,
+      now: () => clock,
+    });
+    await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: fetchImpl,
+      now: () => clock,
+    });
+    assert.ok(r2SqlOutageRemainingMs(clock) > 0);
+    clock += R2_SQL_OUTAGE_COOLDOWN_MS + 1;
+    assert.equal(r2SqlOutageRemainingMs(clock), 0, "cooldowns expire");
+  });
+
+  test("a NON-5xx response ends the streak — the far side is answering", async () => {
+    // A 429 or a 422 both prove the engine is alive, so the streak is over,
+    // not merely paused.
+    const clock = 1_000;
+    let n = 0;
+    const fetchImpl = (async () =>
+      res([500, 422, 500][n++] ?? 500)) as unknown as typeof fetch;
+    for (let i = 0; i < 3; i += 1) {
+      await r2SqlQuery(mockEnv(TOKEN), SQL, {
+        fetch: fetchImpl,
+        now: () => clock,
+      });
+    }
+    assert.equal(
+      r2SqlOutageRemainingMs(clock),
+      0,
+      "500, 422, 500 is never two IN A ROW",
+    );
+  });
+
+  test("a fetch that resolves to nothing is not counted as a 5xx", async () => {
+    // `res?.status ?? 0` is reachable: a transport-level failure can hand back
+    // no response at all, and that is a `transport` fault, not an upstream 5xx.
+    const clock = 1_000;
+    const fetchImpl = (async () => undefined) as unknown as typeof fetch;
+    await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: fetchImpl,
+      now: () => clock,
+    });
+    await r2SqlQuery(mockEnv(TOKEN), SQL, {
+      fetch: fetchImpl,
+      now: () => clock,
+    });
+    assert.equal(
+      r2SqlOutageRemainingMs(clock),
+      0,
+      "no response is not evidence the engine returned 5xx",
+    );
+  });
+
+  test("a suppressed query is a usage event; the 5xx itself is not", async () => {
+    // The distinction the whole fix rests on: the follow-ups stop being billed
+    // as errors, while a first 500 still reaches the inbox.
+    assert.equal(isExpectedR2SqlFailure("upstream_down"), true);
+    assert.equal(isExpectedR2SqlFailure("http_500"), false);
   });
 });


### PR DESCRIPTION
## The evidence

PostHog issue [`019fc680`](https://us.posthog.com/project/220683/error_tracking/019fc680-62c0-75c2-b6d0-9eea2f579402): **1,548 captured exceptions** in production (`distinct_id: metagraphed-worker`), 2026-08-03 → 08-10, all identical:

```
r2 sql: HTTP 500: {"errors":[{"code":80010,"message":"Internal error"}]}
```

We can't fix Cloudflare's engine. We can stop paying for 1,548 copies of the news.

## The asymmetry

A **429** opens a breaker: one exception per cooldown, every caller behind it declined without its own exception hop. A **5xx** opened nothing — so each of ~44 cold-tier entry points and the projection lanes' 148 queries per tick paid for its own.

That is the entire distance between **86** occurrences and **1,548**.

## A separate breaker, not a widened one

429 and 5xx mean different things and must be able to be open at once:

| | means | backing off |
| --- | --- | --- |
| `429` | the account budget is spent | **refills it** |
| `5xx` | the engine itself is failing | changes nothing upstream |

Collapsing them would let a 15s outage cooldown clear a 60s rate-limit cooldown early.

## Two consecutive 5xx, not one

A lone 500 is a blip **worth an exception** — it might be the first sign of a query in this repo that broke the engine. That's exactly why:

- `http_500` stays **off** the expected-failure list — the first still reaches the inbox
- `upstream_down` (the query the breaker never sent) goes **on** it — the 1,546 after it carry nothing

Any non-5xx response **ends** the streak, including a rejection: a 429 or a 422 both prove the far side is answering.

## Cooldown: 15s, not 60s

A 429 has a budget that genuinely needs a minute to refill. An upstream fault has no budget, so a longer cooldown buys only "not re-reporting" — and holding a whole tier dark for a minute to save log lines is the wrong trade.

## A test-hygiene consequence, stated

`tests/projection-lanes.test.ts` and `tests/cross-view-agreement.test.ts` now reset module state **per test**. Both deliberately fail a tier read, and r2-sql's breakers are module-global *because the facts they represent are account-wide*. The global setup resets per **file** — right for `isolate: false`, too coarse when one test's opened breaker declines the next test's query.

That surfaced as 31 failures on the first full run, and it was worth understanding rather than working around: it is the same blast radius the breaker has in production, which is correct there (a 500 is engine-level; a malformed query is a 422 and is deliberately not breakered).

## Validation

```
npx tsc --noEmit                clean
npm run lint / format:check     clean
npm run validate                pass
npm run build                   no drift
npx vitest run                  19483 passed, 0 failed
npm run scan:public-safety      pass
```

Patch coverage by diff intersection: **83 changed lines in `src/r2-sql.ts`, 0 uncovered.** 59 tests, including the first-500-still-throws case, the streak-broken-by-422 case, and a fetch resolving to nothing (which is `transport`, not a 5xx).

Closes #10741
