### PR TITLE
refactor(types): the last casts, and the directory race one of them was hiding

### DIFF
--- a/scripts/build-network-registry.ts
+++ b/scripts/build-network-registry.ts
@@ -285,12 +285,25 @@ export async function buildNetworkRegistry({
     ),
   });
 
+  // A deregistered netuid must not keep a detail file, so the stale ones go --
+  // but PRUNED by name rather than by clearing the directory first.
+  //
+  // `rm -rf` then `mkdir` is destructive for as long as it takes to rewrite
+  // every subnet, and this builder is not the only caller in the process: two
+  // test files build the same testnet registry, and vitest runs them in
+  // different workers. One `rm` landing while the other was writing failed the
+  // build outright (`ENOTEMPTY`) or, worse, left the survivor reading a
+  // half-built directory and answering 404 for subnets that exist. Writing
+  // first and deleting only what this build did NOT write is idempotent: the
+  // content is deterministic, so two concurrent builds converge instead of
+  // racing.
   const detailDir = path.dirname(
     artifactOutputPath(`${prefix}/subnets/0.json`),
   );
-  await fs.rm(detailDir, { recursive: true, force: true });
   await fs.mkdir(detailDir, { recursive: true });
+  const written = new Set<string>();
   for (const subnet of subnets) {
+    written.add(`${subnet.netuid}.json`);
     await writeJson(
       artifactOutputPath(`${prefix}/subnets/${subnet.netuid}.json`),
       {
@@ -305,6 +318,13 @@ export async function buildNetworkRegistry({
         verified_surfaces: [],
       },
     );
+  }
+  for (const entry of await fs.readdir(detailDir)) {
+    if (written.has(entry)) continue;
+    await fs.rm(path.join(detailDir, entry), {
+      recursive: true,
+      force: true,
+    });
   }
 
   await writeJson(

--- a/scripts/validate-tool-route-divergence.ts
+++ b/scripts/validate-tool-route-divergence.ts
@@ -147,10 +147,7 @@ const usedDeclarations = new Set<string>();
 let pairs = 0;
 let agree = 0;
 
-for (const tool of listToolDefinitions() as unknown as {
-  name: string;
-  inputSchema?: Row;
-}[]) {
+for (const tool of listToolDefinitions()) {
   const entry = (
     MCP_TOOL_ROUTES as Record<
       string,

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -7060,13 +7060,19 @@ function wireSchema(schema: z.ZodObject): z.ZodObject {
  * keep honest, and this runs for every parameter of every route.
  */
 function declaredBaseType(field: z.ZodType): string | undefined {
-  let current = field as unknown as {
-    def?: { type?: string; innerType?: unknown };
-  };
-  for (let hops = 0; hops < 10 && current?.def?.innerType; hops += 1) {
-    current = current.def.innerType as typeof current;
+  // `def` is Zod v4's own public property, so this walks the schema through
+  // its declared type rather than a hand-written shape. Only the WRAPPERS
+  // (optional/default/nullable) carry `innerType`, which is why each hop is
+  // narrowed rather than assumed -- the loop ends at the first def without one.
+  /** The wrapper shape: only optional/default/nullable carry an inner schema. */
+  type Wrapper = { innerType?: { def?: z.core.$ZodTypeDef } };
+  let current: z.core.$ZodTypeDef = field.def;
+  for (let hops = 0; hops < 10; hops += 1) {
+    const inner = (current as Wrapper).innerType?.def;
+    if (!inner) break;
+    current = inner;
   }
-  return current?.def?.type;
+  return current.type;
 }
 
 /**

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14713,7 +14713,7 @@ const TOOL_OUTPUT_SCHEMAS = {
 };
 
 export function listToolDefinitions() {
-  return MCP_TOOLS.map((tool: Row) => {
+  return MCP_TOOLS.map((tool) => {
     // NORMALISED HERE, not at the spread below (#9654). The sentinel is a Zod
     // artifact of `z.int()`, not a property of which side of the call a schema
     // describes, so it landed on 1,083 of 1,083 output integer fields while

--- a/src/response-validation-tripwire.ts
+++ b/src/response-validation-tripwire.ts
@@ -36,6 +36,7 @@
 // quietly shipping. That is the trade the flag exists to make.
 import { successEnvelopeSchema } from "../schemas-src/envelope.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
+import type { z } from "zod";
 
 /** A response that does not match the schema its route publishes. */
 export class ResponseSchemaDriftError extends Error {
@@ -50,7 +51,9 @@ export class ResponseSchemaDriftError extends Error {
 }
 
 /** Resolved schemas, so a hot route pays the lookup once per isolate. */
-const cache = new Map<string, { safeParse: (value: unknown) => unknown }>();
+/** The composed envelope schema per artifact path -- Zod's own type, so
+ * `safeParse` narrows here rather than being re-declared at the call site. */
+const cache = new Map<string, z.ZodType>();
 
 /** Artifact paths with no component -- reported once, never re-resolved. */
 const unresolved = new Set<string>();
@@ -90,9 +93,7 @@ async function schemaForArtifact(artifactPath: string) {
     );
     return null;
   }
-  const schema = successEnvelopeSchema(component) as unknown as {
-    safeParse: (value: unknown) => unknown;
-  };
+  const schema = successEnvelopeSchema(component);
   cache.set(artifactPath, schema);
   return schema;
 }
@@ -111,10 +112,7 @@ export async function validateResponseTripwire(
   try {
     const schema = await schemaForArtifact(artifactPath);
     if (!schema) return;
-    const result = schema.safeParse(envelope) as {
-      success: boolean;
-      error?: unknown;
-    };
+    const result = schema.safeParse(envelope);
     if (!result.success) {
       throw new ResponseSchemaDriftError(routeId, result.error);
     }

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -32,9 +32,30 @@ type Ctx = {
    */
   methodProbe?: boolean;
 };
-// The Cache API (`caches.default`) isn't in the generated Env/global types --
-// it's a Workers-runtime global, not an Env binding.
-const globalWithCaches = globalThis as unknown as { caches?: Row };
+/**
+ * The Workers Cache API, or null where there isn't one.
+ *
+ * `caches` IS in the generated types -- `declare const caches: CacheStorage`
+ * in worker-configuration.d.ts -- which is not what the comment here used to
+ * say while it reached the global through a cast on `globalThis`.
+ *
+ * That cast was carrying a second job, though, and it is why this is a
+ * function rather than a plain reference: outside the Workers runtime the
+ * identifier is not merely undefined, it is UNDECLARED, so naming it throws
+ * `ReferenceError` before any `?.` can help -- which is exactly what the test
+ * suite does. Reading it off `globalThis` turned that into a property access
+ * on an object that simply lacked the key. `typeof` is the narrowing that
+ * survives both, and it keeps the real `CacheStorage` type.
+ */
+function edgeCacheStore(): Cache | null {
+  return typeof caches === "undefined" ? null : caches.default;
+}
+
+/** A key paired with the store, or null where the runtime has no cache. */
+function cacheableWith(key: Request): { store: Cache; key: Request } | null {
+  const store = edgeCacheStore();
+  return store ? { store, key } : null;
+}
 import {
   isUsageTelemetryConfigured,
   recordExceptionEvent,
@@ -658,11 +679,7 @@ import {
 } from "../src/projection-lanes.ts";
 import { TOP_HOLDERS_FLOW_LANE } from "../src/top-holders-flow-tier.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
-import type {
-  EnqueueResult,
-  LaneMessage,
-  LaneQueue,
-} from "../src/lane-queue.ts";
+import type { EnqueueResult, LaneMessage } from "../src/lane-queue.ts";
 import {
   OPERATIONAL_SURFACES_ARTIFACT,
   REVENUE_PROBE_QUEUE,
@@ -2557,25 +2574,16 @@ export const LANE_PRODUCERS: ReadonlyArray<{
     name: "attribution-sweep",
     enqueue: async (env) =>
       enqueueSweeps(
-        (
-          env as unknown as {
-            ATTRIBUTION_SWEEPS?: LaneQueue<{ netuid: number }>;
-          }
-        ).ATTRIBUTION_SWEEPS,
+        env.ATTRIBUTION_SWEEPS,
         (await sweepableSubnets(env)).map((s) => s.netuid),
       ),
   },
   {
     name: "origin-reachability",
     enqueue: async (env) =>
-      enqueueOriginChecks(
-        (
-          env as unknown as {
-            ORIGIN_REACHABILITY?: LaneQueue<{ origin: string }>;
-          }
-        ).ORIGIN_REACHABILITY,
-        [...surfacesByOrigin(await registeredSurfaces(env)).keys()],
-      ),
+      enqueueOriginChecks(env.ORIGIN_REACHABILITY, [
+        ...surfacesByOrigin(await registeredSurfaces(env)).keys(),
+      ]),
   },
   {
     name: "revenue-probe",
@@ -2585,11 +2593,7 @@ export const LANE_PRODUCERS: ReadonlyArray<{
         `${OPERATIONAL_SURFACES_ARTIFACT}.json`,
       );
       return enqueueRevenueProbes(
-        (
-          env as unknown as {
-            REVENUE_PROBES?: LaneQueue<{ surface_id: string }>;
-          }
-        ).REVENUE_PROBES,
+        env.REVENUE_PROBES,
         eligibleRevenueSurfaces(
           artifact.ok ? (artifact.data as Row | undefined) : null,
         ).map((s) => s.id),
@@ -3415,12 +3419,17 @@ export async function handleChainEventsFamily(
   }
 
   const chain = chainNetworkId(network.id);
-  const cache =
+  // ONE nullable, not two: the store and its key are only ever both present or
+  // both absent, and holding them apart made that a fact only the reader kept
+  // -- `cache.match(cacheKey)` type-checked solely because reaching `caches`
+  // through a cast had erased the store's type.
+  const cacheable =
     request.method === "GET" || request.method === "HEAD"
-      ? globalWithCaches.caches?.default
+      ? cacheableWith(await chainEventsCacheKey(env, url, chain))
       : null;
-  const cacheKey = cache ? await chainEventsCacheKey(env, url, chain) : null;
-  const cacheHit = cacheKey ? await cache.match(cacheKey) : null;
+  const cacheHit = cacheable
+    ? await cacheable.store.match(cacheable.key)
+    : null;
   // The tier travels WITH the payload through the cache, so a hit reports the
   // same `meta.source` the miss did rather than guessing one back.
   let answer = cacheHit ? ((await cacheHit.json()) as ColdTierAnswer) : null;
@@ -3447,10 +3456,10 @@ export async function handleChainEventsFamily(
                 : "chain-detail-hot-tier",
           }
         : await coldTierChainEventsPayload(env, url, chain);
-    if (answer && cacheKey) {
+    if (answer && cacheable) {
       ctx?.waitUntil?.(
-        cache.put(
-          cacheKey,
+        cacheable.store.put(
+          cacheable.key,
           new Response(JSON.stringify(answer), {
             status: 200,
             headers: {
@@ -8156,44 +8165,49 @@ async function handleApiRequest(
   // The key namespaces by network + contract version so a deploy or a network
   // switch can never serve a cross-version body; the response's own
   // cache-control max-age bounds staleness.
-  const edgeCache =
+  const edgeCacheable =
     request.method === "GET" &&
     !wantsCsv &&
     isStaticEdgeCacheEligible(matched, network)
-      ? globalWithCaches.caches?.default
+      ? cacheableWith(
+          new Request(
+            `https://edge-cache.metagraph.sh/${network.id}/${encodeURIComponent(
+              contractVersion(env),
+            )}${url.pathname}${canonicalCacheSearch(url, matched)}`,
+          ),
+        )
       : null;
-  const edgeCacheKey = edgeCache
-    ? new Request(
-        `https://edge-cache.metagraph.sh/${network.id}/${encodeURIComponent(
-          contractVersion(env),
-        )}${url.pathname}${canonicalCacheSearch(url, matched)}`,
-      )
-    : null;
   // Live-overlay collection cache (the large /api/v1/endpoints index). Excluded
   // from the static edge cache above, but its overlay only changes when the
   // 2-min cron writes a new health snapshot, so cache it keyed on last_run_at —
   // turning a per-request R2-GET + parse + 3-pass overlay + 1.43 MB re-stringify
   // + SHA-256 into at-most-once-per-cron-tick, staleness bounded to one interval.
-  const overlayCache =
+  const overlayCacheStore =
     request.method === "GET" &&
     !wantsCsv &&
     network.isDefault &&
     CACHEABLE_OVERLAY_ROUTE_IDS.has(matched.id)
-      ? globalWithCaches.caches?.default
+      ? edgeCacheStore()
       : null;
-  let overlayCacheKey = null;
-  if (overlayCache) {
+  /** Set only once a real `last_run_at` gives it a key -- see below. */
+  let overlayCacheable: { store: Cache; key: Request } | null = null;
+  if (overlayCacheStore) {
     // Cheap KV read of just the snapshot time; on a hit this + the cache match
     // is the whole request (no R2 GET / overlay / re-stringify).
     const opMeta = await readHealthMetaKv(env);
     const lastRunAt = opMeta?.last_run_at || null;
     if (lastRunAt) {
-      overlayCacheKey = new Request(
-        `https://edge-cache.metagraph.sh/overlay/${network.id}/${encodeURIComponent(
-          contractVersion(env),
-        )}/${encodeURIComponent(lastRunAt)}${url.pathname}${canonicalCacheSearch(url, matched)}`,
+      overlayCacheable = {
+        store: overlayCacheStore,
+        key: new Request(
+          `https://edge-cache.metagraph.sh/overlay/${network.id}/${encodeURIComponent(
+            contractVersion(env),
+          )}/${encodeURIComponent(lastRunAt)}${url.pathname}${canonicalCacheSearch(url, matched)}`,
+        ),
+      };
+      const overlayHit = await overlayCacheable.store.match(
+        overlayCacheable.key,
       );
-      const overlayHit = await overlayCache.match(overlayCacheKey);
       if (overlayHit) {
         if (ifNoneMatchSatisfied(request, overlayHit.headers.get("etag"))) {
           return new Response(null, {
@@ -8205,8 +8219,8 @@ async function handleApiRequest(
       }
     }
   }
-  if (edgeCache) {
-    const hit = await edgeCache.match(edgeCacheKey);
+  if (edgeCacheable) {
+    const hit = await edgeCacheable.store.match(edgeCacheable.key);
     if (hit) {
       // Honour conditional requests against the cached body's weak ETag so
       // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
@@ -8575,15 +8589,19 @@ async function handleApiRequest(
   // are skipped even when their live store is cold and the response falls back
   // to the static artifact. 304/HEAD/non-200 are skipped. The edge entry
   // expires per the response's cache-control max-age.
-  if (edgeCache && live === null && response.status === 200) {
-    ctx?.waitUntil?.(edgeCache.put(edgeCacheKey, response.clone()));
+  if (edgeCacheable && live === null && response.status === 200) {
+    ctx?.waitUntil?.(
+      edgeCacheable.store.put(edgeCacheable.key, response.clone()),
+    );
   }
   // Cache the live-overlay collection only when the overlay actually applied
   // (live !== null) and we keyed on a real last_run_at (overlayCacheKey set) —
   // never cache a cold-KV fallback, which would pin build-time health under a
   // stable key. The entry busts on the next cron snapshot (key) + max-age.
-  if (overlayCacheKey && live !== null && response.status === 200) {
-    ctx?.waitUntil?.(overlayCache.put(overlayCacheKey, response.clone()));
+  if (overlayCacheable && live !== null && response.status === 200) {
+    ctx?.waitUntil?.(
+      overlayCacheable.store.put(overlayCacheable.key, response.clone()),
+    );
   }
   return response;
 }

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -159,7 +159,15 @@ function opaqueTag(tag: string): string {
 
 // True when an If-None-Match precondition matches the current `etag` (caller
 // answers 304). Handles `*`, a comma-separated tag list, and weak validators.
-export function ifNoneMatchSatisfied(request: Request, etag: string): boolean {
+//
+// `etag` is nullable because `Headers.get()` is: a cached response without an
+// ETag has nothing to match, which the body below already answered correctly
+// (`!etag` -> false). Only the signature disagreed, and it type-checked at the
+// call sites solely because they reached the response through a cast.
+export function ifNoneMatchSatisfied(
+  request: Request,
+  etag: string | null,
+): boolean {
   const header = request.headers.get("if-none-match");
   if (!header || !etag) return false;
   const current = opaqueTag(etag);

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -208,11 +208,7 @@ export class McpSessionHub implements DurableObject {
   private emit(record: () => Promise<unknown>): void {
     try {
       const pending = Promise.resolve(record()).catch(() => false);
-      (
-        this.state as unknown as {
-          waitUntil?: (p: Promise<unknown>) => void;
-        }
-      ).waitUntil?.(pending);
+      this.state.waitUntil(pending);
     } catch {
       // Telemetry must never surface into the session path.
     }

--- a/workers/wss-lb.ts
+++ b/workers/wss-lb.ts
@@ -255,7 +255,7 @@ export async function dialUpstream(
       headers: { Upgrade: "websocket" },
       signal: abort.signal,
     } as RequestInit);
-    const socket = (res as unknown as { webSocket?: WebSocket }).webSocket;
+    const socket = res.webSocket;
     if (res.status !== 101 || !socket) return null;
     socket.accept();
     return socket;


### PR DESCRIPTION
Closes #10748

#10733 took `as unknown as { … }` from 20 to 8. This takes it to **zero** across
`src/`, `workers/`, `scripts/` and `schemas-src/`.

## Seven restated something already declared

| cast | already declared in |
|---|---|
| `this.state` → `waitUntil` | `DurableObjectState`, `worker-configuration.d.ts` |
| `res.webSocket` | `Response.webSocket: WebSocket \| null`, same file |
| three lane **queue** bindings | the generated `Env`, as `Queue` |
| `listToolDefinitions()` | `MCP_TOOLS` is `McpToolDefinition[]` — thrown away by a `(tool: Row)` annotation on its own `.map` |
| `successEnvelopeSchema(…)` | it returns a Zod schema; flattening it into the cache is what made the parse **result** need a second cast to read `.success` |
| `field` → `{def}` | `def` is Zod v4's own public property |

## The one that was not redundant

`globalThis as unknown as { caches?: Row }` was doing **two** jobs. `caches` is
declared (`declare const caches: CacheStorage`) — but outside the Workers
runtime the identifier is *undeclared*, so naming it throws `ReferenceError`
before any `?.` can help. Reading it off `globalThis` turned that into a
property access on an object that simply lacked the key.

Removing the cast without noticing that broke 340 tests here. `typeof caches ===
"undefined"` is the narrowing that survives both — the one operator allowed to
name an undeclared binding — and it keeps the real `CacheStorage` type.

## What the real types then exposed

- **`ifNoneMatchSatisfied(request, etag: string)`** is handed
  `headers.get("etag")`, which is `string | null`. The body already answered
  correctly (`!etag` → false); only the signature disagreed, and it compiled
  because the caller reached the response through the cast.
- **The three caches** each kept a store and its key in *separate* nullables,
  correlated only by construction. `cache.match(cacheKey)` compiled solely
  because the cast had erased the store's type. Paired into one nullable,
  narrowing it narrows both.

## The race a cast was hiding

`buildNetworkRegistry` cleared its output directory (`fs.rm` recursive, then
`mkdir`) before rewriting it. Two test files build the same testnet registry and
vitest runs them in different workers: one `rm` landing mid-write failed the
other with `ENOTEMPTY`, or left it reading a half-built directory and answering
**404 for subnets that exist** — four tests, reproducible.

It now writes first and deletes only what the build did *not* write. The content
is deterministic, so two concurrent builds converge rather than race — and a
deregistered netuid still loses its file, verified by planting a stale one and
watching the build remove it.

## Verification

- `typecheck` · `lint` · `format` · `validate` · `contract-drift` — clean
- **849 test files, 19,480 tests passing**
- `as unknown as { … }` in `src/`, `workers/`, `scripts/`, `schemas-src/`: **0**
