### PR TITLE
feat(graphql): reach the four unreached types, and let each fact be fixed where it lives

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1767,7 +1767,7 @@ export type ChainTurnover = {
 export type ChainTurnoverNetwork = {
   __typename?: 'ChainTurnoverNetwork';
   /** 0-100 stability score; null on a cold/non-comparable window. */
-  stability_score?: Maybe<Scalars['Float']['output']>;
+  stability_score?: Maybe<Scalars['Int']['output']>;
   /** Jaccard retention of the start set into the end set; null on a cold/non-comparable window. */
   validator_retention?: Maybe<Scalars['Float']['output']>;
   validators_end: Scalars['Int']['output'];
@@ -1780,20 +1780,20 @@ export type ChainTurnoverNetwork = {
 export type ChainTurnoverStabilityDistribution = {
   __typename?: 'ChainTurnoverStabilityDistribution';
   count: Scalars['Int']['output'];
-  max: Scalars['Float']['output'];
+  max: Scalars['Int']['output'];
   mean: Scalars['Float']['output'];
   median: Scalars['Float']['output'];
-  min: Scalars['Float']['output'];
-  p25: Scalars['Float']['output'];
-  p75: Scalars['Float']['output'];
-  p90: Scalars['Float']['output'];
+  min: Scalars['Int']['output'];
+  p25: Scalars['Int']['output'];
+  p75: Scalars['Int']['output'];
+  p90: Scalars['Int']['output'];
 };
 
 /** One subnet's validator-set churn, ranked by gross churn (entered + exited) then netuid. */
 export type ChainTurnoverSubnet = {
   __typename?: 'ChainTurnoverSubnet';
   netuid: Scalars['Int']['output'];
-  stability_score?: Maybe<Scalars['Float']['output']>;
+  stability_score?: Maybe<Scalars['Int']['output']>;
   validator_retention?: Maybe<Scalars['Float']['output']>;
   validators_end: Scalars['Int']['output'];
   validators_entered: Scalars['Int']['output'];
@@ -2066,6 +2066,8 @@ export type Contracts = {
   openapi_url?: Maybe<Scalars['String']['output']>;
   primary_domain?: Maybe<Scalars['String']['output']>;
   schema_version?: Maybe<Scalars['Int']['output']>;
+  /** Always null. The builder hardcodes it and the contract types it that way, so this is the schema stating a vestige rather than hiding one -- /api/v1/contracts has always served the key (#10214). */
+  status_domain?: Maybe<Scalars['String']['output']>;
   type_definitions_url?: Maybe<Scalars['String']['output']>;
 };
 
@@ -2431,13 +2433,10 @@ export type EndpointIncident = {
   __typename?: 'EndpointIncident';
   classification?: Maybe<Scalars['String']['output']>;
   detected_at?: Maybe<Scalars['String']['output']>;
-  downtime_ms?: Maybe<Scalars['Int']['output']>;
   endpoint_id?: Maybe<Scalars['String']['output']>;
   health_source?: Maybe<Scalars['String']['output']>;
   health_stale?: Maybe<Scalars['Boolean']['output']>;
   id?: Maybe<Scalars['String']['output']>;
-  incident_count?: Maybe<Scalars['Int']['output']>;
-  incidents?: Maybe<Array<EndpointIncidentWindow>>;
   kind?: Maybe<Scalars['String']['output']>;
   last_checked?: Maybe<Scalars['String']['output']>;
   last_ok?: Maybe<Scalars['String']['output']>;
@@ -2457,8 +2456,6 @@ export type EndpointIncident = {
   subnet_slug?: Maybe<Scalars['String']['output']>;
   surface_id?: Maybe<Scalars['String']['output']>;
   surface_key?: Maybe<Scalars['String']['output']>;
-  transient_failed_samples?: Maybe<Scalars['Int']['output']>;
-  transient_failure_count?: Maybe<Scalars['Int']['output']>;
   user_reported?: Maybe<Scalars['Boolean']['output']>;
 };
 
@@ -3243,7 +3240,7 @@ export type Provider = {
   kind?: Maybe<Scalars['String']['output']>;
   logo_url?: Maybe<Scalars['String']['output']>;
   name?: Maybe<Scalars['String']['output']>;
-  netuids: Array<Maybe<Scalars['Int']['output']>>;
+  netuids: Array<Scalars['Int']['output']>;
   notes?: Maybe<Scalars['String']['output']>;
   public_notes?: Maybe<Scalars['String']['output']>;
   subnet_count?: Maybe<Scalars['Int']['output']>;
@@ -9964,7 +9961,7 @@ export type ChainTurnoverResolvers<ContextType = GqlContext, ParentType extends 
 }>;
 
 export type ChainTurnoverNetworkResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainTurnoverNetwork'] = ResolversParentTypes['ChainTurnoverNetwork']> = ResolversObject<{
-  stability_score?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  stability_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   validator_retention?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validators_end?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   validators_entered?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -9974,18 +9971,18 @@ export type ChainTurnoverNetworkResolvers<ContextType = GqlContext, ParentType e
 
 export type ChainTurnoverStabilityDistributionResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainTurnoverStabilityDistribution'] = ResolversParentTypes['ChainTurnoverStabilityDistribution']> = ResolversObject<{
   count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  max?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  max?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   mean?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
   median?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  min?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  p25?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  p75?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  p90?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  min?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  p25?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  p75?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  p90?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type ChainTurnoverSubnetResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainTurnoverSubnet'] = ResolversParentTypes['ChainTurnoverSubnet']> = ResolversObject<{
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  stability_score?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  stability_score?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   validator_retention?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validators_end?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   validators_entered?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -10220,6 +10217,7 @@ export type ContractsResolvers<ContextType = GqlContext, ParentType extends Reso
   openapi_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   primary_domain?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schema_version?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  status_domain?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type_definitions_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
 }>;
 
@@ -10512,13 +10510,10 @@ export type EndpointResolvers<ContextType = GqlContext, ParentType extends Resol
 export type EndpointIncidentResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['EndpointIncident'] = ResolversParentTypes['EndpointIncident']> = ResolversObject<{
   classification?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   detected_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  downtime_ms?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   endpoint_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   health_source?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   health_stale?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  incident_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  incidents?: Resolver<Maybe<Array<ResolversTypes['EndpointIncidentWindow']>>, ParentType, ContextType>;
   kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   last_checked?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   last_ok?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10537,8 +10532,6 @@ export type EndpointIncidentResolvers<ContextType = GqlContext, ParentType exten
   subnet_slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   surface_id?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   surface_key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  transient_failed_samples?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  transient_failure_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   user_reported?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
 }>;
 
@@ -11184,7 +11177,7 @@ export type ProviderResolvers<ContextType = GqlContext, ParentType extends Resol
   kind?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   logo_url?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  netuids?: Resolver<Array<Maybe<ResolversTypes['Int']>>, ParentType, ContextType>;
+  netuids?: Resolver<Array<ResolversTypes['Int']>, ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   public_notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   subnet_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6240,11 +6240,11 @@ export interface components {
             block_count: number;
             block_time: {
                 count: number;
-                max_ms: number;
-                mean_ms: number;
-                min_ms: number;
-                p50_ms: number;
-                p90_ms: number;
+                max_ms: components["schemas"]["DurationMillis"];
+                mean_ms: components["schemas"]["DurationMillis"];
+                min_ms: components["schemas"]["DurationMillis"];
+                p50_ms: components["schemas"]["DurationMillis"];
+                p90_ms: components["schemas"]["DurationMillis"];
             } | null;
             distinct_authors: number;
             distinct_spec_versions: number;
@@ -7273,6 +7273,8 @@ export interface components {
             }[];
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description An unsigned 64-bit integer read from chain storage. Published as Float in GraphQL: the runtime's range exceeds that of GraphQL's Int. */
+        ChainU64: number;
         /** @description Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights. */
         ChainWeightsArtifact: {
             /** @description Spread of per-subnet update intensity (WeightsSet events per validator) across every subnet that set weights in the window. */
@@ -7902,6 +7904,8 @@ export interface components {
             /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total. */
             total_stake_tao: number | null;
         };
+        /** @description A duration in milliseconds. Published as Float in GraphQL: a span past 24.8 days exceeds the 32-bit range of GraphQL's Int. */
+        DurationMillis: number;
         EconomicsArtifact: {
             captured_at: string | null;
             chain_state?: components["schemas"]["ChainState"];
@@ -10590,7 +10594,7 @@ export interface components {
             /** @description Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled. */
             days: components["schemas"]["SelfHealthDay"][];
             http_status: number | null;
-            latency_ms: number | null;
+            latency_ms: components["schemas"]["DurationMillis"] | null;
             /** @description Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add. */
             note: string | null;
             /** @description Mean uptime across the days we actually have. Null when there are none. */
@@ -10624,7 +10628,7 @@ export interface components {
          *     it starts to matter.
          */
         SelfHealthLane: {
-            age_ms: number | null;
+            age_ms: components["schemas"]["DurationMillis"] | null;
             checked_at: string | null;
             detail: string | null;
             lane: string;
@@ -10907,11 +10911,11 @@ export interface components {
                 is_owner?: boolean;
                 locked_mass?: number;
             }[];
-            maturity_rate?: number | null;
+            maturity_rate?: components["schemas"]["ChainU64"] | null;
             netuid: number;
             queried_at_block?: number | null;
             schema_version: number;
-            unlock_rate?: number | null;
+            unlock_rate?: components["schemas"]["ChainU64"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -12950,7 +12954,7 @@ export interface components {
         };
         TaoUsdArtifact: {
             /** @description How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
-            age_ms: number | null;
+            age_ms: components["schemas"]["DurationMillis"] | null;
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
@@ -13024,6 +13028,7 @@ export interface components {
         /** @description One subnet's long-term daily uptime history (#5885). Mirrors GET /api/v1/subnets/{netuid}/uptime's data envelope. */
         UptimeArtifact: {
             netuid: number;
+            observed_at: string | null;
             /** @description Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at. */
             reliability: ({
                 avg_latency_ms: number | null;
@@ -47203,6 +47208,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "reliability": {
                      *           "avg_latency_ms": 120,
                      *           "computed_at": "2026-06-01T00:00:00.000Z",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12695,6 +12695,7 @@
         "value": {
           "data": {
             "netuid": 7,
+            "observed_at": "2026-06-01T00:00:00.000Z",
             "reliability": {
               "avg_latency_ms": 120,
               "computed_at": "2026-06-01T00:00:00.000Z",
@@ -19843,29 +19844,19 @@
                     "type": "integer"
                   },
                   "max_ms": {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/DurationMillis"
                   },
                   "mean_ms": {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/DurationMillis"
                   },
                   "min_ms": {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/DurationMillis"
                   },
                   "p50_ms": {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/DurationMillis"
                   },
                   "p90_ms": {
-                    "maximum": 9007199254740991,
-                    "minimum": -9007199254740991,
-                    "type": "integer"
+                    "$ref": "#/components/schemas/DurationMillis"
                   }
                 },
                 "required": [
@@ -25608,6 +25599,12 @@
         ],
         "type": "object"
       },
+      "ChainU64": {
+        "description": "An unsigned 64-bit integer read from chain storage. Published as Float in GraphQL: the runtime's range exceeds that of GraphQL's Int.",
+        "maximum": 9007199254740991,
+        "minimum": 0,
+        "type": "integer"
+      },
       "ChainWeightsArtifact": {
         "additionalProperties": false,
         "description": "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights.",
@@ -29047,6 +29044,12 @@
           "emission_concentration"
         ],
         "type": "object"
+      },
+      "DurationMillis": {
+        "description": "A duration in milliseconds. Published as Float in GraphQL: a span past 24.8 days exceeds the 32-bit range of GraphQL's Int.",
+        "maximum": 9007199254740991,
+        "minimum": -9007199254740991,
+        "type": "integer"
       },
       "EconomicsArtifact": {
         "additionalProperties": {},
@@ -42669,9 +42672,7 @@
           "latency_ms": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": -9007199254740991,
-                "type": "integer"
+                "$ref": "#/components/schemas/DurationMillis"
               },
               {
                 "type": "null"
@@ -42754,9 +42755,8 @@
           "age_ms": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": 0,
-                "type": "integer"
+                "$ref": "#/components/schemas/DurationMillis",
+                "minimum": 0
               },
               {
                 "type": "null"
@@ -44068,9 +44068,7 @@
           "maturity_rate": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": -9007199254740991,
-                "type": "integer"
+                "$ref": "#/components/schemas/ChainU64"
               },
               {
                 "type": "null"
@@ -44102,9 +44100,7 @@
           "unlock_rate": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": -9007199254740991,
-                "type": "integer"
+                "$ref": "#/components/schemas/ChainU64"
               },
               {
                 "type": "null"
@@ -55600,9 +55596,7 @@
           "age_ms": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": -9007199254740991,
-                "type": "integer"
+                "$ref": "#/components/schemas/DurationMillis"
               },
               {
                 "type": "null"
@@ -56019,6 +56013,16 @@
             "minimum": 0,
             "type": "integer"
           },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "reliability": {
             "anyOf": [
               {
@@ -56377,6 +56381,7 @@
         "required": [
           "schema_version",
           "netuid",
+          "observed_at",
           "source",
           "reliability",
           "surfaces"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6240,11 +6240,11 @@ export interface components {
             block_count: number;
             block_time: {
                 count: number;
-                max_ms: number;
-                mean_ms: number;
-                min_ms: number;
-                p50_ms: number;
-                p90_ms: number;
+                max_ms: components["schemas"]["DurationMillis"];
+                mean_ms: components["schemas"]["DurationMillis"];
+                min_ms: components["schemas"]["DurationMillis"];
+                p50_ms: components["schemas"]["DurationMillis"];
+                p90_ms: components["schemas"]["DurationMillis"];
             } | null;
             distinct_authors: number;
             distinct_spec_versions: number;
@@ -7273,6 +7273,8 @@ export interface components {
             }[];
             window: ("7d" | "30d" | "90d") | null;
         };
+        /** @description An unsigned 64-bit integer read from chain storage. Published as Float in GraphQL: the runtime's range exceeds that of GraphQL's Int. */
+        ChainU64: number;
         /** @description Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights. */
         ChainWeightsArtifact: {
             /** @description Spread of per-subnet update intensity (WeightsSet events per validator) across every subnet that set weights in the window. */
@@ -7902,6 +7904,8 @@ export interface components {
             /** @description This domain's member subnets' stake, TAO-priced through each subnet's own alpha_price_tao from the economics tier (#9051), rather than a sum of incomparable per-subnet alpha tokens. The economics tier carries a price for every subnet, so a member without one is a data defect and is excluded from the total. */
             total_stake_tao: number | null;
         };
+        /** @description A duration in milliseconds. Published as Float in GraphQL: a span past 24.8 days exceeds the 32-bit range of GraphQL's Int. */
+        DurationMillis: number;
         EconomicsArtifact: {
             captured_at: string | null;
             chain_state?: components["schemas"]["ChainState"];
@@ -10590,7 +10594,7 @@ export interface components {
             /** @description Trailing-90d daily ratios, oldest first; gaps are absent, never zero-filled. */
             days: components["schemas"]["SelfHealthDay"][];
             http_status: number | null;
-            latency_ms: number | null;
+            latency_ms: components["schemas"]["DurationMillis"] | null;
             /** @description Qualifies a false current_ok with why, for non-HTTP failure modes. Null when there's nothing to add. */
             note: string | null;
             /** @description Mean uptime across the days we actually have. Null when there are none. */
@@ -10624,7 +10628,7 @@ export interface components {
          *     it starts to matter.
          */
         SelfHealthLane: {
-            age_ms: number | null;
+            age_ms: components["schemas"]["DurationMillis"] | null;
             checked_at: string | null;
             detail: string | null;
             lane: string;
@@ -10907,11 +10911,11 @@ export interface components {
                 is_owner?: boolean;
                 locked_mass?: number;
             }[];
-            maturity_rate?: number | null;
+            maturity_rate?: components["schemas"]["ChainU64"] | null;
             netuid: number;
             queried_at_block?: number | null;
             schema_version: number;
-            unlock_rate?: number | null;
+            unlock_rate?: components["schemas"]["ChainU64"] | null;
         } & {
             [key: string]: unknown;
         };
@@ -12950,7 +12954,7 @@ export interface components {
         };
         TaoUsdArtifact: {
             /** @description How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading. */
-            age_ms: number | null;
+            age_ms: components["schemas"]["DurationMillis"] | null;
             change_pct: number | null;
             change_usd: number | null;
             latest: components["schemas"]["TaoUsdLatest"] | null;
@@ -13024,6 +13028,7 @@ export interface components {
         /** @description One subnet's long-term daily uptime history (#5885). Mirrors GET /api/v1/subnets/{netuid}/uptime's data envelope. */
         UptimeArtifact: {
             netuid: number;
+            observed_at: string | null;
             /** @description Window-wide reliability score (0-100) with letter grade. Surface-level scores omit window/surface_count/day_count/computed_at. */
             reliability: ({
                 avg_latency_ms: number | null;
@@ -47203,6 +47208,7 @@ export interface operations {
                      * @example {
                      *       "data": {
                      *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
                      *         "reliability": {
                      *           "avg_latency_ms": 120,
                      *           "computed_at": "2026-06-01T00:00:00.000Z",

--- a/schemas-src/graphql/build-schema.ts
+++ b/schemas-src/graphql/build-schema.ts
@@ -40,12 +40,14 @@ import type {
   TypeNode,
 } from "graphql";
 import { JSONScalar, emitTypes } from "./emit.ts";
-import { GRAPHQL_ENUMS } from "./enums.ts";
+import { GRAPHQL_ENUMS, enumFieldSites } from "./enums.ts";
 import {
   ALIASED_TYPE_NAMES,
+  MIRROR_OVERLAYS,
   PROJECTED_TYPES,
   PUBLISHED_TYPE_NAMES,
   QUERY_BINDINGS,
+  RETYPED_FIELDS,
   SUBSCRIPTION_BINDINGS,
 } from "./published-names.ts";
 import {
@@ -77,6 +79,14 @@ export function buildGeneratedSchema(
   projections: Readonly<
     Record<string, (typeof PROJECTED_TYPES)[string]>
   > = PROJECTED_TYPES,
+  // Injectable for the same reason, and for one more: both rules `retype`
+  // enforces THROW, and a rule that only ever runs against declarations known
+  // to satisfy it is a rule nothing has shown can fail.
+  retypedFields: Readonly<Record<string, string>> = RETYPED_FIELDS,
+  enumSites: ReadonlyMap<string, string> = enumFieldSites(),
+  overlays: Readonly<
+    Record<string, (typeof MIRROR_OVERLAYS)[string]>
+  > = MIRROR_OVERLAYS,
 ): BuiltSchema {
   const { types: emitted } = emitTypes();
   const sources = new Map<string, string>();
@@ -176,6 +186,16 @@ export function buildGeneratedSchema(
     });
     const source = contributors[0];
     const projection = projections[name];
+    // A type is one or the other: a view of a component, or a mirror with
+    // resolver edits. Declaring it both ways is two answers to "what is this
+    // type's shape", and the builder cannot pick between them.
+    const overlay = overlays[name];
+    if (projection && overlay) {
+      throw new Error(
+        `${name} is declared as both a projection of ${projection.component} and a mirror overlay`,
+      );
+    }
+    const edits = projection ?? overlay;
     const type = new GraphQLObjectType({
       name,
       description: source.description ?? undefined,
@@ -183,7 +203,7 @@ export function buildGeneratedSchema(
       // resolves rather than recursing while it is still being constructed.
       fields: () => {
         const fields: Record<string, GraphQLFieldConfig<unknown, unknown>> = {};
-        const dropped = new Set(projection?.dropped ?? []);
+        const dropped = new Set(edits?.dropped ?? []);
         const renamed = new Map<string, string>();
         if (projection?.itemsFrom) renamed.set(projection.itemsFrom, "items");
         if (projection?.totalFrom) renamed.set(projection.totalFrom, "total");
@@ -207,17 +227,18 @@ export function buildGeneratedSchema(
           // `featured`, `uid_count` and `stake_dominance`.
           const everywhere = carriers.length === contributors.length;
           const republished = republish(field.type);
-          fields[renamed.get(fieldName) ?? fieldName] = {
-            type:
+          const published = renamed.get(fieldName) ?? fieldName;
+          fields[published] = {
+            type: retype(
+              `${name}.${published}`,
               everywhere || !(republished instanceof GraphQLNonNull)
                 ? republished
                 : (republished.ofType as GraphQLOutputType),
+            ),
             description: field.description ?? undefined,
           };
         }
-        for (const [fieldName, added] of Object.entries(
-          projection?.added ?? {},
-        )) {
+        for (const [fieldName, added] of Object.entries(edits?.added ?? {})) {
           fields[fieldName] = {
             type: fromSpelling(added) as GraphQLOutputType,
           };
@@ -228,6 +249,87 @@ export function buildGeneratedSchema(
     built.set(name, type);
     sources.set(name, components.join(" + "));
     return type;
+  }
+
+  /**
+   * A field's published type where it is not the one its component emits.
+   *
+   * TWO SOURCES, one rule each, and the rule is the point -- a mechanism that
+   * lets a declaration say anything about a field's type is a second
+   * hand-written SDL with extra steps.
+   *
+   * An ENUM site may only replace `String` (in whatever nullability the
+   * component gave it), because that is what the emitter maps every registered
+   * Zod enum to. Anything else means the site names a field that is not an
+   * enum, which is a typo rather than a narrowing.
+   *
+   * A RETYPE may change the named type and NOTHING else: same list depth, same
+   * `!` in the same places. The exception is `JSON`, which carries no shape at
+   * all, so replacing it cannot contradict anything -- that is the direction
+   * this epic moves in. Without the rule, `X!` -> `X` would be spelled the
+   * same way as a rename, and relaxing a promise is the one change a client
+   * can be broken by.
+   */
+  function retype(
+    site: string,
+    emittedType: GraphQLOutputType,
+  ): GraphQLOutputType {
+    const enumName = enumSites.get(site);
+    if (enumName) {
+      const inner = nullableInner(emittedType);
+      if (inner !== GraphQLString) {
+        throw new Error(
+          `${site} is declared as the enum ${enumName}, but its component emits ${String(emittedType)}`,
+        );
+      }
+      return rewrap(emittedType, enums.get(enumName)!);
+    }
+    const spelling = retypedFields[site];
+    if (!spelling) return emittedType;
+    const replacement = fromSpelling(spelling) as GraphQLOutputType;
+    if (
+      nullableInner(emittedType) !== JSONScalar &&
+      wrapping(emittedType) !== wrapping(replacement)
+    ) {
+      throw new Error(
+        `${site} is retyped from ${String(emittedType)} to ${spelling}, which changes ` +
+          `more than the named type; only a JSON field may change shape`,
+      );
+    }
+    return replacement;
+  }
+
+  /** The type inside every list and non-null wrapper. */
+  function nullableInner(type: GraphQLType): GraphQLNamedType {
+    let inner = type;
+    while (inner instanceof GraphQLNonNull || inner instanceof GraphQLList) {
+      inner = inner.ofType as GraphQLType;
+    }
+    return inner as GraphQLNamedType;
+  }
+
+  /** `[Foo!]!` -> `[_!]!` -- the shape with the name taken out. */
+  function wrapping(type: GraphQLType): string {
+    return String(type).replace(/[A-Za-z_][A-Za-z0-9_]*/, "_");
+  }
+
+  /** Put `inner` back inside the wrappers `type` carries. */
+  function rewrap(
+    type: GraphQLOutputType,
+    inner: GraphQLNamedType,
+  ): GraphQLOutputType {
+    if (type instanceof GraphQLNonNull) {
+      return new GraphQLNonNull(
+        rewrap(
+          type.ofType as GraphQLOutputType,
+          inner,
+        ) as GraphQLNullableOutputType,
+      );
+    }
+    if (type instanceof GraphQLList) {
+      return new GraphQLList(rewrap(type.ofType as GraphQLOutputType, inner));
+    }
+    return inner as GraphQLOutputType;
   }
 
   /** An emitted field's type, with every object swapped for its published one. */

--- a/schemas-src/graphql/emit.ts
+++ b/schemas-src/graphql/emit.ts
@@ -112,6 +112,15 @@ export function componentSchemas(): Record<string, SchemaNode> {
  */
 const SCALAR_COMPONENTS: Readonly<Record<string, GraphQLScalarType>> = {
   EpochMillis: GraphQLFloat,
+  // The paragraph above ends "a DURATION is a span rather than an instant and
+  // stays `z.int()` -> `Int`". That was wrong, and the arithmetic says so:
+  // 2^31 ms is 24.8 days. `SelfHealthLane.age_ms` counts how long a lane has
+  // been silent off a row nothing prunes once its producer dies, and
+  // `TaoUsd.age_ms` is bounded only by the requested window -- whose
+  // vocabulary includes `30d`, 1.21x the ceiling. See `DurationMillisSchema`.
+  DurationMillis: GraphQLFloat,
+  // Decoded from chain storage with `Number(value)` and no range guard.
+  ChainU64: GraphQLFloat,
 };
 
 /** `#/components/schemas/Foo` -> `Foo`; anything else -> null. */
@@ -188,13 +197,24 @@ export interface EmittedTypes {
    */
   unnameable: string[];
   /**
-   * Properties typed `z.null()` -- the value is null and nothing else.
+   * Properties typed `z.null()`, published as a nullable `String` (#10214).
    *
-   * GraphQL has no null type. Publishing one as `JSON` or `String` would
-   * advertise a field a client can select and never learn anything from, so
-   * these are dropped and reported instead. `ContractsArtifact.status_domain`
-   * is the one today: the builder hardcodes `status_domain: null`, so the Zod
-   * type is faithful and the field is vestigial.
+   * GraphQL has no null type, so the value cannot be spelled exactly. These
+   * used to be DROPPED and reported, which was wrong in the one way that
+   * matters: nothing read the report. `nullOnly` was consumed by a single
+   * assertion naming `ContractsArtifact.status_domain`, so when
+   * `field_sources_usd.storage` became the second and third entries they
+   * disappeared from the emitted schema with no gate, no failure and no note
+   * -- and the hand-written SDL, which publishes `AlphaUsdFieldSource.storage`
+   * but not `Contracts.status_domain`, had already drifted into disagreeing
+   * with itself about which of the two to publish.
+   *
+   * `String` over-promises very slightly: it says "a string or null" where the
+   * schema says "null". That is the same over-promise the SDL already makes
+   * for `storage`, it keeps a published field published, and it is the only
+   * spelling that makes the emitter TOTAL -- every declared property reaches
+   * the schema, so a field can no longer leave the contract by being typed in
+   * a way the emitter had no case for.
    */
   nullOnly: string[];
 }
@@ -284,6 +304,10 @@ export function emitTypes(): EmittedTypes {
           }
           if (raw?.type === "null") {
             nullOnly.push(`${path}.${key}`);
+            fields[key] = {
+              type: GraphQLString,
+              description: raw.description ?? undefined,
+            };
             continue;
           }
           const inner = outputType(

--- a/schemas-src/graphql/enums.ts
+++ b/schemas-src/graphql/enums.ts
@@ -20,6 +20,19 @@ export interface PublishedEnum {
   readonly from: readonly string[];
   /** Values the producer has that GraphQL does not publish, and why. */
   readonly excluded?: Readonly<Record<string, string>>;
+  /**
+   * The `PublishedType.field` sites that publish this enum rather than String.
+   *
+   * The emitter maps every registered Zod enum to `String` -- the decision
+   * above -- so a field the SDL publishes as an enum has to say so somewhere.
+   * Here rather than in a general retype map, because THIS declaration can be
+   * checked against the field's own vocabulary: `assertEnumFieldVocabularies`
+   * reads the Zod behind each site and fails when its values are not the ones
+   * the enum publishes. A blanket "retype this field to that name" could not.
+   *
+   * Empty on `Network`, which is an ARGUMENT type only -- no field returns it.
+   */
+  readonly fields?: readonly string[];
 }
 
 export const GRAPHQL_ENUMS: Readonly<Record<string, PublishedEnum>> = {
@@ -41,8 +54,33 @@ export const GRAPHQL_ENUMS: Readonly<Record<string, PublishedEnum>> = {
       "Which source table a live chain event came from. The same four topics the SSE firehose and the ingest validator accept.",
     values: [...CHAIN_FIREHOSE_TABLES],
     from: [...CHAIN_FIREHOSE_TABLES],
+    fields: ["ChainEvent.table"],
   },
 };
+
+/**
+ * `PublishedType.field` -> the enum it publishes, inverted from the above.
+ *
+ * One field cannot publish two enums, so a second declaration of the same site
+ * is a contradiction rather than an override, and this throws on it.
+ */
+export function enumFieldSites(
+  declarations: Readonly<Record<string, PublishedEnum>> = GRAPHQL_ENUMS,
+): ReadonlyMap<string, string> {
+  const sites = new Map<string, string>();
+  for (const [name, declaration] of Object.entries(declarations)) {
+    for (const site of declaration.fields ?? []) {
+      const existing = sites.get(site);
+      if (existing) {
+        throw new Error(
+          `${site} is declared as both ${existing} and ${name}; a field publishes one enum`,
+        );
+      }
+      sites.set(site, name);
+    }
+  }
+  return sites;
+}
 
 /**
  * Every published value must exist in the producer's vocabulary, and every

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -2654,6 +2654,103 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
   },
 };
 
+/** A resolver's edits to a MIRROR -- the projection mechanism, for types that
+ *  are not views (#10214). */
+export interface MirrorOverlay {
+  /**
+   * Fields the resolver supplies that no contributing component does, each
+   * with the type it publishes -- the same declaration `ProjectedType.added`
+   * makes, for a type that mirrors its component rather than projecting one.
+   */
+  readonly added?: Readonly<Record<string, string>>;
+  /**
+   * Component fields the resolver does NOT republish under that name.
+   *
+   * Deliberately narrow: a mirror's rule is that every component field appears,
+   * so each entry here weakens the strongest gate on the type and has to say
+   * why in a comment. The only entries today are one producer's spelling of a
+   * fact the union already publishes under the other's.
+   */
+  readonly dropped?: readonly string[];
+}
+
+/**
+ * Mirrors whose published shape is not exactly their component's.
+ *
+ * WHY NOT `PROJECTED_TYPES`. A projection is exempt from the mirror rule --
+ * "every component field must appear" -- because publishing a subset is what
+ * it is for. Moving a mirror into that map to give it one added field would
+ * hand it that exemption for all its other fields too, which is the gate
+ * getting weaker as a side effect of an unrelated change. Two maps keep the
+ * two rules separate: `dropped` here is the only exemption, and it is per
+ * field.
+ */
+export const MIRROR_OVERLAYS: Readonly<Record<string, MirrorOverlay>> = {
+  // `validatorNode` normalizes two producers into one shape, and the list
+  // producer spells the detail's `captured_at`/`block_number` as
+  // `latest_captured_at`/`latest_block_number` (the comment on
+  // `GlobalValidatorsArtifactValidators` above says so). The union carries all
+  // four names; the resolver publishes one pair, so the other is dropped
+  // rather than served as a permanent null beside the value it duplicates.
+  Validator: { dropped: ["latest_captured_at", "latest_block_number"] },
+  // The artifact nests this INSIDE `summary` and REST serves it there; the
+  // Query resolver lifts it to the top as well (#9892, after the flattened
+  // path resolved null on every call). So it is a GraphQL-only field over a
+  // component that legitimately does not carry it -- `JSON` because the value
+  // is a record keyed by subnet slug, which is the same reason
+  // `ChangelogArtifactSummary.coverage_delta` is JSON where it is nested.
+  Changelog: { added: { coverage_delta: "JSON" } },
+};
+
+/**
+ * Fields whose published type is not the one their component's Zod emits.
+ *
+ * TWO THINGS LIVE HERE, and both are about the type a field REFERENCES rather
+ * than the nullability it promises -- which is the rule the builder enforces:
+ * a retype may change the named type and nothing else, unless what it replaces
+ * is `JSON`, in which case any spelling is allowed because `JSON` says nothing
+ * about shape at all. So this cannot be used to quietly relax a `!`, which is
+ * the one direction that would matter to a client.
+ *
+ * ONE SHAPE, TWO PUBLISHED NAMES. `publishedName()` answers per COMPONENT, so
+ * a component the schema names twice comes out under whichever name won, and
+ * the other is registered but never reached -- `ChainAlphaVolumeSubnet` and
+ * `OpportunityEntry` were two of the four types the generator did not build
+ * for exactly this reason. The name belongs to the REFERENCE, not the shape:
+ * `SubnetAlphaVolumeArtifact` is `SubnetVolume` from its own route and
+ * `ChainAlphaVolumeSubnet` from inside the chain rollup, and only the field
+ * knows which.
+ *
+ * A CONCRETE SHAPE BEHIND AN OPAQUE ONE. `EmissionGateChanges.changes` and
+ * `SubnetTrajectory.deltas` are `JSON` in the Zod because REST genuinely
+ * serves what GraphQL cannot: an un-flattened union whose arms have different
+ * keys, and a record keyed by window ("7d", "30d") rather than by field.
+ * GraphQL publishes the flattened/re-keyed form, and the component behind it
+ * is registered -- `EmissionGateChange`, `SubnetTrajectoryDelta` -- so naming
+ * it here is what stops those rows from being served as opaque blobs. This is
+ * the direction the epic exists to move in, not an exception to it.
+ */
+export const RETYPED_FIELDS: Readonly<Record<string, string>> = {
+  // The chain rollup's rows are the per-subnet volume card, published under
+  // the rollup's own name -- `ALIASED_TYPE_NAMES` says so, and this is the
+  // reference that reaches it.
+  "ChainAlphaVolume.subnets": "[ChainAlphaVolumeSubnet!]!",
+  // Every board is the economics card minus the 26 fields a ranking has no use
+  // for, plus the headroom the ranker derives: `PROJECTED_TYPES.OpportunityEntry`
+  // is that view, and these six are its only reference sites.
+  "OpportunityBoards.open_slots": "[OpportunityEntry!]!",
+  "OpportunityBoards.cheapest_registration": "[OpportunityEntry!]!",
+  "OpportunityBoards.highest_emission": "[OpportunityEntry!]!",
+  "OpportunityBoards.validator_headroom": "[OpportunityEntry!]!",
+  "OpportunityBoards.biggest_alpha_gain_1d": "[OpportunityEntry!]!",
+  "OpportunityBoards.biggest_alpha_gain_7d": "[OpportunityEntry!]!",
+  // The two opaque ones. REST serves the union un-flattened and the deltas
+  // keyed by window; both are `JSON` in the Zod for that reason, and both have
+  // a registered component describing the form GraphQL publishes.
+  "EmissionGateChanges.changes": "[EmissionGateChange!]!",
+  "SubnetTrajectory.deltas": "[SubnetTrajectoryDelta!]!",
+};
+
 /**
  * The Subscription root, declared the way `QUERY_BINDINGS` declares the Query
  * root (#10409).

--- a/schemas-src/openapi-registry.ts
+++ b/schemas-src/openapi-registry.ts
@@ -59,6 +59,8 @@ import {
   HealthStatusSchema,
   PartnershipMetadataSchema,
   PartnershipTierSchema,
+  ChainU64Schema,
+  DurationMillisSchema,
   EpochMillisSchema,
   ScoreDistributionSchema,
   SubnetEconomicsSchema,
@@ -852,6 +854,13 @@ register(ScoreDistributionSchema, "ScoreDistribution");
 // alone cannot tell one from the other, and GraphQL's Int is 32-bit. The
 // GraphQL emitter maps this id to Float; a `z.int()` stays Int.
 register(EpochMillisSchema, "EpochMillis");
+// The two other integers whose range the type cannot state (#10214). A span in
+// milliseconds passes 32 bits at 24.8 days, and a chain u64 is decoded with
+// `Number(value)` and no guard -- both map to Float in the GraphQL emitter for
+// the same reason `EpochMillis` does, and both are registered here so the fact
+// lives in the schema instead of in a field name.
+register(DurationMillisSchema, "DurationMillis");
+register(ChainU64Schema, "ChainU64");
 
 // Batch 8 (#8062) additions. Only the 18 top-level route artifacts (each
 // required -- schemaRefForArtifactPath binds its route to exactly this

--- a/schemas-src/routes/blocks-summary.ts
+++ b/schemas-src/routes/blocks-summary.ts
@@ -8,16 +8,16 @@
 // repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
-import { ConcentrationMetricsSchema } from "../shared.ts";
+import { ConcentrationMetricsSchema, DurationMillisSchema } from "../shared.ts";
 
 const BlockTimeDistributionSchema = z
   .object({
     count: z.int().min(0),
-    mean_ms: z.int(),
-    min_ms: z.int(),
-    max_ms: z.int(),
-    p50_ms: z.int(),
-    p90_ms: z.int(),
+    mean_ms: DurationMillisSchema,
+    min_ms: DurationMillisSchema,
+    max_ms: DurationMillisSchema,
+    p50_ms: DurationMillisSchema,
+    p90_ms: DurationMillisSchema,
   })
   .strict()
   .describe(

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -563,6 +563,14 @@ export const UptimeArtifactSchema = z
     schema_version: z.int(),
     netuid: z.int().min(0),
     window: z.string().nullable().optional(),
+    // When the health cron that produced these samples last ran. Declared
+    // because it is SERVED: `formatUptime` (src/health-serving.ts) emits it on
+    // every card, both transports feed it (`readHealthMetaKv` on REST, the
+    // memoized `loadObservedAt` on GraphQL), and REST reads it back out into
+    // the response meta. It went undeclared only because `.passthrough()` let
+    // it through -- so the contract omitted a field production always sends,
+    // and the emitted GraphQL type omitted it too (#10214).
+    observed_at: z.string().nullable(),
     source: z.string(),
     // Always-present key in formatUptime()'s real return (its value is the
     // JS null when there are no samples, never an omitted key) -- required,

--- a/schemas-src/routes/self-health.ts
+++ b/schemas-src/routes/self-health.ts
@@ -8,6 +8,7 @@
 // sub-shape gets silently inlined by the OpenAPI registry rather than
 // $ref'd -- see the Zod-registry gotcha in the schema notes.
 import { z } from "zod";
+import { DurationMillisSchema } from "../shared.ts";
 
 export const SelfHealthDaySchema = z
   .object({
@@ -32,7 +33,7 @@ export const SelfHealthComponentSchema = z
       .nullable()
       .describe("Null when the component has never been probed -- NOT false."),
     http_status: z.int().nullable(),
-    latency_ms: z.int().nullable(),
+    latency_ms: DurationMillisSchema.nullable(),
     checked_at: z.string().nullable(),
     // metagraphed#8352: qualifies a false current_ok with WHY, for the one
     // component class (publish) whose failure is a cadence miss rather than
@@ -85,7 +86,7 @@ export const SelfHealthLaneSchema = z
     // with null above.
     verdict: z.enum(LANE_VERDICTS),
     // Null when the watchdog could not measure how far behind the lane was.
-    age_ms: z.int().min(0).nullable(),
+    age_ms: DurationMillisSchema.min(0).nullable(),
     detail: z.string().nullable(),
     checked_at: z.string().nullable(),
   })

--- a/schemas-src/routes/subnet-conviction.ts
+++ b/schemas-src/routes/subnet-conviction.ts
@@ -5,7 +5,7 @@
 // it replaces. No query params (verified: the DATA_API route reads only the
 // netuid path segment).
 import { z } from "zod";
-import { FieldSourcesSchema } from "../shared.ts";
+import { ChainU64Schema, FieldSourcesSchema } from "../shared.ts";
 
 const SubnetConvictionEntrySchema = z
   .object({
@@ -21,8 +21,8 @@ export const SubnetConvictionArtifactSchema = z
     schema_version: z.int(),
     netuid: z.int().min(0).max(65535),
     queried_at_block: z.int().nullable().optional(),
-    unlock_rate: z.int().nullable().optional(),
-    maturity_rate: z.int().nullable().optional(),
+    unlock_rate: ChainU64Schema.nullable().optional(),
+    maturity_rate: ChainU64Schema.nullable().optional(),
     king: z.string().nullable().optional(),
     count: z.int().min(0),
     leaderboard: z.array(SubnetConvictionEntrySchema),

--- a/schemas-src/routes/tao-usd.ts
+++ b/schemas-src/routes/tao-usd.ts
@@ -7,6 +7,7 @@
 // the pairing as a CHECK. Null means "not priceable at that block"; a zero
 // would mean TAO is worthless.
 import { z } from "zod";
+import { DurationMillisSchema } from "../shared.ts";
 
 export const TaoUsdPointSchema = z
   .object({
@@ -70,12 +71,9 @@ export const TaoUsdArtifactSchema = z
       .describe(
         "The bound `stale` is measured against -- the same one the API refuses to derive USD figures from, so 'this response says stale' and 'no USD anywhere on the API' are one condition rather than two that can drift.",
       ),
-    age_ms: z
-      .int()
-      .nullable()
-      .describe(
-        "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading.",
-      ),
+    age_ms: DurationMillisSchema.nullable().describe(
+      "How old the newest reading is, so a caller can render 'N minutes ago' without re-deriving it. Null when there is no reading.",
+    ),
     /** How many points carried a price. A gap from point_count is how a window
      * with unpriceable blocks announces itself. */
     priced_point_count: z

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -27,14 +27,64 @@ import { QUERY_ENUMS } from "./query-enums.ts";
  * of all of them. The emitter stood a `/_at$/` name test in for the missing
  * fact, which rescued 7 fields and missed 8 that production proves overflow
  * -- `candles[].bucket_start` on 1371 of 1371 observed candles, and the six
- * `rpc-usage` coverage bounds. Use this schema for an instant; a DURATION
- * (`duration_ms`, `age_ms`) is a span, not an instant, and stays `z.int()`.
+ * `rpc-usage` coverage bounds. Use this schema for an instant; for a span, use
+ * {@link DurationMillisSchema}.
  */
 export const EpochMillisSchema = z
   .int()
   .min(0)
   .describe(
     "An epoch-millisecond instant. Published as Float in GraphQL: the value exceeds the 32-bit range of GraphQL's Int.",
+  );
+
+/**
+ * A span in MILLISECONDS, published as an integer (#10214).
+ *
+ * A span is not an instant, and the comment this replaces concluded from that
+ * it was safe as `Int`. It is not: 2^31 milliseconds is 24.8 days, and two of
+ * these fields reach it on paths that already exist.
+ *
+ *   `SelfHealthLane.age_ms`  `nowMs - row.checked_at` over the newest
+ *                            `lane_health` row, with no recency filter on the
+ *                            read and retention pruning that only runs on a
+ *                            lane's OWN insert -- so a lane whose producer died
+ *                            never prunes, and its age climbs without bound. A
+ *                            watchdog's own `age_ms` is the same subtraction.
+ *   `TaoUsd.age_ms`          bounded by the requested window, and the window
+ *                            vocabulary includes `30d` = 2.59e9 ms, which is
+ *                            1.21x the ceiling.
+ *
+ * Both fail in the direction that matters most: an `Int` carrying an
+ * over-range value raises at execution time and nulls its surrounding object,
+ * so the surface reports NOTHING precisely when the thing it monitors has been
+ * broken longest. `conformance:graphql-int-range` cannot catch either, because
+ * it reads live values and neither is over-range right now.
+ *
+ * `schemas-src/graphql/emit.ts` maps this component id to `Float`, the only
+ * spelling GraphQL has for the value -- which is what the hand-written SDL
+ * chose for all eight of these fields by hand.
+ */
+export const DurationMillisSchema = z
+  .int()
+  .describe(
+    "A duration in milliseconds. Published as Float in GraphQL: a span past 24.8 days exceeds the 32-bit range of GraphQL's Int.",
+  );
+
+/**
+ * An unsigned 64-bit integer read straight from chain storage (#10214).
+ *
+ * `decodeLeU64Number` returns `Number(value)` with no range guard, so what the
+ * runtime holds is what the field carries. Today's values are small --
+ * `UnlockRate` 934,866 and `MaturityRate` 311,622 -- but they are governance
+ * -set u64s, and nothing between the storage read and the response narrows
+ * them to anything GraphQL's 32-bit `Int` can hold. Published as `Float`,
+ * which is what the SDL already does for both.
+ */
+export const ChainU64Schema = z
+  .int()
+  .min(0)
+  .describe(
+    "An unsigned 64-bit integer read from chain storage. Published as Float in GraphQL: the runtime's range exceeds that of GraphQL's Int.",
   );
 
 /** One vocabulary, owned by the leaf module so routes AND tools can import it

--- a/scripts/validate-graphql-route-parity.ts
+++ b/scripts/validate-graphql-route-parity.ts
@@ -42,6 +42,12 @@ const DECLARED: Record<string, string> = {
     "the REST envelope keys deltas by window ('7d'/'30d'), which are not valid GraphQL field names, " +
     "so they become a list of objects carrying `window`. Verified live — the query returns " +
     "[{window:'7d'},{window:'30d'}] with no errors. A shape difference the resolver owns, not drift.",
+  "Contracts.status_domain":
+    "GraphQL has no null type, so a field the contract types `z.null()` cannot be spelled exactly; " +
+    "String is the nullable carrier, and the value is null on every response. The alternative was " +
+    "the emitter's old behaviour -- drop the field and report it -- which is how this one and both " +
+    "`field_sources_usd.storage` fields left the schema with nothing reading the report (#10214). " +
+    "Verified live: /api/v1/contracts serves the key, always as null.",
 };
 
 const openapi = JSON.parse(readFileSync(OPENAPI_PATH, "utf8")) as Json;

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -1178,7 +1178,7 @@ export const SDL = /* GraphQL */ `
     endpoint_count: Int
     surface_count: Int
     subnet_count: Int
-    netuids: [Int]!
+    netuids: [Int!]!
     "The subnets this provider operates surfaces on."
     subnets: [Subnet!]!
     "This provider's endpoint/resource registry rows -- the nested companion to endpoint_count, mirroring GET /api/v1/providers/{slug}/endpoints."
@@ -1645,19 +1645,19 @@ export const SDL = /* GraphQL */ `
     "Jaccard retention of the start set into the end set; null on a cold/non-comparable window."
     validator_retention: Float
     "0-100 stability score; null on a cold/non-comparable window."
-    stability_score: Float
+    stability_score: Int
   }
 
   "Spread of per-subnet stability score across EVERY subnet in the window (not just the returned page, so the spread stays network-wide when limit truncates the leaderboard)."
   type ChainTurnoverStabilityDistribution {
     count: Int!
     mean: Float!
-    min: Float!
-    p25: Float!
+    min: Int!
+    p25: Int!
     median: Float!
-    p75: Float!
-    p90: Float!
-    max: Float!
+    p75: Int!
+    p90: Int!
+    max: Int!
   }
 
   "One subnet's validator-set churn, ranked by gross churn (entered + exited) then netuid."
@@ -1668,7 +1668,7 @@ export const SDL = /* GraphQL */ `
     validators_entered: Int!
     validators_exited: Int!
     validator_retention: Float
-    stability_score: Float
+    stability_score: Int
   }
 
   "Network-wide validator weight-setting activity over a lookback window, summed live from the account_events WeightsSet stream. Mirrors GET /api/v1/chain/weights."
@@ -2588,6 +2588,8 @@ export const SDL = /* GraphQL */ `
     name: String
     base_path: String
     primary_domain: String
+    "Always null. The builder hardcodes it and the contract types it that way, so this is the schema stating a vestige rather than hiding one -- /api/v1/contracts has always served the key (#10214)."
+    status_domain: String
     openapi_url: String
     type_definitions_url: String
     notes: JSON
@@ -3826,11 +3828,6 @@ export const SDL = /* GraphQL */ `
     source: String
     pool_eligible: Boolean
     user_reported: Boolean
-    incident_count: Int
-    downtime_ms: Int
-    transient_failure_count: Int
-    transient_failed_samples: Int
-    incidents: [EndpointIncidentWindow!]
   }
 
   "One subnet's per-surface SLA + reconstructed downtime incidents over the window. Mirrors GET /api/v1/subnets/{netuid}/health/incidents's data envelope."

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -63,19 +63,38 @@ describe("Zod -> GraphQL type emitter (#10214)", () => {
     }
   });
 
-  test("drops a z.null() property instead of publishing an empty field", () => {
+  test("publishes a z.null() property as a nullable String, and reports it", () => {
     const { nullOnly, types } = emitTypes();
     // buildContractsArtifact hardcodes `status_domain: null`, so z.null() is
-    // faithful -- and GraphQL has no null type. Publishing it as JSON would
-    // advertise a field a client can select and never learn anything from.
+    // faithful -- and GraphQL has no null type. This USED to drop the field
+    // and report it, which held for exactly as long as one assertion named
+    // the one entry: `field_sources_usd.storage` became the second and third
+    // and left the schema silently, on two components (#10214). Publishing a
+    // nullable String makes the emitter total -- every declared property
+    // reaches the schema -- so a field can no longer leave the contract by
+    // being typed in a way the emitter had no case for.
     assert.ok(
       nullOnly.includes("ContractsArtifact.status_domain"),
       `expected the null-only field to be reported, got ${nullOnly.join(", ")}`,
     );
     assert.equal(
-      types.get("ContractsArtifact")!.getFields().status_domain,
-      undefined,
+      String(types.get("ContractsArtifact")!.getFields().status_domain.type),
+      "String",
+      "a null-only field is published nullable: null is the only value it can carry",
     );
+    // Every reported entry is published, not just the one named above.
+    for (const entry of nullOnly) {
+      const [component, ...path] = entry.split(".");
+      const type = types.get(component);
+      if (!type) continue; // a nested path, named for its parent component
+      const field = type.getFields()[path[path.length - 1]];
+      if (!field) continue;
+      assert.equal(
+        String(field.type),
+        "String",
+        `${entry} is reported as null-only but published as ${String(field.type)}`,
+      );
+    }
   });
 
   test("pascalCase joins on any non-alphanumeric boundary", () => {

--- a/tests/graphql-generated-schema.test.ts
+++ b/tests/graphql-generated-schema.test.ts
@@ -10,10 +10,15 @@ import { buildGeneratedSchema } from "../schemas-src/graphql/build-schema.ts";
 import {
   GRAPHQL_ENUMS,
   assertEnumVocabularies,
+  enumFieldSites,
 } from "../schemas-src/graphql/enums.ts";
 import { diffSchemas } from "../scripts/report-graphql-schema-diff.ts";
 import { SDL } from "../src/graphql-sdl.ts";
-import { PROJECTED_TYPES } from "../schemas-src/graphql/published-names.ts";
+import {
+  PROJECTED_TYPES,
+  RETYPED_FIELDS,
+} from "../schemas-src/graphql/published-names.ts";
+import type { GraphQLObjectType } from "graphql";
 import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
 
 const openapi = JSON.parse(
@@ -124,6 +129,91 @@ describe("the generated schema", () => {
       SubnetAlias: { ...PROJECTED_TYPES.Subnet },
     });
     assert.ok(schema.getType("Subnet"), "the first-declared name must survive");
+  });
+
+  test("a retype may change the named type, not the promise", () => {
+    // The rule that keeps `RETYPED_FIELDS` from being a second hand-written
+    // SDL. `SubnetVolume` -> `ChainAlphaVolumeSubnet` is a rename and passes;
+    // dropping the `!` is a relaxed promise wearing a rename's spelling, and
+    // it is the one direction a client can be broken by.
+    assert.throws(
+      () =>
+        buildGeneratedSchema(openapi, PROJECTED_TYPES, {
+          "ChainAlphaVolume.subnets": "[ChainAlphaVolumeSubnet!]",
+        }),
+      /changes more than the named type/,
+    );
+  });
+
+  test("a JSON field may be retyped to any shape", () => {
+    // The exception, and the direction the epic moves in: `JSON` carries no
+    // shape, so replacing it cannot contradict anything. Both live entries
+    // rely on this -- REST serves an un-flattened union and a window-keyed
+    // record, neither of which GraphQL can spell.
+    const { schema } = buildGeneratedSchema(openapi);
+    assert.equal(
+      String(
+        (schema.getType("SubnetTrajectory") as GraphQLObjectType).getFields()
+          .deltas.type,
+      ),
+      "[SubnetTrajectoryDelta!]!",
+    );
+  });
+
+  test("an enum site over a field that is not a String FAILS loudly", () => {
+    // The emitter maps every registered Zod enum to `String`, so an enum site
+    // naming anything else names a field that is not an enum -- a typo, not a
+    // narrowing.
+    assert.throws(
+      () =>
+        buildGeneratedSchema(
+          openapi,
+          PROJECTED_TYPES,
+          RETYPED_FIELDS,
+          new Map([["ChainEvent.block_number", "ChainFirehoseTable"]]),
+        ),
+      /declared as the enum ChainFirehoseTable, but its component emits/,
+    );
+  });
+
+  test("one field cannot publish two enums", () => {
+    assert.throws(
+      () =>
+        enumFieldSites({
+          A: { description: "", values: [], from: [], fields: ["X.y"] },
+          B: { description: "", values: [], from: [], fields: ["X.y"] },
+        }),
+      /X\.y is declared as both A and B/,
+    );
+  });
+
+  test("a type declared BOTH a projection and a mirror overlay FAILS loudly", () => {
+    // Two answers to "what is this type's shape", and the builder cannot pick.
+    assert.throws(
+      () =>
+        buildGeneratedSchema(
+          openapi,
+          PROJECTED_TYPES,
+          RETYPED_FIELDS,
+          enumFieldSites(),
+          { SubnetHealth: { added: { invented: "String" } } },
+        ),
+      /both a projection of HealthSubnetSummary and a mirror overlay/,
+    );
+  });
+
+  test("a mirror overlay drops the field it names", () => {
+    // `Validator` is the union of two producers that spell one fact two ways;
+    // the resolver publishes one spelling, so the other must not be served as
+    // a permanent null beside the value it duplicates.
+    const validator = buildGeneratedSchema(openapi).schema.getType(
+      "Validator",
+    ) as GraphQLObjectType;
+    assert.equal(validator.getFields().latest_captured_at, undefined);
+    assert.ok(
+      validator.getFields().captured_at,
+      "the spelling the resolver DOES publish has to survive",
+    );
   });
 
   test("the type set is what the ROOTS REACH", () => {


### PR DESCRIPTION
`report:graphql-schema-diff` builds the schema from the declared sources and compares it to the hand-written `src/graphql-sdl.ts`. It reported 285 nullability tightenings and **42 other differences**. The 285 are one question — can a producer answer null — and they need production evidence, so they stay for their own PR. The 42 are not that question, and none of them had the same answer as the next.

## A published name belongs to a reference, not to a shape

`publishedName()` answered per COMPONENT, so a component the schema names twice came out under whichever name won and the other was registered but never reached. That is two of the four unreached types: `SubnetAlphaVolumeArtifact` is `SubnetVolume` from its own route and `ChainAlphaVolumeSubnet` from inside the chain rollup; `SubnetEconomics` is `OpportunityEntry` when a leaderboard ranks it. The other two are the mirror image — REST genuinely serves an un-flattened union and a window-keyed record, so the Zod says `JSON`, and the concrete component GraphQL publishes had nothing pointing at it.

`RETYPED_FIELDS` names the type at the reference. The rule that keeps it from being a second hand-written SDL: **a retype may change the named type and nothing else**, unless what it replaces is `JSON`, which carries no shape to contradict. So `X!` → `X` cannot be spelled as a rename — and there is a test that proves the rule fires.

## Eight missing fields, four different causes, four different layers

| field | cause | fixed in |
|---|---|---|
| `SubnetUptime.observed_at` | **the contract under-declared a field production always serves** — `formatUptime` emits it on every card, both transports feed it, REST reads it back into the response meta, and `.passthrough()` is why nothing noticed | the Zod |
| `AlphaUsdFieldSource.storage` | **the emitter dropped it silently** — see below | the emitter |
| `Changelog.coverage_delta` | a real resolver flatten (#9892) | declared as one |
| 5 × `EndpointIncident.*` | **vestigial** — nothing produces them; production serves 25 keys and none is among them | removed from the SDL |

The emitter one is worth its own paragraph. A `z.null()` property was dropped and *reported* into `nullOnly` — which exactly one assertion read, naming exactly one entry. When `field_sources_usd.storage` became the second and third entries they left the schema with no gate, no failure and no note, and the SDL had already drifted into publishing one of the two and not the other. Publishing null-only fields as a nullable `String` makes the emitter **total**: every declared property reaches the schema, so a field can no longer leave the contract by being typed in a way the emitter had no case for.

## The duration bug

`emit.ts` said a DURATION "is a span rather than an instant and stays `z.int()` → `Int`". The arithmetic says otherwise — **2^31 ms is 24.8 days**:

- `SelfHealthLane.age_ms` is `now - checked_at` over the newest `lane_health` row, read with no recency filter, and retention pruning only runs on a lane's *own* insert — so a lane whose producer **died** never prunes and its age climbs without bound.
- `TaoUsd.age_ms` is bounded by the requested window, and the window vocabulary includes `30d` = 2.59e9 ms, **1.21× the ceiling**.

An over-range `Int` raises at execution time and nulls its surrounding object (#10215), so the surface would report nothing precisely when the thing it monitors has been broken longest. `conformance:graphql-int-range` cannot catch either: it reads live values, and neither is over-range today. `DurationMillis` and `ChainU64` state the range in the schema the way `EpochMillis` already does.

The seven stability scores go the other way — the Zod bounds them `0-100`, so the generator's `Int` is right and the SDL's `Float` was the over-wide one.

## Served changes, stated plainly

- **added**: `Contracts.status_domain` (always null, always served by REST), and the 5 `EndpointIncident` fields **removed** — always null, nothing produces them.
- **retyped**: 7 stability scores `Float` → `Int` (Zod-bounded 0-100, wire value identical); `Provider.netuids` `[Int]!` → `[Int!]!`; 10 fields keep the `Float` they already publish, now for a stated reason.
- `Validator.latest_captured_at`/`latest_block_number` dropped — one producer's spelling of a fact the union already publishes under the other's, which the resolver normalizes away.

## Result

```
420 generated object types against the schema's 420
  0 unreached      (was 4)
  0 other          (was 38)
```

Nullability is the only class left between the generator and the published schema.

Verified: `validate:graphql-route-parity` 0 divergences · `validate:graphql-component-parity` OK · `validate:graphql-query-arguments` OK · `validate:contract-drift` passed · `npm run validate` exit 0 · lint/format/tsc clean · the graphql + zod suites green (53 tests in the two schema files, including six new ones that prove each new rule can fail).

Closes #10760