### PR TITLE
fix(identity): take captured_at on the wire, as every sibling sync route does

### DIFF
--- a/src/sync-row-schemas.ts
+++ b/src/sync-row-schemas.ts
@@ -235,9 +235,14 @@ export function accountIdentitySyncRowSchema({
  * would let a consumer overwrite a real curated fallback with nothing, which is
  * the failure the lane's own header calls out.
  *
- * netuid, block_number and observed_at are required: the table's
- * append-on-change contract is meaningless without them, since a row with no
- * block cannot be ordered against the revision it supersedes.
+ * netuid, block_number and captured_at are required: the append-on-change
+ * contract is meaningless without them, since a row with no block cannot be
+ * ordered against the revision it supersedes.
+ *
+ * `captured_at` on the WIRE, `observed_at` in the history table. Every other
+ * sync route here names the wire field captured_at, and the history column is
+ * called observed_at; the handler maps between them rather than making this
+ * lane the one that spells its timestamp differently from its siblings.
  */
 export function subnetIdentitySyncRowSchema({
   columns,
@@ -249,7 +254,7 @@ export function subnetIdentitySyncRowSchema({
     .looseObject({
       netuid: z.number().int().min(0).max(maxNetuid),
       block_number: z.number().int().min(0),
-      observed_at: capturedAtMs(minCapturedAtMs),
+      captured_at: capturedAtMs(minCapturedAtMs),
     })
     .superRefine((row, ctx) => {
       onlyKnownColumns(columns)(row as Row, ctx);
@@ -257,7 +262,7 @@ export function subnetIdentitySyncRowSchema({
         if (
           key === "netuid" ||
           key === "block_number" ||
-          key === "observed_at"
+          key === "captured_at"
         ) {
           continue;
         }

--- a/tests/data-api-subnet-identity-sync.test.ts
+++ b/tests/data-api-subnet-identity-sync.test.ts
@@ -82,7 +82,7 @@ function row(overrides: Row = {}): Row {
   return {
     netuid: 1,
     block_number: 8_800_000,
-    observed_at: 1_780_000_000_000,
+    captured_at: 1_780_000_000_000,
     subnet_name: "Apex",
     symbol: "α",
     description: "Open competitions",
@@ -194,7 +194,7 @@ test("an unchanged identity appends nothing on a second pass", async () => {
   assert.equal(await count("subnet_identity_history"), 1);
 
   await call(
-    req([row({ observed_at: 1_780_000_999_000, block_number: 8_800_500 })]),
+    req([row({ captured_at: 1_780_000_999_000, block_number: 8_800_500 })]),
   );
   assert.equal(await count("subnet_identity_history"), 1);
   assert.equal(await count("subnet_identity"), 1);
@@ -203,7 +203,7 @@ test("an unchanged identity appends nothing on a second pass", async () => {
 test("a CHANGED identity appends a second history row", async () => {
   await call(req([row()]));
   await call(
-    req([row({ subnet_name: "Apex Reborn", observed_at: 1_780_001_000_000 })]),
+    req([row({ subnet_name: "Apex Reborn", captured_at: 1_780_001_000_000 })]),
   );
   assert.equal(await count("subnet_identity_history"), 2);
   // The card is latest-only: one row per netuid, carrying the new name.

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -382,7 +382,7 @@ import {
   SUBNET_HYPERPARAMS_NEON_LANE,
   SUBNET_IDENTITY_NEON_LANE,
   SUBNET_IDENTITY_FIELDS,
-  SUBNET_IDENTITY_HISTORY_COLUMNS,
+  SUBNET_IDENTITY_INSERT_COLUMNS,
   failedTables,
   mirrorFamilyToNeon,
   FAMILY_MIRROR_PLANS,
@@ -1940,7 +1940,7 @@ const SUBNET_IDENTITY_SYNC_MAX_NETUID = 65_535;
 const SUBNET_IDENTITY_SYNC_MAX_STRING_BYTES = 4_096;
 
 const SUBNET_IDENTITY_SYNC_ROW_SCHEMA = subnetIdentitySyncRowSchema({
-  columns: SUBNET_IDENTITY_HISTORY_COLUMNS,
+  columns: SUBNET_IDENTITY_INSERT_COLUMNS,
   minCapturedAtMs: SYNC_MIN_CAPTURED_AT_MS,
   maxNetuid: SUBNET_IDENTITY_SYNC_MAX_NETUID,
   maxStringBytes: SUBNET_IDENTITY_SYNC_MAX_STRING_BYTES,
@@ -2023,9 +2023,9 @@ async function handleSubnetIdentitySync(
       snapshot[field] = row[field] ?? null;
     }
     const hash = await subnetIdentityHash(snapshot);
-    // `observed_at` is REQUIRED by the schema above, so there is no fallback
-    // to reach: a row without it never gets here.
-    const observedAt = row.observed_at;
+    // captured_at on the wire, observed_at in the history table. Required by
+    // the schema, so there is no fallback to reach.
+    const observedAt = row.captured_at;
     const base: Row = {
       netuid: row.netuid,
       block_number: row.block_number,


### PR DESCRIPTION
Follow-up to #10740, found the way these things should be found — by watching the producer's first real request.

It came back **400**. I built the row schema from `READ_COLUMNS` (what the serving routes *select*) without checking what the poller lane actually *sends*. That is the same mistake as the missing route itself: two halves each specified against the other's absence.

**The wire field is `captured_at`**, matching every other sync route in this repo. The history column stays `observed_at`, and the handler maps between them — the alternative was making this one lane spell its timestamp differently from all its siblings.

The row schema is now `SUBNET_IDENTITY_INSERT_COLUMNS` (the card's shape, which is what arrives); the history's column list is derived in the handler.

Pairs with metagraphed-infra#444, which adds `block_number` to the payload and drops `additional`/`contact_present` — neither is selected by any serving route, so both were write-only.

19 tests still pass against real Postgres through the real Worker handler; `tsc` and prettier clean.