### PR TITLE
obs(api): say what the history routes actually covered, not just what was asked

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3031,7 +3031,13 @@ export type Neuron = {
 /** One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history. */
 export type NeuronHistory = {
   __typename?: 'NeuronHistory';
+  /** DISTINCT days present in points, counted from the ROWS rather than the requested window -- so a day with no snapshot is absent rather than reported as a day of zero. Does not equal point_count when a day carries several rows. */
+  days_covered: Scalars['Int']['output'];
   netuid: Scalars['Int']['output'];
+  /** Latest snapshot_date in points, or null on an empty series. */
+  newest_day?: Maybe<Scalars['String']['output']>;
+  /** Earliest snapshot_date in points, or null on an empty series. With newest_day, says what the answer COVERS -- window only says what was asked for. */
+  oldest_day?: Maybe<Scalars['String']['output']>;
   point_count: Scalars['Int']['output'];
   points: Array<NeuronHistoryPoint>;
   schema_version: Scalars['Int']['output'];
@@ -6272,7 +6278,13 @@ export type SubnetHealthTrends = {
 /** One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope. */
 export type SubnetHistory = {
   __typename?: 'SubnetHistory';
+  /** DISTINCT days present in points, counted from the ROWS rather than the requested window -- so a day with no snapshot is absent rather than reported as a day of zero. Does not equal point_count when a day carries several rows. */
+  days_covered: Scalars['Int']['output'];
   netuid: Scalars['Int']['output'];
+  /** Latest snapshot_date in points, or null on an empty series. */
+  newest_day?: Maybe<Scalars['String']['output']>;
+  /** Earliest snapshot_date in points, or null on an empty series. With newest_day, says what the answer COVERS -- window only says what was asked for. */
+  oldest_day?: Maybe<Scalars['String']['output']>;
   point_count: Scalars['Int']['output'];
   points: Array<SubnetHistoryPoint>;
   schema_version: Scalars['Int']['output'];
@@ -11002,7 +11014,10 @@ export type NeuronResolvers<ContextType = GqlContext, ParentType extends Resolve
 }>;
 
 export type NeuronHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['NeuronHistory'] = ResolversParentTypes['NeuronHistory']> = ResolversObject<{
+  days_covered?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  newest_day?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  oldest_day?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   points?: Resolver<Array<ResolversTypes['NeuronHistoryPoint']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -12298,7 +12313,10 @@ export type SubnetHealthTrendsResolvers<ContextType = GqlContext, ParentType ext
 }>;
 
 export type SubnetHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetHistory'] = ResolversParentTypes['SubnetHistory']> = ResolversObject<{
+  days_covered?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  newest_day?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  oldest_day?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   points?: Resolver<Array<ResolversTypes['SubnetHistoryPoint']>, ParentType, ContextType>;
   schema_version?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9260,7 +9260,10 @@ export interface components {
         };
         /** @description One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history. */
         NeuronHistoryArtifact: {
+            days_covered: number;
             netuid: number;
+            newest_day: string | null;
+            oldest_day: string | null;
             point_count: number;
             points: ({
                 active: boolean;
@@ -11318,7 +11321,10 @@ export interface components {
         };
         /** @description One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope. */
         SubnetHistoryArtifact: {
+            days_covered: number;
             netuid: number;
+            newest_day: string | null;
+            oldest_day: string | null;
             point_count: number;
             points: {
                 neuron_count?: number | null;
@@ -42729,7 +42735,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "days_covered": 1,
                      *         "netuid": 7,
+                     *         "newest_day": "example",
+                     *         "oldest_day": "example",
                      *         "point_count": 1,
                      *         "points": [
                      *           {
@@ -44079,7 +44088,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "days_covered": 1,
                      *         "netuid": 7,
+                     *         "newest_day": "example",
+                     *         "oldest_day": "example",
                      *         "point_count": 1,
                      *         "points": [
                      *           {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6735,7 +6735,10 @@
       "NeuronHistoryArtifactResponse": {
         "value": {
           "data": {
+            "days_covered": 1,
             "netuid": 7,
+            "newest_day": "example",
+            "oldest_day": "example",
             "point_count": 1,
             "points": [
               {
@@ -9696,7 +9699,10 @@
       "SubnetHistoryArtifactResponse": {
         "value": {
           "data": {
+            "days_covered": 1,
             "netuid": 7,
+            "newest_day": "example",
+            "oldest_day": "example",
             "point_count": 1,
             "points": [
               {
@@ -36260,10 +36266,35 @@
         "additionalProperties": {},
         "description": "One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history.",
         "properties": {
+          "days_covered": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "netuid": {
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "newest_day": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "oldest_day": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "point_count": {
             "maximum": 9007199254740991,
@@ -36510,6 +36541,9 @@
           "netuid",
           "uid",
           "point_count",
+          "oldest_day",
+          "newest_day",
+          "days_covered",
           "points"
         ],
         "type": "object"
@@ -46416,10 +46450,35 @@
         "additionalProperties": {},
         "description": "One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope.",
         "properties": {
+          "days_covered": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
           "netuid": {
             "maximum": 9007199254740991,
             "minimum": 0,
             "type": "integer"
+          },
+          "newest_day": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "oldest_day": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "point_count": {
             "maximum": 9007199254740991,
@@ -46506,6 +46565,9 @@
           "schema_version",
           "netuid",
           "point_count",
+          "oldest_day",
+          "newest_day",
+          "days_covered",
           "points"
         ],
         "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9260,7 +9260,10 @@ export interface components {
         };
         /** @description One neuron's per-day metagraph history. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history. */
         NeuronHistoryArtifact: {
+            days_covered: number;
             netuid: number;
+            newest_day: string | null;
+            oldest_day: string | null;
             point_count: number;
             points: ({
                 active: boolean;
@@ -11318,7 +11321,10 @@ export interface components {
         };
         /** @description One subnet's daily history series (#7172) from the neuron_daily rollup, newest first. Empty series (point_count 0) on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/history' data envelope. */
         SubnetHistoryArtifact: {
+            days_covered: number;
             netuid: number;
+            newest_day: string | null;
+            oldest_day: string | null;
             point_count: number;
             points: {
                 neuron_count?: number | null;
@@ -42729,7 +42735,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "days_covered": 1,
                      *         "netuid": 7,
+                     *         "newest_day": "example",
+                     *         "oldest_day": "example",
                      *         "point_count": 1,
                      *         "points": [
                      *           {
@@ -44079,7 +44088,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "days_covered": 1,
                      *         "netuid": 7,
+                     *         "newest_day": "example",
+                     *         "oldest_day": "example",
                      *         "point_count": 1,
                      *         "points": [
                      *           {

--- a/schemas-src/routes/subnet-history.ts
+++ b/schemas-src/routes/subnet-history.ts
@@ -37,6 +37,21 @@ export const SubnetHistoryArtifactSchema = z
     netuid: z.int().min(0),
     window: z.string().nullable().optional(),
     point_count: z.int().min(0),
+    /**
+     * WHAT THE RESPONSE ACTUALLY COVERED, beside what was asked for (#10788).
+     *
+     * `window` echoes the REQUEST -- ask for `1y` and this says `1y` -- so
+     * without these a consumer receiving 33 points could not tell "that is all
+     * that happened" from "that is all we hold". Same reasoning, and the same
+     * shape, as /health/failure-reasons: depth counted from the ROWS rather
+     * than the requested window.
+     *
+     * `days_covered` counts DISTINCT days present rather than the span, so a
+     * gap in the middle is visible instead of implied away by oldest/newest.
+     */
+    oldest_day: z.string().nullable(),
+    newest_day: z.string().nullable(),
+    days_covered: z.int().min(0),
     points: z.array(SubnetHistoryPointSchema),
   })
   .passthrough()

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -184,6 +184,21 @@ export const NeuronHistoryArtifactSchema = z
     uid: z.int().min(0),
     window: z.string().nullable().optional(),
     point_count: z.int().min(0),
+    /**
+     * WHAT THE RESPONSE ACTUALLY COVERED, beside what was asked for (#10788).
+     *
+     * `window` echoes the REQUEST -- ask for `1y` and this says `1y` -- so
+     * without these a consumer receiving 33 points could not tell "that is all
+     * that happened" from "that is all we hold". Same reasoning, and the same
+     * shape, as /health/failure-reasons: depth counted from the ROWS rather
+     * than the requested window.
+     *
+     * `days_covered` counts DISTINCT days present rather than the span, so a
+     * gap in the middle is visible instead of implied away by oldest/newest.
+     */
+    oldest_day: z.string().nullable(),
+    newest_day: z.string().nullable(),
+    days_covered: z.int().min(0),
     points: z.array(NeuronHistoryPointSchema),
   })
   .passthrough()

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -3491,6 +3491,12 @@ export const SDL = /* GraphQL */ `
     netuid: Int!
     window: String
     point_count: Int!
+    "DISTINCT days present in points, counted from the ROWS rather than the requested window -- so a day with no snapshot is absent rather than reported as a day of zero. Does not equal point_count when a day carries several rows."
+    days_covered: Int!
+    "Earliest snapshot_date in points, or null on an empty series. With newest_day, says what the answer COVERS -- window only says what was asked for."
+    oldest_day: String
+    "Latest snapshot_date in points, or null on an empty series."
+    newest_day: String
     points: [SubnetHistoryPoint!]!
   }
 
@@ -4802,6 +4808,12 @@ export const SDL = /* GraphQL */ `
     uid: Int!
     window: String
     point_count: Int!
+    "DISTINCT days present in points, counted from the ROWS rather than the requested window -- so a day with no snapshot is absent rather than reported as a day of zero. Does not equal point_count when a day carries several rows."
+    days_covered: Int!
+    "Earliest snapshot_date in points, or null on an empty series. With newest_day, says what the answer COVERS -- window only says what was asked for."
+    oldest_day: String
+    "Latest snapshot_date in points, or null on an empty series."
+    newest_day: String
     points: [NeuronHistoryPoint!]!
   }
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3653,6 +3653,13 @@ const rootValue = {
       uid: data.uid ?? uid,
       window: data.window ?? label,
       point_count: data.point_count ?? 0,
+      // Explicit, because this object is BUILT rather than spread: the parity
+      // gate compares the SDL to the component and cannot see a resolver that
+      // drops a field, so a declared-but-unlisted non-null field would resolve
+      // to undefined and error at request time.
+      days_covered: data.days_covered ?? 0,
+      oldest_day: data.oldest_day ?? null,
+      newest_day: data.newest_day ?? null,
       points: data.points || [],
     };
   },
@@ -4057,6 +4064,11 @@ const rootValue = {
       netuid: data.netuid ?? netuid,
       window: data.window ?? label,
       point_count: data.point_count ?? 0,
+      // See the neuron-history resolver: built object, so the coverage fields
+      // have to be listed or the SDL declares what nothing returns.
+      days_covered: data.days_covered ?? 0,
+      oldest_day: data.oldest_day ?? null,
+      newest_day: data.newest_day ?? null,
       points: data.points ?? [],
     };
   },

--- a/src/neuron-history.ts
+++ b/src/neuron-history.ts
@@ -24,6 +24,48 @@ import type { NeuronDaily } from "../generated/db/types.ts";
 // Bounds any single time-series response (1y = 365 daily points < this cap).
 export const MAX_HISTORY_POINTS = 400;
 
+/**
+ * What the response ACTUALLY covered, beside what was asked for.
+ *
+ * WHY THIS IS NOT COSMETIC (#10788). `window` echoes the request -- ask for
+ * `1y` and the payload says `1y` -- while `point_count` says how many days came
+ * back. Nothing said which days, so a consumer asking for a year and receiving
+ * 33 points could not tell "that is all that happened on chain" from "that is
+ * all we hold". Those are different answers and only one of them is a reason to
+ * go looking elsewhere.
+ *
+ * The repo already made this call once, in the opposite direction, and the
+ * reasoning is quoted in src/contracts.ts for /health/failure-reasons: depth is
+ * counted from the ROWS rather than the requested window, "so a day the prober
+ * did not run is absent rather than reported as a day of perfect health". The
+ * history routes were the family that never got it.
+ *
+ * Counted from the points themselves for the same reason -- a gap in the middle
+ * is invisible to `oldest`/`newest`, but `days_covered` is the count of days
+ * actually present, so the two together say "33 days spanning 2026-07-10 to
+ * 2026-08-11" rather than implying a dense month.
+ */
+function coverage(points: readonly Row[]): {
+  oldest_day: string | null;
+  newest_day: string | null;
+  days_covered: number;
+} {
+  const days = new Set<string>();
+  for (const p of points) {
+    const day = p.snapshot_date;
+    if (typeof day === "string" && day !== "") days.add(day);
+  }
+  if (days.size === 0) {
+    return { oldest_day: null, newest_day: null, days_covered: 0 };
+  }
+  const sorted = [...days].sort();
+  return {
+    oldest_day: sorted[0]!,
+    newest_day: sorted[sorted.length - 1]!,
+    days_covered: days.size,
+  };
+}
+
 export function unsupportedWindowMessage(
   value: unknown,
   windows: Record<string, unknown>,
@@ -117,6 +159,7 @@ export function buildNeuronHistory(
     uid,
     window: window ?? null,
     point_count: points.length,
+    ...coverage(points),
     points,
   };
 }
@@ -318,6 +361,7 @@ export function buildSubnetHistory(
     netuid,
     window: window ?? null,
     point_count: points.length,
+    ...coverage(points),
     points,
   };
 }

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -13582,6 +13582,51 @@ describe("graphql — neuron_history (#5900, Postgres-tier + empty-points fallba
     ]);
   });
 
+  test("neuron_history publishes the coverage the SDL declares, from the tier and on the cold path (#10788)", async () => {
+    // Same reason as the subnet_history case: a built resolver object is
+    // invisible to the schema-vs-schema parity gate, so only selecting the
+    // fields proves they resolve.
+    const env = {
+      METAGRAPH_NEURONS_SOURCE: "postgres",
+      DATA_API: dataApi(
+        Response.json({
+          schema_version: 1,
+          netuid: 5,
+          uid: 12,
+          window: "90d",
+          point_count: 1,
+          days_covered: 1,
+          oldest_day: "2026-07-01",
+          newest_day: "2026-07-01",
+          points: [{ snapshot_date: "2026-07-01" }],
+        }),
+      ),
+    };
+    const { body } = await gql(
+      `{ neuron_history(netuid: 5, uid: 12, window: "90d") {
+          point_count days_covered oldest_day newest_day
+        } }`,
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.neuron_history, {
+      point_count: 1,
+      days_covered: 1,
+      oldest_day: "2026-07-01",
+      newest_day: "2026-07-01",
+    });
+
+    const cold = await gql(
+      "{ neuron_history(netuid: 5, uid: 12) { days_covered oldest_day newest_day } }",
+    );
+    assert.equal(cold.body.errors, undefined);
+    assert.deepEqual(cold.body.data.neuron_history, {
+      days_covered: 0,
+      oldest_day: null,
+      newest_day: null,
+    });
+  });
+
   test("window is forwarded as a query param to the Postgres tier", async () => {
     let capturedUrl: URL | undefined;
     const env = {
@@ -14524,6 +14569,51 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
     assert.equal(h.window, "90d");
     assert.equal(h.point_count, 0);
     assert.deepEqual(h.points, []);
+  });
+
+  test("subnet_history publishes the coverage the SDL declares, from the tier and on the cold path (#10788)", async () => {
+    // The parity gate compares the SDL to the component and cannot see this
+    // resolver, which BUILDS its object -- so declaring days_covered as
+    // non-null while the resolver omitted it would pass every schema gate and
+    // error at request time. Only selecting the fields proves they resolve.
+    const env = tierEnv("METAGRAPH_NEURONS_SOURCE", {
+      schema_version: 1,
+      netuid: 7,
+      window: "7d",
+      point_count: 2,
+      days_covered: 2,
+      oldest_day: "2026-06-29",
+      newest_day: "2026-06-30",
+      points: [
+        { snapshot_date: "2026-06-30" },
+        { snapshot_date: "2026-06-29" },
+      ],
+    });
+    const { body } = await gql(
+      `{ subnet_history(netuid: 7, window: "7d") {
+          point_count days_covered oldest_day newest_day
+        } }`,
+      env as unknown as Env,
+    );
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(body.data.subnet_history, {
+      point_count: 2,
+      days_covered: 2,
+      oldest_day: "2026-06-29",
+      newest_day: "2026-06-30",
+    });
+
+    // Cold path: an empty series still answers, rather than erroring on the
+    // non-null field.
+    const cold = await gql(
+      "{ subnet_history(netuid: 5) { days_covered oldest_day newest_day } }",
+    );
+    assert.equal(cold.body.errors, undefined);
+    assert.deepEqual(cold.body.data.subnet_history, {
+      days_covered: 0,
+      oldest_day: null,
+      newest_day: null,
+    });
   });
 
   test("subnet_history rejects an invalid window", async () => {

--- a/tests/neuron-history.test.ts
+++ b/tests/neuron-history.test.ts
@@ -565,3 +565,50 @@ describe("history endpoints (via the Worker dispatch)", () => {
     assert.equal(body.meta.parameter, "window");
   });
 });
+
+describe("coverage: what the response actually held (#10788)", () => {
+  // `window` echoes the REQUEST. Without these, a consumer asking for 1y and
+  // getting 33 points cannot tell "that is all that happened" from "that is all
+  // we hold" -- and only one of those is a reason to look elsewhere.
+  const row = (day: string) => ({
+    snapshot_date: day,
+    netuid: 1,
+    uid: 0,
+    hotkey: "5F",
+    coldkey: "5G",
+    captured_at: 1_785_800_000_000,
+    block_number: 100,
+  });
+
+  test("reports the real span and DISTINCT day count", () => {
+    const out = buildNeuronHistory(
+      [row("2026-08-11"), row("2026-07-10"), row("2026-08-01")],
+      1,
+      0,
+      { window: "1y" },
+    );
+    assert.equal(out.window, "1y", "the request is still echoed");
+    assert.equal(out.oldest_day, "2026-07-10");
+    assert.equal(out.newest_day, "2026-08-11");
+    assert.equal(out.days_covered, 3);
+  });
+
+  test("counts DISTINCT days, so a duplicated day is not double-counted", () => {
+    // days_covered is the count of days PRESENT, not the row count -- a neuron
+    // with two rows on one day has one day of coverage.
+    const out = buildNeuronHistory(
+      [row("2026-08-11"), row("2026-08-11")],
+      1,
+      0,
+    );
+    assert.equal(out.days_covered, 1);
+    assert.equal(out.point_count, 2, "point_count still counts rows");
+  });
+
+  test("an empty series reports null span rather than a fabricated one", () => {
+    const out = buildNeuronHistory([], 1, 0, { window: "1y" });
+    assert.equal(out.oldest_day, null);
+    assert.equal(out.newest_day, null);
+    assert.equal(out.days_covered, 0);
+  });
+});


### PR DESCRIPTION
## Problem

`/subnets/{netuid}/history` and `/subnets/{netuid}/neurons/{uid}/history` echo the **request**:

```json
{ "window": "1y", "point_count": 33, "points": [...] }
```

`neuron_daily` holds **33 days**. So a consumer asking for a year gets 33 points labelled `1y`, with nothing saying which days — and no way to tell *"that is all that happened on chain"* from *"that is all we hold"*. Only one of those is a reason to go looking elsewhere.

## The repo already made this call, in the other direction

`/health/failure-reasons` publishes `days_covered` / `oldest_day` / `newest_day`, and `src/contracts.ts` says why: depth counted from the **rows** rather than the requested window, *"so a day the prober did not run is absent rather than reported as a day of perfect health"*. The history family never got it.

## Fix

`oldest_day`, `newest_day`, `days_covered` beside `point_count`.

- **`days_covered` counts DISTINCT days**, not the span — a gap in the middle stays visible instead of being implied away by oldest/newest. It deliberately does **not** equal `point_count` when a day carries several rows, and there is a test for that.
- **Declared in `schemas-src`**, not left to `.passthrough()` — otherwise they are undocumented extras a consumer finds by inspection. `openapi.json` and the generated types are regenerated in the same commit.

## Why this grows in importance

This is a block explorer storing data **forever**. `neuron_daily` and `account_position_daily` each add ~30,000 rows/day (~5.3 and ~5.5 GB/year). As real history accumulates, `all` becomes a large and variable span — exactly when a response most needs to state what it covered.

## Validation

```
npm run validate · validate:contract-drift · lint · format:check   # clean
npx tsc --noEmit                                                   # clean
npm run build                                                      # openapi + types regenerated
npx vitest run neuron-history, subnet-history                      # 31 passed
```

`public/metagraph/r2-manifest.json` and `schemas/index.json` are **not** in the diff — the build left them untouched.

Closes #10788