### PR TITLE
fix(neon): replace an orphaned alarm instead of respecting it

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -739,3 +739,57 @@ describe("the enqueue is O(1) (#10755)", () => {
     assert.match(String(out.reason), /buffer full/);
   });
 });
+
+describe("an orphaned alarm must not block the buffer forever (#10763)", () => {
+  test("a STALE alarm is replaced", async () => {
+    // The last fault standing after #10755. An alarm whose time has passed
+    // without the handler running is orphaned -- the object was reset
+    // mid-flight often enough to leave one behind -- and `=== null` read that
+    // as "pending, nothing to do". Nothing fired it, nothing replaced it, and
+    // the buffer had no path to a first drain: enqueues succeeded, storage was
+    // healthy, and no flush ran for thirteen minutes.
+    const storage = fakeStorage();
+    await storage.setAlarm(NOW - 60_000);
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    assert.equal(
+      await storage.getAlarm(),
+      NOW + FLUSH_INTERVAL_MS,
+      "a past alarm must be replaced, not respected",
+    );
+  });
+
+  test("a LIVE alarm is left alone", async () => {
+    // The property the original guard was protecting, and it still holds: a
+    // steady stream of enqueues must not push the flush further away with
+    // every write.
+    const storage = fakeStorage();
+    const live = NOW + 5 * 60_000;
+    await storage.setAlarm(live);
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    assert.equal(await storage.getAlarm(), live);
+  });
+
+  test("an alarm exactly at now counts as stale", async () => {
+    // The boundary. `<= now` rather than `< now`: an alarm due this instant
+    // that has not run is the same orphan one second later.
+    const storage = fakeStorage();
+    await storage.setAlarm(NOW);
+    await enqueueStatement(storage, stmt("neurons", "A"), NOW);
+    assert.equal(await storage.getAlarm(), NOW + FLUSH_INTERVAL_MS);
+  });
+
+  test("an EMPTY drain records a verdict rather than returning silently", async () => {
+    // Why three incidents were hard to tell apart: no verdict meant both "the
+    // alarm never fired" and "it fired and found nothing".
+    const spy = laneSpy();
+    const out = await flushBuffer(fakeStorage(), {}, CTX, {
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      sql: null,
+    });
+    assert.equal(out.drained, 0);
+    assert.equal(spy.rows.length, 1);
+    assert.equal(spy.rows[0].lane, BUFFER_FLUSH_LANE);
+    assert.match(String(spy.rows[0].detail), /nothing buffered/);
+  });
+});

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -182,10 +182,22 @@ export async function enqueueStatement(
     entries[chunkKey(seq, index)] = part;
   });
   await storage.put(entries);
-  // Set the alarm only when none is pending: re-arming on every enqueue would
-  // push the flush further out on every write, which at these cadences means
-  // never.
-  if ((await storage.getAlarm()) === null) {
+  // ARM WHEN THERE IS NO ALARM, OR WHEN THE ONE THERE IS HAS GONE STALE.
+  //
+  // `=== null` alone was not enough (#10763). An alarm whose time has passed
+  // without the handler running is ORPHANED -- the object was reset mid-flight
+  // often enough during #10755's CPU spiral to leave one behind -- and the old
+  // guard read that as "an alarm is pending, nothing to do". Nothing then ever
+  // fired it and nothing ever replaced it, so the buffer had no path to a first
+  // drain even once every other fault was gone: enqueues succeeded, storage was
+  // healthy, and no flush ran for thirteen minutes.
+  //
+  // Comparing against `now` rather than re-arming unconditionally keeps the
+  // property the original guard was protecting: a live alarm is left alone, so
+  // a steady stream of enqueues cannot push the flush further away with every
+  // write.
+  const existingAlarm = await storage.getAlarm();
+  if (existingAlarm === null || existingAlarm <= now) {
     await storage.setAlarm(now + FLUSH_INTERVAL_MS);
   }
   return { accepted: true, seq };
@@ -233,6 +245,17 @@ export async function flushBuffer(
   // to come back, not exactly how much is left.
   const truncated = stored.size >= FLUSH_LIST_LIMIT;
   if (groups.length === 0) {
+    // RECORD IT. An empty drain returning silently is why "the alarm never
+    // fired" and "the alarm fired and found nothing" were indistinguishable
+    // for three incidents -- the absence of a verdict meant both. A cheap row
+    // once per wake makes the next question answerable in one query.
+    await recordLaneVerdict(laneDb, {
+      lane: BUFFER_FLUSH_LANE,
+      verdict: "ok",
+      age_ms: null,
+      detail: "nothing buffered",
+      checked_at: now(),
+    });
     return { drained: 0, undecodable: 0, ok: true, remaining: false };
   }
 


### PR DESCRIPTION
## Problem

With #10755 fixed, the buffer went live at 12:36:59 and **still did not drain**. Thirteen minutes later:

```
enqueues              succeeding
buffered-lane errors  0
DO storage errors     0
flushes               0
```

Everything healthy, nothing draining — which isolates the last fault cleanly.

## Cause

`enqueueStatement` armed only when `getAlarm() === null`. An alarm whose time has **passed without the handler running** is orphaned, and #10755's CPU spiral reset the object mid-flight often enough to leave one behind. The guard read that orphan as "pending, nothing to do" — so nothing ever fired it and nothing ever replaced it.

## Fix

Arm on `null || <= now`. That keeps what the original guard protected — a live alarm is left alone, so a steady stream of enqueues cannot push the flush further away with every write — while making an orphan self-correcting.

## An empty drain now records a verdict

Returning silently on `groups.length === 0` is **why three incidents were hard to tell apart**: the absence of a `neon:buffer-flush` row meant both "the alarm never fired" and "it fired and found nothing". One cheap row per wake turns that into a query instead of an inference.

## Validation

```
tsc · lint · format:check · validate   # clean
npx vitest run neon-write-buffer-hub   # 41 passed
```

New tests: past alarm replaced, live alarm left alone, alarm exactly at `now` counts as stale, empty drain records a verdict.

Closes #10763