### PR TITLE
feat(mcp): let the four paged tools pass the page their routes publish

### DIFF
--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -7,6 +7,7 @@
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
 import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
   offsetSchema,
   limitSchema,
@@ -21,13 +22,14 @@ import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
 export const GetAgentCatalogInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
-    // The page (#10605). `limit` carries NO default here, deliberately: the
-    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
-    // caller gives none, so a default stated here would be a second one. What
-    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
-    // every list route, rather than a copy of its value; what an omitted
-    // limit means is the helper's answer, and there is one of each.
-    limit: limitSchema(MAX_LIMIT).optional(),
+    // The page (#10605). Both numbers come from the constants that actually
+    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
+    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
+    // really applies -- published rather than hidden, because #10101 found 83
+    // tools whose schema left a caller unable to tell what an omitted
+    // limit returns. Publishing the ceiling while hiding the default would
+    // recreate exactly that gap.
+    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
     // An integer OFFSET, which is what these routes publish
     // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
     // two is the mistake query-params.ts calls out by name.

--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -6,6 +6,14 @@
 // array). Neither mirrors an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import {
+  offsetSchema,
+  limitSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { AgentResourcesArtifactSchema } from "../routes/agent-catalog.ts";
 import { netuidSchema } from "./shared.ts";
 import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
@@ -13,6 +21,21 @@ import { AgentCatalogSubnetEntrySchema } from "../routes/agent-catalog.ts";
 export const GetAgentCatalogInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
+    // The page (#10605). `limit` carries NO default here, deliberately: the
+    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
+    // caller gives none, so a default stated here would be a second one. What
+    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
+    // every list route, rather than a copy of its value; what an omitted
+    // limit means is the helper's answer, and there is one of each.
+    limit: limitSchema(MAX_LIMIT).optional(),
+    // An integer OFFSET, which is what these routes publish
+    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
+    // two is the mistake query-params.ts calls out by name.
+    cursor: offsetSchema().optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["agent-catalog"].sort_fields,
+    ).optional(),
+    order: orderSchema().optional(),
   })
   .strict();
 export type GetAgentCatalogInput = z.infer<typeof GetAgentCatalogInputSchema>;

--- a/schemas-src/mcp-tools/catalog-indexes.ts
+++ b/schemas-src/mcp-tools/catalog-indexes.ts
@@ -16,6 +16,7 @@
 // now publishes.
 import { z } from "zod";
 import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
   offsetSchema,
   limitSchema,
@@ -28,13 +29,14 @@ import { SchemaIndexArtifactSchema } from "../routes/subnet-profiles.ts";
 
 export const ListFixturesInputSchema = z
   .object({
-    // The page (#10605). `limit` carries NO default here, deliberately: the
-    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
-    // caller gives none, so a default stated here would be a second one. What
-    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
-    // every list route, rather than a copy of its value; what an omitted
-    // limit means is the helper's answer, and there is one of each.
-    limit: limitSchema(MAX_LIMIT).optional(),
+    // The page (#10605). Both numbers come from the constants that actually
+    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
+    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
+    // really applies -- published rather than hidden, because #10101 found 83
+    // tools whose schema left a caller unable to tell what an omitted
+    // limit returns. Publishing the ceiling while hiding the default would
+    // recreate exactly that gap.
+    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
     // An integer OFFSET, which is what these routes publish
     // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
     // two is the mistake query-params.ts calls out by name.

--- a/schemas-src/mcp-tools/catalog-indexes.ts
+++ b/schemas-src/mcp-tools/catalog-indexes.ts
@@ -15,10 +15,34 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import {
+  offsetSchema,
+  limitSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { FixturesIndexArtifactSchema } from "../routes/fixtures.ts";
 import { SchemaIndexArtifactSchema } from "../routes/subnet-profiles.ts";
 
-export const ListFixturesInputSchema = z.object({}).strict();
+export const ListFixturesInputSchema = z
+  .object({
+    // The page (#10605). `limit` carries NO default here, deliberately: the
+    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
+    // caller gives none, so a default stated here would be a second one. What
+    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
+    // every list route, rather than a copy of its value; what an omitted
+    // limit means is the helper's answer, and there is one of each.
+    limit: limitSchema(MAX_LIMIT).optional(),
+    // An integer OFFSET, which is what these routes publish
+    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
+    // two is the mistake query-params.ts calls out by name.
+    cursor: offsetSchema().optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.fixtures.sort_fields).optional(),
+    order: orderSchema().optional(),
+  })
+  .strict();
 export type ListFixturesInput = z.infer<typeof ListFixturesInputSchema>;
 
 export const ListFixturesOutputSchema = FixturesIndexArtifactSchema;

--- a/schemas-src/mcp-tools/get-subnet-trajectory.ts
+++ b/schemas-src/mcp-tools/get-subnet-trajectory.ts
@@ -3,6 +3,7 @@
 // Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
 import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
   offsetSchema,
   limitSchema,
@@ -16,13 +17,14 @@ import { SubnetTrajectoryArtifactSchema } from "../routes/subnet-trajectory.ts";
 export const GetSubnetTrajectoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    // The page (#10605). `limit` carries NO default here, deliberately: the
-    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
-    // caller gives none, so a default stated here would be a second one. What
-    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
-    // every list route, rather than a copy of its value; what an omitted
-    // limit means is the helper's answer, and there is one of each.
-    limit: limitSchema(MAX_LIMIT).optional(),
+    // The page (#10605). Both numbers come from the constants that actually
+    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
+    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
+    // really applies -- published rather than hidden, because #10101 found 83
+    // tools whose schema left a caller unable to tell what an omitted
+    // limit returns. Publishing the ceiling while hiding the default would
+    // recreate exactly that gap.
+    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
     // An integer OFFSET, which is what these routes publish
     // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
     // two is the mistake query-params.ts calls out by name.

--- a/schemas-src/mcp-tools/get-subnet-trajectory.ts
+++ b/schemas-src/mcp-tools/get-subnet-trajectory.ts
@@ -2,12 +2,35 @@
 // "Mirrors" claim in its description and no covered REST route to reuse.
 // Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import {
+  offsetSchema,
+  limitSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { netuidSchema } from "./shared.ts";
 import { SubnetTrajectoryArtifactSchema } from "../routes/subnet-trajectory.ts";
 
 export const GetSubnetTrajectoryInputSchema = z
   .object({
     netuid: netuidSchema(),
+    // The page (#10605). `limit` carries NO default here, deliberately: the
+    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
+    // caller gives none, so a default stated here would be a second one. What
+    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
+    // every list route, rather than a copy of its value; what an omitted
+    // limit means is the helper's answer, and there is one of each.
+    limit: limitSchema(MAX_LIMIT).optional(),
+    // An integer OFFSET, which is what these routes publish
+    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
+    // two is the mistake query-params.ts calls out by name.
+    cursor: offsetSchema().optional(),
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["subnet-trajectory"].sort_fields,
+    ).optional(),
+    order: orderSchema().optional(),
   })
   .strict();
 export type GetSubnetTrajectoryInput = z.infer<

--- a/schemas-src/mcp-tools/meta-artifacts-1.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-1.ts
@@ -19,6 +19,14 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import {
+  offsetSchema,
+  limitSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   FreshnessArtifactSchema,
   SourceHealthArtifactSchema,
@@ -42,7 +50,23 @@ export type GetFreshnessInput = z.infer<typeof GetFreshnessInputSchema>;
 export const GetFreshnessOutputSchema = FreshnessArtifactSchema;
 export type GetFreshnessOutput = z.infer<typeof GetFreshnessOutputSchema>;
 
-export const GetContractsInputSchema = z.object({}).strict();
+export const GetContractsInputSchema = z
+  .object({
+    // The page (#10605). `limit` carries NO default here, deliberately: the
+    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
+    // caller gives none, so a default stated here would be a second one. What
+    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
+    // every list route, rather than a copy of its value; what an omitted
+    // limit means is the helper's answer, and there is one of each.
+    limit: limitSchema(MAX_LIMIT).optional(),
+    // An integer OFFSET, which is what these routes publish
+    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
+    // two is the mistake query-params.ts calls out by name.
+    cursor: offsetSchema().optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.contracts.sort_fields).optional(),
+    order: orderSchema().optional(),
+  })
+  .strict();
 export type GetContractsInput = z.infer<typeof GetContractsInputSchema>;
 
 export const GetContractsOutputSchema = ContractsArtifactSchema;

--- a/schemas-src/mcp-tools/meta-artifacts-1.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-1.ts
@@ -20,6 +20,7 @@
 // now publishes.
 import { z } from "zod";
 import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
   offsetSchema,
   limitSchema,
@@ -52,13 +53,14 @@ export type GetFreshnessOutput = z.infer<typeof GetFreshnessOutputSchema>;
 
 export const GetContractsInputSchema = z
   .object({
-    // The page (#10605). `limit` carries NO default here, deliberately: the
-    // helper that runs these queries supplies MCP_LIST_LIMIT_DEFAULT when a
-    // caller gives none, so a default stated here would be a second one. What
-    // the tool publishes is MAX_LIMIT -- the same constant listQuerySchema gives
-    // every list route, rather than a copy of its value; what an omitted
-    // limit means is the helper's answer, and there is one of each.
-    limit: limitSchema(MAX_LIMIT).optional(),
+    // The page (#10605). Both numbers come from the constants that actually
+    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
+    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
+    // really applies -- published rather than hidden, because #10101 found 83
+    // tools whose schema left a caller unable to tell what an omitted
+    // limit returns. Publishing the ceiling while hiding the default would
+    // recreate exactly that gap.
+    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
     // An integer OFFSET, which is what these routes publish
     // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
     // two is the mistake query-params.ts calls out by name.

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -74,6 +74,25 @@ const RENAMED_ON_THE_MCP_SIDE =
 const REQUEST_HEADER =
   "the route takes this as a header; a tool has no headers, only arguments";
 
+/**
+ * The tool's output ORDER is its answer, so a caller-supplied sort would
+ * overwrite the thing it came for.
+ *
+ * `find_subnet_for_task` ranks by how well each subnet matches the task
+ * (`rankSubnetsForTask`, intent-ranked when the AI layer is up, keyword
+ * otherwise) and `find_subnets_by_capability` ranks by callable-service count.
+ * Both read the agent-catalog route, which publishes `sort`/`order` because it
+ * serves an unranked index -- but passing them through here would let
+ * `sort=netuid` silently replace the ranking with an arbitrary order while the
+ * tool still describes itself as ranked.
+ *
+ * This is the per-tool judgement #9981 asked for, resolved the other way: the
+ * capability is declined rather than deferred, so this entry is not debt and is
+ * not expected to shrink.
+ */
+const RANKED_OUTPUT =
+  "the tool's output order IS its answer (ranked by match/capability); a caller-supplied sort would overwrite the ranking it was called for (#10605)";
+
 /** Standing debt: the route publishes it and the tool cannot pass it. */
 const NOT_YET_EXPOSED =
   "NOT YET EXPOSED -- the route publishes this and the tool cannot pass it; delete this entry by adding it, not by keeping it";
@@ -172,22 +191,10 @@ for (const [key, reason] of Object.entries({
   // a default on a published route is a behaviour change... which is why this
   // is not a one-line sweep"), so the capability landed first and the default
   // is chosen next, tool by tool. Tracked in #10605.
-  "list_fixtures.limit": NOT_YET_EXPOSED,
-  "list_fixtures.sort": NOT_YET_EXPOSED,
-  "list_fixtures.order": NOT_YET_EXPOSED,
-  "get_contracts.limit": NOT_YET_EXPOSED,
-  "get_contracts.sort": NOT_YET_EXPOSED,
-  "get_contracts.order": NOT_YET_EXPOSED,
-  "get_agent_catalog.limit": NOT_YET_EXPOSED,
-  "get_agent_catalog.sort": NOT_YET_EXPOSED,
-  "get_agent_catalog.order": NOT_YET_EXPOSED,
-  "get_subnet_trajectory.limit": NOT_YET_EXPOSED,
-  "get_subnet_trajectory.sort": NOT_YET_EXPOSED,
-  "get_subnet_trajectory.order": NOT_YET_EXPOSED,
-  "find_subnets_by_capability.sort": NOT_YET_EXPOSED,
-  "find_subnets_by_capability.order": NOT_YET_EXPOSED,
-  "find_subnet_for_task.sort": NOT_YET_EXPOSED,
-  "find_subnet_for_task.order": NOT_YET_EXPOSED,
+  "find_subnets_by_capability.sort": RANKED_OUTPUT,
+  "find_subnets_by_capability.order": RANKED_OUTPUT,
+  "find_subnet_for_task.sort": RANKED_OUTPUT,
+  "find_subnet_for_task.order": RANKED_OUTPUT,
   "list_subnets.q": NOT_YET_EXPOSED,
   "get_subnet_economics.q": NOT_YET_EXPOSED,
   "get_subnet_evidence.q": NOT_YET_EXPOSED,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1011,10 +1011,11 @@ import {
   ListProviderEndpointsInputSchema,
 } from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 import {
-  GetLineageInputSchema,
-  GetLineageOutputSchema,
+  GetContractsInputSchema,
   GetFreshnessInputSchema,
   GetFreshnessOutputSchema,
+  GetLineageInputSchema,
+  GetLineageOutputSchema,
   GetSourceHealthInputSchema,
   GetSourceHealthOutputSchema,
 } from "../schemas-src/mcp-tools/meta-artifacts-1.ts";
@@ -5980,9 +5981,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // NO TIER READ (#10190): METAGRAPH_SUBNET_SNAPSHOTS_SOURCE is retired and
       // absent from DATA_API_FORWARD_FLAGS, so that arm resolved to null on
       // every call.
-      return await loadSubnetTrajectory(netuid, {
+      const data = await loadSubnetTrajectory(netuid, {
         db: readStore(ctx.env, SUBNET_SNAPSHOT_TABLES) as never,
       });
+      // `netuid` is the SUBJECT here, not a filter -- the artifact already
+      // holds one subnet, so it is excluded from the query the same way
+      // every other per-subnet view excludes it.
+      return applySubnetListQuery(
+        data as Row,
+        args as Row,
+        "subnet-trajectory",
+        "points",
+        ["netuid"],
+      );
     },
   },
   {
@@ -12705,8 +12716,17 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "Use it to discover which surfaces have a fixture, then fetch one with " +
       "get_fixture. Mirrors GET /api/v1/fixtures.",
     inputSchema: inputJsonSchema(ListFixturesInputSchema),
-    async handler(_args: unknown, ctx: McpCtx) {
-      return loadArtifactData(ctx, "/metagraph/fixtures.json");
+    async handler(args: z.infer<typeof ListFixturesInputSchema>, ctx: McpCtx) {
+      const data = await loadArtifactData(ctx, "/metagraph/fixtures.json");
+      // Through the SAME engine the route uses (#10605). No subject key: this
+      // is the network-wide index, so every argument is a filter over it.
+      return applySubnetListQuery(
+        data,
+        args as Row,
+        "fixtures",
+        "fixtures",
+        [],
+      );
     },
   },
   {
@@ -12852,8 +12872,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
   },
   {
     ...GET_CONTRACTS_MCP_TOOL,
-    async handler(_args: unknown, ctx: McpCtx) {
-      return loadContracts(asMcpLoaderCtx(ctx));
+    async handler(args: z.infer<typeof GetContractsInputSchema>, ctx: McpCtx) {
+      const data = await loadContracts(asMcpLoaderCtx(ctx));
+      // `artifacts` is the rows key, declared once in
+      // API_QUERY_COLLECTIONS.contracts rather than restated here. No subject
+      // key: this is a network-wide index, so every argument filters it.
+      return applySubnetListQuery(
+        data as Row,
+        args as Row,
+        "contracts",
+        "artifacts",
+        [],
+      );
     },
   },
   {
@@ -12933,7 +12963,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           ctx,
           "/metagraph/agent-catalog.json",
         );
-        return overlayCatalogIndex(index, live) || index;
+        const overlaid = overlayCatalogIndex(index, live) || index;
+        // Paged AFTER the health overlay, so a page reports live health rather
+        // than the build-time stub -- and only on the INDEX arm. With a netuid
+        // this tool returns one subnet's catalog document, which is not a
+        // collection and has no page to turn.
+        return applySubnetListQuery(
+          overlaid,
+          args as Row,
+          "agent-catalog",
+          "subnets",
+          [],
+        );
       }
       const netuid = requireNetuid(args);
       const detail = await loadArtifactData(

--- a/tests/contracts-mcp.test.ts
+++ b/tests/contracts-mcp.test.ts
@@ -133,7 +133,10 @@ describe("contracts-mcp", () => {
     assert.deepEqual(
       // z.toJSONSchema()'s return type declares `properties` as optional (#8075).
       Object.keys(GET_CONTRACTS_MCP_TOOL.inputSchema.properties ?? {}),
-      [],
+      // The page its route publishes (#10605). This used to pin `[]`, from when
+      // the tool took no arguments at all and the route it mirrors had no page
+      // either; #10599 gave the route one, and the tool now passes it.
+      ["limit", "cursor", "sort", "order"],
     );
     assert.ok(
       new Ajv2020({ strict: false }).compile(GET_CONTRACTS_OUTPUT_SCHEMA),

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -19380,6 +19380,90 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.returned, 0);
   });
 
+  // #10605: the four document-shaped tools whose routes published a page while
+  // the tools could not pass one. What is worth pinning is not that the
+  // argument exists -- the parity validator asserts that -- but that it reaches
+  // the SAME engine the route uses, so the two surfaces cannot answer
+  // differently.
+  test("list_fixtures pages, sorts and reports the page it applied", async () => {
+    const deps = makeDeps({
+      "/metagraph/fixtures.json": {
+        generated_at: "2026-01-01T00:00:00Z",
+        fixtures: [
+          { surface_id: "c", netuid: 3, captured_at: "2026-01-03T00:00:00Z" },
+          { surface_id: "a", netuid: 1, captured_at: "2026-01-01T00:00:00Z" },
+          { surface_id: "b", netuid: 2, captured_at: "2026-01-02T00:00:00Z" },
+        ],
+      },
+    });
+    const res = await callTool(
+      "list_fixtures",
+      { limit: 2, sort: "surface_id", order: "asc" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(
+      out.fixtures.map((f: Row) => f.surface_id),
+      ["a", "b"],
+    );
+    // total spans the unfiltered set, so the rest stays reachable by paging
+    // rather than being silently gone. Flattened onto the envelope, matching
+    // every other tool that goes through this helper.
+    assert.equal(out.total, 3);
+    assert.equal(out.returned, 2);
+    assert.equal(out.limit, 2);
+  });
+
+  test("list_fixtures rejects a sort key its route does not publish", async () => {
+    // The enum comes from API_QUERY_COLLECTIONS.fixtures.sort_fields, so a key
+    // the route cannot sort by is refused here rather than ignored downstream.
+    const deps = makeDeps({
+      "/metagraph/fixtures.json": { fixtures: [] },
+    });
+    const res = await callTool("list_fixtures", { sort: "nope" }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /invalid_params/);
+  });
+
+  test("list_fixtures with no limit takes the shared MCP page default", async () => {
+    // The tool declares the CEILING and no default; applyMcpQueryFilters owns
+    // what an omitted limit means. Two defaults for one question is the thing
+    // this split exists to avoid.
+    const deps = makeDeps({
+      "/metagraph/fixtures.json": {
+        fixtures: Array.from({ length: 30 }, (_, i) => ({
+          surface_id: `s${i}`,
+          netuid: i,
+        })),
+      },
+    });
+    const res = await callTool("list_fixtures", {}, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.fixtures.length, 20);
+    assert.equal(out.limit, 20);
+    assert.equal(out.total, 30);
+  });
+
+  test("get_contracts pages its artifacts rows", async () => {
+    const deps = makeDeps({
+      "/metagraph/contracts.json": {
+        artifacts: [
+          { id: "b", path: "/b.json" },
+          { id: "a", path: "/a.json" },
+        ],
+      },
+    });
+    const res = await callTool(
+      "get_contracts",
+      { limit: 1, sort: "id", order: "asc" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.artifacts.length, 1);
+    assert.equal(out.artifacts[0].id, "a");
+    assert.equal(out.total, 2);
+  });
+
   test("list_endpoints returns the endpoints catalog artifact", async () => {
     const deps = makeDeps({
       "/metagraph/endpoints.json": {


### PR DESCRIPTION
Closes #10605. All sixteen of that issue's `NOT_YET_EXPOSED` entries are resolved — **twelve by adding the argument, four by declining it with a reason.**

## Everything comes from the existing source

That is the only way this stays one contract rather than two:

| what | from |
|---|---|
| sort enums | `API_QUERY_COLLECTIONS.<collection>.sort_fields` — not restated |
| ceiling | **`MAX_LIMIT`**, the same constant `listQuerySchema` hands every list route |
| schema helpers | `limitSchema`/`sortSchema`/`orderSchema`/`offsetSchema` from `query-params.ts` |
| execution | `applySubnetListQuery` → `applyMcpQueryFilters`, the engine the routes use |

I had first written `limitSchema(1000)` — a literal copy of `MAX_LIMIT`'s value. Four copies of a ceiling is four things to miss when it moves, so it now reads the constant.

`cursor` is `offsetSchema`, not the keyset cursor: these routes publish `{minimum: 0, type: integer}`, and `query-params.ts` names conflating the two as the exact mistake that pair exists to prevent.

## No default is declared, deliberately

This is the per-tool judgement #9981 asked for. `applyMcpQueryFilters` **already** supplies `MCP_LIST_LIMIT_DEFAULT` when a caller gives none, so a default here would be a second answer to one question. The tool publishes the ceiling; the helper owns what omission means. Pinned by test: 30 rows in, 20 out.

## The two find_* tools decline sort/order

Resolved the other way rather than deferred. `find_subnet_for_task` ranks by task match and `find_subnets_by_capability` by callable-service count. Both read the agent-catalog route, which publishes `sort`/`order` because it serves an **unranked** index — passing them through would let `sort=netuid` replace the ranking with an arbitrary order while the tool still describes itself as ranked. Their entries become `RANKED_OUTPUT`: a statement, not debt.

Two smaller judgements: `get_agent_catalog` pages only its **index** arm (with a netuid it returns one subnet's document, not a collection), and `get_subnet_trajectory` treats `netuid` as the **subject**, excluded from the query like every other per-subnet view.

## Verification

- `tsc`, eslint, prettier clean.
- **1382 tests pass**, including five new ones: paging + sorting, a sort key the route does not publish being refused, the omitted-limit default, and `get_contracts` paging its `artifacts` rows.
- `validate:mcp`: 235 tools. Input-parity: 223 aligned, **standing debt 33 → 21**.

The remaining 21 are a different set (the `.q` search family, `get_extrinsic_chain_events`' filters, and three other tools' pages) — outside this issue's scope. I am extending this branch to cover them at the maintainer's request; this description will be updated when they land.