### PR TITLE
fix(watchdogs): the SafeMode monitor was blind for a week, and three alarms that could not name their own cause

### DIFF
--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -44,14 +44,64 @@
 
 import { laneHealthStore } from "./lane-health-store.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
+import {
+  FLUSH_INTERVAL_MS,
+  neonWriteBufferEnabled,
+} from "./neon-write-buffer.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
+
+/** The buffer lane these rows are written on, when buffering is on. */
+export const NEURONS_BUFFER_LANE = "neurons";
 
 /** Three missed 15-minute ticks: one restart is routine (a deploy or an
  * eviction costs one tick by design), two could be an unlucky pair, three is
  * a stall. */
 export const NEURONS_STALENESS_THRESHOLD_MS = missedTicksMs("metagraph", 3);
+
+/**
+ * The threshold, plus the delay the WRITE PATH can add before a captured row
+ * becomes readable (#10665).
+ *
+ * ## What this watchdog actually measures
+ *
+ * `now - MAX(captured_at)`, where `captured_at` is the PRODUCER's clock but
+ * the row is only in the table once it has been WRITTEN. So the age is
+ * producer lag plus write-visibility lag, and until 2026-08-11 the second term
+ * was ~zero because every lane wrote straight through.
+ *
+ * `neurons` is now a buffered lane (#10758), and the buffer holds statements
+ * for up to FLUSH_INTERVAL_MS before they land. Ten of the forty-five minutes
+ * this alarm allows are therefore spent by a producer that is working
+ * perfectly and a buffer that is merely waiting -- so the alarm would fire
+ * after ~2.3 missed ticks while its own message claimed three. Adding the
+ * flush interval keeps the threshold meaning what it says.
+ *
+ * MEASURED, not theorised. On 2026-08-11 the buffer was enabled at 01:33 PDT
+ * and this lane alarmed from 02:21 with an age climbing 80.6 -> 170.6 minutes
+ * in exact 15-minute steps; it was disabled at 03:47 and the age fell back to
+ * 52.4 by 04:52. Three hours of "the poller Container has missed at least
+ * three ticks" for a poller that had missed nothing -- the rows existed, and
+ * the buffer had not flushed them. The O(n) enqueue behind that stall is
+ * #10755, fixed in #10756; this is the watchdog half, which would have
+ * misreported the same way again on the next flush that ran long.
+ *
+ * Conditional on the lane actually being buffered, so turning the buffer off
+ * restores the tighter bound rather than leaving ten minutes of permanent
+ * slack behind a flag nobody re-reads.
+ */
+export function neuronsStalenessThresholdMs(
+  env: Record<string, unknown> | null | undefined,
+): number {
+  const declared =
+    Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||
+    NEURONS_STALENESS_THRESHOLD_MS;
+  return (
+    declared +
+    (neonWriteBufferEnabled(env, NEURONS_BUFFER_LANE) ? FLUSH_INTERVAL_MS : 0)
+  );
+}
 
 /**
  * How many subnets a COMPLETE pass is expected to cover.
@@ -217,9 +267,7 @@ export async function runNeuronsStalenessWatchdog(
   const db = readStore(env, ["neurons"]) as unknown as D1Like | undefined;
   if (!db?.prepare) return { ok: false, reason: "no store bound" };
 
-  const thresholdMs =
-    Number(env?.NEURONS_STALENESS_THRESHOLD_MS) ||
-    NEURONS_STALENESS_THRESHOLD_MS;
+  const thresholdMs = neuronsStalenessThresholdMs(env);
   const passWindowMs =
     Number(env?.NEURONS_PASS_WINDOW_MS) || NEURONS_PASS_WINDOW_MS;
   const coverageFloorNetuids =
@@ -251,10 +299,21 @@ export async function runNeuronsStalenessWatchdog(
         verdict.age_ms === null
           ? "no rows at all"
           : `${(verdict.age_ms / 60_000).toFixed(1)} min old`;
+      // NAMES WHAT WAS MEASURED, NOT A CAUSE IT DID NOT CHECK (#10665). This
+      // used to end "the poller Container has missed at least three ticks",
+      // which is one of two explanations and the watchdog can tell them apart
+      // from neither end: it reads the table, so a producer that stopped and a
+      // write path that is holding rows are the same observation. It said the
+      // first for three hours on 2026-08-11 while the truth was the second,
+      // and an alert that asserts a cause sends its reader to the wrong place
+      // before they have read the second line.
+      const suspects = neonWriteBufferEnabled(env, NEURONS_BUFFER_LANE)
+        ? "the poller Container has stopped capturing, or the neon write buffer is not flushing"
+        : "the poller Container has stopped capturing";
       const message =
         verdict.reason === "partial"
           ? `neurons lane truncated: the newest pass covered only ${verdict.covered_netuids} of ${verdict.total_netuids} subnets against a floor of ${verdict.coverage_floor_netuids} (newest stamp ${age}) -- the capture is RECENT and PARTIAL, so every route over a subnet the scan never reached is serving a pass-old metagraph behind a MAX(captured_at) that just advanced`
-          : `neurons lane stalled: latest snapshot is ${age} (threshold ${thresholdMs / 60_000} min) -- the poller Container has missed at least three ticks`;
+          : `neurons lane stalled: the newest READABLE snapshot is ${age} (threshold ${thresholdMs / 60_000} min) -- ${suspects}`;
       await record(env as never, {
         error: new Error(message),
         route: "watchdog:neurons-staleness",

--- a/src/safe-mode-watchdog.ts
+++ b/src/safe-mode-watchdog.ts
@@ -31,12 +31,55 @@
 // Zero alerts is the correct steady state: it means nothing has gone wrong, not
 // that the monitor is broken. The summary line prints every run for that
 // reason, matching check-emission-drift.ts.
+//
+// ## HOW THIS MONITOR WENT BLIND, AND WHY IT STAYED THAT WAY (#10765)
+//
+// From 2026-08-04 to 2026-08-11 every hourly tick of this watchdog returned
+// `ok:false, reason:"unreachable"`, and the single most consequential thing
+// this repo watches for was not being watched. Three separate defects stacked,
+// and each one alone was enough:
+//
+//  1. THE HISTORY READ WAS A SELF-FETCH. It asked `https://api.metagraph.sh`
+//     for its extrinsics -- a custom domain of the very Worker this cron runs
+//     on. Cloudflare refuses that and answers 522, every time, deterministically
+//     (the same trap #10194 published a false outage with). The read now goes
+//     through the in-process cold-tier loader the public route itself uses, so
+//     there is no hop to refuse.
+//
+//  2. IT ASKED FOR MORE THAN THE ROUTE ALLOWS. `limit=200` against a route
+//     whose published ceiling is 100, so even reached, it was a 400. That
+//     second fault was invisible underneath the first, and fixing only the
+//     522 would have swapped one deterministic failure for another.
+//
+//  3. AND A FAILED HISTORY READ DISCARDED THE PAUSE CHECK. This is the one
+//     that matters. The storage read -- `SafeMode.EnteredUntil`, the
+//     AUTHORITATIVE "are we paused right now" signal -- succeeded on every one
+//     of those ticks. Its result was then thrown away, because the extrinsics
+//     read threw on the next line and the whole tick fell into the catch. A
+//     secondary, historical read failing must not silence the primary one, so
+//     the two halves now fail independently: history that cannot be read is
+//     reported as UNREAD (never as "no SafeMode activity"), and the pause
+//     verdict is still computed and still alerts.
 import { bytesToHex, storageMapPrefix } from "../src/twox-storage-key.ts";
+import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 /** Public archive RPC. A var, not a secret: the endpoint is public. */
 export const SAFE_MODE_RPC_URL_DEFAULT = "https://archive.chain.opentensor.ai";
-export const SAFE_MODE_API_BASE_DEFAULT = "https://api.metagraph.sh";
+
+/**
+ * How many SafeMode extrinsics one tick reads.
+ *
+ * ONE HUNDRED, matching the extrinsics route's own published ceiling rather
+ * than exceeding it the way the retired HTTP call did. The set is a single row
+ * historically, so the bound is not doing arithmetic -- it is there so this
+ * monitor cannot become the expensive query on a table that only grows.
+ *
+ * NEWEST FIRST, which is what makes the truncation safe in the only direction
+ * that matters: a SafeMode call made from here on lands at the top of the page,
+ * so the alerting rule sees it even if the tail is cut.
+ */
+export const SAFE_MODE_EXTRINSIC_LIMIT = 100;
 
 /** `SafeMode.EnteredUntil`: Option<BlockNumber>. Set iff the chain is paused. */
 const ENTERED_UNTIL_KEY = bytesToHex(
@@ -57,25 +100,37 @@ interface Extrinsic {
  * matching check-publish-freshness.ts's `evaluateFreshness`. The rule is small
  * and its edges are the entire point: a FAILED historical call must not alert,
  * and an active pause must, even with no extrinsic behind it.
+ *
+ * `extrinsics: null` is HISTORY WE COULD NOT READ, and it is a third state that
+ * has to exist separately from the empty list (#10765). The tier declines by
+ * returning null, and collapsing that into `[]` would publish `succeeded: 0` --
+ * an assertion that no SafeMode call has ever landed, made by a monitor that
+ * just failed to look. Every count below is therefore null in that case rather
+ * than zero, and the caller reports the blind half on its own channel.
  */
 export function evaluateSafeMode({
   enteredUntil,
   extrinsics,
 }: {
   enteredUntil: string | null;
-  extrinsics: Extrinsic[];
+  extrinsics: Extrinsic[] | null;
 }): { paused: boolean; reasons: string[]; summary: Record<string, unknown> } {
   // `null` is an unset key. "0x" is a present-but-empty value, which is not a
   // block number and must not read as a pause.
+  //
+  // COMPUTED FIRST AND UNCONDITIONALLY, because this is the authoritative
+  // signal and it does not depend on the history read at all -- safe mode can
+  // be entered by root with no signed extrinsic ever appearing. #10765's fault
+  // was letting the other half's failure reach this one.
   const paused = typeof enteredUntil === "string" && enteredUntil !== "0x";
-  const succeeded = extrinsics.filter((x) => x.success === true);
+  const succeeded = extrinsics?.filter((x) => x.success === true) ?? null;
   const reasons: string[] = [];
   if (paused) {
     reasons.push(
       `SafeMode is ACTIVE — SafeMode.EnteredUntil is set (${enteredUntil}). The chain is paused.`,
     );
   }
-  for (const x of succeeded) {
+  for (const x of succeeded ?? []) {
     reasons.push(
       `a SafeMode extrinsic SUCCEEDED — block ${x.block_number}, ${x.call_function}, signer ${x.signer ?? "root"}`,
     );
@@ -86,14 +141,18 @@ export function evaluateSafeMode({
     summary: {
       chain_paused: paused,
       entered_until_raw: enteredUntil,
-      safe_mode_extrinsics: extrinsics.length,
-      succeeded: succeeded.length,
+      /** False when the history half was blind this tick. The pause verdict
+       * beside it is still trustworthy; these three counts are not. */
+      history_read: extrinsics !== null,
+      safe_mode_extrinsics: extrinsics?.length ?? null,
+      succeeded: succeeded?.length ?? null,
       // Recorded so a reader can see the monitor is looking at real data
       // rather than an empty response, and so the known historical failure is
       // visible WITHOUT being alerted on.
-      known_failed: extrinsics
-        .filter((x) => x.success === false)
-        .map((x) => `${x.block_number}:${x.call_function}`),
+      known_failed:
+        extrinsics
+          ?.filter((x) => x.success === false)
+          .map((x) => `${x.block_number}:${x.call_function}`) ?? null,
     },
   };
 }
@@ -118,26 +177,35 @@ async function rpc(
   return body.result;
 }
 
-/** Every indexed SafeMode extrinsic. Small by construction -- one, historically. */
-async function safeModeExtrinsics(
-  base: string,
-  doFetch: Fetcher,
-): Promise<Extrinsic[]> {
-  const res = await doFetch(
-    `${base}/api/v1/extrinsics?call_module=SafeMode&limit=200`,
-    { signal: AbortSignal.timeout(20_000) },
-  );
-  if (!res.ok) throw new Error(`extrinsics: HTTP ${res.status}`);
-  const body = (await res.json()) as {
-    ok?: boolean;
-    data?: { extrinsics?: Extrinsic[] };
-  };
-  // A degraded tier answers with a well-formed empty list (#9110/#9114), which
-  // would read here as "no SafeMode activity" -- the exact false negative this
-  // monitor must not produce. Treat it as an error, not as an answer.
-  if (body.ok !== true) throw new Error("extrinsics: not an ok envelope");
-  return body.data?.extrinsics ?? [];
-}
+/** Reads the SafeMode extrinsic history, or null when the tier declined. */
+export type SafeModeExtrinsicReader = (
+  env: Record<string, unknown> | null | undefined,
+) => Promise<Extrinsic[] | null>;
+
+/**
+ * Every indexed SafeMode extrinsic. Small by construction -- one, historically.
+ *
+ * IN PROCESS, NOT OVER HTTP (#10765). This used to fetch our own public API,
+ * which is a custom domain of the Worker the cron runs on: Cloudflare refuses
+ * that self-fetch with a 522 and it never once succeeded. The cold-tier loader
+ * below is the exact reader `handleExtrinsics` falls through to, so this asks
+ * the same tier the same question with no hop to refuse and no route-level
+ * `limit` ceiling to trip over.
+ *
+ * NULL IS A DECLINE, NOT AN ANSWER. `loadExtrinsicFeedColdTier` returns null
+ * when it cannot express the query safely or the lakehouse will not serve it --
+ * the same distinction the retired envelope check was reaching for when it
+ * refused a `ok:false` body. An empty feed, by contrast, IS an answer: it says
+ * the decoded range holds no SafeMode call.
+ */
+export const readSafeModeExtrinsics: SafeModeExtrinsicReader = async (env) => {
+  const feed = await loadExtrinsicFeedColdTier(env as never, {
+    limit: SAFE_MODE_EXTRINSIC_LIMIT,
+    module: "SafeMode",
+  });
+  if (feed === null) return null;
+  return (feed.extrinsics ?? []) as Extrinsic[];
+};
 
 /**
  * One watchdog tick.
@@ -151,21 +219,36 @@ export async function runSafeModeWatchdog(
   env: Record<string, unknown> | null | undefined,
   deps: {
     fetchImpl?: Fetcher;
+    readExtrinsics?: SafeModeExtrinsicReader;
     recordExceptionEvent?: typeof recordExceptionEvent;
   } = {},
 ): Promise<Record<string, unknown>> {
   const doFetch = deps.fetchImpl ?? fetch;
+  const readExtrinsics = deps.readExtrinsics ?? readSafeModeExtrinsics;
   const record = deps.recordExceptionEvent ?? recordExceptionEvent;
   const rpcUrl = String(env?.SAFE_MODE_RPC_URL || SAFE_MODE_RPC_URL_DEFAULT);
-  const apiBase = String(env?.SAFE_MODE_API_BASE || SAFE_MODE_API_BASE_DEFAULT);
   try {
+    // THE PRIMARY READ, and the only one whose failure makes the whole tick
+    // unreachable: without it there is no answer to "are we paused right now",
+    // which is what this monitor is for.
     const entered = (await rpc(
       rpcUrl,
       "state_getStorage",
       [ENTERED_UNTIL_KEY],
       doFetch,
     )) as string | null;
-    const extrinsics = await safeModeExtrinsics(apiBase, doFetch);
+    // THE SECONDARY READ, isolated (#10765). Its failure costs the history
+    // half and nothing else -- for a week it cost the pause check too, because
+    // a throw here landed in the catch below and the verdict was never
+    // computed. A null from the reader and a throw from it mean the same thing
+    // to the rule, so both arrive as null.
+    let extrinsics: Extrinsic[] | null = null;
+    let historyError: unknown = null;
+    try {
+      extrinsics = await readExtrinsics(env);
+    } catch (err) {
+      historyError = err;
+    }
     const { reasons, summary } = evaluateSafeMode({
       enteredUntil: entered,
       extrinsics,
@@ -188,8 +271,24 @@ export async function runSafeModeWatchdog(
         errorCode: "safe_mode_active",
       }).catch(() => false);
     }
+    // A BLIND HALF IS STILL REPORTED, on the monitor's own channel rather than
+    // the chain's. It carries `watchdog_unreachable` and not `safe_mode_active`
+    // because nothing about the chain has been observed here -- and it is
+    // reported at all because "the history read has been failing for a week"
+    // is exactly the fact that went unnoticed while the 522 ran.
+    if (extrinsics === null) {
+      await record(env as never, {
+        error:
+          historyError ??
+          new Error("SafeMode history: the extrinsics tier declined the read"),
+        route: "watchdog:safe-mode",
+        errorCode: "watchdog_unreachable",
+      }).catch(() => false);
+    }
     return {
       // `ok` describes whether the TICK ran, not whether SafeMode is quiet.
+      // The PAUSE check ran whenever this is true, even on a blind history
+      // half -- `history_read` in the summary is what says which.
       ok: true,
       alerted: reasons.length > 0,
       reasons,

--- a/tests/head-poller.test.ts
+++ b/tests/head-poller.test.ts
@@ -28,7 +28,10 @@ import {
   SYSTEM_EVENTS_STORAGE_KEY,
 } from "../src/head-poller.ts";
 import { DEFAULT_SS58_PREFIX, encodeAccountId32 } from "../src/ss58.ts";
-import { ChainFirehoseHub } from "../workers/chain-firehose-hub.ts";
+import {
+  CHAIN_HEAD_ALARM_OVERDUE_MS,
+  ChainFirehoseHub,
+} from "../workers/chain-firehose-hub.ts";
 
 const rpcFetch = (handlers: Record<string, (params: unknown[]) => unknown>) =>
   (async (_url: unknown, init?: { body?: string }) => {
@@ -344,14 +347,68 @@ test("poll-start arms the alarm once and is idempotent", async () => {
   const first = await hub.fetch(
     new Request("https://x/poll-start", { method: "POST" }),
   );
-  assert.deepEqual(await first.json(), { ok: true, armed: true });
+  assert.deepEqual(await first.json(), {
+    ok: true,
+    armed: true,
+    rearmed: false,
+  });
   const armedAt = alarm();
   assert.ok(armedAt !== null);
   const second = await hub.fetch(
     new Request("https://x/poll-start", { method: "POST" }),
   );
-  assert.deepEqual(await second.json(), { ok: true, armed: false });
+  assert.deepEqual(await second.json(), {
+    ok: true,
+    armed: false,
+    rearmed: false,
+  });
   assert.equal(alarm(), armedAt, "existing alarm untouched");
+});
+
+// #10668. The bootstrap could only repair a MISSING alarm, and `getAlarm()`
+// returns a scheduled TIME rather than a liveness check -- so an alarm whose
+// handler never ran (storage reset mid-setAlarm, eviction between scheduling
+// and firing) read as armed forever and this branch left it alone. The lane
+// then sat until something else happened to touch the object, which is what
+// `/api/v1/chain/indexer-lag` measured as a write-latency tail out to 24
+// minutes against a p50 of 36 seconds.
+test("poll-start re-arms an OVERDUE alarm, which the old idempotence could not", async () => {
+  const { hub, state, alarm } = hubWith({}, new Map());
+  const wedged = Date.now() - CHAIN_HEAD_ALARM_OVERDUE_MS - 60_000;
+  await state.storage.setAlarm(wedged);
+  const res = await hub.fetch(
+    new Request("https://x/poll-start", { method: "POST" }),
+  );
+  assert.deepEqual(await res.json(), {
+    ok: true,
+    // Reported apart from `armed` on purpose: "was not running" and "was
+    // wedged" have different causes and a reader should see which.
+    armed: false,
+    rearmed: true,
+  });
+  const rearmed = alarm();
+  assert.ok(
+    rearmed !== null && rearmed > wedged,
+    "the dead alarm was replaced",
+  );
+});
+
+test("poll-start leaves an alarm that is merely LATE alone", async () => {
+  // The floor the grace period buys: a tick catching up 25 blocks does 25
+  // serial round trips plus a write each, and re-arming underneath one that is
+  // still running would race two alarms against the same head:last_seen.
+  const { hub, state, alarm } = hubWith({}, new Map());
+  const stillWorking = Date.now() - CHAIN_HEAD_ALARM_OVERDUE_MS + 30_000;
+  await state.storage.setAlarm(stillWorking);
+  const res = await hub.fetch(
+    new Request("https://x/poll-start", { method: "POST" }),
+  );
+  assert.deepEqual(await res.json(), {
+    ok: true,
+    armed: false,
+    rearmed: false,
+  });
+  assert.equal(alarm(), stillWorking, "a working tick is not disturbed");
 });
 
 test("alarm: kill switch off -> no polling, but always re-arms", async () => {

--- a/tests/neurons-staleness-watchdog.test.ts
+++ b/tests/neurons-staleness-watchdog.test.ts
@@ -24,13 +24,16 @@ const { pg } = await vi.hoisted(async () => ({
 vi.mock("pg", () => pg.module);
 
 import {
+  NEURONS_BUFFER_LANE,
   NEURONS_COVERAGE_FLOOR_NETUIDS,
   NEURONS_EXPECTED_NETUIDS,
   NEURONS_PASS_WINDOW_MS,
   NEURONS_STALENESS_THRESHOLD_MS,
   evaluateNeuronsStaleness,
+  neuronsStalenessThresholdMs,
   runNeuronsStalenessWatchdog,
 } from "../src/neurons-staleness-watchdog.ts";
+import { FLUSH_INTERVAL_MS } from "../src/neon-write-buffer.ts";
 import { handleScheduled } from "../workers/api.ts";
 import * as workerConfig from "../workers/config.ts";
 
@@ -448,5 +451,138 @@ describe("handleScheduled NEURONS_STALENESS_WATCHDOG_CRON", () => {
       q.includes("INSERT INTO lane_health"),
     );
     assert.equal(writes.length, 2);
+  });
+});
+
+// ---- the threshold against the WRITE path (#10665) ----
+//
+// This watchdog reads `now - MAX(captured_at)`, and a row is only in the table
+// once it has been written. Until 2026-08-11 that second term was ~zero because
+// every lane wrote straight through. `neurons` is a buffered lane now (#10758),
+// and the buffer holds statements for up to FLUSH_INTERVAL_MS.
+//
+// Measured, not theorised: the buffer was enabled at 01:33 PDT that day and
+// this lane alarmed from 02:21 with an age climbing 80.6 -> 170.6 minutes in
+// exact 15-minute steps, falling back to 52.4 by 04:52 after it was disabled at
+// 03:47. Three hours of "the poller Container has missed at least three ticks"
+// for a poller that had missed nothing.
+describe("the staleness threshold absorbs write-visibility lag", () => {
+  const buffered = { NEON_WRITE_BUFFER_LANES: NEURONS_BUFFER_LANE };
+
+  test("an unbuffered lane keeps the bare three-missed-ticks bound", () => {
+    assert.equal(
+      neuronsStalenessThresholdMs({ NEON_WRITE_BUFFER_LANES: "" }),
+      NEURONS_STALENESS_THRESHOLD_MS,
+    );
+  });
+
+  test("a buffered lane adds the flush interval, so three ticks still means three", () => {
+    assert.equal(
+      neuronsStalenessThresholdMs(buffered),
+      NEURONS_STALENESS_THRESHOLD_MS + FLUSH_INTERVAL_MS,
+    );
+  });
+
+  test("turning the buffer off restores the tighter bound", () => {
+    // Conditional rather than a flat widening: ten minutes of permanent slack
+    // behind a flag nobody re-reads is how a threshold stops meaning anything.
+    assert.ok(
+      neuronsStalenessThresholdMs({ NEON_WRITE_BUFFER_LANES: "" }) <
+        neuronsStalenessThresholdMs(buffered),
+    );
+  });
+
+  test("the env override is still the base, and still absorbs the flush", () => {
+    assert.equal(
+      neuronsStalenessThresholdMs({
+        ...buffered,
+        NEURONS_STALENESS_THRESHOLD_MS: "300000",
+      }),
+      300_000 + FLUSH_INTERVAL_MS,
+    );
+  });
+
+  test("a lane held under the widened bound no longer alarms", async () => {
+    // 50 minutes: over the bare 45-minute threshold, under the buffered one.
+    // Before #10665 this was a page; the rows exist and the buffer has simply
+    // not flushed them yet.
+    const { env } = fakeDb(NOW - 50 * 60_000);
+    const result = await runNeuronsStalenessWatchdog(
+      { ...env, ...buffered },
+      { now: () => NOW, recordException: (async () => true) as never },
+    );
+    assert.equal(result.alerted, false);
+    assert.equal(
+      result.threshold_ms,
+      NEURONS_STALENESS_THRESHOLD_MS + FLUSH_INTERVAL_MS,
+    );
+  });
+
+  test("a genuinely dead lane still alarms through the widened bound", async () => {
+    // The direction that matters: absorbing the flush must not buy silence for
+    // a producer that really has stopped.
+    const recorded: { error?: Error }[] = [];
+    const { env } = fakeDb(NOW - 3 * 60 * 60_000);
+    const result = await runNeuronsStalenessWatchdog(
+      { ...env, ...buffered },
+      {
+        now: () => NOW,
+        recordException: (async (_e: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    assert.equal(result.alerted, true);
+    assert.equal(result.reason, "stale");
+    assert.match(
+      String(recorded[0].error?.message),
+      /newest READABLE snapshot/,
+    );
+  });
+});
+
+describe("the stall message names what was measured, not a cause", () => {
+  test("a buffered lane names BOTH suspects", async () => {
+    // The watchdog reads the table, so a producer that stopped and a write
+    // path holding rows are the same observation to it. Asserting the first
+    // sends its reader to the wrong place before they reach the second line.
+    const recorded: { error?: Error }[] = [];
+    const { env } = fakeDb(NOW - 5 * 60 * 60_000);
+    await runNeuronsStalenessWatchdog(
+      { ...env, NEON_WRITE_BUFFER_LANES: NEURONS_BUFFER_LANE },
+      {
+        now: () => NOW,
+        recordException: (async (_e: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    const message = String(recorded[0].error?.message);
+    assert.match(message, /poller Container has stopped capturing/);
+    assert.match(message, /neon write buffer is not flushing/);
+    assert.ok(
+      !message.includes("missed at least three ticks"),
+      "the retired claim asserted a cause this watchdog cannot see",
+    );
+  });
+
+  test("an unbuffered lane names only the producer, because that is the only suspect", async () => {
+    const recorded: { error?: Error }[] = [];
+    const { env } = fakeDb(NOW - 5 * 60 * 60_000);
+    await runNeuronsStalenessWatchdog(
+      { ...env, NEON_WRITE_BUFFER_LANES: "" },
+      {
+        now: () => NOW,
+        recordException: (async (_e: never, event: never) => {
+          recorded.push(event);
+          return true;
+        }) as never,
+      },
+    );
+    const message = String(recorded[0].error?.message);
+    assert.match(message, /poller Container has stopped capturing/);
+    assert.ok(!message.includes("write buffer"));
   });
 });

--- a/tests/postgres-tier.test.ts
+++ b/tests/postgres-tier.test.ts
@@ -7,6 +7,7 @@
 import assert from "node:assert/strict";
 import { test } from "vitest";
 import {
+  POSTGRES_TIER_RETRY_ATTEMPTS,
   currentPostgresTierFallbackGeneration,
   tryPostgresTier,
 } from "../workers/postgres-tier.ts";
@@ -225,4 +226,142 @@ test("tryPostgresTier: rewrites a HEAD request to GET before forwarding to DATA_
     "METAGRAPH_HEALTH_SOURCE",
   );
   assert.equal(receivedMethod, "GET");
+});
+
+// ---- the transient retry (#10665) ----
+//
+// The neurons tier degraded to the schema-stable empty response in BURSTS for
+// sixteen days, with clean days in between. That shape is a transient -- the
+// DATA_API service binding failing to produce a response while that Worker is
+// mid-deploy -- and degrading on the first refusal turned each blip into a
+// confidently wrong answer served to a caller. One retry is the difference
+// between a slow correct answer and a fast wrong one.
+
+test("tryPostgresTier: a 5xx is asked a second time, and a recovered retry ANSWERS", async () => {
+  const before = currentPostgresTierFallbackGeneration();
+  let calls = 0;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: dataApi(async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response(null, { status: 503 })
+        : Response.json({ schema_version: 1, recovered: true });
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(calls, 2, "the first 5xx must not be the final answer");
+  assert.deepEqual(result, { schema_version: 1, recovered: true });
+  assert.equal(
+    currentPostgresTierFallbackGeneration(),
+    before,
+    "a recovered retry is not a fallback and must not invalidate an edge write",
+  );
+});
+
+test("tryPostgresTier: a transport THROW is retried too, and a recovered retry answers", async () => {
+  // A thrown subrequest and a 5xx are the same fault from two sides: the
+  // binding could not reach a Worker able to answer.
+  let calls = 0;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: dataApi(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("Network connection lost.");
+      return Response.json({ schema_version: 1 });
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(calls, 2);
+  assert.deepEqual(result, { schema_version: 1 });
+});
+
+test("tryPostgresTier: a 4xx is NOT retried -- it will be exactly as wrong twice", async () => {
+  let calls = 0;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: dataApi(async () => {
+      calls += 1;
+      return new Response(null, { status: 400 });
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(calls, 1, "retrying a bad request only doubles the load");
+  assert.equal(result, null);
+});
+
+test("tryPostgresTier: a 2xx is not retried", async () => {
+  let calls = 0;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: dataApi(async () => {
+      calls += 1;
+      return Response.json({ ok: true });
+    }),
+  });
+  await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(calls, 1);
+});
+
+test("tryPostgresTier: the retry is capped at one extra ask", async () => {
+  // A DATA_API that is genuinely down must degrade quickly rather than hold
+  // every request open behind an unbounded retry loop.
+  let calls = 0;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: dataApi(async () => {
+      calls += 1;
+      return new Response(null, { status: 502 });
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(calls, POSTGRES_TIER_RETRY_ATTEMPTS);
+  assert.equal(calls, 2, "the cap is one retry, stated as a number here too");
+  assert.equal(result, null);
+});
+
+test("tryPostgresTier: a persistent transport throw still degrades after the cap", async () => {
+  const before = currentPostgresTierFallbackGeneration();
+  let calls = 0;
+  const env = mockEnv({
+    METAGRAPH_HEALTH_SOURCE: "postgres",
+    DATA_API: dataApi(async () => {
+      calls += 1;
+      throw new Error("Network connection lost.");
+    }),
+  });
+  const result = await tryPostgresTier(env, req(), "METAGRAPH_HEALTH_SOURCE");
+  assert.equal(calls, POSTGRES_TIER_RETRY_ATTEMPTS);
+  assert.equal(result, null);
+  assert.equal(currentPostgresTierFallbackGeneration(), before + 1);
+});
+
+test("tryPostgresTier: the failing request PATH is in the message, masked", async () => {
+  // #10665 was unanswerable for sixteen days because the capture named the
+  // FLAG and never the request: "DATA_API returned 502" with no way to tell
+  // which of the twenty-nine neurons-gated routes produced it. The path is
+  // masked with the analytics labeller so a per-account route cannot turn one
+  // recurring fault into one message per address.
+  const seen: string[] = [];
+  const realError = console.error;
+  console.error = (...args: unknown[]) => void seen.push(args.join(" "));
+  try {
+    const env = mockEnv({
+      METAGRAPH_NEURONS_SOURCE: "d1",
+      DATA_API: dataApi(async () => new Response(null, { status: 503 })),
+    });
+    await tryPostgresTier(
+      env,
+      new Request("https://api.metagraph.sh/api/v1/subnets/64/metagraph"),
+      "METAGRAPH_NEURONS_SOURCE",
+    );
+  } finally {
+    console.error = realError;
+  }
+  const line = seen.join("\n");
+  assert.match(line, /\/api\/v1\/subnets\/:n\/metagraph/);
+  assert.ok(
+    !line.includes("/64/"),
+    "the netuid must be masked, or one fault becomes one message per subnet",
+  );
 });

--- a/tests/safe-mode-extrinsics-reader.test.ts
+++ b/tests/safe-mode-extrinsics-reader.test.ts
@@ -1,0 +1,86 @@
+// The SafeMode watchdog's history reader (#10765), in its own file so
+// the cold-tier module can be mocked without that mock reaching the twenty-odd
+// rule tests in tests/safe-mode-watchdog.test.ts.
+//
+// WHAT THIS PINS is the seam the 522 lived at. The reader used to fetch
+// `https://api.metagraph.sh/api/v1/extrinsics?call_module=SafeMode&limit=200`
+// -- a custom domain of the very Worker the cron runs on, which Cloudflare
+// refuses with a 522 every time, and a `limit` the route caps at 100 anyway.
+// It now calls the in-process loader `handleExtrinsics` itself falls through
+// to, so the two things worth asserting are that it asks that tier the right
+// question and that it keeps the decline distinguishable from an empty answer.
+import assert from "node:assert/strict";
+import { test, vi } from "vitest";
+
+const { coldTier } = vi.hoisted(() => ({
+  coldTier: { calls: [] as unknown[][], result: null as unknown },
+}));
+
+vi.mock("../src/extrinsics-cold-tier.ts", () => ({
+  loadExtrinsicFeedColdTier: async (...args: unknown[]) => {
+    coldTier.calls.push(args);
+    if (coldTier.result instanceof Error) throw coldTier.result;
+    return coldTier.result;
+  },
+}));
+
+const { SAFE_MODE_EXTRINSIC_LIMIT, readSafeModeExtrinsics } =
+  await import("../src/safe-mode-watchdog.ts");
+
+test("it asks the extrinsics cold tier for the SafeMode module, within the route's own ceiling", async () => {
+  coldTier.calls.length = 0;
+  coldTier.result = { extrinsics: [] };
+  const env = { MARKER: 1 };
+  await readSafeModeExtrinsics(env);
+  assert.equal(coldTier.calls.length, 1, "one tier read, no HTTP hop");
+  const [passedEnv, query] = coldTier.calls[0] as [
+    unknown,
+    Record<string, unknown>,
+  ];
+  assert.equal(passedEnv, env, "the reader threads env through to the tier");
+  assert.equal(query.module, "SafeMode");
+  assert.equal(query.limit, SAFE_MODE_EXTRINSIC_LIMIT);
+  assert.ok(
+    (query.limit as number) <= 100,
+    "the retired HTTP call asked for 200 against a route that caps at 100",
+  );
+});
+
+test("a DECLINED tier reads as null, never as 'no SafeMode activity'", async () => {
+  // loadExtrinsicFeedColdTier returns null when it cannot express the query
+  // safely or the lakehouse will not serve it. Collapsing that to [] would
+  // publish `succeeded: 0` -- an assertion that no SafeMode call has ever
+  // landed, made by a monitor that just failed to look.
+  coldTier.result = null;
+  assert.equal(await readSafeModeExtrinsics({}), null);
+});
+
+test("an EMPTY feed is a real answer, and reads as the empty list", async () => {
+  coldTier.result = { extrinsics: [] };
+  assert.deepEqual(await readSafeModeExtrinsics({}), []);
+});
+
+test("a feed with no extrinsics key still reads as empty rather than throwing", async () => {
+  // Shape tolerance on an answered read: the tier said it could serve the
+  // query, so an absent list is an empty list.
+  coldTier.result = {};
+  assert.deepEqual(await readSafeModeExtrinsics({}), []);
+});
+
+test("the rows come back as the rule's own shape", async () => {
+  const row = {
+    block_number: 4_222_830,
+    call_function: "force_release_deposit",
+    success: false,
+    signer: "5H6tCSXfWreW",
+  };
+  coldTier.result = { extrinsics: [row] };
+  assert.deepEqual(await readSafeModeExtrinsics({}), [row]);
+});
+
+test("a throwing tier propagates, and the runner turns it into the same blind half", async () => {
+  // The reader does not swallow: runSafeModeWatchdog catches, so a throw and a
+  // null arrive at the rule identically. Swallowing here would lose the cause.
+  coldTier.result = new Error("r2 sql: HTTP 500");
+  await assert.rejects(() => readSafeModeExtrinsics({}), /r2 sql: HTTP 500/);
+});

--- a/tests/safe-mode-watchdog.test.ts
+++ b/tests/safe-mode-watchdog.test.ts
@@ -84,67 +84,58 @@ describe("SafeMode alerting rule (#8696)", () => {
     }
   });
 
+  // `fetchImpl` now serves the STORAGE read only -- the history half is
+  // `readExtrinsics`, an in-process tier call rather than an HTTP hop (#10765).
+  const storageReads = (result: unknown) =>
+    (async () =>
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+
   test("a quiet chain reports a ran-and-found-nothing tick", async () => {
-    // The measured path. Injectable fetch, because a branch that only runs
-    // against a live chain is a branch nothing verifies.
+    // The measured path. Both reads injectable, because a branch that only
+    // runs against a live chain is a branch nothing verifies.
     const result = await runSafeModeWatchdog(null, {
-      fetchImpl: (async (url: string) =>
-        String(url).includes("/api/v1/extrinsics")
-          ? new Response(
-              JSON.stringify({ ok: true, data: { extrinsics: [] } }),
-              { status: 200 },
-            )
-          : new Response(
-              JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }),
-              {
-                status: 200,
-              },
-            )) as unknown as typeof fetch,
+      fetchImpl: storageReads(null),
+      readExtrinsics: async () => [],
     });
     assert.equal(result.ok, true);
     assert.equal(result.alerted, false);
     assert.equal(result.chain_paused, false);
+    assert.equal(result.history_read, true);
   });
 
   test("an ACTIVE pause alerts through the runner", async () => {
     const result = await runSafeModeWatchdog(null, {
-      fetchImpl: (async (url: string) =>
-        String(url).includes("/api/v1/extrinsics")
-          ? new Response(
-              JSON.stringify({ ok: true, data: { extrinsics: [] } }),
-              { status: 200 },
-            )
-          : new Response(
-              JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1234" }),
-              { status: 200 },
-            )) as unknown as typeof fetch,
+      fetchImpl: storageReads("0x1234"),
+      readExtrinsics: async () => [],
     });
     assert.equal(result.alerted, true);
     assert.equal(result.chain_paused, true);
   });
 
-  test("a degraded extrinsics tier is an ERROR, not 'no activity'", async () => {
-    // The false negative this monitor exists to avoid: an ok:false envelope
-    // carries an empty list, which would otherwise read as a clean chain.
+  test("a degraded extrinsics tier is UNREAD, not 'no activity'", async () => {
+    // The false negative this monitor exists to avoid, unchanged in intent and
+    // moved in mechanism (#10765). It used to fail the whole tick, which threw
+    // away the pause check with it; now the history half alone goes null. What
+    // must never happen either way is a degraded tier reading as a clean chain.
     const result = await runSafeModeWatchdog(null, {
-      fetchImpl: (async (url: string) =>
-        String(url).includes("/api/v1/extrinsics")
-          ? new Response(JSON.stringify({ ok: false, data: null }), {
-              status: 200,
-            })
-          : new Response(
-              JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }),
-              {
-                status: 200,
-              },
-            )) as unknown as typeof fetch,
+      fetchImpl: (async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
+          status: 200,
+        })) as unknown as typeof fetch,
+      readExtrinsics: async () => null,
     });
-    assert.equal(result.ok, false);
-    assert.equal(result.reason, "unreachable");
+    assert.equal(result.history_read, false);
     assert.equal(
-      result.alerted,
-      undefined,
-      "a failed read must not read as quiet",
+      result.succeeded,
+      null,
+      "a failed read must not count zero successes",
+    );
+    assert.equal(
+      result.safe_mode_extrinsics,
+      null,
+      "nor zero extrinsics -- that is an assertion it did not earn",
     );
   });
 
@@ -177,63 +168,95 @@ describe("SafeMode alerting rule (#8696)", () => {
     );
   });
 
-  test("every upstream failure mode reports unreachable, never 'quiet'", async () => {
-    // Each of these is a way the two reads can fail while still returning a
-    // response. All of them must surface as a failed TICK -- a monitor that
-    // reports "no SafeMode activity" because it could not look is worse than
-    // one that reports nothing at all.
+  test("a failed PRIMARY read reports unreachable, never 'quiet'", async () => {
+    // The storage read is the authoritative "are we paused right now" signal.
+    // Without it there is no verdict to give, so both of its failure modes
+    // have to surface as a failed TICK -- a monitor that reports "no SafeMode
+    // activity" because it could not look is worse than one that reports
+    // nothing at all.
     const ok = (body: unknown, status = 200) =>
       new Response(JSON.stringify(body), { status });
-    const rpcOk = { jsonrpc: "2.0", id: 1, result: null };
-    const cases: [string, (url: string) => Response][] = [
-      [
-        "RPC returns a non-200",
-        (url) =>
-          url.includes("/api/v1/extrinsics")
-            ? ok({ ok: true, data: { extrinsics: [] } })
-            : ok({}, 503),
-      ],
+    const cases: [string, () => Response][] = [
+      ["RPC returns a non-200", () => ok({}, 503)],
       [
         "RPC returns a JSON-RPC error",
-        (url) =>
-          url.includes("/api/v1/extrinsics")
-            ? ok({ ok: true, data: { extrinsics: [] } })
-            : ok({ jsonrpc: "2.0", id: 1, error: { code: -32000 } }),
-      ],
-      [
-        "the extrinsics route returns a non-200",
-        (url) => (url.includes("/api/v1/extrinsics") ? ok({}, 502) : ok(rpcOk)),
+        () => ok({ jsonrpc: "2.0", id: 1, error: { code: -32000 } }),
       ],
     ];
     for (const [name, impl] of cases) {
       const result = await runSafeModeWatchdog(null, {
-        fetchImpl: (async (url: string) =>
-          impl(String(url))) as unknown as typeof fetch,
+        fetchImpl: (async () => impl()) as unknown as typeof fetch,
+        readExtrinsics: async () => [],
       });
       assert.equal(result.ok, false, name);
       assert.equal(result.reason, "unreachable", name);
     }
   });
 
-  test("an ok envelope with no extrinsics array is treated as empty, not as a crash", async () => {
-    // `data.extrinsics` absent on an ok:true envelope is a shape question, not
-    // a trust question -- the envelope asserted success, so an absent list is
-    // an empty list.
+  // #10765. THE REGRESSION THIS FILE EXISTS TO HOLD FROM NOW ON. For a week
+  // every hourly tick returned unreachable because the history read 522'd on a
+  // self-fetch, and the pause check -- which had SUCCEEDED on every one of
+  // those ticks -- was discarded with it. A chain pause would not have been
+  // reported. The two halves fail independently now.
+  test("a failed history read keeps the pause verdict", async () => {
+    const paused = (async () =>
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1234" }),
+        {
+          status: 200,
+        },
+      )) as unknown as typeof fetch;
+    for (const [name, readExtrinsics] of [
+      ["the tier declined", async () => null],
+      [
+        "the reader threw",
+        async () => {
+          throw new Error("r2 sql: HTTP 500");
+        },
+      ],
+    ] as const) {
+      const result = await runSafeModeWatchdog(null, {
+        fetchImpl: paused,
+        readExtrinsics: readExtrinsics as never,
+      });
+      assert.equal(result.ok, true, name);
+      assert.equal(result.alerted, true, `${name}: the pause still alerts`);
+      assert.equal(result.chain_paused, true, name);
+      assert.equal(result.history_read, false, name);
+    }
+  });
+
+  test("history that could not be read counts nothing, rather than zero", async () => {
+    // `succeeded: 0` from a monitor that failed to look asserts that no
+    // SafeMode call has ever landed. Null is the only honest value.
     const result = await runSafeModeWatchdog(null, {
-      fetchImpl: (async (url: string) =>
-        String(url).includes("/api/v1/extrinsics")
-          ? new Response(JSON.stringify({ ok: true, data: {} }), {
-              status: 200,
-            })
-          : new Response(
-              JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }),
-              {
-                status: 200,
-              },
-            )) as unknown as typeof fetch,
+      fetchImpl: (async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
+          status: 200,
+        })) as unknown as typeof fetch,
+      readExtrinsics: async () => null,
     });
     assert.equal(result.ok, true);
+    assert.equal(result.history_read, false);
+    assert.equal(result.safe_mode_extrinsics, null);
+    assert.equal(result.succeeded, null);
+    assert.equal(result.known_failed, null);
+  });
+
+  test("an empty history IS an answer, and counts zero", async () => {
+    // The distinction the null case above turns on: the tier answering "the
+    // decoded range holds no SafeMode call" is a real reading, not a decline.
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: (async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
+          status: 200,
+        })) as unknown as typeof fetch,
+      readExtrinsics: async () => [],
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.history_read, true);
     assert.equal(result.safe_mode_extrinsics, 0);
+    assert.equal(result.succeeded, 0);
   });
 
   test("a non-Error thrown upstream still yields a readable detail", async () => {
@@ -268,29 +291,24 @@ describe("the watchdog's own reporting", () => {
     };
   }
 
-  const quietChain = (async (url: string) =>
-    String(url).includes("/api/v1/extrinsics")
-      ? new Response(JSON.stringify({ ok: true, data: { extrinsics: [] } }), {
-          status: 200,
-        })
-      : new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
-          status: 200,
-        })) as unknown as typeof fetch;
+  const quietChain = (async () =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
+      status: 200,
+    })) as unknown as typeof fetch;
 
-  const pausedChain = (async (url: string) =>
-    String(url).includes("/api/v1/extrinsics")
-      ? new Response(JSON.stringify({ ok: true, data: { extrinsics: [] } }), {
-          status: 200,
-        })
-      : new Response(
-          JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1234" }),
-          { status: 200 },
-        )) as unknown as typeof fetch;
+  const pausedChain = (async () =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1234" }), {
+      status: 200,
+    })) as unknown as typeof fetch;
+
+  /** The history half answering normally: no SafeMode call in range. */
+  const quietHistory = async () => [];
 
   test("an ACTIVE pause is reported, not merely returned", async () => {
     const spy = captureSpy();
     const result = await runSafeModeWatchdog(null, {
       fetchImpl: pausedChain,
+      readExtrinsics: quietHistory,
       recordExceptionEvent: spy.recordExceptionEvent,
     });
     assert.equal(result.alerted, true);
@@ -304,10 +322,44 @@ describe("the watchdog's own reporting", () => {
     const spy = captureSpy();
     const result = await runSafeModeWatchdog(null, {
       fetchImpl: quietChain,
+      readExtrinsics: quietHistory,
       recordExceptionEvent: spy.recordExceptionEvent,
     });
     assert.equal(result.alerted, false);
     assert.deepEqual(spy.captures, [], "a quiet chain pages no one");
+  });
+
+  test("a blind history half reports on the MONITOR's channel, not the chain's", async () => {
+    // It has to be reported -- "the history read has been failing for a week"
+    // is precisely the fact that went unnoticed while the 522 ran (#10765).
+    // But it carries watchdog_unreachable, not safe_mode_active: nothing about
+    // the chain was observed, and filing it as a chain event would be a false
+    // statement on the alert channel that exists for real pauses.
+    const spy = captureSpy();
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: quietChain,
+      readExtrinsics: async () => null,
+      recordExceptionEvent: spy.recordExceptionEvent,
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.alerted, false, "a blind half is not a chain alert");
+    assert.equal(spy.captures.length, 1);
+    assert.equal(spy.captures[0].errorCode, "watchdog_unreachable");
+    assert.equal(spy.captures[0].route, "watchdog:safe-mode");
+  });
+
+  test("a pause AND a blind history report on both channels", async () => {
+    const spy = captureSpy();
+    await runSafeModeWatchdog(null, {
+      fetchImpl: pausedChain,
+      readExtrinsics: async () => null,
+      recordExceptionEvent: spy.recordExceptionEvent,
+    });
+    assert.deepEqual(
+      spy.captures.map((c) => c.errorCode).sort(),
+      ["safe_mode_active", "watchdog_unreachable"],
+      "neither report may swallow the other",
+    );
   });
 
   test("an unreachable tick reports itself", async () => {
@@ -330,6 +382,7 @@ describe("the watchdog's own reporting", () => {
   test("a capture that fails never breaks the tick", async () => {
     const result = await runSafeModeWatchdog(null, {
       fetchImpl: pausedChain,
+      readExtrinsics: quietHistory,
       recordExceptionEvent: (async () => {
         throw new Error("posthog unreachable");
       }) as never,
@@ -337,4 +390,53 @@ describe("the watchdog's own reporting", () => {
     assert.equal(result.ok, true);
     assert.equal(result.alerted, true);
   });
+});
+
+// ---- the rule's third state, at the pure-function level (#10765) ----
+describe("history that could not be read is a state of its own", () => {
+  test("null extrinsics never alert, and never assert a count", () => {
+    const v = evaluateSafeMode({ enteredUntil: null, extrinsics: null });
+    assert.deepEqual(v.reasons, [], "a blind read is not a chain event");
+    assert.equal(v.summary.history_read, false);
+    assert.equal(v.summary.safe_mode_extrinsics, null);
+    assert.equal(v.summary.succeeded, null);
+    assert.equal(v.summary.known_failed, null);
+  });
+
+  test("the pause verdict is computed from storage alone", () => {
+    // The regression: for a week the pause check succeeded on every tick and
+    // was discarded because the history read threw beside it.
+    const v = evaluateSafeMode({
+      enteredUntil: "0x40e2010000000000",
+      extrinsics: null,
+    });
+    assert.equal(v.paused, true);
+    assert.equal(v.reasons.length, 1);
+    assert.match(v.reasons[0], /SafeMode is ACTIVE/);
+  });
+
+  test("an empty list still reads as a real, counted answer", () => {
+    const v = evaluateSafeMode({ enteredUntil: null, extrinsics: [] });
+    assert.equal(v.summary.history_read, true);
+    assert.equal(v.summary.safe_mode_extrinsics, 0);
+    assert.equal(v.summary.succeeded, 0);
+    assert.deepEqual(v.summary.known_failed, []);
+  });
+});
+
+test("a capture that fails on the BLIND-HALF report never breaks the tick", async () => {
+  // Same contract as the pause-report capture beside it: PostHog being
+  // unreachable must not turn one missed report into a failed tick.
+  const result = await runSafeModeWatchdog(null, {
+    fetchImpl: (async () =>
+      new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: null }), {
+        status: 200,
+      })) as unknown as typeof fetch,
+    readExtrinsics: async () => null,
+    recordExceptionEvent: (async () => {
+      throw new Error("posthog unreachable");
+    }) as never,
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.history_read, false);
 });

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -202,6 +202,47 @@ export function chainFirehoseCapRefusal(
 export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
 export const CHAIN_FIREHOSE_MAX_WS_CONNECTIONS = 1000;
 
+/**
+ * How far past its scheduled time an alarm has to be before `/poll-start`
+ * treats it as dead and re-arms it (#10766).
+ *
+ * ## Why this one has a grace period and #10764's does not
+ *
+ * `enqueueStatement` in workers/neon-write-buffer-hub.ts fixed the identical
+ * class of bug -- an orphaned alarm read as "one is pending, nothing to do" --
+ * and arms on `existingAlarm === null || existingAlarm <= now`, with no slack
+ * at all. That is right THERE and would be wrong here, because the two alarms
+ * have opposite shapes.
+ *
+ * The buffer's alarm is scheduled ten minutes out and its handler is a drain
+ * that either runs or does not, so any scheduled time in the past is an
+ * orphan. This one is scheduled SIX SECONDS out and re-armed in a `finally`
+ * that runs when the tick FINISHES -- and a tick that catches up 25 blocks
+ * spends 25 serial `fetchBlockAt` calls (three RPC round trips each) plus a
+ * Neon write on every one. A scheduled time in the past is that lane's normal
+ * steady state while it is working, not evidence of anything.
+ *
+ * FIVE MINUTES, and the two bounds it sits between are what pick it:
+ *
+ *  * The FLOOR is one legitimate tick. The alarm re-arms at `Date.now() +
+ *    CHAIN_HEAD_POLL_INTERVAL_MS` (6s) in a `finally`, but that clock starts
+ *    when the tick FINISHES, and a tick that catches up 25 blocks does 25
+ *    serial `fetchBlockAt` round trips plus a Neon write each. A bound tight
+ *    enough to trip on a slow catch-up would re-arm an alarm that is merely
+ *    working, and two alarms racing the same `head:last_seen` is a worse
+ *    failure than the one being repaired.
+ *
+ *  * The CEILING is the bootstrap's own cadence. The cron that calls
+ *    `/poll-start` runs every 15 minutes, so anything at or over that would
+ *    let a wedged poller survive a tick of its own repair.
+ *
+ * Not derived from the poll interval, deliberately -- see
+ * src/producer-cadence.ts. Fifty missed 6-second ticks is arithmetic that
+ * means nothing; "longer than any real tick, shorter than the repair cadence"
+ * is the actual statement.
+ */
+export const CHAIN_HEAD_ALARM_OVERDUE_MS = 5 * 60 * 1000;
+
 // #8364: a periodic SSE comment (`: heartbeat\n\n`) so a client -- and any
 // intermediary proxy that times out an idle connection -- sees traffic even
 // during a chain-quiet stretch. A comment, never a named event: EventSource
@@ -1031,14 +1072,37 @@ export class ChainFirehoseHub implements DurableObject {
     // #204: arm (or re-arm) the head poller. Called from the main worker's
     // 15-minute cron as a self-healing bootstrap -- if the alarm chain ever
     // dies (deploy, DO eviction mid-error), the next cron tick restarts it.
-    // Idempotent: an already-scheduled alarm is left alone.
+    //
+    // AN OVERDUE ALARM IS A DEAD ONE, and repairing only the MISSING case was
+    // a bootstrap that could not reach the failure it exists for (#10766) --
+    // the same fault #10764 fixed in the neon write buffer's enqueue, on a
+    // different grace period and for the reason spelled out at
+    // CHAIN_HEAD_ALARM_OVERDUE_MS.
+    // `getAlarm()` returns the scheduled time, not a liveness check, so an
+    // alarm whose handler never ran -- the storage reset mid-`setAlarm`, the
+    // eviction between scheduling and firing -- reads as armed forever and
+    // this branch left it alone. The lane then sits until something else
+    // happens to touch the object, which is why `/api/v1/chain/indexer-lag`
+    // measured a write-latency tail out to 24 minutes against a p50 of 36
+    // seconds, and why the 20-minute chain-detail staleness alarm fires
+    // occasionally on a lane that is otherwise keeping pace.
     if (url.pathname === "/poll-start" && request.method === "POST") {
       const existing = await this.state.storage.getAlarm();
-      if (existing === null) {
-        await this.state.storage.setAlarm(Date.now() + 1000);
+      const now = Date.now();
+      const overdue =
+        existing !== null && existing < now - CHAIN_HEAD_ALARM_OVERDUE_MS;
+      if (existing === null || overdue) {
+        await this.state.storage.setAlarm(now + 1000);
       }
       return new Response(
-        JSON.stringify({ ok: true, armed: existing === null }),
+        JSON.stringify({
+          ok: true,
+          armed: existing === null,
+          // Distinct from `armed` on purpose: a caller (and the cron log)
+          // should be able to tell "the poller was not running" apart from
+          // "the poller was wedged", because they have different causes.
+          rearmed: overdue,
+        }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
     }

--- a/workers/postgres-tier.ts
+++ b/workers/postgres-tier.ts
@@ -1,4 +1,5 @@
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
+import { maskRouteParams } from "../src/route-label.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 
 // DATA_API-forwarding serving gate, one env flag per data source (originally
@@ -71,6 +72,16 @@ export function currentPostgresTierFallbackGeneration(): number {
 // tryPostgresTier is a shared chokepoint across every data source (blocks,
 // health, neurons, ...), so `flagName` (e.g. "METAGRAPH_HEALTH_SOURCE") is
 // the tag -- the one thing that distinguishes which tier actually degraded.
+//
+// THE ROUTE STAYS FLAG-SCOPED AND THE PATH GOES IN THE MESSAGE (#10665).
+// PostHog fingerprints on `route`, so folding the path into it would split one
+// issue into one-per-endpoint and multiply a fingerprint count that the free
+// tier's $exception budget actually binds. But flag-scoped alone is what made
+// #10665 unanswerable: sixteen days of captures that named the tier and never
+// the request, so "which route is degrading" could not be read off the events
+// at all -- and the issue's own title said 502 while every recent event said
+// 503, because both group under the same flag. The path in the message is
+// per-event, which is exactly where that distinction is legible.
 async function capturePostgresTierFallback(
   err: unknown,
   flagName: keyof Env,
@@ -82,6 +93,41 @@ async function capturePostgresTierFallback(
     errorCode: "upstream_unavailable",
   });
 }
+
+/**
+ * The masked path a failure was serving, for the message above.
+ *
+ * Masked with the same function the analytics labels use, so an ss58 or a
+ * block height cannot turn one recurring fault into thousands of distinct
+ * messages. No parse guard: the Request constructor rejects a URL it cannot
+ * parse, so by the time one exists here `request.url` is absolute and valid --
+ * a try/catch would be a branch no test could ever reach.
+ */
+function maskedPath(request: Request): string {
+  return maskRouteParams(new URL(request.url).pathname);
+}
+
+/**
+ * How many times a 5xx is worth asking again.
+ *
+ * ONE RETRY (#10665). A 5xx here is overwhelmingly the service binding failing
+ * to produce a response while the DATA_API Worker is mid-deploy -- the same
+ * transient #10730 fixed one layer over for the Durable Object enqueue path,
+ * and the reason those captures arrive in BURSTS separated by clean days
+ * rather than at a steady rate. Degrading straight to the schema-stable empty
+ * response turns that blip into a confidently wrong answer served to a caller,
+ * which is strictly worse than the extra round trip.
+ *
+ * ONLY 5xx, deliberately. A 4xx is the request being wrong and will be exactly
+ * as wrong the second time; retrying it would double the load on a path that
+ * cannot recover. And the retry is capped at one because a DATA_API that is
+ * genuinely down should degrade quickly rather than hold every request open --
+ * the empty response is still the right destination, just not the first stop.
+ */
+export const POSTGRES_TIER_RETRY_ATTEMPTS = 2;
+
+/** The floor for "the upstream failed", as opposed to "we asked wrongly". */
+const SERVER_ERROR_FLOOR = 500;
 
 // Flags whose "d1" value FORWARDS to DATA_API. "d1" is a legacy token here,
 // not a store: DATA_API's dispatcher for these three routes sits ahead of its
@@ -123,23 +169,42 @@ export async function tryPostgresTier(
     request.method === "HEAD"
       ? new Request(request, { method: "GET" })
       : request;
-  let upstream;
-  try {
-    upstream = await env.DATA_API.fetch(upstreamRequest);
-  } catch (err) {
+  const path = maskedPath(request);
+  // Safe to re-issue: DATA_API is GET-only and this request has been
+  // normalized to GET above, so there is no consumed body to replay.
+  let upstream: Response | undefined;
+  let transportError: unknown = null;
+  for (let attempt = 0; attempt < POSTGRES_TIER_RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      upstream = await env.DATA_API.fetch(upstreamRequest);
+      transportError = null;
+    } catch (err) {
+      upstream = undefined;
+      transportError = err;
+    }
+    // A transport failure and a 5xx are the same fault seen from two sides --
+    // the binding could not reach a Worker that could answer -- so both get
+    // the second ask, and anything else (2xx, or a 4xx we will not fix by
+    // asking twice) leaves the loop on the first pass.
+    const retryable =
+      transportError !== null ||
+      (upstream !== undefined && upstream.status >= SERVER_ERROR_FLOOR);
+    if (!retryable) break;
+  }
+  if (upstream === undefined) {
     console.error(
-      `tryPostgresTier(${flagName}): DATA_API fetch failed, degrading to the schema-stable empty response:`,
-      err,
+      `tryPostgresTier(${flagName}): DATA_API fetch failed for ${path}, degrading to the schema-stable empty response:`,
+      transportError,
     );
-    await capturePostgresTierFallback(err, flagName, env);
+    await capturePostgresTierFallback(transportError, flagName, env);
     return markPostgresTierFallback();
   }
   if (!upstream.ok) {
     const err = new Error(
-      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status}`,
+      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status} for ${path}`,
     );
     console.error(
-      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status}, degrading to the schema-stable empty response`,
+      `tryPostgresTier(${flagName}): DATA_API returned ${upstream.status} for ${path}, degrading to the schema-stable empty response`,
     );
     await capturePostgresTierFallback(err, flagName, env);
     return markPostgresTierFallback();


### PR DESCRIPTION
Closes #10665. Closes #10765. Closes #10766. Part of #10668.

The four standing error-tracking fingerprints, root-caused and fixed. **Three of the four titles were fossils** — the PostHog fingerprint is lane-scoped, so every event a lane emits groups under whatever it emitted first, and the issue title froze there. Reading the events instead of the titles changed the diagnosis in three of four cases.

| fingerprint | the title said | the events say |
| --- | --- | --- |
| `extrinsics: HTTP 522` | an upstream RPC failure (#10668) | our own API, self-fetched |
| `tryPostgresTier(NEURONS): DATA_API returned 502` | 502 | **503**, in deploy-shaped bursts |
| `neurons lane stalled … poller has missed three ticks` | the poller stopped | the **write buffer** was holding rows |
| `chain-detail stalled … head block none` | an empty table | **21–23 min behind a live, advancing head** |

---

## 1. SafeMode — blind for a week (#10765)

Every hourly tick since 2026-08-04 returned `ok:false, reason:"unreachable"`. The chain-pause monitor was not watching. Three defects, stacked:

**It self-fetched.** `https://api.metagraph.sh` is a custom domain of the very Worker `SAFE_MODE_WATCHDOG_CRON` (`41 * * * *`) runs on; Cloudflare refuses that and returns 522. The `:41:5x` alignment on every event — one per hour, no clean ticks — is the tell. Same trap as #10194. It now calls `loadExtrinsicFeedColdTier`, the in-process reader `handleExtrinsics` itself falls through to.

**It asked for `limit=200` against a route that caps at 100**, verified against production:

```
{"error":{"code":"invalid_query","message":"limit must be an integer between 1 and 100. Received: \"200\"."}}
```

so fixing only the 522 would have swapped one deterministic failure for another.

**And a failed history read discarded the pause check.** `SafeMode.EnteredUntil` — the authoritative "are we paused right now" signal, and the one that catches a root-entered pause with no extrinsic behind it — succeeded on every one of those ticks, then fell into the `catch` with the throw on the next line. **A chain pause would not have been reported.** The halves now fail independently, and history that could not be read is a third state: `null`, never `0`, because `succeeded: 0` from a monitor that failed to look asserts that no SafeMode call has ever landed.

## 2. DATA_API 5xx on the neurons tier (#10665)

Titled 502; every recent event says 503. The shape — bursts with clean days between — is the service binding failing to produce a response while DATA_API is mid-deploy, the same transient #10730 fixed one layer over for the DO enqueue path. Degrading on the first refusal turned each blip into a confidently wrong empty answer.

A 5xx or a transport throw is now asked **once** more; a 4xx is not, because it will be exactly as wrong twice. And the failing request path goes in the message, masked through `maskRouteParams` — sixteen days of captures named the flag and never the route, which is why the issue could not be answered from its own events. The `route` stays flag-scoped so the fingerprint does not split one issue into one-per-endpoint.

## 3. neurons lane stalled — not the poller (#10665)

The alarm tracks the write-buffer toggles exactly:

| time (PDT) | event |
| --- | --- |
| 01:33 | buffer **enabled** (#10686) |
| 02:21 → 03:51 | age climbs 80.6 → 170.6 min in exact 15-minute steps |
| 03:47 | buffer **off** — "failing inside DO storage" (#10734) |
| 04:52 | age falls to 52.4 — recovering |
| 05:36 | buffer **on**, O(n) enqueue fixed (#10758) |

The watchdog reads `MAX(captured_at)`, and a row is only in the table once **written** — so its age is producer lag *plus write-visibility lag*, and `neurons` became a buffered lane an hour ago. Ten of the forty-five minutes it allows are now spent by a healthy producer and a buffer that is merely waiting, so it would fire at ~2.3 missed ticks while claiming three.

The threshold absorbs `FLUSH_INTERVAL_MS` **while the lane is buffered** — conditional, so turning the buffer off restores the tighter bound rather than leaving ten minutes of permanent slack behind a flag nobody re-reads. And the message stops asserting a cause it never checked: the watchdog reads the table, so a stopped producer and a stalled write path are the same observation to it.

## 4. chain-detail — the tail, not a stall (#10766)

The head is live and advancing at chain rate (8820213 → 8820591 is 378 blocks over 75 min = 12s/block). `/api/v1/chain/indexer-lag` prices the tail:

```json
{"write_latency_ms":{"min":29386,"p50":36592,"p95":1074536,"p99":1359030,"max":1466617}}
```

p50 **36.6s**, p95 **17.9 min**, max **24.4 min**. The 20-minute threshold sits between p95 and p99, so the alarm fires on the natural tail of a lane that is working. **The threshold is not the bug** — it is sized against the decode seam, not the producer's cadence, and widening it would suppress a real signal.

`/poll-start` re-armed only a **missing** alarm, and `getAlarm()` returns a scheduled time rather than a liveness check — so an alarm whose handler never ran read as armed forever and the bootstrap could not reach the case it exists for. An overdue alarm is now treated as dead.

This is the same class #10764 fixed in the write buffer's enqueue two hours ago. That one arms on `<= now` with no slack; this one needs a grace period, and the file says why: the buffer's alarm is scheduled ten minutes out with a short handler, while this one is scheduled six seconds out and re-armed when the tick *finishes* — so a scheduled time in the past is this lane's normal state while it is working. Five minutes sits between one legitimate 25-block catch-up and the 15-minute repair cadence.

---

## Not fixed here

The other two faults in #10668 stay open there: `-32004 RPC work limit exceeded` on `scan Delegates`/`discover netuids` (deterministic, a query-shape problem in the infra producers) and the emission-gate sampler's 429. Hence `Part of`, not `Closes`.

## Validation

- `npm run typecheck` · `npm run validate` · `npm run lint` · `npm run format:check` · `npm run scan:public-safety` — all clean
- **3,423 tests across the 28 files importing any changed module** — all pass
- The 93 test files touching `DATA_API` re-run for the retry's blast radius — 6,356 tests, all pass
- **Patch coverage 100%** — statements, branches *and* functions on every changed line in `src/**`/`workers/**`, measured by diff intersection against `origin/main`
- Production reads used as evidence: `/api/v1/extrinsics?call_module=SafeMode&limit=200`, `/api/v1/chain/indexer-lag`, `/health`
