### PR TITLE
refactor(types): take `Row` off `any`, and fix the 214 errors it was hiding

### DIFF
--- a/scripts/openapi-components.ts
+++ b/scripts/openapi-components.ts
@@ -16,12 +16,16 @@
 import { buildOpenApiArtifact } from "../src/contracts.ts";
 import { generateOpenApiZodComponents } from "./generate-openapi-zod-components.ts";
 import { buildTimestamp } from "./lib.ts";
+import type { Schema } from "../src/openapi-sample.ts";
 
 type Row = Record<string, unknown>;
 
 export async function loadOpenApiComponentSchemas(
+  // `Record<string, Schema>`, which is what `buildOpenApiArtifact` takes and
+  // what the generator already returns. `Row` typed the VALUES `unknown`, so
+  // the one consumer had to be told these were schemas (#10782).
   generatedAt: string = buildTimestamp(),
-): Promise<Row> {
+): Promise<Record<string, Schema>> {
   return {
     ...generateOpenApiZodComponents(),
     GeneratedOpenApiMarker: {

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -65,9 +65,15 @@ const MCP_URL = "https://api.metagraph.sh/mcp";
 // output can never drift from its advertised outputSchema.
 const ajv = new Ajv2020({ strict: false });
 const OUTPUT_VALIDATORS = new Map(
-  listToolDefinitions()
-    .filter((def) => def.outputSchema)
-    .map((def) => [def.name, ajv.compile(def.outputSchema)]),
+  // `flatMap` with the schema read INSIDE the ternary, not `.filter` then
+  // `.map`: `Array.prototype.filter` with a plain boolean callback narrows
+  // nothing, so `def.outputSchema` was still `JsonSchemaLike | undefined` at
+  // the `ajv.compile` beside it (#10782).
+  listToolDefinitions().flatMap((def) =>
+    def.outputSchema
+      ? [[def.name, ajv.compile(def.outputSchema)] as const]
+      : [],
+  ),
 );
 
 // --- Response-shape coverage (#9795) ---------------------------------------

--- a/scripts/validate-unreferenced-exports.ts
+++ b/scripts/validate-unreferenced-exports.ts
@@ -63,8 +63,13 @@ import { repoRoot } from "./lib.ts";
  * that were only ever counted as unreferenced because the linkage was
  * invisible, not because nothing used them. A measurement fix, and the ceiling
  * takes it the same way it takes a deletion.
+ *
+ * 737 after #10782, which took `Row` off `any` and fixed the 214 errors that
+ * hid behind it. Nothing was deleted to earn this one either: the narrowing
+ * moved a single export across the referenced/unreferenced line, and the
+ * ceiling takes a measurement change the same way it takes a deletion.
  */
-export const MAX_UNREFERENCED_EXPORTS: number = 738;
+export const MAX_UNREFERENCED_EXPORTS: number = 737;
 
 /** knip's JSON shape, as much of it as this gate reads. */
 interface KnipIssue {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -77,8 +77,19 @@ const CHAIN_CONCENTRATION_SUBNETS_DESCRIPTION =
   `${CONCENTRATION_RANKING_SORTS.join(", ")} (default ${DEFAULT_CONCENTRATION_RANKING_SORT}). EACH SORT KEY HAS ITS OWN "WIDEST FIRST" DIRECTION and that is the default, because getting it wrong inverts the answer: a HIGH nakamoto coefficient means widely shared while a HIGH gini means the opposite. ?order= overrides. A subnet whose lens has no positive distribution sorts LAST in EITHER direction and is flagged unmeasured — riding its nulls up an ascending gini ranking would read as the most perfectly equal subnet on the network when in fact nothing was measured. limit caps the returned subnets (default ` +
   `${CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT}, max ${CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX}) and the max sits above the subnet count on purpose, so ranking the whole network is one request. The network rollup carries dimension-free facts only — MEDIAN gini/nakamoto/top-1 share and how many subnets have a single holder taking the lens — because each subnet's alpha is a different token and a cross-subnet sum of it means nothing. Mainnet-only: the neurons tier carries no network dimension.`;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+import type { Schema } from "./openapi-sample.ts";
+
+type Row = Record<string, unknown>;
+
+/** A typed empty row, so a `?? ` fallback needs no cast. */
+const EMPTY_CONTRACT_ROW: Row = {};
+
+/** The row under an untyped value, or null. */
+function rowOf(value: unknown): Row | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Row)
+    : null;
+}
 
 /**
  * The parameter names `SHARED_QUERY_PARAMETER_DESCRIPTIONS` covers.
@@ -5683,7 +5694,7 @@ type OpenApiExampleRegistry = {
  * than the code merely asserting it never will.
  */
 export function buildOpenApiExampleRegistry(
-  componentSchemas: Row,
+  componentSchemas: Record<string, Schema>,
   routes: readonly (typeof API_ROUTES)[number][] = API_ROUTES,
 ): OpenApiExampleRegistry {
   const examples: Row = {};
@@ -5911,7 +5922,7 @@ function withSharedParameterDescription<T extends object>(parameter: T): T {
 
 export function buildOpenApiArtifact(
   generatedAt: string,
-  componentSchemas: Row | null,
+  componentSchemas: Record<string, Schema> | null,
 ) {
   if (!componentSchemas) {
     throw new Error(
@@ -6053,7 +6064,9 @@ export function buildOpenApiArtifact(
     // previously had no way to even discover.
     const variantPath = networkVariantPath(entry.path);
     if (variantPath) {
-      const base = paths[openApiPath][entry.method.toLowerCase()];
+      const base =
+        rowOf(rowOf(paths[openApiPath])?.[entry.method.toLowerCase()]) ??
+        EMPTY_CONTRACT_ROW;
       paths[variantPath] = {
         ...(paths[variantPath] || {}),
         [entry.method.toLowerCase()]: {
@@ -6077,7 +6090,7 @@ export function buildOpenApiArtifact(
                an empty array is truthy -- so the fallback is unreachable. It
                stays because spreading an absent `parameters` would throw, not
                degrade, if that construction ever became conditional. */
-            ...(base.parameters || []),
+            ...(Array.isArray(base.parameters) ? base.parameters : []),
           ],
         },
       };
@@ -6261,9 +6274,11 @@ const FIXTURE_DETAIL_OPENAPI_EXAMPLE = {
 function openApiExampleForRoute(
   entry: (typeof API_ROUTES)[number],
   responseSchema: Row,
-  componentSchemas: Row,
+  componentSchemas: Record<string, Schema>,
 ) {
-  const example = sampleFromSchema(responseSchema, componentSchemas) as Row;
+  const example =
+    rowOf(sampleFromSchema(responseSchema, componentSchemas)) ??
+    EMPTY_CONTRACT_ROW;
   if (entry.id !== "fixture-detail") {
     return example;
   }
@@ -6638,10 +6653,36 @@ function parameterSchemaFor(
     : { description: inSchemaDescription, ...constraints };
 }
 
+/**
+ * What `queryCollection` accepts, DECLARED.
+ *
+ * It was `Row & { filters?; sort? }`, so the two named options were typed and
+ * every other one was `any` -- `options.rangeFilters` could have been a
+ * string and `options.search` a number, and both would have compiled straight
+ * into the published collection config (#10782).
+ */
+interface QueryCollectionOptions<
+  Filters extends Record<string, z.ZodType>,
+  Sort extends readonly [string, ...string[]],
+> {
+  filters?: Filters;
+  sort?: Sort;
+  /** Param name -> the row field a comma-separated list matches against. */
+  csvFilters?: Record<string, string>;
+  /** Param name -> the row array field(s) whose union is tested. */
+  arrayFilters?: Record<string, string[]>;
+  /** Fields accepting `min_F` / `max_F` inclusive numeric bounds. */
+  rangeFilters?: string[];
+  /** Param name -> the row field whose PRESENCE it tests. */
+  presenceFilters?: Record<string, string>;
+  /** Row fields a free-text `q` searches across. */
+  search?: string[];
+}
+
 function queryCollection<
   Filters extends Record<string, z.ZodType> = Record<string, z.ZodType>,
   Sort extends readonly [string, ...string[]] = readonly [string, ...string[]],
->(dataKey: string, options: Row & { filters?: Filters; sort?: Sort } = {}) {
+>(dataKey: string, options: QueryCollectionOptions<Filters, Sort> = {}) {
   // `filters` is authored as ZOD and stored twice (#10080): once as the emitted
   // JSON every existing reader already uses, and once as the Zod itself so
   // `listQuerySchema()` can compose with it.
@@ -6728,7 +6769,8 @@ export function listQuerySchema(
     extend = {},
   }: ListQuerySchemaOptions = {},
 ): z.ZodObject {
-  const config = (API_QUERY_COLLECTIONS as Record<string, Row>)[collection];
+  const config =
+    API_QUERY_COLLECTIONS[collection as keyof typeof API_QUERY_COLLECTIONS];
   /* v8 ignore next 3 -- same developer config invariant listQuery() guards */
   if (!config) {
     throw new Error(`Unknown API query collection: ${collection}`);
@@ -6994,7 +7036,8 @@ export function collectionQuerySchemas(
   filterNames: string[] = [],
   { csvResponse = false }: { csvResponse?: boolean } = {},
 ): RouteQuerySchemas | null {
-  const config = (API_QUERY_COLLECTIONS as Record<string, Row>)[collection];
+  const config =
+    API_QUERY_COLLECTIONS[collection as keyof typeof API_QUERY_COLLECTIONS];
   if (!config) return null;
   const key = `${collection}|${filterNames.join(",")}|${csvResponse}`;
   const cached = routeQuerySchemas.get(key);
@@ -7153,7 +7196,8 @@ interface ListQuerySchemaOptions {
 }
 
 function listQuery(collection: string, options: { exclude?: string[] } = {}) {
-  const config = (API_QUERY_COLLECTIONS as Record<string, Row>)[collection];
+  const config =
+    API_QUERY_COLLECTIONS[collection as keyof typeof API_QUERY_COLLECTIONS];
   /* v8 ignore next 3 -- developer config invariant validated by OpenAPI/schema checks */
   if (!config) {
     throw new Error(`Unknown API query collection: ${collection}`);

--- a/src/field-projection.ts
+++ b/src/field-projection.ts
@@ -227,8 +227,8 @@ export function projectRows(
  * `fields` -- and so the echo's presence is itself the signal that the body in
  * hand is narrowed, which matters when the response is cached or passed on.
  */
-export function projectionMeta(
-  fields: string[] | null | undefined,
-): Record<string, unknown> {
+export function projectionMeta(fields: string[] | null | undefined): {
+  projection?: { fields: string[] };
+} {
   return fields ? { projection: { fields } } : {};
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -13,7 +13,14 @@ import {
 import {
   GraphQLBoolean,
   GraphQLError,
+  Kind,
+  type ASTVisitor,
+  type DocumentNode,
+  type FragmentDefinitionNode,
   type GraphQLArgument,
+  type SelectionNode,
+  type SelectionSetNode,
+  type ValidationContext,
   type GraphQLObjectType,
   buildSchema,
   execute,
@@ -735,6 +742,14 @@ import {
 } from "./chain-transfer-pairs.ts";
 import { loadBulkHealthTrends } from "./bulk-health-trends.ts";
 import { SDL } from "./graphql-sdl.ts";
+// Types only -- erased at build, so naming the Durable Object's contract here
+// costs the bundle nothing (#10782).
+import type { EconomicsArtifact } from "../schemas-src/routes/economics.ts";
+import type { SubnetRevenueView } from "./revenue-serving.ts";
+import type {
+  ChainFirehoseHub,
+  GraphqlWsConnectionInfo,
+} from "../workers/chain-firehose-hub.ts";
 // types-epic D pilot adoption (#7862): the generated arg types for the 5
 // Query fields with a Zod-covered REST mirror from types-epic A (#7859).
 // NOT the generated `QueryResolvers['field']` Resolver function type itself
@@ -935,8 +950,7 @@ import {
   TAO_USD_TABLES,
 } from "./read-store-tables.ts";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...args: any[]) => any;
 
@@ -1002,9 +1016,22 @@ export const schema = buildSchema(SDL);
 // curated-surfaces collection the REST route uses, so the allowlists cannot
 // drift; with no arguments the parent's surfaces pass through untouched.
 const SUBNET_SURFACES_FILTER_NAMES = ["kind", "provider", "id"];
+
+/**
+ * A `Subnet` as `subnetNode` builds it: a row plus the two lazy list thunks.
+ *
+ * The two resolvers below invoke `parent.surfaces(...)` / `parent.endpoints
+ * (...)` directly rather than letting the default field resolver do it, so
+ * they depend on those being FUNCTIONS -- which `Row` did not say and
+ * `Record<string, any>` let them assume (#10782).
+ */
+interface SubnetNodeParent extends Row {
+  surfaces: (args: Row, context: GqlContext, info: unknown) => unknown;
+  endpoints: (args: Row, context: GqlContext, info: unknown) => unknown;
+}
 (schema.getType("Subnet") as GraphQLObjectType).getFields().surfaces.resolve =
   async function subnetSurfaces(
-    parent: Row,
+    parent: SubnetNodeParent,
     args: Row,
     context: GqlContext,
     info: unknown,
@@ -1055,7 +1082,7 @@ const SUBNET_SURFACES_FILTER_NAMES = ["kind", "provider", "id"];
 // sibling nested Subnet.surfaces field.
 (schema.getType("Subnet") as GraphQLObjectType).getFields().endpoints.resolve =
   async function subnetEndpoints(
-    parent: Row,
+    parent: SubnetNodeParent,
     args: Row,
     context: GqlContext,
     info: unknown,
@@ -1101,11 +1128,36 @@ const SUBNET_SURFACES_FILTER_NAMES = ["kind", "provider", "id"];
   };
 
 export const GRAPHQL_SUBSCRIPTION_CONTEXT_KEY = "chainFirehose";
+
+/**
+ * What `chainEvents.subscribe` reads off its context, named (#10782).
+ *
+ * It was `Row`, and while `Row` was `Record<string, any>` that read as a full
+ * type: `context[KEY].subscribeChainEvents(...)` type-checked because `any`
+ * has every method. The hub crosses the `src/` <-> `workers/` boundary here
+ * with no declaration on either side of it, so nothing said which two methods
+ * this file depends on -- renaming either in the Durable Object would have
+ * compiled and failed at runtime, on the one transport no REST test covers.
+ *
+ * `import type` is fully erased, so naming the real class costs the bundle
+ * nothing and cannot drift from it.
+ */
+interface ChainEventsSubscriptionContext {
+  [GRAPHQL_SUBSCRIPTION_CONTEXT_KEY]?: Pick<
+    ChainFirehoseHub,
+    "subscribeChainEvents" | "unsubscribeChainEvents"
+  >;
+  /** Set by the graphqlWsServer context() callback from ctx.extra.ip. */
+  clientIp?: string;
+  /** The per-socket record the connection-count cap is keyed on. */
+  graphqlWsConnection?: GraphqlWsConnectionInfo;
+}
+
 schema.getSubscriptionType()!.getFields().chainEvents.subscribe =
   async function* chainEventsSubscribe(
     _source: unknown,
     args: Row,
-    context: Row,
+    context: ChainEventsSubscriptionContext,
   ) {
     const hub = context?.[GRAPHQL_SUBSCRIPTION_CONTEXT_KEY];
     if (!hub) {
@@ -1119,7 +1171,12 @@ schema.getSubscriptionType()!.getFields().chainEvents.subscribe =
     // parseChainFirehoseTopics semantics (an all-unrecognized topics= string
     // also collapses to an empty Set, never silently falling back to
     // "everything"). Previously both cases collapsed to null.
-    const topics = args.tables === undefined ? null : new Set(args.tables);
+    // `undefined` (no filter) stays distinct from `[]` (match nothing) --
+    // see the comment above; `stringsOf` only changes what a NON-list or a
+    // non-string element does, which the published `[ChainFirehoseTable!]`
+    // already forbids.
+    const topics =
+      args.tables === undefined ? null : new Set(stringsOf(args.tables));
     // context.clientIp/context.graphqlWsConnection are set by
     // workers/chain-firehose-hub.ts's graphqlWsServer context() callback
     // from ctx.extra.ip/ctx.extra.graphqlWsConnection (populated by
@@ -1378,10 +1435,15 @@ function fieldComplexity(fieldName: string) {
 
 // --- Validation rules ---
 
-function buildFragmentMap(documentNode: Row) {
-  const fragments = new Map();
+// The AST types below are graphql-js's own. They were `Row`, and `Row` was
+// `Record<string, any>` -- so this whole walker read as typed while every
+// `.kind`, `.selections` and `.name.value` was unchecked. A renamed AST field,
+// or a wrong string in a `kind` comparison, would have compiled and silently
+// measured every query as depth 0, disabling both limits (#10782).
+function buildFragmentMap(documentNode: DocumentNode) {
+  const fragments = new Map<string, FragmentDefinitionNode>();
   for (const def of documentNode.definitions) {
-    if (def.kind === "FragmentDefinition") {
+    if (def.kind === Kind.FRAGMENT_DEFINITION) {
       fragments.set(def.name.value, def);
     }
   }
@@ -1396,8 +1458,10 @@ function buildFragmentMap(documentNode: Row) {
 // stays enabled over POST, matching the documented contract. Sibling data fields
 // in the same operation are still measured, so a mixed query stays bounded.
 const INTROSPECTION_ROOT_FIELDS = new Set(["__schema", "__type"]);
-function isIntrospectionRootField(sel: Row) {
-  return sel.kind === "Field" && INTROSPECTION_ROOT_FIELDS.has(sel.name?.value);
+function isIntrospectionRootField(sel: SelectionNode) {
+  return (
+    sel.kind === Kind.FIELD && INTROSPECTION_ROOT_FIELDS.has(sel.name.value)
+  );
 }
 
 // Depth/complexity must follow named fragment spreads. Otherwise a client moves
@@ -1412,8 +1476,8 @@ function isIntrospectionRootField(sel: Row) {
 // field. Counting them would over-measure a query relative to its equivalent
 // inlined or named-fragment form, wrongly rejecting valid queries.
 function selectionDepth(
-  selectionSet: Row,
-  fragments: Map<string, Row>,
+  selectionSet: SelectionSetNode,
+  fragments: Map<string, FragmentDefinitionNode>,
   visited: Set<string>,
   memo: Map<string, number>,
   max: number,
@@ -1422,7 +1486,7 @@ function selectionDepth(
   for (const sel of selectionSet.selections) {
     if (isIntrospectionRootField(sel)) continue; // schema-only: depth 0
     let depth = 0;
-    if (sel.kind === "FragmentSpread") {
+    if (sel.kind === Kind.FRAGMENT_SPREAD) {
       const fragName = sel.name.value;
       const frag = fragments.get(fragName);
       if (frag && !visited.has(fragName)) {
@@ -1439,7 +1503,7 @@ function selectionDepth(
           memo.set(fragName, depth);
         }
       }
-    } else if (sel.kind === "InlineFragment") {
+    } else if (sel.kind === Kind.INLINE_FRAGMENT) {
       // Transparent: recurse at the same depth (the type condition is not a level).
       depth = selectionDepth(sel.selectionSet, fragments, visited, memo, max);
     } else if (sel.selectionSet) {
@@ -1453,12 +1517,12 @@ function selectionDepth(
 }
 
 export function maxDepthRule(max: number) {
-  return (context: Row) => ({
+  return (context: ValidationContext): ASTVisitor => ({
     Document: {
-      leave(node: Row) {
+      leave(node: DocumentNode) {
         const fragments = buildFragmentMap(node);
         for (const def of node.definitions) {
-          if (def.kind === "OperationDefinition") {
+          if (def.kind === Kind.OPERATION_DEFINITION) {
             const depth = selectionDepth(
               def.selectionSet,
               fragments,
@@ -1482,8 +1546,8 @@ export function maxDepthRule(max: number) {
 }
 
 function selectionComplexity(
-  selectionSet: Row,
-  fragments: Map<string, Row>,
+  selectionSet: SelectionSetNode,
+  fragments: Map<string, FragmentDefinitionNode>,
   visited: Set<string>,
   memo: Map<string, number>,
   max: number,
@@ -1491,7 +1555,7 @@ function selectionComplexity(
   let count = 0;
   for (const sel of selectionSet.selections) {
     if (isIntrospectionRootField(sel)) continue; // schema-only: no complexity cost
-    if (sel.kind === "FragmentSpread") {
+    if (sel.kind === Kind.FRAGMENT_SPREAD) {
       const fragName = sel.name.value;
       const frag = fragments.get(fragName);
       if (frag && !visited.has(fragName)) {
@@ -1509,7 +1573,7 @@ function selectionComplexity(
           count += fragCount;
         }
       }
-    } else if (sel.kind === "InlineFragment") {
+    } else if (sel.kind === Kind.INLINE_FRAGMENT) {
       // Transparent like a named spread: count the contained fields, not the
       // inline type condition itself.
       count += selectionComplexity(
@@ -1537,12 +1601,12 @@ function selectionComplexity(
 }
 
 export function maxComplexityRule(max: number) {
-  return (context: Row) => ({
+  return (context: ValidationContext): ASTVisitor => ({
     Document: {
-      leave(node: Row) {
+      leave(node: DocumentNode) {
         const fragments = buildFragmentMap(node);
         for (const def of node.definitions) {
-          if (def.kind === "OperationDefinition") {
+          if (def.kind === Kind.OPERATION_DEFINITION) {
             const complexity = selectionComplexity(
               def.selectionSet,
               fragments,
@@ -1656,24 +1720,142 @@ const LIVE_ECONOMICS_KEY = "live:economics";
 // Resolve an async value at most once per query: a page of subnets each pulling
 // a relationship shares one read of each registry artifact (and one live health
 // snapshot). The promise is cached so concurrent thunks collapse onto one read.
-function once(
+/**
+ * Memoise one load per request, KEEPING ITS TYPE.
+ *
+ * This returned `Promise<Row | null>` regardless of what it was handed, so
+ * every loader that went through it came out an untyped bag -- and with `Row`
+ * as `Record<string, any>` that bag then satisfied any shape a caller wanted.
+ * It is the choke point the whole file's typing runs through: 17 of the errors
+ * this generic removes are callers doing `data?.subnets?.find(...)` on a value
+ * nothing described (#10782).
+ *
+ * The cast remains and is the load-bearing one: the cache is a single map
+ * shared by loads of different shapes, keyed by string, so its value type
+ * cannot be expressed without a per-key registry. `key` and `load` agreeing is
+ * the caller's invariant -- the same one the old signature had, now visible in
+ * exactly one place instead of erased at every call site.
+ */
+function once<T>(
   context: GqlContext,
   key: string,
-  load: AnyFn,
-): Promise<Row | null> {
+  load: () => Promise<T>,
+): Promise<T> {
   let pending = context.cache.get(key);
   if (!pending) {
     pending = load();
     context.cache.set(key, pending);
   }
-  return pending as Promise<Row | null>;
+  return pending as Promise<T>;
+}
+
+/**
+ * The rows under an untyped value, or empty.
+ *
+ * Replaces `rowsOf(data.x).map(...)`, which was two bugs wearing one idiom:
+ * `??` only substitutes for null/undefined, so a truthy NON-array (an object
+ * where the producer meant a list, a cold tier answering `{}`) sailed through
+ * to `.map` and threw at runtime. And with `Row` as `Record<string, any>` the
+ * type system had nothing to say about it. This checks what the idiom only
+ * looked like it checked (#10782).
+ */
+function rowsOf(value: unknown): Row[] {
+  return Array.isArray(value) ? (value as Row[]) : [];
+}
+
+/**
+ * The single row under an untyped value, or null.
+ *
+ * The scalar sibling of {@link rowsOf}, and it closes the same hole: a bare
+ * `value ? value.field : …` accepts any truthy value, so a string or a number
+ * where the producer meant an object reached the property access and answered
+ * `undefined` for every field. An ARRAY is rejected too -- reading `.field`
+ * off a list is the same mistake with a different shape.
+ */
+/**
+ * A thrown value's message.
+ *
+ * `catch (e)` gives `unknown`, correctly -- anything can be thrown. This file
+ * was casting each one to a `Row` and reading `.message` off it, which with
+ * `Row` as `Record<string, any>` compiled and would have printed `undefined`
+ * for a thrown string. Same idiom the watchdogs already use
+ * (`err instanceof Error ? err.message : String(err)`), in one place.
+ */
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/** A typed empty row, so `rowOf(x) ?? EMPTY_ROW` needs no cast. */
+const EMPTY_ROW: Row = {};
+
+/**
+ * A declared object, viewed as a row.
+ *
+ * An `interface` has no index signature, so TypeScript will not accept one as
+ * `Record<string, unknown>` even though every property is assignable to
+ * `unknown`. That is the rule, not a smell -- an interface can be augmented.
+ * Spreading produces a fresh object literal, which IS assignable, so this is
+ * the structural conversion rather than an assertion over it. Used where a
+ * producer that HAS a real type meets a resolver path that still speaks rows
+ * (#10782); each call is a place the row-shaped path should eventually take
+ * the producer's type instead (#10784).
+ */
+function toRow(value: object): Row {
+  // The one assertion this file keeps, and the reason it cannot be removed:
+  // TypeScript refuses `interface -> Record<string, unknown>` because an
+  // interface is open to declaration merging, so a later augmentation could
+  // add a property the index signature does not describe. Every property of
+  // every caller here IS assignable to `unknown`; the rule is about what
+  // could be added later, not about the value. Spreading first makes the
+  // result a fresh literal, so nothing aliases the producer's object.
+  return { ...value } as Row;
+}
+
+/** The numbers under an untyped value, or empty. */
+function numbersOf(value: unknown): number[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is number => typeof entry === "number")
+    : [];
+}
+
+/** The strings under an untyped value, or empty. The scalar-list sibling of
+ *  {@link rowsOf}. */
+function stringsOf(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function rowOf(value: unknown): Row | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Row)
+    : null;
 }
 
 // Artifact data, or null when cold/absent — resolvers degrade to empty shapes
 // rather than erroring, like the REST handlers.
-function loadArtifact(context: GqlContext, path: string) {
+//
+// GENERIC, and the type parameter is a CLAIM, not a proof: `readArtifact`
+// honestly returns `data: unknown`, because a baked artifact is data crossing
+// a trust boundary. Naming the expected shape at the call site is strictly
+// better than the `Row` this returned before -- every USE of the value is now
+// checked against the shape the caller says it is, where previously
+// `Record<string, any>` accepted any use at all. It is not a substitute for
+// parsing the boundary, which is #10789's job; REST already parses its own
+// side (`src/response-validation-tripwire.ts`).
+// The default is `Row` -- `Record<string, unknown>` -- because that is what a
+// parsed JSON artifact honestly is: an object whose values are not yet known.
+// It keeps property ACCESS legal (a JSON object has arbitrary keys) while
+// keeping every USE checked, which is the split `unknown` gets wrong in one
+// direction and `any` in the other. A caller that knows the shape names it.
+function loadArtifact<T = Row>(
+  context: GqlContext,
+  path: string,
+): Promise<T | null> {
   return once(context, path, () =>
-    readArtifact(context.env, path).then((res) => (res.ok ? res.data : null)),
+    readArtifact(context.env, path).then((res) =>
+      res.ok ? (res.data as T) : null,
+    ),
   );
 }
 
@@ -1685,8 +1867,7 @@ async function loadRows(
   netuid?: number | null,
 ) {
   const data = await loadArtifact(context, path);
-  const rows = data?.[key];
-  if (!Array.isArray(rows)) return [];
+  const rows = rowsOf(data?.[key]);
   return netuid == null ? rows : rows.filter((row) => row?.netuid === netuid);
 }
 
@@ -1729,14 +1910,16 @@ function loadEconomics(
       });
       // Spot on every row (#9408 completion), on whichever tier answered.
       if (Array.isArray(live?.data?.subnets)) {
-        return withSpotPricedEconomics(live.data as Row);
+        return withSpotPricedEconomics(live.data as EconomicsArtifact);
       }
     }
     const res = await readArtifact(
       context.env,
       networkArtifactPath(ARTIFACT.economics, network),
     );
-    return res.ok ? withSpotPricedEconomics(res.data as Row) : null;
+    return res.ok
+      ? withSpotPricedEconomics(res.data as EconomicsArtifact)
+      : null;
   });
 }
 
@@ -1789,7 +1972,7 @@ async function taoUsdForRevenue(context: GqlContext): Promise<number | null> {
 async function revenueForNetuid(
   context: GqlContext,
   netuid: number,
-): Promise<Row> {
+): Promise<SubnetRevenueView> {
   const rows = (await loadEconomicsRows(context)) as Row[];
   const economics = rows.find((row) => Number(row?.netuid) === netuid) ?? null;
   const observations = await loadRevenueObservations(
@@ -1917,8 +2100,14 @@ async function fetchAllEventsTierFromDataApi(
 // `prefetch` lets the single-subnet path serve surfaces/endpoints from the
 // detail artifact it already read; economics + health are not in that artifact.
 function subnetNode(identity: Row, prefetch: Row = {}) {
-  const netuid = identity.netuid;
-  const bundledOr = (rows: Row[] | undefined, load: AnyFn) =>
+  // Every consumer below takes a number, and the identity row's value is
+  // whatever the artifact carried. `Number(...)` is what each loader did to it
+  // internally anyway; doing it once here is the same coercion, stated.
+  const netuid = Number(identity.netuid);
+  const bundledOr = (
+    rows: Row[] | undefined,
+    load: (context: GqlContext, netuid: number) => unknown,
+  ) =>
     rows !== undefined
       ? () => rows ?? []
       : (_args: unknown, context: GqlContext) => load(context, netuid);
@@ -1928,8 +2117,14 @@ function subnetNode(identity: Row, prefetch: Row = {}) {
       loadSubnetHealth(context, netuid),
     economics: (_args: unknown, context: GqlContext) =>
       loadSubnetEconomics(context, netuid),
-    surfaces: bundledOr(prefetch.surfaces, loadSubnetSurfaces),
-    endpoints: bundledOr(prefetch.endpoints, loadSubnetEndpoints),
+    surfaces: bundledOr(
+      prefetch.surfaces === undefined ? undefined : rowsOf(prefetch.surfaces),
+      loadSubnetSurfaces,
+    ),
+    endpoints: bundledOr(
+      prefetch.endpoints === undefined ? undefined : rowsOf(prefetch.endpoints),
+      loadSubnetEndpoints,
+    ),
   };
 }
 
@@ -1987,7 +2182,10 @@ function turnoverChangesNode(detail: Row | null | undefined) {
 // JSON scalar exists in this schema yet" -- `scalar JSON` is the SDL's first
 // declaration and 116 fields already use it, `ChainEvent.args` (the sibling
 // with the same object-or-array duality) among them.
-function extrinsicNode(extrinsic: Row) {
+// Takes the nullish it was already written to handle: the body is
+// `extrinsic ?? null`, and the parameter said `Row`. Callers pass a value that
+// may be absent (a malformed tier body has no `extrinsic` key).
+function extrinsicNode(extrinsic: Row | null | undefined) {
   return extrinsic ?? null;
 }
 
@@ -2093,14 +2291,16 @@ function accountSummaryNode(data: Row, ss58: string) {
 }
 
 function providerNode(provider: Row) {
-  const netuids = provider?.netuids || [];
+  // The artifact's own list; `numbersOf` is what `|| []` only looked like it
+  // was doing -- a truthy non-list reached `loadProviderSubnets` before.
+  const netuids = numbersOf(provider?.netuids);
   return {
     ...provider,
     netuids,
     subnets: (_args: unknown, context: GqlContext) =>
       loadProviderSubnets(context, netuids),
     endpoints: (_args: unknown, context: GqlContext) =>
-      loadProviderEndpoints(context, provider.id),
+      loadProviderEndpoints(context, String(provider.id)),
   };
 }
 
@@ -2146,10 +2346,15 @@ async function loadProviderSubnets(context: GqlContext, netuids: number[]) {
   if (!netuids.length) return [];
   const rows = await loadRows(context, ARTIFACT.subnets, "subnets");
   const byNetuid = new Map(rows.map((row) => [row.netuid, row]));
-  return netuids
-    .map((netuid: number) => byNetuid.get(netuid))
-    .filter(Boolean)
-    .map((row: Row) => subnetNode(row));
+  return (
+    netuids
+      .map((netuid: number) => byNetuid.get(netuid))
+      // `.filter(Boolean)` does not narrow the type -- a netuid the index does
+      // not carry yielded `undefined` and reached `subnetNode`, which read
+      // `identity.netuid` off it. The predicate says what the filter meant.
+      .filter((row): row is Row => Boolean(row))
+      .map((row: Row) => subnetNode(row))
+  );
 }
 
 // --- Resolvers ---
@@ -2169,6 +2374,29 @@ const SUBNET_SORT_FIELDS = [
 
 // Shared list shape: load → optional netuid filter → paginate → wrap. `map`
 // node-wraps rows; `resultKey` is the list field's name (economics uses
+/**
+ * `listPage`'s options, declared rather than destructured out of a `Row`.
+ *
+ * A local options bag is one of the few shapes that legitimately has no
+ * contract behind it -- but destructuring it from `Record<string, any>` gave
+ * every field `any`, so `filterFn` could have been a number and `limit` a
+ * function and both would have compiled (#10782).
+ */
+interface ListPageOptions {
+  limit?: unknown;
+  cursor?: unknown;
+  /** REQUIRED: `paginate` calls it unconditionally to mint the next cursor,
+   *  so an omitted one threw the moment a list outgrew a page. */
+  keyFn: (row: Row) => unknown;
+  netuid?: number | null;
+  map?: (row: Row) => unknown;
+  /** `subnets` for the subnet index, `items` everywhere else. */
+  resultKey?: string;
+  filterFn?: (row: Row) => boolean;
+  /** A whole-list transform (multi-filter + sort) applied before pagination. */
+  transform?: (rows: Row[]) => Row[];
+}
+
 // `subnets`, the rest use `items`).
 async function listPage(
   context: GqlContext,
@@ -2183,7 +2411,7 @@ async function listPage(
     resultKey = "items",
     filterFn,
     transform,
-  }: Row,
+  }: ListPageOptions,
 ) {
   let all = await loadRows(context, path, key, netuid);
   if (filterFn) {
@@ -2447,7 +2675,7 @@ const rootValue = {
     // The detail artifact nests identity under `subnet` (flat shapes fall back)
     // and bundles surfaces/endpoints, so those resolve from this one read;
     // economics is overlaid live at serve time, so it loads lazily.
-    const identity = data.subnet ?? data;
+    const identity = rowOf(data.subnet) ?? data;
     // The detail artifact omits the list artifact's computed registry metrics
     // (integration_readiness, official_surface_count, gap_count, first_party),
     // so without this backfill the single-subnet path returns them null while
@@ -2643,9 +2871,9 @@ const rootValue = {
         readArtifact: loadArtifact as AnyFn,
       });
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       if (err?.profilesMcp) {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -2682,9 +2910,9 @@ const rootValue = {
     try {
       return await loadFixture(mcpCtx(context), args, { readArtifact });
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -4253,9 +4481,9 @@ const rootValue = {
       });
       rows = data.providers as Row[];
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -4277,7 +4505,7 @@ const rootValue = {
     if (typeof id !== "string" || !VALID_PROVIDER_ID.test(id)) return null;
     const data = await loadArtifact(context, `/metagraph/providers/${id}.json`);
     if (!data) return null;
-    return providerNode(data.provider ?? data);
+    return providerNode(rowOf(data.provider) ?? data);
   },
 
   // #6984: reuse loadAdapter (the same loader MCP get_adapter already calls)
@@ -4290,9 +4518,9 @@ const rootValue = {
     try {
       return await loadAdapter(mcpCtx(context), { slug }, { readArtifact });
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -4463,12 +4691,12 @@ const rootValue = {
       // flow" contract as every other opaque-JSON boundary in this file.
       return await runSavedQuery(context.env, id, (params ?? {}) as Row);
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       if (
         err?.toolError &&
         (err.code === "not_found" || err.code === "invalid_params")
       ) {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -5425,11 +5653,11 @@ const rootValue = {
         readArtifact,
       });
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       // An unsupported sort/limit/cursor is BAD_USER_INPUT, matching every
       // other field's "not a silently substituted default" convention.
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -5465,11 +5693,11 @@ const rootValue = {
         readArtifact,
       });
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       // An unsupported filter/sort value is BAD_USER_INPUT, matching every
       // other field's "not a silently substituted default" convention.
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -5498,12 +5726,12 @@ const rootValue = {
         readArtifact,
       });
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       // An invalid netuid or unsupported filter/sort value is BAD_USER_INPUT,
       // matching every other field's "not a silently substituted default"
       // convention.
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -5648,7 +5876,7 @@ const rootValue = {
         nextCursor: null,
       });
     return {
-      items: (data.extrinsics || []).map(extrinsicNode),
+      items: rowsOf(data.extrinsics).map(extrinsicNode),
       total: data.extrinsic_count ?? 0,
       next_cursor: data.next_cursor ?? null,
     };
@@ -5711,9 +5939,9 @@ const rootValue = {
         })),
       };
     } catch (rawErr) {
-      const err = rawErr as Row;
+      const err = rowOf(rawErr);
       if (err?.toolError && err.code === "invalid_params") {
-        throw new GraphQLError(err.message, {
+        throw new GraphQLError(errorMessage(rawErr), {
           extensions: { code: "BAD_USER_INPUT" },
         });
       }
@@ -5740,11 +5968,10 @@ const rootValue = {
     try {
       window = optionalBlocksWindow({ blocks });
     } catch (rawErr) {
-      const err = rawErr as Row;
       // optionalBlocksWindow's only failure is invalid_params (a non-positive
       // or non-integer blocks) — surface it as BAD_USER_INPUT, mirroring how
       // chain_events maps the sibling feed's invalid-filter error.
-      throw new GraphQLError(err.message, {
+      throw new GraphQLError(errorMessage(rawErr), {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
@@ -5832,7 +6059,7 @@ const rootValue = {
         nextCursor: null,
       });
     return {
-      items: (data.extrinsics || []).map(extrinsicNode),
+      items: rowsOf(data.extrinsics).map(extrinsicNode),
       total: data.extrinsic_count ?? 0,
       next_cursor: data.next_cursor ?? null,
     };
@@ -5851,15 +6078,17 @@ const rootValue = {
       // The same hot/cold cascade REST and MCP run (#9540). A composite
       // "<block>-<index>" ref routes through answerBlockDetail, so it inherits
       // the gap case -- raised, not flattened to an empty extrinsic.
-      (gapAwareBlockDetail(
-        await answerExtrinsicDetail(context.env, ref, () =>
-          loadExtrinsicColdTier(context.env, ref),
+      toRow(
+        gapAwareBlockDetail(
+          await answerExtrinsicDetail(context.env, ref, () =>
+            loadExtrinsicColdTier(context.env, ref),
+          ),
+          () => buildExtrinsic(undefined, ref),
         ),
-        () => buildExtrinsic(undefined, ref),
-      ) as Row);
+      );
     return {
       ref: data.ref ?? ref,
-      extrinsic: extrinsicNode(data.extrinsic),
+      extrinsic: extrinsicNode(rowOf(data.extrinsic)),
     };
   },
 
@@ -5951,7 +6180,7 @@ const rootValue = {
         nextCursor: null,
       });
     return {
-      items: (data.extrinsics || []).map(extrinsicNode),
+      items: rowsOf(data.extrinsics).map(extrinsicNode),
       total: data.extrinsic_count ?? 0,
       next_cursor: data.next_cursor ?? null,
     };
@@ -6296,7 +6525,7 @@ const rootValue = {
           priceByNetuid: NO_ALPHA_PRICES,
         }),
     )! as Row;
-    const nodes = (data.validators || []).map(validatorNode);
+    const nodes = rowsOf(data.validators).map(validatorNode);
     const { page, total, nextCursor } = paginate(
       nodes,
       limit,
@@ -6666,9 +6895,9 @@ const rootValue = {
     }
     const data =
       postgres ??
-      ((answer?.kind === "answer"
-        ? answer.data
-        : buildAccountSummary(ss58, {})) as Row);
+      (answer?.kind === "answer"
+        ? toRow(answer.data)
+        : toRow(buildAccountSummary(ss58, {})));
     return accountSummaryNode(data, ss58);
   },
 
@@ -6969,7 +7198,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s: Row) => ({
+      subnets: rowsOf(data.subnets).map((s: Row) => ({
         netuid: s.netuid,
         registrations: s.registrations,
         first_registered_at: s.first_registered_at ?? null,
@@ -7022,9 +7251,11 @@ const rootValue = {
           window: windowParam,
         })
       )?.data as Row | undefined) ??
-      (markDeregistrationsNotDerived(
-        buildAccountDeregistrations([], ss58, { window: windowParam }),
-      ) as Row);
+      toRow(
+        markDeregistrationsNotDerived(
+          buildAccountDeregistrations([], ss58, { window: windowParam }),
+        ),
+      );
     return {
       schema_version: data.schema_version ?? 1,
       address: data.address ?? ss58,
@@ -7033,7 +7264,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s: Row) => ({
+      subnets: rowsOf(data.subnets).map((s: Row) => ({
         netuid: s.netuid,
         deregistrations: s.deregistrations,
         first_deregistered_at: s.first_deregistered_at ?? null,
@@ -7096,7 +7327,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s: Row) => ({
+      subnets: rowsOf(data.subnets).map((s: Row) => ({
         netuid: s.netuid,
         announcements: s.announcements,
         first_served_at: s.first_served_at ?? null,
@@ -7150,7 +7381,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s: Row) => ({
+      subnets: rowsOf(data.subnets).map((s: Row) => ({
         netuid: s.netuid,
         removals: s.removals,
         first_removed_at: s.first_removed_at ?? null,
@@ -7214,7 +7445,7 @@ const rootValue = {
       subnet_count: data.subnet_count ?? 0,
       concentration: data.concentration ?? null,
       dominant_netuid: data.dominant_netuid ?? null,
-      subnets: (data.subnets ?? []).map((s: Row) => ({
+      subnets: rowsOf(data.subnets).map((s: Row) => ({
         netuid: s.netuid,
         movements: s.movements,
         first_moved_at: s.first_moved_at ?? null,
@@ -7310,7 +7541,9 @@ const rootValue = {
     const data = await answerAccountEntities(context.env, ss58, null);
     const labels = labelsForSs58(
       entityLabelsIndex(
-        entitiesArtifact.ok ? (entitiesArtifact.data as Row)?.entities : [],
+        entitiesArtifact.ok
+          ? rowsOf(rowOf(entitiesArtifact.data)?.entities)
+          : [],
       ),
       ss58,
     );
@@ -7411,7 +7644,7 @@ const rootValue = {
       limit: data.limit ?? null,
       offset: data.offset ?? null,
       next_cursor: data.next_cursor ?? null,
-      entries: (data.entries ?? []).map((e: Row) => ({
+      entries: rowsOf(data.entries).map((e: Row) => ({
         observed_at: e.observed_at ?? null,
         name: e.name ?? null,
         url: e.url ?? null,
@@ -7504,10 +7737,12 @@ const rootValue = {
           relationship: rel,
         };
       } else {
-        data = buildCounterparties([], ss58, { limit: limit ?? undefined });
+        data = toRow(
+          buildCounterparties([], ss58, { limit: limit ?? undefined }),
+        );
       }
     }
-    const rel = data.relationship;
+    const rel = rowOf(data.relationship);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -7516,7 +7751,7 @@ const rootValue = {
       scan_capped: data.scan_capped ?? false,
       total_sent_tao: data.total_sent_tao ?? 0,
       total_received_tao: data.total_received_tao ?? 0,
-      counterparties: (data.counterparties ?? []).map((c: Row) => ({
+      counterparties: rowsOf(data.counterparties).map((c: Row) => ({
         address: c.address,
         sent_tao: c.sent_tao ?? 0,
         received_tao: c.received_tao ?? 0,
@@ -7540,7 +7775,7 @@ const rootValue = {
             first_seen_at: rel.first_seen_at ?? null,
             last_seen_at: rel.last_seen_at ?? null,
             limit: rel.limit ?? 0,
-            transfers: (rel.transfers ?? []).map((t: Row) => ({
+            transfers: rowsOf(rel.transfers).map((t: Row) => ({
               block_number: t.block_number ?? null,
               event_index: t.event_index ?? null,
               netuid: t.netuid ?? null,
@@ -7623,7 +7858,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      transfers: (data.transfers ?? []).map((t: Row) => ({
+      transfers: rowsOf(data.transfers).map((t: Row) => ({
         block_number: t.block_number ?? null,
         event_index: t.event_index ?? null,
         from: t.from ?? null,
@@ -7702,7 +7937,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      extrinsics: (data.extrinsics || []).map(extrinsicNode),
+      extrinsics: rowsOf(data.extrinsics).map(extrinsicNode),
     };
   },
 
@@ -7777,7 +8012,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      events: (data.events ?? []).map((e: Row) => ({
+      events: rowsOf(data.events).map((e: Row) => ({
         block_number: e.block_number ?? null,
         event_index: e.event_index ?? null,
         event_kind: e.event_kind ?? null,
@@ -7863,7 +8098,7 @@ const rootValue = {
       limit: data.limit ?? safeLimit,
       offset: data.offset ?? safeOffset,
       next_cursor: data.next_cursor ?? null,
-      days: (data.days ?? []).map((d: Row) => ({
+      days: rowsOf(data.days).map((d: Row) => ({
         day: d.day ?? null,
         netuid: d.netuid ?? null,
         event_count: d.event_count ?? null,
@@ -8073,7 +8308,7 @@ const rootValue = {
         sort: requestedSort,
         limit: requestedLimit,
       });
-    const network = data.network ?? {};
+    const network = rowOf(data.network) ?? EMPTY_ROW;
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? requestedWindow,
@@ -8213,7 +8448,7 @@ const rootValue = {
       window: data.window ?? label,
       observed_at: data.observed_at ?? null,
       day_count: data.day_count ?? 0,
-      days: (data.days ?? []).map((d: Row) => ({
+      days: rowsOf(data.days).map((d: Row) => ({
         day: d.day,
         block_count: d.block_count ?? 0,
         extrinsic_count: d.extrinsic_count ?? 0,
@@ -8300,7 +8535,7 @@ const rootValue = {
       observed_at: data.observed_at ?? null,
       total_extrinsics: data.total_extrinsics ?? 0,
       call_count: data.call_count ?? 0,
-      calls: (data.calls ?? []).map((c: Row) => ({
+      calls: rowsOf(data.calls).map((c: Row) => ({
         call_module: c.call_module,
         call_function: c.call_function ?? null,
         count: c.count ?? 0,
@@ -8367,7 +8602,7 @@ const rootValue = {
       window: data.window ?? label,
       observed_at: data.observed_at ?? null,
       day_count: data.day_count ?? 0,
-      daily: (data.daily ?? []).map((d: Row) => ({
+      daily: rowsOf(data.daily).map((d: Row) => ({
         day: d.day,
         extrinsic_count: d.extrinsic_count ?? 0,
         signed_extrinsic_count: d.signed_extrinsic_count ?? 0,
@@ -8378,7 +8613,7 @@ const rootValue = {
         avg_tip_tao: d.avg_tip_tao ?? null,
         median_tip_tao: d.median_tip_tao ?? null,
       })),
-      top_fee_payers: (data.top_fee_payers ?? []).map((p: Row) => ({
+      top_fee_payers: rowsOf(data.top_fee_payers).map((p: Row) => ({
         signer: p.signer,
         total_fee_tao: p.total_fee_tao ?? null,
         total_tip_tao: p.total_tip_tao ?? null,
@@ -8594,12 +8829,14 @@ const rootValue = {
         },
         chainNetworkFromChainName(network),
       )) as Row | null) ??
-      (markDeregistrationsNotDerived(
-        buildChainDeregistrations([], {
-          window: requestedWindow,
-          limit: safeLimit,
-        }),
-      ) as Row);
+      toRow(
+        markDeregistrationsNotDerived(
+          buildChainDeregistrations([], {
+            window: requestedWindow,
+            limit: safeLimit,
+          }),
+        ),
+      );
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? requestedWindow,
@@ -8821,7 +9058,7 @@ const rootValue = {
       sort: data.sort ?? CHAIN_SIGNERS_SORTS[0],
       observed_at: data.observed_at ?? null,
       signer_count: data.signer_count ?? 0,
-      signers: (data.signers ?? []).map((entry: Row) => ({
+      signers: rowsOf(data.signers).map((entry: Row) => ({
         signer: entry.signer,
         tx_count: entry.tx_count ?? 0,
         total_fee_tao: entry.total_fee_tao ?? null,
@@ -9582,9 +9819,9 @@ const rootValue = {
       window: requestedWindow,
       observedAt: await loadObservedAt(context),
     })) as Row;
-    const summary = data.summary ?? {};
-    const latency = summary.latency_ms ?? {};
-    const coverage = data.coverage ?? {};
+    const summary = rowOf(data.summary) ?? EMPTY_ROW;
+    const latency = rowOf(summary.latency_ms) ?? EMPTY_ROW;
+    const coverage = rowOf(data.coverage) ?? EMPTY_ROW;
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? requestedWindow,
@@ -9701,7 +9938,7 @@ const rootValue = {
         postgresTierRequest(context, "/api/v1/chain/yield"),
         "METAGRAPH_NEURONS_SOURCE",
       )) as Row | null) ?? buildChainYield([]);
-    const distribution = data.distribution ?? null;
+    const distribution = rowOf(data.distribution);
     return {
       schema_version: data.schema_version ?? 1,
       subnet_count: data.subnet_count ?? 0,

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -7,6 +7,7 @@
 // serving zero-downtime and regression-proof. No I/O here: callers pass parsed
 // objects + D1 rows in.
 
+import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
 import {
   computeReliability,
   scoreFromStats,
@@ -2223,9 +2224,15 @@ export async function resolveLiveEconomics({
  * cannot drift about what "spot" means -- including the root special case, where there
  * is no AMM and the price is 1 by definition rather than a ratio of absent reserves.
  */
-export function withSpotPrice(
-  row: Row | null | undefined,
-): Row | null | undefined {
+// Typed to the CONTRACT rather than to a bag (#10782). Every caller of the
+// pair below already cast on the way in and on the way out --
+// `withSpotPricedEconomics(blob as Row) as typeof baseData` at three of the
+// four sites -- which is the signature being ignored rather than used. Both
+// functions are shape-preserving, so the honest spelling is the row/artifact
+// in and the same out.
+export function withSpotPrice<T extends SubnetEconomicsRow | null | undefined>(
+  row: T,
+): T {
   if (!row || typeof row !== "object") return row;
   return {
     ...row,
@@ -2248,16 +2255,43 @@ export function withSpotPrice(
  * here. Null-safe: a blob that is not an object, or has no subnets array, is
  * returned unchanged.
  */
-export function withSpotPricedEconomics(
-  blob: Row | null | undefined,
-): Row | null | undefined {
+export function withSpotPricedEconomics<T extends object | null | undefined>(
+  blob: T,
+): T {
   if (!blob || typeof blob !== "object") return blob;
-  const rows = blob.subnets;
+  // Read through a row view rather than constraining `T` to `{subnets?: …}`:
+  // that constraint turns every object-literal argument into an
+  // excess-property check, which is a different rule from the one intended.
+  const rows = (blob as Row).subnets;
   if (!Array.isArray(rows)) return blob;
   return {
     ...blob,
-    subnets: (rows as Row[]).map((row) => withSpotPrice(row)),
+    subnets: (rows as SubnetEconomicsRow[]).map((row) => withSpotPrice(row)),
   };
+}
+
+/**
+ * One subnet's row out of an economics blob, typed to the contract.
+ *
+ * THE ONE PLACE the blob's rows become `SubnetEconomicsRow`. The assertion is
+ * this module's declared boundary -- the blob is produced against
+ * `SubnetEconomicsSchema` and `withSpotPrice`/`withSpotPricedEconomics` above
+ * already read it that way -- and consolidating it here is what lets the MCP
+ * economics tools hand a typed row to `loadSubnetOwnerCut` and
+ * `loadSubnetRevenue`, both of which declare `SubnetEconomicsRow | null`,
+ * without each of them restating the assumption (#10782). #10789 replaces the
+ * assertion with a parse; until then there is exactly one to replace.
+ */
+export function subnetEconomicsRow(
+  economicsBlob: Row | null | undefined,
+  netuid: unknown,
+): SubnetEconomicsRow | null {
+  const rows = economicsBlob?.subnets;
+  if (!Array.isArray(rows)) return null;
+  return (
+    (rows as SubnetEconomicsRow[]).find((entry) => entry?.netuid === netuid) ??
+    null
+  );
 }
 
 export function overlaySubnetEconomics(
@@ -2266,9 +2300,7 @@ export function overlaySubnetEconomics(
   netuid: unknown,
 ): Row | null | undefined {
   if (!detail || typeof detail !== "object") return detail;
-  const rows = economicsBlob?.subnets;
-  if (!Array.isArray(rows)) return detail;
-  const row = (rows as Row[]).find((entry) => entry?.netuid === netuid);
+  const row = subnetEconomicsRow(economicsBlob, netuid);
   if (!row) return detail;
   return { ...detail, economics: withSpotPrice(row) };
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -35,6 +35,7 @@
 // exists to prevent for a human clicking through a browser. Revisit only via
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
+import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
 import { clampToolLimit } from "../workers/request-params.ts";
 import { serveWithSdk } from "./mcp-sdk-adapter.ts";
@@ -1211,6 +1212,7 @@ import {
   buildChainSigners,
   trimChainActivityToWindow,
   trimChainFeesToWindow,
+  type ChainSignersResult,
 } from "./chain-analytics.ts";
 import {
   loadCompareSubnets,
@@ -1281,6 +1283,7 @@ import { loadFixture } from "./fixtures-mcp.ts";
 import {
   callSubnetSurface,
   matchSchemaOperation,
+  type CallSubnetSurfaceCredential,
 } from "./call-subnet-surface.ts";
 import {
   ECONOMIC_LEADERBOARD_BOARDS,
@@ -1297,6 +1300,7 @@ import {
   overlaySubnetHealth,
   resolveLiveEconomics,
   resolveLiveHealth,
+  subnetEconomicsRow,
   withSpotPrice,
 } from "./health-serving.ts";
 import {
@@ -1602,7 +1606,7 @@ import {
 } from "./subnet-ohlc.ts";
 import { loadSubnetOhlcColdTier } from "./subnet-ohlc-cold-tier.ts";
 import { GET_SUBNET_OHLC_CANDLE_DEFAULT } from "../schemas-src/mcp-tools/get-subnet-volume-ohlc.ts";
-import { computeStakeQuote } from "./stake-quote.ts";
+import { computeStakeQuote, type StakeQuote } from "./stake-quote.ts";
 import { buildAccountPositionHistory } from "./account-position-history.ts";
 import { buildAccountIdentity } from "./account-identity.ts";
 import { buildAccountIdentityHistory } from "./account-identity-history.ts";
@@ -1706,10 +1710,138 @@ import {
   UPTIME_DAILY_TABLES,
 } from "./read-store-tables.ts";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyFn = (...args: any[]) => any;
+
+// ── reading an untyped value ─────────────────────────────────────────────────
+//
+// `Row` was `Record<string, any>` until #10782, which made every read off one
+// an `any` -- so `row.total + 1`, `row.items.map(...)` and `row.name.trim()`
+// all compiled against a value that is a JSON blob from an artifact, a KV
+// entry, or a database. These are the narrowings this file was doing in its
+// head. The same four exist in `workers/api.ts` and `src/graphql.ts`, each
+// close to the reads it serves rather than shared through a module none of the
+// three would otherwise import.
+
+/** The row under an untyped value, or null. */
+function rowOf(value: unknown): Row | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Row)
+    : null;
+}
+
+/** The rows under an untyped value, or empty. */
+function rowsOf(value: unknown): Row[] {
+  return Array.isArray(value) ? (value as Row[]) : [];
+}
+
+/**
+ * The values under an array OR an object keyed by index, or empty.
+ *
+ * `Object.values` accepts both spellings and says which it got about neither,
+ * which is how `rpc/pools.json` came to be read as one and published as the
+ * other: the artifact serves `pools` as an ARRAY of five, the test fixtures
+ * spell it as `{ 0: {...} }`, and `Object.values(pools)` on an `any` was
+ * silently correct for both. `rowOf` rejects an array, so narrowing that one
+ * read to a row emptied `get_best_rpc_endpoint` against the real artifact
+ * while the object-keyed fixture kept every unit test green (#10782).
+ *
+ * Both spellings are live, so this takes both and neither is a guess.
+ */
+function valuesOf(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value as unknown[];
+  const row = rowOf(value);
+  return row ? Object.values(row) : [];
+}
+
+/**
+ * The items under an untyped value, or empty.
+ *
+ * `rowsOf` with the row claim withheld. A `value is T` filter only narrows
+ * when `T` is assignable to the array's element type, and an INTERFACE never
+ * is: TypeScript keeps interfaces open to declaration merging, so it will not
+ * grant them an index signature. Filtering `Row[]` with a predicate silently
+ * picks `filter`'s non-narrowing overload.
+ */
+function itemsOf(value: unknown): unknown[] {
+  return Array.isArray(value) ? (value as unknown[]) : [];
+}
+
+/** A finite number, or null. */
+function numberOf(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** An integer, or null. `Number.isInteger` is not a type predicate, so the
+ *  `typeof` is what lets the value be used as a number afterwards. */
+function intOf(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+/** One of the four places a credential can be attached, or null. Equality
+ *  against a literal is what narrows `unknown`; a chain of `!==` guards does
+ *  not, which is why the call_subnet_surface handler validated its location
+ *  four ways and still handed on an untyped value. */
+function authLocationOf(
+  value: unknown,
+): "header" | "query" | "cookie" | "body" | null {
+  return value === "header" ||
+    value === "query" ||
+    value === "cookie" ||
+    value === "body"
+    ? value
+    : null;
+}
+
+/**
+ * The netuid tie-break every ranked list ends with, deterministically.
+ *
+ * Three sorts spelled this `a.netuid - b.netuid`, which on a bag is `NaN`
+ * whenever either row's netuid is not a number -- and a comparator that
+ * answers NaN hands the order to the sort implementation, which is the exact
+ * opposite of the stable page the tie-break exists to produce. An unreadable
+ * netuid now sorts as 0 rather than as chaos (#10782).
+ */
+function compareNetuid(a: Row, b: Row): number {
+  return (intOf(a.netuid) ?? 0) - (intOf(b.netuid) ?? 0);
+}
+
+/** A non-empty string, or null. */
+function stringOf(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+/**
+ * A thrown value's message.
+ *
+ * `catch` binds `unknown`, and reading `.message` off it through a cast is
+ * what let a thrown string or a rejected non-Error render as `undefined` in a
+ * tool's error text. `String(value)` is the honest fallback.
+ */
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
+
+/**
+ * A loader's own tagged error, as the tool should report it -- or null.
+ *
+ * Four handlers spelled this `rawErr as Row` and then read `.code` and
+ * `.message` straight off the bag into `toolError(code, message)`, whose
+ * parameters are both `string`. The loaders that set a marker set `code` in
+ * the same constructor (`healthHistoryMcpError` and its siblings), so the
+ * marker and the code are ONE question and this asks it once: a tagged error
+ * without a usable code now propagates RAW, where before it became an MCP
+ * error whose `code` was `undefined` (#10782).
+ */
+function taggedLoaderError(
+  raw: unknown,
+  marker: string,
+): { code: string; message: string } | null {
+  const row = rowOf(raw);
+  const code = stringOf(row?.[marker] === true ? row.code : null);
+  return code === null ? null : { code, message: errorMessage(raw) };
+}
 
 // Bridges McpCtx (readArtifact optional -- direct-call tests omit it) to the
 // per-domain loader ctx interfaces that declare readArtifact required; every
@@ -1785,7 +1917,11 @@ interface McpCtx {
   clientName?: string;
   clientVersion?: string;
   recordUsageEvent?: AnyFn;
-  chainSignersCache?: Map<string, unknown>;
+  /** Keyed by {@link chainSignersCacheKey}; holds the in-flight promise so a
+   *  batch of identical calls shares one rate-limiter charge. Typed by what it
+   *  stores rather than `unknown`, which is what made the one read of it need
+   *  an `as { data: Row }` (#10782). */
+  chainSignersCache?: Map<string, Promise<McpChainSignersLoad>>;
   recordMcpToolCallEvent?: AnyFn;
   recordMcpInitializeEvent?: AnyFn;
   recordMcpToolsListEvent?: AnyFn;
@@ -1815,6 +1951,38 @@ interface McpCtx {
 // behavior as `handler` above if used directly across 204 heterogeneous
 // entries). `properties`/`required` stay accessible for tests that inspect
 // a specific tool's wire schema.
+/**
+ * The injectable dependencies the entry copies onto a context.
+ *
+ * DERIVED from `McpCtx` rather than restated, so a member added there and
+ * forgotten here is a compile error instead of a test-injected double that
+ * silently falls through to the real recorder -- the exact defect the
+ * `buildContext` body's own comment describes having shipped once.
+ *
+ * It was `Row`, which made all fourteen members `any`: the object
+ * `buildContext` returns therefore did not satisfy `McpCtx`, and the three
+ * places that pass it were told so rather than fixed (#10782).
+ */
+type McpDeps = Partial<
+  Pick<
+    McpCtx,
+    | "readArtifact"
+    | "readHealthKv"
+    | "executionCtx"
+    | "recordUsageEvent"
+    | "recordMcpToolCallEvent"
+    | "recordMcpInitializeEvent"
+    | "recordMcpToolsListEvent"
+    | "recordMcpMissingCapabilityEvent"
+    | "recordMcpResourcesListEvent"
+    | "recordMcpResourceReadEvent"
+    | "recordMcpPromptsListEvent"
+    | "recordMcpPromptGetEvent"
+    | "recordExceptionEvent"
+    | "recordAiDegradedEvent"
+  >
+>;
+
 interface JsonSchemaLike {
   type?: string | string[];
   properties?: Record<string, unknown>;
@@ -1925,9 +2093,14 @@ const STAKE_PREVIEW_IMPACT_MAX_PCT = 5;
 // `ok` flag) purely from a computed stake quote's price impact — the one signal
 // the preview already carries that reflects how much this size moves the pool.
 // Additive over get_subnet_stake_quote's numbers; adds no execution capability.
-function computeStakePreviewAdvisory(quote: Row) {
+function computeStakePreviewAdvisory(quote: StakeQuote) {
+  // `StakeQuote`, not `Row`. The quote comes straight off `computeStakeQuote`,
+  // which declares `price_impact_pct: number` -- and the bag had this function
+  // comparing an `any` against both thresholds, where an absent impact reads
+  // false in every direction and lands on `ok: false` with no warning saying
+  // why (#10782).
   const impact = quote.price_impact_pct;
-  const warnings = [];
+  const warnings: string[] = [];
   if (impact >= STAKE_PREVIEW_IMPACT_MAX_PCT) {
     warnings.push(
       `Estimated price impact ${impact}% meets or exceeds the ${STAKE_PREVIEW_IMPACT_MAX_PCT}% high-impact threshold: this size would move the pool price substantially against you — consider a smaller amount.`,
@@ -2801,7 +2974,7 @@ function requireCredentialStore(ctx: McpCtx): {
 async function requireCredentialStoreSurface(
   ctx: McpCtx,
   surfaceId: string,
-): Promise<Row> {
+): Promise<{ surface: Row; canonicalId: string }> {
   if (!SURFACE_ID_PATTERN.test(surfaceId)) {
     throw toolError("invalid_params", "Invalid surface_id format.");
   }
@@ -2814,7 +2987,11 @@ async function requireCredentialStoreSurface(
         `for it would have no effect.`,
     );
   }
-  return surface;
+  // The STORE KEY, resolved here rather than by the caller: a row reached
+  // through `surface_key` or a deprecated alias carries a different id than
+  // the caller asked with, and a credential written under one and read under
+  // the other is a credential that silently never applies (#10782).
+  return { surface, canonicalId: stringOf(surface.surface_id) ?? surfaceId };
 }
 
 /**
@@ -3054,11 +3231,17 @@ async function readMcpWebhookDeliveryStatus(env: Env, id: unknown) {
     const records = await Promise.all(
       keys
         .slice(0, WEBHOOK_REDELIVERY_LIST_LIMIT)
-        .map((entry: Row) =>
+        // No `(entry: Row)` annotation: `list()` already types its keys, and
+        // restating the parameter as a bag was what picked `get`'s STRING
+        // overload -- so the records below were `(string | null)[]` and the
+        // `as Row[]` put them back (#10782).
+        .map((entry) =>
           env.METAGRAPH_CONTROL.get(entry.name, { type: "json" }),
         ),
     );
-    return summarizeDeliveryRecords(records as Row[]);
+    return summarizeDeliveryRecords(
+      records.filter((record): record is Row => rowOf(record) !== null),
+    );
   } catch {
     return summarizeDeliveryRecords([]);
   }
@@ -3070,7 +3253,11 @@ async function readMcpWebhookDeliveryStatus(env: Env, id: unknown) {
 // METAGRAPH_ACCOUNT_IDENTITY_SOURCE flag as get_account_identity.
 function mcpAccountIdentityHistoryRequest(
   ss58: string,
-  { limit, offset, cursor }: Row,
+  {
+    limit,
+    offset,
+    cursor,
+  }: { limit?: number; offset?: number; cursor?: string | null },
 ) {
   const params = new URLSearchParams();
   if (limit != null) params.set("limit", String(limit));
@@ -3092,16 +3279,15 @@ async function mcpEconomicsBlob(ctx: McpCtx): Promise<Row | null> {
   }
 }
 
-/** One subnet's economics row, or null. */
+/** One subnet's economics row, or null. Typed to the contract through
+ *  health-serving's own boundary rather than handed on as a bag: all three
+ *  callers pass it to a loader that declares `SubnetEconomicsRow | null`
+ *  (#10782). */
 async function mcpEconomicsRow(
   ctx: McpCtx,
   netuid: number,
-): Promise<Row | null> {
-  const blob = await mcpEconomicsBlob(ctx);
-  const rows = Array.isArray(blob?.subnets)
-    ? (blob.subnets as Array<Record<string, unknown>>)
-    : [];
-  return rows.find((r) => Number(r?.netuid) === netuid) ?? null;
+): Promise<SubnetEconomicsRow | null> {
+  return subnetEconomicsRow(await mcpEconomicsBlob(ctx), netuid);
 }
 
 /** A subnet's surface declarations, or null on any read failure --
@@ -3440,45 +3626,83 @@ async function requireDataTierRateLimit(ctx: McpCtx) {
   }
 }
 
-function chainSignersCacheKey({ label, limit, callModule, sort }: Row) {
+/**
+ * One chain-signers lookup, as its single caller spells it.
+ *
+ * A named shape rather than `Row`: the cache KEY is built from four of these
+ * members and the leaderboard from three, and with the bag they were the same
+ * `any` -- so a caller adding a scope the key does not include would have
+ * shared a cache entry across two different questions, silently (#10782).
+ */
+interface McpChainSignersOptions {
+  label: string;
+  days: number | null;
+  observedAt: string | null;
+  limit: number;
+  callModule?: string | null;
+  sort: string;
+}
+
+/** What one cached lookup holds. `rows` is the aggregation input, which since
+ *  the #4772 D1 retirement is always empty -- kept so the shape does not
+ *  change if a store comes back. */
+interface McpChainSignersLoad {
+  data: ChainSignersResult;
+  rows: Row[];
+}
+
+function chainSignersCacheKey({
+  label,
+  limit,
+  callModule,
+  sort,
+}: McpChainSignersOptions) {
   return JSON.stringify([label, limit, callModule || "", sort]);
 }
 
-async function loadMcpChainSigners(ctx: McpCtx, options: Row) {
-  ctx.chainSignersCache ||= new Map();
+async function loadMcpChainSigners(
+  ctx: McpCtx,
+  options: McpChainSignersOptions,
+): Promise<McpChainSignersLoad> {
+  const cache = (ctx.chainSignersCache ||= new Map());
   const key = chainSignersCacheKey(options);
-  if (!ctx.chainSignersCache.has(key)) {
-    // The limiter charge lives inside the cache-miss promise (not ahead of the
-    // cache check) so a batch of identical calls shares one limiter charge,
-    // instead of paying the limiter once per duplicate request in the batch.
-    // #4772 D1 retirement: the `extrinsics` D1 table is dropped in production, so
-    // there is no live D1 aggregation left to run here -- this always resolves to
-    // the schema-stable empty leaderboard via buildChainSigners([...]).
-    ctx.chainSignersCache.set(
-      key,
-      requireDataTierRateLimit(ctx)
-        .then(() => ({
-          data: buildChainSigners({
-            window: options.label,
-            sort: options.sort,
-            observedAt: options.observedAt,
-            rows: [],
-          }),
-          rows: [],
-        }))
-        .catch((error: unknown) => {
-          ctx.chainSignersCache!.delete(key);
-          throw error;
-        }),
-    );
-  }
-  return ctx.chainSignersCache.get(key);
+  // One `get`, not `has` then `get`. The second lookup answers
+  // `| undefined` however the first one went, so the old form needed the
+  // caller to accept a value the function had already proved was there --
+  // which is what the `as { data: Row }` at the call site was doing (#10782).
+  const cached = cache.get(key);
+  if (cached) return cached;
+  // The limiter charge lives inside the cache-miss promise (not ahead of the
+  // cache check) so a batch of identical calls shares one limiter charge,
+  // instead of paying the limiter once per duplicate request in the batch.
+  // #4772 D1 retirement: the `extrinsics` D1 table is dropped in production, so
+  // there is no live D1 aggregation left to run here -- this always resolves to
+  // the schema-stable empty leaderboard via buildChainSigners([...]).
+  const pending = requireDataTierRateLimit(ctx)
+    .then(() => ({
+      data: buildChainSigners({
+        window: options.label,
+        sort: options.sort,
+        observedAt: options.observedAt,
+        rows: [],
+      }),
+      rows: [] as Row[],
+    }))
+    .catch((error: unknown) => {
+      cache.delete(key);
+      throw error;
+    });
+  cache.set(key, pending);
+  return pending;
 }
 
-async function mcpObservedAt(ctx: McpCtx) {
+async function mcpObservedAt(ctx: McpCtx): Promise<string | null> {
   if (!ctx.readHealthKv) return null;
   const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
-  return meta?.last_run_at || null;
+  // `readHealthKv` is injected and typed `AnyFn`, so its result is `any` and
+  // the old `meta?.last_run_at || null` inferred `any` too -- a timestamp that
+  // every caller then treated as a string without one of them checking.
+  return stringOf(rowOf(meta)?.last_run_at);
 }
 
 // Resolve + validate a history window arg (7d|30d|90d|1y|all) the way the REST
@@ -3615,11 +3839,13 @@ async function loadEconomicsSubnetRows(ctx: McpCtx) {
     contractVersion: mcpContractVersion(ctx),
   });
   if (Array.isArray(live?.data?.subnets)) {
-    return live.data.subnets.map((row: Row) => withSpotPrice(row) as Row);
+    return live.data.subnets.map((row: SubnetEconomicsRow) =>
+      withSpotPrice(row),
+    );
   }
   const blob = await loadArtifactData(ctx, "/metagraph/economics.json");
   return Array.isArray(blob?.subnets)
-    ? blob.subnets.map((row: Row) => withSpotPrice(row) as Row)
+    ? blob.subnets.map((row: SubnetEconomicsRow) => withSpotPrice(row))
     : [];
 }
 
@@ -3700,8 +3926,9 @@ async function runAi(fn: AnyFn) {
   try {
     return await fn();
   } catch (rawError) {
-    const error = rawError as Row;
-    if (error?.aiInput) throw toolError("invalid_params", error.message);
+    const error = rowOf(rawError);
+    if (error?.aiInput)
+      throw toolError("invalid_params", errorMessage(rawError));
     // Already classified deeper in the stack (requireAi's own ai_unavailable,
     // requireAiRateLimit's rate_limited) — do not re-wrap and do not turn a
     // rate limit into a fault.
@@ -3714,8 +3941,9 @@ async function runAi(fn: AnyFn) {
 // `subnet` string (numeric, curated slug, or chain native_slug). Slug lookup
 // joins the committed index curated-slug-first, then native_slug — the same
 // precedence the REST resolver uses (see lookupSubnetNetuid, #331).
-async function resolveNetuid(ctx: McpCtx, args: Row) {
-  if (Number.isInteger(args?.netuid) && args.netuid >= 0) return args.netuid;
+async function resolveNetuid(ctx: McpCtx, args: Row): Promise<number> {
+  const declared = intOf(args?.netuid);
+  if (declared !== null && declared >= 0) return declared;
   const ref = typeof args?.subnet === "string" ? args.subnet.trim() : "";
   if (ref === "") {
     throw toolError(
@@ -3724,25 +3952,44 @@ async function resolveNetuid(ctx: McpCtx, args: Row) {
     );
   }
   if (/^\d+$/.test(ref)) return Number(ref);
-  const index = await loadArtifactData(ctx, "/metagraph/subnets.json");
-  const subnets = Array.isArray(index.subnets) ? index.subnets : [];
+  const index = rowOf(await loadArtifactData(ctx, "/metagraph/subnets.json"));
+  const subnets = rowsOf(index?.subnets);
   const key = ref.toLowerCase();
+  const matches = (field: string) => (s: Row) => {
+    const value = s[field];
+    return typeof value === "string" && value.toLowerCase() === key;
+  };
   const match =
-    subnets.find(
-      (s: Row) => typeof s.slug === "string" && s.slug.toLowerCase() === key,
-    ) ||
-    subnets.find(
-      (s: Row) =>
-        typeof s.native_slug === "string" &&
-        s.native_slug.toLowerCase() === key,
-    );
-  if (!match) {
+    subnets.find(matches("slug")) ?? subnets.find(matches("native_slug"));
+  // A row matched by slug but carrying an unusable netuid resolves to NOTHING,
+  // which is what "no subnet matches" already meant -- the old form returned
+  // `match.netuid` unchecked, so a corrupt index entry handed every downstream
+  // route a netuid that was not a number (#10782).
+  const netuid = intOf(match?.netuid);
+  if (netuid === null) {
     throw toolError(
       "not_found",
       `No subnet matches '${ref}'. Use search_subnets to discover one.`,
     );
   }
-  return match.netuid;
+  return netuid;
+}
+
+/** One ranked candidate. Both members are numbers because both are SORTED on
+ *  -- `b.relevance - a.relevance || a.netuid - b.netuid` -- and subtraction on
+ *  a bag's member is how a non-numeric one produces `NaN` and an order that
+ *  depends on the engine's sort implementation (#10782). */
+interface RankedSubnet {
+  netuid: number;
+  relevance: number;
+}
+
+/** One RPC endpoint admitted to the best-of ranking, with the two values it
+ *  is SORTED on already resolved to numbers. */
+interface RankedRpcEndpoint {
+  endpoint: Row;
+  score: number;
+  latencyMs: number;
 }
 
 // Rank subnets relevant to a free-form task. Uses semantic (intent) ranking when
@@ -3765,14 +4012,18 @@ async function rankSubnetsForTask(
       const out = await semanticSearch(ctx.env, task, {
         limit: Math.min(poolSize, 20),
       });
-      const ranked = (out.results || [])
-        .filter(
-          (r: Row) =>
-            r.type === "subnet" &&
-            Number.isInteger(r.netuid) &&
-            isCallable(r.netuid),
-        )
-        .map((r: Row) => ({ netuid: r.netuid, relevance: r.score }));
+      // `SemanticMatch.netuid` is declared `unknown`, so the integer check is
+      // what produces the number -- and hoisting it out of the filter is what
+      // lets the map below carry that number instead of re-reading the bag
+      // (#10782).
+      const ranked: RankedSubnet[] = [];
+      for (const r of out.results || []) {
+        const netuid = intOf(r.netuid);
+        if (r.type !== "subnet" || netuid === null || !isCallable(netuid)) {
+          continue;
+        }
+        ranked.push({ netuid, relevance: r.score });
+      }
       // Only commit to semantic mode when it yields callable hits; a pool of
       // purely non-callable matches falls through to keyword discovery.
       if (ranked.length > 0) return { mode: "semantic", ranked };
@@ -3789,20 +4040,23 @@ async function rankSubnetsForTask(
       });
     }
   }
-  const index = await loadArtifactData(ctx, "/metagraph/search.json");
+  const index = rowOf(await loadArtifactData(ctx, "/metagraph/search.json"));
   const terms = queryTerms(task);
-  const docs = Array.isArray(index.documents) ? index.documents : [];
-  const ranked = docs
-    .filter((doc: Row) => doc.type === "subnet")
-    .map((doc: Row) => ({
-      netuid: doc.netuid,
-      relevance: scoreDocument(doc, terms),
-    }))
-    .filter((entry: Row) => entry.relevance > 0 && isCallable(entry.netuid))
-    .sort((a: Row, b: Row) => b.relevance - a.relevance || a.netuid - b.netuid)
-    .slice(0, poolSize);
-  return { mode: "keyword", ranked };
+  const ranked: RankedSubnet[] = [];
+  for (const doc of rowsOf(index?.documents)) {
+    if (doc.type !== "subnet") continue;
+    const netuid = intOf(doc.netuid);
+    if (netuid === null || !isCallable(netuid)) continue;
+    const relevance = scoreDocument(doc, terms);
+    if (relevance > 0) ranked.push({ netuid, relevance });
+  }
+  ranked.sort((a, b) => b.relevance - a.relevance || a.netuid - b.netuid);
+  return { mode: "keyword", ranked: ranked.slice(0, poolSize) };
 }
+
+/** What the argument pipeline reads off a tool: its name (for the error
+ *  message) and its published input schema. */
+type ToolArgumentSource = Pick<McpToolDefinition, "name" | "inputSchema">;
 
 /**
  * The arguments a handler actually receives, from the ones a caller sent.
@@ -3814,14 +4068,28 @@ async function rankSubnetsForTask(
  * here covers every tool at once, where a gate per handler covers whichever
  * ones somebody remembered.
  */
-export function validateToolArguments(tool: Row, args: Row) {
+export function validateToolArguments(
+  // Exactly the two members this reads, not the whole definition: it runs
+  // over BOTH tool objects -- the raw registry entry at dispatch and the
+  // SERVED definition in the tests -- and those are different shapes
+  // (`listToolDefinitions` adds annotations/execution and drops the handler).
+  // Asking for what it uses is what lets one function serve both without
+  // either side being cast into position (#10782).
+  tool: ToolArgumentSource,
+  rawArgs: unknown,
+) {
+  // `unknown`, because that is what a JSON-RPC `params.arguments` IS -- the
+  // two checks below are the whole reason this function exists, and taking a
+  // `Row` meant the caller had to assert the answer before asking (#10782).
+  //
   // `arguments` absent entirely is the same request as `arguments: {}` -- the
   // caller supplied nothing either way, so it must resolve to the same defaults
   // rather than to a bare {}. Returning early here is how the omitted-argument
   // path skipped them (#10306).
-  if (args === undefined || args === null)
+  if (rawArgs === undefined || rawArgs === null)
     return applyPublishedDefaults(tool, {});
-  if (typeof args !== "object" || Array.isArray(args)) {
+  const args = rowOf(rawArgs);
+  if (!args) {
     throw toolError(
       "invalid_params",
       `Invalid arguments for tool ${tool.name}: expected an object of named arguments.`,
@@ -3954,17 +4222,17 @@ function callerSuppliedArg(args: Row, name: string) {
  * the handlers whose parameters are only valid in some modes.
  * `callerSuppliedArg` above gives the distinction back.
  */
-function applyPublishedDefaults(tool: Row, args: Row): Row {
-  const properties = tool.inputSchema?.properties as
-    Record<string, Row> | undefined;
+function applyPublishedDefaults(tool: ToolArgumentSource, args: Row): Row {
+  const properties = tool.inputSchema?.properties;
   if (!properties) return args;
   let filled: Row | null = null;
   const supplied = new Set<string>();
   for (const [name, schema] of Object.entries(properties)) {
-    if (schema?.default === undefined) continue;
+    const declared = rowOf(schema)?.default;
+    if (declared === undefined) continue;
     if (args[name] !== undefined) continue;
     filled ??= { ...args };
-    filled[name] = schema.default;
+    filled[name] = declared;
     supplied.add(name);
   }
   if (!filled) return args;
@@ -4007,9 +4275,8 @@ function applyPublishedDefaults(tool: Row, args: Row): Row {
  * the row builders honour it as zero), so rewriting it here would flatten a
  * distinction tests/pagination-bound-parity.test.ts exists to keep.
  */
-function clampPublishedLimit(tool: Row, args: Row): Row {
-  const schema = tool.inputSchema?.properties?.limit as Row | undefined;
-  const max = schema?.maximum;
+function clampPublishedLimit(tool: ToolArgumentSource, args: Row): Row {
+  const max = rowOf(tool.inputSchema?.properties?.limit)?.maximum;
   const value = args?.limit;
   if (typeof max !== "number" || typeof value !== "number") return args;
   if (!Number.isInteger(value) || value <= max) return args;
@@ -4028,9 +4295,16 @@ function clampPublishedLimit(tool: Row, args: Row): Row {
  * Returns the ORIGINAL object when there is nothing to strip, so the
  * overwhelmingly common case allocates nothing.
  */
-export function splitMcpIntent(args: Row): { intent?: string; rest: Row } {
+export function splitMcpIntent(args: Row | null | undefined): {
+  intent?: string;
+  rest: Row;
+} {
+  // The nullable is in the SIGNATURE now: the body has always handled a
+  // missing argument object by returning it unchanged, and the dispatch
+  // caller reached it through `params?.arguments as Row` -- a cast whose only
+  // job was to hide that this is exactly the case being handled (#10782).
   if (!args || typeof args !== "object" || !Object.hasOwn(args, MCP_INTENT_ARG))
-    return { rest: args };
+    return { rest: args ?? {} };
   const { [MCP_INTENT_ARG]: intent, ...rest } = args;
   return {
     // A non-string, or a caller sending only whitespace, is not an intent.
@@ -4110,9 +4384,13 @@ function optionalNonNegativeNumber(args: Row, key: string) {
 // Like optionalNonNegativeInt, but 0 is invalid (a "cap the list to zero rows"
 // argument reads as a misuse, not a legitimate empty-result request).
 function optionalPositiveInt(args: Row, key: string) {
-  const value = args?.[key];
-  if (value === undefined || value === null) return null;
-  if (!Number.isInteger(value) || value < 1) {
+  const raw = args?.[key];
+  if (raw === undefined || raw === null) return null;
+  // `intOf`, not `Number.isInteger`: the latter is not a type predicate, so
+  // the `value < 1` beside it was comparing an `unknown` -- and the value
+  // RETURNED from here was untyped for every caller that pages on it.
+  const value = intOf(raw);
+  if (value === null || value < 1) {
     throw toolError(
       "invalid_params",
       `Argument \`${key}\` must be a positive integer.`,
@@ -4347,10 +4625,9 @@ function requireHotkey(args: Row) {
 // bespoke `offset` handling (floor + clamp to 0, no throw): tools/call does not
 // enforce the inputSchema `minimum`, so a bad cursor degrades to the first page
 // instead of erroring.
-function resolveCursor(args: Row) {
-  return Number.isFinite(args?.cursor)
-    ? Math.max(0, Math.floor(args.cursor))
-    : 0;
+function resolveCursor(args: Row): number {
+  const cursor = numberOf(args?.cursor);
+  return cursor === null ? 0 : Math.max(0, Math.floor(cursor));
 }
 
 // Cursor-window an already-filtered/ranked row set through the shared list-query
@@ -4364,9 +4641,19 @@ function resolveCursor(args: Row) {
 // present cursor as paging on its own. The caller pre-resolves both bounds (limit
 // clamped, cursor a non-negative integer), so validateListQuery inside
 // applyQueryFilters cannot fail here and always returns a pagination envelope.
+interface CursorWindowOptions {
+  /** The API_QUERY_COLLECTIONS entry whose rules window the rows. */
+  collection: string;
+  /** The key the rows travel under, both in and out. */
+  dataKey: string;
+  /** Null means "the whole list unless the caller pages". */
+  limit: number | null;
+  cursor: number;
+}
+
 function cursorWindow(
   rows: Row[],
-  { collection, dataKey, limit, cursor }: Row,
+  { collection, dataKey, limit, cursor }: CursorWindowOptions,
 ) {
   const url = new URL("https://mcp.internal/list");
   if (limit != null) {
@@ -4380,20 +4667,21 @@ function cursorWindow(
     url,
     collection,
     [],
-  ) as { data: Row; meta: Row };
-  const {
-    total,
-    returned,
-    limit: pageLimit,
-    cursor: pageCursor,
-  } = meta.pagination;
+  );
+  // The header above says this always windows -- and it did, so the four
+  // destructured members were read off a `meta.pagination` nobody checked and
+  // the `as { data: Row; meta: Row }` made that read type-clean. The fallbacks
+  // are the ones every sibling loader already carries
+  // (src/global-incidents-mcp.ts): an unwindowed answer reports the FULL set,
+  // where the bag reported four `undefined`s in a published envelope (#10782).
+  const page = meta?.pagination;
   return {
-    page: data[dataKey],
-    total,
-    returned,
-    limit: pageLimit,
-    cursor: pageCursor,
-    next_cursor: meta.pagination.next_cursor,
+    page: rowsOf(rowOf(data)?.[dataKey]),
+    total: page?.total ?? rows.length,
+    returned: page?.returned ?? rows.length,
+    limit: page?.limit ?? rows.length,
+    cursor: page?.cursor ?? cursor,
+    next_cursor: page?.next_cursor ?? null,
   };
 }
 
@@ -4466,7 +4754,7 @@ export function sortSubnets(rows: Row[], field: string, order: unknown) {
     const av = subnetSortValue(a, field);
     const bv = subnetSortValue(b, field);
     if (av === null || bv === null) {
-      if (av === null && bv === null) return a.netuid - b.netuid;
+      if (av === null && bv === null) return compareNetuid(a, b);
       return av === null ? 1 : -1;
     }
     // Numeric fields subtract; the string field (name) compares lexically. This
@@ -4476,7 +4764,7 @@ export function sortSubnets(rows: Row[], field: string, order: unknown) {
       typeof av === "number"
         ? av - (bv as number)
         : String(av).localeCompare(String(bv));
-    return cmp !== 0 ? cmp * dir : a.netuid - b.netuid;
+    return cmp !== 0 ? cmp * dir : compareNetuid(a, b);
   });
 }
 
@@ -4564,9 +4852,14 @@ export function identityFilterSubnets(rows: Row[], args: Row) {
 }
 
 export function rangeFilterSubnets(rows: Row[], args: Row) {
-  const bounds = LIST_SUBNETS_RANGE_BOUNDS.filter(({ arg }) =>
-    Number.isFinite(args?.[arg]),
-  ).map(({ field, op, arg }) => ({ field, op, limit: args[arg] }));
+  // `Number.isFinite` is not a type predicate, so the filter proved nothing to
+  // the map beside it and every `limit` reached the comparison below as an
+  // `any`. Reading the bound ONCE and keeping the number is the same two
+  // passes with the value carried instead of re-read (#10782).
+  const bounds = LIST_SUBNETS_RANGE_BOUNDS.flatMap(({ field, op, arg }) => {
+    const limit = numberOf(args?.[arg]);
+    return limit === null ? [] : [{ field, op, limit }];
+  });
   if (bounds.length === 0) {
     return rows;
   }
@@ -4661,14 +4954,16 @@ export function categoricalFilterSubnets(rows: Row[], args: Row) {
   const includes: { field: string; value: string }[] = [];
   const excludes: { field: string; value: string }[] = [];
   for (const arg of LIST_SUBNETS_CATEGORICAL) {
-    const inc = typeof args?.[arg] === "string" ? args[arg].trim() : "";
+    // A computed key does not carry its `typeof` narrowing -- TypeScript
+    // cannot know `args[arg]` reads the same slot twice -- so read once and
+    // keep the string (#10782).
+    const inc = stringOf(args?.[arg])?.trim() ?? "";
     if (inc) {
       const lowered = inc.toLowerCase();
       requireCategoricalEnumMember(arg, lowered);
       includes.push({ field: arg, value: lowered });
     }
-    const exc =
-      typeof args?.[`not_${arg}`] === "string" ? args[`not_${arg}`].trim() : "";
+    const exc = stringOf(args?.[`not_${arg}`])?.trim() ?? "";
     if (exc) {
       const lowered = exc.toLowerCase();
       requireCategoricalEnumMember(arg, lowered);
@@ -4743,7 +5038,12 @@ function optionalGapCode(args: Row) {
   return value;
 }
 
-function coverageDepthTarget(row: Row, rank = null) {
+function coverageDepthTarget(row: Row, rank: number | null = null) {
+  // `row.dimensions` is read eleven times below. Reading it ONCE is what lets
+  // the `?.` mean what it says: on a bag every one of those was an `any`, so
+  // the eleven defaults were unreachable-looking code guarding a value the
+  // type system had already promised (#10782).
+  const dimensions = rowOf(row.dimensions);
   return {
     rank,
     netuid: row.netuid,
@@ -4755,7 +5055,7 @@ function coverageDepthTarget(row: Row, rank = null) {
     agent_status: row.agent_status,
     blocker_level: row.blocker_level,
     top_gap_codes: row.top_gap_codes || [],
-    top_gaps: (row.top_gaps || []).map((gap: Row) => ({
+    top_gaps: rowsOf(row.top_gaps).map((gap) => ({
       code: gap.code,
       severity: gap.severity,
       field: gap.field,
@@ -4763,35 +5063,41 @@ function coverageDepthTarget(row: Row, rank = null) {
     })),
     recommended_next_action: row.recommended_next_action || null,
     dimensions: {
-      callable_service_count: row.dimensions?.callable_service_count ?? 0,
-      service_kinds: row.dimensions?.service_kinds || [],
-      schema_service_count: row.dimensions?.schema_service_count ?? 0,
-      schema_missing_count: row.dimensions?.schema_missing_count ?? 0,
-      fixture_available_count: row.dimensions?.fixture_available_count ?? 0,
-      fixture_status_counts: row.dimensions?.fixture_status_counts || {},
-      example_count: row.dimensions?.example_count ?? 0,
-      sdk_count: row.dimensions?.sdk_count ?? 0,
-      candidate_operational_count:
-        row.dimensions?.candidate_operational_count ?? 0,
-      official_surface_count: row.dimensions?.official_surface_count ?? 0,
+      callable_service_count: dimensions?.callable_service_count ?? 0,
+      service_kinds: dimensions?.service_kinds || [],
+      schema_service_count: dimensions?.schema_service_count ?? 0,
+      schema_missing_count: dimensions?.schema_missing_count ?? 0,
+      fixture_available_count: dimensions?.fixture_available_count ?? 0,
+      fixture_status_counts: dimensions?.fixture_status_counts || {},
+      example_count: dimensions?.example_count ?? 0,
+      sdk_count: dimensions?.sdk_count ?? 0,
+      candidate_operational_count: dimensions?.candidate_operational_count ?? 0,
+      official_surface_count: dimensions?.official_surface_count ?? 0,
       provider_claimed_surface_count:
-        row.dimensions?.provider_claimed_surface_count ?? 0,
+        dimensions?.provider_claimed_surface_count ?? 0,
     },
   };
 }
 
+interface CoverageDepthFilters {
+  tier?: string | null;
+  severity?: string | null;
+  gapCode?: string | null;
+  agentStatus?: string | null;
+}
+
 function coverageDepthMatches(
   row: Row,
-  { tier, severity, gapCode, agentStatus }: Row,
+  { tier, severity, gapCode, agentStatus }: CoverageDepthFilters,
 ) {
   if (tier && row.tier !== tier) return false;
   // Agent readiness is an axis independent of tier -- the same agent_status
   // filter REST's GET /api/v1/coverage-depth accepts.
   if (agentStatus && row.agent_status !== agentStatus) return false;
-  if (gapCode && !(row.top_gap_codes || []).includes(gapCode)) return false;
+  if (gapCode && !itemsOf(row.top_gap_codes).includes(gapCode)) return false;
   if (
     severity &&
-    !(row.top_gaps || []).some((gap: Row) => gap.severity === severity)
+    !rowsOf(row.top_gaps).some((gap) => gap.severity === severity)
   ) {
     return false;
   }
@@ -5047,18 +5353,16 @@ const MCP_INTENT_ARG_SCHEMA = {
  * trust. Tested directly rather than annotated away.
  */
 export function withIntentArgument(tool: McpToolDefinition): McpToolDefinition {
-  const schema = tool.inputSchema as Row;
-  return {
-    ...tool,
-    inputSchema: {
-      ...schema,
-      type: schema?.type ?? "object",
-      properties: {
-        ...((schema?.properties as Row) ?? {}),
-        [MCP_INTENT_ARG]: MCP_INTENT_ARG_SCHEMA,
-      },
-    } as JsonSchemaLike,
+  const schema = tool.inputSchema;
+  const withIntent: JsonSchemaLike = {
+    ...schema,
+    type: schema?.type ?? "object",
+    properties: {
+      ...(schema?.properties ?? {}),
+      [MCP_INTENT_ARG]: MCP_INTENT_ARG_SCHEMA,
+    },
   };
+  return { ...tool, inputSchema: withIntent };
 }
 
 // Applied ONCE, here, rather than in listToolDefinitions() -- and that is the
@@ -5135,16 +5439,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // this tool shipped with. Canonical wins when both are given, so the
       // resolution is stated rather than left to argument order.
       const query = requireEitherString(args, "q", "query");
-      const index = await loadArtifactData(ctx, "/metagraph/search.json");
+      const index = rowOf(
+        await loadArtifactData(ctx, "/metagraph/search.json"),
+      );
       const terms = queryTerms(query);
-      const docs = Array.isArray(index.documents) ? index.documents : [];
-      const matched = docs
-        .filter((doc: Row) => doc.type === "subnet")
-        .map((doc: Row) => ({ doc, score: scoreDocument(doc, terms) }))
-        .filter((entry: Row) => entry.score > 0)
-        .sort(
-          (a: Row, b: Row) => b.score - a.score || a.doc.netuid - b.doc.netuid,
-        );
+      const matched = rowsOf(index?.documents)
+        .filter((doc) => doc.type === "subnet")
+        .map((doc) => ({ doc, score: scoreDocument(doc, terms) }))
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score || compareNetuid(a.doc, b.doc));
       return searchResponse({ query }, matched, args, ({ doc }) => ({
         netuid: doc.netuid,
         slug: doc.slug,
@@ -5261,35 +5564,38 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         "/metagraph/agent-catalog.json",
       );
       const live = await mcpLiveHealth(ctx);
-      const catalog = overlayCatalogIndex(staticCatalog, live) || staticCatalog;
+      const catalog = rowOf(
+        overlayCatalogIndex(staticCatalog, live) || staticCatalog,
+      );
       const terms = queryTerms(capability);
-      const subnets = Array.isArray(catalog.subnets) ? catalog.subnets : [];
-      const matched = subnets
-        .map((subnet: Row) => ({
+      // `callable_count` and `integration_readiness` are both FILTERED and
+      // SORTED on, so both are resolved to numbers once, here, rather than
+      // compared as bag members three lines apart -- which is how
+      // `callable_count > 0` passed a row whose count was the string "3" and
+      // then subtracted it into a NaN comparator (#10782).
+      const matched = rowsOf(catalog?.subnets)
+        .map((subnet) => ({
           subnet,
           score: keywordScore(
             {
               name: subnet.name,
               slug: subnet.slug,
               text: [
-                ...(Array.isArray(subnet.categories) ? subnet.categories : []),
-                ...(Array.isArray(subnet.service_kinds)
-                  ? subnet.service_kinds
-                  : []),
+                ...itemsOf(subnet.categories),
+                ...itemsOf(subnet.service_kinds),
               ],
             },
             terms,
           ),
+          callableCount: numberOf(subnet.callable_count) ?? 0,
+          readiness: numberOf(subnet.integration_readiness) ?? 0,
         }))
-        .filter(
-          (entry: Row) => entry.score > 0 && entry.subnet.callable_count > 0,
-        )
+        .filter((entry) => entry.score > 0 && entry.callableCount > 0)
         .sort(
-          (a: Row, b: Row) =>
+          (a, b) =>
             b.score - a.score ||
-            (b.subnet.integration_readiness || 0) -
-              (a.subnet.integration_readiness || 0) ||
-            b.subnet.callable_count - a.subnet.callable_count,
+            b.readiness - a.readiness ||
+            b.callableCount - a.callableCount,
         );
       return searchResponse({ capability }, matched, args, ({ subnet }) => ({
         netuid: subnet.netuid,
@@ -5490,11 +5796,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           readArtifact: loadArtifactData as AnyFn,
         });
       } catch (rawErr) {
-        const err = rawErr as Row;
-        if (err?.healthHistoryMcp) {
-          throw toolError(err.code, err.message);
-        }
-        throw err;
+        const tagged = taggedLoaderError(rawErr, "healthHistoryMcp");
+        if (tagged) throw toolError(tagged.code, tagged.message);
+        throw rawErr;
       }
     },
   },
@@ -5842,20 +6146,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             // partial answer into no answer at all.
             const blob = await resolveEconomicsBlob(ctx.env, async () => {
               try {
-                return (await loadArtifactData(
-                  ctx,
-                  "/metagraph/economics.json",
-                )) as Record<string, unknown> | null;
+                return rowOf(
+                  await loadArtifactData(ctx, "/metagraph/economics.json"),
+                );
               } catch {
                 return null;
               }
             });
-            const rows = Array.isArray(blob?.subnets)
-              ? (blob.subnets as Array<Record<string, unknown>>)
-              : [];
+            // Through the same `subnetEconomicsRow` the REST default reader
+            // uses, so the two ladders cannot disagree about what a row IS on
+            // top of already agreeing about where it comes from (#10782).
             return {
-              row:
-                rows.find((entry) => Number(entry?.netuid) === netuid) ?? null,
+              row: subnetEconomicsRow(blob, netuid),
               generatedAt: blob?.generated_at ?? blob?.captured_at ?? null,
             };
           },
@@ -6058,11 +6360,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           readOptionalArtifact: loadOptionalArtifact,
         });
       } catch (rawErr) {
-        const err = rawErr as Row;
-        if (err?.networkEconomics) {
-          throw toolError(err.code, err.message);
-        }
-        throw err;
+        const tagged = taggedLoaderError(rawErr, "networkEconomics");
+        if (tagged) throw toolError(tagged.code, tagged.message);
+        throw rawErr;
       }
     },
   },
@@ -7963,11 +8263,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           readOptionalArtifact: loadOptionalArtifact,
         });
       } catch (rawErr) {
-        const err = rawErr as Row;
-        if (err?.profilesMcp) {
-          throw toolError(err.code, err.message);
-        }
-        throw err;
+        const tagged = taggedLoaderError(rawErr, "profilesMcp");
+        if (tagged) throw toolError(tagged.code, tagged.message);
+        throw rawErr;
       }
     },
   },
@@ -7983,11 +8281,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           readArtifact: loadArtifactData,
         });
       } catch (rawErr) {
-        const err = rawErr as Row;
-        if (err?.profilesMcp) {
-          throw toolError(err.code, err.message);
-        }
-        throw err;
+        const tagged = taggedLoaderError(rawErr, "profilesMcp");
+        if (tagged) throw toolError(tagged.code, tagged.message);
+        throw rawErr;
       }
     },
   },
@@ -10040,13 +10336,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           : buildAccountSummary(ss58, {}));
       // Community-contributable entity labels (#6739), same REST-parity join
       // as workers/request-handlers/entities.ts's own handleAccount.
-      const entitiesArtifact = (await ctx.readArtifact!(
-        ctx.env,
-        ENTITY_LABELS_ARTIFACT,
-      )) as Row | null;
+      const entitiesArtifact = rowOf(
+        await ctx.readArtifact!(ctx.env, ENTITY_LABELS_ARTIFACT),
+      );
       (data as Row).labels = labelsForSs58(
         entityLabelsIndex(
-          entitiesArtifact?.ok ? entitiesArtifact.data?.entities : [],
+          entitiesArtifact?.ok
+            ? rowsOf(rowOf(entitiesArtifact.data)?.entities)
+            : [],
         ),
         ss58,
       );
@@ -11118,10 +11415,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           `direction must be one of: ${ACCOUNT_TRANSFERS_DIRECTIONS.join(", ")}.`,
         );
       }
+      // Narrowed by the two literals it can be. `ACCOUNT_TRANSFERS_DIRECTIONS
+      // .includes(...)` above is the VALIDATION and proves nothing to the type
+      // system -- `string[].includes` returns a boolean, not a predicate -- so
+      // the assignment below was `any` flowing into a published union (#10782).
       const direction: "sent" | "received" | undefined =
-        rawDirection === undefined || rawDirection === "all"
-          ? undefined
-          : rawDirection;
+        rawDirection === "sent" || rawDirection === "received"
+          ? rawDirection
+          : undefined;
       // block_start/block_end/cursor are validated for REST-parity and forwarded to
       // the Postgres tier below; the local D1 fallback still ignores them (like the
       // D1 filters they used to bound, they have nothing left to filter now that
@@ -12129,14 +12430,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         callModule,
       });
       if (projected) return projected;
-      const { data } = (await loadMcpChainSigners(ctx, {
+      const { data } = await loadMcpChainSigners(ctx, {
         label,
         days,
         observedAt: await mcpObservedAt(ctx),
         limit,
         callModule,
         sort,
-      })) as { data: Row };
+      });
       return data;
     },
   },
@@ -12697,17 +12998,22 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // config/data_key are guaranteed here (the "endpoints" collection always
       // exists and data.endpoints is always an array by this point, thanks to
       // the schema-stability guard above), so applyQueryFilters always returns
-      // meta.pagination -- no fallback to reason about.
-      const page = transformed.meta!.pagination as Row;
+      // meta.pagination. Read through `?.` anyway, with the same fallbacks
+      // every sibling loader carries: the `as Row` this replaces made the
+      // seven published members `any`, so the ONE thing the guard exists to
+      // prevent -- omitting total/returned/cursor -- was also the one thing
+      // the types could no longer report (#10782).
+      const page = transformed.meta.pagination;
+      const rows = rowsOf(rowOf(transformed.data)?.endpoints);
       return {
-        ...(transformed.data as Row),
-        total: page.total,
-        returned: page.returned,
-        cursor: page.cursor,
-        limit: page.limit,
-        next_cursor: page.next_cursor,
-        sort: page.sort,
-        order: page.order,
+        ...rowOf(transformed.data),
+        total: page?.total ?? rows.length,
+        returned: page?.returned ?? rows.length,
+        cursor: page?.cursor ?? cursor,
+        limit: page?.limit ?? rows.length,
+        next_cursor: page?.next_cursor ?? null,
+        sort: page?.sort ?? null,
+        order: page?.order ?? null,
       };
     },
   },
@@ -13236,36 +13542,48 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const limit = clampToolLimit(args?.limit, 3, 10);
-      const poolData = await loadArtifactData(ctx, "/metagraph/rpc/pools.json");
+      const poolData = rowOf(
+        await loadArtifactData(ctx, "/metagraph/rpc/pools.json"),
+      );
       const liveRpcPool = ctx.readHealthKv
         ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
         : null;
-      const pools =
-        poolData.pools && typeof poolData.pools === "object"
-          ? poolData.pools
-          : {};
-      // Pool map keys ("0"/"1"/"2") are pool indices, NOT networks — and the
-      // same physical endpoint can appear in more than one pool. Dedupe by
-      // endpoint id, keeping the best-scored instance.
-      const bestById = new Map<string, Row>();
-      for (const pool of Object.values(pools)) {
-        const overlaid = overlayRpcPoolEligibility(
-          pool as Row,
-          liveRpcPool,
-        ) as Row;
-        for (const endpoint of overlaid.endpoints || []) {
+      // Pool keys are pool INDICES, not networks -- and the artifact spells
+      // that as an array where the fixtures spell it as an object, so the read
+      // takes both (see `valuesOf`). The same physical endpoint can appear in
+      // more than one pool, so dedupe by endpoint id, keeping the best-scored
+      // instance.
+      //
+      // `score` and `latency_ms` are BOTH the sort key, so both are resolved
+      // to numbers as the endpoint is admitted rather than compared as bag
+      // members inside the comparator -- `(b.score || 0) - (a.score || 0)` on
+      // a bag is a subtraction of two `any`s, and a string score there
+      // produces NaN and an engine-defined order (#10782).
+      const bestById = new Map<string, RankedRpcEndpoint>();
+      for (const pool of valuesOf(poolData?.pools)) {
+        const overlaid = rowOf(
+          overlayRpcPoolEligibility(rowOf(pool), liveRpcPool),
+        );
+        for (const endpoint of rowsOf(overlaid?.endpoints)) {
           if (!endpoint.pool_eligible) continue;
-          const existing = bestById.get(endpoint.id);
-          if (!existing || (endpoint.score || 0) > (existing.score || 0)) {
-            bestById.set(endpoint.id, endpoint);
+          // `String(...)` rather than a string check: an id-less endpoint used
+          // to key the map on `undefined`, and dropping it here would be a
+          // behaviour change this issue is not making.
+          const id = String(endpoint.id);
+          const score = numberOf(endpoint.score) ?? 0;
+          const existing = bestById.get(id);
+          if (!existing || score > existing.score) {
+            bestById.set(id, {
+              endpoint,
+              score,
+              latencyMs: numberOf(endpoint.latency_ms) ?? Infinity,
+            });
           }
         }
       }
-      const candidates = [...bestById.values()].sort(
-        (a, b) =>
-          (b.score || 0) - (a.score || 0) ||
-          (a.latency_ms ?? Infinity) - (b.latency_ms ?? Infinity),
-      );
+      const candidates = [...bestById.values()]
+        .sort((a, b) => b.score - a.score || a.latencyMs - b.latencyMs)
+        .map((ranked) => ranked.endpoint);
       const endpoints = candidates.slice(0, limit).map((endpoint) => ({
         id: endpoint.id,
         // The connectable endpoint URL — the whole point of the tool.
@@ -13608,16 +13926,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         args?.netuid === undefined || args?.netuid === null
           ? null
           : requireNetuid(args);
-      const scorecard = await loadArtifactData(
-        ctx,
-        "/metagraph/coverage-depth.json",
+      const scorecard = rowOf(
+        await loadArtifactData(ctx, "/metagraph/coverage-depth.json"),
       );
-      const rows = Array.isArray(scorecard.rows) ? scorecard.rows : [];
-      const rowsByNetuid = new Map(rows.map((row: Row) => [row.netuid, row]));
-      const queue = Array.isArray(scorecard.ranked_queue)
-        ? scorecard.ranked_queue
-        : [];
-      let candidates;
+      const rows = rowsOf(scorecard?.rows);
+      const rowsByNetuid = new Map(rows.map((row) => [row.netuid, row]));
+      const queue = rowsOf(scorecard?.ranked_queue);
+      // `rank` reaches `coverageDepthTarget`, which publishes it. Resolving it
+      // to a number HERE is what keeps the published field a number: the map
+      // callback was annotated `(entry: Row)` and its result destructured as
+      // `Row` again three lines down, so `rank` was an `any` at both ends
+      // (#10782).
+      let candidates: { row: Row; rank: number | null }[];
       if (netuid !== null) {
         const row = rowsByNetuid.get(netuid);
         if (!row) {
@@ -13629,11 +13949,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         candidates = [{ row, rank: null }];
       } else {
         candidates = queue
-          .map((entry: Row) => ({
-            row: rowsByNetuid.get(entry.netuid) || entry,
-            rank: entry.rank ?? null,
+          .map((entry) => ({
+            row: rowOf(rowsByNetuid.get(entry.netuid)) ?? entry,
+            rank: intOf(entry.rank),
           }))
-          .filter((entry: Row) => Number.isInteger(entry.row?.netuid));
+          .filter((entry) => intOf(entry.row.netuid) !== null);
       }
       // Free-text over the collection's own search_keys, through the ENGINE's
       // matcher rather than a second one (#10793). Matched once over the row
@@ -13642,7 +13962,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const q = optionalString(args, "q");
       const matched = new Set(
         searchMatchingRows(
-          candidates.map(({ row }: Row) => row),
+          candidates.map(({ row }) => row),
           q,
           API_QUERY_COLLECTIONS["coverage-depth"].search_keys,
         ),
@@ -13657,7 +13977,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       };
       const targets = candidates
         .filter(
-          ({ row }: Row) =>
+          ({ row }) =>
             matched.has(row) &&
             coverageDepthMatches(row, {
               tier,
@@ -13667,10 +13987,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             }),
         )
         .slice(0, limit)
-        .map(({ row, rank }: Row) => coverageDepthTarget(row, rank));
+        .map(({ row, rank }) => coverageDepthTarget(row, rank));
       return {
-        generated_at: scorecard.generated_at || null,
-        coverage_depth_version: scorecard.coverage_depth_version || null,
+        generated_at: scorecard?.generated_at || null,
+        coverage_depth_version: scorecard?.coverage_depth_version || null,
         total_rows: rows.length,
         queue_count: queue.length,
         returned: targets.length,
@@ -13915,20 +14235,31 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         `/metagraph/agent-catalog/${netuid}.json`,
       );
       const live = await mcpLiveHealth(ctx);
-      const detail =
-        overlayCatalogDetail(staticDetail, live, netuid) || staticDetail;
-      const services = Array.isArray(detail.services) ? detail.services : [];
-      const callable = services.filter((s: Row) => s.eligibility?.callable);
-      const steps = (callable.length > 0 ? callable : services).map(
-        (s: Row) => ({
+      const detail = rowOf(
+        overlayCatalogDetail(staticDetail, live, netuid) || staticDetail,
+      );
+      const services = rowsOf(detail?.services);
+      const callable = services.filter(
+        (s) => rowOf(s.eligibility)?.callable === true,
+      );
+      // The four nested blocks -- eligibility, schema_source, fixture,
+      // fixture_status, health -- are each read through `rowOf` ONCE per
+      // service. On a bag `s.fixture.response?.status` compiled without the
+      // `?.` on `fixture` itself, which is only safe because the `s.fixture`
+      // ternary above it happens to guard it; nothing said so (#10782).
+      const steps = (callable.length > 0 ? callable : services).map((s) => {
+        const fixture = rowOf(s.fixture);
+        const fixtureStatus = rowOf(s.fixture_status);
+        const health = rowOf(s.health);
+        return {
           surface_id: s.surface_id,
           kind: s.kind,
           capability: s.capability,
           base_url: s.base_url,
-          callable: Boolean(s.eligibility?.callable),
+          callable: rowOf(s.eligibility)?.callable === true,
           auth: {
             required: Boolean(s.auth_required),
-            schemes: Array.isArray(s.auth_schemes) ? s.auth_schemes : [],
+            schemes: itemsOf(s.auth_schemes),
           },
           // Ready-to-run curl/Python/TS for a first call (issue #351).
           // Regenerate from base_url + auth so cleartext credential guards stay
@@ -13938,43 +14269,43 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             ? {
                 available: true,
                 fetch_with: `get_api_schema with surface_id ${
-                  s.schema_source?.surface_id || s.surface_id
+                  rowOf(s.schema_source)?.surface_id || s.surface_id
                 }`,
                 schema_url: s.schema_url || null,
               }
             : { available: false, schema_url: s.schema_url || null },
-          fixture: s.fixture
+          fixture: fixture
             ? {
                 available: true,
                 fetch_with: `get_fixture with surface_id ${s.surface_id}`,
-                artifact_path: s.fixture.artifact_path,
-                captured_at: s.fixture.captured_at,
-                response_status: s.fixture.response?.status ?? null,
-                content_type: s.fixture.response?.content_type ?? null,
+                artifact_path: fixture.artifact_path,
+                captured_at: fixture.captured_at,
+                response_status: rowOf(fixture.response)?.status ?? null,
+                content_type: rowOf(fixture.response)?.content_type ?? null,
               }
             : {
                 available: false,
-                status: s.fixture_status?.status || "missing",
+                status: fixtureStatus?.status || "missing",
                 reason:
-                  s.fixture_status?.reason || "no captured fixture available",
+                  fixtureStatus?.reason || "no captured fixture available",
               },
           health: {
-            status: s.health?.status ?? "unknown",
-            stale: s.health?.stale ?? false,
-            observed_by: s.health?.observed_by ?? null,
+            status: health?.status ?? "unknown",
+            stale: health?.stale ?? false,
+            observed_by: health?.observed_by ?? null,
           },
-        }),
-      );
+        };
+      });
       const isCallable = callable.length > 0;
-      const schemaStep = steps.find((s: Row) => s.schema.available);
-      const fixtureStep = steps.find((s: Row) => s.fixture.available);
+      const schemaStep = steps.find((s) => s.schema.available);
+      const fixtureStep = steps.find((s) => s.fixture.available);
       return {
         netuid,
-        name: detail.name,
-        slug: detail.slug,
-        integration_readiness: detail.integration_readiness,
-        operational_observed_at: detail.operational_observed_at ?? null,
-        health_source: detail.health_source ?? "unavailable",
+        name: detail?.name,
+        slug: detail?.slug,
+        integration_readiness: detail?.integration_readiness,
+        operational_observed_at: detail?.operational_observed_at ?? null,
+        health_source: detail?.health_source ?? "unavailable",
         callable: isCallable,
         callable_count: callable.length,
         guidance: isCallable
@@ -14113,6 +14444,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       if (!surface) {
         throw await uncallableSurfaceError(ctx, args.surface_id);
       }
+      // The catalog row's OWN id -- the credential-store key and the id echoed
+      // back in the result. A row can be matched by `surface_key` or by a
+      // deprecated alias, so it is not necessarily the id the caller asked
+      // with; falling back to that one keeps the key a string rather than
+      // storing a credential under `undefined` (#10782).
+      const surfaceId = stringOf(surface.surface_id) ?? args.surface_id;
       const hasInBandStringCredential =
         typeof args?.credential === "string" && args.credential.length > 0;
       const hasInBandObjectCredential =
@@ -14146,7 +14483,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         const stored = await loadSurfaceCredential(
           asCredentialStoreEnv(ctx.env),
           storeIdentity,
-          surface.surface_id,
+          surfaceId,
         );
         if (stored) {
           resolvedCredential = stored;
@@ -14160,7 +14497,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         typeof resolvedCredential === "object" &&
         !Array.isArray(resolvedCredential);
       const hasCredentialArg = hasStringCredentialArg || hasObjectCredentialArg;
-      let credentialPlacement;
+      let credentialPlacement: CallSubnetSurfaceCredential | undefined;
       if (surface.auth_required) {
         if (!hasCredentialArg) {
           throw toolError(
@@ -14168,16 +14505,20 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             "This surface requires a credential. Supply `credential` (see this tool's description for the required format), register one first with store_surface_credential if you are authenticated, or use list_subnet_apis / how_do_i_call to see how to call it directly.",
           );
         }
-        const scheme = surface.auth?.scheme;
-        const location = surface.auth?.location;
+        // The curated auth block, read ONCE. `surface.auth?.scheme` on a bag
+        // is an `any` five times over, and one of those five (`names`) is
+        // then `Array.isArray`-checked and re-read from the bag rather than
+        // from what the check proved (#10782).
+        const auth = rowOf(surface.auth);
+        const scheme = auth?.scheme;
+        // `location` reaches `CallSubnetSurfaceCredential.location`, a union
+        // of four literals. The `!==` chains below VALIDATE it and narrow
+        // nothing -- excluding literals from `unknown` leaves `unknown` -- so
+        // it crossed into the published placement as an `any` (#10782).
+        const location = authLocationOf(auth?.location);
         if (scheme === "bearer" || scheme === "api-key" || scheme === "basic") {
-          const name = surface.auth?.name;
-          if (
-            !name ||
-            (location !== "header" &&
-              location !== "query" &&
-              location !== "cookie")
-          ) {
+          const name = stringOf(auth?.name);
+          if (!name || location === null || location === "body") {
             throw toolError(
               "credential_not_supported",
               "This surface's auth mechanism (location/name) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
@@ -14196,17 +14537,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             value: resolvedCredential as string,
           };
         } else if (scheme === "signature") {
-          const names = Array.isArray(surface.auth?.names)
-            ? surface.auth.names
-            : null;
-          if (
-            !names ||
-            names.length === 0 ||
-            (location !== "header" &&
-              location !== "query" &&
-              location !== "cookie" &&
-              location !== "body")
-          ) {
+          const names = Array.isArray(auth?.names) ? auth.names : null;
+          if (!names || names.length === 0 || location === null) {
             throw toolError(
               "credential_not_supported",
               "This surface's auth mechanism (location/names) isn't documented completely enough for this tool to attach a credential automatically. Use list_subnet_apis / how_do_i_call to see how to call it directly.",
@@ -14267,7 +14599,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           // merge -- auth.body_envelope, curated registry data, describes
           // that shape. Only meaningful for location:"body"; malformed or
           // absent falls back to the existing flat-merge behavior.
-          const envelope = surface.auth?.body_envelope;
+          const envelope = rowOf(auth?.body_envelope);
           const bodyEnvelope =
             location === "body" &&
             envelope &&
@@ -14292,7 +14624,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           );
         }
       }
-      if (surface.probe?.enabled === false) {
+      if (rowOf(surface.probe)?.enabled === false) {
         throw toolError(
           "surface_unavailable",
           "This surface is flagged as not safe to call automatically (probe.enabled:false).",
@@ -14302,7 +14634,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       let requestContentType;
       if (hasPath) {
         const schemaArtifactId =
-          surface.schema_source?.surface_id || surface.surface_id;
+          rowOf(surface.schema_source)?.surface_id || surface.surface_id;
         const schema = await loadOptionalArtifact(
           ctx,
           `/metagraph/schemas/${schemaArtifactId}.json`,
@@ -14316,8 +14648,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // hasPath already proved args.path is a string; the `hasPath !==
         // hasMethod` check above guarantees normalizedMethod is set
         // whenever hasPath is true.
-        const match: Row | null = matchSchemaOperation(
-          schema.document,
+        const match = matchSchemaOperation(
+          rowOf(schema)?.document,
           args.path as string,
           normalizedMethod as string,
         );
@@ -14331,11 +14663,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           hasBodyArg &&
           (normalizedMethod === "POST" || normalizedMethod === "PUT")
         ) {
-          const declaredMediaTypes =
-            match.operation?.requestBody?.content &&
-            typeof match.operation.requestBody.content === "object"
-              ? Object.keys(match.operation.requestBody.content)
-              : [];
+          const declaredContent = rowOf(
+            rowOf(match.operation.requestBody)?.content,
+          );
+          const declaredMediaTypes = declaredContent
+            ? Object.keys(declaredContent)
+            : [];
           if (declaredMediaTypes.length === 0) {
             throw toolError(
               "invalid_params",
@@ -14439,7 +14772,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return {
-        surface_id: surface.surface_id,
+        surface_id: surfaceId,
         url: result.url,
         status_code: result.status_code,
         content_type: result.content_type,
@@ -14495,17 +14828,20 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const { identity, storeEnv } = requireCredentialStore(ctx);
-      const surface = await requireCredentialStoreSurface(ctx, args.surface_id);
+      const { canonicalId } = await requireCredentialStoreSurface(
+        ctx,
+        args.surface_id,
+      );
       const credential = normalizeSurfaceCredentialArgument(args.credential);
       const { expiresAt, replaced } = await storeSurfaceCredential(
         storeEnv,
         identity,
-        surface.surface_id,
+        canonicalId,
         credential,
         args.ttl_seconds,
       );
       return {
-        surface_id: surface.surface_id,
+        surface_id: canonicalId,
         stored: true,
         expires_at: expiresAt,
         replaced,
@@ -14671,7 +15007,13 @@ const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
 // never drift from reality. A schema only constrains successful results — a tool
 // that returns isError (e.g. the AI tools when the AI layer is off) carries no
 // structuredContent, so its schema is simply not applied on that path.
-const TOOL_OUTPUT_SCHEMAS = {
+//
+// Typed as a record of schemas rather than left to inference: the two readers
+// below index it by a tool NAME resolved at runtime, which the inferred
+// literal type cannot answer -- so both wrote `(TOOL_OUTPUT_SCHEMAS as Row)`
+// and got back an `any` where a `JsonSchemaLike | undefined` was wanted
+// (#10782).
+const TOOL_OUTPUT_SCHEMAS: Record<string, JsonSchemaLike> = {
   search_subnets: outputJsonSchema(SearchSubnetsOutputSchema),
   list_subnets: outputJsonSchema(ListSubnetsOutputSchema),
   find_subnets_by_capability: outputJsonSchema(
@@ -14992,7 +15334,7 @@ export function listToolDefinitions() {
     // passes a non-object straight through, which is what keeps the
     // absent-schema case below unchanged rather than adding a branch to it.
     const outputSchema = stripSentinelIntegerBounds(
-      tool.outputSchema || (TOOL_OUTPUT_SCHEMAS as Row)[tool.name],
+      tool.outputSchema || TOOL_OUTPUT_SCHEMAS[tool.name],
     );
     return {
       name: tool.name,
@@ -15328,7 +15670,7 @@ async function mcpCompletionCandidates(
  * than erroring: the spec models completion as best-effort, and a client
  * probing an argument we cannot complete has done nothing wrong.
  */
-async function completeArgument(params: Row, ctx: McpCtx) {
+async function completeArgument(params: Row | null, ctx: McpCtx) {
   const argument = (params?.argument ?? {}) as Row;
   const source = mcpCompletionSource(
     (params?.ref ?? {}) as Row,
@@ -15357,7 +15699,7 @@ function decodeResourceCursor(cursor: unknown) {
   return Number.isInteger(n) && n >= 0 ? n : 0;
 }
 
-async function listResources(params: Row, ctx: McpCtx) {
+async function listResources(params: Row | null, ctx: McpCtx) {
   const all = await listAllResources(ctx);
   const start = decodeResourceCursor(params?.cursor);
   const page = all.slice(start, start + RESOURCE_PAGE_SIZE);
@@ -15443,7 +15785,7 @@ async function readSubnetStatusResource(ctx: McpCtx, netuid: number) {
   };
 }
 
-async function readResource(params: Row, ctx: McpCtx) {
+async function readResource(params: Row | null, ctx: McpCtx) {
   const uri = params?.uri;
   if (uri === MCP_CHAIN_STREAM_RESOURCE_URI) {
     const data = await readLiveChainStreamResource(ctx);
@@ -15486,7 +15828,7 @@ async function readResource(params: Row, ctx: McpCtx) {
 // mirroring the lesson from this session's graphql-ws fix
 // (validateChainEventsSubscribePayload) -- a hand-rolled second validation
 // path is exactly how a security guarantee quietly drifts from the first.
-async function subscribeResource(params: Row, ctx: McpCtx) {
+async function subscribeResource(params: Row | null, ctx: McpCtx) {
   const uri = params?.uri;
   if (typeof uri !== "string" || !isSubscribableResourceUri(uri)) {
     throw toolError(
@@ -15526,7 +15868,7 @@ async function subscribeResource(params: Row, ctx: McpCtx) {
   return {};
 }
 
-async function unsubscribeResource(params: Row, ctx: McpCtx) {
+async function unsubscribeResource(params: Row | null, ctx: McpCtx) {
   const uri = params?.uri;
   if (typeof uri !== "string") {
     throw toolError("invalid_params", "Missing required field: uri.");
@@ -15689,15 +16031,18 @@ export function listPromptDefinitions() {
   }));
 }
 
-function getPrompt(params: Row) {
-  const prompt = PROMPTS_BY_NAME.get(params?.name);
+function getPrompt(params: Row | null) {
+  // `String(params?.name)` in the error message was doing the narrowing the
+  // LOOKUP needed one line earlier: the map is keyed by string, and a
+  // non-string `name` looked it up as one anyway (#10782).
+  const prompt = PROMPTS_BY_NAME.get(String(params?.name));
   if (!prompt) {
     throw toolError(
       "invalid_params",
       `Unknown prompt: ${String(params?.name)}`,
     );
   }
-  const args = params?.arguments || {};
+  const args = rowOf(params?.arguments) ?? {};
   for (const arg of prompt.arguments) {
     if (arg.required && (args[arg.name] == null || args[arg.name] === "")) {
       throw toolError(
@@ -15736,13 +16081,18 @@ function negotiateProtocol(requested: unknown) {
 // but only after recordMcpToolCallEvent (src/usage-telemetry.ts) redacts and
 // size-caps them; see that module's header comment for why (no SDK
 // instrument() wrapper here, so no default redaction pipeline either).
-async function callTool(params: Row, ctx: McpCtx) {
+async function callTool(params: Row | null, ctx: McpCtx) {
   const startedAt = Date.now();
   const result = await dispatchTool(params, ctx);
   const durationMs = Date.now() - startedAt;
   // One bucket for both events, so the tool dimension can never disagree
   // between usage_event and $mcp_tool_call. See mcpToolLabel.
   const toolLabel = mcpToolLabel(params?.name);
+  // The failure code both events report. `structuredContent.error.code` was
+  // two chained reads off a bag; every isError result is built by the same
+  // two producers (toolError's wrapper and the unknown_tool branch) and both
+  // set it, so this is where that gets said once (#10782).
+  const errorCode = rowOf(result.structuredContent.error)?.code;
   scheduleToolUsageEvent(ctx, {
     mcpTool: toolLabel,
     ok: result.isError !== true,
@@ -15753,16 +16103,14 @@ async function callTool(params: Row, ctx: McpCtx) {
     // through so analytics can break failures down by cause, not just count
     // them. Omitted entirely on success (no `errorCode` key at all), same as
     // `route`/`mcpTool` being omitted when absent.
-    ...(result.isError
-      ? { errorCode: result?.structuredContent?.error?.code }
-      : {}),
+    ...(result.isError ? { errorCode } : {}),
   });
   // #9642: `context` is the argument an agent uses to say WHY it called, and
   // PostHog records it as $mcp_intent. Split here rather than read in place so
   // `parameters` below carries the real arguments only -- the intent travels
   // as its own property, not as a second copy inside the parameter blob.
   const { intent, rest: toolParameters } = splitMcpIntent(
-    params?.arguments as Row,
+    rowOf(params?.arguments),
   );
   scheduleMcpToolCallEvent(ctx, {
     toolName: toolLabel,
@@ -15789,9 +16137,7 @@ async function callTool(params: Row, ctx: McpCtx) {
     // #8963: the same structuredContent.error.code usage_event already
     // threads above, projected onto PostHog's $mcp_error_type by
     // classifyMcpErrorType inside the recorder. Omitted on success.
-    ...(result.isError
-      ? { errorCode: result?.structuredContent?.error?.code }
-      : {}),
+    ...(result.isError ? { errorCode } : {}),
     ...mcpAttributionFor(ctx),
   });
   // The capability gap, recorded from the same split intent the tool call
@@ -16273,7 +16619,7 @@ export function markMcpTierDegraded(
 }
 
 async function dispatchTool(
-  params: Row,
+  params: Row | null,
   ctx: McpCtx,
 ): Promise<{
   content: { type: string; text: string }[];
@@ -16369,7 +16715,7 @@ async function dispatchTool(
           endTimeMs: Date.now(),
           ok: toolOk,
           serviceName: "metagraphed-api",
-          attributes: { mcp_tool: name },
+          attributes: { mcp_tool: tool.name },
         });
       }
     }
@@ -16377,8 +16723,7 @@ async function dispatchTool(
     // one generic shape onto whichever tool degraded and `degraded` is a
     // per-tool object (#9910). Applied to every result, not just a stamped
     // one: a handler that built its own partial block is the same violation.
-    const outputSchema =
-      tool.outputSchema ?? (TOOL_OUTPUT_SCHEMAS as Row)[tool.name];
+    const outputSchema = tool.outputSchema ?? TOOL_OUTPUT_SCHEMAS[tool.name];
     const payload = completeDegradedBlock(
       markMcpTierDegraded(data, tierGenerationBefore),
       outputSchema,
@@ -16459,11 +16804,16 @@ async function dispatchTool(
  * request to the SDK, and two copies of "well-formed" is precisely how the two
  * envelopes would start disagreeing about what a malformed request is.
  */
-export function isDispatchableJsonRpcMessage(message: unknown): boolean {
-  const row = message as Row | null;
+export function isDispatchableJsonRpcMessage(
+  message: unknown,
+): message is Row & { method: string } {
+  // A type PREDICATE, not a boolean. The guard already proves `method` is a
+  // string, and the router then read `message.method` as `unknown` and fed it
+  // to `mcpMethodLabel(label: string)` -- so the one check that establishes
+  // the fact told nothing to the code that depends on it (#10782).
+  const row = rowOf(message);
   return (
     row !== null &&
-    typeof row === "object" &&
     row.jsonrpc === JSONRPC_VERSION &&
     typeof row.method === "string"
   );
@@ -16484,7 +16834,13 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
     return rpcError(id, RPC_INVALID_REQUEST, "Invalid JSON-RPC request.");
   }
 
-  const { method, params } = message;
+  const method = message.method;
+  // Narrowed ONCE, here. Destructuring `params` off a `Row` gives `unknown`,
+  // and every case below either forwards it to a handler declared
+  // `(params: Row, …)` or reads a member straight off it -- including two
+  // that read it into a telemetry DIMENSION through an `as string` justified
+  // by a throw inside a different function (#10782).
+  const params = rowOf(message.params);
 
   // #8993: the dispatch chokepoint. `ok` starts true and is falsified by the
   // catch and by the unknown-method default -- an unknown method returns
@@ -16496,6 +16852,7 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
   try {
     switch (method) {
       case "initialize": {
+        const clientInfo = rowOf(params?.clientInfo);
         const result = {
           protocolVersion: negotiateProtocol(params?.protocolVersion),
           capabilities: MCP_CAPABILITIES,
@@ -16511,10 +16868,10 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
           // produced an event with server attribution only -- even though
           // ctx.clientName had already been parsed two lines away.
           ...mcpAttributionFor(ctx),
-          ...(params?.clientInfo?.name
+          ...(clientInfo?.name
             ? {
-                clientName: params.clientInfo.name,
-                clientVersion: params.clientInfo.version,
+                clientName: clientInfo.name,
+                clientVersion: clientInfo.version,
                 clientNameSource: "client_info" as const,
               }
             : {}),
@@ -16617,7 +16974,7 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
           // `uri` matched a resource this server serves, and every one of those
           // is a string. The false half was unreachable, and codecov counts an
           // unreachable branch the same as an untested one.
-          resourceName: params.uri as string,
+          resourceName: String(params?.uri),
           sessionId: ctx?.sessionId,
           parameters: params,
           response: result,
@@ -16659,7 +17016,7 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         scheduleMcpPromptGetEvent(ctx, {
           // Same as resources/read above: getPrompt threw unless the name is
           // one of PROMPTS_BY_NAME's own keys, all of which are strings.
-          resourceName: params.name as string,
+          resourceName: String(params?.name),
           sessionId: ctx?.sessionId,
           parameters: params,
           ...mcpAttributionFor(ctx),
@@ -16683,7 +17040,7 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
           : rpcError(id, RPC_METHOD_NOT_FOUND, `Unknown method: ${method}`);
     }
   } catch (rawError) {
-    const error = rawError as Row;
+    const error = rowOf(rawError);
     dispatchOk = false;
     // A toolError thrown by a protocol method (resources/read, prompts/get) is a
     // bad-params condition, not an internal fault — surface it as -32602.
@@ -16691,7 +17048,7 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
     if (error?.toolError) {
       return isNotification
         ? null
-        : rpcError(id, RPC_INVALID_PARAMS, error.message);
+        : rpcError(id, RPC_INVALID_PARAMS, errorMessage(rawError));
     }
     // Don't echo raw internals to the public client; log server-side instead.
     // Same discipline as callTool's sibling catch above: a handled toolError
@@ -16794,7 +17151,7 @@ export function mcpDistinctId(
 function buildContext(
   request: Request,
   env: Env,
-  deps: Row,
+  deps: McpDeps,
   authTier: string,
   accountId: string | null = null,
 ) {
@@ -17128,7 +17485,10 @@ function validateMcpProtocolVersionHeader(request: Request) {
 // initialize. Batched/legacy-array requests predate the 2025-06-18 session
 // concept and are left alone.
 function mintMcpSessionHeaderIfNeeded(
-  body: Row | null,
+  // `Row[]` too: the first line below is `Array.isArray(body)`, because a
+  // BATCHED initialize mints no session. That was the whole contract and the
+  // signature did not admit the case it exists to handle (#10782).
+  body: Row | Row[] | null,
   response: Row | null,
   // #8994: the id is generated BEFORE dispatch and passed in, rather than
   // minted here. It has to exist while the initialize event is emitted, and
@@ -17407,7 +17767,7 @@ export function mcpRefusalReason(response: Response): string | null {
 export function scheduleMcpRefusalEvent(
   request: Request,
   env: Env,
-  deps: Row,
+  deps: McpDeps,
   response: Response,
   /** Injectable clock, mirroring admitMcpRefusalCapture's own `nowMs`. Only a
    * test passes it. Without it the storm window can only be crossed by real
@@ -17456,7 +17816,7 @@ export function scheduleMcpRefusalEvent(
         {},
       ),
     ).catch(() => false);
-    (deps.executionCtx as Row | undefined)?.waitUntil?.(pending);
+    deps.executionCtx?.waitUntil?.(pending);
 
     // ...and the same refusal in PostHog's OWN event family.
     //
@@ -17500,7 +17860,7 @@ export function scheduleMcpRefusalEvent(
         {},
       ),
     ).catch(() => false);
-    (deps.executionCtx as Row | undefined)?.waitUntil?.(pendingMcp);
+    deps.executionCtx?.waitUntil?.(pendingMcp);
   } catch {
     // Telemetry must never surface into the MCP path.
   }
@@ -17620,7 +17980,7 @@ async function serveMcpThroughSdk(
 export async function handleMcpRequest(
   request: Request,
   env: Env = {} as unknown as Env,
-  deps: Row = {},
+  deps: McpDeps = {},
 ) {
   const response = await dispatchMcpRequest(request, env, deps);
   if (!response.ok) scheduleMcpRefusalEvent(request, env, deps, response);
@@ -17630,7 +17990,7 @@ export async function handleMcpRequest(
 async function dispatchMcpRequest(
   request: Request,
   env: Env = {} as unknown as Env,
-  deps: Row = {},
+  deps: McpDeps = {},
 ) {
   const { rejection, authTier, accountId, quotaPending } =
     await enforceMcpRateLimit(request, env, deps.executionCtx);

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -108,7 +108,11 @@ export function isEpochMillis(value: unknown): value is number {
  * put `account_position_daily`'s date range at `1970-01-21 .. 2026-08-07`,
  * outside every served window and inside every COUNT(*).
  */
-export function neuronSnapshotDate(capturedAtMs: number): string | null {
+// Takes `unknown`, matching its own guard: `isEpochMillis` is a type
+// predicate over `unknown` and `Number.isFinite` does not coerce, so a
+// numeric STRING is rejected here and always was. Declaring the parameter
+// `number` said the caller had already checked, which no caller had (#10782).
+export function neuronSnapshotDate(capturedAtMs: unknown): string | null {
   if (!isEpochMillis(capturedAtMs)) return null;
   return new Date(capturedAtMs).toISOString().slice(0, 10);
 }

--- a/src/openapi-sample.ts
+++ b/src/openapi-sample.ts
@@ -8,7 +8,7 @@
 // responses rather than bare placeholders. Validity is enforced downstream by
 // scripts/validate-openapi-examples.ts (ajv against each operation's schema).
 
-type Schema = Record<string, unknown>;
+export type Schema = Record<string, unknown>;
 type Sample = Record<string, unknown>;
 
 // Top levels show optional fields (informative); deeper levels stay required-only

--- a/src/registry-surface-key.ts
+++ b/src/registry-surface-key.ts
@@ -24,8 +24,7 @@ import { BlockList, isIP } from "node:net";
 // Mirrors scripts/lib.ts's own Row: registry overlays are validated against
 // the surface schema, not against a TS type, and threading `unknown` through
 // every `?.` would add casts without adding safety.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 
 const credentialedUrlParams = new Set([
   "access_key",

--- a/src/registry-sync-payload.ts
+++ b/src/registry-sync-payload.ts
@@ -18,13 +18,37 @@ import { subnetSurfaceKey } from "./registry-surface-key.ts";
 // Registry overlays are validated against the surface schema rather than a TS
 // type; threading `unknown` through every `?.` would add casts without adding
 // safety. Mirrors the readJson precedent in scripts/lib.ts.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Row = Record<string, any>;
+export type Row = Record<string, unknown>;
+
+/** The row under an untyped value, or null -- a nested artifact object. */
+function rowOf(value: unknown): Row | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Row)
+    : null;
+}
 
 const OPERATIONAL_KINDS = new Set<string>(OPERATIONAL_SURFACE_KINDS);
 
+/**
+ * The subnet row this lane writes.
+ *
+ * Named rather than `Row`, because `overlay` is the one member a reader goes
+ * INTO -- the sync asserts the surfaces array was stripped out of it -- and a
+ * bag makes that read an `unknown` two levels down (#10782).
+ */
+export interface SubnetSyncRow {
+  netuid: unknown;
+  slug: unknown;
+  name: unknown;
+  source: "community";
+  /** The file's own overlay, MINUS `surfaces`: those are stored as rows, not
+   *  as a blob nested inside the parent. */
+  overlay: Row;
+  source_commit: string;
+}
+
 export interface SubnetSyncRows {
-  subnet: Row;
+  subnet: SubnetSyncRow;
   surfaces: Row[];
   prune: Row;
 }
@@ -77,11 +101,11 @@ export function buildSubnetRows(
       kind: surface.kind,
       url: surface.url,
       authority: surface.authority || "community",
-      review_state: surface.review?.state || "community-submitted",
+      review_state: rowOf(surface.review)?.state || "community-submitted",
       probe_eligible: Boolean(
-        surface.probe?.enabled &&
+        rowOf(surface.probe)?.enabled &&
         surface.public_safe &&
-        OPERATIONAL_KINDS.has(surface.kind),
+        OPERATIONAL_KINDS.has(String(surface.kind)),
       ),
       public_safe: surface.public_safe !== false,
       overlay: surface,
@@ -109,7 +133,7 @@ export function buildSubnetRows(
 
 export interface RegistrySyncPayload {
   providers: Row[];
-  subnets: Row[];
+  subnets: SubnetSyncRow[];
   surfaces: Row[];
   prune_surfaces: Row[];
   delete_subnets: Row[];

--- a/src/revenue-feed.ts
+++ b/src/revenue-feed.ts
@@ -350,8 +350,7 @@ export interface RevenueFeedDb {
 // instead -- see RevenueObservations/RevenueProbeFailures at the read sites,
 // where `observed_at: number | string` is the honest BIGINT type and the reason
 // epochMs exists at all.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 
 /** Bounded so one pathological surface cannot make the feed read the table. The
  * feed caps at FEED_MAX_ITEMS anyway; this bounds the SCAN, not the output. */
@@ -362,18 +361,22 @@ const FEED_ROW_LIMIT = 2000;
 const DENOMINATOR_WINDOW = "30d";
 const DENOMINATOR_WINDOW_HOURS = 24 * 30;
 
-async function queryRows(
+// GENERIC over the row the SELECT returns, so the caller names the generated
+// table type once instead of casting the result. The assertion below is the
+// D1 trust boundary -- `all()` answers `unknown` and only the SQL knows the
+// shape -- and it is now in one place rather than at every call site (#10782).
+async function queryRows<T = Row>(
   db: RevenueFeedDb | null | undefined,
   sql: string,
   binds: unknown[],
-): Promise<Row[] | null> {
+): Promise<T[] | null> {
   if (!db?.prepare) return null;
   try {
     const statement = db.prepare(sql);
     const res = await (
       binds.length ? statement.bind(...binds) : statement
     ).all?.();
-    return (res?.results ?? []) as Row[];
+    return (res?.results ?? []) as T[];
   } catch {
     // Null, not []: a failed read and an empty table are different facts, and
     // an empty feed derived from a broken store would read as "nothing moved".
@@ -409,13 +412,13 @@ export async function loadRevenueFeedItems(
   const cutoff = now - windowDays * DAY_MS;
 
   const [observationRows, failureRows] = await Promise.all([
-    queryRows(
+    queryRows<RevenueObservations>(
       db,
       `SELECT surface_id, netuid, period, grain, amount, currency, provenance, observed_at` +
         ` FROM revenue_observations ORDER BY observed_at DESC LIMIT ${FEED_ROW_LIMIT}`,
       [],
     ),
-    queryRows(
+    queryRows<RevenueProbeFailures>(
       db,
       `SELECT surface_id, netuid, reason, observed_at` +
         ` FROM revenue_probe_failures WHERE observed_at >= ?` +
@@ -425,21 +428,19 @@ export async function loadRevenueFeedItems(
   ]);
   if (observationRows === null && failureRows === null) return [];
 
-  const observations: RevenueObservationRow[] = (
-    (observationRows ?? []) as RevenueObservations[]
-  ).map((r) => ({
-    surface_id: String(r.surface_id ?? ""),
-    netuid: r.netuid == null ? null : Number(r.netuid),
-    period: String(r.period ?? ""),
-    grain: r.grain == null ? null : String(r.grain),
-    amount: Number(r.amount),
-    currency: r.currency == null ? null : String(r.currency),
-    provenance: r.provenance == null ? null : String(r.provenance),
-    observed_at: isoOrNull(r.observed_at),
-  }));
-  const failures: RevenueProbeFailureRow[] = (
-    (failureRows ?? []) as RevenueProbeFailures[]
-  ).map((r) => ({
+  const observations: RevenueObservationRow[] = (observationRows ?? []).map(
+    (r) => ({
+      surface_id: String(r.surface_id ?? ""),
+      netuid: r.netuid == null ? null : Number(r.netuid),
+      period: String(r.period ?? ""),
+      grain: r.grain == null ? null : String(r.grain),
+      amount: Number(r.amount),
+      currency: r.currency == null ? null : String(r.currency),
+      provenance: r.provenance == null ? null : String(r.provenance),
+      observed_at: isoOrNull(r.observed_at),
+    }),
+  );
+  const failures: RevenueProbeFailureRow[] = (failureRows ?? []).map((r) => ({
     surface_id: String(r.surface_id ?? ""),
     netuid: r.netuid == null ? null : Number(r.netuid),
     reason: r.reason == null ? null : String(r.reason),

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -13,6 +13,7 @@
 // endpoint, and a caller sweeping the network would see 127 failures instead of
 // 127 answers.
 import {
+  type SubnetRevenueView,
   buildSubnetRevenue,
   type RevenueObservation,
   type RevenueSourceRow,
@@ -20,8 +21,7 @@ import {
 
 // Registry/artifact rows are read for shaping only, never trusted for control
 // flow. Mirrors the readJson precedent elsewhere.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 
 export const SUBNET_REVENUE_FIELD_SOURCES = {
   "emission.tao": {
@@ -116,7 +116,12 @@ export interface LoadSubnetRevenueInput {
 }
 
 /** Compose the served body. Never throws on missing pieces. */
-export function loadSubnetRevenue(input: LoadSubnetRevenueInput): Row {
+// Returns the VIEW it builds, not a row bag. It always did; the declaration
+// said otherwise, and `Row` as `Record<string, any>` let both readings stand
+// (#10782).
+export function loadSubnetRevenue(
+  input: LoadSubnetRevenueInput,
+): SubnetRevenueView {
   const sources = revenueSourcesFor(input.surfaces);
   const view = buildSubnetRevenue({
     netuid: input.netuid,

--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -33,8 +33,7 @@ import {
 export const REVENUE_OBSERVATIONS_TABLE = "revenue_observations";
 export const REVENUE_PROBE_FAILURES_TABLE = "revenue_probe_failures";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 
 export interface RevenueStoreDb {
   prepare(sql: string): {
@@ -201,7 +200,12 @@ export function eligibleRevenueSurfaces(
   const surfaces = Array.isArray(artifact?.surfaces) ? artifact.surfaces : [];
   const out: ProbeSurfaceInput[] = [];
   for (const surface of surfaces as Row[]) {
-    const revenue = surface?.revenue as Row | undefined;
+    // The registry's own declaration, asserted at the SAME boundary the
+    // artifact read already is -- narrower than the `as Row` it replaces, not
+    // an additional claim. It says what the object IS, never that its members
+    // are valid: `extractRevenue` validates `shape` against REVENUE_SHAPES
+    // itself, which is the whole point of the paragraph above (#10782).
+    const revenue = surface?.revenue as ProbeSurfaceInput["revenue"];
     if (!revenue) continue;
     // The two `extractRevenue` refuses without, checked in the order it checks
     // them so the reason a surface is skipped here matches the reason it would
@@ -213,7 +217,7 @@ export function eligibleRevenueSurfaces(
       url: String(surface.url ?? ""),
       auth_required: surface.auth_required === true,
       probe: { enabled: true },
-      revenue: surface.revenue,
+      revenue,
     });
   }
   return out;

--- a/src/wallets-load.ts
+++ b/src/wallets-load.ts
@@ -28,8 +28,16 @@ type ServedWalletActivity = Omit<WalletActivity, "address" | "window_days">;
 
 // Registry/artifact rows are read for shaping only, never trusted for control
 // flow. Mirrors the readJson precedent elsewhere.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
+
+type Row = Record<string, unknown>;
+
+/** The row under an untyped value, or null -- a nested artifact object. */
+function rowOf(value: unknown): Row | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Row)
+    : null;
+}
 
 export const SUBNET_WALLETS_FIELD_SOURCES = {
   "wallets[].ss58": { kind: "measured", storage: null },
@@ -126,10 +134,10 @@ export function subnetWalletRows(
       source_urls: Array.isArray(entity?.source_urls)
         ? entity.source_urls.map(String)
         : [],
-      unspendable_proof_basis:
-        typeof entity?.unspendable_proof?.basis === "string"
-          ? entity.unspendable_proof.basis
-          : null,
+      unspendable_proof_basis: ((proof) =>
+        typeof proof?.basis === "string" ? proof.basis : null)(
+        rowOf(entity?.unspendable_proof),
+      ),
       activity: activityFor(ss58),
     });
   }
@@ -139,7 +147,15 @@ export function subnetWalletRows(
 export interface LoadSubnetOwnerCutInput {
   netuid: number;
   window_days?: number;
-  economics: Row | null;
+  /** The subnet's economics card, typed to the contract rather than to a bag:
+   *  `alpha_out_emission` and `alpha_price_tao` are read straight out of it
+   *  and handed to a calculation that takes numbers (#10782).
+   *
+   *  `Partial`, because this reads FOUR of its ~39 members and each read is
+   *  already null-tolerant -- an absent emission nulls the accrual with a
+   *  reason rather than failing. Every name is still checked against the
+   *  contract, so a typo is a compile error; only the arity is relaxed. */
+  economics: Partial<SubnetEconomicsRow> | null;
   /** network-parameters' `subnet_owner_cut_effective`. Null makes the accrual
    * null rather than silently 18% (#10484). */
   owner_cut: number | null;
@@ -190,7 +206,7 @@ export function loadSubnetOwnerCut(
     burned_alpha: input.burned_alpha ?? null,
     flows_observed: input.flows_observed,
   });
-  const owner = (key: string): string | null => {
+  const owner = (key: keyof SubnetEconomicsRow): string | null => {
     const value = input.economics?.[key];
     return typeof value === "string" && value ? value : null;
   };

--- a/tests/candidates-mcp.test.ts
+++ b/tests/candidates-mcp.test.ts
@@ -381,7 +381,11 @@ describe("candidates-mcp (#7889)", () => {
           { id: "b", netuid: 10 },
         ],
       },
-      meta: undefined,
+      // `{}`, not `undefined`: the passthrough this test exercises
+      // returns `{ data, meta: {} }` -- an unwindowed answer, not a missing
+      // meta. The union `applyQueryFilters` declares has no arm that omits
+      // `meta` beside a `data` (#10782).
+      meta: {},
     });
     try {
       const out = await loadCandidatesList(

--- a/tests/health-history-mcp.test.ts
+++ b/tests/health-history-mcp.test.ts
@@ -255,7 +255,18 @@ describe("health-history-mcp — loadHealthHistory", () => {
   test("falls back when list-query data omits date, summary, and surface rows", async () => {
     const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
       data: { surfaces: null },
-      meta: { pagination: { total: 0, returned: 0, limit: 0, cursor: 0 } },
+      meta: {
+        pagination: {
+          collection: "surfaces",
+          total: 0,
+          returned: 0,
+          limit: 0,
+          cursor: 0,
+          next_cursor: null,
+          sort: null,
+          order: "asc" as const,
+        },
+      },
     });
     try {
       const out = await loadHealthHistory(

--- a/tests/mcp-published-default.test.ts
+++ b/tests/mcp-published-default.test.ts
@@ -40,18 +40,21 @@ import {
 import type { Row } from "./row-type.ts";
 
 /** The published defaults one served tool advertises, argument -> value. */
-function publishedDefaults(tool: Row): [string, unknown][] {
-  const properties = (tool.inputSchema?.properties ?? {}) as Record<
-    string,
-    Row
-  >;
-  return Object.entries(properties)
-    .filter(([, schema]) => schema?.default !== undefined)
-    .map(([name, schema]) => [name, schema.default]);
+function publishedDefaults(tool: ServedTool): [string, unknown][] {
+  const properties = tool.inputSchema?.properties ?? {};
+  return Object.entries(properties).flatMap(([name, raw]) => {
+    const schema = raw as Row | null;
+    return schema?.default === undefined ? [] : [[name, schema.default]];
+  });
 }
 
+/** The served tool shape, from the function that produces it -- not `Row`.
+ *  `validateToolArguments` takes an `McpToolDefinition` since #10782, and a
+ *  bag is not one. */
+type ServedTool = ReturnType<typeof listToolDefinitions>[number];
+
 describe("a tool serves the default it publishes", () => {
-  const tools = listToolDefinitions() as Row[];
+  const tools = listToolDefinitions();
 
   test("every published default reaches the handler when omitted", () => {
     const missed: string[] = [];
@@ -93,7 +96,7 @@ describe("a tool serves the default it publishes", () => {
     for (const tool of tools) {
       if (publishedDefaults(tool).length === 0) continue;
       assert.deepEqual(
-        validateToolArguments(tool, undefined as unknown as Row),
+        validateToolArguments(tool, undefined),
         validateToolArguments(tool, {}),
         `${tool.name} answers differently for absent vs empty arguments`,
       );
@@ -167,7 +170,7 @@ describe("validateToolArguments on schemas the registry does not contain", () =>
     // is spelled this way today, which is exactly why the fallback was never
     // taken -- and a tool added without `properties` would hit it first.
     const resolved = validateToolArguments(
-      { name: "no_properties", inputSchema: { type: "object" } } as Row,
+      { name: "no_properties", inputSchema: { type: "object" } },
       { anything: 1 },
     );
     assert.deepEqual(resolved, { anything: 1 });
@@ -182,7 +185,7 @@ describe("validateToolArguments on schemas the registry does not contain", () =>
           {
             name: "closed_empty",
             inputSchema: { type: "object", additionalProperties: false },
-          } as Row,
+          },
           { nope: 1 },
         ),
       /nope/,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -241,6 +241,49 @@ beforeEach(() => {
   pg.control.db = null;
 });
 
+/**
+ * One tool's published outputSchema, asserted present.
+ *
+ * `listToolDefinitions().find(...)?.outputSchema` is
+ * `JsonSchemaLike | undefined`, and `ajv.compile` takes a schema -- so the
+ * ~54 call sites below were feeding it a possibly-undefined value, which
+ * compiled only while the definition list was reached through a cast
+ * (#10782). Asserting here names the TOOL when a schema goes missing, instead
+ * of leaving Ajv to throw about `undefined` from whichever test ran first.
+ */
+/**
+ * Walk into a published JSON Schema by key path.
+ *
+ * `schema?.properties?.points?.items?.properties` reads through four `unknown`
+ * members: JsonSchemaLike declares `properties` as
+ * `Record<string, unknown>`, which is honest -- a sub-schema is not itself
+ * typed -- and the chained `?.` only compiled while the definition list was an
+ * `any` (#10782).
+ */
+function schemaAt(
+  schema: unknown,
+  path: string[],
+): Record<string, unknown> | undefined {
+  let node: unknown = schema;
+  for (const key of path) {
+    if (!node || typeof node !== "object" || Array.isArray(node)) {
+      return undefined;
+    }
+    node = (node as Record<string, unknown>)[key];
+  }
+  return node && typeof node === "object" && !Array.isArray(node)
+    ? (node as Record<string, unknown>)
+    : undefined;
+}
+
+function outputSchemaFor(name: string) {
+  const schema = listToolDefinitions().find(
+    (t) => t.name === name,
+  )?.outputSchema;
+  assert.ok(schema, `${name}: no published outputSchema`);
+  return schema;
+}
+
 describe("MCP tool registry", () => {
   test("every tool has a unique name, description, and object inputSchema", () => {
     const names = new Set();
@@ -301,18 +344,22 @@ describe("MCP tool registry", () => {
         assert.equal(def.annotations.destructiveHint, false, `${def.name}`);
       }
       // Every tool declares a compilable object outputSchema for its structuredContent.
+      // `assert.ok` rather than `typeof === "object"`: the first is an
+      // assertion signature, so it establishes for the two reads below what
+      // the second only checked (#10782).
+      // `assert.ok` rather than `typeof === "object"`: the first is an
+      // assertion signature, so it establishes for the reads below what the
+      // second only checked (#10782). Bound to a const because the closure
+      // handed to `doesNotThrow` does not inherit the narrowing.
+      assert.ok(def.outputSchema, `${def.name}: outputSchema`);
+      const outputSchema = def.outputSchema;
       assert.equal(
-        typeof def.outputSchema,
-        "object",
-        `${def.name}: outputSchema`,
-      );
-      assert.equal(
-        def.outputSchema.type,
+        outputSchema.type,
         "object",
         `${def.name}: outputSchema.type`,
       );
       assert.doesNotThrow(
-        () => ajv.compile(def.outputSchema),
+        () => ajv.compile(outputSchema),
         `${def.name}: outputSchema must be a valid JSON Schema`,
       );
     }
@@ -328,8 +375,12 @@ describe("MCP tool registry", () => {
       (def) => def.name === "get_subnet_concentration_history",
     );
     assert.equal(defs.length, 1);
-    const pointProperties =
-      defs[0].outputSchema?.properties?.points?.items?.properties;
+    const pointProperties = schemaAt(defs[0].outputSchema, [
+      "properties",
+      "points",
+      "items",
+      "properties",
+    ]);
     assert.ok(pointProperties?.snapshot_date);
     assert.ok(pointProperties?.stake_gini);
     assert.ok(pointProperties?.emission_top_10pct_share);
@@ -338,13 +389,27 @@ describe("MCP tool registry", () => {
   test("get_rpc_usage advertises a typed RpcUsageArtifact-shaped outputSchema", () => {
     const def = listToolDefinitions().find((t) => t.name === "get_rpc_usage");
     assert.ok(def);
-    const summary = def.outputSchema?.properties?.summary?.properties;
+    const summary = schemaAt(def.outputSchema, [
+      "properties",
+      "summary",
+      "properties",
+    ]);
     assert.ok(summary?.total_requests);
-    assert.ok(summary?.latency_ms?.properties?.p50);
-    const endpoint = def.outputSchema?.properties?.endpoints?.items?.properties;
+    assert.ok(schemaAt(summary?.latency_ms, ["properties", "p50"]));
+    const endpoint = schemaAt(def.outputSchema, [
+      "properties",
+      "endpoints",
+      "items",
+      "properties",
+    ]);
     assert.ok(endpoint?.endpoint_id);
     assert.ok(endpoint?.error_rate);
-    const bucket = def.outputSchema?.properties?.buckets?.items?.properties;
+    const bucket = schemaAt(def.outputSchema, [
+      "properties",
+      "buckets",
+      "items",
+      "properties",
+    ]);
     assert.ok(bucket?.ts);
     assert.ok(bucket?.avg_latency_ms);
   });
@@ -2109,8 +2174,15 @@ describe("MCP tools (injected deps)", () => {
         ],
       },
       "/metagraph/rpc/pools.json": {
-        pools: {
-          0: {
+        // The published artifact spells `pools` as an ARRAY -- five of them on
+        // /metagraph/rpc/pools.json -- so the fixture the bulk of these tests
+        // run against spells it that way too. It was an object keyed by pool
+        // index, a shape no artifact serves, and that disagreement is exactly
+        // what let #10782 empty `get_best_rpc_endpoint` against the real
+        // artifact with every test in this file still green. The object
+        // spelling is accepted too, and is still covered below.
+        pools: [
+          {
             endpoints: [
               {
                 id: "a",
@@ -2148,7 +2220,7 @@ describe("MCP tools (injected deps)", () => {
           },
           // Same physical endpoint 'b' also appears in a second pool — must be
           // deduped, not returned twice.
-          1: {
+          {
             endpoints: [
               {
                 id: "b",
@@ -2163,7 +2235,7 @@ describe("MCP tools (injected deps)", () => {
               },
             ],
           },
-        },
+        ],
       },
     },
     {
@@ -2624,6 +2696,9 @@ describe("MCP tools (injected deps)", () => {
     const noKvDeps = makeDeps(
       {
         "/metagraph/rpc/pools.json": {
+          // Keyed by pool index rather than the artifact's array — the other
+          // spelling `valuesOf` accepts, kept exercised here so the array
+          // fixture above is not the only shape this reads.
           pools: {
             0: { endpoints: [{ id: "a", pool_eligible: true, score: 1 }] },
           },
@@ -2672,9 +2747,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_curation payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_curation",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_curation");
     const deps = makeDeps({
       "/metagraph/curation.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -2761,9 +2834,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_gaps payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_gaps",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_gaps");
     const deps = makeDeps({
       "/metagraph/gaps.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -2852,9 +2923,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_enrichment_queue payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_enrichment_queue",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_enrichment_queue");
     const deps = makeDeps({
       "/metagraph/review/enrichment-queue.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -2977,9 +3046,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_adapter_candidates payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_adapter_candidates",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_adapter_candidates");
     const deps = makeDeps({
       "/metagraph/review/adapter-candidates.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3087,9 +3154,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_enrichment_evidence payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_enrichment_evidence",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_enrichment_evidence");
     const deps = makeDeps({
       "/metagraph/review/enrichment-evidence.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3183,9 +3248,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_review_gaps payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_review_gaps",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_review_gaps");
     const deps = makeDeps({
       "/metagraph/review/gap-priorities.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3262,9 +3325,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_review_enrichment_targets payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_review_enrichment_targets",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_review_enrichment_targets");
     const deps = makeDeps({
       "/metagraph/review/enrichment-targets.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3384,9 +3445,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_subnet_endpoints payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_subnet_endpoints",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_subnet_endpoints");
     const deps = makeDeps({
       "/metagraph/endpoints/7.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3516,9 +3575,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_subnet_health payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_subnet_health",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_subnet_health");
     const deps = makeDeps({
       "/metagraph/health/subnets/7.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3609,9 +3666,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_subnet_surfaces payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_subnet_surfaces",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_subnet_surfaces");
     const deps = makeDeps({
       "/metagraph/surfaces/7.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3695,9 +3750,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_endpoint_pools payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_endpoint_pools",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_endpoint_pools");
     const deps = makeDeps({
       "/metagraph/endpoint-pools.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -3921,9 +3974,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_provider_endpoints payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_provider_endpoints",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_provider_endpoints");
     const deps = makeDeps({
       "/metagraph/providers/datura/endpoints.json": {
         // A REAL captured production row. #9796 expressed this tool's
@@ -4050,9 +4101,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("list_endpoint_incidents payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_endpoint_incidents",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_endpoint_incidents");
     const deps = makeDeps({
       "/metagraph/endpoint-incidents.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -4320,9 +4369,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("get_changelog payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_changelog",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_changelog");
     // schema_version/generated_at are part of every real artifact and were
     // simply missing from this synthetic fixture. It passed while the tool
     // published a hand-written schema that did not require them; deriving from
@@ -4377,9 +4424,7 @@ describe("MCP tools (injected deps)", () => {
   });
 
   test("get_build payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_build",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_build");
     const deps = makeDeps({
       "/metagraph/build-summary.json": {
         // A real captured production row, trimmed to one item. Deriving these
@@ -6651,9 +6696,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_stake_moves payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_stake_moves",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_stake_moves");
     const res = await callTool(
       "get_account_stake_moves",
       { ss58: SS58 },
@@ -6704,9 +6747,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_axon_removals payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_axon_removals",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_axon_removals");
     const res = await callTool(
       "get_account_axon_removals",
       { ss58: SS58 },
@@ -6757,9 +6798,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_prometheus payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_prometheus",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_prometheus");
     const res = await callTool(
       "get_account_prometheus",
       { ss58: SS58 },
@@ -6810,9 +6849,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_registrations payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_registrations",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_registrations");
     const res = await callTool(
       "get_account_registrations",
       { ss58: SS58 },
@@ -6863,9 +6900,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_serving payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_serving",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_serving");
     const res = await callTool(
       "get_account_serving",
       { ss58: SS58 },
@@ -6916,9 +6951,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_deregistrations payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_deregistrations",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_deregistrations");
     const res = await callTool(
       "get_account_deregistrations",
       { ss58: SS58 },
@@ -6969,9 +7002,7 @@ describe("MCP stake-flow and movers economics tools", () => {
   });
 
   test("get_account_weight_setters payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_account_weight_setters",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_account_weight_setters");
     const res = await callTool(
       "get_account_weight_setters",
       { ss58: SS58 },
@@ -7017,10 +7048,7 @@ describe("MCP stake-flow and movers economics tools", () => {
 
   test("stake-flow and movers payloads validate against outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name: string) =>
-      ajv.compile(
-        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
-      );
+    const validatorFor = (name: string) => ajv.compile(outputSchemaFor(name));
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-30T00:00:00.000Z"));
     try {
@@ -7257,9 +7285,7 @@ describe("MCP get_subnet_stake_moves", () => {
   });
 
   test("get_subnet_stake_moves payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_stake_moves",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_stake_moves");
     const res = await callTool(
       "get_subnet_stake_moves",
       { netuid: 5 },
@@ -7297,9 +7323,7 @@ describe("MCP get_subnet_stake_transfers", () => {
   });
 
   test("get_subnet_stake_transfers payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_stake_transfers",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_stake_transfers");
     const res = await callTool(
       "get_subnet_stake_transfers",
       { netuid: 5 },
@@ -7336,9 +7360,7 @@ describe("MCP get_subnet_registrations", () => {
   });
 
   test("get_subnet_registrations payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_registrations",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_registrations");
     const res = await callTool(
       "get_subnet_registrations",
       { netuid: 5 },
@@ -7379,9 +7401,7 @@ describe("MCP get_subnet_weights", () => {
   });
 
   test("get_subnet_weights payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_weights",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_weights");
     const res = await callTool(
       "get_subnet_weights",
       { netuid: 5 },
@@ -7488,9 +7508,7 @@ describe("MCP get_subnet_serving", () => {
   });
 
   test("get_subnet_serving payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_serving",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_serving");
     const res = await callTool(
       "get_subnet_serving",
       { netuid: 7 },
@@ -7531,9 +7549,7 @@ describe("MCP get_subnet_prometheus", () => {
   });
 
   test("get_subnet_prometheus payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_prometheus",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_prometheus");
     const res = await callTool(
       "get_subnet_prometheus",
       { netuid: 7 },
@@ -7658,9 +7674,7 @@ describe("MCP get_subnet_yield_history", () => {
   });
 
   test("get_subnet_yield_history payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_subnet_yield_history",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_subnet_yield_history");
     const res = await callTool(
       "get_subnet_yield_history",
       { netuid: 7 },
@@ -7891,10 +7905,7 @@ describe("MCP get_rpc_usage", () => {
 
   test("cold and populated payloads validate against the declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validate = ajv.compile(
-      listToolDefinitions().find((t: Row) => t.name === "get_rpc_usage")!
-        .outputSchema,
-    );
+    const validate = ajv.compile(outputSchemaFor("get_rpc_usage"));
     for (const [label, env] of [
       ["cold", {}],
       ["populated", rpcUsageDb()],
@@ -11475,10 +11486,7 @@ describe("MCP economics + metagraph data tools", () => {
 
   test("get_economics payload validates against its declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validate = ajv.compile(
-      listToolDefinitions().find((t: Row) => t.name === "get_economics")!
-        .outputSchema,
-    );
+    const validate = ajv.compile(outputSchemaFor("get_economics"));
     const res = await callTool(
       "get_economics",
       { sort: "netuid", order: "asc" },
@@ -11671,10 +11679,7 @@ describe("MCP economics + metagraph data tools", () => {
 
   test("list_profiles payload validates against its declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validate = ajv.compile(
-      listToolDefinitions().find((t: Row) => t.name === "list_profiles")!
-        .outputSchema,
-    );
+    const validate = ajv.compile(outputSchemaFor("list_profiles"));
     const res = await callTool(
       "list_profiles",
       { sort: "netuid", order: "asc" },
@@ -11688,10 +11693,7 @@ describe("MCP economics + metagraph data tools", () => {
 
   test("get_subnet_profile payload validates against its declared outputSchema", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validate = ajv.compile(
-      listToolDefinitions().find((t: Row) => t.name === "get_subnet_profile")!
-        .outputSchema,
-    );
+    const validate = ajv.compile(outputSchemaFor("get_subnet_profile"));
     // A COMPLETE profile artifact, not a four-key stub. The stub validated only
     // because the hand-written schema this tool used to publish required almost
     // nothing; deriving from SubnetProfileArtifactSchema (#9796) requires the
@@ -12635,9 +12637,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_turnover payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_turnover",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_turnover");
     const res = await callTool(
       "get_chain_turnover",
       {},
@@ -12746,9 +12746,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_stake_flow payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_stake_flow",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_stake_flow");
     const res = await callTool(
       "get_chain_stake_flow",
       {},
@@ -12862,9 +12860,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_alpha_volume payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_alpha_volume",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_alpha_volume");
     const res = await callTool(
       "get_chain_alpha_volume",
       {},
@@ -12970,9 +12966,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_weights payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_weights",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_weights");
     const res = await callTool(
       "get_chain_weights",
       {},
@@ -13117,9 +13111,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_weight_setters payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_weight_setters",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_weight_setters");
     const res = await callTool(
       "get_chain_weight_setters",
       {},
@@ -13226,9 +13218,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_stake_moves payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_stake_moves",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_stake_moves");
     const res = await callTool(
       "get_chain_stake_moves",
       {},
@@ -13335,9 +13325,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_stake_transfers payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_stake_transfers",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_stake_transfers");
     const res = await callTool(
       "get_chain_stake_transfers",
       {},
@@ -13444,9 +13432,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_axon_removals payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_axon_removals",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_axon_removals");
     const res = await callTool(
       "get_chain_axon_removals",
       {},
@@ -13553,9 +13539,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_deregistrations payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_deregistrations",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_deregistrations");
     const res = await callTool(
       "get_chain_deregistrations",
       {},
@@ -13654,9 +13638,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_serving payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_serving",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_serving");
     const res = await callTool(
       "get_chain_serving",
       {},
@@ -13759,9 +13741,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_prometheus payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_prometheus",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_prometheus");
     const res = await callTool(
       "get_chain_prometheus",
       {},
@@ -13909,9 +13889,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_chain_transfer_pairs payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_chain_transfer_pairs",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_chain_transfer_pairs");
     const res = await callTool(
       "get_chain_transfer_pairs",
       {},
@@ -14197,9 +14175,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_network_health payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_network_health",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_network_health");
     const globalLiveKv = {
       last_run_at: FRESH_RUN,
       summary: { surface_count: 1, status_counts: { ok: 1 } },
@@ -14365,9 +14341,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_health_history payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_health_history",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_health_history");
     const deps = makeDeps({
       [`/metagraph/health/history/${HEALTH_HISTORY_BLOB.date}.json`]:
         HEALTH_HISTORY_BLOB,
@@ -15202,9 +15176,7 @@ describe("MCP economics + metagraph data tools", () => {
   });
 
   test("get_feed payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_feed",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_feed");
     const feedDeps = makeDeps({
       "/metagraph/changelog.json": {
         generated_at: "2026-06-15T00:00:00.000Z",
@@ -15883,10 +15855,7 @@ describe("MCP account tools (get_account + events + subnets)", () => {
     // validate-mcp only exercises the cold (empty-array) path, so assert the
     // POPULATED shapes here — the only check that the item schemas match the rows.
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name: string) =>
-      ajv.compile(
-        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
-      );
+    const validatorFor = (name: string) => ajv.compile(outputSchemaFor(name));
     const reg = {
       netuid: 7,
       uid: 3,
@@ -16328,10 +16297,7 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
 
   test("account tail payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name: string) =>
-      ajv.compile(
-        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
-      );
+    const validatorFor = (name: string) => ajv.compile(outputSchemaFor(name));
     const dayRow = {
       day: "2025-06-24",
       netuid: 7,
@@ -17762,10 +17728,7 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
 
   test("block-explorer payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name: string) =>
-      ajv.compile(
-        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
-      );
+    const validatorFor = (name: string) => ajv.compile(outputSchemaFor(name));
     const hash = "0x" + "c".repeat(64);
     // Every block-explorer tool now goes tryPostgresTier -> buildXxx(...) on
     // any miss/outage, never a live D1 read (#4772/D1 fully eliminated
@@ -18164,10 +18127,7 @@ describe("MCP all-events tier tools (get_block_chain_events, get_extrinsic_chain
 
   test("all-events tool payloads validate against their declared outputSchemas", async () => {
     const ajv = new Ajv2020({ strict: false });
-    const validatorFor = (name: string) =>
-      ajv.compile(
-        listToolDefinitions().find((t: Row) => t.name === name)!.outputSchema,
-      );
+    const validatorFor = (name: string) => ajv.compile(outputSchemaFor(name));
     const blockLake = makeExtrinsicLakehouse({
       rows: DATA_API_BLOCK_CHAIN_EVENTS_PAYLOAD.events,
     });
@@ -18639,9 +18599,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_search_index payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_search_index",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_search_index");
     const deps = makeDeps({
       "/metagraph/search-index.json": {
         // A REAL captured production row. #9796 expressed this tool's
@@ -18705,9 +18663,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_search payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_search",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_search");
     const deps = makeDeps({
       "/metagraph/search.json": {
         documents: [{ id: "subnet-7", title: "Subnet Seven" }],
@@ -18760,9 +18716,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_providers payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_providers",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_providers");
     const deps = makeDeps({
       "/metagraph/providers.json": {
         // A real captured production row, trimmed to one item. Deriving these
@@ -19045,9 +18999,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_surfaces payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_surfaces",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_surfaces");
     const deps = makeDeps({
       "/metagraph/surfaces.json": {
         // A real captured production row, trimmed to one item. Deriving these
@@ -19829,9 +19781,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_evidence payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_evidence",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_evidence");
     const deps = makeDeps({
       "/metagraph/evidence-ledger.json": {
         // A real captured production row, trimmed to one item. Deriving these
@@ -19987,9 +19937,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_source_snapshots payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_source_snapshots",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_source_snapshots");
     const deps = makeDeps({
       "/metagraph/source-snapshots.json": {
         // A real captured production row, trimmed to one item. Deriving these
@@ -20314,9 +20262,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_rpc_pools payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_rpc_pools",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_rpc_pools");
     const deps = makeDeps({
       "/metagraph/rpc/pools.json": {
         generated_at: "2026-01-01T00:00:00Z",
@@ -20606,9 +20552,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("list_subnet_evidence payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "list_subnet_evidence",
-    )?.outputSchema;
+    const schema = outputSchemaFor("list_subnet_evidence");
     const deps = makeDeps({
       "/metagraph/evidence/7.json": {
         generated_at: "2026-07-01T00:00:00.000Z",
@@ -20816,9 +20760,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("get_contracts payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_contracts",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_contracts");
     const deps = makeDeps({
       "/metagraph/contracts.json": {
         // A real captured production row, trimmed to one item. Deriving these
@@ -20903,9 +20845,7 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
   });
 
   test("get_adapter payload validates against its declared outputSchema", async () => {
-    const schema = listToolDefinitions().find(
-      (t) => t.name === "get_adapter",
-    )?.outputSchema;
+    const schema = outputSchemaFor("get_adapter");
     const deps = makeDeps({
       "/metagraph/adapters/gittensor.json": {
         schema_version: 1,

--- a/tests/mcp-unknown-argument-message.test.ts
+++ b/tests/mcp-unknown-argument-message.test.ts
@@ -143,8 +143,8 @@ describe("unknown MCP tool arguments are reported, not just refused", () => {
           {
             name: "takes_nothing",
             inputSchema: { additionalProperties: false, properties: {} },
-          } as Row,
-          { nope: 1 } as Row,
+          },
+          { nope: 1 },
         ),
       (error: Error) => {
         assert.match(error.message, /`nope`/);

--- a/tests/profiles-mcp.test.ts
+++ b/tests/profiles-mcp.test.ts
@@ -233,7 +233,18 @@ describe("profiles-mcp — loadProfilesList", () => {
   test("falls back when list-query data omits captured_at and profile rows", async () => {
     const spy = vi.spyOn(listQuery, "applyQueryFilters").mockReturnValue({
       data: { profiles: null },
-      meta: { pagination: { total: 0, returned: 0, limit: 0, cursor: 0 } },
+      meta: {
+        pagination: {
+          collection: "profiles",
+          total: 0,
+          returned: 0,
+          limit: 0,
+          cursor: 0,
+          next_cursor: null,
+          sort: null,
+          order: "asc" as const,
+        },
+      },
     });
     try {
       const out = await loadProfilesList(makeCtx(), {}, makeDeps());

--- a/tests/rpc-endpoints-mcp.test.ts
+++ b/tests/rpc-endpoints-mcp.test.ts
@@ -393,7 +393,11 @@ describe("rpc-endpoints-mcp (#7886, #7893)", () => {
       data: {
         endpoints: [{ id: "a" }, { id: "b" }],
       },
-      meta: undefined,
+      // `{}`, not `undefined`: the passthrough this test exercises
+      // returns `{ data, meta: {} }` -- an unwindowed answer, not a missing
+      // meta. The union `applyQueryFilters` declares has no arm that omits
+      // `meta` beside a `data` (#10782).
+      meta: {},
     });
     try {
       const out = await loadRpcEndpointsList(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -9,7 +9,6 @@ import {
 } from "../src/pg-statement-client.ts";
 import { neonOwnsTable } from "../src/neon-write.ts";
 import {
-  API_QUERY_COLLECTIONS,
   API_ROUTES,
   PUBLIC_ARTIFACTS,
   artifactPathFromTemplate,
@@ -17,8 +16,101 @@ import {
   liveOnlyArtifactRoute,
 } from "../src/contracts.ts";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
+
+/**
+ * No stored artifact to read.
+ *
+ * The live-only routes assigned a bare `{ ok: false }` here, which typed fine
+ * while the slot was `Record<string, any>` -- and the shared failure path below
+ * reads `artifact.code`, `.message` and `.status` off it. Those branches always
+ * set `live`, so the read never happened; the invariant was real and nothing
+ * stated it. A COMPLETE sentinel makes the slot exactly `StorageReadResult`,
+ * and if that invariant ever breaks the caller gets this 404 instead of an
+ * error response built from three `undefined`s (#10782).
+ */
+const NO_STORED_ARTIFACT: StorageReadError = {
+  ok: false,
+  status: 404,
+  code: "not_found",
+  message: "No stored artifact for this route (live-only).",
+};
+
+/**
+ * The three diagnostics headers a served artifact advertises (#8301), or none.
+ *
+ * `source`, `storage_tier` and `resolution` exist only on the SUCCESS arm of a
+ * `StorageReadResult`. Reading them straight off the union compiled while the
+ * slot was a bag, and the envelope relied on `envelopeResponse` dropping the
+ * three `undefined`s it got back on a live-only response. That is still the
+ * behaviour -- a response with no artifact behind it omits all three rather
+ * than asserting a tier it did not read -- it is just stated here now, once,
+ * instead of being a property of what the header writer happens to do with
+ * `undefined` (#10782).
+ */
+function artifactDiagnosticHeaders(
+  artifact: StorageReadResult,
+): Record<string, string> {
+  if (!artifact.ok) return {};
+  return {
+    [X_METAGRAPH_ARTIFACT_SOURCE_HEADER]: artifact.source,
+    "x-metagraph-storage-tier": artifact.storage_tier,
+    ...(artifact.resolution
+      ? { [X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER]: artifact.resolution }
+      : {}),
+  };
+}
+
+/** The row under an untyped value, or null. */
+function rowOf(value: unknown): Row | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Row)
+    : null;
+}
+
+/** The rows under an untyped value, or empty. */
+function rowsOf(value: unknown): Row[] {
+  return Array.isArray(value) ? (value as Row[]) : [];
+}
+
+/**
+ * The items under an untyped value, or empty.
+ *
+ * `rowsOf` with the row claim withheld, and that is the whole difference: a
+ * `value is T` filter only narrows when `T` is assignable to the array's
+ * element type, and an INTERFACE is never assignable to `Row` -- TypeScript
+ * keeps interfaces open to declaration merging, so it will not grant them an
+ * index signature. Filtering a `Row[]` with a predicate therefore picks
+ * `filter`'s non-narrowing overload and hands back `Row[]` while looking like
+ * it worked (#10782).
+ */
+function itemsOf(value: unknown): unknown[] {
+  return Array.isArray(value) ? (value as unknown[]) : [];
+}
+
+/** An integer, or null. `Number.isInteger` is not a type predicate, so the
+ *  `typeof` is what lets the value be used as a number afterwards. */
+function intOf(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+/** A non-empty string, or null -- the exact reading `value || null` had while
+ *  the value was `any`, now stated where a caller can rely on it. */
+function stringOf(value: unknown): string | null {
+  return typeof value === "string" && value !== "" ? value : null;
+}
+
+/**
+ * A thrown value's message.
+ *
+ * `catch` binds `unknown`, and reading `.message` off it through a `Row` cast
+ * was the shape that let a thrown STRING or a rejected non-Error render as
+ * `undefined` in a log line and an error body. `String(value)` is the honest
+ * fallback: something was thrown, and this says what (#10782).
+ */
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : String(value);
+}
 // Loose ctx shape (matches request-handlers/analytics.ts's own EdgeCacheCtx) --
 // call sites here sometimes pass a real Workers-runtime ExecutionContext,
 // sometimes {} (e.g. handleScheduled's default), so a full ExecutionContext
@@ -83,6 +175,7 @@ import {
   applyQueryFilters,
   canonicalListSearch,
   paginationLinkHeader,
+  queryCollectionConfig,
 } from "./list-query.ts";
 import { csvRequested, csvResponse } from "./csv.ts";
 import {
@@ -103,6 +196,7 @@ import {
   readHealthKv,
   readR2Object,
 } from "./storage.ts";
+import type { StorageReadError, StorageReadResult } from "./storage.ts";
 import {
   contractStaleness,
   contractVersion,
@@ -1256,7 +1350,7 @@ const LIVE_OVERLAY_ROUTE_IDS = new Set([
 ]);
 
 function isStaticEdgeCacheEligible(
-  matched: Row,
+  matched: MatchedRoute,
   network: typeof DEFAULT_NETWORK,
 ) {
   return !network.isDefault || !LIVE_OVERLAY_ROUTE_IDS.has(matched.id);
@@ -1278,7 +1372,7 @@ const CACHEABLE_OVERLAY_ROUTE_IDS = new Set(["endpoints"]);
 // cache. Routes with no query collection (pure static artifacts) honour no
 // params at all, so their canonical search is the empty string. Shared by both
 // the static edge cache and the live-overlay collection cache.
-function canonicalCacheSearch(url: URL, matched: Row) {
+function canonicalCacheSearch(url: URL, matched: MatchedRoute) {
   return canonicalListSearch(
     url,
     matched.queryCollection,
@@ -2416,15 +2510,49 @@ export async function resolveRevenueFeedItems(
  */
 export const WALLET_FEED_MAX_ADDRESSES = 40;
 
+/**
+ * Is this artifact record one the wallet feed can read?
+ *
+ * A type PREDICATE, where the filter used to be a plain boolean followed by
+ * `as WalletAttributionRecord[]`. The two are not the same claim: the filter
+ * checked `ss58` and `category`, and the cast then asserted the OPTIONAL
+ * members too -- `netuid` reaches `subnetPageUrl` and is interpolated into a
+ * published URL, `source_urls` reaches `evidenceClause` and is `.join`ed. A
+ * string netuid would have published `/subnets/12abc` and a non-array
+ * `source_urls` would have thrown inside a feed item, and nothing here would
+ * have said so first.
+ *
+ * schemas/entity.schema.json already enforces all of this at contribution
+ * time. This is the read side of that boundary, and a served artifact is not
+ * the file that was validated (#10782/#10789).
+ */
+function isWalletAttributionRecord(
+  value: unknown,
+): value is WalletAttributionRecord {
+  const row = rowOf(value);
+  if (!row) return false;
+  if (typeof row.ss58 !== "string" || !row.ss58) return false;
+  if (typeof row.category !== "string") return false;
+  if (row.netuid != null && typeof row.netuid !== "number") return false;
+  if (row.name != null && typeof row.name !== "string") return false;
+  if (
+    row.source_urls !== undefined &&
+    !(
+      Array.isArray(row.source_urls) &&
+      row.source_urls.every((url) => typeof url === "string")
+    )
+  ) {
+    return false;
+  }
+  // `review` is read only through `?.`, so absent and null are both fine; a
+  // non-object present under the name is not.
+  return row.review == null || rowOf(row.review) !== null;
+}
+
 export async function resolveWalletFeedItems(env: Env): Promise<FeedItem[]> {
   const artifact = await readArtifact(env, ENTITY_LABELS_ARTIFACT);
-  const entities = artifact.ok
-    ? ((artifact.data as Row | undefined)?.entities as Row[] | undefined)
-    : undefined;
-  const wallets = (Array.isArray(entities) ? entities : []).filter(
-    (e) =>
-      typeof e?.ss58 === "string" && e.ss58 && typeof e?.category === "string",
-  ) as WalletAttributionRecord[];
+  const entities = artifact.ok ? rowOf(artifact.data)?.entities : undefined;
+  const wallets = itemsOf(entities).filter(isWalletAttributionRecord);
   if (wallets.length === 0) return [];
 
   // Only the roles whose movement is an event: a burn's outbound is the
@@ -2441,25 +2569,22 @@ export async function resolveWalletFeedItems(env: Env): Promise<FeedItem[]> {
         env,
         `/api/v1/accounts/${encodeURIComponent(wallet.ss58)}/transfers?limit=100`,
       );
-      const transfers = (payload?.data as Row | undefined)?.transfers;
+      const transfers = rowOf(payload?.data)?.transfers;
+      // Still `Array.isArray` rather than `rowsOf(...).length`: an ABSENT
+      // `transfers` and an empty one are different answers here, and only the
+      // first should leave the address out of the map.
       if (!Array.isArray(transfers)) return;
       rowsByAddress.set(
         wallet.ss58,
-        transfers.map((t) => ({
+        rowsOf(transfers).map((t) => ({
           address: wallet.ss58,
           denomination: "tao" as const,
           netuid: null,
           // The route says `received`/`sent` from the queried account's point
           // of view; the aggregator's vocabulary is in/out.
-          direction: (t as Row).direction === "received" ? "in" : "out",
-          amount:
-            typeof (t as Row).amount_tao === "number"
-              ? ((t as Row).amount_tao as number)
-              : null,
-          observed_at:
-            typeof (t as Row).observed_at === "string"
-              ? ((t as Row).observed_at as string)
-              : null,
+          direction: t.direction === "received" ? "in" : "out",
+          amount: typeof t.amount_tao === "number" ? t.amount_tao : null,
+          observed_at: typeof t.observed_at === "string" ? t.observed_at : null,
         })),
       );
     }),
@@ -2467,8 +2592,7 @@ export async function resolveWalletFeedItems(env: Env): Promise<FeedItem[]> {
 
   const taoUsd = await readArtifact(env, "/metagraph/network/tao-usd.json");
   const usdPerTao = taoUsd.ok
-    ? (((taoUsd.data as Row | undefined)?.latest as Row | undefined)
-        ?.usd_per_tao as number | undefined)
+    ? rowOf(rowOf(taoUsd.data)?.latest)?.usd_per_tao
     : undefined;
 
   return walletFeedItems({
@@ -4413,10 +4537,12 @@ function emissionGateSyncBodyError(parsed: unknown): string | null {
     return "body must be a JSON object";
   }
   const body = parsed as Row;
-  if (!Number.isInteger(body.block_number) || body.block_number < 0) {
+  const blockNumber = intOf(body.block_number);
+  if (blockNumber === null || blockNumber < 0) {
     return "block_number must be a non-negative integer";
   }
-  if (!Number.isInteger(body.observed_at) || body.observed_at <= 0) {
+  const observedAt = intOf(body.observed_at);
+  if (observedAt === null || observedAt <= 0) {
     return "observed_at must be a positive epoch-ms integer";
   }
   if (
@@ -4453,12 +4579,9 @@ function emissionGateSyncBodyError(parsed: unknown): string | null {
   ) {
     return "flow_observations must be an array of {item, raw} observations";
   }
-  for (const observation of body.flow_observations as Row[]) {
-    if (
-      !observation ||
-      typeof observation !== "object" ||
-      Array.isArray(observation)
-    ) {
+  for (const entry of itemsOf(body.flow_observations)) {
+    const observation = rowOf(entry);
+    if (!observation) {
       return "flow_observations entries must be {item, raw} objects";
     }
     if (
@@ -4476,15 +4599,11 @@ function emissionGateSyncBodyError(parsed: unknown): string | null {
     }
   }
   if (
-    !validEmissionGateSyncPairs(
-      body.current_ema,
-      (second) =>
-        second === null ||
-        (typeof second === "object" &&
-          !Array.isArray(second) &&
-          Number.isInteger((second as Row).block) &&
-          (second as Row).block >= 0),
-    )
+    !validEmissionGateSyncPairs(body.current_ema, (second) => {
+      if (second === null) return true;
+      const block = intOf(rowOf(second)?.block);
+      return block !== null && block >= 0;
+    })
   ) {
     return "current_ema must be an array of [netuid, {block} | null] pairs";
   }
@@ -8217,7 +8336,9 @@ async function lookupSubnetNetuid(
 // names) drops straight into them.
 function loadPreviouslyKnownAsTiered(
   netuid: number,
-  currentName: string | null,
+  // The name comes off an artifact row, so it is whatever that row carried.
+  // `derivePreviouslyKnownAs` compares it as a string and tolerates the rest.
+  currentName: unknown,
 ) {
   return derivePreviouslyKnownAs([], currentName);
 }
@@ -8276,7 +8397,7 @@ async function handleApiRequest(
     // Cheap KV read of just the snapshot time; on a hit this + the cache match
     // is the whole request (no R2 GET / overlay / re-stringify).
     const opMeta = await readHealthMetaKv(env);
-    const lastRunAt = opMeta?.last_run_at || null;
+    const lastRunAt = stringOf(opMeta?.last_run_at);
     if (lastRunAt) {
       overlayCacheable = {
         store: overlayCacheStore,
@@ -8317,7 +8438,7 @@ async function handleApiRequest(
   // Live operational-health overlay (Phase 3): current health is live-only.
   // Static current-health artifacts are not read for mainnet health routes, so
   // stale R2 objects left behind by earlier publishes cannot affect responses.
-  let artifact: Row;
+  let artifact: StorageReadResult;
   let live: Row | null = null;
   if (!network.isDefault) {
     // Non-default networks serve only the static partitioned artifact; the live
@@ -8340,9 +8461,9 @@ async function handleApiRequest(
         { contractVersion: (e: Env) => contractVersion(e) },
       ),
     };
-    artifact = { ok: false };
+    artifact = NO_STORED_ARTIFACT;
   } else if (matched.id === "subnet-health") {
-    artifact = { ok: false };
+    artifact = NO_STORED_ARTIFACT;
     live = await liveHealthOverlay(env, matched, null);
     // Per-subnet health is live-only too: never 404 on a cold store — serve an
     // explicit `unknown` payload instead of the (now absent) static artifact.
@@ -8365,7 +8486,7 @@ async function handleApiRequest(
     live = await liveHealthOverlay(
       env,
       matched,
-      artifact.ok ? artifact.data : null,
+      artifact.ok ? rowOf(artifact.data) : null,
     );
   }
 
@@ -8375,7 +8496,22 @@ async function handleApiRequest(
     });
   }
 
-  let baseData = live ? live.data : artifact.data;
+  /**
+   * The STORED body, or null when this response has no artifact behind it.
+   *
+   * Narrowed once. `artifact.data` only exists on the success arm, and three
+   * separate places downstream re-derived that -- the base body, the
+   * contract-staleness read, and (through `.source`) the envelope's `meta`.
+   * Each of those was its own `artifact.ok ?` while the read answered `any`,
+   * so each was free to disagree with the others about what an absent
+   * artifact means (#10782).
+   */
+  const storedData: Row | null = artifact.ok ? rowOf(artifact.data) : null;
+
+  // The response body being shaped: an object or null. Every use below either
+  // spreads it or reads a field off it, which is what `Row` says and
+  // `unknown` does not.
+  let baseData: Row | null = live ? rowOf(live.data) : storedData;
   // Spot on every economics row (#9408 completion): the detail card and the
   // leaderboards already derive spot_price_tao at serve time; the full blob was
   // the one surface still without it. Both tiers pass through this point.
@@ -8406,27 +8542,27 @@ async function handleApiRequest(
       env,
       contractVersion: contractVersion(env),
     });
-    baseData = overlaySubnetEconomics(
-      baseData,
-      liveEconomics?.data,
-      Number(matched.params.netuid),
-    );
-    const aliasTarget =
-      baseData.subnet && typeof baseData.subnet === "object"
-        ? baseData.subnet
-        : baseData;
+    // `overlaySubnetEconomics` returns its input unchanged when there is
+    // nothing to overlay, so falling back to `baseData` keeps that path; what
+    // it does NOT do is return null for a row it was handed, which is why the
+    // reads below were safe and said so nowhere.
+    const overlaid =
+      rowOf(
+        overlaySubnetEconomics(
+          baseData,
+          liveEconomics?.data,
+          Number(matched.params.netuid),
+        ),
+      ) ?? baseData;
+    const nested = rowOf(overlaid.subnet);
+    const aliasTarget = nested ?? overlaid;
     const aliasNames = loadPreviouslyKnownAsTiered(
       Number(matched.params.netuid),
       aliasTarget.native_name ?? aliasTarget.name,
     );
-    if (baseData.subnet && typeof baseData.subnet === "object") {
-      baseData = {
-        ...baseData,
-        subnet: overlayPreviouslyKnownAs(baseData.subnet, aliasNames),
-      };
-    } else {
-      baseData = overlayPreviouslyKnownAs(baseData, aliasNames);
-    }
+    baseData = nested
+      ? { ...overlaid, subnet: overlayPreviouslyKnownAs(nested, aliasNames) }
+      : rowOf(overlayPreviouslyKnownAs(overlaid, aliasNames));
   }
   // Identity-history aliases are D1-backed and independent of the live health KV
   // overlay — apply them whenever the catalog artifact is served (static or live).
@@ -8440,26 +8576,47 @@ async function handleApiRequest(
       Number(matched.params.netuid),
       baseData.name,
     );
-    baseData = overlayPreviouslyKnownAs(baseData, aliasNames);
+    baseData = rowOf(overlayPreviouslyKnownAs(baseData, aliasNames));
   }
   if (
     network.isDefault &&
     matched.id === "agent-catalog" &&
-    baseData?.subnets?.length
+    baseData &&
+    rowsOf(baseData.subnets).length
   ) {
-    const aliasMap = loadPreviouslyKnownAsForNetuidsTiered(baseData.subnets);
+    const catalogSubnets = rowsOf(baseData.subnets);
+    const aliasMap = loadPreviouslyKnownAsForNetuidsTiered(catalogSubnets);
     baseData = {
       ...baseData,
-      subnets: baseData.subnets.map((entry: Row) =>
-        overlayPreviouslyKnownAs(entry, aliasMap.get(entry.netuid) || []),
-      ),
+      // `aliasMap` is keyed by INTEGER netuid -- deriveNetuidGroupedAliases
+      // filters on `Number.isInteger` -- so an entry without one has no
+      // aliases by construction, and this says that instead of indexing the
+      // map with whatever the artifact held.
+      subnets: catalogSubnets.map((entry) => {
+        const netuid = intOf(entry.netuid);
+        return overlayPreviouslyKnownAs(
+          entry,
+          (netuid === null ? undefined : aliasMap.get(netuid)) ?? [],
+        );
+      }),
     };
   }
-  const baseSource = live
-    ? live.source || baseData?.health_source || "live-cron-prober"
-    : matched.id === "economics"
-      ? "r2-fallback"
-      : artifact.source;
+  // The live tier names its own source; the two fallbacks below it are the
+  // artifact's. Read `live` first because an artifact that FAILED to read
+  // implies a live overlay (the guard above returned otherwise) -- but the
+  // reads stay null-safe rather than asserting that, so a future edit to the
+  // guard shows up as a wrong-looking source rather than a thrown request.
+  const liveSource =
+    stringOf(live?.source) ??
+    stringOf(baseData?.health_source) ??
+    "live-cron-prober";
+  const baseSource = !artifact.ok
+    ? liveSource
+    : live
+      ? liveSource
+      : matched.id === "economics"
+        ? "r2-fallback"
+        : artifact.source;
 
   // Serve-time contract drift (#1001): when serving a STORED artifact (not a
   // live overlay) that was built under an older contract than the live one, the
@@ -8468,7 +8625,7 @@ async function handleApiRequest(
   // otherwise-silent drift is observable.
   const staleContract = live
     ? null
-    : contractStaleness(env, artifact.data?.contract_version);
+    : contractStaleness(env, stringOf(storedData?.contract_version));
   if (staleContract) {
     logEvent(env, "warn", "stale_contract_served", {
       artifact_path: artifactPath,
@@ -8480,10 +8637,10 @@ async function handleApiRequest(
   const transformed = applyQueryFilters(
     baseData,
     url,
-    matched.queryCollection as string,
+    matched.queryCollection,
     matched.queryFilterNames,
     { csvResponse: matched.csvResponse === true },
-  ) as Row;
+  );
   if (transformed.error) {
     return errorResponse("invalid_query", transformed.error.message, 400, {
       artifact_path: artifactPath,
@@ -8510,13 +8667,15 @@ async function handleApiRequest(
     },
   );
   if (wantsCsv) {
-    let collectionKey = (API_QUERY_COLLECTIONS as Record<string, Row>)[
-      matched.queryCollection as string
-    ].data_key;
-    if (transformed.meta.pagination) {
-      collectionKey = transformed.meta.pagination.collection;
-    }
-    const rows = transformed.data[collectionKey];
+    // The windowed collection names itself; the route's declared config is the
+    // fallback for an unwindowed body. `?? ""` covers the route that declares
+    // no collection at all -- unreachable while only list routes answer CSV,
+    // and previously an unguarded `.data_key` on an `undefined` config.
+    const collectionKey =
+      transformed.meta.pagination?.collection ??
+      queryCollectionConfig(matched.queryCollection)?.data_key ??
+      "";
+    const rows = rowOf(transformed.data)?.[collectionKey];
     if (!Array.isArray(rows)) {
       return errorResponse(
         "invalid_artifact",
@@ -8582,7 +8741,7 @@ async function handleApiRequest(
     // how the served row was read. Keyed off the same `live.source` the
     // effectivePublishedAt branch above already trusts.
     if (matched.id === "economics") {
-      patch.field_sources = economicsFieldSources(live?.source);
+      patch.field_sources = economicsFieldSources(stringOf(live?.source));
     }
     if (effectivePublishedAt && "generated_at" in responseData) {
       patch.generated_at = effectivePublishedAt;
@@ -8661,9 +8820,7 @@ async function handleApiRequest(
       // (#8287) until #8299 repointed it. envelopeResponse drops null/undefined
       // entries, so a live-overlay response with no artifact behind it simply
       // omits them rather than asserting a tier it did not read.
-      "x-metagraph-artifact-source": artifact.source,
-      "x-metagraph-storage-tier": artifact.storage_tier,
-      [X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER]: artifact.resolution,
+      ...artifactDiagnosticHeaders(artifact),
     },
   );
   // Cache only route-declared pure static-artifact 200s. Live-overlay routes
@@ -8694,6 +8851,9 @@ function matchRawArtifact(pathname: string) {
     candidate.pattern.test(pathname),
   );
 }
+
+/** What `matchRoute` returns, named so the handlers that take it can say so. */
+export type MatchedRoute = NonNullable<ReturnType<typeof matchRoute>>;
 
 function matchRoute(pathname: string) {
   for (const candidate of ROUTES) {
@@ -8765,7 +8925,8 @@ async function handleHealthRequest(request: Request, env: Env) {
   // Operational-health freshness — the 15-minute cron prober's last run. Reported
   // for observability (a stuck prober shows a growing age); does not gate the
   // HTTP status here (Phase 4 wires alerting). Null until the first cron run.
-  const opRunAtMs = meta?.last_run_at ? Date.parse(meta.last_run_at) : NaN;
+  const opLastRunAt = stringOf(meta?.last_run_at);
+  const opRunAtMs = opLastRunAt ? Date.parse(opLastRunAt) : NaN;
   const opAgeMinutes = Number.isFinite(opRunAtMs)
     ? (Date.now() - opRunAtMs) / 60_000
     : null;
@@ -9368,12 +9529,11 @@ async function handleSemanticSearchRequest(
     });
     return dataResponse(env, data, 200, { source: "ai-live" });
   } catch (error) {
-    const err = error as Row;
-    if (err?.aiInput) {
-      return errorResponse("invalid_query", err.message, 400);
+    if (rowOf(error)?.aiInput) {
+      return errorResponse("invalid_query", errorMessage(error), 400);
     }
     logEvent(env, "error", "semantic_search_failed", {
-      message: err?.message,
+      message: errorMessage(error),
     });
     await captureAiRouteError(error, "semantic_search", env);
     return errorResponse(
@@ -9457,11 +9617,10 @@ async function handleAskRequest(request: Request, env: Env, ctx?: Ctx) {
     );
     return dataResponse(env, data, 200, { source: "ai-live" });
   } catch (error) {
-    const err = error as Row;
-    if (err?.aiInput) {
-      return errorResponse("invalid_request", err.message, 400);
+    if (rowOf(error)?.aiInput) {
+      return errorResponse("invalid_request", errorMessage(error), 400);
     }
-    logEvent(env, "error", "ask_failed", { message: err?.message });
+    logEvent(env, "error", "ask_failed", { message: errorMessage(error) });
     await captureAiRouteError(error, "ask", env);
     return errorResponse(
       "ai_error",
@@ -9508,7 +9667,7 @@ const ENDPOINT_OVERLAY_EXCLUDED_IDS = new Set([
 
 async function liveHealthOverlay(
   env: Env,
-  matched: Row,
+  matched: MatchedRoute,
   staticData: Row | null,
 ) {
   let resolved: Row | null | undefined;

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -802,7 +802,7 @@ interface SseRetainedEvent {
   payload: ChainFirehoseIngestPayload;
 }
 
-interface GraphqlWsConnectionInfo {
+export interface GraphqlWsConnectionInfo {
   activeSubscriptions: number;
 }
 

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -546,8 +546,7 @@ import type {
   WatchPushSubscriptions,
 } from "../generated/db/types.ts";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Row = Record<string, any>;
+type Row = Record<string, unknown>;
 
 // --- POST /api/v1/internal/neurons-sync (#4771) -----------------------------
 // The write path into this Worker's own Postgres for neurons/neuron_daily.
@@ -3346,9 +3345,16 @@ function d1Bool(value: unknown): boolean {
  * mergeAlertTriggerUpdateBody, validateAlertTriggerInput) already expects:
  * table_filter/condition parsed from their TEXT-JSON columns, active a real
  * boolean. */
-function normalizeAlertTriggerRow(row: Row): Row;
-function normalizeAlertTriggerRow(row: Row | undefined): Row | null;
-function normalizeAlertTriggerRow(row: Row | undefined): Row | null {
+// Takes the GENERATED table row. It took `Row`, and an interface has no index
+// signature, so every caller reading a real `ChainAlertTriggers` out of the
+// store had to be laundered through `Record<string, any>` first (#10782).
+function normalizeAlertTriggerRow(row: ChainAlertTriggers): Row;
+function normalizeAlertTriggerRow(
+  row: ChainAlertTriggers | undefined,
+): Row | null;
+function normalizeAlertTriggerRow(
+  row: ChainAlertTriggers | undefined,
+): Row | null {
   if (!row) return null;
   return {
     ...row,
@@ -3360,7 +3366,7 @@ function normalizeAlertTriggerRow(row: Row | undefined): Row | null {
 
 /** One chain_alert_deliveries row: success is INTEGER 0/1 on D1, and
  * deliveryRecordView's `success === true` check needs the boolean. */
-function normalizeDeliveryRow(row: Row): Row {
+function normalizeDeliveryRow(row: ChainAlertDeliveries): Row {
   return { ...row, success: d1Bool(row.success) };
 }
 

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -47,16 +47,85 @@ export interface QueryCollectionConfig {
   sort_fields?: string[];
 }
 
-export interface ApplyQueryFiltersResult {
-  data?: unknown;
-  meta?: Record<string, unknown>;
-  error?: QueryError;
+/**
+ * The window `applyListTransform` emits, and the ONLY thing that emits it.
+ *
+ * Every member is required because the producer sets every member on every
+ * paginated result -- there is no branch that omits one. The Worker read
+ * `meta.pagination.collection` to pick the CSV data key and
+ * `meta.pagination` to build the RFC 8288 Link header off a
+ * `Record<string, unknown>`, which typed both as `unknown` and let the
+ * `as Row` cast one line up put them back (#10782).
+ */
+export interface ListPaginationMeta {
+  /** The data key the windowed rows live under. */
+  collection: string;
+  total: number;
+  returned: number;
+  limit: number;
+  cursor: number;
+  next_cursor: number | null;
+  sort: string | null;
+  order: "asc" | "desc";
+}
+
+/** Present only when `fields` narrowed the rows -- `projectionMeta` returns an
+ *  EMPTY object otherwise, which is why this member is optional and its own
+ *  `fields` is not. */
+export interface ListProjectionMeta {
+  fields: string[];
+}
+
+/** What a list transform reports about the window it produced. Spread whole
+ *  into the REST envelope's `meta`, so a member added here is published. */
+export interface ApplyQueryFiltersMeta {
+  pagination?: ListPaginationMeta;
+  projection?: ListProjectionMeta;
+}
+
+/**
+ * A transform either REJECTED the query or WINDOWED the rows -- never both,
+ * and never neither.
+ *
+ * A discriminated union rather than three optional members, because the three
+ * were not independent: every caller checks `error` first and then reads
+ * `data` and `meta` as though they are there, which they are, and the type
+ * said they might not be. Optional members made `if (transformed.error)
+ * return` prove nothing, so the reads afterwards each needed their own `?.` --
+ * a null check for a case the function cannot produce, which is how a real one
+ * stops being distinguishable (#10782).
+ */
+export type ApplyQueryFiltersResult =
+  | { error: QueryError; data?: undefined; meta?: undefined }
+  | { error?: undefined; data: unknown; meta: ApplyQueryFiltersMeta };
+
+/**
+ * One query collection's declared config, or null.
+ *
+ * THE SINGLE LOOKUP. `API_QUERY_COLLECTIONS` is a generated record whose value
+ * type TypeScript widens per entry, so every reader was writing its own
+ * `as Record<string, ...>` to index it -- three of them, one of which
+ * (`workers/api.ts`'s CSV branch) then read `.data_key` off the result with no
+ * null check at all, because the cast said the miss could not happen (#10782).
+ *
+ * A route with no collection is the routine case, not an error: the pure
+ * static artifacts declare `query_collection: null`.
+ */
+export function queryCollectionConfig(
+  queryCollection: string | null | undefined,
+): QueryCollectionConfig | null {
+  if (!queryCollection) return null;
+  return (
+    (API_QUERY_COLLECTIONS as Record<string, QueryCollectionConfig>)[
+      queryCollection
+    ] ?? null
+  );
 }
 
 export function applyQueryFilters(
   data: Record<string, unknown> | null | undefined,
   url: URL,
-  queryCollection: string,
+  queryCollection: string | null | undefined,
   queryFilterNames: string[] = [],
   {
     csvResponse = false,
@@ -64,9 +133,11 @@ export function applyQueryFilters(
   }: { csvResponse?: boolean; defaultLimit?: number } = {},
 ): ApplyQueryFiltersResult {
   const params = url.searchParams;
-  const config = (
-    API_QUERY_COLLECTIONS as Record<string, QueryCollectionConfig>
-  )[queryCollection];
+  // A route with no collection funnels into the SAME miss branch as an unknown
+  // one -- `queryCollectionConfig("")` is null -- so accepting the nullable
+  // costs no second exit, and `collection` is a string for the check below.
+  const collection = queryCollection ?? "";
+  const config = queryCollectionConfig(collection);
   if (!config) {
     return { data, meta: {} };
   }
@@ -78,7 +149,7 @@ export function applyQueryFilters(
   // already met it at the router; the MCP list tools come through here, and
   // this is their handler guard.
   const queryError =
-    validateCollectionQuery(params, queryCollection, queryFilterNames, {
+    validateCollectionQuery(params, collection, queryFilterNames, {
       csvResponse,
     }) ?? contradictoryRange(params, config.range_filters || []);
   if (queryError) return { error: queryError };
@@ -140,12 +211,15 @@ function effectiveFilterNames(
 // rebuilding the request. Null when no relation applies (unpaged, single page,
 // or empty) so the caller omits the header.
 export function listQueryParamNames(
-  queryCollection: string,
+  queryCollection: string | null | undefined,
   queryFilterNames: string[] = [],
 ): string[] {
-  const config = (
-    API_QUERY_COLLECTIONS as Record<string, QueryCollectionConfig>
-  )[queryCollection];
+  // A route with NO query collection is the routine case, not an error: the
+  // pure static artifacts declare `query_collection: null` and honour no
+  // params at all. Saying so in the signature is what lets `matchRoute`'s
+  // `string | null` reach here without a cast -- the lookup already answered
+  // `[]` for it, but only by missing (#10782).
+  const config = queryCollectionConfig(queryCollection);
   if (!config) return [];
   return listQueryParamNamesForConfig(config, queryFilterNames);
 }
@@ -185,7 +259,7 @@ function listQueryParamNamesForConfig(
 
 export function canonicalListSearch(
   url: URL,
-  queryCollection: string,
+  queryCollection: string | null | undefined,
   queryFilterNames: string[] = [],
 ): string {
   const canonicalUrl = new URL("https://edge-cache.metagraph.sh/");

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -399,7 +399,10 @@ import {
   withAlphaUsdCandles,
 } from "../../src/alpha-usd-history.ts";
 import { loadSubnetOhlcColdTier } from "../../src/subnet-ohlc-cold-tier.ts";
-import { resolveLiveEconomics } from "../../src/health-serving.ts";
+import {
+  resolveLiveEconomics,
+  subnetEconomicsRow,
+} from "../../src/health-serving.ts";
 import { KV_ECONOMICS_CURRENT } from "../../src/kv-keys.ts";
 import { readArtifact, readHealthKv } from "../storage.ts";
 import {
@@ -3305,11 +3308,12 @@ export async function resolveSubnetEconomicsRow(env: Env, netuid: number) {
       ? ((artifact.data as Record<string, unknown> | undefined) ?? null)
       : null;
   });
-  const rows = Array.isArray(blob?.subnets)
-    ? (blob.subnets as Array<Record<string, unknown>>)
-    : [];
+  // The economics artifact's own rows, named. The trust boundary is the
+  // `readArtifact` above, and `subnetEconomicsRow` is the ONE place the rows
+  // cross it -- this used to keep its own copy of the find, so a third caller
+  // (the MCP tool) kept a fourth (#10782).
   return {
-    row: rows.find((entry) => Number(entry?.netuid) === Number(netuid)) ?? null,
+    row: subnetEconomicsRow(blob, netuid),
     generatedAt: blob?.generated_at ?? blob?.captured_at ?? null,
   };
 }


### PR DESCRIPTION
refactor(types): take `Row` off `any`, and fix the 214 errors it was hiding

`type Row = Record<string, any>` was declared in nine modules, so every read
off a row -- an artifact blob, a KV entry, a database result -- answered `any`.
`row.total + 1`, `row.items.map(...)` and `row.name.trim()` all compiled
against values none of those things had been checked to be.

Making it `Record<string, unknown>` surfaced 214 errors. None of them were
noise; each names a read that had no basis. They are fixed here rather than
suppressed, and the four narrowings this needed -- `rowOf`, `rowsOf`,
`itemsOf`, `stringOf`/`intOf`/`numberOf`, `errorMessage` -- sit beside the
reads they serve rather than in a module all three surfaces would have to
import.

Closes #10782

## What the `any` was hiding

Every one of these compiled before and could not have:

  * `computeStakePreviewAdvisory(quote: Row)` compared `price_impact_pct`
    against both slippage thresholds. An absent impact reads false in every
    direction and lands on `ok: false` with no warning saying why. The quote
    comes straight off `computeStakeQuote`, which declares `price_impact_pct:
    number` -- so the bag was discarding a type it was handed.

  * `NO_STORED_ARTIFACT`. The live-only routes assigned a bare `{ ok: false }`
    into the artifact slot, and the shared failure path reads `.code`,
    `.message` and `.status` off it. Those branches always set `live`, so the
    read never happened -- the invariant was real and nothing stated it. The
    slot is now exactly `StorageReadResult` and the sentinel is complete.

  * Three sorts tie-broke on `a.netuid - b.netuid`, which is `NaN` whenever
    either row's netuid is not a number -- and a comparator that answers NaN
    hands the order to the sort implementation, the opposite of the stable
    page the tie-break exists to produce.

  * `find_subnets_by_capability` filtered on `callable_count > 0` and then
    subtracted it three lines later. A string count passes the filter and
    poisons the comparator.

  * `resolveNetuid` returned `match.netuid` unchecked, so a corrupt index entry
    handed every downstream route a netuid that was not a number.

  * Four handlers rethrew a loader's tagged error as
    `toolError(err.code, err.message)`, both read off a bag into parameters
    that are `string`. A tagged error without a usable code now propagates raw
    instead of becoming an MCP error whose `code` is `undefined`.

  * `call_subnet_surface` validated its credential `location` four ways and
    narrowed nothing -- excluding literals from `unknown` leaves `unknown` --
    so it crossed into the published placement untyped. The store key has the
    same shape of problem: a row reached by `surface_key` or a deprecated alias
    carries a different id than the caller asked with, and a credential written
    under one and read under the other silently never applies.

  * `workers/api.ts`'s CSV branch read `.data_key` off an
    `API_QUERY_COLLECTIONS` lookup with no null check at all, because the cast
    said the miss could not happen.

## What became a contract instead of a bag

  * **`ApplyQueryFiltersResult` is a discriminated union.** A transform either
    REJECTED the query or WINDOWED the rows -- never both, never neither.
    Three optional members made `if (transformed.error) return` prove nothing,
    so every read afterwards needed its own `?.`: a null check for a case the
    function cannot produce, which is how a real one stops being
    distinguishable. `meta.pagination` is now `ListPaginationMeta`, eight
    required members because the producer sets all eight.

  * **`queryCollectionConfig` is the single lookup.** Three readers each wrote
    their own `as Record<string, …>` to index the generated record.

  * **`subnetEconomicsRow` is the single boundary.** The economics blob's rows
    became `SubnetEconomicsRow` in three places; now one, which is what lets
    the MCP tools hand a typed row to `loadSubnetOwnerCut` and
    `loadSubnetRevenue` -- both of which already declared it -- without each
    restating the assumption.

  * **`McpDeps` is derived from `McpCtx`** with `Pick`, so a member added there
    and forgotten here is a compile error rather than a test-injected double
    that silently falls through to the real recorder. That defect has shipped
    here before; `buildContext`'s own comment describes it.

  * **`isDispatchableJsonRpcMessage` is a type predicate.** It already proved
    `method` is a string and told nothing to the code that depends on it.

  * `validateToolArguments` takes `unknown` -- which is what a JSON-RPC
    `params.arguments` is -- and asks for `Pick<McpToolDefinition, "name" |
    "inputSchema">`, the two members it reads. It runs over both tool objects
    (the raw registry entry at dispatch, the served definition in the tests),
    and those are different shapes.

  * `isWalletAttributionRecord` is a type predicate where a boolean filter plus
    `as WalletAttributionRecord[]` used to be. Those are not the same claim:
    the filter checked `ss58` and `category`, and the cast then asserted the
    optional members too -- `netuid` reaches `subnetPageUrl` and is
    interpolated into a published URL, `source_urls` reaches `evidenceClause`
    and is `.join`ed.

## Behaviour

Held, deliberately, everywhere it could be. Where a narrowing forced a choice
the old expression made implicitly, the old verdict is preserved and stated:
`cursorWindow`'s pagination fallbacks are the ones every sibling loader already
carries, an id-less RPC endpoint still buckets under `String(undefined)` rather
than being dropped, and `mintMcpSessionHeaderIfNeeded` now admits the `Row[]`
its first line has always handled.

Two test mocks were lying about shapes production never emits: `meta:
undefined` beside a `data` (the passthrough returns `meta: {}`), and a
four-member pagination where the producer sets eight.

## Out of scope, and filed

`AnyFn` and the injected-dependency surface (`readArtifact`, `readHealthKv`)
are still `any` -- 58 call sites in `mcp-server.ts` alone read through
`loadArtifactData`, and closing that is a different unit of work. Filed to
#10786 rather than half-done here.
