### PR TITLE
fix(neon): make the buffer's enqueue O(1) -- the scan was resetting the object

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -130,11 +130,11 @@ describe("enqueueStatement", () => {
 
   test("REFUSES at the ceiling rather than growing", async () => {
     const storage = fakeStorage();
-    // Seed the ceiling directly; enqueuing 5,000 real statements would test
-    // the fake's speed, not the policy.
-    for (let i = 1; i <= MAX_BUFFERED_STATEMENTS; i += 1) {
-      storage.map.set(chunkKey(i, 0), new Uint8Array(0));
-    }
+    // Seed the COUNTER, not the keys. Fullness is O(1) now (#10755) precisely
+    // because counting keys per enqueue is what burned 2.4s of CPU and got the
+    // object reset -- so a test that seeds keys would no longer be testing the
+    // policy that exists.
+    storage.map.set("pending", MAX_BUFFERED_STATEMENTS);
     const out = await enqueueStatement(storage, stmt("l", "A"), NOW);
     assert.equal(out.accepted, false);
     assert.match(String(out.reason), /buffer full/);
@@ -380,9 +380,7 @@ describe("NeonWriteBufferHub", () => {
 
   test("a full buffer answers 503 -- backpressure, not a bug in the request", async () => {
     const h = hub();
-    for (let i = 1; i <= MAX_BUFFERED_STATEMENTS; i += 1) {
-      h.storage.map.set(chunkKey(i, 0), new Uint8Array(0));
-    }
+    h.storage.map.set("pending", MAX_BUFFERED_STATEMENTS);
     const res = await h.do.fetch(post(stmt("l", "A")));
     assert.equal(res.status, 503);
   });
@@ -673,5 +671,71 @@ describe("a truncated drain must come back (#10722)", () => {
       true,
       "a drain that left work behind MUST schedule another",
     );
+  });
+});
+
+describe("the enqueue is O(1) (#10755)", () => {
+  // THE BUG. enqueueStatement called countPending(), which lists every chunk
+  // in the buffer and sorts them -- on every enqueue. Cloudflare's logs:
+  //
+  //     POST /enqueue  outcome: exception  cpuTimeMs: 2424
+  //     -> Internal error in Durable Object storage caused object to be reset
+  //
+  // 2.4s of CPU to append one row, worsening as the backlog grew, until the
+  // platform reset the object mid-request -- before setAlarm, so nothing armed
+  // the flush, so the backlog grew further.
+
+  test("does NOT list storage -- the scan is what killed it", async () => {
+    const storage = fakeStorage();
+    let lists = 0;
+    const realList = storage.list.bind(storage);
+    storage.list = async (options) => {
+      lists += 1;
+      return realList(options);
+    };
+    for (let i = 0; i < 25; i += 1) {
+      await enqueueStatement(storage, stmt("neurons", `S${i}`), NOW);
+    }
+    assert.equal(lists, 0, "an enqueue must never scan the backlog");
+  });
+
+  test("the pending counter tracks the enqueues", async () => {
+    const storage = fakeStorage();
+    for (let i = 0; i < 5; i += 1) {
+      await enqueueStatement(storage, stmt("l", `S${i}`), NOW);
+    }
+    assert.equal(await storage.get("pending"), 5);
+  });
+
+  test("a clean drain RECONCILES the counter to zero, never just decrements", async () => {
+    // A counter that can only be adjusted is a counter that eventually lies.
+    const storage = fakeStorage();
+    for (let i = 0; i < 3; i += 1) {
+      await enqueueStatement(storage, stmt("l", `S${i}`), NOW);
+    }
+    // Drift it deliberately, the way a partial failure would.
+    storage.map.set("pending", 99);
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(
+      await storage.get("pending"),
+      0,
+      "reconciled, not decremented",
+    );
+  });
+
+  test("the ceiling still refuses, now from the counter", async () => {
+    const storage = fakeStorage();
+    storage.map.set("pending", MAX_BUFFERED_STATEMENTS);
+    const out = await enqueueStatement(storage, stmt("l", "A"), NOW);
+    assert.equal(out.accepted, false);
+    assert.match(String(out.reason), /buffer full/);
   });
 });

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -70,6 +70,31 @@ export const BUFFER_ROUTE = "neon-write-buffer";
 /** Where the monotonic sequence lives, outside the statement prefix. */
 const SEQ_KEY = "seq";
 
+/**
+ * How many statements are waiting, maintained as a COUNTER.
+ *
+ * THE BUG THIS EXISTS TO KILL (#10755). enqueueStatement used to call
+ * countPending(), which does a full storage.list() over every chunk in the
+ * buffer and then sorts and groups the keys -- on EVERY enqueue. Cloudflare's
+ * own logs show what that cost once a backlog existed:
+ *
+ *     POST /enqueue   outcome: exception
+ *     cpuTimeMs: 2424   wallTimeMs: 2699
+ *     -> Internal error in Durable Object storage caused object to be reset
+ *
+ * 2.4 SECONDS OF CPU TO APPEND ONE ROW. And it is a death spiral rather than a
+ * slow path: each enqueue scans a bigger backlog, takes more CPU, and the
+ * platform eventually resets the object mid-request -- at which point the
+ * enqueue throws BEFORE reaching setAlarm, so nothing arms the flush, so the
+ * backlog grows, so the next scan is worse.
+ *
+ * That one O(n) call is what produced all three failures this buffer was
+ * disabled for: the storage "internal error", the enqueues that stopped
+ * landing, and the alarm that never fired. A counter makes the enqueue O(1)
+ * and the whole spiral unreachable.
+ */
+const PENDING_KEY = "pending";
+
 export interface FlushOutcome {
   /** Statements this drain took from storage. */
   drained: number;
@@ -137,7 +162,8 @@ export async function enqueueStatement(
   statement: BufferedStatement,
   now: number,
 ): Promise<{ accepted: boolean; seq?: number; reason?: string }> {
-  const pending = await countPending(storage);
+  // O(1). NEVER countPending() here -- see PENDING_KEY.
+  const pending = (await storage.get<number>(PENDING_KEY)) ?? 0;
   if (pending >= MAX_BUFFERED_STATEMENTS) {
     // REFUSE rather than grow. See this file's header: an unbounded queue is
     // an outage nobody can see, and the producer's retry still holds the rows.
@@ -148,7 +174,10 @@ export async function enqueueStatement(
   }
   const seq = ((await storage.get<number>(SEQ_KEY)) ?? 0) + 1;
   const parts = splitPayload(encodeStatement(statement));
-  const entries: Record<string, unknown> = { [SEQ_KEY]: seq };
+  const entries: Record<string, unknown> = {
+    [SEQ_KEY]: seq,
+    [PENDING_KEY]: pending + 1,
+  };
   parts.forEach((part, index) => {
     entries[chunkKey(seq, index)] = part;
   });
@@ -278,6 +307,7 @@ export async function flushBuffer(
       // alarm, and a failure here is nearly always the connection rather than
       // the row -- so the rest would fail too, one wasted round trip each.
       await storage.delete(drainedKeys);
+      await storage.put({ [PENDING_KEY]: await countPending(storage) });
       await recordFlushVerdicts(laneDb, perLane, now());
       const reason = error instanceof Error ? error.message : String(error);
       await capture(asEnv, {
@@ -299,6 +329,13 @@ export async function flushBuffer(
   }
 
   await storage.delete(drainedKeys);
+  // RECONCILE, do not just decrement. A drain that was not truncated has
+  // emptied the buffer by definition, so writing the true value here stops any
+  // drift between the counter and the keys from accumulating -- a counter that
+  // can only be adjusted is a counter that eventually lies.
+  await storage.put({
+    [PENDING_KEY]: truncated ? Math.max(0, await countPending(storage)) : 0,
+  });
   await recordFlushVerdicts(laneDb, perLane, now());
   await recordLaneVerdict(laneDb, {
     lane: BUFFER_FLUSH_LANE,


### PR DESCRIPTION
## Root cause, from Cloudflare's own logs

You were right that I hadn't read them. They give the answer the last three fixes were guessing at:

```
POST /enqueue    outcome: exception
cpuTimeMs: 2424    wallTimeMs: 2699
entrypoint: NeonWriteBufferHub    executionModel: durableObject
→ Internal error in Durable Object storage caused object to be reset
```

**2.4 seconds of CPU to append one row.** `enqueueStatement` opened with `countPending(storage)`, and
that does a full `storage.list()` over every chunk in the buffer, then sorts and groups the keys — **on
every single enqueue**.

## Why it was a spiral, not a slow path

1. Each enqueue scans the whole backlog → CPU grows with the backlog
2. The platform resets the object mid-request
3. The reset lands **before `setAlarm`** — so nothing arms the flush
4. Nothing drains → backlog grows → next scan is worse

## It explains all three "separate" failures

| Symptom | I chased it as | It actually was |
|---|---|---|
| `Internal error in DO storage` | #10744 — payload too large | CPU burn from the scan |
| Enqueues stopped landing | #10729 — deploy resets | The object reset by the scan |
| Alarm never fired | #10722 — missing re-arm | Reset happened before `setAlarm` |

Each of those fixes was correct for the failure it named. **None could fix this, because none touched
the scan.** I should have read the logs before the second attempt, not the fourth.

## Fix

`pending` is a counter: one `get`, one `put`, **no `list`**. The enqueue is O(1).

**Reconciled, not decremented.** A clean drain writes the true value rather than subtracting — a
counter that can only be adjusted eventually lies, and the drain already knows the answer.

## On KV

Worth stating since it came up: **DO storage was never the wrong primitive.** It is strongly
consistent, transactional, and alarm-capable. KV is eventually consistent with a ~1 write/sec/key
limit — strictly worse for a queue. The bug was mine.

## Validation

```
npx tsc --noEmit · lint · format:check   # clean
npm run validate                         # exit 0
npx vitest run <4 suites>                # 149 passed
```

New regression tests: **an enqueue never calls `storage.list()`** (asserted by counting calls), the
counter tracks enqueues, a clean drain reconciles to zero even after deliberate drift, and the ceiling
still refuses from the counter.

Patch coverage by diff intersection: zero uncovered statements, zero uncovered branches.

Closes #10755
