### PR TITLE
feat(mcp): the last 21 published parameters a tool could not pass

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -49626,6 +49626,7 @@ export interface operations {
     validatorNominators: {
         parameters: {
             query?: {
+                /** @description Which question to answer. `flow` (the default) sums TAO MOVED inside `window`, so a delegator who staked earlier and has not touched it since is absent. `positions` reads the standing ledger instead: every coldkey (an ss58 address) delegating right now and how much alpha each holds per subnet, whenever they staked. Different units over different time semantics, so the two are not comparable. On `positions`, `window` and `sort` are REJECTED rather than ignored. */
                 basis?: "flow" | "positions";
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -8114,6 +8114,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
+          "description": "Which question to answer. `flow` (the default) sums TAO MOVED inside `window`, so a delegator who staked earlier and has not touched it since is absent. `positions` reads the standing ledger instead: every coldkey (an ss58 address) delegating right now and how much alpha each holds per subnet, whenever they staked. Different units over different time semantics, so the two are not comparable. On `positions`, `window` and `sort` are REJECTED rather than ignored.",
           "name": "basis",
           "schema": {
             "default": "flow",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -99007,6 +99007,7 @@
             }
           },
           {
+            "description": "Which question to answer. `flow` (the default) sums TAO MOVED inside `window`, so a delegator who staked earlier and has not touched it since is absent. `positions` reads the standing ledger instead: every coldkey (an ss58 address) delegating right now and how much alpha each holds per subnet, whenever they staked. Different units over different time semantics, so the two are not comparable. On `positions`, `window` and `sort` are REJECTED rather than ignored.",
             "in": "query",
             "name": "basis",
             "required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -49626,6 +49626,7 @@ export interface operations {
     validatorNominators: {
         parameters: {
             query?: {
+                /** @description Which question to answer. `flow` (the default) sums TAO MOVED inside `window`, so a delegator who staked earlier and has not touched it since is absent. `positions` reads the standing ledger instead: every coldkey (an ss58 address) delegating right now and how much alpha each holds per subnet, whenever they staked. Different units over different time semantics, so the two are not comparable. On `positions`, `window` and `sort` are REJECTED rather than ignored. */
                 basis?: "flow" | "positions";
                 /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `7d`, `30d`, `90d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
                 window?: "7d" | "30d" | "90d";

--- a/schemas-src/mcp-tools/chain-events.ts
+++ b/schemas-src/mcp-tools/chain-events.ts
@@ -5,8 +5,11 @@
 // matching each hand-written literal field-for-field.
 import { z } from "zod";
 import { CHAIN_EVENTS_LIMIT_DEFAULT } from "../../src/route-limits.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import { keysetCursorSchema, limitSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
+
+const RouteQuery_chain_events = ROUTE_QUERY_SCHEMAS["/api/v1/chain-events"];
 
 export const GetBlockChainEventsInputSchema = z
   .object({
@@ -74,6 +77,25 @@ export const GetExtrinsicChainEventsInputSchema = z
         "Extrinsic reference, as the composite id `block_number-extrinsic_index` -- the index is the extrinsic's position within that block, from 0. A bare block number or block hash is NOT accepted here, unlike the sibling block-scoped tools.",
       )
       .meta({ examples: ["8791987-0"] }),
+    // The two filters an extrinsic's OWN event list can still take (#10793).
+    // One extrinsic emits many events, often across several pallets -- a
+    // `add_stake` carries Balances, SubtensorModule and System events together
+    // -- so "which Balances events did this extrinsic emit" is a real question
+    // that cost a full page and a client-side scan before.
+    //
+    // Straight off the route's query schema, the same way list_chain_events
+    // takes them, so the three surfaces cannot disagree about the length bound
+    // or the case sensitivity.
+    pallet: RouteQuery_chain_events.shape.pallet
+      .describe(
+        "Restrict to events emitted by this pallet, by runtime name (`SubtensorModule`). Case-sensitive. Applied within this extrinsic's events, not across the feed.",
+      )
+      .meta({ examples: ["SubtensorModule"] }),
+    method: RouteQuery_chain_events.shape.method
+      .describe(
+        "Restrict to events emitted by this runtime call, by name (`set_weights`). Case-sensitive. Applied within this extrinsic's events, not across the feed.",
+      )
+      .meta({ examples: ["set_weights"] }),
     limit: limitSchema(200, CHAIN_EVENTS_LIMIT_DEFAULT).optional(),
     // `block_number.event_index`, not an opaque token -- the route publishes
     // and enforces that shape, so a bare string advertised a value it rejects

--- a/schemas-src/mcp-tools/get-network-health.ts
+++ b/schemas-src/mcp-tools/get-network-health.ts
@@ -14,7 +14,15 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
+import {
+  limitSchema,
+  offsetSchema,
+  orderSchema,
+  sortSchema,
+} from "./shared.ts";
 import { HealthSummaryArtifactSchema } from "../routes/health.ts";
 
 /**
@@ -38,6 +46,27 @@ export const GetNetworkHealthInputSchema = z
         "Restrict to subnets in this operational state. `failed` is the one an alerting caller usually wants; `unknown` means unprobed, which is NOT the same as healthy.",
       )
       .meta({ examples: ["failed"] }),
+    // The page the route publishes and this tool could not pass (#10797).
+    //
+    // The handler ALREADY pages: it runs applySubnetListQuery over the
+    // `health-subnets` collection with no explicit default, which
+    // applyMcpQueryFilters then serves at MCP_LIST_LIMIT_DEFAULT. So a caller
+    // was getting 20 of the network's ~129 health rows with no argument that
+    // could say otherwise, and no `limit` in the schema to reveal that a
+    // narrowing had happened at all. Exposing it is the only change here --
+    // the default is what it already was, which is why both numbers come from
+    // the constants that decide them rather than from literals restated here.
+    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
+    // Integer OFFSET, matching what the route publishes
+    // (`{minimum: 0, type: integer}`). Added alongside `limit` deliberately: a
+    // page size with no way to advance is a narrowing dressed as a capability.
+    cursor: offsetSchema().optional(),
+    // The collection's own sort list, so a column added to the health model
+    // cannot become one this tool rejects.
+    sort: sortSchema(
+      API_QUERY_COLLECTIONS["health-subnets"].sort_fields,
+    ).optional(),
+    order: orderSchema().optional(),
   })
   .strict();
 export type GetNetworkHealthInput = z.infer<typeof GetNetworkHealthInputSchema>;

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -23,6 +23,7 @@ import {
   netuidSchema,
   numericCursorSchema,
   orderSchema,
+  querySchema,
   sortSchema,
 } from "./shared.ts";
 import {
@@ -42,6 +43,15 @@ export const ListSubnetsInputSchema = z
   .object({
     cursor: numericCursorSchema().optional(),
     limit: limitSchema(100, 50).optional(),
+    // Free-text over `name` and `slug` -- the `subnets` collection's own
+    // search_keys, applied by the engine's own matcher (#10793).
+    //
+    // NOT a duplicate of search_subnets, which is a curated view on
+    // /api/v1/search with its own ranking and cannot be combined with anything.
+    // Here `q` is one filter among the rest, so "inference in the name AND
+    // readiness above 70" becomes reachable -- it was reachable from neither
+    // tool before.
+    q: querySchema().optional(),
     // A SUBNET status, not a health one. This described "rows with this health
     // status" and gave `ok` as the example -- a health verdict, on a parameter
     // whose route accepts active | inactive. The prose and the example both

--- a/schemas-src/mcp-tools/meta-artifacts-2.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-2.ts
@@ -25,6 +25,7 @@ import {
   limitSchema,
   numericCursorSchema,
   orderSchema,
+  querySchema,
   sortSchema,
   projectableRows,
 } from "./shared.ts";
@@ -102,6 +103,12 @@ export const GetCoverageDepthInputSchema = z
         "Restrict to subnets blocked this badly. `none` means nothing is blocking promotion.",
       )
       .meta({ examples: ["hard-blocked"] }),
+    // Free-text over the collection's own `search_keys` -- name, slug,
+    // top_gap_codes, recommended_next_action (#10793). The engine this handler
+    // already runs through implements it; only the argument was missing, so a
+    // caller could narrow by tier or netuid but not by "which subnets have a
+    // schema gap".
+    q: querySchema().optional(),
     sort: sortSchema(
       API_QUERY_COLLECTIONS["coverage-depth"].sort_fields,
     ).optional(),

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -19,6 +19,7 @@ import {
   numericCursorSchema,
   orderSchema,
   projectableRows,
+  querySchema,
   sortSchema,
 } from "./shared.ts";
 import { SubnetGapsArtifactSchema } from "../routes/review-gaps-profile.ts";
@@ -87,6 +88,12 @@ export const ListEnrichmentTargetsInputSchema = z
       .meta({ examples: ["hard-blocked"] }),
     netuid:
       API_QUERY_COLLECTIONS["coverage-depth"].filter_schemas.netuid.optional(),
+    // Free-text over the collection's own search_keys -- name, slug,
+    // top_gap_codes, recommended_next_action (#10793). It NARROWS the ranked
+    // queue rather than reordering it, which is why `q` lands here while this
+    // tool's `sort`/`order` are declined: rank survives a filter and does not
+    // survive a re-sort.
+    q: querySchema().optional(),
   })
   .strict();
 export type ListEnrichmentTargetsInput = z.infer<
@@ -153,6 +160,10 @@ export const ListEnrichmentTargetsOutputSchema = z
         gap_code: z.string().nullable(),
         agent_status: z.string().nullable(),
         netuid: z.int().min(0).nullable(),
+        // Added with the `q` input (#10793), because the comment above is a
+        // rule and not a description: a filter that narrowed the result and
+        // does not appear in the echo makes the echo a lie.
+        q: z.string().nullable(),
       })
       .passthrough()
       .optional(),

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -18,6 +18,8 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   idFilterSchema,
@@ -28,6 +30,7 @@ import {
   limitSchema,
   netuidSchema,
   numericCursorSchema,
+  offsetSchema,
   orderSchema,
   projectableRows,
   providerSlugSchema,
@@ -126,16 +129,63 @@ export type ListSubnetCandidatesOutput = z.infer<
   typeof ListSubnetCandidatesOutputSchema
 >;
 
+/**
+ * #10793. This took `netuid` alone and returned the whole ledger -- measured at
+ * 77 claims / ~33 KB for SN64, with no pagination block in the response at all,
+ * while GET /api/v1/subnets/{netuid}/evidence publishes `q`, `sort`, `order`,
+ * `limit` and `cursor`. The same no-lever shape #10011 found on
+ * get_coverage_depth (293 KB, zero arguments) and #10027 resolved by giving it
+ * a page.
+ *
+ * The four are NOT copied from the sibling below: both read the `claims`
+ * collection, so both take their vocabulary from it, and a search key or sort
+ * column added there reaches the two tools together.
+ */
 export const GetSubnetEvidenceInputSchema = z
   .object({
     netuid: netuidSchema(),
+    q: querySchema().optional(),
+    sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
+    order: orderSchema().optional(),
+    // Both numbers come from the constants that DECIDE them, not from the
+    // sibling's literals. This handler runs applySubnetListQuery, so the
+    // ceiling is whatever the route publishes -- MAX_LIMIT, since
+    // validateListQuery reads the bound off the published schema -- and the
+    // default is the one applyMcpQueryFilters really supplies. Restating the
+    // sibling's `limitSchema(100, 20)` would advertise a ceiling this handler
+    // does not enforce: `limit: 200` is served, not rejected.
+    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
+    // An integer OFFSET, which is what this route publishes
+    // (`{minimum: 0, type: integer}`) -- not the keyset cursor.
+    cursor: offsetSchema().optional(),
   })
   .strict();
 export type GetSubnetEvidenceInput = z.infer<
   typeof GetSubnetEvidenceInputSchema
 >;
 
-export const GetSubnetEvidenceOutputSchema = SubnetEvidenceArtifactSchema;
+// Extended with the page fields the handler now returns. Left as the full
+// artifact rather than narrowed to the sibling's `pick({netuid, claims})`: this
+// tool has always returned `name`, `slug` and `generated_at` too, and dropping
+// them to share a schema would break callers for tidiness.
+//
+// FIVE fields, not McpListPageFields' seven. applySubnetListQuery lifts
+// total/returned/cursor/limit/next_cursor out of the engine's pagination block
+// and does not lift `sort`/`order`, so spreading the shared group here would
+// declare two fields this handler never emits -- the sibling below carries all
+// seven because its loader really does return them.
+//
+// Optional because the lift is conditional on the engine having produced a
+// pagination block at all; a required field the handler can omit is a schema
+// that fails on its own output.
+export const GetSubnetEvidenceOutputSchema =
+  SubnetEvidenceArtifactSchema.extend({
+    total: McpListPageFields.total.optional(),
+    returned: McpListPageFields.returned.optional(),
+    limit: McpListPageFields.limit.optional(),
+    cursor: McpListPageFields.cursor.optional(),
+    next_cursor: McpListPageFields.next_cursor.optional(),
+  });
 export type GetSubnetEvidenceOutput = z.infer<
   typeof GetSubnetEvidenceOutputSchema
 >;

--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -36,7 +36,10 @@ import {
 import { GlobalValidatorsArtifactSchema } from "../routes/global-validators.ts";
 import { ValidatorDetailArtifactSchema } from "../routes/validator-detail.ts";
 import { ValidatorHistoryArtifactSchema } from "../routes/validator-history.ts";
-import { ValidatorNominatorsArtifactSchema } from "../routes/validator-nominators.ts";
+import {
+  ValidatorNominatorPositionsSchema,
+  ValidatorNominatorsArtifactSchema,
+} from "../routes/validator-nominators.ts";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
 import { CompareValidatorEntrySchema } from "../routes/compare-validators.ts";
 import {} from "../routes/validator-nominators.ts";
@@ -202,6 +205,19 @@ export type CompareValidatorsOutput = z.infer<
 export const GetValidatorNominatorsInputSchema = z
   .object({
     hotkey: accountKeySchema("hotkey"),
+    // WHICH QUESTION is answered, not how well (#9617, exposed on MCP by
+    // #10793). The default does not move, and must not: the two bases are
+    // different units over different time semantics, so flipping it would
+    // silently change what every existing caller's numbers mean.
+    //
+    // It was the one parameter of this route's five that MCP could not reach,
+    // and the gap had teeth. `flow` sums TAO MOVED inside the window, so a
+    // nominator who staked before it and has not touched it since is invisible
+    // and a long-standing one reads as smaller than they are -- which is the
+    // wrong answer to "who delegates to this validator", the question an agent
+    // actually asks. Taken from the route's own query schema, alongside the
+    // `window` and `sort` already read from it.
+    basis: RouteQuery_validators_hotkey_nominators.shape.basis,
     window: RouteQuery_validators_hotkey_nominators.shape.window,
     sort: RouteQuery_validators_hotkey_nominators.shape.sort,
     // NOT the route's ceiling. REST enforces GLOBAL_VALIDATOR_LIMIT_MAX (2000)
@@ -220,8 +236,57 @@ export type GetValidatorNominatorsInput = z.infer<
 >;
 
 // objectItems(...) properties, none required at the item level.
-export const GetValidatorNominatorsOutputSchema =
-  ValidatorNominatorsArtifactSchema;
+//
+// TWO CARDS IN ONE OBJECT, since #10793 gave the tool `basis`. Not a
+// `z.union` -- MCP's outputSchema must be an object schema (the registry test
+// asserts `outputSchema.type === "object"` for every tool), and a union emits
+// a top-level `anyOf` with no `type` at all, so the union that reads better
+// here is one the protocol cannot carry.
+//
+// So: the fields BOTH cards always carry stay required, and each basis's own
+// fields are optional with prose saying which basis brings them. That is a
+// weaker statement than either card alone -- it cannot say "window is required
+// when basis=flow" -- but it is a TRUE one, where declaring only the flow card
+// would leave every positions call serving a response its own published schema
+// rejects.
+export const GetValidatorNominatorsOutputSchema = z
+  .object({
+    // Carried by both builders, on every path including the decline.
+    schema_version: z.int(),
+    hotkey: z.unknown(),
+    limit: z.union([z.int().min(0), z.null()]),
+    offset: z.int().min(0),
+    nominator_count: z.int().min(0).nullable(),
+    // The item shape follows the basis: TAO totals over a window, or standing
+    // alpha broken down per subnet. An item-level union is fine -- the
+    // protocol's object requirement is on the TOP level only.
+    nominators: z.array(
+      z.union([
+        ValidatorNominatorsArtifactSchema.shape.nominators.element,
+        ValidatorNominatorPositionsSchema.shape.nominators.element,
+      ]),
+    ),
+    // --- basis=flow only ---------------------------------------------------
+    window: ValidatorNominatorsArtifactSchema.shape.window.optional(),
+    sort: ValidatorNominatorsArtifactSchema.shape.sort.optional(),
+    concentration_complete:
+      ValidatorNominatorsArtifactSchema.shape.concentration_complete.optional(),
+    top_nominator_share:
+      ValidatorNominatorsArtifactSchema.shape.top_nominator_share.optional(),
+    top5_nominator_share:
+      ValidatorNominatorsArtifactSchema.shape.top5_nominator_share.optional(),
+    nominator_gini:
+      ValidatorNominatorsArtifactSchema.shape.nominator_gini.optional(),
+    // --- basis=positions only ----------------------------------------------
+    // Absent on the flow card, which never stamps a basis -- verified against
+    // production: the default response has no `basis` key at all.
+    basis: ValidatorNominatorPositionsSchema.shape.basis.optional(),
+    captured_at: ValidatorNominatorPositionsSchema.shape.captured_at.optional(),
+    positions_captured_at:
+      ValidatorNominatorPositionsSchema.shape.positions_captured_at.optional(),
+    degraded: ValidatorNominatorPositionsSchema.shape.degraded,
+  })
+  .passthrough();
 export type GetValidatorNominatorsOutput = z.infer<
   typeof GetValidatorNominatorsOutputSchema
 >;

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -675,9 +675,27 @@ export const ROUTE_QUERY_SCHEMAS = {
     format: formatSchema().optional(),
   }),
   "/api/v1/validators/{hotkey}/nominators": z.object({
+    // Described here rather than on the MCP tool, so BOTH surfaces carry the
+    // sentence -- REST published this parameter with no prose at all, and the
+    // one thing a caller cannot guess about it is that the two values answer
+    // different questions rather than the same one better or worse (#10793).
     basis: z
       .enum(NOMINATOR_BASES)
-      .meta({ default: DEFAULT_NOMINATOR_BASIS })
+      .describe(
+        "Which question to answer. `flow` (the default) sums TAO MOVED inside " +
+          "`window`, so a delegator who staked earlier and has not touched it " +
+          "since is absent. `positions` reads the standing ledger instead: " +
+          // "coldkey (an ss58 address)" rather than a bare one, matching this
+          // route's existing description and scan-public-safety's explanatory-
+          // parenthetical exemption: an ss58 coldkey is public on-chain data,
+          // and the scan's job is to catch prose that treats it as a secret.
+          "every coldkey (an ss58 address) delegating right now and how much " +
+          "alpha each holds " +
+          "per subnet, whenever they staked. Different units over different " +
+          "time semantics, so the two are not comparable. On `positions`, " +
+          "`window` and `sort` are REJECTED rather than ignored.",
+      )
+      .meta({ default: DEFAULT_NOMINATOR_BASIS, examples: ["positions"] })
       .optional(),
     window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     sort: sortSchema(

--- a/schemas-src/routes/validator-nominators.ts
+++ b/schemas-src/routes/validator-nominators.ts
@@ -84,3 +84,74 @@ export const ValidatorNominatorsArtifactSchema = z
 export type ValidatorNominatorsArtifact = z.infer<
   typeof ValidatorNominatorsArtifactSchema
 >;
+
+/**
+ * The OTHER shape this route serves: `?basis=positions` (#9617).
+ *
+ * A different question, so a different card rather than optional fields bolted
+ * onto the one above -- `window`, `sort` and the concentration block do not
+ * exist here (they belong to the flow aggregation, and the route 400s rather
+ * than ignore them), and `nominators` carries alpha PER SUBNET instead of TAO
+ * totals. Modeled from src/validator-nominator-positions.ts's
+ * buildNominatorPositions and verified against production 2026-08-11:
+ * 2,377 nominators for 5E2LP6En...TKeZ5u, where the flow basis over the same
+ * hotkey reports 0.
+ *
+ * Written now because #10793 gives the MCP tool `basis`, and a tool that can
+ * return this shape while publishing only the flow one publishes a schema its
+ * own output fails.
+ */
+const ValidatorNominatorPositionSchema = z
+  .object({
+    netuid: z.int().min(0),
+    alpha: z.number().min(0),
+  })
+  .strict();
+
+const ValidatorNominatorPositionEntrySchema = z
+  .object({
+    coldkey: z.string(),
+    subnet_count: z.int().min(0),
+    // The largest SINGLE holding, netuid attached. Each subnet's alpha is a
+    // different token, so a cross-subnet total is not computed here and a bare
+    // number would invite one -- the netuid rides with it for that reason.
+    largest_position: ValidatorNominatorPositionSchema,
+    subnets: z.array(ValidatorNominatorPositionSchema),
+  })
+  .strict()
+  .describe(
+    "One delegating `coldkey`'s standing alpha positions toward a validator, broken down by subnet.",
+  );
+
+export const ValidatorNominatorPositionsSchema = z
+  .object({
+    schema_version: z.int(),
+    hotkey: z.unknown(),
+    basis: z.literal("positions"),
+    limit: z.int().min(0).nullable(),
+    offset: z.int().min(0),
+    nominator_count: z
+      .int()
+      .min(0)
+      .nullable()
+      .describe(
+        "The WHOLE delegator set, never bounded by the page -- unlike the flow basis, where it is null when the true total could not be read.",
+      ),
+    captured_at: z.string().nullable(),
+    positions_captured_at: z.string().nullable(),
+    nominators: z.array(ValidatorNominatorPositionEntrySchema),
+    // Present only on the decline. The positions basis refuses to answer while
+    // the hotkey_alpha pool ledger has no complete pass, because a partial
+    // ledger underprices a nominator rather than dropping them -- a wrong
+    // number that looks right.
+    degraded: z.object({ reason: z.string() }).passthrough().optional(),
+  })
+  .passthrough()
+  .describe(
+    "One validator's standing delegator positions (#9617). Mirrors GET /api/v1/validators/{hotkey}/nominators?basis=positions.",
+  );
+// NO `export type ValidatorNominatorPositions` beside it, unlike the sibling
+// above. Nothing infers one, and validate:unreferenced-exports is a ratchet
+// over exactly this pile -- 241 of its 738 are schemas-src/routes type aliases
+// exported by convention rather than by need. A caller who wants the type can
+// `z.infer<typeof ValidatorNominatorPositionsSchema>` at the point of use.

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -93,7 +93,49 @@ const REQUEST_HEADER =
 const RANKED_OUTPUT =
   "the tool's output order IS its answer (ranked by match/capability); a caller-supplied sort would overwrite the ranking it was called for (#10605)";
 
-/** Standing debt: the route publishes it and the tool cannot pass it. */
+/**
+ * The tool takes this VALUE already, under another argument.
+ *
+ * `get_extrinsic_chain_events` is pinned to one extrinsic by `ref`, a composite
+ * `block_number-extrinsic_index` it parses and validates. Both halves reach the
+ * feed loader from there, so accepting `block` and `extrinsic` separately would
+ * give a caller a second way to say what they already said -- and therefore a
+ * way to contradict it, which has no correct resolution.
+ */
+const RESOLVED_FROM_REF =
+  "the tool already takes this inside `ref` (block_number-extrinsic_index) and passes it on; a second way to say it is a way to contradict it (#10793)";
+
+/**
+ * A range bound over a set that spans one point.
+ *
+ * `before` is a block-height ceiling (`safeBlockNumber`), and this tool reads
+ * the events of a single extrinsic -- so every row shares one block_number and
+ * the bound selects either all of them or none. Exposing it would publish a
+ * filter whose only two outcomes are "no effect" and "empty".
+ */
+const SINGLE_BLOCK_SCOPE =
+  "a block-height bound on a tool scoped to ONE block by `ref`; it can only select every event or none (#10793)";
+
+/**
+ * The route's filter, on the route's OWN tool.
+ *
+ * `list_review_gaps` is declared against `/api/v1/gaps` with `/api/v1/review/gaps`
+ * as an additional route, but it reads /metagraph/review/gap-priorities.json
+ * through the `review-gap-priorities` collection -- which has no
+ * `coverage_level` column to filter on. `/api/v1/gaps` is `list_gaps`' route,
+ * and `list_gaps` exposes `coverage_level` already.
+ */
+const SIBLINGS_ROUTE_FILTER =
+  "this filter belongs to the sibling tool that actually mirrors the route (list_gaps); this tool reads the review feed, whose collection has no such column (#10793)";
+
+/**
+ * Standing debt: the route publishes it and the tool cannot pass it.
+ *
+ * EMPTY as of #10793, and kept anyway. The next route to publish a parameter
+ * its tool cannot pass needs somewhere honest to land, and deleting the reason
+ * would make "add it to DECLARED with a made-up category" the path of least
+ * resistance. An entry here is an admission with a deadline, not a decision.
+ */
 const NOT_YET_EXPOSED =
   "NOT YET EXPOSED -- the route publishes this and the tool cannot pass it; delete this entry by adding it, not by keeping it";
 
@@ -180,42 +222,31 @@ for (const [key, reason] of Object.entries({
   "list_subnets.max_readiness": RENAMED_ON_THE_MCP_SIDE,
   // --- headers -------------------------------------------------------------
   "get_alert_trigger.owner_token": REQUEST_HEADER,
-  // --- standing debt -------------------------------------------------------
-  // Free-text search over a list the tool otherwise mirrors. Each of these
-  // routes publishes `q` and the tool cannot pass it.
-  // #9981 gave four document-shaped routes a page. Their tools do not pass it
-  // YET, and that is a second decision rather than an oversight:
-  // applyMcpQueryFilters supplies MCP_LIST_LIMIT_DEFAULT, so exposing `limit`
-  // here changes each tool's DEFAULT payload -- a behaviour change for every
-  // agent already calling them. #9981 says that choice is per tool ("changing
-  // a default on a published route is a behaviour change... which is why this
-  // is not a one-line sweep"), so the capability landed first and the default
-  // is chosen next, tool by tool. Tracked in #10605.
+  // --- output whose ORDER is the answer ------------------------------------
   "find_subnets_by_capability.sort": RANKED_OUTPUT,
   "find_subnets_by_capability.order": RANKED_OUTPUT,
   "find_subnet_for_task.sort": RANKED_OUTPUT,
   "find_subnet_for_task.order": RANKED_OUTPUT,
-  "list_subnets.q": NOT_YET_EXPOSED,
-  "get_subnet_economics.q": NOT_YET_EXPOSED,
-  "get_subnet_evidence.q": NOT_YET_EXPOSED,
-  "get_coverage_depth.q": NOT_YET_EXPOSED,
-  "list_enrichment_targets.q": NOT_YET_EXPOSED,
-  "find_subnet_opportunities.q": NOT_YET_EXPOSED,
-  "get_network_health.limit": NOT_YET_EXPOSED,
-  "get_network_health.sort": NOT_YET_EXPOSED,
-  "get_network_health.order": NOT_YET_EXPOSED,
-  "get_subnet_evidence.limit": NOT_YET_EXPOSED,
-  "get_subnet_evidence.sort": NOT_YET_EXPOSED,
-  "get_subnet_evidence.order": NOT_YET_EXPOSED,
-  "get_validator_nominators.basis": NOT_YET_EXPOSED,
-  "get_extrinsic_chain_events.pallet": NOT_YET_EXPOSED,
-  "get_extrinsic_chain_events.method": NOT_YET_EXPOSED,
-  "get_extrinsic_chain_events.block": NOT_YET_EXPOSED,
-  "get_extrinsic_chain_events.extrinsic": NOT_YET_EXPOSED,
-  "get_extrinsic_chain_events.before": NOT_YET_EXPOSED,
-  "list_review_gaps.coverage_level": NOT_YET_EXPOSED,
-  "list_enrichment_targets.sort": NOT_YET_EXPOSED,
-  "list_enrichment_targets.order": NOT_YET_EXPOSED,
+  // list_enrichment_targets returns the coverage-depth scorecard's ranked
+  // QUEUE and carries `rank` on every row, so the same judgement applies: a
+  // caller-supplied sort would replace the priority order this tool exists to
+  // publish. `q` is exposed rather than declined because a filter narrows the
+  // queue without reordering it -- rank survives a filter and does not survive
+  // a re-sort (#10793).
+  "list_enrichment_targets.sort": RANKED_OUTPUT,
+  "list_enrichment_targets.order": RANKED_OUTPUT,
+  // --- resolved from another argument the tool already takes ---------------
+  "get_extrinsic_chain_events.block": RESOLVED_FROM_REF,
+  "get_extrinsic_chain_events.extrinsic": RESOLVED_FROM_REF,
+  "get_extrinsic_chain_events.before": SINGLE_BLOCK_SCOPE,
+  // --- the sibling list tool carries them (#10793) -------------------------
+  // Both mirror /api/v1/economics, and `get_economics` IS that route's list
+  // view -- it already publishes q/sort/order/limit/cursor. Every OTHER list
+  // parameter on these two tools was already declared CURATED_VIEW above; `q`
+  // sat under NOT_YET_EXPOSED by oversight rather than by a second decision.
+  "get_subnet_economics.q": CURATED_VIEW,
+  "find_subnet_opportunities.q": CURATED_VIEW,
+  "list_review_gaps.coverage_level": SIBLINGS_ROUTE_FILTER,
 })) {
   DECLARED[key] = reason;
 }

--- a/src/data-api-mcp.ts
+++ b/src/data-api-mcp.ts
@@ -226,7 +226,21 @@ const COMPOSITE_REF_RE = /^(\d+)-(\d+)$/;
 export async function loadExtrinsicChainEvents(
   ctx: DataApiMcpContext,
   ref: unknown,
-  { limit, cursor }: { limit?: unknown; cursor?: unknown } = {},
+  {
+    limit,
+    cursor,
+    // #10793: the two feed filters that still mean something once the read is
+    // pinned to one extrinsic. `block` and `extrinsic` are NOT accepted here --
+    // this function derives both from `ref`, and taking them separately would
+    // let a caller contradict the reference they passed.
+    pallet,
+    method,
+  }: {
+    limit?: unknown;
+    cursor?: unknown;
+    pallet?: unknown;
+    method?: unknown;
+  } = {},
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): Promise<{
   schema_version: 1;
@@ -263,6 +277,13 @@ export async function loadExtrinsicChainEvents(
       extrinsic: extrinsicIndex,
       limit: lim,
       cursor: cursor ?? undefined,
+      // Passed straight through, unlike `cursor` above. Both the validator and
+      // the query builder gate these on `value == null`, which is true for an
+      // absent argument and a null alike, so an omitted filter cannot widen the
+      // read -- and an unusable one is the caller's `invalid_params` rather
+      // than a silently dropped filter.
+      pallet,
+      method,
     },
     network,
   );

--- a/src/global-operational-health.ts
+++ b/src/global-operational-health.ts
@@ -84,8 +84,11 @@ export const GET_NETWORK_HEALTH_MCP_TOOL = {
   description:
     "Fetch the live global operational health rollup: global surface counts " +
     "by status (ok/degraded/failed/unknown) and per-subnet operational status " +
-    "from the ~15-minute health prober (KV health:current → D1 surface_status). " +
-    "Use it for a network-wide health snapshot before drilling into " +
+    "from the ~15-minute health prober (KV health:current → Postgres " +
+    "surface_status). Narrow with netuid/status, sort with sort + order, and " +
+    "page with limit (default 20) / cursor -- the subnet rows ARE paged, so a " +
+    "call that omits limit sees 20 of them while `global` still counts every " +
+    "one. Use it for a network-wide health snapshot before drilling into " +
     "get_subnet_health or get_health_trends. Mirrors GET /api/v1/health.",
   inputSchema: inputJsonSchema(GetNetworkHealthInputSchema),
 };

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -30,11 +30,16 @@ import { readLiveSurfaceStatus } from "./health-status-live.ts";
 
 type Row = Record<string, unknown>;
 
-// Must exceed the probe cadence (15 min) so a live D1 health row is never treated
+// Must exceed the probe cadence (15 min) so a live health row is never treated
 // as stale just because the next probe hasn't run yet. 25 min = cadence + a
-// one-missed-run buffer. (KV health:current has no TTL, so this only bounds the
-// D1 fallback path.)
-const D1_HEALTH_FALLBACK_MAX_AGE_MS = 25 * 60 * 1000;
+// one-missed-run buffer.
+//
+// It bounds BOTH tiers, despite the old name saying otherwise: KV
+// health:current has no TTL, so without this gate a wedged prober would serve
+// its last snapshot as fresh forever. Renamed off the retired store's name
+// -- the fallback it gates has been Postgres since D1 was eliminated, and a
+// constant naming a store this repo no longer has is a reader's wrong turn.
+const HEALTH_FALLBACK_MAX_AGE_MS = 25 * 60 * 1000;
 
 // Pool-eligibility hysteresis (cosmos.directory-style "don't flap"): an RPC
 // endpoint is only dropped from the proxy pool after this many CONSECUTIVE
@@ -2104,7 +2109,7 @@ export async function resolveLiveHealth({
         const lastRun = Date.parse(current.last_run_at as string);
         if (
           !Number.isFinite(lastRun) ||
-          lastRun >= currentTime - D1_HEALTH_FALLBACK_MAX_AGE_MS
+          lastRun >= currentTime - HEALTH_FALLBACK_MAX_AGE_MS
         ) {
           return { ...current, health_source: "live-cron-prober" };
         }
@@ -2114,7 +2119,7 @@ export async function resolveLiveHealth({
     }
   }
   const currentTime = typeof now === "function" ? now() : Date.now();
-  const freshnessCutoff = currentTime - D1_HEALTH_FALLBACK_MAX_AGE_MS;
+  const freshnessCutoff = currentTime - HEALTH_FALLBACK_MAX_AGE_MS;
   if (env) {
     // #9522: same route, same previously-dead read as the prober's continuity
     // load — see src/health-status-live.ts. A freshness cutoff here rather

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -227,6 +227,7 @@ import {
 import { MCP_TIERED_RATE_LIMIT } from "./api-tiers.ts";
 import { recordApiKeyUsage } from "../workers/api.ts";
 import { DAY_PATTERN } from "../workers/request-params.ts";
+import { searchMatchingRows } from "../workers/list-query.ts";
 import { applyMcpQueryFilters } from "./mcp-list-query.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import {
@@ -1676,6 +1677,11 @@ import {
   NOMINATOR_LIMIT_MAX,
 } from "./validator-nominators.ts";
 import { buildValidatorHistory } from "./validator-history.ts";
+import {
+  NOMINATOR_BASES,
+  buildNominatorPositions,
+  loadNominatorPositions,
+} from "./validator-nominator-positions.ts";
 import { readStore } from "./read-store.ts";
 import {
   ALPHA_PRICING_TABLES,
@@ -3845,6 +3851,48 @@ export function validateToolArguments(tool: Row, args: Row) {
 }
 
 /**
+ * Which arguments were SUPPLIED here rather than by the caller (#10793).
+ *
+ * `url.searchParams.has(name)` is the question a REST handler asks when a
+ * parameter is only valid in some modes -- handleValidatorNominators 400s on
+ * `window` under `?basis=positions` precisely that way. Filling defaults (above)
+ * takes that question away from an MCP handler: once `window: "30d"` is in the
+ * object, "the caller asked for 30d" and "nobody asked" are the same value.
+ *
+ * That is not hypothetical. get_validator_nominators' positions basis rejects
+ * `window` and `sort`, and reading them straight off `args` made EVERY
+ * positions call fail on an argument the caller never sent -- caught by
+ * tests/mcp-published-parameter-parity.ts before it shipped.
+ *
+ * A SYMBOL key, so it cannot reach anywhere the value would be mistaken for
+ * input: `Object.entries`, `Object.keys` and `JSON.stringify` all skip it, and
+ * several handlers forward their whole argument object into a query builder or
+ * an upstream call, where an unexpected key becomes a filter or someone else's
+ * 400. Use `callerSuppliedArg` rather than reading it directly.
+ */
+const DEFAULTED_ARGS: unique symbol = Symbol("mcp.defaulted-args");
+
+/**
+ * Did the CALLER name this argument, as opposed to it being defaulted in?
+ *
+ * The MCP equivalent of `url.searchParams.has(name)`. False for an argument
+ * absent from the call and for one this dispatch supplied; true only when the
+ * caller wrote it down -- including when they wrote the default's own value,
+ * which is a real request and not a coincidence to be guessed at.
+ */
+function callerSuppliedArg(args: Row, name: string) {
+  // Not `args?.` -- validateToolArguments resolves an absent `arguments` to an
+  // object before any handler runs, so a nullable guard here would be a branch
+  // that cannot be taken. An explicit `null` CAN arrive (dispatch does no
+  // schema validation) and reads as "no value", matching the REST side where
+  // `?window=` resolves to null and is not applied.
+  if (args[name] === undefined || args[name] === null) return false;
+  const defaulted = (args as Record<symbol, unknown>)[DEFAULTED_ARGS] as
+    Set<string> | undefined;
+  return !defaulted?.has(name);
+}
+
+/**
  * Fill every omitted argument the tool PUBLISHES a default for (#10306).
  *
  * A tool that advertises `"default": 100` and then serves nothing is lying to
@@ -3875,19 +3923,33 @@ export function validateToolArguments(tool: Row, args: Row) {
  * would get for omitting the argument -- the same thing `pageLimit` does on the
  * REST side, at the one place every tools/call passes through rather than in
  * the 230 handlers behind it.
+ *
+ * WHAT IT COSTS (#10793): once a default is in the object, a handler can no
+ * longer tell "the caller asked for this" from "nobody asked". That matters to
+ * the handlers whose parameters are only valid in some modes.
+ * `callerSuppliedArg` above gives the distinction back.
  */
 function applyPublishedDefaults(tool: Row, args: Row): Row {
   const properties = tool.inputSchema?.properties as
     Record<string, Row> | undefined;
   if (!properties) return args;
   let filled: Row | null = null;
+  const supplied = new Set<string>();
   for (const [name, schema] of Object.entries(properties)) {
     if (schema?.default === undefined) continue;
     if (args[name] !== undefined) continue;
     filled ??= { ...args };
     filled[name] = schema.default;
+    supplied.add(name);
   }
-  return filled ?? args;
+  if (!filled) return args;
+  // Non-enumerable as well as symbol-keyed, so a spread of these args does not
+  // carry the marker into a copy that may outlive the dispatch.
+  Object.defineProperty(filled, DEFAULTED_ARGS, {
+    value: supplied,
+    enumerable: false,
+  });
+  return filled;
 }
 
 /**
@@ -5074,8 +5136,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "Enumerate the full Bittensor subnet registry, paginated. Returns every " +
       "subnet's netuid, slug, title, type, status, integration-readiness score " +
       "(0-100), and callable-surface count. Use this to walk or page through the " +
-      "whole registry; for keyword or capability discovery use search_subnets / " +
-      "find_subnets_by_capability instead. Defaults to mainnet; pass " +
+      "whole registry, and q to narrow it by name/slug alongside the other " +
+      "filters -- for ranked keyword or capability discovery use search_subnets " +
+      "/ find_subnets_by_capability instead. Defaults to mainnet; pass " +
       'network:"test" for the Bittensor testnet registry, which is native-only ' +
       "(chain identity, no curated surfaces/health, so readiness and " +
       "surface_count are zero there).",
@@ -5094,7 +5157,22 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // (not_status/not_subnet_type/not_domain), then the numeric range bounds.
       const categorical = categoricalFilterSubnets(all, args);
       const identified = identityFilterSubnets(categorical, args);
-      const filtered = rangeFilterSubnets(identified, args);
+      const bounded = rangeFilterSubnets(identified, args);
+      // Free-text over the collection's own `search_keys` (#10793). Through the
+      // ENGINE's matcher, not a second one written here, so `q` means the same
+      // thing on both surfaces -- and over `search_keys` rather than a list
+      // repeated here, so a key added to the collection reaches this tool too.
+      //
+      // Last in the chain because it is the most expensive pass (a join and a
+      // substring scan per row) and the three cheap filters above have already
+      // cut the set. It composes with them, which is the point: "inference in
+      // the name AND readiness above 70" is reachable from neither this tool
+      // nor search_subnets today.
+      const filtered = searchMatchingRows(
+        bounded,
+        optionalString(args, "q"),
+        API_QUERY_COLLECTIONS.subnets.search_keys,
+      );
       // Sort the filtered list before paging; unscored subnets sort last and
       // equal values tie-break by netuid for a stable page (sortSubnets).
       const sort = optionalEnum(args, "sort", LIST_SUBNETS_SORT_FIELDS);
@@ -8343,15 +8421,74 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     title: "Get who has staked to a validator",
     description:
       "Fetch the nominators (stakers) of one validator across every subnet it " +
-      "operates in, over a window (7d, 30d, default 90d), ranked by net_staked " +
-      "(default), gross_staked, or last_activity. Optional coldkey narrows to " +
-      "one nominator's own flow. Mirrors GET /api/v1/validators/{hotkey}/nominators.",
+      "operates in. `basis` selects WHICH QUESTION is answered. basis=flow (the " +
+      "default) is TAO MOVED over a window (7d, 30d, default 90d), ranked by " +
+      "net_staked (default), gross_staked, or last_activity, with coldkey " +
+      "narrowing to one nominator's own flow — so a delegator who staked before " +
+      "the window and has not touched it since is INVISIBLE there. " +
+      "basis=positions instead reads the standing ledger: every coldkey " +
+      "(an ss58 address) " +
+      "currently delegating and how much alpha each holds PER SUBNET, whenever " +
+      "they staked. Ask for positions when the question is who delegates now; " +
+      "flow when it is who moved stake lately. The two are different units over " +
+      "different time semantics and are not comparable, which is why the " +
+      "default does not move. On the positions basis window and sort are " +
+      "REJECTED rather than ignored, nominator_count is the whole delegator set " +
+      "rather than the page, and there is no cross-subnet alpha total because " +
+      "each subnet's alpha is a different token. Mirrors " +
+      "GET /api/v1/validators/{hotkey}/nominators.",
     inputSchema: inputJsonSchema(GetValidatorNominatorsInputSchema),
     async handler(
       args: z.infer<typeof GetValidatorNominatorsInputSchema>,
       ctx: McpCtx,
     ) {
       const hotkey = requireHotkey(args);
+      // #10793: the one parameter of this route's five MCP could not reach, and
+      // the gap had teeth -- measured against production on 2026-08-11, the
+      // flow basis reports 0 nominators for 5E2LP6En...TKeZ5u while positions
+      // reports 2,377. "Who delegates to this validator" was answerable only
+      // over REST.
+      if (optionalEnum(args, "basis", NOMINATOR_BASES) === "positions") {
+        // REJECTED, not ignored -- the same two the route 400s on. Accepting
+        // them would imply the snapshot honoured them, and a caller who asked
+        // for a 7d window and got an all-time holdings card has no way to tell.
+        //
+        // On what the CALLER named, not on what `args` holds: both carry a
+        // published default that dispatch fills in, so reading them directly
+        // would refuse every positions call over arguments nobody sent.
+        for (const unsupported of ["window", "sort"] as const) {
+          if (callerSuppliedArg(args as Row, unsupported)) {
+            throw toolError(
+              "invalid_params",
+              `\`${unsupported}\` applies to basis=flow only; the positions basis is a current-holdings snapshot, not a windowed aggregation.`,
+            );
+          }
+        }
+        return buildNominatorPositions(
+          await loadNominatorPositions(
+            readStore(
+              ctx.env,
+              ALPHA_PRICING_TABLES,
+            ) as never as unknown as Parameters<
+              typeof loadNominatorPositions
+            >[0],
+            hotkey,
+          ),
+          hotkey,
+          // Its own page expressions rather than ones shared with the flow
+          // path below, matching how handleValidatorNominators splits the two
+          // bases: they page over different row sets, and the day one of them
+          // needs a different ceiling a shared line would have to be unpicked.
+          {
+            limit: clampToolLimit(
+              args?.limit,
+              NOMINATOR_LIMIT_DEFAULT,
+              NOMINATOR_LIMIT_MAX,
+            ),
+            offset: optionalNonNegativeInt(args, "offset") ?? 0,
+          },
+        );
+      }
       const window =
         optionalEnum(args, "window", Object.keys(NOMINATOR_WINDOWS)) ??
         DEFAULT_NOMINATOR_WINDOW;
@@ -11745,7 +11882,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     description:
       "Fetch raw pallet.method events one extrinsic emitted from the all-events " +
       "lakehouse tier (newest first). ref must be the composite id " +
-      "'block_number-extrinsic_index' (e.g. '4200000-3'). Page with limit (1-200, " +
+      "'block_number-extrinsic_index' (e.g. '4200000-3'). Narrow to one pallet " +
+      "or runtime call with pallet/method — an extrinsic usually emits events " +
+      "from several. Page with limit (1-200, " +
       "default 50) or follow next_cursor for deeper pages. Distinct from the curated " +
       "account_events embedded in get_extrinsic. Pass network to read testnet's " +
       "decoded history instead of mainnet's. Mirrors GET /api/v1/chain-events?block=&extrinsic=.",
@@ -11759,7 +11898,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       return loadExtrinsicChainEvents(
         ctx,
         ref,
-        { limit: args?.limit, cursor: cursor ?? undefined },
+        {
+          limit: args?.limit,
+          cursor: cursor ?? undefined,
+          // #10793. `block` and `extrinsic` stay unexposed on purpose: both are
+          // already carried by `ref`, and a second way to say them is a way to
+          // contradict it.
+          pallet: optionalString(args, "pallet") ?? undefined,
+          method: optionalString(args, "method") ?? undefined,
+        },
         chainNetworkFromChainName(
           optionalEnum(args, "network", MCP_NETWORK_VALUES),
         ),
@@ -12665,14 +12812,29 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "Fetch the public evidence-ledger claims for one subnet by netuid: the " +
       "provenance and verification evidence recorded for that subnet's surfaces " +
       "(what was checked and the outcome). The per-subnet view of list_evidence " +
-      "(the network-wide ledger). Mirrors GET /api/v1/subnets/{netuid}/evidence.",
+      "(the network-wide ledger). Search with q across subject, claim, " +
+      "source_url and support_summary; sort with sort + order; page with limit " +
+      "(1-100, default 20) / cursor. Mirrors " +
+      "GET /api/v1/subnets/{netuid}/evidence.",
     inputSchema: inputJsonSchema(GetSubnetEvidenceInputSchema),
     async handler(
       args: z.infer<typeof GetSubnetEvidenceInputSchema>,
       ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
-      return loadArtifactData(ctx, `/metagraph/evidence/${netuid}.json`);
+      // #10793: this returned the whole ledger on every call -- measured at 77
+      // claims / ~33 KB for SN64, with no pagination block at all -- while the
+      // route published q/sort/order/limit/cursor. Through the SAME engine the
+      // route uses, so the two cannot search or order differently. "claims" is
+      // the collection's own data_key, and `netuid` stays the default SUBJECT
+      // key: the artifact already holds one subnet, so passing it on as a row
+      // filter would match nothing (the claims carry `subject`, not `netuid`).
+      return applySubnetListQuery(
+        await loadArtifactData(ctx, `/metagraph/evidence/${netuid}.json`),
+        args as Row,
+        "claims",
+        "claims",
+      );
     },
   },
   {
@@ -13380,8 +13542,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     description:
       "Fetch the coverage-depth scorecard's ranked enrichment targets: which " +
       "subnets need schema, fixture, example/SDK, provenance, candidate-review, " +
-      "or hard-blocker follow-up next. Use this for curation/work-planning, not " +
-      "live uptime; call get_subnet_health for current health.",
+      "or hard-blocker follow-up next. Narrow with q across name, slug, " +
+      "top_gap_codes and recommended_next_action — the queue's own ranking is " +
+      "preserved, so there is no sort/order here. Use this for " +
+      "curation/work-planning, not live uptime; call get_subnet_health for " +
+      "current health.",
     inputSchema: inputJsonSchema(ListEnrichmentTargetsInputSchema),
     async handler(
       args: z.infer<typeof ListEnrichmentTargetsInputSchema>,
@@ -13431,16 +13596,36 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           }))
           .filter((entry: Row) => Number.isInteger(entry.row?.netuid));
       }
+      // Free-text over the collection's own search_keys, through the ENGINE's
+      // matcher rather than a second one (#10793). Matched once over the row
+      // objects and tested by identity below, so the {row, rank} pairing --
+      // and with it the queue's ranking -- survives the filter.
+      const q = optionalString(args, "q");
+      const matched = new Set(
+        searchMatchingRows(
+          candidates.map(({ row }: Row) => row),
+          q,
+          API_QUERY_COLLECTIONS["coverage-depth"].search_keys,
+        ),
+      );
       const filters = {
         tier,
         severity,
         gap_code: gapCode,
         agent_status: agentStatus,
         netuid,
+        q,
       };
       const targets = candidates
-        .filter(({ row }: Row) =>
-          coverageDepthMatches(row, { tier, severity, gapCode, agentStatus }),
+        .filter(
+          ({ row }: Row) =>
+            matched.has(row) &&
+            coverageDepthMatches(row, {
+              tier,
+              severity,
+              gapCode,
+              agentStatus,
+            }),
         )
         .slice(0, limit)
         .map(({ row, rank }: Row) => coverageDepthTarget(row, rank));

--- a/tests/global-operational-health.test.ts
+++ b/tests/global-operational-health.test.ts
@@ -102,14 +102,17 @@ describe("global-operational-health", () => {
     assert.equal(GET_NETWORK_HEALTH_MCP_TOOL.name, "get_network_health");
     assert.match(GET_NETWORK_HEALTH_INSTRUCTIONS, /get_network_health/);
     // Asserted an EMPTY argument set until #10014: this tool took nothing at
-    // all and returned every subnet's health row on every call. It now takes
-    // the two filters its collection declares. Kept as an EXACT set so an
-    // argument appearing here by accident still fails.
+    // all and returned every subnet's health row on every call. #10014 gave it
+    // the two filters its collection declares, and #10793 the page its route
+    // publishes -- which the handler had been applying all along, silently, so
+    // that a caller got 20 of 123 subnets and a `next_cursor` no argument could
+    // accept. Kept as an EXACT set so an argument appearing here by accident
+    // still fails.
     assert.deepEqual(
       Object.keys(
         GET_NETWORK_HEALTH_MCP_TOOL.inputSchema.properties ?? {},
       ).sort(),
-      ["netuid", "status"],
+      ["cursor", "limit", "netuid", "order", "sort", "status"],
     );
     assert.ok(
       new Ajv2020({ strict: false }).compile(GET_NETWORK_HEALTH_OUTPUT_SCHEMA),

--- a/tests/mcp-list-query-default.test.ts
+++ b/tests/mcp-list-query-default.test.ts
@@ -34,6 +34,58 @@ const SRC_DIR = path.resolve(
  */
 const MAY_IMPORT_THE_RAW_ENGINE = new Set(["mcp-list-query.ts", "graphql.ts"]);
 
+/**
+ * Symbols in the raw engine that CANNOT page, and so are not what this gate is
+ * about (#10793).
+ *
+ * The rule was written as "do not import the module", which is a proxy for the
+ * real one: do not reach a function that returns every row when nobody asked.
+ * `searchMatchingRows` is `?q=`'s matcher with the URLSearchParams lifted off
+ * -- it filters and returns a subset, and cannot produce a page of any size.
+ * Two MCP tools filter their rows by hand (`list_subnets`,
+ * `list_enrichment_targets`) and need it so that `q` means the same thing on
+ * both surfaces; the alternative was a second copy of the matcher, which is how
+ * the two surfaces start disagreeing about what a search is.
+ *
+ * An ALLOWLIST of names rather than a relaxed module check, so the gate still
+ * fails on the next symbol somebody reaches for. Adding one here is a claim
+ * that it cannot page, and it has to be true.
+ */
+const NON_PAGING_ENGINE_EXPORTS = new Set(["searchMatchingRows"]);
+
+/** The symbols a `from "../workers/list-query.ts"` import brings in. */
+function importedEngineSymbols(source: string): string[] {
+  const names: string[] = [];
+  const importRe =
+    /import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*"\.\.\/workers\/list-query\.ts"/g;
+  for (const match of source.matchAll(importRe)) {
+    for (const clause of match[1].split(",")) {
+      const name = clause
+        .trim()
+        .split(/\s+as\s+/)[0]
+        .trim();
+      if (name) names.push(name);
+    }
+  }
+  return names;
+}
+
+/**
+ * The rule itself, over one module's source: which PAGING symbols it reaches.
+ *
+ * Extracted from the sweep so it can be run against sources written to break
+ * it -- a gate nobody has seen fail is a gate nobody knows still works.
+ */
+export function pagingEngineImports(source: string): string[] {
+  if (!/from "\.\.\/workers\/list-query\.ts"/.test(source)) return [];
+  const symbols = importedEngineSymbols(source);
+  // A bare/namespace/`export *` form parses to no named symbols and is refused
+  // outright -- it reaches everything, including what pages.
+  return symbols.length === 0
+    ? ["<non-named import>"]
+    : symbols.filter((symbol) => !NON_PAGING_ENGINE_EXPORTS.has(symbol));
+}
+
 function sourceFiles(): string[] {
   return readdirSync(SRC_DIR).filter((name) => name.endsWith(".ts"));
 }
@@ -48,16 +100,16 @@ describe("MCP list pagination default (#9730)", () => {
       checked += 1;
       if (MAY_IMPORT_THE_RAW_ENGINE.has(name)) continue;
       // The import specifier, not the call: a module could alias the symbol,
-      // and what must not happen is reaching the raw module at all.
-      if (/from "\.\.\/workers\/list-query\.ts"/.test(source)) {
-        offenders.push(name);
-      }
+      // and what must not happen is reaching a PAGING function at all.
+      const paging = pagingEngineImports(source);
+      if (paging.length > 0) offenders.push(`${name} (${paging.join(", ")})`);
     }
     assert.deepEqual(
       offenders,
       [],
-      `these import the raw engine directly and so page unbounded — import ` +
-        `applyMcpQueryFilters from ./mcp-list-query.ts instead: ${offenders.join(", ")}`,
+      `these import a paging function from the raw engine and so page ` +
+        `unbounded — import applyMcpQueryFilters from ./mcp-list-query.ts ` +
+        `instead: ${offenders.join(", ")}`,
     );
     // A pass over nothing proves nothing. If the layout changes such that no
     // module matches, this fails rather than going quietly green.
@@ -65,6 +117,54 @@ describe("MCP list pagination default (#9730)", () => {
       checked > 25,
       `expected well over 25 modules touching the list engine, saw ${checked}`,
     );
+  });
+
+  // The rule was narrowed from "imports the module" to "imports something that
+  // PAGES" when #10793 needed the `?q=` matcher in two hand-filtered tools.
+  // Narrowing a gate is where gates quietly stop working, so these run it
+  // against sources written to break it.
+  describe("the narrowed rule still catches what it was written for", () => {
+    test("a paging import is an offender, however it is written", () => {
+      for (const source of [
+        `import { applyQueryFilters } from "../workers/list-query.ts";`,
+        // Aliased -- the reason the check reads the specifier, not the call.
+        `import { applyQueryFilters as page } from "../workers/list-query.ts";`,
+        // Smuggled in beside an allowed one.
+        `import { searchMatchingRows, paginateRows } from "../workers/list-query.ts";`,
+        // Multi-line, which is how a real import of two symbols is formatted.
+        `import {\n  searchMatchingRows,\n  applyQueryFilters,\n} from "../workers/list-query.ts";`,
+        // Type-only still reaches the module's shape; refuse it too rather
+        // than reason about erasure.
+        `import type { Row } from "../workers/list-query.ts";`,
+        // Namespace and side-effect forms name nothing, so they reach
+        // everything.
+        `import * as engine from "../workers/list-query.ts";`,
+      ]) {
+        assert.notDeepEqual(
+          pagingEngineImports(source),
+          [],
+          `should have been refused: ${source.replace(/\n/g, " ")}`,
+        );
+      }
+    });
+
+    test("the declared non-paging symbol is allowed, alone", () => {
+      assert.deepEqual(
+        pagingEngineImports(
+          `import { searchMatchingRows } from "../workers/list-query.ts";`,
+        ),
+        [],
+      );
+    });
+
+    test("a module that does not touch the engine is not an offender", () => {
+      assert.deepEqual(
+        pagingEngineImports(
+          `import { applyMcpQueryFilters } from "./mcp-list-query.ts";`,
+        ),
+        [],
+      );
+    });
   });
 
   test("the wrapper defaults a page the raw engine would have left unbounded", () => {

--- a/tests/mcp-published-parameter-parity.test.ts
+++ b/tests/mcp-published-parameter-parity.test.ts
@@ -1,0 +1,675 @@
+// The last 21 published parameters no MCP tool could pass (#10793).
+//
+// Each of these is a query parameter our own OpenAPI advertises, over a tool
+// that mirrors the route. An agent reading the contract and sending the
+// published name was rejected for an unknown argument, so every test here is a
+// call in the form the contract already promised would work.
+//
+// MEASURED, NOT ASSERTED. The two findings that motivated the change were both
+// taken from production and both are pinned below as behaviour rather than
+// prose: get_network_health returned 20 of 123 subnets AND a `next_cursor`
+// there was no argument to send back, and get_subnet_evidence returned every
+// claim with no pagination block at all. A test that only checked "the argument
+// is in the schema" would pass on a tool that ignored it -- which is the
+// failure this repo keeps paying for -- so each one is asserted through the
+// HANDLER, on output that differs.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleMcpRequest, MCP_TOOLS } from "../src/mcp-server.ts";
+import { searchMatchingRows } from "../workers/list-query.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../src/route-limits.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import type { Row } from "./row-type.ts";
+
+const MCP_URL = "https://api.metagraph.sh/mcp";
+const HOTKEY = "5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV";
+
+function makeDeps(artifacts: Row = {}) {
+  return {
+    readArtifact(_env: unknown, path: string) {
+      if (Object.prototype.hasOwnProperty.call(artifacts, path)) {
+        return Promise.resolve({
+          ok: true,
+          data: artifacts[path],
+          source: "test",
+          storage_tier: "git",
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        code: "artifact_not_found",
+        message: `Artifact not found: ${path}`,
+      });
+    },
+    readHealthKv() {
+      return Promise.resolve(null);
+    },
+  };
+}
+
+async function callTool(name: string, args: unknown, deps: Row = makeDeps()) {
+  const response = await handleMcpRequest(
+    new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name, arguments: args },
+      }),
+    }),
+    {} as unknown as Env,
+    deps,
+  );
+  return JSON.parse(await response.text());
+}
+
+const out = (res: Row) => (res.result as Row).structuredContent as Row;
+const errored = (res: Row) => (res.result as Row).isError === true;
+const errorText = (res: Row) =>
+  ((res.result as Row).content as Row[])[0].text as string;
+
+const argsOf = (name: string) =>
+  Object.keys(
+    ((MCP_TOOLS.find((t: Row) => t.name === name) as Row)?.inputSchema as Row)
+      ?.properties ?? {},
+  );
+
+// ---------------------------------------------------------------------------
+
+describe("get_network_health pages, and now says so (#10793)", () => {
+  // 40 rows so the shared MCP default (20) visibly narrows. `summary` is
+  // required: buildGlobalHealth returns null without it and the tool serves its
+  // `unknown` card, which would make every assertion below vacuous.
+  const health = {
+    last_run_at: new Date().toISOString(),
+    summary: {
+      surface_count: 820,
+      status_counts: { ok: 20, degraded: 20, failed: 0, unknown: 0 },
+    },
+    subnets: Array.from({ length: 40 }, (_, i) => ({
+      netuid: i,
+      name: `sn-${i}`,
+      status: i % 2 === 0 ? "ok" : "degraded",
+      surface_count: 40 - i,
+    })),
+  };
+  const deps = {
+    ...makeDeps(),
+    readHealthKv: () => Promise.resolve(health as unknown as Row),
+  };
+
+  test("the default page was ALREADY 20, and the schema now publishes it", async () => {
+    // The finding, reproduced: measured against production this returned
+    // "total":123,"returned":20 with neither `limit` nor `cursor` in its
+    // published schema. The narrowing is unchanged -- only its visibility is.
+    const res = await callTool("get_network_health", {}, deps);
+    const body = out(res);
+    assert.equal(body.total, 40);
+    assert.equal(body.returned, MCP_LIST_LIMIT_DEFAULT);
+    assert.equal(body.limit, MCP_LIST_LIMIT_DEFAULT);
+
+    const limit = (
+      (MCP_TOOLS.find((t: Row) => t.name === "get_network_health") as Row)
+        .inputSchema as Row
+    ).properties as Row;
+    assert.equal((limit.limit as Row).default, MCP_LIST_LIMIT_DEFAULT);
+  });
+
+  test("the next_cursor it returns can now be sent back", async () => {
+    // The sharp end of the finding: the response advertised a paging protocol
+    // whose other half had no argument. A tool that returns a cursor it cannot
+    // accept has told the caller to do something impossible.
+    const first = out(await callTool("get_network_health", {}, deps));
+    assert.equal(first.next_cursor, MCP_LIST_LIMIT_DEFAULT);
+
+    const second = out(
+      await callTool("get_network_health", { cursor: first.next_cursor }, deps),
+    );
+    assert.equal(second.cursor, MCP_LIST_LIMIT_DEFAULT);
+    assert.equal((second.subnets as Row[])[0].netuid, MCP_LIST_LIMIT_DEFAULT);
+    assert.equal(second.next_cursor, null);
+  });
+
+  test("limit and sort reach the rows, not just the schema", async () => {
+    const res = await callTool(
+      "get_network_health",
+      { limit: 3, sort: "surface_count", order: "asc" },
+      deps,
+    );
+    const body = out(res);
+    assert.equal(body.returned, 3);
+    assert.deepEqual(
+      (body.subnets as Row[]).map((s) => s.surface_count),
+      [1, 2, 3],
+    );
+  });
+
+  test("the global counts still span the network, not the page", async () => {
+    // `global` is the reason a narrowed page is safe here: an alerting caller
+    // filtered to one status still needs the network's real denominator.
+    const res = await callTool(
+      "get_network_health",
+      { status: "degraded", limit: 2 },
+      deps,
+    );
+    const body = out(res);
+    assert.equal(body.returned, 2);
+    assert.equal(body.total, 20);
+    assert.equal((body.global as Row).surface_count, 820);
+  });
+});
+
+describe("get_subnet_evidence gained the lever it never had (#10793)", () => {
+  const claims = Array.from({ length: 30 }, (_, i) => ({
+    subject: `surface:sn-64-item-${i}`,
+    claim: i < 4 ? "Chutes OpenAPI schema is public." : `Claim number ${i}.`,
+    source_url: `https://example.invalid/${i}`,
+    support_summary: "Listed in curated overlay for sn-64.",
+    verified_at: `2026-08-${String((i % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+  }));
+  const deps = makeDeps({
+    "/metagraph/evidence/64.json": {
+      netuid: 64,
+      name: "Chutes",
+      slug: "sn-64",
+      generated_at: "2026-08-11T08:16:17.556Z",
+      claims,
+    },
+  });
+
+  test("an unfiltered call is a PAGE now, and reports the whole total", async () => {
+    // Before this it returned every claim with no pagination block at all --
+    // 77 of them, ~33 KB, measured on SN64 in production.
+    const body = out(
+      await callTool("get_subnet_evidence", { netuid: 64 }, deps),
+    );
+    assert.equal((body.claims as Row[]).length, MCP_LIST_LIMIT_DEFAULT);
+    assert.equal(body.total, 30);
+    assert.equal(body.next_cursor, MCP_LIST_LIMIT_DEFAULT);
+    // The artifact's own stamp survives the narrowing -- this tool returns the
+    // full card, unlike its list sibling.
+    assert.equal(body.name, "Chutes");
+    assert.equal(body.slug, "sn-64");
+  });
+
+  test("q searches the claims the collection declares searchable", async () => {
+    const body = out(
+      await callTool("get_subnet_evidence", { netuid: 64, q: "openapi" }, deps),
+    );
+    assert.equal(body.total, 4);
+    for (const claim of body.claims as Row[]) {
+      assert.match(claim.claim as string, /OpenAPI/);
+    }
+  });
+
+  test("sort + order reach the rows", async () => {
+    const body = out(
+      await callTool(
+        "get_subnet_evidence",
+        { netuid: 64, sort: "subject", order: "desc", limit: 2 },
+        deps,
+      ),
+    );
+    assert.deepEqual(
+      (body.claims as Row[]).map((c) => c.subject),
+      ["surface:sn-64-item-9", "surface:sn-64-item-8"],
+    );
+  });
+
+  test("netuid stays the SUBJECT and never becomes a row filter", async () => {
+    // The claims carry `subject`, not `netuid`. Passing the tool's netuid on as
+    // a filter would match zero rows and look like an empty ledger.
+    const body = out(
+      await callTool("get_subnet_evidence", { netuid: 64 }, deps),
+    );
+    assert.equal(body.total, 30);
+    assert.equal(body.netuid, 64);
+  });
+
+  test("an unsortable column is refused rather than silently ignored", async () => {
+    const res = await callTool(
+      "get_subnet_evidence",
+      { netuid: 64, sort: "not_a_column" },
+      deps,
+    );
+    assert.equal(errored(res), true);
+  });
+});
+
+describe("free-text q on the hand-filtered tools (#10793)", () => {
+  test("list_subnets composes q with the filters search_subnets cannot", async () => {
+    // The capability that existed on neither tool: search_subnets ranks and
+    // cannot be combined, so "inference in the name AND readiness above 70"
+    // was unreachable from both.
+    const deps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [
+          {
+            netuid: 1,
+            name: "Apex Inference",
+            slug: "apex",
+            integration_readiness: 90,
+          },
+          {
+            netuid: 2,
+            name: "Inference Lab",
+            slug: "inflab",
+            integration_readiness: 40,
+          },
+          {
+            netuid: 3,
+            name: "Storage Grid",
+            slug: "storage",
+            integration_readiness: 95,
+          },
+        ],
+      },
+    });
+    const body = out(
+      await callTool(
+        "list_subnets",
+        { q: "inference", min_integration_readiness: 70 },
+        deps,
+      ),
+    );
+    assert.deepEqual(
+      (body.subnets as Row[]).map((s) => s.netuid),
+      [1],
+    );
+  });
+
+  test("list_subnets q matches slug as well as name, and every term must hit", async () => {
+    const deps = makeDeps({
+      "/metagraph/subnets.json": {
+        subnets: [
+          { netuid: 1, name: "Apex", slug: "text-embedding" },
+          { netuid: 2, name: "Zeus", slug: "weather" },
+        ],
+      },
+    });
+    const bySlug = out(
+      await callTool("list_subnets", { q: "embedding" }, deps),
+    );
+    assert.deepEqual(
+      (bySlug.subnets as Row[]).map((s) => s.netuid),
+      [1],
+    );
+
+    // AND, not OR: `apex` alone matches row 1, and adding a term row 1 lacks
+    // must empty the result rather than widen it.
+    const both = out(
+      await callTool("list_subnets", { q: "apex weather" }, deps),
+    );
+    assert.deepEqual(both.subnets, []);
+  });
+
+  test("list_enrichment_targets narrows the queue and KEEPS its ranking", async () => {
+    // The reason q is exposed here while sort/order are declined: a filter
+    // preserves rank, a re-sort destroys it.
+    const rows = [
+      {
+        netuid: 1,
+        name: "Apex",
+        slug: "apex",
+        recommended_next_action: "add openapi schema",
+      },
+      {
+        netuid: 2,
+        name: "Zeus",
+        slug: "zeus",
+        recommended_next_action: "capture a fixture",
+      },
+      {
+        netuid: 3,
+        name: "Hone",
+        slug: "hone",
+        recommended_next_action: "add openapi schema",
+      },
+    ];
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows,
+        ranked_queue: [
+          { netuid: 3, rank: 1 },
+          { netuid: 1, rank: 2 },
+          { netuid: 2, rank: 3 },
+        ],
+      },
+    });
+    const body = out(
+      await callTool("list_enrichment_targets", { q: "openapi" }, deps),
+    );
+    assert.deepEqual(
+      (body.targets as Row[]).map((t) => t.netuid),
+      [3, 1],
+    );
+    // Rank order survived, and the ranks themselves came through unrenumbered.
+    assert.deepEqual(
+      (body.targets as Row[]).map((t) => t.rank),
+      [1, 2],
+    );
+  });
+
+  test("list_enrichment_targets ECHOES q, because the echo's keys are the parameters", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [{ netuid: 1, name: "Apex", slug: "apex" }],
+        ranked_queue: [{ netuid: 1, rank: 1 }],
+      },
+    });
+    const applied = out(
+      await callTool("list_enrichment_targets", { q: "apex" }, deps),
+    );
+    assert.equal((applied.filters as Row).q, "apex");
+    // Null rather than absent when unsupplied, matching every sibling key.
+    const omitted = out(await callTool("list_enrichment_targets", {}, deps));
+    assert.equal((omitted.filters as Row).q, null);
+  });
+
+  test("get_coverage_depth q reaches the engine it already ran through", async () => {
+    const deps = makeDeps({
+      "/metagraph/coverage-depth.json": {
+        rows: [
+          {
+            netuid: 1,
+            name: "Apex",
+            slug: "apex",
+            top_gap_codes: ["missing-openapi"],
+          },
+          {
+            netuid: 2,
+            name: "Zeus",
+            slug: "zeus",
+            top_gap_codes: ["missing-fixture"],
+          },
+        ],
+      },
+    });
+    const body = out(
+      await callTool("get_coverage_depth", { q: "missing-openapi" }, deps),
+    );
+    assert.equal(body.total, 1);
+    assert.deepEqual(
+      (body.rows as Row[]).map((r) => r.netuid),
+      [1],
+    );
+  });
+});
+
+describe("get_extrinsic_chain_events filters within one extrinsic (#10793)", () => {
+  test("pallet and method are published, block/extrinsic/before are NOT", async () => {
+    // The declared half of this change, asserted rather than left to prose:
+    // `block`/`extrinsic` are already inside `ref`, and `before` is a
+    // block-height bound on a read pinned to one block.
+    const args = argsOf("get_extrinsic_chain_events");
+    assert.ok(args.includes("pallet"));
+    assert.ok(args.includes("method"));
+    for (const declined of ["block", "extrinsic", "before"]) {
+      assert.ok(
+        !args.includes(declined),
+        `${declined} must stay unexposed: it is resolved from ref or degenerate here`,
+      );
+    }
+  });
+
+  test("both reach the lakehouse WHERE clause, not just the schema", async () => {
+    // The failure worth catching is a published argument the handler drops, so
+    // this asserts on the SQL the cold tier actually issues rather than on the
+    // tool's own echo -- an echo can report a filter that never ran.
+    const queries: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      queries.push(JSON.parse(String(init.body)).query);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      await handleMcpRequest(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: {
+              name: "get_extrinsic_chain_events",
+              arguments: {
+                ref: "8791987-3",
+                pallet: "SubtensorModule",
+                method: "set_weights",
+              },
+            },
+          }),
+        }),
+        { [R2_SQL_TOKEN_ENV]: "cfut_test" } as unknown as Env,
+        makeDeps(),
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    assert.ok(queries.length > 0, "the loader never reached the lakehouse");
+    const sql = queries[0]!;
+    assert.match(sql, /pallet = 'SubtensorModule'/);
+    assert.match(sql, /method = 'set_weights'/);
+    // Still pinned to the ref's own block and index, which is exactly why the
+    // two path-shaped filters stay unexposed.
+    assert.match(sql, /block_number = 8791987/);
+    assert.match(sql, /extrinsic_index = 3/);
+  });
+
+  test("omitting them does not widen the read to every pallet", async () => {
+    // The inverse failure: an absent filter that becomes an empty-string one,
+    // or a `null` that reaches the WHERE clause as a literal.
+    const queries: string[] = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      queries.push(JSON.parse(String(init.body)).query);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true, result: { rows: [] } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    try {
+      await callTool(
+        "get_extrinsic_chain_events",
+        { ref: "8791987-3" },
+        {
+          ...makeDeps(),
+        },
+      );
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    // No lakehouse token in that env, so the read declines before issuing SQL;
+    // what matters is that nothing was issued with an empty filter.
+    for (const sql of queries) {
+      assert.doesNotMatch(sql, /pallet = ''/);
+      assert.doesNotMatch(sql, /method = ''/);
+      assert.doesNotMatch(sql, /pallet = 'null'/);
+    }
+  });
+});
+
+describe("get_validator_nominators.basis (#10793)", () => {
+  test("basis is published with flow as the default that does not move", async () => {
+    const basis = (
+      (
+        (
+          MCP_TOOLS.find(
+            (t: Row) => t.name === "get_validator_nominators",
+          ) as Row
+        ).inputSchema as Row
+      ).properties as Row
+    ).basis as Row;
+    assert.deepEqual(basis.enum, ["flow", "positions"]);
+    assert.equal(basis.default, "flow");
+  });
+
+  test("the positions basis REJECTS window and sort rather than ignoring them", async () => {
+    // Accepting them would imply the snapshot honoured them, and a caller who
+    // asked for 7d and got an all-time holdings card cannot tell. The route
+    // 400s on both -- verified live -- so the tool must too.
+    for (const unsupported of ["window", "sort"]) {
+      const res = await callTool("get_validator_nominators", {
+        hotkey: HOTKEY,
+        basis: "positions",
+        [unsupported]: unsupported === "window" ? "7d" : "net_staked",
+      });
+      assert.equal(errored(res), true, `${unsupported} must be refused`);
+      assert.match(errorText(res), /basis=flow only/);
+    }
+  });
+
+  test("an explicit window is refused even when it equals the default", async () => {
+    // The distinguishing case, and the reason the check reads what the CALLER
+    // named rather than comparing values: `window: "30d"` is the published
+    // default, so a value comparison would wave it through — but the caller
+    // wrote it down, and on this basis it is not honoured.
+    const res = await callTool("get_validator_nominators", {
+      hotkey: HOTKEY,
+      basis: "positions",
+      window: "30d",
+    });
+    assert.equal(errored(res), true);
+    assert.match(errorText(res), /basis=flow only/);
+  });
+
+  test("an OMITTED window is not mistaken for an explicit one", async () => {
+    // The inverse, and the bug this caught before it shipped: dispatch fills
+    // window/sort from their published defaults, so reading them off `args`
+    // refused every positions call over arguments nobody sent.
+    const res = await callTool("get_validator_nominators", {
+      hotkey: HOTKEY,
+      basis: "positions",
+    });
+    assert.equal(errored(res), false);
+  });
+
+  test("an explicit null window reads as no window, not as a request", async () => {
+    // Dispatch does no schema validation, so `window: null` can arrive. It says
+    // "no value" the way `?window=` does on the REST side -- refusing it would
+    // reject a caller who asked for nothing.
+    const res = await callTool("get_validator_nominators", {
+      hotkey: HOTKEY,
+      basis: "positions",
+      window: null,
+    });
+    assert.equal(errored(res), false);
+  });
+
+  test("the positions page honours an explicit limit and offset", async () => {
+    const body = out(
+      await callTool("get_validator_nominators", {
+        hotkey: HOTKEY,
+        basis: "positions",
+        limit: 5,
+        offset: 10,
+      }),
+    );
+    assert.equal(body.limit, 5);
+    assert.equal(body.offset, 10);
+  });
+
+  test("an explicit null limit/offset falls back rather than paging by null", async () => {
+    // `null` survives dispatch -- a default is only filled for an argument that
+    // is ABSENT -- so it reaches the handler and each fallback has to hold. A
+    // null offset reaching the builder would slice from `null` and return the
+    // whole set.
+    const body = out(
+      await callTool("get_validator_nominators", {
+        hotkey: HOTKEY,
+        basis: "positions",
+        limit: null,
+        offset: null,
+      }),
+    );
+    assert.equal(body.limit, 20);
+    assert.equal(body.offset, 0);
+  });
+
+  test("an unproven pool ledger DECLINES rather than underpricing a nominator", async () => {
+    // No store bound, so latestCompleteHotkeyAlphaPass cannot prove a complete
+    // pass. A partial ledger drops a nominator's alpha instead of dropping the
+    // nominator, which is a wrong number that looks right.
+    const body = out(
+      await callTool("get_validator_nominators", {
+        hotkey: HOTKEY,
+        basis: "positions",
+      }),
+    );
+    assert.equal(body.basis, "positions");
+    assert.equal(body.nominator_count, null);
+    assert.deepEqual(body.nominators, []);
+    assert.equal(typeof (body.degraded as Row).reason, "string");
+  });
+
+  test("the flow basis is untouched, and still stamps no basis at all", async () => {
+    const body = out(
+      await callTool("get_validator_nominators", { hotkey: HOTKEY }),
+    );
+    assert.equal(body.window, "30d");
+    assert.equal(body.sort, "net_staked");
+    assert.equal(body.basis, undefined);
+  });
+
+  test("basis=flow explicitly is the same answer as omitting it", async () => {
+    const explicit = out(
+      await callTool("get_validator_nominators", {
+        hotkey: HOTKEY,
+        basis: "flow",
+        window: "7d",
+      }),
+    );
+    assert.equal(explicit.window, "7d");
+    assert.equal(explicit.basis, undefined);
+  });
+});
+
+describe("the shared search matcher (#10793)", () => {
+  // Exported so the hand-filtered tools do not write a second one. These pin
+  // the five behaviours a re-implementation would get wrong.
+  const rows = [
+    { name: "Apex", slug: "apex", tags: ["inference", "text"] },
+    { name: "Zeus", slug: "weather", tags: ["forecast"] },
+    { name: "Zero", slug: "zero", tags: [], count: 0 },
+  ];
+
+  test("no query returns the rows untouched", () => {
+    assert.equal(searchMatchingRows(rows, null, ["name"]), rows);
+    assert.equal(searchMatchingRows(rows, "", ["name"]), rows);
+    // Whitespace-only is a query that names no terms, not a filter to nothing.
+    assert.equal(searchMatchingRows(rows, "   ", ["name"]).length, 3);
+  });
+
+  test("no keys returns the rows untouched", () => {
+    assert.equal(searchMatchingRows(rows, "apex", []), rows);
+  });
+
+  test("every term must match, and matching is case-insensitive substring", () => {
+    assert.equal(searchMatchingRows(rows, "APE", ["name"]).length, 1);
+    assert.equal(
+      searchMatchingRows(rows, "apex weather", ["name", "slug"]).length,
+      0,
+    );
+    assert.equal(searchMatchingRows(rows, "z", ["name"]).length, 2);
+  });
+
+  test("an array field is flattened, so a match may span two entries", () => {
+    assert.equal(
+      searchMatchingRows(rows, "inference text", ["tags"]).length,
+      1,
+    );
+  });
+
+  test("falsy values are dropped before the join, so 0 is not searchable text", () => {
+    assert.equal(searchMatchingRows(rows, "0", ["count"]).length, 0);
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -25127,6 +25127,7 @@ describe("get_coverage_depth MCP tool (#6983)", () => {
         "limit",
         "netuid",
         "order",
+        "q",
         "sort",
         "tier",
       ],

--- a/workers/list-query.ts
+++ b/workers/list-query.ts
@@ -427,12 +427,25 @@ function applyListTransform(
   };
 }
 
-function searchRows(
+/**
+ * What `?q=` MEANS, separated from where it arrives (#10793).
+ *
+ * EXPORTED so a hand-rolled loader can search the way the engine does. Two MCP
+ * tools (`list_subnets`, `list_enrichment_targets`) filter and page their rows
+ * themselves rather than through `applyQueryFilters`, so exposing `q` on them
+ * meant either a second matcher or this. A second matcher is how the two
+ * surfaces start disagreeing about what a search is -- and they would disagree
+ * on real cases, not hypothetical ones: every term must match (AND, not OR),
+ * matching is case-insensitive substring rather than word or prefix, an array
+ * field is flattened and joined so a match may span two of its entries, and
+ * falsy values are dropped before the join so `0` and `false` are not
+ * searchable text. Nobody writing the second copy guesses all five.
+ */
+export function searchMatchingRows(
   rows: Row[],
-  params: URLSearchParams,
-  keys: string[],
+  q: string | null | undefined,
+  keys: readonly string[],
 ): Row[] {
-  const q = params.get("q");
   if (!q || keys.length === 0) {
     return rows;
   }
@@ -455,6 +468,14 @@ function searchRows(
       .toLowerCase();
     return terms.every((term) => haystack.includes(term));
   });
+}
+
+function searchRows(
+  rows: Row[],
+  params: URLSearchParams,
+  keys: string[],
+): Row[] {
+  return searchMatchingRows(rows, params.get("q"), keys);
 }
 
 function sortRows(rows: Row[], params: URLSearchParams): Row[] {


### PR DESCRIPTION
`validate-mcp-input-parity` carried **21 `NOT_YET_EXPOSED` entries**. Each is a query parameter our own OpenAPI advertises, over a tool that mirrors the route — so an agent that reads our contract and sends the published name is rejected for an unknown argument. #10605 cleared 16; this is the remainder, and standing debt is now **0**.

```
before: 223 tools compared, 93 declared divergences (21 of them standing debt)
after:  223 tools compared, 80 declared divergences ( 0 of them standing debt)
```

## Two of them were worse than "missing"

**`get_network_health` had been paging all along and never said so.** Its handler runs `applySubnetListQuery`, which serves `MCP_LIST_LIMIT_DEFAULT`, while the published schema had neither `limit` nor `cursor`. Measured against production:

```
"total":123,"returned":20,"cursor":0,"limit":20,"next_cursor":20
```

20 of 123 subnets — and it **returns a `next_cursor` there was no argument to send back**. A paging protocol advertised with one end missing. An agent asking "which subnets are failing" got a truthful-looking answer over a sixth of the network with nothing in the schema to reveal the narrowing.

**`get_subnet_evidence` had no lever at all** — `netuid` in, the whole ledger out: 77 claims, ~33 KB for SN64, with no pagination block in the response. The same shape #10011 found on `get_coverage_depth` (293 KB, zero arguments) and #10027 resolved by giving it a page.

## One was a capability, not a page

`get_validator_nominators.basis` selects **which question is answered** (#9617). `flow` — the default, and the only basis MCP could reach — sums TAO *moved inside a window*, so a delegator who staked earlier and hasn't touched it since is invisible. Measured on the same hotkey:

| basis | nominator_count |
|---|---|
| `flow` (default) | **0** |
| `positions` | **2,377** |

"Who delegates to this validator" was answerable only over REST. The positions basis carries all four of its own rules, or it isn't the same capability: `window` and `sort` are **rejected** rather than ignored, `nominator_count` is the whole delegator set rather than the page, alpha is reported per subnet with no cross-subnet total, and it declines with `pool_totals_unproven` while the `hotkey_alpha` ledger has no complete pass.

## Exposed

| tool | arguments |
|---|---|
| `get_network_health` | `limit`, `cursor`, `sort`, `order` |
| `get_subnet_evidence` | `q`, `limit`, `cursor`, `sort`, `order` — now through the engine the route uses |
| `get_coverage_depth` | `q` |
| `list_subnets` | `q` |
| `list_enrichment_targets` | `q` |
| `get_extrinsic_chain_events` | `pallet`, `method` |
| `get_validator_nominators` | `basis` |

Every value comes from the definition that already decides it — `MAX_LIMIT`, `MCP_LIST_LIMIT_DEFAULT`, `API_QUERY_COLLECTIONS.<coll>.{sort_fields,search_keys}`, `ROUTE_QUERY_SCHEMAS`, and the `query-params.ts` builders. No restated literals; `offsetSchema` where the route publishes an offset rather than a keyset cursor.

`?q=`'s matcher is **lifted out of `workers/list-query.ts` and shared** rather than re-implemented for the two hand-filtered tools. A second copy would have got five things wrong that a re-implementation cannot guess: every term must match (AND, not OR), matching is case-insensitive substring, array fields are flattened so a match may span two entries, and falsy values are dropped before the join so `0` is not searchable text.

## Declined — five, each with a reason that is checkable

Not relabelled to make the count fall. Each states something falsifiable:

- **`get_extrinsic_chain_events.block` / `.extrinsic`** — already inside `ref`, which the tool parses and validates as a composite. A second way to say it is a way to contradict it.
- **`get_extrinsic_chain_events.before`** — a block-height bound on a read pinned to one block. Its only outcomes are "no effect" and "empty".
- **`get_subnet_economics.q` / `find_subnet_opportunities.q`** — both mirror `/api/v1/economics`, and `get_economics` **is** that route's list view; it already carries `q`/`sort`/`order`/`limit`/`cursor`. Every other list parameter on these two tools was already `CURATED_VIEW`; `q` was filed as debt by oversight.
- **`list_review_gaps.coverage_level`** — this tool reads the review feed through `review-gap-priorities`, which has no such column. `/api/v1/gaps` is `list_gaps`' route and `list_gaps` exposes the filter already.
- **`list_enrichment_targets.sort` / `.order`** — the tool returns the scorecard's ranked queue and carries `rank` on every row, so a caller-supplied sort would overwrite the ranking it was called for. `q` narrows without reordering, which is why it lands in the exposed column and these two don't.

## Two things this uncovered

**Dispatch fills published defaults (#10306), so a handler can no longer tell an explicit argument from an injected one.** Reading `args.window` directly would have refused *every* `basis=positions` call over arguments nobody sent — caught by a test before it shipped, not by reasoning. Handlers now get `callerSuppliedArg`, the MCP equivalent of the `url.searchParams.has()` the REST route already uses for exactly this decision. It reads a symbol-keyed, non-enumerable marker, so it cannot leak into the handlers that forward their whole argument object into a query builder.

**The raw-engine import gate banned the module as a proxy for "do not page".** Narrowed to the paging symbols with a named allowlist — and since narrowing a gate is where gates quietly stop working, it now runs against six sources written to break it (aliased, smuggled beside an allowed symbol, multi-line, type-only, namespace).

## Verification

- **19,659 tests pass**, 855 files. `npm run validate` exit 0. `tsc --noEmit` clean. `eslint` clean.
- **Patch coverage: 256 changed lines in `src/**`/`workers/**`, 0 uncovered lines, 0 uncovered branches**, measured unsharded by diff intersection against `coverage/lcov.info`.
- 32 new tests, each asserted **through the handler on output that differs** — a test that only checked "the argument is in the schema" would pass on a tool that ignored it.
- Rebuilt on current `main` after rebase; no contract drift.

`tests/graphql-nullability-conformance.test.ts` is excluded from that local count: it queries production GraphQL over the network and its cases time out under a parallel full-suite run on this machine (a different subset each time). All 8 pass when the file is run alone. It is untouched by this diff and CI's own coverage job passes it on `main`.

`tests/lakehouse-schema.test.ts` was failing on `main` itself as of 4d80c4ac4 — reproduced on a clean `origin/main` worktree, unrelated to this diff, fixed separately in #10801, which has since merged. This branch is rebased on top of it.

## Also, while in here

Renamed `health-serving.ts`'s `D1_HEALTH_FALLBACK_MAX_AGE_MS` (it has gated the Postgres fallback since D1 was eliminated) and corrected `get_network_health`'s description, which told agents its data came from `D1 surface_status`. Both are in files this change already touches. The broader 44-identifier sweep stays with #10228.

Closes #10793
