### PR TITLE
chore(lakehouse): snapshot the two daily rollups, now that they are readable

### DIFF
--- a/scripts/refresh-lakehouse-schema.ts
+++ b/scripts/refresh-lakehouse-schema.ts
@@ -40,11 +40,10 @@ const WAREHOUSE =
  * READ, rather than "all 26", on purpose. A type for a table nothing queries is
  * dead code the moment it is generated -- `DatabaseTables` and `TableName` on
  * the Neon side are the standing example, generated and imported by nothing.
- * The twelve unlisted tables (account_balances, featured_validators, neurons,
- * neuron_daily, account_position_daily, providers, rehearsal, subnet_ownership,
- * subnet_snapshots, subnets, surfaces, validator_nominator_counts) are written
- * by producers outside this repo and never read through R2 SQL here; add one
- * here the moment a reader does.
+ * The ten unlisted tables (account_balances, featured_validators, neurons,
+ * providers, rehearsal, subnet_ownership, subnet_snapshots, subnets, surfaces,
+ * validator_nominator_counts) are written by producers outside this repo and
+ * never read through R2 SQL here; add one here the moment a reader does.
  */
 const TABLES = [
   // The four the decoder appends to.
@@ -67,6 +66,18 @@ const TABLES = [
   "subnet_hyperparams_history",
   "subnet_identity_history",
   "subnet_ownership_history",
+  // The two daily rollups. Listed the moment they became READABLE rather than
+  // when they became present: they have existed since the 2026-08-02 seed, but
+  // that seed is a strict SUBSET of Neon (lakehouse 07-10..08-02, Neon
+  // 07-10..08-11, measured), so nothing could have been served from them. The
+  // continuous producer (metagraphed-infra#445) is what changes that.
+  //
+  // Neither is written by the decoder, so neither belongs in DECODER_TABLES --
+  // they are derived in the Worker from one metagraph snapshot and copied out
+  // of Postgres. The generator's `decoderTables` subset test is what keeps that
+  // distinction honest.
+  "neuron_daily",
+  "account_position_daily",
 ];
 
 const token = process.env.R2_CATALOG_TOKEN ?? "";


### PR DESCRIPTION
## The condition this file set for itself

`scripts/refresh-lakehouse-schema.ts` already named both tables and said when to act:

> The twelve unlisted tables (…, **neuron_daily, account_position_daily**, …) are written by producers outside this repo and never read through R2 SQL here; **add one here the moment a reader does.**

## What actually changed: readability, not presence

Both tables have existed in the catalog since the 2026-08-02 seed. Measured against the live catalog before touching anything:

| table | Neon | lakehouse |
|---|---|---|
| `neuron_daily` | 07-10 → **08-11** (997,597) | 07-10 → **08-02** (726,485) |
| `account_position_daily` | 07-11 → **08-11** (988,694) | 07-11 → **08-02** (710,753) |

A strict **subset** — a frozen duplicate of rows Postgres already had, with nothing in it worth reading. metagraphed-infra#445 gives them a continuous producer, and a cold tier needs generated tuples before it can have a SELECT list that `validate:untyped-lakehouse-reads` can check.

## Why this is safe to land on its own

`TABLES` is read **only** by this script, which needs `R2_CATALOG_TOKEN` and so cannot run from a PR. The change is inert by construction: the snapshot arrives on the next `refresh-lakehouse-schema` run (weekly, or `workflow_dispatch`), and that run opens **its own PR for a human** — deliberately no auto-merge, because a schema change rewrites what the cold tiers ask for.

Neither table joins `DECODER_TABLES`: they are derived in the Worker from one metagraph snapshot, not decoded from chain bytes. The generator's subset test keeps that from blurring.

## Validation

```
npx tsc --noEmit                                      # clean
npm run validate:lakehouse-types-drift                # types match the snapshot
npx vitest run lakehouse-schema, untyped-lakehouse-reads  # 23 passed
prettier --check                                      # clean
```

`validate:lakehouse-types-drift` stays green because it compares committed types to the committed snapshot, and neither moves in this diff.

Closes #10794