### PR TITLE
fix(graphql): say that postgresTierRequest takes a query string, not a row

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1815,7 +1815,12 @@ async function loadEconomicsRows(context: GqlContext) {
 function postgresTierRequest(
   context: GqlContext,
   pathname: string,
-  params?: Row,
+  // URLSearchParams, which is what every one of the 70+ call sites passes and
+  // the only thing the body uses (`params.toString()`). It was typed `Row`,
+  // and `Row` was `Record<string, any>` -- so the signature said "a row bag"
+  // while the contract was "a query string builder", and `any` let the two
+  // coexist (#10782).
+  params?: URLSearchParams,
   // #10394: which chain's rows to read. Mainnet keeps the base path, so every
   // existing caller is unchanged; testnet reaches the `/api/v1/{network}/…`
   // twin the router already serves and REST callers already use.


### PR DESCRIPTION
First slice of #10782, landed on its own because it is correct independently of the rest.

`postgresTierRequest(context, pathname, params?: Row)` — and the entire body's use of `params` is:

```ts
pgUrl.search = params ? params.toString() : "";
```

Every one of its 70+ call sites passes a `URLSearchParams`. The declaration said "a bag of rows". Both have been true in the type system this whole time because `Row` is `Record<string, any>`, and `any` lets a `URLSearchParams` satisfy an index signature it has nothing to do with.

## How it was found

By flipping `type Row = Record<string, any>` to `unknown` in `src/graphql.ts` — the measurement behind #10782. That surfaces **199 errors** in this file, and **72 of them are this one signature**, reported at every call site at once.

Nothing is wrong at any of those 72 sites. The declaration was wrong, once. That ratio is the argument for #10782: a single `any` in the repo's largest producer (10,282 lines) was absorbing a signature-level contradiction across a third of the errors it hides.

## Scope

Deliberately just this. The `Row` flip is **not** in this PR — the remaining 127 errors need per-error judgement, and #10782's own completion requirements forbid casting them away. Restoring `Row` to `any` leaves this fix compiling clean on its own, which is what makes it landable now.

No behaviour change: `params.toString()` ran before and runs now.

Verified: `tsc` clean · `npm run lint` clean · **1101/1101** resolver tests pass, unchanged.

Refs #10782