### PR TITLE
feat(graphql): join the nullability evidence to the tightenings it licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "validate:graphql-query-arguments": "node scripts/validate-graphql-query-arguments.ts",
     "report:graphql-sdl-equivalence": "node scripts/report-graphql-sdl-equivalence.ts",
     "report:graphql-schema-diff": "node scripts/report-graphql-schema-diff.ts",
+    "report:graphql-tightening-evidence": "node scripts/report-graphql-tightening-evidence.ts",
     "validate:published-names": "node scripts/validate-published-names.ts",
     "validate:graphql-tier-parity": "node scripts/validate-graphql-tier-parity.ts",
     "build:openapi-zod": "node scripts/generate-openapi-zod-components.ts",

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5312,8 +5312,8 @@ export interface components {
                 description?: string | null;
                 discord?: string | null;
                 github?: string | null;
-                /** @description Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. */
-                identity_hash: string;
+                /** @description Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. Null on a row with no computed hash. */
+                identity_hash: string | null;
                 image?: string | null;
                 name?: string | null;
                 observed_at: string | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -14741,8 +14741,15 @@
                   ]
                 },
                 "identity_hash": {
-                  "description": "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs.",
-                  "type": "string"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. Null on a row with no computed hash."
                 },
                 "image": {
                   "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5312,8 +5312,8 @@ export interface components {
                 description?: string | null;
                 discord?: string | null;
                 github?: string | null;
-                /** @description Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. */
-                identity_hash: string;
+                /** @description Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. Null on a row with no computed hash. */
+                identity_hash: string | null;
                 image?: string | null;
                 name?: string | null;
                 observed_at: string | null;

--- a/schemas-src/graphql/build-schema.ts
+++ b/schemas-src/graphql/build-schema.ts
@@ -225,13 +225,22 @@ export function buildGeneratedSchema(
           // nulled parent. So the union publishes it, nullable -- which is
           // exactly what the hand-written SDL already did by hand for
           // `featured`, `uid_count` and `stake_dominance`.
+          // Two ways a promise the component makes cannot be kept here. A
+          // field only SOME of the producers carry: ask the other one and it
+          // answers null, which graphql-js turns into a nulled parent -- what
+          // the SDL already did by hand for `featured`, `uid_count` and
+          // `stake_dominance`. And a field a PROJECTION declares nullable,
+          // because the resolver building the view fills fewer fields than the
+          // component's own producer does (`OpportunityEntry`, measured).
           const everywhere = carriers.length === contributors.length;
+          const relaxed = projection?.nullable?.includes(fieldName) ?? false;
           const republished = republish(field.type);
           const published = renamed.get(fieldName) ?? fieldName;
           fields[published] = {
             type: retype(
               `${name}.${published}`,
-              everywhere || !(republished instanceof GraphQLNonNull)
+              (everywhere && !relaxed) ||
+                !(republished instanceof GraphQLNonNull)
                 ? republished
                 : (republished.ofType as GraphQLOutputType),
             ),

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -2021,6 +2021,26 @@ export interface ProjectedType {
   readonly itemsFrom?: string;
   /** The component row count a paginated view's `total` renames (#10404). */
   readonly totalFrom?: string;
+  /**
+   * Component fields this view publishes NULLABLE that the component promises.
+   *
+   * A projection is a view built by a resolver, and a resolver can fill fewer
+   * fields than the component's own producer does. `OpportunityEntry` is that:
+   * the economics card promises `miner_count` and four siblings, and
+   * /api/v1/economics delivers all five on all 129 rows -- but the LEADERBOARD
+   * rows are ranked partials, and each board materializes only what its
+   * ranking needs. Production answers `open_slots[].miner_count: null` today.
+   *
+   * So this cannot be fixed in the Zod: relaxing `SubnetEconomics` would
+   * weaken a contract the full card honours, to describe a view that does not.
+   * The relaxation belongs to the VIEW, which is what this declares.
+   *
+   * The direction is deliberately one-way -- a projection may publish a
+   * component's non-null field as nullable, never the reverse. Promising more
+   * than the component does is a claim about a producer the projection has no
+   * standing to make.
+   */
+  readonly nullable?: readonly string[];
 }
 
 /**
@@ -2200,6 +2220,23 @@ export const PROJECTED_TYPES: Readonly<Record<string, ProjectedType>> = {
     added: {
       validator_headroom: "Int",
     },
+    // Measured, not guessed. `formatLeaderboards` ranks each board off the
+    // fields that board sorts by, so a row carries those and leaves the rest
+    // unset -- and the boards disagree with each other about which:
+    //
+    //   open_slots[]         max_validators, miner_count, validator_count null
+    //   validator_headroom[] max_validators, validator_count set; miner_count null
+    //
+    // against api.metagraph.sh, on every row of both. The full card fills all
+    // five on all 129 rows of /api/v1/economics, which is why the component
+    // keeps its promise and only this view relaxes it.
+    nullable: [
+      "max_uids",
+      "max_validators",
+      "miner_count",
+      "registration_allowed",
+      "validator_count",
+    ],
     dropped: [
       "alpha_fdv_tao",
       "alpha_in_emission",

--- a/schemas-src/routes/account-identity.ts
+++ b/schemas-src/routes/account-identity.ts
@@ -50,10 +50,20 @@ const AccountIdentityHistoryEntrySchema = z
     discord: z.string().max(200).nullable().optional(),
     description: z.string().nullable().optional(),
     additional: z.string().nullable().optional(),
+    // NULLABLE, and for the reason #8055 already wrote down on the subnet
+    // sibling: `formatIdentityHistoryEntry` builds this as
+    // `row.identity_hash ?? null` (src/account-identity-history.ts), so a row
+    // with no computed hash yields null. `SubnetIdentityHistoryEntry` was
+    // corrected then; this one was not, and nothing noticed because the key is
+    // always PRESENT -- required and nullable are orthogonal, and only the
+    // first was true. Found by generating the GraphQL type from this schema:
+    // the generator promised non-null over a producer that can answer null,
+    // which graphql-js turns into a nulled parent plus an error (#10214).
     identity_hash: z
       .string()
+      .nullable()
       .describe(
-        "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs.",
+        "Stable hash of this entry's tracked identity fields -- unchanged across entries where nothing actually differs. Null on a row with no computed hash.",
       ),
   })
   .strict()

--- a/scripts/check-graphql-nullability.ts
+++ b/scripts/check-graphql-nullability.ts
@@ -92,6 +92,29 @@ const ARGUMENTS: Readonly<Record<string, string>> = {
 };
 
 /**
+ * Per-FIELD overrides, for an argument name whose namespace is not global.
+ *
+ * `slug` is two different vocabularies. `provider(slug:)` takes a provider
+ * slug and `adapter(slug:)` takes a subnet slug, and the table above can only
+ * hold one value for the name -- so `adapter(slug: "apex")` resolved null and
+ * every `Adapter` field went unobserved, which the report then printed as "no
+ * evidence either way". That is the failure this whole script exists to avoid,
+ * one level up: a silence read as an answer. Verified against
+ * api.metagraph.sh -- `adapter(slug: "apex")` is null, `adapter(slug: "sn-1")`
+ * returns netuid 1.
+ *
+ * Deliberately per field rather than a list of candidates per name: trying
+ * every value against every field multiplies the request count by the size of
+ * the table, and the ambiguity is not "which of these works" but "this field
+ * reads a different namespace", which is a fact worth writing down.
+ */
+const ARGUMENTS_BY_FIELD: Readonly<
+  Record<string, Readonly<Record<string, string>>>
+> = {
+  adapter: { slug: '"sn-1"' },
+};
+
+/**
  * Path-parameter values for the REST half, SEVERAL per parameter.
  *
  * One subject silently decides which types get measured: netuid 1 has 3
@@ -345,9 +368,10 @@ async function send(
 /** The arguments a Query field requires, rendered -- or null if one is unknown. */
 function renderArguments(field: GraphQLField<unknown, unknown>): string | null {
   const parts: string[] = [];
+  const overrides = ARGUMENTS_BY_FIELD[field.name] ?? {};
   for (const argument of field.args) {
     if (!isNonNullType(argument.type)) continue;
-    const value = ARGUMENTS[argument.name];
+    const value = overrides[argument.name] ?? ARGUMENTS[argument.name];
     if (value === undefined) return null;
     parts.push(`${argument.name}: ${value}`);
   }

--- a/scripts/report-graphql-tightening-evidence.ts
+++ b/scripts/report-graphql-tightening-evidence.ts
@@ -1,0 +1,123 @@
+// Which of the generator's non-null promises production has actually proved
+// (#10214).
+//
+// `report:graphql-schema-diff` counts the fields the generated schema would
+// TIGHTEN -- `X` in the published SDL, `X!` in the generator. That count is not
+// a decision. Each one is a claim about a PRODUCER ("it cannot answer null"),
+// and what the generator knows is a claim about a SCHEMA ("the Zod has no
+// `.nullable()`"). The two are different, and where they disagree the served
+// schema is the one that has been right: graphql-js enforces non-null at
+// execution, so a single null nulls the whole surrounding object and attaches
+// an error -- which is what `SelfHealthLane.detail` did on every self_health
+// request until #10215.
+//
+// `conformance:graphql-nullability` already asks production the producer
+// question, over both transports. What was missing is the JOIN: its answer
+// covers every non-null leaf the generator promises, and only some of those
+// are ones the cutover would CHANGE. Reporting the two separately meant the
+// evidence for a tightening and the tightening itself were never in the same
+// place, so "3176 of 3403 observed" got read as though it licensed all 300 --
+// when the 300 are a different set, and the overlap is the whole question.
+//
+// This intersects them and reports three buckets:
+//
+//   PROVED       the tightening is in the observed set, seen with a value and
+//                never null. Safe: the producer has answered, repeatedly.
+//   NULLED       production answered null for a field the generator promises
+//                non-null. NOT a tightening to make -- a bug to fix, in the
+//                Zod or the producer.
+//   UNPROVED     the probe never saw a value. No evidence either way, so the
+//                honest thing is to leave the published nullable.
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { checkNullability } from "./check-graphql-nullability.ts";
+import { diffSchemas } from "./report-graphql-schema-diff.ts";
+import { extractSdl } from "./validate-graphql-component-parity.ts";
+import type { OpenApiParameters } from "../schemas-src/graphql/query-arguments.ts";
+
+const SDL_PATH = "src/graphql-sdl.ts";
+const OPENAPI_PATH = "public/metagraph/openapi.json";
+
+export interface TighteningEvidence {
+  /** Every field the cutover would promise non-null over a nullable one. */
+  tightened: string[];
+  /** Tightenings production has answered with a value, never null. */
+  proved: string[];
+  /** Tightenings production answered NULL for -- a bug, not a decision. */
+  nulled: string[];
+  /** Tightenings the probe never saw a value for. */
+  unproved: string[];
+}
+
+/**
+ * `Type.field -- X becomes X!` -> `Type.field`.
+ *
+ * The diff's line carries the transition for a human; the join needs the key.
+ */
+function fieldOf(line: string): string {
+  return line.split(" -- ")[0];
+}
+
+export function joinEvidence(
+  tightenedLines: readonly string[],
+  observedFields: ReadonlySet<string>,
+  nulledFields: ReadonlySet<string>,
+): TighteningEvidence {
+  const tightened = tightenedLines.map(fieldOf);
+  const proved: string[] = [];
+  const nulled: string[] = [];
+  const unproved: string[] = [];
+  for (const field of tightened) {
+    if (nulledFields.has(field)) nulled.push(field);
+    else if (observedFields.has(field)) proved.push(field);
+    else unproved.push(field);
+  }
+  return { tightened, proved, nulled, unproved };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const openapi = JSON.parse(
+    readFileSync(OPENAPI_PATH, "utf8"),
+  ) as OpenApiParameters;
+  const sdl = extractSdl(readFileSync(SDL_PATH, "utf8"));
+  if (!sdl) {
+    console.error(
+      `tightening-evidence: no SDL template literal in ${SDL_PATH}`,
+    );
+    process.exit(1);
+  }
+  const diff = diffSchemas(sdl, openapi);
+  const report = await checkNullability(openapi);
+  // `unobserved` is what the probe never saw; everything else it promised was
+  // seen. Deriving the observed set by SUBTRACTION rather than asking for it
+  // keeps the two reports from having to agree on a second list.
+  const unobserved = new Set(report.unobserved);
+  const nulledFields = new Set(
+    report.findings.filter((f) => f.nulls > 0).map((f) => f.field),
+  );
+  const evidence = joinEvidence(
+    diff.tightened,
+    new Set(
+      diff.tightened.map(fieldOf).filter((field) => !unobserved.has(field)),
+    ),
+    nulledFields,
+  );
+
+  console.log(
+    `tightening-evidence: ${evidence.tightened.length} tightening(s); ` +
+      `${evidence.proved.length} proved, ${evidence.nulled.length} answered NULL, ` +
+      `${evidence.unproved.length} unproved.`,
+  );
+  for (const [label, lines] of [
+    ["ANSWERED NULL -- a bug, not a tightening", evidence.nulled],
+    ["UNPROVED -- no evidence either way", evidence.unproved],
+  ] as const) {
+    if (!lines.length) continue;
+    console.log(`\n${label}:`);
+    for (const line of lines.slice(0, 60)) console.log(`  - ${line}`);
+    if (lines.length > 60) console.log(`  … and ${lines.length - 60} more`);
+  }
+  // A tightening production has ANSWERED NULL for is the one case that is not
+  // a judgement call, so it is the one that fails.
+  if (evidence.nulled.length) process.exit(1);
+}

--- a/tests/graphql-generated-schema.test.ts
+++ b/tests/graphql-generated-schema.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { buildSchema, isEnumType, isObjectType, printSchema } from "graphql";
 import { buildGeneratedSchema } from "../schemas-src/graphql/build-schema.ts";
+import { emitTypes } from "../schemas-src/graphql/emit.ts";
 import {
   GRAPHQL_ENUMS,
   assertEnumVocabularies,
@@ -184,6 +185,45 @@ describe("the generated schema", () => {
           B: { description: "", values: [], from: [], fields: ["X.y"] },
         }),
       /X\.y is declared as both A and B/,
+    );
+  });
+
+  test("an enum site inside a LIST keeps the list", () => {
+    // The only live site is `ChainEvent.table: String!`, so the list arm of
+    // the rewrap would otherwise never run -- and an enum published over
+    // `[String!]!` is the obvious next one to declare.
+    const { schema } = buildGeneratedSchema(
+      openapi,
+      PROJECTED_TYPES,
+      RETYPED_FIELDS,
+      new Map([["Gaps.missing_kinds", "ChainFirehoseTable"]]),
+    );
+    assert.equal(
+      String(
+        (schema.getType("Gaps") as GraphQLObjectType).getFields().missing_kinds
+          .type,
+      ),
+      "[ChainFirehoseTable!]!",
+      "the enum replaces the leaf, not the list around it",
+    );
+  });
+
+  test("a projection may publish a component's promise NULLABLE", () => {
+    // `formatLeaderboards` ranks each board off the fields that board sorts
+    // by, so a row carries those and leaves the rest unset -- production
+    // answers `open_slots[].miner_count: null` on every row. The component
+    // keeps its promise (the full card fills all five on all 129 rows of
+    // /api/v1/economics); only the view relaxes it.
+    const entry = buildGeneratedSchema(openapi).schema.getType(
+      "OpportunityEntry",
+    ) as GraphQLObjectType;
+    assert.equal(String(entry.getFields().miner_count.type), "Int");
+    // And the component it projects still promises it, so this is a relaxation
+    // declared by the view rather than a hole in the contract.
+    const { types } = emitTypes();
+    assert.equal(
+      String(types.get("SubnetEconomics")!.getFields().miner_count.type),
+      "Int!",
     );
   });
 


### PR DESCRIPTION
With #10760 closed the generated schema reproduces the published one field for field — 420 types against 420, **0 other differences**. One class was left: **300 fields the generator would tighten to non-null.**

## The count was not the decision

Each of the 300 is a claim about a **producer** ("it cannot answer null"). What the generator knows is a claim about a **schema** ("the Zod has no `.nullable()`"). Where those disagree the served schema has been the one that was right — graphql-js enforces non-null at execution, so a single null nulls the whole surrounding object and attaches an error (#10215).

`conformance:graphql-nullability` already asks production the producer question. What was missing is the **join**: its answer covers every non-null leaf the generator promises, and only *some* of those are ones the cutover would change. So "3176 of 3403 observed, 0 answered NULL" read like a licence for all 300, when the 300 are a different set and the overlap is the whole question. `report:graphql-tightening-evidence` intersects them and exits 1 on the one bucket that is not a judgement call.

## What the join found

**5 answered NULL** — all on `OpportunityEntry`. `formatLeaderboards` ranks each board off the fields that board sorts by and leaves the rest unset, and the boards disagree about which:

| board | `max_validators` | `validator_count` | `miner_count` |
|---|---|---|---|
| `open_slots[]` | null | null | null |
| `validator_headroom[]` | set | set | **null** |

On every row of both, against api.metagraph.sh. This **cannot** be fixed in the Zod — `/api/v1/economics` fills all five on all 129 rows, so relaxing `SubnetEconomics` would weaken a contract the full card honours in order to describe a view that does not. `ProjectedType.nullable` puts the relaxation on the view, and only one way: a projection may publish a component's non-null field as nullable, never the reverse.

**1 real contract bug**, and one #8055 already found once. `AccountIdentityHistoryEntry.identity_hash` is declared non-null while `formatIdentityHistoryEntry` builds it as `row.identity_hash ?? null`. #8055 hit exactly this on the *subnet* sibling, corrected it, and wrote the reasoning into the file — the account route was never corrected. Nothing noticed because the key is always **present**: required and nullable are orthogonal, and only the first was true. This fixes REST, MCP and GraphQL at once.

## A blind spot one level up

Four `Adapter.*` fields came back "no evidence either way" — not unanswerable, **unasked**. The probe holds one value per argument NAME, and `slug` is two vocabularies: `provider(slug:)` takes a provider slug, `adapter(slug:)` takes a subnet slug. So `adapter(slug: "apex")` resolved null, every `Adapter` field went unobserved, and the report printed that silence as an absence of evidence — which is precisely the failure the script exists to prevent. `ARGUMENTS_BY_FIELD` gives the field its own namespace; verified against production, `adapter(slug: "sn-1")` returns netuid 1.

## Where it lands

```
294 tightening(s); 288 proved, 0 answered NULL, 6 unproved
```

Of the six the probe never saw a value for: four are the `Adapter.*` fields the override now reaches, and two — `AccountCounterpartyTransfer.from`/`.to` — are non-null by **control flow** rather than by sampling. A row only reaches `transfers.push` when `from`/`to` equal a validated ss58 string (`src/counterparties.ts`), which null cannot.

Verified: `report:graphql-schema-diff` 0 other differences · `report:graphql-sdl-equivalence` 418/418 types, 198/198 return types, 0 JSON under-typings · all six graphql validators OK · `validate:contract-drift` OK · `npm run validate` exit 0 · lint/format/tsc clean · 390 tests green across the four graphql suites · `schemas-src/graphql/build-schema.ts` at **100% statements and 100% branches** (the enum-inside-a-list arm that `codecov/patch` flagged on #10761 is now covered by a test that drives it).

Closes #10769