### PR TITLE
fix(identity): repoint the identity timelines at the live store — the writer came back and the readers did not

### DIFF
--- a/src/chain-identity-history.ts
+++ b/src/chain-identity-history.ts
@@ -11,8 +11,15 @@
 // never a live D1 read). Null-safe: a non-array/empty read yields a
 // schema-stable empty feed and never throws.
 
-import { formatIdentityHistoryEntry } from "./subnet-identity-history.ts";
-import { clampToolLimit } from "../workers/request-params.ts";
+import {
+  READ_COLUMNS,
+  formatIdentityHistoryEntry,
+} from "./subnet-identity-history.ts";
+import {
+  FEED_PAGINATION,
+  clampLimit,
+  clampToolLimit,
+} from "../workers/request-params.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -87,4 +94,39 @@ export function buildChainIdentityHistory(
     subnet_count: netuids.size,
     changes,
   };
+}
+
+/**
+ * The network-wide identity feed, newest first, from the LIVE store (#10773).
+ *
+ * The twin of `loadSubnetIdentityHistory` for /api/v1/chain/identity-history
+ * and its MCP + GraphQL surfaces. It did not exist because nothing could call
+ * it: `METAGRAPH_SUBNET_IDENTITY_SOURCE` was retired while
+ * `subnet_identity_history` had no writer at all, so #10190 removed the tier
+ * read as unreachable and every surface fell through to the frozen lakehouse
+ * export. The writer landed on 2026-08-11 (#10740 / #10762 and
+ * metagraphed-infra#444) and the reader was never repointed -- the lane wrote
+ * 248 rows at 13:15Z while all three surfaces still served 2026-07-31.
+ *
+ * ORDER MATCHES THE COLD TIER'S, deliberately -- `block_number DESC, netuid
+ * ASC, id DESC`, the same total order `loadChainIdentityHistoryColdTier` uses.
+ * The two legs answer the same question and a caller cannot tell which one
+ * did; feeds that disagreed on ordering would surface as rows shuffling
+ * whenever the live store went cold.
+ *
+ * `netuid` leads the column list because the network feed carries it and the
+ * per-subnet timeline does not -- the same split the cold tier makes, and the
+ * reason this selects `READ_COLUMNS` rather than restating it.
+ */
+export async function loadChainIdentityHistory(
+  d1: (sql: string, params: unknown[]) => Promise<Record<string, unknown>[]>,
+  { limit }: { limit?: string | number | null } = {},
+): Promise<ChainIdentityHistoryResult> {
+  const lim = clampLimit(limit, FEED_PAGINATION);
+  const rows = await d1(
+    `SELECT netuid, ${READ_COLUMNS} FROM subnet_identity_history` +
+      " ORDER BY block_number DESC, netuid ASC, id DESC LIMIT ?",
+    [lim],
+  );
+  return buildChainIdentityHistory(rows, { limit: lim });
 }

--- a/src/identity-history-answer.ts
+++ b/src/identity-history-answer.ts
@@ -29,17 +29,89 @@ import {
   loadChainIdentityHistoryColdTier,
   loadSubnetIdentityHistoryColdTier,
 } from "./subnet-identity-cold-tier.ts";
-import { buildSubnetIdentityHistory } from "./subnet-identity-history.ts";
-import { buildChainIdentityHistory } from "./chain-identity-history.ts";
+import {
+  buildSubnetIdentityHistory,
+  loadSubnetIdentityHistory,
+} from "./subnet-identity-history.ts";
+import {
+  buildChainIdentityHistory,
+  loadChainIdentityHistory,
+} from "./chain-identity-history.ts";
+import { SUBNET_IDENTITY_HISTORY_TABLES } from "./read-store-tables.ts";
+import { readStore } from "./read-store.ts";
+import { d1All } from "./analytics-live.ts";
 
 type Row = Record<string, unknown>;
 
+/**
+ * The LIVE leg, and why it lives in the composer rather than at the surfaces
+ * (#10773).
+ *
+ * `subnet_identity_history` had no writer from the D1 cutover until
+ * 2026-08-11: `syncSubnetIdentityToPostgres` was named as its sole writer in
+ * four places and was never written. #10190 removed the tier read on exactly
+ * that ground -- it "resolved to null on every request" -- and the frozen
+ * lakehouse export became the only leg. The writer landed the same day
+ * (#10740 / #10762 and metagraphed-infra#444) and nothing repointed the read:
+ * the lane wrote 248 rows at 13:15Z while REST, MCP and GraphQL all still
+ * served 2026-07-31, which is 11 days of identity changes that exist and are
+ * not served.
+ *
+ * Put HERE, beside the cold tier, for the reason this module exists at all: a
+ * live leg added at one surface is exactly the divergence #9153 created and
+ * this composer was written to end. Five call sites pass `null` for
+ * `tierResult`; one of them growing a Neon read would leave the other four on
+ * the frozen export with nothing to catch it.
+ *
+ * ORDER: caller-supplied tier, then live, then frozen, then the empty shape.
+ * The live store goes AHEAD of the export because the export is a one-time
+ * 2026-08-02 seed that never advances -- preferring it would mean the newest
+ * identity change is permanently 2026-07-31 no matter what the chain does.
+ * And a live-store MISS still falls through, so the frozen history stays
+ * readable for the range that predates the writer.
+ */
+async function liveStore(env: unknown): Promise<D1Runner | null> {
+  const db = readStore(env as never, SUBNET_IDENTITY_HISTORY_TABLES);
+  return db ? (sql, params) => d1All(db as never, sql, params) : null;
+}
+
+type D1Runner = (
+  sql: string,
+  params: unknown[],
+) => Promise<Record<string, unknown>[]>;
+
+/** A live read that throws is a MISS, not an outage. The frozen leg and the
+ * schema-stable empty shape are both still ahead, and a cold Hyperdrive or an
+ * unmigrated table must not turn a readable timeline into a 500. */
+async function tryLive<T>(read: () => Promise<T>): Promise<T | null> {
+  try {
+    return await read();
+  } catch {
+    return null;
+  }
+}
+
+/** An empty live read is a MISS, not an answer.
+ *
+ * The distinction matters only while the table is filling: the writer landed
+ * on 2026-08-11 and the frozen export holds everything before it, so a netuid
+ * whose identity last changed in July has zero live rows and a real frozen
+ * timeline. Treating the empty read as authoritative would publish "this
+ * subnet has never changed its identity" for most of the network. */
+function nonEmpty(result: Row | null, key: "entries" | "changes"): Row | null {
+  const rows = result?.[key];
+  return Array.isArray(rows) && rows.length > 0 ? result : null;
+}
+
 export interface AnswerSubnetIdentityHistoryOptions {
   coldTier?: typeof loadSubnetIdentityHistoryColdTier;
+  /** Injectable so a test can drive the live leg without a store. */
+  live?: (env: unknown) => Promise<D1Runner | null>;
 }
 
 export interface AnswerChainIdentityHistoryOptions {
   coldTier?: typeof loadChainIdentityHistoryColdTier;
+  live?: (env: unknown) => Promise<D1Runner | null>;
 }
 
 /** One subnet's identity timeline from whichever store can answer. */
@@ -50,10 +122,26 @@ export async function answerSubnetIdentityHistory(
   query: { limit: number; offset?: number | null; cursor?: unknown },
   {
     coldTier = loadSubnetIdentityHistoryColdTier,
+    live = liveStore,
   }: AnswerSubnetIdentityHistoryOptions = {},
 ): Promise<Row> {
+  const db = tierResult ? null : await tryLive(() => live(env));
+  const fresh = db
+    ? nonEmpty(
+        await tryLive(
+          async () =>
+            (await loadSubnetIdentityHistory(db, netuid, {
+              limit: query.limit,
+              offset: query.offset ?? null,
+              cursor: query.cursor ?? null,
+            })) as Row,
+        ),
+        "entries",
+      )
+    : null;
   return (
     tierResult ??
+    fresh ??
     ((await coldTier(env as never, netuid, {
       limit: query.limit,
       offset: query.offset ?? null,
@@ -74,10 +162,24 @@ export async function answerChainIdentityHistory(
   query: { limit?: unknown } = {},
   {
     coldTier = loadChainIdentityHistoryColdTier,
+    live = liveStore,
   }: AnswerChainIdentityHistoryOptions = {},
 ): Promise<Row> {
+  const db = tierResult ? null : await tryLive(() => live(env));
+  const fresh = db
+    ? nonEmpty(
+        await tryLive(
+          async () =>
+            (await loadChainIdentityHistory(db, {
+              limit: query.limit as number | null,
+            })) as unknown as Row,
+        ),
+        "changes",
+      )
+    : null;
   return (
     tierResult ??
+    fresh ??
     ((await coldTier(env as never, { limit: query.limit })) as Row | null) ??
     (buildChainIdentityHistory([], {
       limit: query.limit,

--- a/src/read-store-tables.ts
+++ b/src/read-store-tables.ts
@@ -67,6 +67,19 @@ export const SUBNET_HYPERPARAMS_TEMPO_TABLES = ["subnet_hyperparams"] as const;
 /** loadSubnetBurnHistory */
 export const SUBNET_BURN_HISTORY_TABLES = ["subnet_burn_history"] as const;
 
+/**
+ * loadSubnetIdentityHistory + loadChainIdentityHistory.
+ *
+ * Declared late (#10773) because until 2026-08-11 the table had no writer:
+ * `syncSubnetIdentityToPostgres` was named as its sole writer in four places
+ * and never existed, so #10190 removed the tier read as unreachable and every
+ * surface fell to the frozen lakehouse export. The writer landed in #10740 /
+ * #10762 and metagraphed-infra#444; this is the read half catching up.
+ */
+export const SUBNET_IDENTITY_HISTORY_TABLES = [
+  "subnet_identity_history",
+] as const;
+
 /** loadRevenueObservations, and the probe lane's own write (#10566).
  *
  * Both tables, because the lane writes both in one pass and producerStore gates

--- a/src/subnet-identity-history.ts
+++ b/src/subnet-identity-history.ts
@@ -28,7 +28,10 @@ const BLOCKS_HEAD_TABLES = ["blocks_head"] as const;
 type Row = Record<string, unknown>;
 type D1Runner = (sql: string, params: unknown[]) => Promise<Row[]>;
 
-const READ_COLUMNS =
+/** The identity columns both timelines select. Exported so the network
+ * feed in chain-identity-history.ts selects the SAME list rather than a second
+ * copy that can drift from this one. */
+export const READ_COLUMNS =
   "id, block_number, observed_at, subnet_name, symbol, description, github_repo, subnet_url, discord, logo_url, identity_hash";
 
 function stableStringify(value: unknown): string {

--- a/tests/identity-history-live-leg.test.ts
+++ b/tests/identity-history-live-leg.test.ts
@@ -1,0 +1,368 @@
+// The LIVE store leg of the identity-history composer (#10773).
+//
+// `subnet_identity_history` had no writer from the D1 cutover until
+// 2026-08-11 -- `syncSubnetIdentityToPostgres` was named as its sole writer in
+// four places and never existed -- so #10190 removed the tier read as
+// unreachable and the frozen lakehouse export became the only leg. The writer
+// landed the same day (#10740 / #10762 and metagraphed-infra#444) and nothing
+// repointed the read: the lane wrote 248 rows at 13:15Z while REST, MCP and
+// GraphQL all still served 2026-07-31.
+//
+// These pin the ORDER of the cascade, which is the whole of the fix: live
+// ahead of frozen, because the export is a one-time 2026-08-02 seed that never
+// advances -- and a live MISS still falling through, because the export holds
+// everything from before the writer existed.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  answerChainIdentityHistory,
+  answerSubnetIdentityHistory,
+} from "../src/identity-history-answer.ts";
+
+/** One live row, as the store hands it back. */
+const LIVE_ROW = {
+  id: 9,
+  netuid: 64,
+  block_number: 8_821_000,
+  observed_at: 1_786_000_000_000,
+  subnet_name: "Live Name",
+  symbol: "L",
+  description: null,
+  github_repo: null,
+  subnet_url: null,
+  discord: null,
+  logo_url: null,
+  identity_hash: "abc",
+};
+
+/** A live runner that returns `rows` and records the SQL it was asked for. */
+function liveRunner(rows: Record<string, unknown>[]) {
+  const seen: { sql: string; params: unknown[] }[] = [];
+  return {
+    seen,
+    live: async () => async (sql: string, params: unknown[]) => {
+      seen.push({ sql, params });
+      return rows;
+    },
+  };
+}
+
+/** A frozen leg that is distinguishable from the live one in the output. */
+const frozenChain = async () =>
+  ({
+    schema_version: 1,
+    count: 1,
+    subnet_count: 1,
+    changes: [{ netuid: 1, subnet_name: "Frozen Name" }],
+  }) as never;
+
+const frozenSubnet = async () =>
+  ({
+    schema_version: 1,
+    netuid: 64,
+    entry_count: 1,
+    entries: [{ subnet_name: "Frozen Name" }],
+  }) as never;
+
+describe("the network feed prefers the live store over the frozen export", () => {
+  test("a live row answers, and the frozen export is never consulted", async () => {
+    let frozenCalls = 0;
+    const { live, seen } = liveRunner([LIVE_ROW]);
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      {
+        live,
+        coldTier: (async () => {
+          frozenCalls += 1;
+          return frozenChain();
+        }) as never,
+      },
+    )) as Record<string, unknown>;
+    const changes = out.changes as Record<string, unknown>[];
+    assert.equal(changes[0].subnet_name, "Live Name");
+    assert.equal(frozenCalls, 0, "the frozen export must not be paid for");
+    assert.match(seen[0].sql, /FROM subnet_identity_history/);
+  });
+
+  test("the live query keeps the cold tier's total order", async () => {
+    // The two legs answer the same question and a caller cannot tell which
+    // one did. Disagreeing orders would show up as rows shuffling whenever
+    // the live store went cold.
+    const { live, seen } = liveRunner([LIVE_ROW]);
+    await answerChainIdentityHistory({}, null, { limit: 5 }, { live });
+    assert.match(
+      seen[0].sql,
+      /ORDER BY block_number DESC, netuid ASC, id DESC/,
+    );
+  });
+
+  test("an EMPTY live read falls through to the frozen export", async () => {
+    // The table is filling from 2026-08-11 forward; everything before that
+    // lives only in the export. Treating the empty read as authoritative
+    // would publish "no identity has ever changed" for most of the network.
+    const { live } = liveRunner([]);
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      { live, coldTier: frozenChain as never },
+    )) as Record<string, unknown>;
+    const changes = out.changes as Record<string, unknown>[];
+    assert.equal(changes[0].subnet_name, "Frozen Name");
+  });
+
+  test("a THROWING live read is a miss, not an outage", async () => {
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      {
+        live: async () => async () => {
+          throw new Error("hyperdrive cold");
+        },
+        coldTier: frozenChain as never,
+      },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.changes as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("a store that cannot be resolved at all falls through", async () => {
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      { live: async () => null, coldTier: frozenChain as never },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.changes as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("a THROWING store resolver is a miss too", async () => {
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      {
+        live: async () => {
+          throw new Error("no binding");
+        },
+        coldTier: frozenChain as never,
+      },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.changes as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("a caller-supplied tier still wins, and skips the live read entirely", async () => {
+    // THE TIER PROBE STAYS WITH THE SURFACE, per this module's header. A
+    // surface that did probe must not have its answer overridden here, and
+    // must not pay for a store read it does not need.
+    let liveCalls = 0;
+    const out = (await answerChainIdentityHistory(
+      {},
+      { changes: [{ subnet_name: "Tier Name" }] },
+      { limit: 5 },
+      {
+        live: async () => {
+          liveCalls += 1;
+          return null;
+        },
+        coldTier: frozenChain as never,
+      },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.changes as Record<string, unknown>[])[0].subnet_name,
+      "Tier Name",
+    );
+    assert.equal(liveCalls, 0);
+  });
+
+  test("everything declining still yields the schema-stable empty feed", async () => {
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      { live: async () => null, coldTier: (async () => null) as never },
+    )) as Record<string, unknown>;
+    assert.equal(out.count, 0);
+    assert.deepEqual(out.changes, []);
+  });
+});
+
+describe("the per-subnet timeline takes the same cascade", () => {
+  test("a live row answers ahead of the frozen export", async () => {
+    let frozenCalls = 0;
+    const { live, seen } = liveRunner([LIVE_ROW]);
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      null,
+      { limit: 5 },
+      {
+        live,
+        coldTier: (async () => {
+          frozenCalls += 1;
+          return frozenSubnet();
+        }) as never,
+      },
+    )) as Record<string, unknown>;
+    const entries = out.entries as Record<string, unknown>[];
+    assert.equal(entries[0].subnet_name, "Live Name");
+    assert.equal(frozenCalls, 0);
+    assert.deepEqual(seen[0].params[0], 64, "scoped to the netuid asked for");
+  });
+
+  test("an empty live read falls through to the frozen timeline", async () => {
+    const { live } = liveRunner([]);
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      null,
+      { limit: 5 },
+      { live, coldTier: frozenSubnet as never },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.entries as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("a throwing live read is a miss", async () => {
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      null,
+      { limit: 5 },
+      {
+        live: async () => async () => {
+          throw new Error("relation does not exist");
+        },
+        coldTier: frozenSubnet as never,
+      },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.entries as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("a resolver that throws is a miss", async () => {
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      null,
+      { limit: 5 },
+      {
+        live: async () => {
+          throw new Error("no binding");
+        },
+        coldTier: frozenSubnet as never,
+      },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.entries as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("no store at all falls through", async () => {
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      null,
+      { limit: 5 },
+      { live: async () => null, coldTier: frozenSubnet as never },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.entries as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+    );
+  });
+
+  test("a caller-supplied tier wins and skips the live read", async () => {
+    let liveCalls = 0;
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      { entries: [{ subnet_name: "Tier Name" }] },
+      { limit: 5 },
+      {
+        live: async () => {
+          liveCalls += 1;
+          return null;
+        },
+        coldTier: frozenSubnet as never,
+      },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.entries as Record<string, unknown>[])[0].subnet_name,
+      "Tier Name",
+    );
+    assert.equal(liveCalls, 0);
+  });
+
+  test("everything declining still yields the schema-stable empty timeline", async () => {
+    const out = (await answerSubnetIdentityHistory(
+      {},
+      64,
+      null,
+      { limit: 5 },
+      { live: async () => null, coldTier: (async () => null) as never },
+    )) as Record<string, unknown>;
+    assert.equal(out.entry_count, 0);
+    assert.deepEqual(out.entries, []);
+  });
+});
+
+// ---- the DEFAULT resolver, not an injected one ----
+//
+// Every test above injects `live`, which is what makes the cascade testable --
+// and would also let the real `liveStore` be wrong without anything noticing.
+// These two drive the default path.
+describe("liveStore, the resolver the surfaces actually get", () => {
+  test("an env with no store resolves to null and falls through", async () => {
+    const out = (await answerChainIdentityHistory(
+      {},
+      null,
+      { limit: 5 },
+      { coldTier: frozenChain as never },
+    )) as Record<string, unknown>;
+    assert.equal(
+      (out.changes as Record<string, unknown>[])[0].subnet_name,
+      "Frozen Name",
+      "no binding must reach the frozen export, not throw",
+    );
+  });
+
+  test("an env that DOES declare the table resolves a runner and reads it", async () => {
+    // readStore is all-or-nothing on the declared set, so this is also the
+    // assertion that SUBNET_IDENTITY_HISTORY_TABLES names what the SQL reads:
+    // an env declaring only this table must still resolve a store.
+    const { pgMockEnv } = await import("./helpers/pg-mock.ts");
+    let frozenCalls = 0;
+    await answerChainIdentityHistory(
+      pgMockEnv(["subnet_identity_history"]),
+      null,
+      { limit: 5 },
+      {
+        coldTier: (async () => {
+          frozenCalls += 1;
+          return frozenChain();
+        }) as never,
+      },
+    );
+    // The mock connection cannot actually answer, so the read misses and the
+    // frozen leg runs -- which is the point: the resolver produced a runner
+    // rather than declining before the query, and a failed query is a MISS.
+    assert.equal(frozenCalls, 1);
+  });
+});

--- a/tests/read-store-tables-match-the-sql.test.ts
+++ b/tests/read-store-tables-match-the-sql.test.ts
@@ -32,6 +32,13 @@ const OWNER: Record<string, string[]> = {
     "src/hotkey-alpha-completeness.ts",
   ],
   SUBNET_BURN_HISTORY_TABLES: ["src/subnet-burn-history.ts"],
+  // #10773. Only the network feed's module is listed: the per-subnet loader
+  // shares src/subnet-identity-history.ts with latestBlockNumber, whose
+  // `blocks_head` read carries its own module-private declaration, and this
+  // scanner is file-scoped rather than function-scoped. Naming that file here
+  // would force `blocks_head` into this set -- routing the identity read on a
+  // table it does not touch, which is the opposite of what the set is for.
+  SUBNET_IDENTITY_HISTORY_TABLES: ["src/chain-identity-history.ts"],
   TAO_USD_TABLES: ["src/tao-usd-series.ts"],
   ATTRIBUTION_SWEEP_TABLES: ["src/attribution-sweep.ts"],
   // The feed's own SQL is the revenue pair; the denominator legs are read


### PR DESCRIPTION
Closes #10773.

`subnet_identity_history` got its writer back this morning (#10740 / #10762 and metagraphed-infra#444). **Nothing repointed the read.**

Measured minutes after the producer's first successful pass:

```
lane subnet-identity       ok   "129 scanned, 124 written, 5 error(s)"
lane neon:subnet-identity  ok   "248 row(s) in 2 statement(s)"

GET /api/v1/chain/identity-history  →  newest change: 2026-07-31T11:00:20.942Z
```

248 rows written, and the newest identity change the API would admit to was eleven days old. Re-read with two different cache keys and `Cache-Control: no-cache` — not an edge cache.

## Why it was pinned, not merely behind

`handleChainIdentityHistory` passes `null` as the tier result, and the composer's only remaining leg was the frozen lakehouse export — one of the 22 tables that are a one-time 2026-08-02 seed and never advance. The feed was fixed at 2026-07-31 regardless of what the chain did.

The comment justifying that was **correct when it was written**:

> `NO TIER READ (#10190). METAGRAPH_SUBNET_IDENTITY_SOURCE reads "retired" in every deployed config and is absent from DATA_API_FORWARD_FLAGS, so this resolved to null on every request.`

`syncSubnetIdentityToPostgres` was named as the table's sole writer in four places and never existed, so the tier read genuinely was unreachable. The premise expired this morning; the code did not.

## The live leg goes in the composer, not the surfaces

Five call sites pass `null` — REST ×2, MCP ×2, GraphQL ×2. `src/identity-history-answer.ts` exists precisely because #9153 added the lakehouse leg to one surface and left MCP and GraphQL reporting `entry_count: 0`. Adding a live read at one call site would recreate exactly that, so it goes where no surface can diverge from it.

**Cascade:** caller-supplied tier → **live** → frozen → schema-stable empty.

## Two properties, both tested

**A live MISS falls through rather than answering.** The table fills from 2026-08-11 forward and the export holds everything before it, so a netuid whose identity last changed in July has zero live rows and a real frozen timeline. Treating the empty read as authoritative would publish *"this subnet has never changed its identity"* for most of the network. A **throwing** read is a miss too — a cold Hyperdrive or an unmigrated table must not turn a readable timeline into a 500.

**The live query uses the cold tier's total order** — `block_number DESC, netuid ASC, id DESC`. The two legs answer the same question and a caller cannot tell which one did; disagreeing orders would surface as rows shuffling whenever the live store went cold.

## Shape notes

- `loadChainIdentityHistory` is new — nothing could call it before. It lives in `chain-identity-history.ts` because that module already imports from `subnet-identity-history.ts`; the reverse direction would be an import cycle.
- `READ_COLUMNS` is exported rather than restated, so the two timelines cannot drift on what they select.
- `SUBNET_IDENTITY_HISTORY_TABLES` names only `src/chain-identity-history.ts` in the SQL-vs-declaration gate. The per-subnet loader shares its file with `latestBlockNumber`, whose `blocks_head` read carries its own module-private declaration, and that scanner is file-scoped — naming that file would force `blocks_head` into this set and route the identity read on a table it never touches.
- `subnet_identity_history` was already in `NEON_SOLE_STORE_TABLES` in all three configs, so this is a read-store declaration plus the cascade, not the six-place new-table change.

## Validation

- `npm run typecheck` · `npm run validate` · `npm run lint` · `npm run format:check` · `npm run scan:public-safety` — all clean
- **3,472 tests across the 17 files importing any changed module** — all pass
- 17 new tests pinning the cascade order and every miss path on both timelines
- **Patch coverage 100%** — statements, branches and functions on every changed line in `src/**`, measured by diff intersection against `origin/main`

## Out of scope

The producer's pass reports `5 error(s)` of 129 subnets. Real, worth its own look, and it does not block the repoint.
