### PR TITLE
test(lakehouse): name the two daily rollups the snapshot already carries

### DIFF
--- a/tests/lakehouse-schema.test.ts
+++ b/tests/lakehouse-schema.test.ts
@@ -37,9 +37,16 @@ const snapshot = readSnapshot();
 describe("the committed snapshot", () => {
   test("covers every chain.* table this repo reads", () => {
     // Named rather than derived from the file: the file is what could be
-    // wrong. The four the decoder appends to, plus the nine the cold tiers
+    // wrong. The four the decoder appends to, plus the eleven the cold tiers
     // read -- the set was four until the readers were included, which left
     // ten queried tables with no snapshot and no drift coverage.
+    //
+    // STILL WRITTEN OUT BY HAND after #10795 added the two daily rollups
+    // (#10800). Deriving this from the snapshot would have made it pass without
+    // anyone noticing they had arrived, which is the one thing the list is for:
+    // a table reaching the snapshot is a decision, and this is where the
+    // decision is recorded. The cost is that adding a table is two edits; that
+    // cost IS the check.
     //
     // account_events_daily is NOT here on purpose: it is named in four
     // comments and a route description and queried by nothing, because
@@ -49,9 +56,14 @@ describe("the committed snapshot", () => {
       "account_events",
       "account_identity",
       "account_identity_history",
+      // The per-(account, netuid, day) position rollup #4908 added;
+      // src/account-position-history.ts serves from it.
+      "account_position_daily",
       "blocks",
       "chain_events",
       "extrinsics",
+      // The per-(uid, day) neuron rollup the history routes read.
+      "neuron_daily",
       "nominator_positions",
       "rpc_proxy_events",
       "self_health_daily",


### PR DESCRIPTION
`tests/lakehouse-schema.test.ts > the committed snapshot > covers every chain.* table this repo reads` has been failing on `main` since #10795 (4d80c4ac4 is the current head and still fails), so every open PR inherits a red run through no fault of its own.

## What happened

#10795 added `account_position_daily` and `neuron_daily` to the committed snapshot and to `LAKEHOUSE_TABLES`. The gate's expected set is written out by hand — deliberately, per its own comment: *"Named rather than derived from the file: the file is what could be wrong."* That list did not gain the two names.

```
+   'account_position_daily',
+   'neuron_daily',
```

Both are real. They are in `generated/lakehouse/types.ts`'s reader list, and `src/account-position-history.ts` is built on `account_position_daily`. So the snapshot was right and the expectation was stale — the benign direction, but the gate that would catch the malign one was down while it was.

## What this does not do

It does not derive the list from the snapshot. That would make the test pass unconditionally and stop it ever reporting a table that arrived without anyone deciding it should, which is the only thing the list is for. Adding a table stays two edits, and that cost **is** the check.

## Verification

- `tests/lakehouse-schema.test.ts` — 16 passed (was 1 failed | 15 passed).
- Reproduced on a clean `origin/main` worktree first, to confirm the failure was not mine: identical assertion, identical two names.
- One file, tests only.

Closes #10800