### PR TITLE
fix(neon): stop the flush's reconcile from scanning the backlog

### DIFF
--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -793,3 +793,73 @@ describe("an orphaned alarm must not block the buffer forever (#10763)", () => {
     assert.match(String(spy.rows[0].detail), /nothing buffered/);
   });
 });
+
+describe("the flush never scans either (#10775)", () => {
+  test("a TRUNCATED drain does not list the remaining backlog", async () => {
+    // The same O(n) that #10755 removed from the enqueue, reintroduced in the
+    // alarm's reconcile. Measured in production: the flush at 13:23:12 drained
+    // its 500 and never came back for the rest, because the scan outran the
+    // handler and the re-arm never ran.
+    const storage = fakeStorage();
+    for (let i = 0; i < FLUSH_LIST_LIMIT + 30; i += 1) {
+      await enqueueStatement(storage, stmt("neurons", `S${i}`), NOW);
+    }
+    let listsAfterDrain = 0;
+    const realList = storage.list.bind(storage);
+    let draining = false;
+    storage.list = async (options) => {
+      if (draining) listsAfterDrain += 1;
+      return realList(options);
+    };
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          draining = true;
+          return [];
+        },
+      },
+    });
+    assert.equal(out.remaining, true, "it must report work left");
+    assert.equal(listsAfterDrain, 0, "and must not scan to work that out");
+  });
+
+  test("a clean drain still reconciles the counter to exactly zero", async () => {
+    // Drift correction lives here: an untruncated flush emptied the buffer by
+    // definition, so 0 is exact and free.
+    const storage = fakeStorage();
+    for (let i = 0; i < 3; i += 1) {
+      await enqueueStatement(storage, stmt("l", `S${i}`), NOW);
+    }
+    storage.map.set("pending", 4242);
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(await storage.get("pending"), 0);
+  });
+
+  test("a truncated drain decrements by what it settled", async () => {
+    const storage = fakeStorage();
+    for (let i = 0; i < FLUSH_LIST_LIMIT + 10; i += 1) {
+      await enqueueStatement(storage, stmt("l", `S${i}`), NOW);
+    }
+    const before = (await storage.get<number>("pending")) ?? 0;
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(await storage.get("pending"), before - out.drained);
+  });
+});

--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -863,3 +863,47 @@ describe("the flush never scans either (#10775)", () => {
     assert.equal(await storage.get("pending"), before - out.drained);
   });
 });
+
+describe("the counter may be absent, and the drain must cope", () => {
+  // A buffer written before the counter existed, or an object whose storage was
+  // reset between the enqueue and the drain. `?? 0` is what stops the reconcile
+  // producing NaN and poisoning the ceiling for good.
+
+  test("a TRUNCATED drain with no counter still reconciles", async () => {
+    const storage = fakeStorage();
+    for (let i = 0; i < FLUSH_LIST_LIMIT + 5; i += 1) {
+      await enqueueStatement(storage, stmt("l", `S${i}`), NOW);
+    }
+    storage.map.delete("pending");
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    assert.equal(out.remaining, true);
+    assert.equal(await storage.get("pending"), 0, "clamped, never negative");
+  });
+
+  test("a FAILED drain with no counter still reconciles", async () => {
+    const storage = fakeStorage();
+    for (const t of ["A", "B"])
+      await enqueueStatement(storage, stmt("l", t), NOW);
+    storage.map.delete("pending");
+    const out = await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: laneSpy().db,
+      now: () => NOW,
+      sql: {
+        async unsafe(text: string) {
+          if (text === "B") throw new Error("connection reset");
+          return [];
+        },
+      },
+    });
+    assert.equal(out.ok, false);
+    assert.equal(await storage.get("pending"), 0, "clamped, never negative");
+  });
+});

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -330,7 +330,15 @@ export async function flushBuffer(
       // alarm, and a failure here is nearly always the connection rather than
       // the row -- so the rest would fail too, one wasted round trip each.
       await storage.delete(drainedKeys);
-      await storage.put({ [PENDING_KEY]: await countPending(storage) });
+      // Decrement, never scan -- same reason as the success path below.
+      await storage.put({
+        [PENDING_KEY]: Math.max(
+          0,
+          ((await storage.get<number>(PENDING_KEY)) ?? 0) -
+            drained -
+            undecodable,
+        ),
+      });
       await recordFlushVerdicts(laneDb, perLane, now());
       const reason = error instanceof Error ? error.message : String(error);
       await capture(asEnv, {
@@ -352,12 +360,28 @@ export async function flushBuffer(
   }
 
   await storage.delete(drainedKeys);
-  // RECONCILE, do not just decrement. A drain that was not truncated has
-  // emptied the buffer by definition, so writing the true value here stops any
-  // drift between the counter and the keys from accumulating -- a counter that
-  // can only be adjusted is a counter that eventually lies.
+  // O(1) ON BOTH PATHS (#10775). This reconciled with countPending() when the
+  // drain was truncated -- which is the same full storage.list() that #10755
+  // removed from the enqueue, just moved into the alarm. Measured in
+  // production: the flush at 13:23:12 drained its 500 and then did NOT come
+  // back for the remainder, because the scan on a large backlog outran the
+  // handler.
+  //
+  // A clean drain still reconciles to the TRUE value, and that is where drift
+  // gets corrected: an untruncated flush has emptied the buffer by definition,
+  // so 0 is exact and costs nothing to write. A truncated one decrements, which
+  // can drift slightly but is bounded and self-corrects on the next clean
+  // drain -- and a counter that is slightly high only makes the ceiling
+  // slightly conservative, which is the safe direction.
   await storage.put({
-    [PENDING_KEY]: truncated ? Math.max(0, await countPending(storage)) : 0,
+    [PENDING_KEY]: truncated
+      ? Math.max(
+          0,
+          ((await storage.get<number>(PENDING_KEY)) ?? 0) -
+            drained -
+            undecodable,
+        )
+      : 0,
   });
   await recordFlushVerdicts(laneDb, perLane, now());
   await recordLaneVerdict(laneDb, {


### PR DESCRIPTION
## Problem

#10755 removed a full `storage.list()` from the enqueue. The reconcile I added alongside it put the same scan into the **alarm**:

```ts
[PENDING_KEY]: truncated ? Math.max(0, await countPending(storage)) : 0
```

On a truncated drain — exactly when the backlog is large — that lists the whole remainder.

**Measured in production:** the flush at 13:23:12 drained its 500, reported `remaining: true`, and **never came back**. Four minutes later still one flush, where a truncated drain re-arms at +10s. The scan outran the handler; the re-arm never ran.

Data did land — `account_balances` and `nominator_positions` moved **08:47 → 11:30** — so this is "drains one batch then stops", not another stall.

## Fix

Both paths O(1): one `get`, one `put`, no `list`.

| Path | Behaviour |
|---|---|
| Clean drain | Reconciles to exactly `0` — the buffer is empty by definition, so it is exact and free. **Drift correction lives here.** |
| Truncated drain | Decrements by what it settled. Bounded drift, self-corrects on the next clean drain, and errs **high** — a conservative ceiling, not a permissive one. |

## Validation

```
tsc · lint · format:check · validate   # clean
npx vitest run neon-write-buffer-hub   # 44 passed
```

New tests: a truncated drain reports `remaining` **without scanning** (asserted by counting `list` calls after the drain begins), a clean drain reconciles to zero after deliberate drift, and a truncated drain decrements by what it settled.

Closes #10775