### PR TITLE
fix(revenue): eligible means extractable, not merely annotated

### DIFF
--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -166,6 +166,34 @@ export const OPERATIONAL_SURFACES_ARTIFACT = "/metagraph/operational-surfaces";
  * because every row in the file has it. probeEligibility still checks it, so it
  * is restored here rather than assumed away, and
  * tests/revenue-observations.test.ts pins the build filter that makes it true.
+ *
+ * ## ELIGIBLE MEANS EXTRACTABLE, NOT MERELY ANNOTATED (#10783)
+ *
+ * The test was `!surface.revenue` -- any revenue block at all. `extractRevenue`
+ * opens with `if (!shape) return fail("no shape declared")` and fails the same
+ * way on a missing `currency`, so a surface carrying only `{provenance, role}`
+ * is one this lane can fetch and can never read.
+ *
+ * Measured on the live artifact 2026-08-11: 632 surfaces, **35** with a revenue
+ * block, **5** with a shape and a currency. So every hour the producer enqueued
+ * 35 messages, 30 of which were guaranteed to fetch a 200 and then fail
+ * extraction -- 30 wasted round trips against other people's APIs, 30 failure
+ * rows an hour, and the retries behind them are what put messages on
+ * `revenue-probes-dlq`. `/api/v1/chain/revenue-coverage` reported
+ * `observed_count: 1` of 129 subnets throughout.
+ *
+ * The 30 are not broken registry entries. `role: "not-revenue"` is a real and
+ * useful annotation -- it records that somebody looked at a surface and
+ * concluded it does not report revenue -- and so is a bare `provenance`. They
+ * are simply not probe inputs, and eligibility asking a different question from
+ * extraction is what made them look like ones.
+ *
+ * WHAT IS DELIBERATELY NOT CHECKED HERE: whether `shape` is in the
+ * REVENUE_SHAPES vocabulary. `extractRevenue` validates that and fails with
+ * `unknown shape "..."`, which writes a failure row naming the surface -- and a
+ * typo'd shape in the registry is exactly the thing that failure row should
+ * surface. Filtering it out here would make a registry error look like a
+ * surface that was never meant to be probed.
  */
 export function eligibleRevenueSurfaces(
   artifact: Row | null | undefined,
@@ -173,7 +201,12 @@ export function eligibleRevenueSurfaces(
   const surfaces = Array.isArray(artifact?.surfaces) ? artifact.surfaces : [];
   const out: ProbeSurfaceInput[] = [];
   for (const surface of surfaces as Row[]) {
-    if (!surface?.revenue) continue;
+    const revenue = surface?.revenue as Row | undefined;
+    if (!revenue) continue;
+    // The two `extractRevenue` refuses without, checked in the order it checks
+    // them so the reason a surface is skipped here matches the reason it would
+    // have failed there.
+    if (!revenue.shape || !revenue.currency) continue;
     out.push({
       id: String(surface.surface_id ?? ""),
       netuid: Number(surface.netuid),

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -212,16 +212,73 @@ describe("eligibleRevenueSurfaces", () => {
         netuid: 64,
         url: "https://example/a",
         auth_required: false,
-        revenue: { role: "external-revenue", provenance: "probe-derived" },
+        revenue: {
+          role: "external-revenue",
+          provenance: "probe-derived",
+          shape: "scalar",
+          currency: "USD",
+        },
       },
       { surface_id: "b", netuid: 2, url: "https://example/b" },
+      // Annotated but not EXTRACTABLE (#10783): `extractRevenue` refuses
+      // without a shape, so this is a surface the lane could fetch and never
+      // read. 30 of the live artifact's 35 looked exactly like this.
+      {
+        surface_id: "c",
+        netuid: 9,
+        url: "https://example/c",
+        revenue: { role: "not-revenue", provenance: "probe-derived" },
+      },
     ],
   };
 
-  test("only surfaces carrying a declaration are handed to the probe", () => {
+  test("only EXTRACTABLE surfaces are handed to the probe", () => {
+    // Not merely "carries a revenue block". `extractRevenue` opens with
+    // `if (!shape) return fail("no shape declared")` and refuses a missing
+    // currency the same way, so a surface without both is one this lane can
+    // fetch and can never read. Measured on the live artifact 2026-08-11: 35
+    // surfaces had a revenue block and 5 had a shape and a currency, so 30
+    // fetches an hour went out against other people's APIs to produce a
+    // failure row apiece.
     const out = eligibleRevenueSurfaces(ARTIFACT);
-    assert.equal(out.length, 1);
-    assert.equal(out[0].id, "a");
+    assert.deepEqual(
+      out.map((s) => s.id),
+      ["a"],
+    );
+  });
+
+  test("a shape with no currency is not eligible either", () => {
+    assert.deepEqual(
+      eligibleRevenueSurfaces({
+        surfaces: [
+          { surface_id: "x", netuid: 1, revenue: { shape: "scalar" } },
+          { surface_id: "y", netuid: 2, revenue: { currency: "USD" } },
+        ],
+      }),
+      [],
+      "extractRevenue needs both, so eligibility needs both",
+    );
+  });
+
+  test("an UNKNOWN shape is still eligible, deliberately", () => {
+    // extractRevenue validates the vocabulary and fails with `unknown shape`,
+    // which writes a failure row naming the surface -- and a typo in the
+    // registry is exactly what that row should surface. Filtering it here
+    // would make a registry error look like a surface never meant to be
+    // probed.
+    assert.deepEqual(
+      eligibleRevenueSurfaces({
+        surfaces: [
+          {
+            surface_id: "typo",
+            netuid: 1,
+            url: "https://example/typo",
+            revenue: { shape: "scalarr", currency: "USD" },
+          },
+        ],
+      }).map((s) => s.id),
+      ["typo"],
+    );
   });
 
   test("probe.enabled is restored rather than assumed away", () => {
@@ -483,7 +540,16 @@ describe("degenerate input", () => {
     // probeEligibility and the store both read these as strings; "undefined"
     // rendered into a surface_id would be written to the table as a real key.
     const [surface] = eligibleRevenueSurfaces({
-      surfaces: [{ netuid: 7, revenue: { role: "external-revenue" } }],
+      surfaces: [
+        {
+          netuid: 7,
+          revenue: {
+            role: "external-revenue",
+            shape: "scalar",
+            currency: "USD",
+          },
+        },
+      ],
     });
     assert.equal(surface.id, "");
     assert.equal(surface.url, "");
@@ -847,6 +913,11 @@ describe("the revenue queue, through the Worker's own handler", () => {
     revenue: {
       role: "external-revenue",
       provenance: "probe-derived",
+      // shape + currency are what make a surface EXTRACTABLE, and therefore
+      // what make it eligible (#10783). This fixture carried currency and no
+      // shape, which is a surface the lane could fetch and never read.
+      shape: "scalar",
+      fields: { amount: "revenue_usd" },
       currency: "USD",
       grain: "daily",
     },


### PR DESCRIPTION
Closes #10783.

`/api/v1/chain/revenue-coverage` reports **`observed_count: 1`** against 129 subnets. `/api/v1/subnets/4/revenue` returns `revenue_usd: null` for a surface the lane probes every hour.

## Eligibility asked a different question from extraction

```ts
// eligibleRevenueSurfaces
if (!surface?.revenue) continue;
```

```ts
// extractRevenue
if (!shape) return fail("no shape declared");
...
if (!currency) return fail("no currency declared");
```

Measured on the live artifact, 2026-08-11:

| | count |
| --- | --: |
| surfaces in `operational-surfaces.json` | 632 |
| with a `revenue` block → **enqueued hourly** | **35** |
| with `shape` **and** `currency` → **extractable** | **5** |

I probed the first 14 eligible surfaces directly: **all return HTTP 200.** The fetch was never the problem — 30 surfaces an hour were fetched successfully and then failed extraction, permanently, because they declare no shape.

Revenue-block keys across those 35:

```
provenance 35 · role 35 · source_url 6 · circularity 5 · currency 5
grain 5 · shape 5 · fields 4 · excludes 1 · supersedes 1
```

## What it cost

- 30 unnecessary round trips an hour **against other people's APIs** — the lane was a well-behaved citizen only by accident of its low cadence.
- 30 `revenue_probe_failures` rows an hour, all saying the same thing, burying any real failure.
- The retries behind them are what put messages on `revenue-probes-dlq` (`2 dead-lettered message(s) … (unidentified)` before #10778 taught it to name them).

## The 30 are not broken entries

`role: "not-revenue"` is a real and useful annotation — it records that somebody looked at a surface and concluded it does not report revenue — and **nine of the 35 said exactly that while being probed anyway**. They are simply not probe inputs, and eligibility asking a different question from extraction is what made them look like ones.

## What is deliberately not checked

Whether `shape` is in the `REVENUE_SHAPES` vocabulary. `extractRevenue` validates that and fails with `unknown shape "..."`, writing a failure row that names the surface — and a typo in the registry is precisely what that row should surface. Filtering it here would make a registry error look like a surface that was never meant to be probed. There's a test pinning that.

## The fixtures had the same gap

The test surfaces carried `currency` and no `shape` — a surface the lane could fetch and never read. The tests meant to catch this encoded it instead.

## Validation

- `npm run typecheck` · `npm run validate` · `npm run lint` · `npm run format:check` · `npm run scan:public-safety` — all clean
- 112 tests across the 5 files touching the revenue lane — all pass
- **Patch coverage 100%** — statements and branches, by diff intersection against `origin/main`

## The remaining 5 are fine — checked, not assumed

`observed_count: 1` looked like it might mean the other four were failing too. It does not. I ran `extractRevenue` against the two live payloads directly:

```
SN51 lium         : OK  observations=20  newest={"period":"2025-01","amount":11590.56,"currency":"USD"}
SN64 chutes daily : OK  observations=90  newest={"period":"2026-08-11","amount":5909.53,"currency":"USD"}
```

Both extract. SN51 carries 20 monthly periods running 2025-01 → 2026-08, so its data is current. `observed_count: 1` is the **correct** answer at `window_days: 1`: SN64 publishes a daily figure and lands in the window; SN51's grain is monthly and a one-day window cannot contain a monthly period, so `/subnets/51/revenue` returns `revenue_usd: null`.

That null is the right answer, not a gap — prorating a month into a day would be inventing the number, and the epic's own rule is that absent revenue serialises as null rather than zero. Two of the remaining SN64 surfaces are also marked `supersedes`d by the daily summary, so the effective set is smaller still.

So this PR removes 30 guaranteed failures an hour and changes nothing about what is served.
