### PR TITLE
obs(firehose): say which cap refused, without telling the caller (#10753)

### DIFF
--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -48,6 +48,7 @@ import {
   CHAIN_FIREHOSE_PUBLISHED_TABLES,
   formatChainFirehoseTopicNoticeFrame,
   unpublishedChainFirehoseTopics,
+  chainFirehoseCapRefusal,
 } from "../workers/chain-firehose-hub.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.ts";
 import { resetModuleState } from "../src/module-state-registry.ts";
@@ -2478,4 +2479,59 @@ test("#9900: a release with no ip in the attachment emits nothing", () => {
   } finally {
     cap.restore();
   }
+});
+
+// ── which cap refused (#10744) ──────────────────────────────────────────────
+
+/** Swap console.error for the duration of one assertion, and restore it. */
+function withCapLog<T>(fn: (lines: string[]) => T): T {
+  const original = console.error;
+  const lines: string[] = [];
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  try {
+    return fn(lines);
+  } finally {
+    console.error = original;
+  }
+}
+
+test("every cap answers the SAME body — a distinct one would map the limits", () => {
+  // Telling a scraper which limit it hit is telling it how to spread around
+  // that limit. The response must not carry the distinction.
+  withCapLog((lines) => {
+    for (const kind of [
+      "ws-global",
+      "ws-per-ip",
+      "sse-global",
+      "sse-per-ip",
+    ] as const) {
+      const r = chainFirehoseCapRefusal(kind, 20, 20);
+      assert.equal(r.status, 503);
+    }
+    assert.equal(lines.length, 4, "but each one is logged");
+  });
+});
+
+test("the LOG names the cap, because the two mean opposite things", () => {
+  // A global cap means every subscriber is refused -- an outage. A per-IP cap
+  // means one client is contained -- the design working. Production could not
+  // tell them apart, so a headless-browser farm read the same as an outage.
+  withCapLog((lines) => {
+    chainFirehoseCapRefusal("sse-per-ip", 20, 20);
+    chainFirehoseCapRefusal("sse-global", 1000, 1000);
+    assert.match(lines[0]!, /\[chain-firehose\] cap sse-per-ip 20\/20/);
+    assert.match(lines[1]!, /\[chain-firehose\] cap sse-global 1000\/1000/);
+  });
+});
+
+test("the observed count rides along, so a near-miss is visible too", () => {
+  withCapLog((lines) => {
+    chainFirehoseCapRefusal("ws-global", 1000, 1000);
+    assert.ok(
+      lines[0]!.includes("1000/1000"),
+      "observed/limit, not just the fact of a refusal",
+    );
+  });
 });

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -168,6 +168,37 @@ export const CHAIN_FIREHOSE_MAX_FIELD_STRING_BYTES = 256;
 // hibernatable sockets), so a per-message byte watermark isn't a reliable WS
 // primitive here; the connection cap plus per-send try/catch are the bounds.
 export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
+/**
+ * Which cap turned a subscriber away.
+ *
+ * ALL FOUR RETURN THE SAME BODY, deliberately -- a distinct message per cap
+ * would tell a scraper which limit it had hit and how to spread around it. What
+ * changes is that the LOG now says, because the two facts are operationally
+ * opposite and were indistinguishable in production (#10744):
+ *
+ *   - a GLOBAL cap means every subscriber is being refused. An outage.
+ *   - a PER-IP cap means one client is being contained. The design working.
+ *
+ * On 2026-08-11 a headless-browser farm on Azure addresses drew a steady stream
+ * of 503s from /subscribe, and nothing in the telemetry could say which of those
+ * two it was.
+ */
+export type ChainFirehoseCapKind =
+  "ws-global" | "ws-per-ip" | "sse-global" | "sse-per-ip";
+
+/** The 503 every cap answers with, and the one line that tells them apart. */
+export function chainFirehoseCapRefusal(
+  kind: ChainFirehoseCapKind,
+  observed: number,
+  limit: number,
+): Response {
+  // Same labelled shape src/r2-sql.ts gives its suppressed queries, for the same
+  // reason: the tail is where every occurrence can be read, and the response
+  // deliberately will not carry it.
+  console.error("[chain-firehose] cap", kind, `${observed}/${limit}`);
+  return new Response("too many connections", { status: 503 });
+}
+
 export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
 
@@ -1143,7 +1174,11 @@ export class ChainFirehoseHub implements DurableObject {
       if (
         this.state.getWebSockets().length >= CHAIN_FIREHOSE_MAX_WS_CONNECTIONS
       ) {
-        return new Response("too many connections", { status: 503 });
+        return chainFirehoseCapRefusal(
+          "ws-global",
+          this.state.getWebSockets().length,
+          CHAIN_FIREHOSE_MAX_WS_CONNECTIONS,
+        );
       }
       // #5004 item 1: per-IP sub-quota, checked in addition to the global cap
       // above. Applies to BOTH WS "modes" below (plain firehose and
@@ -1158,7 +1193,11 @@ export class ChainFirehoseHub implements DurableObject {
         (this.wsClientsByIp.get(clientIp) || 0) >=
         CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
       ) {
-        return new Response("too many connections", { status: 503 });
+        return chainFirehoseCapRefusal(
+          "ws-per-ip",
+          this.wsClientsByIp.get(clientIp) ?? 0,
+          CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
+        );
       }
       const requestedProtocols = (
         request.headers.get("sec-websocket-protocol") || ""
@@ -1236,18 +1275,26 @@ export class ChainFirehoseHub implements DurableObject {
     /* v8 ignore stop */
 
     if (this.sseClients.size >= CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS) {
-      return new Response("too many connections", { status: 503 });
+      return chainFirehoseCapRefusal(
+        "sse-global",
+        this.sseClients.size,
+        CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS,
+      );
     }
 
     // #5004 item 1: per-IP sub-quota, checked in addition to the global cap
     // above. Same 503 shape as the global-cap response -- see the WS-upgrade
     // branch's identical comment above for why no distinct error is used.
     const clientIp = resolveClientIp(request);
-    if (
-      (this.sseClientsByIp.get(clientIp) || 0) >=
-      CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP
-    ) {
-      return new Response("too many connections", { status: 503 });
+    const sseForIp = this.sseClientsByIp.get(clientIp) || 0;
+    if (sseForIp >= CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP) {
+      // Read once: the guard has already proved this is at the cap, so a second
+      // `|| 0` in the refusal would be a branch that cannot be taken.
+      return chainFirehoseCapRefusal(
+        "sse-per-ip",
+        sseForIp,
+        CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
+      );
     }
 
     const encoder = new TextEncoder();


### PR DESCRIPTION
## The problem

`ChainFirehoseHub` refuses a subscriber with `503 "too many connections"` from **four** places, all returning the identical body:

| site | cap |
| --- | --- |
| WS upgrade | global, 1000 |
| WS upgrade | per-IP, 20 |
| SSE `/subscribe` | global, 1000 |
| SSE `/subscribe` | per-IP, 20 |

**The identical body is correct and stays.** A distinct message per cap would tell a scraper which limit it hit, and therefore how to spread around it.

What was missing: nothing else recorded *which* one fired — so two operationally **opposite** facts were indistinguishable.

- a **global** cap → every subscriber refused. An outage.
- a **per-IP** cap → one client contained. The design working.

## Not hypothetical

On 2026-08-11, `GET /subscribe?topics=blocks` returned a steady stream of 503s over ~20 minutes to a headless-browser farm on Azure addresses (`origin: http://localhost:8080`, HeadlessChrome/151, repeated IPs across MSP/LAX/SJC/IAD).

Most likely the per-IP cap doing its job. **Nothing in the logs could confirm it**, and an exhausted global cap would have looked the same.

## The fix

One helper, four call sites. The cap and `observed/limit` go to the log; the response is byte-identical.

Same labelled shape `src/r2-sql.ts` gives its suppressed queries, and for the same reason: the tail is where every occurrence can be read, and the response deliberately will not carry it.

The per-IP count is now read **once** and shared by the guard and the refusal — reading it twice would have put a `|| 0` in the refusal that cannot be taken, since the guard has already proved the value is at the cap.

## Tests

Three, in the file's existing flat style:

- **every cap answers the same body** — asserted across all four kinds, so a future edit that "helpfully" differentiates them fails here
- **the log names the cap**, with the two contrasting kinds side by side
- **observed/limit rides along**, so a near-miss is readable

## Validation

```
npx tsc --noEmit                clean
npm run lint / format:check     clean
npm run validate                pass
npm run build                   no drift
npx vitest run                  19490 passed, 0 failed
npm run scan:public-safety      pass
```

Patch coverage by diff intersection: **55 changed lines in `workers/chain-firehose-hub.ts`, 0 uncovered.**

Closes #10753
