### PR TITLE
fix(queues): a lane that can say it ran, why it retried, and what it lost

### DIFF
--- a/src/dead-letter.ts
+++ b/src/dead-letter.ts
@@ -58,13 +58,73 @@ export function isDeadLetterQueue(name: unknown): boolean {
 }
 
 /**
+ * The field naming a message's SUBJECT, per queue family — first match wins.
+ *
+ * ONE LIST, CHECKED IN ORDER, because a summariser with a per-queue branch is
+ * a summariser that silently stops naming the next queue somebody adds. That
+ * is exactly what happened: this read `lane ?? subscription_id`, which covers
+ * `sync-batches` and `webhook-deliveries` and nothing else, and #10715/#10739
+ * then added three more queues whose bodies carry none of them. All three
+ * reported `(unidentified)` — a dead-letter verdict that says something was
+ * lost and cannot say what, which is most of the value of having one.
+ *
+ * Measured 2026-08-11: `2 dead-lettered message(s) on revenue-probes-dlq
+ * (unidentified)`, with the two `surface_id`s sitting unread in the bodies.
+ *
+ * The keys, and the queue each belongs to:
+ *
+ *   lane            sync-batches          the producer lane
+ *   subscription_id webhook-deliveries    the subscriber
+ *   surface_id      revenue-probes        the surface being probed
+ *   origin          origin-reachability   the origin being checked
+ *   netuid          attribution-sweeps    the subnet being swept
+ *
+ * A new queue whose body carries none of these still reports `unidentified`,
+ * which is the honest answer — but the fix is one entry here rather than a
+ * branch, and tests/dead-letter.test.ts asserts every live queue is covered so
+ * the next omission fails rather than degrading quietly.
+ */
+export const DEAD_LETTER_SUBJECT_KEYS = [
+  "lane",
+  "subscription_id",
+  "surface_id",
+  "origin",
+  "netuid",
+] as const;
+
+/**
+ * How many distinct subjects the summary will name before counting the rest.
+ *
+ * A DLQ batch is up to 100 messages and this string lands in a log line and a
+ * `lane_health.detail` column. Naming a hundred netuids there is the dump this
+ * function exists to avoid; naming a dozen is the shape a reader needs, and
+ * "+N more" keeps the total honest.
+ */
+export const DEAD_LETTER_MAX_NAMED_SUBJECTS = 12;
+
+/** The subject a body names, or null when it names none of them. */
+function subjectOf(body: Record<string, unknown>): string | null {
+  for (const key of DEAD_LETTER_SUBJECT_KEYS) {
+    const value = body[key];
+    // Numbers count -- `netuid` is one, and rejecting it would have left the
+    // sweep queue unidentified for the same reason the string-only check left
+    // all three. NaN and Infinity do not: neither names a subject.
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return `${key}=${value}`;
+    }
+    if (typeof value === "string" && value) return value;
+  }
+  return null;
+}
+
+/**
  * One line describing what landed, for the log and the lane verdict.
  *
  * SUMMARISED, NOT DUMPED. A dead-lettered `sync-batches` message can carry
  * 5,000 rows and a `webhook-deliveries` one carries a whole event body; neither
  * belongs in a log line or a `lane_health.detail` column. What is worth keeping
- * is the shape — how many, from which lanes or subscriptions — because that is
- * what tells a reader whether one producer broke or the database did.
+ * is the shape — how many, and which subjects — because that is what tells a
+ * reader whether one producer broke or the database did.
  *
  * Pure, so the summary is testable without a queue.
  */
@@ -79,13 +139,14 @@ export function summarizeDeadLetterBatch(
       keys.add("unparseable");
       continue;
     }
-    // `lane` for sync-batches, `subscription_id` for webhook-deliveries. One
-    // reader for both queues means reading whichever identity the message has,
-    // rather than two near-identical modules that drift.
-    const key = body.lane ?? body.subscription_id;
-    keys.add(typeof key === "string" && key ? key : "unidentified");
+    keys.add(subjectOf(body) ?? "unidentified");
   }
-  const named = [...keys].sort().join(",");
+  const sorted = [...keys].sort();
+  const shown = sorted.slice(0, DEAD_LETTER_MAX_NAMED_SUBJECTS);
+  const named =
+    sorted.length > shown.length
+      ? `${shown.join(",")},+${sorted.length - shown.length} more`
+      : shown.join(",");
   return `${messages.length} dead-lettered message(s) on ${queueName} (${named})`;
 }
 

--- a/src/lane-queue.ts
+++ b/src/lane-queue.ts
@@ -101,6 +101,21 @@ export interface ConsumeHandlers<TSubject> {
   /** Do the work. Return false or throw to have the message redelivered;
    * return true when the result is durably written. */
   run(subject: TSubject): Promise<boolean>;
+  /**
+   * Called ONCE per batch when something was retried, with the first failure
+   * and the count.
+   *
+   * ONCE, not once per message: a batch is up to 100 messages and a lane whose
+   * dependency is down fails every one of them identically, so per-message
+   * reporting would turn a single outage into a hundred records -- the same
+   * storm control the head poller applies by capturing only when the message
+   * CHANGES. The count rides along, so "one probe broke" and "all of them did"
+   * stay distinguishable.
+   *
+   * Optional, and defaulted to a console.error by the loop, so opting out of
+   * reporting has to be deliberate rather than the result of forgetting.
+   */
+  onRetry?(reason: string, retried: number): void;
 }
 
 /**
@@ -117,6 +132,17 @@ export async function consumeBatch<TSubject>(
   let done = 0;
   let retried = 0;
   let dropped = 0;
+  // WHY THE RETRY HAPPENED, which this loop used to discard entirely.
+  //
+  // The catch below was a bare `catch { message.retry(); }`. A message that
+  // fails its whole budget and dead-letters therefore produced NO log line, no
+  // $exception, nothing -- and the dead-letter verdict on the other end could
+  // only say how many were lost. Measured 2026-08-11: `revenue-probe` had gone
+  // 187 minutes with no verdict against a ~60 minute cadence while messages
+  // were being enqueued on schedule and quietly dead-lettering, and error
+  // tracking held not one event for the lane. A retry is the loop working; a
+  // retry nobody can explain is how a lane dies silently.
+  let firstFailure: string | null = null;
   for (const message of messages) {
     try {
       // `parse` is inside the try as well: a parse that throws is a programming
@@ -135,10 +161,30 @@ export async function consumeBatch<TSubject>(
       } else {
         message.retry();
         retried += 1;
+        // A HANDLER THAT RETURNS FALSE IS ALSO A FAILURE. It is the quieter of
+        // the two -- no stack, no message -- and leaving it unreported would
+        // keep exactly half of this fix.
+        firstFailure ??= "run() declined without throwing";
       }
-    } catch {
+    } catch (error) {
       message.retry();
       retried += 1;
+      firstFailure ??= error instanceof Error ? error.message : String(error);
+    }
+  }
+  if (firstFailure !== null) {
+    const report =
+      handlers.onRetry ??
+      ((reason: string, count: number) =>
+        console.error(`lane-queue: ${count} message(s) retried -- ${reason}`));
+    // Reporting must never be able to make the batch worse: every message has
+    // already been acked or retried by the time this runs, so a throwing
+    // reporter would lose nothing -- but it would turn a diagnosable failure
+    // into an undiagnosable one, which is the whole thing being fixed.
+    try {
+      report(firstFailure, retried);
+    } catch {
+      // Deliberately empty: see above.
     }
   }
   return { done, retried, dropped };

--- a/tests/dead-letter.test.ts
+++ b/tests/dead-letter.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   DEAD_LETTER_LANES,
+  DEAD_LETTER_MAX_NAMED_SUBJECTS,
   handleDeadLetterBatch,
   isDeadLetterQueue,
   summarizeDeadLetterBatch,
@@ -201,5 +202,128 @@ describe("handleDeadLetterBatch", () => {
     );
     assert.equal(detail, "0 dead-lettered message(s) on sync-batches-dlq ()");
     assert.equal(store.inserts.length, 1);
+  });
+});
+
+// ---- naming the subject (#10777) ----
+//
+// The summariser read `lane ?? subscription_id`, which covers sync-batches and
+// webhook-deliveries and nothing else. #10715/#10739 then added three queues
+// whose bodies carry none of them, and all three reported `(unidentified)` --
+// a dead-letter verdict that says something was lost and cannot say what.
+// Measured in production 2026-08-11: "2 dead-lettered message(s) on
+// revenue-probes-dlq (unidentified)", with the two surface_ids sitting unread.
+describe("the summary names the subject on every live queue", () => {
+  const CASES: [string, string, Record<string, unknown>, string][] = [
+    ["sync-batches-dlq", "lane", { lane: "neurons" }, "neurons"],
+    [
+      "webhook-deliveries-dlq",
+      "subscription_id",
+      { subscription_id: "sub_a" },
+      "sub_a",
+    ],
+    [
+      "revenue-probes-dlq",
+      "surface_id",
+      { surface_id: "sn-64-api" },
+      "sn-64-api",
+    ],
+    [
+      "origin-reachability-dlq",
+      "origin",
+      { origin: "https://example.com" },
+      "https://example.com",
+    ],
+    ["attribution-sweeps-dlq", "netuid", { netuid: 64 }, "netuid=64"],
+  ];
+
+  for (const [queue, key, body, expected] of CASES) {
+    test(`${queue} is named by its ${key}`, () => {
+      const line = summarizeDeadLetterBatch(queue, [{ body }]);
+      assert.match(
+        line,
+        new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+      );
+      assert.ok(
+        !line.includes("unidentified"),
+        `${queue} still reports unidentified, which is the bug`,
+      );
+    });
+  }
+
+  test("EVERY declared dead-letter queue has a case above", () => {
+    // The gate. A queue added to DEAD_LETTER_LANES without a subject key would
+    // otherwise report `unidentified` in production and pass every test here.
+    const covered = new Set(CASES.map(([q]) => q));
+    const declared = Object.keys(DEAD_LETTER_LANES);
+    assert.deepEqual(
+      declared.filter((q) => !covered.has(q)),
+      [],
+      "a dead-letter queue with no case here is one nobody has checked can " +
+        "name its own subject",
+    );
+  });
+
+  test("netuid 0 is a subject, not a missing one", () => {
+    // Root. A falsy-number check would have dropped it, and netuid 0 is the
+    // one subnet where a silent drop is least acceptable.
+    const line = summarizeDeadLetterBatch("attribution-sweeps-dlq", [
+      { body: { netuid: 0 } },
+    ]);
+    assert.match(line, /netuid=0/);
+  });
+
+  test("a non-finite number is not a subject", () => {
+    const line = summarizeDeadLetterBatch("attribution-sweeps-dlq", [
+      { body: { netuid: Number.NaN } },
+    ]);
+    assert.match(line, /unidentified/);
+  });
+
+  test("a body naming none of the keys is honestly unidentified", () => {
+    const line = summarizeDeadLetterBatch("revenue-probes-dlq", [
+      { body: { something_else: "x" } },
+    ]);
+    assert.match(line, /\(unidentified\)/);
+  });
+
+  test("the first matching key wins, in declared order", () => {
+    const line = summarizeDeadLetterBatch("sync-batches-dlq", [
+      { body: { lane: "neurons", surface_id: "sn-1" } },
+    ]);
+    assert.match(line, /\(neurons\)/);
+  });
+
+  test("distinct subjects are capped, and the remainder is counted", () => {
+    // The string lands in a log line and lane_health.detail; a batch is up to
+    // 100 messages. Naming a hundred netuids there is the dump this function
+    // exists to avoid.
+    const messages = Array.from({ length: 40 }, (_, i) => ({
+      body: { surface_id: `sn-${String(i).padStart(3, "0")}` },
+    }));
+    const line = summarizeDeadLetterBatch("revenue-probes-dlq", messages);
+    assert.match(line, /\+28 more/);
+    assert.match(line, /^40 dead-lettered message\(s\)/);
+    assert.ok(line.length < 400, "the detail column must stay readable");
+  });
+
+  test("exactly the cap names everything, with no remainder clause", () => {
+    const messages = Array.from(
+      { length: DEAD_LETTER_MAX_NAMED_SUBJECTS },
+      (_, i) => ({ body: { surface_id: `sn-${i}` } }),
+    );
+    const line = summarizeDeadLetterBatch("revenue-probes-dlq", messages);
+    assert.ok(!line.includes("more"), "no remainder when nothing remains");
+  });
+
+  test("repeated subjects collapse rather than counting toward the cap", () => {
+    const messages = Array.from({ length: 30 }, () => ({
+      body: { surface_id: "sn-64-api" },
+    }));
+    const line = summarizeDeadLetterBatch("revenue-probes-dlq", messages);
+    assert.equal(
+      line,
+      "30 dead-lettered message(s) on revenue-probes-dlq (sn-64-api)",
+    );
   });
 });

--- a/tests/lane-heartbeat-verdicts.test.ts
+++ b/tests/lane-heartbeat-verdicts.test.ts
@@ -1,0 +1,171 @@
+// The lane heartbeat's own reporting (#10777).
+//
+// LANE_PRODUCERS computed exactly the right per-lane object and handed it to
+// handleScheduled, whose return value workers/api.entry.ts DISCARDS -- the same
+// #9440 shape the SafeMode watchdog had, reintroduced by the three lanes that
+// moved onto this heartbeat (#10715) and lost their own verdict writes on the
+// way.
+//
+// Measured 2026-08-11: `revenue-probe` read `unknown -- no verdict for 194m
+// (cadence ~60m)` on /api/v1/self-health while the heartbeat had been running
+// on schedule every hour, because "ran and could not enqueue" and "never ran"
+// produce the same nothing.
+//
+// Its own file, with the pg module mocked, because laneHealthStore builds a
+// real client from HYPERDRIVE and the module is the only seam handleScheduled
+// exposes for it -- see tests/helpers/pg-mock.ts.
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import {
+  LANE_PRODUCERS,
+  handleScheduled,
+  laneHeartbeatVerdict,
+} from "../workers/api.ts";
+import { LANE_HEARTBEAT_CRON } from "../workers/config.ts";
+
+/** The lanes the heartbeat declares, which every tick must account for. */
+const LANE_NAMES = LANE_PRODUCERS.map((l) => l.name);
+
+/** One heartbeat tick, returning the lane_health statements it wrote. */
+async function runTick() {
+  pg.control.queries.length = 0;
+  const waits: Promise<unknown>[] = [];
+  await handleScheduled(
+    { cron: LANE_HEARTBEAT_CRON } as never,
+    pgMockEnv(["lane_health"]) as never,
+    { waitUntil: (p: Promise<unknown>) => void waits.push(p) } as never,
+  );
+  // The verdicts go through waitUntil, so a test that did not await them would
+  // assert on an empty list and pass for the wrong reason.
+  await Promise.allSettled(waits);
+  return pg.control.queries.filter((q) => /lane_health/i.test(q.text));
+}
+
+describe("the heartbeat records a verdict per producer", () => {
+  test("a failing producer is RECORDED, not merely returned", async () => {
+    // With no queue bindings every lane declines. Before this that produced no
+    // row anywhere and the lane read `unknown` forever -- indistinguishable
+    // from a cron that had stopped firing.
+    const written = await runTick();
+    assert.ok(
+      written.length > 0,
+      "the heartbeat wrote no lane_health row at all -- returning a verdict " +
+        "is not reporting one, which is the whole of #10777",
+    );
+  });
+
+  test("every declared producer gets its own row", async () => {
+    // One row for the heartbeat would collapse `no_eligible_surfaces` on the
+    // revenue lane and a missing binding on the sweep lane into "the heartbeat
+    // is unhappy", which sends a reader to the wrong place.
+    const written = await runTick();
+    const seen = new Set(
+      written.flatMap((q) =>
+        q.values.filter(
+          (v): v is string => typeof v === "string" && LANE_NAMES.includes(v),
+        ),
+      ),
+    );
+    assert.deepEqual(
+      [...seen].sort(),
+      [...LANE_NAMES].sort(),
+      "a producer with no verdict is one nobody can tell apart from a " +
+        "producer that never ran",
+    );
+  });
+
+  test("the producer's own reason is carried into the verdict", async () => {
+    const written = await runTick();
+    const flat = JSON.stringify(written.map((q) => q.values));
+    assert.match(
+      flat,
+      /no_queue_binding/,
+      "the detail must say WHY, or the row is only a timestamp",
+    );
+  });
+
+  test("the verdict is stale, never ok, when a producer declined", async () => {
+    // An `ok` here would publish a working lane on the public self-health card
+    // while nothing was enqueued.
+    const written = await runTick();
+    const flat = JSON.stringify(written.map((q) => q.values));
+    assert.match(flat, /stale/);
+  });
+});
+
+describe("laneHeartbeatVerdict, the rule alone", () => {
+  test("a producer that enqueued reports ok and its count", () => {
+    assert.deepEqual(
+      laneHeartbeatVerdict({ lane: "revenue-probe", ok: true, enqueued: 42 }),
+      {
+        lane: "revenue-probe",
+        verdict: "ok",
+        age_ms: null,
+        detail: "42 enqueued",
+      },
+    );
+  });
+
+  test("a producer that declined reports stale and its own words", () => {
+    assert.deepEqual(
+      laneHeartbeatVerdict({
+        lane: "revenue-probe",
+        ok: false,
+        enqueued: 0,
+        reason: "no_eligible_surfaces",
+      }),
+      {
+        lane: "revenue-probe",
+        verdict: "stale",
+        age_ms: null,
+        detail: "no_eligible_surfaces",
+      },
+    );
+  });
+
+  test("a partial send keeps BOTH the reason and the count it managed", () => {
+    // enqueueAll reports partial sends as partial. A verdict that dropped the
+    // reason would make "the queue rejected half of these" look like a clean
+    // pass over a smaller set.
+    const v = laneHeartbeatVerdict({
+      lane: "origin-reachability",
+      ok: false,
+      enqueued: 50,
+      reason: "send_failed: over quota",
+    });
+    assert.equal(v.verdict, "stale");
+    assert.match(v.detail, /send_failed: over quota/);
+  });
+
+  test("a declining producer with no reason still reports something", () => {
+    // Defensive rather than reachable today: every enqueueAll failure sets a
+    // reason. A verdict with an empty detail would be a timestamp pretending
+    // to be a report.
+    const v = laneHeartbeatVerdict({
+      lane: "attribution-sweep",
+      ok: false,
+      enqueued: 0,
+    });
+    assert.equal(v.verdict, "stale");
+    assert.equal(v.detail, "0 enqueued");
+  });
+
+  test("age_ms is null, never a number", () => {
+    // Nothing here is behind; something here either enqueued or did not. A
+    // number would be read as lag by every consumer of lane_health.
+    for (const ok of [true, false]) {
+      assert.equal(
+        laneHeartbeatVerdict({ lane: "x", ok, enqueued: 1, reason: "r" })
+          .age_ms,
+        null,
+      );
+    }
+  });
+});

--- a/tests/lane-queue.test.ts
+++ b/tests/lane-queue.test.ts
@@ -1,0 +1,172 @@
+// src/lane-queue.ts -- the ack/retry/drop decision, shared by every lane that
+// moved from a cron to a queue (#10715).
+//
+// It had no direct test file: the three lanes each exercised it incidentally
+// through their own handlers, which covers the happy path and leaves the
+// decision itself -- the part with consequences -- asserted nowhere.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { consumeBatch } from "../src/lane-queue.ts";
+
+// ---- the retry now says WHY (#10777) ----
+//
+// The catch was a bare `catch { message.retry(); }`. A message that failed its
+// whole budget and dead-lettered produced no log line, no $exception, nothing,
+// and the dead-letter verdict on the other end could only say how many were
+// lost. Measured 2026-08-11: `revenue-probe` had gone 187 minutes with no
+// verdict against a ~60 minute cadence, messages enqueuing on schedule and
+// quietly dead-lettering, and error tracking held not one event for the lane.
+describe("a retry reports its reason", () => {
+  const msg = (body: unknown) => {
+    const calls: string[] = [];
+    return {
+      calls,
+      message: {
+        body,
+        ack: () => void calls.push("ack"),
+        retry: () => void calls.push("retry"),
+      },
+    };
+  };
+
+  test("a THROWN failure reaches onRetry with its message", async () => {
+    const seen: [string, number][] = [];
+    const a = msg({ id: 1 });
+    const result = await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => {
+        throw new Error("r2 sql: HTTP 500");
+      },
+      onRetry: (reason, count) => void seen.push([reason, count]),
+    });
+    assert.deepEqual(a.calls, ["retry"]);
+    assert.equal(result.retried, 1);
+    assert.deepEqual(seen, [["r2 sql: HTTP 500", 1]]);
+  });
+
+  test("a handler returning FALSE is reported too", async () => {
+    // The quieter of the two failures -- no stack, no message. Leaving it
+    // unreported would keep exactly half of the fix.
+    const seen: string[] = [];
+    const a = msg({ id: 1 });
+    await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => false,
+      onRetry: (reason) => void seen.push(reason),
+    });
+    assert.deepEqual(seen, ["run() declined without throwing"]);
+  });
+
+  test("a non-Error throw still yields a readable reason", async () => {
+    const seen: string[] = [];
+    const a = msg({ id: 1 });
+    await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => {
+        throw "socket closed";
+      },
+      onRetry: (reason) => void seen.push(reason),
+    });
+    assert.deepEqual(seen, ["socket closed"]);
+  });
+
+  test("ONE report per batch, carrying the full retry count", async () => {
+    // A lane whose dependency is down fails every message identically; per
+    // message reporting would turn one outage into a hundred records.
+    const messages = Array.from({ length: 40 }, (_, i) => msg({ id: i }));
+    const seen: [string, number][] = [];
+    const result = await consumeBatch(
+      messages.map((m) => m.message),
+      {
+        parse: (b) => b as { id: number },
+        run: async () => {
+          throw new Error("upstream down");
+        },
+        onRetry: (reason, count) => void seen.push([reason, count]),
+      },
+    );
+    assert.equal(result.retried, 40);
+    assert.equal(seen.length, 1, "one report, not forty");
+    assert.deepEqual(seen[0], ["upstream down", 40]);
+  });
+
+  test("the FIRST failure is the one reported", async () => {
+    const messages = [msg({ id: 1 }), msg({ id: 2 })];
+    const seen: string[] = [];
+    let n = 0;
+    await consumeBatch(
+      messages.map((m) => m.message),
+      {
+        parse: (b) => b as { id: number },
+        run: async () => {
+          n += 1;
+          throw new Error(n === 1 ? "first" : "second");
+        },
+        onRetry: (reason) => void seen.push(reason),
+      },
+    );
+    assert.deepEqual(seen, ["first"]);
+  });
+
+  test("a clean batch reports nothing", async () => {
+    const seen: string[] = [];
+    const a = msg({ id: 1 });
+    const result = await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => true,
+      onRetry: (reason) => void seen.push(reason),
+    });
+    assert.equal(result.done, 1);
+    assert.deepEqual(seen, [], "success is not something to report");
+  });
+
+  test("a batch that only DROPS reports nothing", async () => {
+    // A vanished subject is acked, not retried -- it is the loop working as
+    // designed, and reporting it would train a reader to ignore the channel.
+    const seen: string[] = [];
+    const a = msg({ id: 1 });
+    const result = await consumeBatch([a.message], {
+      parse: () => null,
+      run: async () => true,
+      onRetry: (reason) => void seen.push(reason),
+    });
+    assert.equal(result.dropped, 1);
+    assert.deepEqual(seen, []);
+  });
+
+  test("with no onRetry the loop still says so, on console.error", async () => {
+    // Opting out has to be deliberate: the default is not silence.
+    const lines: string[] = [];
+    const real = console.error;
+    console.error = (...args: unknown[]) => void lines.push(args.join(" "));
+    try {
+      const a = msg({ id: 1 });
+      await consumeBatch([a.message], {
+        parse: (b) => b as { id: number },
+        run: async () => {
+          throw new Error("boom");
+        },
+      });
+    } finally {
+      console.error = real;
+    }
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /1 message\(s\) retried -- boom/);
+  });
+
+  test("a THROWING reporter cannot make the batch worse", async () => {
+    // Every message is already acked or retried by the time the report runs.
+    const a = msg({ id: 1 });
+    const result = await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => {
+        throw new Error("boom");
+      },
+      onRetry: () => {
+        throw new Error("posthog unreachable");
+      },
+    });
+    assert.equal(result.retried, 1);
+    assert.deepEqual(a.calls, ["retry"]);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2567,6 +2567,36 @@ export async function probeOrigin(
  * Each `enqueue` reads a list and sends it. None fetches, none opens a store --
  * that work belongs to the consumer, one invocation per subject.
  */
+/**
+ * One producer's result as a lane verdict (#10777).
+ *
+ * The RULE alone, so both shapes are assertable without standing up three
+ * producers — the same split evaluateSafeMode and evaluateNeuronsStaleness use.
+ *
+ * `detail` prefers the producer's own words and falls back to the count,
+ * because `reason` is set on every failure path in enqueueAll and absent on
+ * success. Writing it as one `??` rather than a second ternary keeps "what the
+ * producer said" and "how many it sent" from being two independent decisions
+ * that could disagree about which case they are in.
+ *
+ * `age_ms` is null and not a number: nothing here is behind, something here
+ * either enqueued or did not, and a number would be read as lag by every
+ * consumer of lane_health.
+ */
+export function laneHeartbeatVerdict(result: {
+  lane: string;
+  ok: boolean;
+  enqueued: number;
+  reason?: string;
+}): { lane: string; verdict: "ok" | "stale"; age_ms: null; detail: string } {
+  return {
+    lane: result.lane,
+    verdict: result.ok ? "ok" : "stale",
+    age_ms: null,
+    detail: result.reason ?? `${result.enqueued} enqueued`,
+  };
+}
+
 export const LANE_PRODUCERS: ReadonlyArray<{
   name: string;
   enqueue: (env: Env) => Promise<EnqueueResult>;
@@ -2749,6 +2779,31 @@ async function dispatchScheduled(
     // The heartbeat is ok only if EVERY producer is. One lane silently failing
     // to enqueue while the others succeed is precisely the shape that let the
     // revenue lane sit dead for two months (#10566).
+    //
+    // A VERDICT PER LANE, because returning them was not reporting them
+    // (#10777). This computed exactly the right object and handed it to
+    // handleScheduled, whose return value workers/api.entry.ts discards -- the
+    // same #9440 shape the SafeMode watchdog had, reintroduced by the three
+    // lanes that moved onto this heartbeat and lost their own verdict writes on
+    // the way. Measured 2026-08-11: `revenue-probe` read `unknown -- no verdict
+    // for 194m (cadence ~60m)` while the heartbeat had run on schedule every
+    // hour, because "ran and could not enqueue" and "never ran" produce the
+    // same nothing.
+    //
+    // Per lane rather than one row for the heartbeat: `no_eligible_surfaces` on
+    // the revenue lane and a missing binding on the sweep lane send a reader to
+    // different places, and a single verdict would collapse them into "the
+    // heartbeat is unhappy".
+    ctx.waitUntil(
+      Promise.all(
+        results.map((r) =>
+          recordLaneVerdict(laneHealthStore(env), {
+            ...laneHeartbeatVerdict(r),
+            checked_at: Date.now(),
+          }),
+        ),
+      ),
+    );
     return {
       ok: results.every((r) => r.ok),
       lanes: results,


### PR DESCRIPTION
Closes #10777.

A queue failure was undiagnosable from **every** end. Three commits, because finding each one is what using the previous one is for.

## 1. The dead-letter verdict could not name what it lost

```
lane revenue-probes-dlq  verdict=stale
  "2 dead-lettered message(s) on revenue-probes-dlq (unidentified)"
```

`summarizeDeadLetterBatch` read `lane ?? subscription_id` — the two keys that existed when it was written. #10715 / #10739 then moved three lanes onto queues and none of their bodies carries either.

| DLQ | body | named before |
| --- | --- | --- |
| `sync-batches-dlq` | `{ lane }` | ✅ |
| `webhook-deliveries-dlq` | `{ subscription_id }` | ✅ |
| `revenue-probes-dlq` | `{ surface_id }` | ❌ |
| `origin-reachability-dlq` | `{ origin }` | ❌ |
| `attribution-sweeps-dlq` | `{ netuid }` | ❌ |

One ordered key list, not a branch per queue — a summariser with a per-queue branch is one that silently stops naming the next queue somebody adds, which is exactly how this happened. **A test asserts every queue in `DEAD_LETTER_LANES` has a case**, so the next omission fails there rather than in production.

Finite numbers count as subjects: the old `typeof key === "string"` guard would have rejected `netuid` even once it was listed, and `netuid=0` is root. Distinct names cap at 12 with `+N more` — a batch is 100 messages and this lands in a log line *and* `lane_health.detail`.

## 2. And the retry did not say why

With the verdict able to name its subject, the next question is why those two failed. Nothing anywhere could answer it — `consumeBatch`'s catch was bare:

```ts
} catch {
  message.retry();
  retried += 1;
}
```

A message that failed its whole budget and dead-lettered produced **no log line, no `$exception`, nothing**.

Measured: `revenue-probe` had gone **187 minutes with no verdict against a ~60 minute cadence**, the hourly heartbeat was enqueuing on schedule (`revenue-probes-dlq` took a verdict at 13:27:45, one minute after the 13:26 tick), and error tracking held not one event for the lane. The loop was working exactly as designed, and there was no way to see what it kept retrying against.

- **One report per batch, not per message.** A lane whose dependency is down fails all 100 identically; per-message reporting turns one outage into a hundred records. Same storm control the head poller applies. The retry count rides along so "one probe broke" and "all of them did" stay apart.
- **A handler returning `false` is reported too** — the quieter failure, no stack, no message. Leaving it out would keep half the fix.
- **`onRetry` is optional and defaults to `console.error`**, so opting out of reporting is deliberate rather than the result of forgetting. A throwing reporter cannot make the batch worse: every message is acked or retried before it runs.

`src/lane-queue.ts` had **no direct test file** — the three lanes exercised it incidentally through their own handlers, which covers the happy path and leaves the ack/retry/drop decision, the part with consequences, asserted nowhere. It has one now.

## Validation

- `npm run typecheck` · `npm run validate` · `npm run lint` · `npm run format:check` · `npm run scan:public-safety` — all clean
- **1,371 tests across the 29 files touching queue, dead-letter, or scheduled-tick handling** — all pass
- 31 new tests across the three halves, including a gate asserting every declared DLQ can name its own subject
- `src/lane-queue.ts` had no direct test file at all; it has one now
- **Patch coverage 100%** — statements, branches and functions across all three files, by diff intersection against `origin/main`

## 3. And the producer could not say it had run at all

With the retry able to explain itself, the next question is why the lane had no verdict *whatsoever*. `LANE_PRODUCERS` computed exactly the right per-lane object and handed it to `handleScheduled` — **whose return value `workers/api.entry.ts` discards.** The #9440 shape the SafeMode watchdog had, reintroduced by the three lanes that moved onto this heartbeat in #10715 and lost their own verdict writes on the way.

Its own comment says one lane silently failing to enqueue is *"precisely the shape that let the revenue lane sit dead for two months"* — and then encoded that in a returned object nobody reads.

```
revenue-probe   unknown   "no verdict for 194m (cadence ~60m)"
```

…while the heartbeat had been running on schedule every hour. "Ran and could not enqueue" and "never ran" produce the same nothing, so the lane read as an *absence* rather than a failure, and `lane-alarm`'s silence check was the only thing that noticed — three hours late.

**A verdict per lane, not one for the heartbeat.** `no_eligible_surfaces` on the revenue lane and a missing binding on the sweep lane send a reader to different places; a single row would collapse them into "the heartbeat is unhappy".

`laneHeartbeatVerdict` is extracted as a pure rule — the same split `evaluateSafeMode` and `evaluateNeuronsStaleness` use — so both shapes are assertable without standing up three producers. `detail` is one `??` rather than a second ternary, so "what the producer said" and "how many it sent" cannot disagree about which case they are in.

## The three together

Producer verdict → retry reason → dead-letter subject. Each was individually silent, and each silence hid the next one; the revenue lane was failing at all three points at once and reported nothing at any of them.

## Not in scope

*Why* the revenue probes fail. This PR is what makes that question answerable from production rather than by guessing — the next tick will say whether the producer enqueued, the next batch will name the surface and the reason.
