### PR TITLE
refactor(tiers): delete the tier reads that could never forward, and fix what that exposes

### DIFF
--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -2972,28 +2972,17 @@ for (const [route, assertion, options = {}] of checks) {
     // projection -- covered by tests/blocks-cold-tier.test.ts,
     // tests/runtime-versions-cold-tier.test.ts and
     // tests/blocks-summary-artifact.test.ts.
-    {
-      flag: "METAGRAPH_EXTRINSICS_SOURCE",
-      route: "/api/v1/extrinsics",
-      upstreamPath: "/api/v1/extrinsics",
-      data: buildExtrinsicFeed([extrinsicRow], {
-        limit: BLOCK_PAGINATION.defaultLimit,
-        offset: 0,
-        nextCursor: null,
-      }),
-      assertion: (body) => assert.equal(body.data.extrinsics[0].signer, SS58),
-    },
-    {
-      flag: "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      route: `/api/v1/accounts/${SS58}/events`,
-      upstreamPath: `/api/v1/accounts/${SS58}/events`,
-      data: buildAccountEvents([accountEventRow], SS58, {
-        limit: FEED_PAGINATION.defaultLimit,
-        offset: 0,
-        nextCursor: null,
-      }),
-      assertion: (body) => assert.equal(body.data.events[0].netuid, 7),
-    },
+    // METAGRAPH_EXTRINSICS_SOURCE's and METAGRAPH_ACCOUNT_EVENTS_SOURCE's cases
+    // were REMOVED (#10190), with METAGRAPH_HEALTH_SOURCE's (which never had one).
+    // Every tryPostgresTier call under those three flags is gone across REST,
+    // GraphQL and MCP -- 174 sites -- so there is no forward left to prove. Their
+    // real legs are the lakehouse cold tiers and the #9146 projections, covered by
+    // the per-reader suites.
+    //
+    // THREE FLAGS REMAIN, and they are exactly DATA_API_FORWARD_FLAGS. That is not
+    // a coincidence to preserve by hand: a flag that gates a DATA_API leg must be
+    // in that set, or it cannot forward at all, which is what made the other eight
+    // families dead.
     {
       flag: "METAGRAPH_NEURONS_SOURCE",
       route: "/api/v1/subnets/7/metagraph",
@@ -3027,8 +3016,8 @@ for (const [route, assertion, options = {}] of checks) {
 
   assert.equal(
     postgresTierChecks.length,
-    5,
-    "postgres-tier AJV coverage must include all 5 flags that gate a DATA_API leg",
+    3,
+    "postgres-tier AJV coverage must include all 3 flags that gate a DATA_API leg",
   );
 
   for (const {
@@ -3097,10 +3086,12 @@ for (const [route, assertion, options = {}] of checks) {
     "METAGRAPH_SUBNET_HYPERPARAMS_SOURCE",
     "METAGRAPH_ACCOUNT_IDENTITY_SOURCE",
   ]);
-  assert.equal(
-    postgresTierChecks.filter((check) => d1ForwardFlags.has(check.flag)).length,
-    d1ForwardFlags.size,
-    'every DATA_API_FORWARD_FLAGS flag needs a case here to drive at "d1"',
+  assert.deepEqual(
+    postgresTierChecks.map((check) => check.flag).sort(),
+    [...d1ForwardFlags].sort(),
+    "postgres-tier cases and DATA_API_FORWARD_FLAGS must be the SAME set: a " +
+      "flag in the set with no case here is an unproven forward, and a case " +
+      "here for a flag outside it is a route reading a tier that cannot answer",
   );
 
   for (const {
@@ -3166,10 +3157,70 @@ for (const [route, assertion, options = {}] of checks) {
     assertion(body);
   }
 
+  // THE NEGATIVE, WHICH NO LONGER HAS A ROUTE-LEVEL HOME ABOVE (#10190). The
+  // loop's `!shouldForward` branch used to be driven by the retired families'
+  // cases; those cases are gone with their tier reads, so the two sets are now
+  // equal and that branch is unreachable from here. The property it protected
+  // did not go away -- it moved:
+  //
+  //   "a flag outside DATA_API_FORWARD_FLAGS does not forward on 'd1'"
+  //       -> tests/postgres-tier.test.ts, driven with METAGRAPH_HEALTH_SOURCE
+  //          (the one flag #10660 guarantees can never enter the set)
+  //
+  //   "a swept route does not read a tier AT ALL"
+  //       -> here, below. This is the stronger statement and the one a
+  //          regression would break first: re-adding a tryPostgresTier call to
+  //          any of these routes brings back a read that resolves to null on
+  //          every request, and every previous such read went unnoticed for
+  //          months precisely because nothing asked this question.
+  //
+  // Driven at "postgres" -- the value that WOULD forward if a call existed --
+  // so a reintroduced call fails here even if its flag were also widened.
+  const sweptFamilyRoutes: { flag: string; route: string }[] = [
+    { flag: "METAGRAPH_BLOCKS_SOURCE", route: "/api/v1/blocks" },
+    { flag: "METAGRAPH_EXTRINSICS_SOURCE", route: "/api/v1/extrinsics" },
+    {
+      flag: "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
+      route: `/api/v1/accounts/${SS58}/events`,
+    },
+    { flag: "METAGRAPH_HEALTH_SOURCE", route: "/api/v1/health/trends" },
+  ];
+  for (const { flag, route } of sweptFamilyRoutes) {
+    assert.equal(
+      d1ForwardFlags.has(flag),
+      false,
+      `${flag}: a swept family's flag must not be in DATA_API_FORWARD_FLAGS`,
+    );
+    let asked: string | null = null;
+    const sweptEnv = createLocalArtifactEnv({
+      [flag]: "postgres",
+      DATA_API: {
+        async fetch(request: Request) {
+          asked = new URL(request.url).pathname;
+          return new Response(JSON.stringify({ schema_version: 1 }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      },
+    });
+    await handleRequest(
+      new Request(`https://metagraph.sh${route}`),
+      sweptEnv as unknown as Env,
+      {},
+    );
+    assert.equal(
+      asked,
+      null,
+      `${flag} ${route}: the tier read is retired (#10190) -- DATA_API must ` +
+        `not be asked even with the flag set to "postgres"`,
+    );
+  }
+
   console.log(
     `Validated ${postgresTierChecks.length} Postgres-tier Worker API route(s) ` +
-      `at "postgres", plus ${d1ForwardFlags.size} forwarding and ` +
-      `${postgresTierChecks.length - d1ForwardFlags.size} non-forwarding at "d1".`,
+      `at "postgres", plus ${d1ForwardFlags.size} forwarding at "d1", plus ` +
+      `${sweptFamilyRoutes.length} swept famil(ies) proven to read no tier.`,
   );
 }
 

--- a/scripts/validate-api.ts
+++ b/scripts/validate-api.ts
@@ -15,17 +15,12 @@ import {
   readJson,
   repoRoot,
 } from "./lib.ts";
-import { buildExtrinsicFeed } from "../src/extrinsics.ts";
-import { buildAccountEvents } from "../src/account-events.ts";
 import { buildSubnetMetagraph } from "../src/metagraph-neurons.ts";
 import { buildSubnetHyperparams } from "../src/subnet-hyperparams.ts";
 import { buildAccountIdentity } from "../src/account-identity.ts";
 import { blockEmissionForIssuance } from "../src/block-emission.ts";
 import { taoToRao } from "../src/emission-decomposition.ts";
-import {
-  BLOCK_PAGINATION,
-  FEED_PAGINATION,
-} from "../workers/request-params.ts";
+import {} from "../workers/request-params.ts";
 
 // OpenAPI document + Worker response bodies are dynamic JSON read only for
 // assertion purposes -- never trusted for control flow. Mirrors the
@@ -2876,36 +2871,12 @@ for (const [route, assertion, options = {}] of checks) {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
   const OBSERVED_AT_MS = 1_750_009_000_000;
   const BLOCK_NUM = 1_000_000;
-  const HASH = `0x${"a".repeat(64)}`;
+  // `HASH` went with the block/extrinsic fixtures it keyed (#10190).
 
   // `blockRow` went with the METAGRAPH_BLOCKS_SOURCE case (#10190) -- it was
   // the only fixture that used it.
-  const extrinsicRow = {
-    block_number: BLOCK_NUM,
-    extrinsic_index: 2,
-    extrinsic_hash: HASH,
-    signer: SS58,
-    call_module: "SubtensorModule",
-    call_function: "add_stake",
-    call_args: null,
-    fee_tao: 0.0125,
-    tip_tao: 0,
-    success: 1,
-    observed_at: OBSERVED_AT_MS,
-  };
-  const accountEventRow = {
-    block_number: BLOCK_NUM,
-    event_index: 1,
-    event_kind: "StakeAdded",
-    hotkey: SS58,
-    coldkey: null,
-    netuid: 7,
-    uid: 3,
-    amount_tao: 1.5,
-    alpha_amount: null,
-    observed_at: OBSERVED_AT_MS,
-    extrinsic_index: 2,
-  };
+  // `extrinsicRow` went with its postgres-tier case (#10190).
+  // `accountEventRow` went with its postgres-tier case (#10190).
   const neuronRow = {
     uid: 3,
     hotkey: SS58,

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -760,11 +760,20 @@ export async function loadValidatorNominatorsColdTier(
   };
 }
 
-/** The bounded newest-first Transfer scan both counterparty modes read.
- * observed_at is selected (it drives the ORDER BY) but STRIPPED before the
- * rows reach a builder: data-api's outer projection drops it, so keeping it
- * would let this tier populate relationship timestamps the Postgres tier
- * leaves null -- a payload difference callers could observe. */
+/**
+ * The bounded newest-first Transfer scan both counterparty modes read.
+ *
+ * observed_at USED TO BE STRIPPED here. The reason was payload parity: data-api's
+ * outer projection dropped it, so keeping it would have let this tier populate
+ * relationship timestamps the Postgres tier left null -- "a payload difference
+ * callers could observe".
+ *
+ * That tier is retired (#10190), and with it the only reason to throw the column
+ * away. Stripping it now just nulls three published fields on purpose --
+ * `first_seen_at`, `last_seen_at`, and every transfer's `observed_at` -- while
+ * the query still pays to select and sort by it. The parity it protected was
+ * parity with a leg that no longer answers.
+ */
 async function counterpartyScan(
   env: Env | null | undefined,
   predicate: string,
@@ -775,8 +784,7 @@ async function counterpartyScan(
       `FROM chain.account_events WHERE event_kind = 'Transfer' AND ${predicate} ` +
       `${FEED_ORDER} LIMIT ${COUNTERPARTIES_SCAN_CAP}`,
   );
-  if (rows === null) return null;
-  return rows.map(({ observed_at: _observedAt, ...rest }) => rest);
+  return rows;
 }
 
 /**

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -97,7 +97,6 @@ import {
   NOMINATOR_SORTS,
   NOMINATOR_WINDOWS,
 } from "./validator-nominators.ts";
-import { ACCOUNT_STAKE_MOVES_PRICE_TABLES } from "./read-store-tables.ts";
 import { d1All } from "./analytics-live.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
@@ -354,6 +353,17 @@ export async function loadAccountStakeMovesColdTier(
     generatedAt: latestObservedIso(rows),
   };
 }
+
+/** The price enrichment's own read (#4332).
+ *
+ * Declared HERE rather than in src/read-store-tables.ts, whose sets exist for
+ * loaders called from two or three modules: this one has a single consumer, and
+ * tests/read-store-declares-its-tables.test.ts holds every ported reader --
+ * this file among them -- to declaring the tables its own SQL names, which it
+ * checks by reading this module. A set it has to follow an import to find is a
+ * set that gate cannot check.
+ */
+const ACCOUNT_STAKE_MOVES_PRICE_TABLES = ["subnet_snapshots"] as const;
 
 /**
  * `netuid:YYYY-MM-DD -> alpha_price_tao`, for the days the rows actually land

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -97,6 +97,8 @@ import {
   NOMINATOR_SORTS,
   NOMINATOR_WINDOWS,
 } from "./validator-nominators.ts";
+import { ACCOUNT_STAKE_MOVES_PRICE_TABLES } from "./read-store-tables.ts";
+import { d1All } from "./analytics-live.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
@@ -340,9 +342,61 @@ export async function loadAccountStakeMovesColdTier(
   );
   if (rows === null) return null;
   return {
-    data: buildAccountStakeMoves(rows, ss58, { window: label }),
+    data: buildAccountStakeMoves(rows, ss58, {
+      window: label,
+      // #4332's price-at-tx enrichment, restored. buildAccountStakeMoves has
+      // always taken this map, and NOBODY passed it once the Postgres tier was
+      // retired (#10190) -- data-api computed it, so `price_tao_at_last_move`
+      // has been null on REST, GraphQL and MCP alike ever since. The tests
+      // could not show it: they doubled the tier, which supplied the field.
+      priceByNetuidDate: await alphaPriceByNetuidDate(env, rows, cutoff),
+    }),
     generatedAt: latestObservedIso(rows),
   };
+}
+
+/**
+ * `netuid:YYYY-MM-DD -> alpha_price_tao`, for the days the rows actually land
+ * on.
+ *
+ * Scoped to those days rather than the whole window: the map is keyed by the
+ * date of each subnet's LAST move, so a wider read would cost more and answer
+ * the same. A store that cannot answer yields an empty map, which the builder
+ * already reads as "no price for that day" -- the same null it published while
+ * this enrichment had no caller at all.
+ */
+async function alphaPriceByNetuidDate(
+  env: Env | null | undefined,
+  rows: Array<Record<string, unknown>>,
+  cutoff: number,
+): Promise<Map<string, number>> {
+  const prices = new Map<string, number>();
+  const netuids = [
+    ...new Set(
+      rows
+        .map((row) => Number(row.netuid))
+        .filter((netuid) => Number.isSafeInteger(netuid)),
+    ),
+  ];
+  if (netuids.length === 0) return prices;
+  try {
+    const since = new Date(cutoff).toISOString().slice(0, 10);
+    const snapshots = await d1All(
+      readStore(env, ACCOUNT_STAKE_MOVES_PRICE_TABLES) as never,
+      `SELECT netuid, snapshot_date, alpha_price_tao FROM subnet_snapshots
+       WHERE snapshot_date >= ? AND netuid IN (${netuids.join(", ")})
+         AND alpha_price_tao IS NOT NULL`,
+      [since],
+    );
+    for (const row of snapshots) {
+      const price = Number(row.alpha_price_tao);
+      if (!Number.isFinite(price)) continue;
+      prices.set(`${Number(row.netuid)}:${String(row.snapshot_date)}`, price);
+    }
+  } catch {
+    // A price the store cannot serve is a null price, never a failed feed.
+  }
+  return prices;
 }
 
 /**

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -22,7 +22,7 @@
 //
 // Worker-computed image/svg+xml, read-only, edge-cached, CORS-open. Unknown
 // entities or missing data render an "n/a" badge (200) so an <img> never breaks.
-import { loadReliabilityAggregate } from "./health-serving.ts";
+import { loadReliabilityAggregate } from "./reliability-badge.ts";
 import { ifNoneMatchSatisfied, weakEtag } from "../workers/http.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 
@@ -556,12 +556,13 @@ export async function handleBadgeRequest(
     target: target as BadgeTarget,
     readArtifact: readArtifact as ReadArtifactFn,
     env,
-    // #8329: bound to this request so the aggregate can synthesize its own
-    // internal /uptime reads through the Postgres tier. The injected `deps`
-    // form stays the test seam.
+    // #8329 bound this to the request so the aggregate could synthesize its own
+    // internal /uptime reads through the Postgres tier. It reads the store
+    // directly now (#10190), so there is no request to bind. The injected
+    // `deps` form stays the test seam.
     loadReliability:
       deps.loadReliability ||
-      ((options) => loadReliabilityAggregate(env, request, options)),
+      ((options) => loadReliabilityAggregate(env, options)),
   };
 
   let content: BadgeContent = NA_CONTENT;

--- a/src/chain-event-rollup-cold-tier.ts
+++ b/src/chain-event-rollup-cold-tier.ts
@@ -12,6 +12,11 @@
 // rows, small enough to serve at request time -- so this is a cold-tier read,
 // not a scheduled projection.
 //
+// THE PAGE SLICE DOES NOT. It belongs to the builders, which own the network
+// rollup and the distribution that are derived from these rows -- interpolating
+// the caller's `limit` here made both of those describe the page instead of the
+// window. See ROLLUP_POPULATION_CAP for the live measurements.
+//
 // THE NETWORK DISTINCT IS ITS OWN QUERY, because it is not summable. A hotkey
 // serving on five subnets is five per-subnet rows but ONE network-wide server,
 // so adding the per-netuid counts would overstate it (measured: 2,941
@@ -165,14 +170,50 @@ export interface ChainEventRollup {
   /**
    * How many subnets the WINDOW covers, not how many the page carries (#10249).
    *
-   * `rows` is capped, so counting it answers a different question the moment
-   * the cap binds -- measured live before this existed:
-   * `/api/v1/chain/weights?limit=20` published `subnet_count: 20`, `?limit=100`
-   * published 99, and the truth was 129. A field named for a population,
-   * tracking a query parameter nobody set.
+   * `rows` used to be capped at the CALLER'S page size, so counting it answered
+   * a different question the moment the cap bound -- measured live before this
+   * existed: `/api/v1/chain/weights?limit=20` published `subnet_count: 20`,
+   * `?limit=100` published 99, and the truth was 129. A field named for a
+   * population, tracking a query parameter nobody set.
+   *
+   * The page size no longer reaches SQL at all (see ROLLUP_POPULATION_CAP), so
+   * `rows.length` is the population again -- but this stays the authority,
+   * because it is the one number that survives the safety cap binding.
    */
   subnetCount: number | null;
 }
+
+/**
+ * How many grouped rows the scan may return, INDEPENDENT of the caller's page.
+ *
+ * The caller's `limit` used to be interpolated here, and that quietly redefined
+ * every window-wide number the builders derive from these rows. Measured live on
+ * 2026-08-11, same window, same second:
+ *
+ *   /api/v1/chain/weights?window=7d&limit=20  network.weight_sets  67,955
+ *   /api/v1/chain/weights?window=7d&limit=100 network.weight_sets 214,842
+ *   /api/v1/chain/weights/setters?window=7d   weight_sets         239,051  <- truth
+ *
+ *   /api/v1/chain/serving?window=30d&limit=1  network.announcements  6,292
+ *   /api/v1/chain/serving?window=30d&limit=59 network.announcements 27,359
+ *
+ * The builders sum these rows for the network block and take the spread over
+ * them for `intensity_distribution` -- buildChainWeights' own comment promises
+ * that distribution covers "EVERY subnet (not just the returned page)". It
+ * could not: the page was all it was given. So the page slice belongs to the
+ * builder, which already does it, and the scan's only job is to return the
+ * POPULATION.
+ *
+ * 1000 is a safety bound, not a page size: the grouping is per netuid and the
+ * network has ~129 subnets, so it is two orders of magnitude clear of the truth
+ * and exists only so a runaway grouping cannot stream unbounded rows into an
+ * isolate. It also costs nothing to raise the old default from 200: `LIMIT`
+ * applies AFTER the aggregation, so the bytes scanned are identical either way.
+ *
+ * If you ever put the caller's page size back in this SQL, you re-break the
+ * network rollup, the distribution, AND `subnet_count` in one edit.
+ */
+export const ROLLUP_POPULATION_CAP = 1000;
 
 /**
  * Every part of one rollup, or null to leave the caller's empty payload
@@ -191,7 +232,6 @@ export async function loadChainEventRollup(
   {
     windowDays,
     now = Date.now(),
-    limit = 200,
     // Injectable so both queries and every decline path are testable without a
     // lakehouse -- a branch that only runs against live infrastructure is a
     // branch nothing verifies.
@@ -199,7 +239,12 @@ export async function loadChainEventRollup(
   }: {
     windowDays: number;
     now?: number;
-    limit?: number;
+    /**
+     * NO `limit`. The page size is deliberately not an input here -- see
+     * ROLLUP_POPULATION_CAP for what taking one did to every window-wide number
+     * on these cards. Callers keep passing their limit to the BUILDER, which is
+     * where the page slice has always belonged.
+     */
     query?: R2SqlReader;
   },
 ): Promise<ChainEventRollup | null> {
@@ -218,10 +263,29 @@ export async function loadChainEventRollup(
 
   const cutoff = now - windowDays * 24 * 60 * 60 * 1000;
   if (!Number.isSafeInteger(cutoff) || cutoff < 0) return null;
-  const cap =
-    Number.isSafeInteger(limit) && limit > 0 ? Math.min(limit, 1000) : 200;
 
   const where = `WHERE event_kind = '${kind}' AND observed_at >= ${cutoff}`;
+  /**
+   * The two PER-SUBNET queries additionally require a subnet.
+   *
+   * `account_events.netuid` is nullable and WeightsSet uses it -- visible from
+   * outside on 2026-08-11 in /api/v1/chain/weights/setters, which publishes
+   * `{"hotkey": null, "netuid": null, "uid": 0, "weight_sets": 633}`. Grouped
+   * by netuid that becomes one row whose netuid is null, and every builder here
+   * drops it (correctly: it cannot be attributed to a subnet). It still cost a
+   * slot in the page and a unit in the subnet count, which is how
+   * `/chain/weights?limit=N` came to publish N-1 subnets and `?limit=1` an
+   * entirely empty card beside a `subnet_count` of 129.
+   *
+   * Filtered in SQL rather than left to the builder so the two numbers agree:
+   * `subnet_count` counts subnets the card COULD show. The network block below
+   * stays unfiltered -- "how many distinct participants" does not need to know
+   * which subnet each was on, and narrowing it would drop real participants.
+   *
+   * Same predicate `src/account-history-cold-tier.ts` already runs against this
+   * table in production, so the dialect support is proven rather than assumed.
+   */
+  const perSubnetWhere = `${where} AND netuid IS NOT NULL`;
 
   // What identifies ONE participant on the network block below. A uid is unique
   // only WITHIN a subnet -- uid 5 on twenty subnets is twenty neurons -- so the
@@ -255,9 +319,9 @@ export async function loadChainEventRollup(
       env,
       `SELECT netuid, sum(n) AS ${countField}, count(*) AS ${distinctField}` +
         ` FROM (SELECT netuid, ${distinctColumn}, count(*) AS n` +
-        ` FROM chain.account_events ${where}` +
+        ` FROM chain.account_events ${perSubnetWhere}` +
         ` GROUP BY netuid, ${distinctColumn})` +
-        ` GROUP BY netuid ORDER BY ${countField} DESC LIMIT ${cap}`,
+        ` GROUP BY netuid ORDER BY ${countField} DESC LIMIT ${ROLLUP_POPULATION_CAP}`,
     ),
     // Separate because a distinct count does not sum across subnets: one
     // participant active on five subnets is five rows above and one here.
@@ -293,8 +357,10 @@ export async function loadChainEventRollup(
     // before settling here:
     //
     //  * The first query cannot carry it: its outer level is `GROUP BY netuid
-    //    ... LIMIT cap`, so a window-wide aggregate cannot ride alongside a
-    //    capped page.
+    //    ... LIMIT`, so a window-wide aggregate cannot ride alongside a capped
+    //    page -- and while that cap is now a safety bound rather than the
+    //    caller's page size, a bound that can bind at all is one this number
+    //    must not depend on.
     //  * Widening the network block's grouping to (identity, netuid) and taking
     //    `count(DISTINCT identity)` / `count(DISTINCT netuid)` off the derived
     //    table LOOKS free -- same source scan -- and it executes at 7d for the
@@ -314,7 +380,8 @@ export async function loadChainEventRollup(
     query(
       env,
       `SELECT count(*) AS subnet_count` +
-        ` FROM (SELECT netuid FROM chain.account_events ${where} GROUP BY netuid)`,
+        ` FROM (SELECT netuid FROM chain.account_events ${perSubnetWhere}` +
+        ` GROUP BY netuid)`,
     ),
   ]);
 

--- a/src/chain-prometheus-loader.ts
+++ b/src/chain-prometheus-loader.ts
@@ -57,7 +57,6 @@ export async function loadChainPrometheusColdTier(
   const rowLimit = limit ?? CHAIN_PROMETHEUS_LIMIT_DEFAULT;
   const rollup = await loadChainEventRollup(env, CHAIN_PROMETHEUS_ROLLUP, {
     windowDays: ANALYTICS_WINDOW_DAYS[label],
-    limit: rowLimit,
     query,
   });
   if (!rollup) return null;

--- a/src/chain-serving-loader.ts
+++ b/src/chain-serving-loader.ts
@@ -38,12 +38,16 @@ import type { R2SqlReader } from "./r2-sql.ts";
  * the label narrowing is worse than either alone, because the response then
  * misdescribes data that is itself correct.
  *
- * The limit mattered because it is optional and the two halves default
- * DIFFERENTLY: `loadChainEventRollup` caps at 200, `buildChainServing` at 20.
- * Left to their own defaults an omitted limit scanned ten times the rows the
- * response could carry. `parseLimitParam` genuinely returns
- * `number | undefined` even when given a defaultLimit, so this is reachable
- * from the REST call site's types rather than merely defensive.
+ * The limit mattered because it is optional and the two halves used to default
+ * DIFFERENTLY: `loadChainEventRollup` capped the scan at 200, `buildChainServing`
+ * the page at 20. `parseLimitParam` genuinely returns `number | undefined` even
+ * when given a defaultLimit, so an omitted limit was reachable from the REST
+ * call site's types rather than merely defensive.
+ *
+ * The scan no longer takes a limit at all (#10190's measurements: a page-sized
+ * scan made `network.announcements` and the distribution describe the page, not
+ * the window), so `rowLimit` now resolves ONE thing -- the builder's page. The
+ * window is still resolved here, for the original reason below.
  */
 export async function loadChainServingColdTier(
   env: Parameters<R2SqlReader>[0],
@@ -66,7 +70,6 @@ export async function loadChainServingColdTier(
   const rowLimit = limit ?? CHAIN_SERVING_LIMIT_DEFAULT;
   const rollup = await loadChainEventRollup(env, CHAIN_SERVING_ROLLUP, {
     windowDays: ANALYTICS_WINDOW_DAYS[label],
-    limit: rowLimit,
     // Passed straight through: a destructuring default applies to an explicit
     // undefined, so the rollup reader falls back to the real r2SqlQuery
     // without a conditional spread here that nothing would ever exercise.

--- a/src/chain-weights-loader.ts
+++ b/src/chain-weights-loader.ts
@@ -47,7 +47,6 @@ export async function loadChainWeightsColdTier(
 ): Promise<ReturnType<typeof buildChainWeights> | null> {
   const rollup = await loadChainEventRollup(env, CHAIN_WEIGHTS_ROLLUP, {
     windowDays: (ANALYTICS_WINDOW_DAYS as Record<string, number>)[window] ?? 7,
-    limit,
     query,
   });
   if (!rollup) return null;

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -232,7 +232,13 @@ export async function loadBlockExtrinsicsColdTier(
     network,
   );
   if (rows === null) return null;
-  return buildBlockExtrinsics(rows.rows, ref, rows.nextCursor, {
+  // `height`, NOT the cursor: buildBlockExtrinsics' third parameter is the
+  // block number this page belongs to. Passing `rows.nextCursor` there published
+  // a cursor token (or null) as `block_number` on every lakehouse-served page --
+  // the sibling loadBlockEventsColdTier passes `height` here, and REST, GraphQL
+  // and MCP all read this one field from the same builder. Invisible until the
+  // retired tier stopped supplying `block_number` itself (#10190).
+  return buildBlockExtrinsics(rows.rows, ref, height, {
     limit: rows.limit,
     offset: rows.offset,
   });

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -6763,11 +6763,37 @@ const rootValue = {
         },
       });
     }
+    // Both changes: #10802's toRow() typing over the tier deletion's shape, plus
+    // the entity-label join below.
     const data =
       answer?.kind === "answer"
         ? toRow(answer.data)
         : toRow(buildAccountSummary(ss58, {}));
-    return accountSummaryNode(data, ss58);
+    // #6739's entity labels, joined HERE. handleAccount and get_account both do
+    // this join; this resolver never did -- it read `labels` out of the Postgres
+    // tier's own payload, which is where data-api put them. That flag reads
+    // "retired" and cannot forward (#10190), so `account.labels` has been null
+    // over GraphQL while REST served the same account's exchange label. The
+    // enumerated return shape is exactly what #10214 was about.
+    //
+    // A missing or cold artifact degrades to an empty list, matching the
+    // never-404 contract the sibling surfaces keep.
+    const entitiesArtifact = await readArtifact(
+      context.env,
+      ENTITY_LABELS_ARTIFACT,
+    );
+    return accountSummaryNode(
+      {
+        ...data,
+        labels: labelsForSs58(
+          entityLabelsIndex(
+            entitiesArtifact.ok ? toRow(entitiesArtifact.data)?.entities : [],
+          ),
+          ss58,
+        ),
+      },
+      ss58,
+    );
   },
 
   async account_prometheus(

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3059,15 +3059,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/registrations`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
         context.env as unknown as Parameters<
           typeof loadSubnetEventCardColdTier
@@ -3079,8 +3073,7 @@ const rootValue = {
           windowLabel: windowParam,
           windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam] ?? 7,
         },
-      )) ??
-      buildSubnetRegistrations(null, netuid, { window: windowParam });
+      )) ?? buildSubnetRegistrations(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -3112,15 +3105,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/deregistrations`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #9307: same UID-reuse derivation REST's handleSubnetDeregistrations
       // reads, then the same MARKED empty when nothing derived it.
       (await loadSubnetDeregistrationsFromArtifact(context.env, netuid, {
@@ -3163,15 +3150,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/serving`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
         context.env as unknown as Parameters<
           typeof loadSubnetEventCardColdTier
@@ -3183,8 +3164,7 @@ const rootValue = {
           windowLabel: windowParam,
           windowDays: SUBNET_SERVING_WINDOWS[windowParam] ?? 7,
         },
-      )) ??
-      buildSubnetServing(null, netuid, { window: windowParam });
+      )) ?? buildSubnetServing(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -3198,7 +3178,7 @@ const rootValue = {
 
   async subnet_axon_removals(
     { netuid, window }: QuerySubnet_Axon_RemovalsArgs,
-    context: GqlContext,
+    _context: GqlContext,
   ) {
     // Same 7d/30d window validation handleSubnetAxonRemovals uses -- an
     // unsupported window is a GraphQL BAD_USER_INPUT error, not a silent card.
@@ -3216,15 +3196,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/axon-removals`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       buildSubnetAxonRemovals(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -3970,15 +3944,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/weights`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadSubnetWeightsColdTier(
         context.env as unknown as Parameters<
           typeof loadSubnetWeightsColdTier
@@ -3988,8 +3956,7 @@ const rootValue = {
           windowLabel: windowParam,
           windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
         },
-      )) ??
-      buildSubnetWeights(null, netuid, { window: windowParam });
+      )) ?? buildSubnetWeights(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -4021,15 +3988,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/stake-moves`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
         context.env as unknown as Parameters<
           typeof loadSubnetEventCardColdTier
@@ -4041,8 +4002,7 @@ const rootValue = {
           windowLabel: windowParam,
           windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam] ?? 7,
         },
-      )) ??
-      buildSubnetStakeMoves(null, netuid, { window: windowParam });
+      )) ?? buildSubnetStakeMoves(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -4074,15 +4034,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/stake-transfers`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadSubnetEventCardColdTier(
         context.env as unknown as Parameters<
           typeof loadSubnetEventCardColdTier
@@ -4094,8 +4048,7 @@ const rootValue = {
           windowLabel: windowParam,
           windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam] ?? 7,
         },
-      )) ??
-      buildSubnetStakeTransfers(null, netuid, { window: windowParam });
+      )) ?? buildSubnetStakeTransfers(null, netuid, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -4169,17 +4122,10 @@ const rootValue = {
     // buildStakeFlow([]) zeroed-card fallback handleSubnetStakeFlow uses;
     // direction only narrows the live query, so a cold tier degrades to the same
     // zeroed card the direction-less builder produces.
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/subnets/${netuid}/stake-flow`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #9146: same chain-stake-flow projection slice REST and MCP read.
       ((
         await loadSubnetStakeFlowFromArtifact(context.env, netuid, {
@@ -4246,15 +4192,10 @@ const rootValue = {
     // is the right shape for "no events"; it is the wrong answer for "441M rows
     // exist and nobody asked the table that holds them".
     const tierResult =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/events`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ?? null;
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      null;
     const data = await answerSubnetEvents(context.env, netuid, tierResult, {
       limit: safeLimit,
       offset: safeOffset,
@@ -4355,15 +4296,9 @@ const rootValue = {
     // uses; a subnet with no PrometheusServed events is a schema-stable zeroed
     // card, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/prometheus`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #10322: the same cold-tier rung REST's handleSubnetPrometheus gained.
       // Without it this resolver bottomed out in the zeroed builder while
       // `chain_prometheus` answered from the same PrometheusServed stream.
@@ -4418,15 +4353,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", windowParam);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/weights/setters`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       ((await loadSubnetWeightSettersColdTier(
         context.env as unknown as Parameters<
           typeof loadSubnetWeightSettersColdTier
@@ -4947,11 +4876,9 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", label);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/incidents", params),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadGlobalIncidentsLedger(context.env, { label })).data;
     const ledger = {
       schema_version: data.schema_version ?? 1,
@@ -5203,19 +5130,15 @@ const rootValue = {
         : null;
     // The tier serves this route inside a { data } envelope (unlike the flat
     // cards), so unwrap it before falling back to the zeroed build.
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(context, `/api/v1/subnets/${netuid}/volume`),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (
         await loadSubnetAlphaVolumeFromArtifact(context.env, netuid, {
           marketCapTao,
         })
-      )?.data ??
-      buildAlphaVolume([], netuid, { marketCapTao });
+      )?.data ?? buildAlphaVolume([], netuid, { marketCapTao });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5291,13 +5214,10 @@ const rootValue = {
     // falling back. Reading the envelope as the payload made `candles` always
     // undefined, so this resolver answered with an empty series even when the
     // tier had returned a full one.
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(context, `/api/v1/subnets/${netuid}/ohlc`, params),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The SAME lakehouse reader REST's handleSubnetOhlc and MCP's
       // get_subnet_ohlc fall to, so the three surfaces cannot disagree about a
       // subnet's candles.
@@ -5476,23 +5396,17 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", label);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/health/percentiles`,
-          params,
-        ),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Row | null) ??
-      (await loadSubnetPercentiles(netuid, {
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      await loadSubnetPercentiles(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
         db: observationsReadDb(
           context.env as unknown as Record<string, unknown>,
           context.ctx,
         ),
-      }));
+      });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -5536,15 +5450,9 @@ const rootValue = {
     params.set("window", windowParam);
     params.set("limit", String(limitParam));
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/event-summary`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #9303: same stream, same rollup -- the non-null contract below is now
       // satisfied with real numbers rather than only with the empty shape.
       ((await loadSubnetEventSummaryColdTier(context.env, netuid, {
@@ -5761,23 +5669,17 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("window", label);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/health/incidents`,
-          params,
-        ),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Row | null) ??
-      (await loadSubnetIncidents(netuid, {
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      await loadSubnetIncidents(netuid, {
         window: label,
         observedAt: await loadObservedAt(context),
         db: observationsReadDb(
           context.env as unknown as Record<string, unknown>,
           context.ctx,
         ),
-      }));
+      });
     return {
       min_incident_samples: data.min_incident_samples ?? null,
       schema_version: data.schema_version ?? 1,
@@ -5834,16 +5736,9 @@ const rootValue = {
     if (from != null) params.set("from", from);
     if (to != null) params.set("to", to);
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/extrinsics",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The extrinsics cold tier REST and MCP both read (#9540).
       //
       // call_hash matches INSIDE call_args, which the lakehouse cannot express,
@@ -6030,11 +5925,9 @@ const rootValue = {
     if (callFunction) params.set("call_function", callFunction);
     if (success != null) params.set("success", String(success));
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/sudo", params),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The extrinsics cold tier REST and MCP both read (#9540). `module` is
       // the pathname->pallet predicate data-api applies to this route
       // (SUDO_GOVERNANCE_ROUTES), expressed against the lakehouse verbatim --
@@ -6067,14 +5960,9 @@ const rootValue = {
 
   async extrinsic({ ref }: QueryExtrinsicArgs, context: GqlContext) {
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/extrinsics/${encodeURIComponent(ref)}`,
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The same hot/cold cascade REST and MCP run (#9540). A composite
       // "<block>-<index>" ref routes through answerBlockDetail, so it inherits
       // the gap case -- raised, not flattened to an empty extrinsic.
@@ -6147,15 +6035,9 @@ const rootValue = {
     // itself (see SUDO_GOVERNANCE_ROUTES in workers/data-api.ts) -- no filter
     // logic duplicated here; the REST route and MCP tool share this exact path.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/governance/config-changes",
-          params,
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The extrinsics cold tier REST and MCP both read (#9540). `module` is
       // the pathname->pallet predicate data-api applies to this route
       // (SUDO_GOVERNANCE_ROUTES), expressed against the lakehouse verbatim --
@@ -6368,53 +6250,48 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
-    const { data } = ((await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/blocks/${encodeURIComponent(ref)}/extrinsics`,
-        params,
-        chainNetworkFromChainName(network),
-      ),
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as Row | null) ?? {
-      // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
-      // a ref can land in the GAP between the decoded seam and the hot window,
-      // and that is a decline, not an empty -- REST answers it 503
-      // block_detail_unavailable and MCP throws. Returning the empty builder
-      // there would state "this block has no extrinsics", which is the confident
-      // zero this whole change exists to remove.
-      data: gapAwareBlockDetail(
-        await answerBlockDetail(
-          context.env,
-          ref,
-          {
-            hot: (height) =>
-              loadBlockExtrinsicsHotTier(context.env, ref, height, {
-                limit: safeLimit,
-                offset: safeOffset,
-              }),
-            cold: () =>
-              loadBlockExtrinsicsColdTier(context.env, ref, {
-                limit: safeLimit,
-                offset: safeOffset,
-              }),
-            isEmpty: isEmptyExtrinsicPayload,
-          },
-          // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
-          // blocks_head and the whole hot path are written by the mainnet
-          // firehose poller and carry no network column -- so a testnet ref
-          // resolves from that chain's lakehouse instead of being looked up in
-          // mainnet's D1 (#10394).
-          chainNetworkFromChainName(network),
+    const { data } =
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      {
+        // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
+        // a ref can land in the GAP between the decoded seam and the hot window,
+        // and that is a decline, not an empty -- REST answers it 503
+        // block_detail_unavailable and MCP throws. Returning the empty builder
+        // there would state "this block has no extrinsics", which is the confident
+        // zero this whole change exists to remove.
+        data: gapAwareBlockDetail(
+          await answerBlockDetail(
+            context.env,
+            ref,
+            {
+              hot: (height) =>
+                loadBlockExtrinsicsHotTier(context.env, ref, height, {
+                  limit: safeLimit,
+                  offset: safeOffset,
+                }),
+              cold: () =>
+                loadBlockExtrinsicsColdTier(context.env, ref, {
+                  limit: safeLimit,
+                  offset: safeOffset,
+                }),
+              isEmpty: isEmptyExtrinsicPayload,
+            },
+            // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
+            // blocks_head and the whole hot path are written by the mainnet
+            // firehose poller and carry no network column -- so a testnet ref
+            // resolves from that chain's lakehouse instead of being looked up in
+            // mainnet's D1 (#10394).
+            chainNetworkFromChainName(network),
+          ),
+          () =>
+            buildBlockExtrinsics([], ref, null, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
         ),
-        () =>
-          buildBlockExtrinsics([], ref, null, {
-            limit: safeLimit,
-            offset: safeOffset,
-          }),
-      ),
-    };
+      };
     return data;
   },
 
@@ -6433,53 +6310,48 @@ const rootValue = {
     const params = new URLSearchParams();
     params.set("limit", String(safeLimit));
     params.set("offset", String(safeOffset));
-    const { data } = ((await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/blocks/${encodeURIComponent(ref)}/events`,
-        params,
-        chainNetworkFromChainName(network),
-      ),
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as Row | null) ?? {
-      // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
-      // a ref can land in the GAP between the decoded seam and the hot window,
-      // and that is a decline, not an empty -- REST answers it 503
-      // block_detail_unavailable and MCP throws. Returning the empty builder
-      // there would state "this block has no events", which is the confident
-      // zero this whole change exists to remove.
-      data: gapAwareBlockDetail(
-        await answerBlockDetail(
-          context.env,
-          ref,
-          {
-            hot: (height) =>
-              loadBlockEventsHotTier(context.env, ref, height, {
-                limit: safeLimit,
-                offset: safeOffset,
-              }),
-            cold: () =>
-              loadBlockEventsColdTier(context.env, ref, {
-                limit: safeLimit,
-                offset: safeOffset,
-              }),
-            isEmpty: isEmptyEventPayload,
-          },
-          // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
-          // blocks_head and the whole hot path are written by the mainnet
-          // firehose poller and carry no network column -- so a testnet ref
-          // resolves from that chain's lakehouse instead of being looked up in
-          // mainnet's D1 (#10394).
-          chainNetworkFromChainName(network),
+    const { data } =
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      {
+        // The hot/cold cascade REST and MCP both run (#9540). Not a plain loader:
+        // a ref can land in the GAP between the decoded seam and the hot window,
+        // and that is a decline, not an empty -- REST answers it 503
+        // block_detail_unavailable and MCP throws. Returning the empty builder
+        // there would state "this block has no events", which is the confident
+        // zero this whole change exists to remove.
+        data: gapAwareBlockDetail(
+          await answerBlockDetail(
+            context.env,
+            ref,
+            {
+              hot: (height) =>
+                loadBlockEventsHotTier(context.env, ref, height, {
+                  limit: safeLimit,
+                  offset: safeOffset,
+                }),
+              cold: () =>
+                loadBlockEventsColdTier(context.env, ref, {
+                  limit: safeLimit,
+                  offset: safeOffset,
+                }),
+              isEmpty: isEmptyEventPayload,
+            },
+            // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
+            // blocks_head and the whole hot path are written by the mainnet
+            // firehose poller and carry no network column -- so a testnet ref
+            // resolves from that chain's lakehouse instead of being looked up in
+            // mainnet's D1 (#10394).
+            chainNetworkFromChainName(network),
+          ),
+          () =>
+            buildBlockEvents([], ref, null, {
+              limit: safeLimit,
+              offset: safeOffset,
+            }),
         ),
-        () =>
-          buildBlockEvents([], ref, null, {
-            limit: safeLimit,
-            offset: safeOffset,
-          }),
-      ),
-    };
+      };
     return data;
   },
 
@@ -6639,17 +6511,9 @@ const rootValue = {
     // retirement: the `account_events` D1 table is dropped in production, so the
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
     const data =
-      ((
-        await tryPostgresTier(
-          context.env,
-          postgresTierRequest(
-            context,
-            `/api/v1/validators/${encodeURIComponent(hotkey)}/nominators`,
-            params,
-          ),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )
-      )?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The SAME lakehouse reader REST's handleValidatorNominators and MCP's
       // get_validator_nominators fall to, so the three surfaces cannot
       // disagree about who is behind a validator. An omitted limit/offset
@@ -6867,22 +6731,15 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    const postgres = (await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}`,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as Row | null;
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+    // guarded resolved to null before it could touch DATA_API.
     // #9254/#9263: the SAME composition REST and MCP run. The zeroed card stays
     // the answer only where there is no tier to ask at all; a tier that exists
     // and could not answer raises, because a card reading zero events for an
     // account whose own events field would return 100 is a wrong answer, not a
     // degraded one.
-    const answer = postgres
-      ? null
-      : await answerAccountSummary(context.env, ss58);
+    const answer = await answerAccountSummary(context.env, ss58);
     if (answer?.kind === "gap") {
       throw new GraphQLError(accountSummaryGapMessage(ss58, answer.reasons), {
         // #9386: the decline names which leg failed, so a client sees the same
@@ -6894,10 +6751,9 @@ const rootValue = {
       });
     }
     const data =
-      postgres ??
-      (answer?.kind === "answer"
+      answer?.kind === "answer"
         ? toRow(answer.data)
-        : toRow(buildAccountSummary(ss58, {})));
+        : toRow(buildAccountSummary(ss58, {}));
     return accountSummaryNode(data, ss58);
   },
 
@@ -6924,17 +6780,10 @@ const rootValue = {
     // destructures. No live D1 fallback exists for this route family (the account
     // event footprints' D1 write path is retired); a cold/absent tier degrades to
     // the pure builder over an empty row set, same as REST's own fallback.
-    const pg = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/prometheus`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (pg?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #10322: the same cold-tier rung REST's handleAccountPrometheus gained.
       // Without it this resolver answered a confident zero for every account.
       ((
@@ -6989,17 +6838,10 @@ const rootValue = {
     // uses. direction only narrows the live Postgres-tier query -- the fallback builder
     // takes no direction argument, so a cold/absent tier degrades to the same zeroed
     // card regardless of the requested direction.
-    const pg = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/stake-flow`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (pg?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540); the loader
       // returns the same { data } envelope the retired tier did.
       ((
@@ -7171,17 +7013,10 @@ const rootValue = {
     // is a schema-stable zeroed card, never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/registrations`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540); the loader
       // returns the same { data } envelope the retired tier did.
       ((
@@ -7232,17 +7067,10 @@ const rootValue = {
     // is a schema-stable zeroed card, never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/deregistrations`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #9307: an account's deregistrations are the slots where it was the
       // PREVIOUS holder, derived from UID reuse — the same reader REST's
       // handleAccountDeregistrations uses, then the same MARKED empty.
@@ -7300,17 +7128,10 @@ const rootValue = {
     // schema-stable zeroed card, never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/serving`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540); the loader
       // returns the same { data } envelope the retired tier did.
       ((
@@ -7338,7 +7159,7 @@ const rootValue = {
 
   async account_axon_removals(
     { ss58, window }: QueryAccount_Axon_RemovalsArgs,
-    context: GqlContext,
+    _context: GqlContext,
   ) {
     // Same SS58 + window validation handleAccountAxonRemovals (via
     // makeAccountEventHandler) uses -- a malformed address or unsupported
@@ -7361,17 +7182,10 @@ const rootValue = {
     // is a schema-stable zeroed card, never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/axon-removals`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       buildAccountAxonRemovals([], ss58, { window: windowParam });
     return {
       schema_version: data.schema_version ?? 1,
@@ -7418,17 +7232,10 @@ const rootValue = {
     // schema-stable zeroed card, never a GraphQL error.
     const params = new URLSearchParams();
     params.set("window", windowParam);
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/stake-moves`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (tier?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540); the loader
       // returns the same { data } envelope the retired tier did.
       ((
@@ -7479,17 +7286,10 @@ const rootValue = {
     // Same tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE) -> { data, generatedAt }
     // envelope handleAccountWeightSetters (makeAccountEventHandler) uses; a cold
     // or absent tier degrades to buildAccountWeightSetters' own zeroed card.
-    const pg = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/weight-setters`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
     const data =
-      (pg?.data as Row | undefined) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540); the loader
       // returns the same { data } envelope the retired tier did.
       ((
@@ -7692,16 +7492,10 @@ const rootValue = {
     const params = new URLSearchParams();
     if (counterparty != null) params.set("counterparty", counterparty);
     if (limit != null) params.set("limit", String(limit));
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        `/api/v1/accounts/${encodeURIComponent(ss58)}/counterparties`,
-        params,
-      ),
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    );
-    let data = tier as Row | null;
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
+    let data: Row | null = null;
     // The cold tiers REST and MCP both read (#9540). Two of them, because this
     // resolver has two modes and they are not interchangeable: a counterparty
     // argument asks about ONE relationship, and answering it from the list
@@ -7827,15 +7621,9 @@ const rootValue = {
     // retired (#4772), so a tier miss resolves through buildAccountTransfers over
     // an empty scan -- a schema-stable empty feed, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/accounts/${encodeURIComponent(ss58)}/transfers`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540). Every filter is
       // forwarded, so the tier filters -- the empty builder below ignores them.
       ((await loadAccountTransfersColdTier(context.env, ss58, {
@@ -7905,15 +7693,9 @@ const rootValue = {
     // (#4772), so a tier miss resolves through buildAccountExtrinsics over an
     // empty scan -- a schema-stable empty feed, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/accounts/${encodeURIComponent(ss58)}/extrinsics`,
-          params,
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540). Every filter is
       // forwarded, so the tier filters -- the empty builder below ignores them.
       ((await loadAccountExtrinsicsColdTier(context.env, ss58, {
@@ -7980,15 +7762,9 @@ const rootValue = {
     // retired (#4772), so a tier miss resolves through buildAccountEvents over an
     // empty scan -- a schema-stable empty feed, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/accounts/${encodeURIComponent(ss58)}/events`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The account cold tier REST and MCP both read (#9540). Every filter is
       // forwarded, so the tier filters -- the empty builder below ignores them.
       ((await loadAccountEventsColdTier(context.env, ss58, {
@@ -8081,16 +7857,10 @@ const rootValue = {
       cursor: cursor ?? undefined,
     };
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/accounts/${encodeURIComponent(ss58)}/history`,
-          params,
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
-      (await loadAccountHistory(context.env, ss58, historyOptions));
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      await loadAccountHistory(context.env, ss58, historyOptions);
     return {
       schema_version: data.schema_version ?? 1,
       ss58: data.ss58 ?? ss58,
@@ -8418,28 +8188,21 @@ const rootValue = {
     // one extra calendar day, so trim the resolved result to the requested
     // window before returning, keeping day_count consistent with the label.
     const data = trimChainActivityToWindow(
-      ((await tryPostgresTier(
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      // The projection tier REST reads (#9540). Window-based like REST's
+      // handleChainActivity, NOT the blocks-based loadChainActivity MCP's
+      // get_chain_activity uses -- that tool takes a block count and answers a
+      // different question, so borrowing its loader would change this
+      // resolver's contract rather than fill it.
+      ((await loadChainActivityFromArtifact(
         context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/activity",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
+        {
+          window: label,
+        },
+        chainNetworkFromChainName(network),
       )) as ReturnType<typeof buildChainActivity> | null) ??
-        // The projection tier REST reads (#9540). Window-based like REST's
-        // handleChainActivity, NOT the blocks-based loadChainActivity MCP's
-        // get_chain_activity uses -- that tool takes a block count and answers a
-        // different question, so borrowing its loader would change this
-        // resolver's contract rather than fill it.
-        ((await loadChainActivityFromArtifact(
-          context.env,
-          {
-            window: label,
-          },
-          chainNetworkFromChainName(network),
-        )) as ReturnType<typeof buildChainActivity> | null) ??
         buildChainActivity({ window: label }),
       days,
     );
@@ -8502,16 +8265,9 @@ const rootValue = {
     // handleChainCalls uses; the tier owns the call-mix aggregation (no logic
     // duplicated here), and a cold store yields a schema-stable empty breakdown.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/calls",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier REST and MCP both read (#9540). callModule is
       // threaded rather than dropped: the reader DECLINES a pallet-scoped call
       // by contract (its value space is not precomputed), so passing it keeps
@@ -8573,27 +8329,20 @@ const rootValue = {
     // #8421: mirror handleChainFees's #8242 fix -- trim the UTC-day buckets to
     // the requested window so a 7d request never reports 8 days.
     const data = trimChainFeesToWindow(
-      ((await tryPostgresTier(
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      // The projection tier REST and MCP both read (#9540); same
+      // declines-a-scoped-call contract as chain_calls above.
+      ((await loadChainFeesFromArtifact(
         context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/fees",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
+        {
+          window: label,
+          limit: safeLimit,
+          callModule,
+        },
+        chainNetworkFromChainName(network),
       )) as ReturnType<typeof buildChainFees> | null) ??
-        // The projection tier REST and MCP both read (#9540); same
-        // declines-a-scoped-call contract as chain_calls above.
-        ((await loadChainFeesFromArtifact(
-          context.env,
-          {
-            window: label,
-            limit: safeLimit,
-            callModule,
-          },
-          chainNetworkFromChainName(network),
-        )) as ReturnType<typeof buildChainFees> | null) ??
         buildChainFees({ window: label }),
       days,
     );
@@ -8646,11 +8395,9 @@ const rootValue = {
     // the `account_events` D1 table is dropped in production, so the fallback goes
     // straight to the pure builder with no rows, never a live D1 query.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/chain/weights", params),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // Same shared loader REST and MCP use; GraphQL keeps its own
       // schema-stable card below because that contract is this surface's own.
       ((await loadChainWeightsColdTier(
@@ -8703,11 +8450,9 @@ const rootValue = {
     // schema-stable zeroed card contract REST's chainServing route uses, never
     // a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/chain/serving", params),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // Same shared loader REST and MCP use. GraphQL keeps its own fallback
       // below because answering with the schema-stable card rather than an
       // error is this surface's deliberate contract, not the loader's call.
@@ -8735,7 +8480,7 @@ const rootValue = {
 
   async chain_axon_removals(
     { window, limit }: QueryChain_Axon_RemovalsArgs,
-    context: GqlContext,
+    _context: GqlContext,
   ) {
     const requestedWindow = window ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
     if (!Object.hasOwn(CHAIN_AXON_REMOVALS_WINDOWS, requestedWindow)) {
@@ -8757,11 +8502,9 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainAxonRemovals uses,
     // never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/chain/axon-removals", params),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       buildChainAxonRemovals([], { window: requestedWindow, limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
@@ -8809,16 +8552,9 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainDeregistrations
     // uses, never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/deregistrations",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #9307: same UID-reuse derivation REST's handleChainDeregistrations
       // reads, then the same MARKED empty when nothing derived it.
       ((await loadChainDeregistrationsFromArtifact(
@@ -8878,16 +8614,9 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainRegistrations uses,
     // never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/registrations",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // #9146: same chain-registrations projection REST reads, so the two
       // surfaces cannot report different registration activity.
       ((await loadChainRegistrationsFromArtifact(
@@ -8941,11 +8670,9 @@ const rootValue = {
     // schema-stable zeroed card contract REST's handleChainPrometheus uses,
     // never a GraphQL error.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/chain/prometheus", params),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The same lakehouse rung REST and MCP now use (#10248). Wiring one
       // surface and not the others is exactly the drift chain-serving-loader.ts
       // was extracted to stop.
@@ -9020,18 +8747,10 @@ const rootValue = {
     // here, and a cold store yields a schema-stable empty leaderboard. #4772 D1
     // retirement: the `extrinsics` D1 table is dropped in production, so the
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
-    const tier = await tryPostgresTier(
-      context.env,
-      postgresTierRequest(
-        context,
-        "/api/v1/chain/signers",
-        params,
-        chainNetworkFromChainName(network),
-      ),
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    );
     const data =
-      (tier as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier (#9146) REST reads and this field skipped. The
       // loader declines a pallet-scoped call itself (serving the unfiltered
       // leaderboard under a filtered label would be a wrong answer), so
@@ -9090,11 +8809,9 @@ const rootValue = {
     // and the table is dropped in production, so a D1 query here would
     // always miss. Postgres → schema-stable empty stub, never a live D1 read.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/chain/weights/setters", params),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // Same lakehouse reader REST and MCP use; the zeroed card below stays the
       // fallback because this resolver's contract is a schema-stable card
       // rather than an error, which is why the loader declines with null.
@@ -9136,16 +8853,9 @@ const rootValue = {
     // retirement: the `account_events` D1 table is dropped in production, so the
     // fallback goes straight to the pure builder with no rows, never a live D1 query.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/alpha-volume",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier REST and MCP both read (#9540); without it this
       // resolver's whole answer was the empty card below. The market-cap index
       // rides along so vol_mcap_ratio is not null on GraphQL alone (#9526).
@@ -9156,8 +8866,7 @@ const rootValue = {
           marketCapByNetuid: await resolveMarketCapIndex(context.env),
         },
         chainNetworkFromChainName(network),
-      )) as Row | null) ??
-      buildChainAlphaVolume([], { limit: safeLimit });
+      )) as Row | null) ?? buildChainAlphaVolume([], { limit: safeLimit });
     return {
       schema_version: data.schema_version ?? 1,
       window: data.window ?? "24h",
@@ -9223,16 +8932,9 @@ const rootValue = {
     // buildChainStakeFlow empty-card fallback REST's handleChainStakeFlow
     // uses. #4909 D1 retirement: never a live D1 read.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/stake-flow",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier REST and MCP both read (#9540). Without this rung
       // the ladder below is the whole answer, and the retired flag above
       // guarantees we reach it -- a confident zero, with no error to say so.
@@ -9291,16 +8993,9 @@ const rootValue = {
     // buildChainStakeMoves empty-card fallback REST's handleChainStakeMoves
     // uses. #4909 D1 retirement: never a live D1 read.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/stake-moves",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier REST and MCP both read (#9540). Without this rung
       // the ladder below is the whole answer, and the retired flag above
       // guarantees we reach it -- a confident zero, with no error to say so.
@@ -9356,16 +9051,9 @@ const rootValue = {
     // buildChainStakeTransfers empty-card fallback REST's
     // handleChainStakeTransfers uses. #4909 D1 retirement: never a live D1 read.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/stake-transfers",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier REST and MCP both read (#9540). Without this rung
       // the ladder below is the whole answer, and the retired flag above
       // guarantees we reach it -- a confident zero, with no error to say so.
@@ -9427,16 +9115,9 @@ const rootValue = {
     // buildChainTransferPairs empty-card fallback REST uses, including the KV
     // health:meta observed_at stamp. #4909 D1 retirement: never a live D1 read.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/transfer-pairs",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier (#9146) REST reads and this field skipped.
       ((await loadChainTransferPairsFromArtifact(
         context.env,
@@ -9491,16 +9172,9 @@ const rootValue = {
     // uses, including the KV health:meta observed_at stamp. #4909 D1
     // retirement: never a live D1 read.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          "/api/v1/chain/transfers",
-          params,
-          chainNetworkFromChainName(network),
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       // The projection tier (#9146): a cron recomputes this window's scorecard
       // from the lakehouse and REST reads it here. GraphQL was never given the
       // rung, so it fell straight past the tier that HAS the data to the empty
@@ -9579,11 +9253,9 @@ const rootValue = {
       if (value != null) trendsParams.set(name, String(value));
     }
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, "/api/v1/health/trends", trendsParams),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Row | null) ??
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (
         await loadBulkHealthTrends({
           observedAt: await loadObservedAt(context),
@@ -9616,18 +9288,16 @@ const rootValue = {
     // tier owns the per-surface uptime/latency aggregation; nothing is
     // duplicated here.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(context, `/api/v1/subnets/${netuid}/health/trends`),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Row | null) ??
-      (await loadSubnetHealthTrends(netuid, {
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      await loadSubnetHealthTrends(netuid, {
         observedAt: await loadObservedAt(context),
         db: observationsReadDb(
           context.env as unknown as Record<string, unknown>,
           context.ctx,
         ),
-      }));
+      });
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,
@@ -9771,23 +9441,17 @@ const rootValue = {
     // surfaces card, never a GraphQL error. The tier owns the
     // surface_uptime_daily aggregation; nothing is duplicated here.
     const data =
-      ((await tryPostgresTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/subnets/${netuid}/uptime`,
-          params,
-        ),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Row | null) ??
-      ((await loadSubnetUptime(netuid, {
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
+      (await loadSubnetUptime(netuid, {
         window: windowParam,
         observedAt: await loadObservedAt(context),
         db: observationsReadDb(
           context.env as unknown as Record<string, unknown>,
           context.ctx,
         ),
-      })) as Row);
+      })) as Row;
     return {
       schema_version: data.schema_version ?? 1,
       netuid: data.netuid ?? netuid,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -6787,7 +6787,12 @@ const rootValue = {
         ...data,
         labels: labelsForSs58(
           entityLabelsIndex(
-            entitiesArtifact.ok ? toRow(entitiesArtifact.data)?.entities : [],
+            // rowsOf, not a bare property read: a cold or malformed artifact can
+            // put a non-array under `entities`, and #10782's typing is what
+            // makes that visible here rather than at the first `.map`.
+            entitiesArtifact.ok
+              ? rowsOf(rowOf(entitiesArtifact.data)?.entities)
+              : [],
           ),
           ss58,
         ),

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -6271,11 +6271,20 @@ const rootValue = {
                   limit: safeLimit,
                   offset: safeOffset,
                 }),
+              // #10394: the network reaches the COLD leg too. It was passed to
+              // answerBlockDetail (which uses it to skip the mainnet-only hot
+              // tier) but not to the reader underneath, so `network: test`
+              // skipped mainnet's hot tier and then read mainnet's lakehouse --
+              // an answer labelled testnet built from mainnet rows. Hidden until
+              // now because the test asserted the path of a tier that never
+              // answered (#10190).
               cold: () =>
-                loadBlockExtrinsicsColdTier(context.env, ref, {
-                  limit: safeLimit,
-                  offset: safeOffset,
-                }),
+                loadBlockExtrinsicsColdTier(
+                  context.env,
+                  ref,
+                  { limit: safeLimit, offset: safeOffset },
+                  chainNetworkFromChainName(network),
+                ),
               isEmpty: isEmptyExtrinsicPayload,
             },
             // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --
@@ -6331,11 +6340,15 @@ const rootValue = {
                   limit: safeLimit,
                   offset: safeOffset,
                 }),
+              // #10394, same as block_extrinsics above: the cold leg needs the
+              // network or a testnet ref resolves out of mainnet's lakehouse.
               cold: () =>
-                loadBlockEventsColdTier(context.env, ref, {
-                  limit: safeLimit,
-                  offset: safeOffset,
-                }),
+                loadBlockEventsColdTier(
+                  context.env,
+                  ref,
+                  { limit: safeLimit, offset: safeOffset },
+                  chainNetworkFromChainName(network),
+                ),
               isEmpty: isEmptyEventPayload,
             },
             // Off mainnet `answerBlockDetail` skips the D1 hot tier entirely --

--- a/src/health-serving.ts
+++ b/src/health-serving.ts
@@ -21,7 +21,6 @@ import {
 import { spotPriceTao } from "./stake-quote.ts";
 import { NETWORK_PARAMETERS_KV_TTL } from "./network-parameters.ts";
 import { KV_ECONOMICS_CURRENT, KV_HEALTH_CURRENT } from "./kv-keys.ts";
-import { tryPostgresTier } from "../workers/postgres-tier.ts";
 
 import {
   comparePoolEndpoints,
@@ -1915,91 +1914,6 @@ export function formatUptime({
 // behavior exactly).
 export async function loadSubnetReliability(): Promise<null> {
   return null;
-}
-
-/** Cap on how many subnets a provider badge will aggregate over.
- *
- * One synthesized request per netuid (see below). A subnet badge -- the case
- * that matters, and the one the README flywheel is about -- is always exactly
- * one. This bounds the pathological provider spanning the whole registry;
- * beyond it the badge scores the first N by netuid rather than timing out. */
-const RELIABILITY_BADGE_MAX_NETUIDS = 24;
-
-/**
- * Sample-weighted reliability across one or many subnets, for the badge.
- *
- * This was a stub returning null from the 2026-07-17 D1 elimination onward --
- * its own comment said the table had "no Postgres-tier mirror wired for the
- * badge read path yet", so `?metric=uptime` and `?metric=grade` rendered "n/a"
- * for every subnet on earth. Confirmed live before this fix: SN64's badge said
- * `metagraphed: n/a` while /api/v1/subnets/64/uptime reported a real 0.9161
- * ratio at grade C from the same underlying data.
- *
- * There was never a missing mirror -- /api/v1/subnets/{netuid}/uptime already
- * serves exactly this, Postgres-tier, through METAGRAPH_HEALTH_SOURCE. So this
- * synthesizes an internal request per netuid rather than adding new plumbing,
- * the same "no client request to forward, synthesize one" shape handleCompare
- * uses for this table.
- *
- * Aggregation is sample-weighted, not a mean of ratios: a subnet with 30k
- * probes and one with 40 shouldn't count equally. Re-derives the composite via
- * scoreFromStats so the badge's grade bands can't drift from the ones
- * /uptime's own `reliability` block reports.
- */
-export async function loadReliabilityAggregate(
-  env: Env,
-  request: Request,
-  { netuids }: { netuids: number[] },
-): Promise<{ grade: string; uptime_ratio: number } | null> {
-  const targets = netuids.slice(0, RELIABILITY_BADGE_MAX_NETUIDS);
-  if (targets.length === 0) return null;
-
-  const blocks = await Promise.all(
-    targets.map(async (netuid) => {
-      const pgUrl = new URL(request.url);
-      pgUrl.pathname = `/api/v1/subnets/${netuid}/uptime`;
-      pgUrl.search = "";
-      const data = (await tryPostgresTier(
-        env,
-        new Request(pgUrl),
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as { reliability?: Record<string, unknown> | null } | null;
-      return data?.reliability ?? null;
-    }),
-  );
-
-  // Reconstruct ok-counts from ratio x samples: /uptime publishes the ratio and
-  // the sample count, not the raw ok total.
-  let samples = 0;
-  let okCount = 0;
-  let latencyWeighted = 0;
-  let latencySamples = 0;
-  for (const r of blocks) {
-    if (!r) continue;
-    const n = Number(r.sample_count);
-    const ratio = Number(r.uptime_ratio);
-    if (!Number.isFinite(n) || n <= 0 || !Number.isFinite(ratio)) continue;
-    samples += n;
-    okCount += ratio * n;
-    const ls = Number(r.latency_sample_count);
-    const avg = Number(r.avg_latency_ms);
-    if (Number.isFinite(ls) && ls > 0 && Number.isFinite(avg)) {
-      latencySamples += ls;
-      latencyWeighted += avg * ls;
-    }
-  }
-  if (samples === 0) return null;
-
-  const scored = scoreFromStats({
-    samples,
-    okCount: Math.round(okCount),
-    avgLatencyMs: latencySamples > 0 ? latencyWeighted / latencySamples : null,
-    latencySamples,
-  });
-  // Total, not a fallback: scoreFromStats returns null only for samples === 0,
-  // which the guard above already excluded. A `scored ? … : null` here would
-  // be a branch that can never be taken.
-  return { grade: scored!.grade, uptime_ratio: scored!.uptime_ratio };
 }
 
 // --- Live-everywhere health resolution + composed-artifact overlays ----------

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10074,15 +10074,23 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const entitiesArtifact = rowOf(
         await ctx.readArtifact!(ctx.env, ENTITY_LABELS_ARTIFACT),
       );
-      (data as Row).labels = labelsForSs58(
-        entityLabelsIndex(
-          entitiesArtifact?.ok
-            ? rowsOf(rowOf(entitiesArtifact.data)?.entities)
-            : [],
+      // SPREAD, not `(data as Row).labels = …`. That assertion compiled only
+      // while the tier arm widened `data` to a row: with the arm deleted
+      // (#10190) it narrows to AccountSummaryResult, and an interface has no
+      // index signature, so #10782's stricter `Row` rejects the cast. Building
+      // a fresh object is the structural conversion rather than an assertion
+      // over it -- and it stops mutating a value the composer owns.
+      return {
+        ...data,
+        labels: labelsForSs58(
+          entityLabelsIndex(
+            entitiesArtifact?.ok
+              ? rowsOf(rowOf(entitiesArtifact.data)?.entities)
+              : [],
+          ),
+          ss58,
         ),
-        ss58,
-      );
-      return data;
+      };
     },
   },
   {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10521,14 +10521,25 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           ),
           // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"
           // in wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this
-          // promise resolved to null on every call and the builder below has been
-          // the answer.
-          Promise.resolve(
-            buildAccountEvents([], ss58, {
-              limit: recentEventsLimit,
-              offset: 0,
-              nextCursor: null,
-            }),
+          // promise resolved to null on every call.
+          //
+          // THE COLD RUNG, the same one `get_account_events` resolves through
+          // (#10320). Without it this card fell straight from the retired tier to
+          // `buildAccountEvents([])` and published `event_count: 0` while the
+          // standalone tool served this coldkey's rows for the same address in the
+          // same second -- the exact defect the subnet snapshot's `recent_events`
+          // had, one composer over. A card is wired and its embedded copy is not.
+          loadAccountEventsColdTier(ctx.env, ss58, {
+            limit: recentEventsLimit,
+            offset: 0,
+          }).then(
+            (data) =>
+              data ??
+              buildAccountEvents([], ss58, {
+                limit: recentEventsLimit,
+                offset: 0,
+                nextCursor: null,
+              }),
           ),
         ]);
       return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1227,8 +1227,6 @@ import {
   parseCompareHotkeyList,
   parseCompareNetuidList,
   parseUptimeWindow,
-  composeCompareData,
-  profilesProjectionFromRows,
   COMPARE_VALIDATORS_MAX,
   loadSubnetTrajectory,
 } from "./analytics-live.ts";
@@ -3108,78 +3106,6 @@ function mcpLiveHealth(ctx: McpCtx) {
 // the economics KV freshness/contract gate behaves the same over MCP.
 function mcpContractVersion(ctx: McpCtx) {
   return ctx.env?.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
-}
-
-// Synthetic GET /api/v1/extrinsics{...} requests forwarded UNCHANGED to
-// DATA_API via tryPostgresTier (#4694) -- MCP tool handlers receive
-// structured args, not an inbound Request the way REST's handleExtrinsics
-// does, so this reconstructs the identical query-string shape
-// workers/data-api.ts's extrinsics routes parse. The host in the URL is
-// never dispatched to (DATA_API.fetch resolves the binding directly, the
-// same convention src/data-api-mcp.ts's dataApiFetchJson already uses).
-function mcpExtrinsicsListRequest(args: Row) {
-  const params = new URLSearchParams();
-  const block = optionalNonNegativeInt(args, "block");
-  if (block != null) params.set("block", String(block));
-  const signer = optionalString(args, "signer");
-  if (signer) params.set("signer", signer);
-  const callModule = optionalString(args, "call_module");
-  if (callModule) params.set("call_module", callModule);
-  const callFunction = optionalString(args, "call_function");
-  if (callFunction) params.set("call_function", callFunction);
-  const callHash = optionalString(args, "call_hash");
-  if (callHash) params.set("call_hash", callHash);
-  const success = optionalSuccessFilter(args);
-  if (success !== undefined) params.set("success", String(success));
-  const blockStart = optionalNonNegativeInt(args, "block_start");
-  if (blockStart != null) params.set("block_start", String(blockStart));
-  const blockEnd = optionalNonNegativeInt(args, "block_end");
-  if (blockEnd != null) params.set("block_end", String(blockEnd));
-  const from = optionalNonNegativeInt(args, "from");
-  if (from != null) params.set("from", String(from));
-  const to = optionalNonNegativeInt(args, "to");
-  if (to != null) params.set("to", String(to));
-  if (args?.limit != null) params.set("limit", String(args.limit));
-  if (args?.offset != null) params.set("offset", String(args.offset));
-  const cursor = optionalString(args, "cursor");
-  if (cursor) params.set("cursor", cursor);
-  return new Request(`https://d/api/v1/extrinsics?${params.toString()}`);
-}
-
-// Synthetic GET {pathname}{...} request for the two fixed-call_module
-// extrinsics-feed variants (get_sudo -> /api/v1/sudo, call_module=Sudo;
-// get_governance_config_changes -> /api/v1/governance/config-changes,
-// call_module=AdminUtils) -- same query-string shape as
-// mcpExtrinsicsListRequest MINUS signer/call_module (workers/data-api.ts
-// derives call_module from the pathname itself for these two routes, not a
-// query param -- see its PATH_TO_CALL_MODULE-style mapping), so passing the
-// correct fixed pathname is what selects the filter, nothing else needed.
-function mcpFixedCallModuleFeedRequest(pathname: string, args: Row) {
-  const params = new URLSearchParams();
-  const block = optionalNonNegativeInt(args, "block");
-  if (block != null) params.set("block", String(block));
-  const callFunction = optionalString(args, "call_function");
-  if (callFunction) params.set("call_function", callFunction);
-  const success = optionalSuccessFilter(args);
-  if (success !== undefined) params.set("success", String(success));
-  const blockStart = optionalNonNegativeInt(args, "block_start");
-  if (blockStart != null) params.set("block_start", String(blockStart));
-  const blockEnd = optionalNonNegativeInt(args, "block_end");
-  if (blockEnd != null) params.set("block_end", String(blockEnd));
-  const from = optionalNonNegativeInt(args, "from");
-  if (from != null) params.set("from", String(from));
-  const to = optionalNonNegativeInt(args, "to");
-  if (to != null) params.set("to", String(to));
-  if (args?.limit != null) params.set("limit", String(args.limit));
-  if (args?.offset != null) params.set("offset", String(args.offset));
-  const cursor = optionalString(args, "cursor");
-  if (cursor) params.set("cursor", cursor);
-  const qs = params.toString();
-  return new Request(`https://d${pathname}${qs ? `?${qs}` : ""}`);
-}
-
-function mcpExtrinsicDetailRequest(ref: string) {
-  return new Request(`https://d/api/v1/extrinsics/${encodeURIComponent(ref)}`);
 }
 
 // TWO REQUEST BUILDERS REMOVED HERE (#10190). They synthesised the
@@ -5718,27 +5644,22 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/validators`),
             "METAGRAPH_NEURONS_SOURCE",
           ).then((data) => data ?? buildSubnetValidators([], netuid)),
-          tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/events`, {
-              limit: recentEventsLimit,
-              offset: 0,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-            // THE COLD RUNG, via the composer that owns the ladder (#10320).
-            // This card fell straight from the retired tier to
-            // `buildSubnetEvents([])`, so the snapshot served
-            // `event_count: 0` while its own standalone twin served ten rows
-            // for the same subnet in the same minute -- verified live on SN64,
-            // 2026-08-09. A card was wired and its embedded copy was not,
-            // which is precisely the class the widened tier-cascade gate now
-            // catches on all three surfaces.
-          ).then((data) =>
-            answerSubnetEvents(ctx.env, netuid, data as Row | null, {
-              limit: recentEventsLimit,
-              offset: 0,
-            }),
-          ),
+          // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"
+          // in wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so the
+          // promise this composer awaited resolved to null on every call -- the
+          // composer's own cold rung has been the answer.
+          //
+          // THE COLD RUNG, via the composer that owns the ladder (#10320). This
+          // card fell straight from the retired tier to `buildSubnetEvents([])`,
+          // so the snapshot served `event_count: 0` while its own standalone twin
+          // served ten rows for the same subnet in the same minute -- verified
+          // live on SN64, 2026-08-09. A card was wired and its embedded copy was
+          // not, which is precisely the class the widened tier-cascade gate now
+          // catches on all three surfaces.
+          answerSubnetEvents(ctx.env, netuid, null, {
+            limit: recentEventsLimit,
+            offset: 0,
+          }),
         ]);
       // list_subnet_validators' own limit post-filter (the loader already
       // ranks by stake_tao DESC, so slicing after is a no-op re-sort) --
@@ -5870,15 +5791,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     ) {
       const netuid = requireNetuid(args);
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/health/trends`),
-          "METAGRAPH_HEALTH_SOURCE",
-        )) ??
-        (await loadSubnetHealthTrends(netuid, {
+        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        await loadSubnetHealthTrends(netuid, {
           observedAt: await mcpObservedAt(ctx),
           db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
-        }))
+        })
       );
     },
   },
@@ -5918,20 +5837,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const offset = Number.isFinite(row?.offset)
         ? Math.max(0, Math.floor(row.offset as number))
         : 0;
-      // Forwarded on the tier request too, so the narrowing survives whichever
-      // tier answers -- a parameter honoured on one path and dropped on the
-      // other is the "looks filtered, is not" failure.
-      const query = new URLSearchParams();
-      if (window) query.set("window", window);
-      if (limit !== null) query.set("limit", String(limit));
-      if (offset) query.set("offset", String(offset));
-      const suffix = query.size ? `?${query}` : "";
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest(`/api/v1/health/trends${suffix}`),
-        "METAGRAPH_HEALTH_SOURCE",
-      );
-      if (postgres) return postgres;
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so the tier this narrowing was
+      // also encoded into a query string for never answered. The loader below
+      // takes the same three parameters directly, so nothing is dropped.
       const { data } = await loadBulkHealthTrends({
         observedAt: await mcpObservedAt(ctx),
         db: readStore(ctx.env, UPTIME_DAILY_TABLES) as never,
@@ -5964,19 +5873,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       }
       const { label } = parsed!;
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(
-            `/api/v1/subnets/${netuid}/health/percentiles`,
-            { window: label },
-          ),
-          "METAGRAPH_HEALTH_SOURCE",
-        )) ??
-        (await loadSubnetPercentiles(netuid, {
+        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        await loadSubnetPercentiles(netuid, {
           window: label,
           observedAt: await mcpObservedAt(ctx),
           db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
-        }))
+        })
       );
     },
   },
@@ -6004,18 +5908,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       }
       const { label } = parsed!;
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/health/incidents`, {
-            window: label,
-          }),
-          "METAGRAPH_HEALTH_SOURCE",
-        )) ??
-        (await loadSubnetIncidents(netuid, {
+        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        await loadSubnetIncidents(netuid, {
           window: label,
           observedAt: await mcpObservedAt(ctx),
           db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
-        }))
+        })
       );
     },
   },
@@ -6933,14 +6833,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_STAKE_FLOW_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/stake-flow", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse
         // aggregate, through the same builder. See
         // src/chain-stake-flow-artifact.ts.
@@ -6977,11 +6872,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_ALPHA_VOLUME_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/alpha-volume", { limit }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse
         // aggregate, through the same builder. See
         // src/chain-alpha-volume-artifact.ts. The market-cap index is
@@ -6990,8 +6883,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         (await loadChainAlphaVolumeFromArtifact(ctx.env, {
           limit,
           marketCapByNetuid: await resolveMarketCapIndex(ctx.env),
-        })) ??
-        buildChainAlphaVolume([], { limit })
+        })) ?? buildChainAlphaVolume([], { limit })
       );
     },
   },
@@ -7027,14 +6919,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_WEIGHTS_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/weights", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // Same shared loader REST and GraphQL use (#9229's parity lesson).
         (await loadChainWeightsColdTier(
           ctx.env as unknown as Parameters<typeof loadChainWeightsColdTier>[0],
@@ -7082,21 +6969,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss. Postgres → schema-stable empty stub, never a live D1 read.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/weights/setters", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadChainWeightSettersColdTier(
           ctx.env as unknown as Parameters<
             typeof loadChainWeightSettersColdTier
           >[0],
           { window, limit },
-        )) ??
-        buildChainWeightSetters([], null, { window, limit })
+        )) ?? buildChainWeightSetters([], null, { window, limit })
       );
     },
   },
@@ -7136,14 +7017,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss. Postgres → schema-stable empty stub, never a live D1 read.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/stake-moves", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse
         // aggregate, through the same builder. See
         // src/chain-stake-moves-artifact.ts.
@@ -7188,22 +7064,16 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss. Postgres → schema-stable empty stub, never a live D1 read.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/stake-transfers", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse
         // aggregate, through the same builder. See
         // src/chain-stake-transfers-artifact.ts.
         (await loadChainStakeTransfersFromArtifact(ctx.env, {
           window,
           limit,
-        })) ??
-        buildChainStakeTransfers([], { window, limit })
+        })) ?? buildChainStakeTransfers([], { window, limit })
       );
     },
   },
@@ -7224,7 +7094,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetChainAxonRemovalsInputSchema),
     async handler(
       args: z.infer<typeof GetChainAxonRemovalsInputSchema>,
-      ctx: McpCtx,
+      _ctx: McpCtx,
     ) {
       const window =
         optionalString(args, "window") ?? DEFAULT_CHAIN_AXON_REMOVALS_WINDOW;
@@ -7243,14 +7113,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss (#6013).
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/axon-removals", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildChainAxonRemovals([], { window, limit })
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        buildChainAxonRemovals([], { window, limit })
       );
     },
   },
@@ -7291,14 +7157,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss (#6013).
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/serving", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // Same shared loader the REST route and GraphQL use, so all three
         // surfaces answer from one implementation. Without this the tool kept
         // returning the zeroed card while /api/v1/chain/serving returned real
@@ -7306,8 +7167,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         (await loadChainServingColdTier(
           ctx.env as unknown as Parameters<typeof loadChainServingColdTier>[0],
           { window, limit },
-        )) ??
-        buildChainServing([], { window, limit })
+        )) ?? buildChainServing([], { window, limit })
       );
     },
   },
@@ -7348,22 +7208,16 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss (#6013).
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/prometheus", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The lakehouse rung, same as REST and GraphQL (#10248).
         (await loadChainPrometheusColdTier(
           ctx.env as unknown as Parameters<
             typeof loadChainPrometheusColdTier
           >[0],
           { window, limit },
-        )) ??
-        buildChainPrometheus([], { window, limit })
+        )) ?? buildChainPrometheus([], { window, limit })
       );
     },
   },
@@ -7563,16 +7417,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/stake-flow`, {
-              window,
-              direction,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9146: same chain-stake-flow projection slice REST reads, so the
         // MCP tool and the route cannot disagree about one subnet's flow.
         (
@@ -7580,8 +7427,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             window,
             direction,
           })
-        )?.data ??
-        buildStakeFlow([], netuid, { window })
+        )?.data ?? buildStakeFlow([], netuid, { window })
       );
     },
   },
@@ -7619,14 +7465,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/event-summary`, {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9303: the lakehouse carries the same stream, so an agent gets the
         // real per-kind rollup instead of a zeroed card.
         (await loadSubnetEventSummaryColdTier(ctx.env, netuid, {
@@ -7665,13 +7506,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/weights`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadSubnetWeightsColdTier(
           ctx.env as unknown as Parameters<typeof loadSubnetWeightsColdTier>[0],
           netuid,
@@ -7679,8 +7516,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: window,
             windowDays: SUBNET_WEIGHTS_WINDOWS[window] ?? 7,
           },
-        )) ??
-        buildSubnetWeights(null, netuid, { window })
+        )) ?? buildSubnetWeights(null, netuid, { window })
       );
     },
   },
@@ -7710,13 +7546,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/weights/setters`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadSubnetWeightSettersColdTier(
           ctx.env as unknown as Parameters<
             typeof loadSubnetWeightSettersColdTier
@@ -7727,8 +7559,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[window] ?? 7,
             limit: SUBNET_WEIGHT_SETTERS_LIMIT,
           },
-        )) ??
-        buildSubnetWeightSetters([], null, netuid, { window })
+        )) ?? buildSubnetWeightSetters([], null, netuid, { window })
       );
     },
   },
@@ -7757,13 +7588,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/registrations`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
           ctx.env as unknown as Parameters<
             typeof loadSubnetEventCardColdTier
@@ -7775,8 +7602,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: window,
             windowDays: SUBNET_REGISTRATIONS_WINDOWS[window] ?? 7,
           },
-        )) ??
-        buildSubnetRegistrations(null, netuid, { window })
+        )) ?? buildSubnetRegistrations(null, netuid, { window })
       );
     },
   },
@@ -7805,13 +7631,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/stake-moves`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
           ctx.env as unknown as Parameters<
             typeof loadSubnetEventCardColdTier
@@ -7823,8 +7645,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: window,
             windowDays: SUBNET_STAKE_MOVES_WINDOWS[window] ?? 7,
           },
-        )) ??
-        buildSubnetStakeMoves(null, netuid, { window })
+        )) ?? buildSubnetStakeMoves(null, netuid, { window })
       );
     },
   },
@@ -7854,13 +7675,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/stake-transfers`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
           ctx.env as unknown as Parameters<
             typeof loadSubnetEventCardColdTier
@@ -7872,8 +7689,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: window,
             windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[window] ?? 7,
           },
-        )) ??
-        buildSubnetStakeTransfers(null, netuid, { window })
+        )) ?? buildSubnetStakeTransfers(null, netuid, { window })
       );
     },
   },
@@ -7891,7 +7707,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetSubnetAxonRemovalsInputSchema),
     async handler(
       args: z.infer<typeof GetSubnetAxonRemovalsInputSchema>,
-      ctx: McpCtx,
+      _ctx: McpCtx,
     ) {
       const netuid = requireNetuid(args);
       const window =
@@ -7903,13 +7719,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/axon-removals`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? buildSubnetAxonRemovals(null, netuid, { window })
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        buildSubnetAxonRemovals(null, netuid, { window })
       );
     },
   },
@@ -7940,13 +7753,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/serving`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadSubnetEventCardColdTier(
           ctx.env as unknown as Parameters<
             typeof loadSubnetEventCardColdTier
@@ -7958,8 +7767,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: window,
             windowDays: SUBNET_SERVING_WINDOWS[window] ?? 7,
           },
-        )) ??
-        buildSubnetServing(null, netuid, { window })
+        )) ?? buildSubnetServing(null, netuid, { window })
       );
     },
   },
@@ -7990,13 +7798,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/prometheus`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #10322: same cold-tier rung as its REST and GraphQL twins.
         (await loadSubnetEventCardColdTier(
           ctx.env as unknown as Parameters<
@@ -8009,8 +7813,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             windowLabel: window,
             windowDays: SUBNET_PROMETHEUS_WINDOWS[window] ?? 7,
           },
-        )) ??
-        buildSubnetPrometheus(null, netuid, { window })
+        )) ?? buildSubnetPrometheus(null, netuid, { window })
       );
     },
   },
@@ -8050,13 +7853,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/deregistrations`, {
-            window,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9307: the UID-reuse derivation REST reads, then the same MARKED
         // empty when nothing derived it.
         (await loadSubnetDeregistrationsFromArtifact(ctx.env, netuid, {
@@ -8180,19 +7979,20 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       }
       const minSamples = optionalNonNegativeInt(args, "min_samples");
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/uptime`, {
-            window: window as string,
-            min_samples: minSamples,
-          }),
-          "METAGRAPH_HEALTH_SOURCE",
-        )) ??
-        ((await loadSubnetUptime(netuid, {
+        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        //
+        // `min_samples` reached the loader only through that dead tier request,
+        // so this tool accepted the argument, validated it, and then answered as
+        // if it had not been given -- a dropped filter reads as a real answer.
+        // Passed through here, exactly as handleUptime passes it.
+        (await loadSubnetUptime(netuid, {
           window: window ?? undefined,
           observedAt: await mcpObservedAt(ctx),
+          minSamples: minSamples ?? null,
           db: readStore(ctx.env, UPTIME_DAILY_TABLES) as never,
-        })) as Row)
+        } as unknown as Parameters<typeof loadSubnetUptime>[1])) as Row
       );
     },
   },
@@ -8323,30 +8123,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // request (structure/economics never touch D1/Postgres, they're
       // registry+economics-tier reads) -- mirror that exactly rather than
       // wrapping the whole tool in tryPostgresTier's usual passthrough.
-      if (dimensions.includes("health")) {
-        const postgres = await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/internal/compare-health", {
-            netuids: netuids.join(","),
-          }),
-          "METAGRAPH_HEALTH_SOURCE",
-        );
-        if (postgres) {
-          const { subnetMeta, mostComplete } =
-            profilesProjectionFromRows(profiles);
-          return composeCompareData({
-            requestedNetuids: netuids,
-            dimensions,
-            subnetMeta,
-            structureRows: mostComplete,
-            economicsRows: dimensions.includes("economics")
-              ? economicsRows
-              : null,
-            healthRows: postgres.rows as Row[],
-            observedAt,
-          });
-        }
-      }
+      // NO TIER READ (#10190): the health dimension used to try
+      // METAGRAPH_HEALTH_SOURCE first. That flag reads "d1" in wrangler.jsonc and
+      // is absent from DATA_API_FORWARD_FLAGS, so the read resolved to null and
+      // the composer below has answered every dimension all along.
       return loadCompareSubnets({
         profiles,
         economicsRows,
@@ -8376,24 +8156,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       }
       const { label, days } = parsed!;
       const data =
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/incidents", {
-            window: label,
-            netuid: args?.netuid,
-            limit: args?.limit,
-            cursor: args?.cursor,
-            sort: args?.sort,
-            order: args?.order,
-          }),
-          "METAGRAPH_HEALTH_SOURCE",
-        )) ??
-        (await loadGlobalIncidents({
+        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        await loadGlobalIncidents({
           windowLabel: label,
           windowDays: days,
           observedAt: await mcpObservedAt(ctx),
           db: readStore(ctx.env, HEALTH_CHECK_TABLES) as never,
-        }));
+        });
       return applyGlobalIncidentsListQuery(
         data as Record<string, unknown>,
         args,
@@ -8835,16 +8606,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // own outputSchema (hotkey/nominator_count/nominators at the top
       // level) the moment METAGRAPH_ACCOUNT_EVENTS_SOURCE flips to postgres.
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(
-              `/api/v1/validators/${encodeURIComponent(hotkey)}/nominators`,
-              { window, sort, limit, offset, coldkey },
-            ),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (
           await loadValidatorNominatorsColdTier(ctx.env, hotkey, {
             window,
@@ -9069,18 +8833,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       const tierResult =
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/events`, {
-            kind,
-            block_start: blockStart,
-            block_end: blockEnd,
-            limit,
-            offset,
-            cursor,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? null;
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        null;
       // Through the composer (src/subnet-events-answer.ts), which owns the tier
       // order and the empty floor for REST, MCP and GraphQL alike -- the
       // lakehouse leg it adds is why this tool no longer reports event_count 0
@@ -9239,19 +8995,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           ? netEconomics.economics.alpha_market_cap_tao
           : null;
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/volume`),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (
           await loadSubnetAlphaVolumeFromArtifact(ctx.env, netuid, {
             marketCapTao,
           })
-        )?.data ??
-        buildAlphaVolume([], netuid, { marketCapTao })
+        )?.data ?? buildAlphaVolume([], netuid, { marketCapTao })
       );
     },
   },
@@ -9302,17 +9053,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/subnets/${netuid}/ohlc`, {
-              interval,
-              days,
-              limit,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The SAME lakehouse reader REST's handleSubnetOhlc falls to, so the
         // two surfaces cannot disagree about a subnet's candles.
         (
@@ -9321,8 +9064,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             days,
             limit,
           })
-        )?.data ??
-        buildSubnetOhlc([], netuid, { interval, limit })
+        )?.data ?? buildSubnetOhlc([], netuid, { interval, limit })
       );
     },
   },
@@ -10311,18 +10053,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetAccountInputSchema),
     async handler(args: z.infer<typeof GetAccountInputSchema>, ctx: McpCtx) {
       const ss58 = requireSs58(args);
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}`),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      );
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+      // guarded resolved to null before it could touch DATA_API.
       // #9263: the SAME composition REST and GraphQL run. A tier that exists
       // and could not answer DECLINES here rather than handing back a zeroed
       // card -- an agent told an account has no history will reason from it and
       // will not think to re-ask, the way a person reloading a page might.
-      const answer = postgres
-        ? null
-        : await answerAccountSummary(ctx.env, ss58);
+      const answer = await answerAccountSummary(ctx.env, ss58);
       if (answer?.kind === "gap") {
         throw toolError(
           ACCOUNT_SUMMARY_GAP_CODE,
@@ -10330,10 +10068,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       const data =
-        postgres ??
-        (answer?.kind === "answer"
-          ? answer.data
-          : buildAccountSummary(ss58, {}));
+        answer?.kind === "answer" ? answer.data : buildAccountSummary(ss58, {});
       // Community-contributable entity labels (#6739), same REST-parity join
       // as workers/request-handlers/entities.ts's own handleAccount.
       const entitiesArtifact = rowOf(
@@ -10592,19 +10327,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/events`, {
-            kind,
-            netuid,
-            block_start: blockStart,
-            block_end: blockEnd,
-            limit,
-            offset,
-            cursor,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadAccountEventsColdTier(ctx.env, ss58, {
           limit,
           offset,
@@ -10794,21 +10519,16 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
                 unavailableAccountPositions(ss58),
             ),
           ),
-          tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/events`, {
+          // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"
+          // in wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this
+          // promise resolved to null on every call and the builder below has been
+          // the answer.
+          Promise.resolve(
+            buildAccountEvents([], ss58, {
               limit: recentEventsLimit,
               offset: 0,
+              nextCursor: null,
             }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          ).then(
-            (data) =>
-              data ??
-              buildAccountEvents([], ss58, {
-                limit: recentEventsLimit,
-                offset: 0,
-                nextCursor: null,
-              }),
           ),
         ]);
       return {
@@ -10960,23 +10680,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/stake-flow`, {
-              window,
-              direction,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (
           await loadAccountStakeFlowColdTier(ctx.env, ss58, {
             window,
             direction,
           })
-        )?.data ??
-        buildAccountStakeFlow([], ss58, { window })
+        )?.data ?? buildAccountStakeFlow([], ss58, { window })
       );
     },
   },
@@ -11007,18 +10719,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/stake-moves`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadAccountStakeMovesColdTier(ctx.env, ss58, { window }))
-          ?.data ??
-        buildAccountStakeMoves([], ss58, { window })
+          ?.data ?? buildAccountStakeMoves([], ss58, { window })
       );
     },
   },
@@ -11037,7 +10742,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetAccountAxonRemovalsInputSchema),
     async handler(
       args: z.infer<typeof GetAccountAxonRemovalsInputSchema>,
-      ctx: McpCtx,
+      _ctx: McpCtx,
     ) {
       const ss58 = requireSs58(args);
       const window =
@@ -11049,15 +10754,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/axon-removals`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ?? buildAccountAxonRemovals([], ss58, { window })
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        buildAccountAxonRemovals([], ss58, { window })
       );
     },
   },
@@ -11089,21 +10789,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/prometheus`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #10322: the cold-tier rung REST and GraphQL gained; without it this
         // tool alone would answer a confident zero and the three surfaces
         // would disagree on one event stream.
         (await loadAccountPrometheusColdTier(ctx.env, ss58, { window }))
-          ?.data ??
-        buildAccountPrometheus([], ss58, { window })
+          ?.data ?? buildAccountPrometheus([], ss58, { window })
       );
     },
   },
@@ -11134,20 +10827,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/registrations`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9146: same lakehouse read the REST handler uses, so the tool and
         // the route cannot report different footprints.
         (await loadAccountRegistrationsColdTier(ctx.env, ss58, { window }))
-          ?.data ??
-        buildAccountRegistrations([], ss58, { window })
+          ?.data ?? buildAccountRegistrations([], ss58, { window })
       );
     },
   },
@@ -11177,18 +10863,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/weight-setters`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadAccountWeightSettersColdTier(ctx.env, ss58, { window }))
-          ?.data ??
-        buildAccountWeightSetters([], ss58, { window })
+          ?.data ?? buildAccountWeightSetters([], ss58, { window })
       );
     },
   },
@@ -11219,15 +10898,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/serving`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9146: same lakehouse read the REST handler uses.
         (await loadAccountServingColdTier(ctx.env, ss58, { window }))?.data ??
         buildAccountServing([], ss58, { window })
@@ -11262,15 +10935,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (
-          await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/deregistrations`, {
-              window,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )
-        )?.data ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9307: an account's deregistrations are the slots where it was the
         // PREVIOUS holder, derived from UID reuse.
         (
@@ -11315,14 +10982,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         cursor: cursor ?? undefined,
       };
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(
-            `/api/v1/accounts/${ss58}/history`,
-            historyOptions,
-          ),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ?? (await loadAccountHistory(ctx.env, ss58, historyOptions))
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        await loadAccountHistory(ctx.env, ss58, historyOptions)
       );
     },
   },
@@ -11354,17 +11017,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/extrinsics`, {
-            block_start: blockStart,
-            block_end: blockEnd,
-            limit,
-            offset,
-            cursor,
-          }),
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadAccountExtrinsicsColdTier(ctx.env, ss58, {
           limit,
           offset,
@@ -11436,18 +11091,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ? Math.max(0, Math.floor(args.offset as number))
         : 0;
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/transfers`, {
-            direction,
-            block_start: blockStart,
-            block_end: blockEnd,
-            limit,
-            offset,
-            cursor,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadAccountTransfersColdTier(ctx.env, ss58, {
           limit,
           offset,
@@ -11508,14 +11154,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           { limit: args?.limit },
         );
         return (
-          (await tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/counterparties`, {
-              counterparty,
-              limit: args?.limit,
-            }),
-            "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-          )) ??
+          // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+          // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+          // resolved to null before it could touch DATA_API.
           (await loadCounterpartyRelationshipColdTier(
             ctx.env,
             ss58,
@@ -11535,17 +11176,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/counterparties`, {
-            limit: args?.limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         (await loadAccountCounterpartiesColdTier(ctx.env, ss58, {
           limit: args?.limit,
-        })) ??
-        buildCounterparties([], ss58, { limit: args?.limit })
+        })) ?? buildCounterparties([], ss58, { limit: args?.limit })
       );
     },
   },
@@ -11665,35 +11301,29 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // tryPostgresTier's result -- workers/data-api.ts's /blocks/:ref/extrinsics
       // route returns `json({ data: buildBlockExtrinsics(...) })`, not a flat
       // buildBlockExtrinsics(...) body like the sibling account-extrinsics route.
-      const { data } = (await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest(
-          `/api/v1/blocks/${encodeURIComponent(ref)}/extrinsics`,
-          {
-            limit,
-            offset,
-          },
-        ),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) ?? {
-        // Lazily built only when the Postgres tier missed, mirroring REST's
-        // handleBlockExtrinsics -- including #9208's hot/cold/decline routing,
-        // so an MCP caller and a REST caller get the same answer for the same
-        // block rather than the tool quietly keeping the old empty.
-        data: chainDetailAnswerOrThrow(
-          await answerBlockDetail(ctx.env, ref, {
-            hot: (height) =>
-              loadBlockExtrinsicsHotTier(ctx.env, ref, height, {
-                limit,
-                offset,
-              }),
-            cold: () =>
-              loadBlockExtrinsicsColdTier(ctx.env, ref, { limit, offset }),
-            isEmpty: isEmptyExtrinsicPayload,
-          }),
-          () => buildBlockExtrinsics([], ref, null, { limit, offset }),
-        ),
-      };
+      const { data } =
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        {
+          // Lazily built only when the Postgres tier missed, mirroring REST's
+          // handleBlockExtrinsics -- including #9208's hot/cold/decline routing,
+          // so an MCP caller and a REST caller get the same answer for the same
+          // block rather than the tool quietly keeping the old empty.
+          data: chainDetailAnswerOrThrow(
+            await answerBlockDetail(ctx.env, ref, {
+              hot: (height) =>
+                loadBlockExtrinsicsHotTier(ctx.env, ref, height, {
+                  limit,
+                  offset,
+                }),
+              cold: () =>
+                loadBlockExtrinsicsColdTier(ctx.env, ref, { limit, offset }),
+              isEmpty: isEmptyExtrinsicPayload,
+            }),
+            () => buildBlockExtrinsics([], ref, null, { limit, offset }),
+          ),
+        };
       return data;
     },
   },
@@ -11720,31 +11350,25 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // tryPostgresTier's result -- workers/data-api.ts's /blocks/:ref/events
       // route returns `json({ data: buildBlockEvents(...) })`, not a flat
       // buildBlockEvents(...) body like the sibling account-events routes.
-      const { data } = (await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest(
-          `/api/v1/blocks/${encodeURIComponent(ref)}/events`,
-          {
-            limit,
-            offset,
-          },
-        ),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ?? {
-        // Lazily built only when the Postgres tier missed, mirroring REST's
-        // handleBlockEvents -- #9208's routing included, for the same reason as
-        // list_block_extrinsics above.
-        data: chainDetailAnswerOrThrow(
-          await answerBlockDetail(ctx.env, ref, {
-            hot: (height) =>
-              loadBlockEventsHotTier(ctx.env, ref, height, { limit, offset }),
-            cold: () =>
-              loadBlockEventsColdTier(ctx.env, ref, { limit, offset }),
-            isEmpty: isEmptyEventPayload,
-          }),
-          () => buildBlockEvents([], ref, null, { limit, offset }),
-        ),
-      };
+      const { data } =
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        {
+          // Lazily built only when the Postgres tier missed, mirroring REST's
+          // handleBlockEvents -- #9208's routing included, for the same reason as
+          // list_block_extrinsics above.
+          data: chainDetailAnswerOrThrow(
+            await answerBlockDetail(ctx.env, ref, {
+              hot: (height) =>
+                loadBlockEventsHotTier(ctx.env, ref, height, { limit, offset }),
+              cold: () =>
+                loadBlockEventsColdTier(ctx.env, ref, { limit, offset }),
+              isEmpty: isEmptyEventPayload,
+            }),
+            () => buildBlockEvents([], ref, null, { limit, offset }),
+          ),
+        };
       return data;
     },
   },
@@ -11815,11 +11439,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // tryPostgresTier contract, same METAGRAPH_EXTRINSICS_SOURCE flag, so this
       // tool and GET /api/v1/extrinsics never diverge on which tier answered.
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpExtrinsicsListRequest(args),
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // call_hash matches inside call_args, which the lakehouse cannot
         // express -- its presence skips the tier entirely rather than
         // ignoring the filter (same gate as REST's handleExtrinsics).
@@ -11868,12 +11490,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // Mirrors REST's handleExtrinsic: try Postgres first (#4694), fall back to
       // the schema-stable empty detail now that extrinsics' D1 write path is
       // retired (#4772) and the table is dropped in production.
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpExtrinsicDetailRequest(ref),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      );
-      if (postgres) return postgres;
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+      // guarded resolved to null before it could touch DATA_API.
       // #9208: hot tier ahead of the lakehouse, and a DECLINE when a composite
       // `<block>-<index>` ref names a position neither tier can answer. A HASH
       // ref keeps the schema-stable empty -- see answerExtrinsicDetail.
@@ -11897,11 +11516,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     inputSchema: inputJsonSchema(GetSudoInputSchema),
     async handler(args: z.infer<typeof GetSudoInputSchema>, ctx: McpCtx) {
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpFixedCallModuleFeedRequest("/api/v1/sudo", args),
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The category predicate is data-api's own pathname->module mapping
         // ("Sudo"), expressed against the lakehouse verbatim.
         (await loadExtrinsicFeedColdTier(ctx.env, {
@@ -12011,14 +11628,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpFixedCallModuleFeedRequest(
-            "/api/v1/governance/config-changes",
-            args,
-          ),
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The category predicate is data-api's own pathname->module mapping
         // ("AdminUtils"), expressed against the lakehouse verbatim.
         (await loadExtrinsicFeedColdTier(ctx.env, {
@@ -12347,16 +11959,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         );
       }
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/calls", {
-            window: label,
-            group_by: groupBy,
-            limit,
-            call_module: callModule,
-          }),
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse call
         // mix, sliced to this call's limit and fed through the same
         // formatter; a call_module scope declines. See
@@ -12408,17 +12013,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           "call_module must be at most 100 characters.",
         );
       }
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest("/api/v1/chain/signers", {
-          window: label,
-          sort,
-          limit,
-          call_module: callModule,
-        }),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      );
-      if (postgres) return postgres;
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+      // guarded resolved to null before it could touch DATA_API.
       // The projection tier (#9146): the cron-recomputed lakehouse
       // leaderboard, sliced to this call's limit and fed through the same
       // formatter; a call_module scope declines. See
@@ -12467,22 +12064,11 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and
       // the table is dropped in production, so a D1 query here would always
       // miss. Postgres → schema-stable empty stub, never a live D1 read.
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest("/api/v1/chain/fees", {
-          window: label,
-          limit,
-          call_module: callModule,
-        }),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      );
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+      // guarded resolved to null before it could touch DATA_API.
       // #8421: mirror handleChainFees's #8242 fix -- trim the UTC-day buckets to
       // the requested window so a 7d request never reports 8 days.
-      if (postgres)
-        return trimChainFeesToWindow(
-          postgres as unknown as ReturnType<typeof buildChainFees>,
-          days,
-        );
       // The projection tier (#9146): the cron-recomputed lakehouse fee
       // series, sliced to this call's limit and fed through the same
       // formatter; a call_module scope declines. Trimmed like every other
@@ -12531,20 +12117,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss (#6013).
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/registrations", {
-            window: label,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9146: same chain-registrations projection REST and GraphQL read.
         (await loadChainRegistrationsFromArtifact(ctx.env, {
           window: label,
           limit,
-        })) ??
-        buildChainRegistrations([], { window: label, limit })
+        })) ?? buildChainRegistrations([], { window: label, limit })
       );
     },
   },
@@ -12584,14 +12164,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // and the table is dropped in production, so a D1 query here would
       // always miss (#6013).
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/deregistrations", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9307: NeuronDeregistered has never been emitted; the feed is
         // derived from UID reuse by the chain-deregistrations projection lane.
         (await loadChainDeregistrationsFromArtifact(ctx.env, {
@@ -12633,14 +12208,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_TRANSFER_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/transfers", {
-            window,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse
         // scorecard, sliced to this call's limit and fed through the same
         // formatter. See src/chain-transfers-artifact.ts.
@@ -12690,15 +12260,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         CHAIN_TRANSFER_PAIR_LIMIT_MAX,
       );
       return (
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest("/api/v1/chain/transfer-pairs", {
-            window,
-            sort,
-            limit,
-          }),
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): the cron-recomputed lakehouse
         // corridor leaderboard, sliced to this call's limit and fed through
         // the same formatter. See src/chain-transfer-pairs-artifact.ts.
@@ -12740,19 +12304,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // (#4772) and the tables are dropped in production, so a D1 query here
       // would always miss. Postgres → schema-stable empty stub, never a live
       // D1 read.
-      const postgres = await tryPostgresTier(
-        ctx.env,
-        mcpNeuronsTierRequest("/api/v1/chain/activity", { window: label }),
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      );
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+      // guarded resolved to null before it could touch DATA_API.
       // #8421: mirror handleChainActivity's #8242 fix -- the UTC-day buckets
       // span one extra calendar day, so trim to the requested window before
       // returning so day_count can't contradict the window label.
-      if (postgres)
-        return trimChainActivityToWindow(
-          postgres as unknown as ReturnType<typeof buildChainActivity>,
-          days,
-        );
       // The projection tier (#9146): the cron-recomputed lakehouse daily
       // series, through the same formatter and the same trim. See
       // src/chain-activity-artifact.ts.

--- a/src/read-store-tables.ts
+++ b/src/read-store-tables.ts
@@ -61,10 +61,6 @@ export const TOP_HOLDERS_HOLDINGS_TABLES = [
   "subnet_snapshots",
 ] as const;
 
-/** loadAccountStakeMovesColdTier's #4332 price-at-tx enrichment: the daily
- * alpha price on the day of each subnet's most recent move. */
-export const ACCOUNT_STAKE_MOVES_PRICE_TABLES = ["subnet_snapshots"] as const;
-
 /** loadSubnetTempo, in the weight-setters loader. */
 export const SUBNET_HYPERPARAMS_TEMPO_TABLES = ["subnet_hyperparams"] as const;
 

--- a/src/read-store-tables.ts
+++ b/src/read-store-tables.ts
@@ -61,6 +61,10 @@ export const TOP_HOLDERS_HOLDINGS_TABLES = [
   "subnet_snapshots",
 ] as const;
 
+/** loadAccountStakeMovesColdTier's #4332 price-at-tx enrichment: the daily
+ * alpha price on the day of each subnet's most recent move. */
+export const ACCOUNT_STAKE_MOVES_PRICE_TABLES = ["subnet_snapshots"] as const;
+
 /** loadSubnetTempo, in the weight-setters loader. */
 export const SUBNET_HYPERPARAMS_TEMPO_TABLES = ["subnet_hyperparams"] as const;
 

--- a/src/reliability-badge.ts
+++ b/src/reliability-badge.ts
@@ -1,0 +1,126 @@
+// The badge's reliability aggregate, and why it does not live in health-serving.
+//
+// It reads surface_uptime_daily through `loadSubnetUptime`, which lives in
+// src/analytics-live.ts -- and analytics-live already imports
+// src/health-serving.ts. Putting this back there closes that into a cycle, and
+// the cycle is not merely untidy: analytics-live reaches
+// workers/request-handlers/analytics-routes.ts and from there
+// workers/responses.ts, whose module-level `SERVICE_DESC_LINK` template then
+// evaluates before `PRIMARY_DOMAIN` is initialised. The build fails at the
+// openapi-zod step with `Cannot access 'PRIMARY_DOMAIN' before initialization`
+// -- a TDZ error hundreds of modules away from the import that caused it.
+//
+// src/badge.ts is the only consumer and nothing analytics-live reaches imports
+// it, so this side of the edge is the one with no cycle to close.
+import { scoreFromStats } from "./reliability.ts";
+import { loadSubnetUptime } from "./analytics-live.ts";
+import { readStore } from "./read-store.ts";
+import { UPTIME_DAILY_TABLES } from "./read-store-tables.ts";
+
+/** Cap on how many subnets a provider badge will aggregate over.
+ *
+ * One synthesized request per netuid (see below). A subnet badge -- the case
+ * that matters, and the one the README flywheel is about -- is always exactly
+ * one. This bounds the pathological provider spanning the whole registry;
+ * beyond it the badge scores the first N by netuid rather than timing out. */
+const RELIABILITY_BADGE_MAX_NETUIDS = 24;
+
+/** The window the badge scores over.
+ *
+ * loadSubnetUptime's own default, stated rather than left implicit: the badge
+ * used to inherit it from /api/v1/subnets/{netuid}/uptime's default and now
+ * asks for it, so a change to that route's default cannot silently move what
+ * the badge means. */
+const RELIABILITY_BADGE_WINDOW = "90d";
+
+/**
+ * Sample-weighted reliability across one or many subnets, for the badge.
+ *
+ * This was a stub returning null from the 2026-07-17 D1 elimination onward --
+ * its own comment said the table had "no Postgres-tier mirror wired for the
+ * badge read path yet", so `?metric=uptime` and `?metric=grade` rendered "n/a"
+ * for every subnet on earth. Confirmed live before this fix: SN64's badge said
+ * `metagraphed: n/a` while /api/v1/subnets/64/uptime reported a real 0.9161
+ * ratio at grade C from the same underlying data.
+ *
+ * There was never a missing mirror -- /api/v1/subnets/{netuid}/uptime already
+ * serves exactly this, Postgres-tier, through METAGRAPH_HEALTH_SOURCE. So this
+ * synthesizes an internal request per netuid rather than adding new plumbing,
+ * the same "no client request to forward, synthesize one" shape handleCompare
+ * uses for this table.
+ *
+ * Aggregation is sample-weighted, not a mean of ratios: a subnet with 30k
+ * probes and one with 40 shouldn't count equally. Re-derives the composite via
+ * scoreFromStats so the badge's grade bands can't drift from the ones
+ * /uptime's own `reliability` block reports.
+ */
+export async function loadReliabilityAggregate(
+  env: Env,
+  { netuids }: { netuids: number[] },
+): Promise<{ grade: string; uptime_ratio: number } | null> {
+  const targets = netuids.slice(0, RELIABILITY_BADGE_MAX_NETUIDS);
+  if (targets.length === 0) return null;
+
+  const blocks = await Promise.all(
+    targets.map(async (netuid) => {
+      // THE LOADER, not a synthesized request through the tier (#10190).
+      //
+      // #8329 fixed the "n/a" badge by forwarding an internal
+      // /api/v1/subnets/{netuid}/uptime request to the Postgres tier, because
+      // that is where the route read from at the time. METAGRAPH_HEALTH_SOURCE
+      // reads "d1" in wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS,
+      // so the forward stopped happening and every block came back null --
+      // measured on production 2026-08-11, before this:
+      //
+      //   /api/v1/subnets/64/badge.svg?metric=uptime  ->  "metagraphed: n/a"
+      //   /api/v1/subnets/64/uptime?window=90d        ->  grade C, 0.9296 over
+      //                                                   78,896 samples
+      //
+      // The same table, the same second, two different answers. So this now
+      // calls the loader the route itself calls, against the store readStore
+      // picks -- one query per netuid, the same shape
+      // src/surface-verification-sync.ts already uses for the same table, and
+      // no internal request to keep in step with a route's plumbing.
+      const data = (await loadSubnetUptime(netuid, {
+        window: RELIABILITY_BADGE_WINDOW,
+        db: readStore(env, UPTIME_DAILY_TABLES) as never,
+      } as unknown as Parameters<typeof loadSubnetUptime>[1])) as {
+        reliability?: Record<string, unknown> | null;
+      } | null;
+      return data?.reliability ?? null;
+    }),
+  );
+
+  // Reconstruct ok-counts from ratio x samples: /uptime publishes the ratio and
+  // the sample count, not the raw ok total.
+  let samples = 0;
+  let okCount = 0;
+  let latencyWeighted = 0;
+  let latencySamples = 0;
+  for (const r of blocks) {
+    if (!r) continue;
+    const n = Number(r.sample_count);
+    const ratio = Number(r.uptime_ratio);
+    if (!Number.isFinite(n) || n <= 0 || !Number.isFinite(ratio)) continue;
+    samples += n;
+    okCount += ratio * n;
+    const ls = Number(r.latency_sample_count);
+    const avg = Number(r.avg_latency_ms);
+    if (Number.isFinite(ls) && ls > 0 && Number.isFinite(avg)) {
+      latencySamples += ls;
+      latencyWeighted += avg * ls;
+    }
+  }
+  if (samples === 0) return null;
+
+  const scored = scoreFromStats({
+    samples,
+    okCount: Math.round(okCount),
+    avgLatencyMs: latencySamples > 0 ? latencyWeighted / latencySamples : null,
+    latencySamples,
+  });
+  // Total, not a fallback: scoreFromStats returns null only for samples === 0,
+  // which the guard above already excluded. A `scored ? … : null` here would
+  // be a branch that can never be taken.
+  return { grade: scored!.grade, uptime_ratio: scored!.uptime_ratio };
+}

--- a/src/saved-queries.ts
+++ b/src/saved-queries.ts
@@ -11,7 +11,7 @@
 // than authoring new query logic -- exactly the discipline #6756 asked for.
 import { composeLeaderboardsData } from "../workers/request-handlers/analytics-routes.ts";
 import { LEADERBOARD_BOARDS } from "./health-serving.ts";
-import { tryPostgresTier } from "../workers/postgres-tier.ts";
+import { loadChainRegistrationsFromArtifact } from "./chain-registrations-artifact.ts";
 import {
   buildChainRegistrations,
   CHAIN_REGISTRATIONS_WINDOWS,
@@ -127,20 +127,6 @@ export const SAVED_QUERY_TEMPLATES: SavedQueryTemplate[] = [
   },
 ];
 
-// Same trick postgresTierRequest (src/graphql.ts) uses: tryPostgresTier only
-// inspects pathname + search (it forwards the Request as-is to the DATA_API
-// service binding, which routes on pathname), so a fixed internal origin is
-// fine here -- there is no real incoming request to borrow one from when this
-// runs from an MCP tool call.
-function internalTierRequest(
-  pathname: string,
-  params: URLSearchParams,
-): Request {
-  const url = new URL(pathname, "https://internal.metagraphed.workers/");
-  url.search = params.toString();
-  return new Request(url);
-}
-
 type SavedQueryHandler = (env: Env, params: Row) => Promise<unknown>;
 
 export const SAVED_QUERY_HANDLERS: Record<string, SavedQueryHandler> = {
@@ -152,15 +138,23 @@ export const SAVED_QUERY_HANDLERS: Record<string, SavedQueryHandler> = {
     return data;
   },
   async "chain-registrations-window"(env, { window, limit }) {
-    const tierParams = new URLSearchParams();
-    tierParams.set("window", String(window));
-    tierParams.set("limit", String(limit));
+    // NO TIER READ (#10190): this ran tryPostgresTier(METAGRAPH_ACCOUNT_EVENTS_SOURCE)
+    // and fell to `buildChainRegistrations([])`. That flag reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so the tier arm
+    // resolved to null on every call -- and unlike its three sibling surfaces
+    // this one had NO rung under it, so run_saved_query has been answering an
+    // empty leaderboard while GET /api/v1/chain/registrations served a full one
+    // for the same window.
+    //
+    // #9146: the same chain-registrations PROJECTION the REST route, the GraphQL
+    // field and the MCP tool read, so the four cannot disagree. The reader
+    // declines (null) when it cannot answer faithfully, which keeps the empty
+    // builder as the floor rather than the answer.
     return (
-      (await tryPostgresTier(
-        env,
-        internalTierRequest("/api/v1/chain/registrations", tierParams),
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) ??
+      (await loadChainRegistrationsFromArtifact(env, {
+        window: window as string,
+        limit: limit as number,
+      })) ??
       buildChainRegistrations([], {
         window: window as string,
         limit: limit as number,

--- a/tests/account-feeds-cold-tier.test.ts
+++ b/tests/account-feeds-cold-tier.test.ts
@@ -566,10 +566,14 @@ describe("loadCounterpartyRelationshipColdTier", () => {
     assert.equal(data!.counterparty_count, 1);
     assert.equal(data!.relationship.transfer_count, 2);
     assert.equal(data!.counterparties[0]!.net_tao, 0);
+    // observed_at is KEPT now (#10190). It was stripped for payload parity with
+    // the Postgres tier, whose projection dropped it -- and that tier is retired,
+    // so the strip only nulled three published fields for no remaining reason
+    // while the query still paid to select and sort by the column.
     assert.equal(
       data!.relationship.last_seen_at,
-      null,
-      "observed_at is stripped so this tier matches data-api's projection",
+      new Date(transferRow(10).observed_at as number).toISOString(),
+      "the newest transfer's observed_at is the relationship's last_seen_at",
     );
   });
 

--- a/tests/account-history-csv.test.ts
+++ b/tests/account-history-csv.test.ts
@@ -51,6 +51,7 @@ test("GET /accounts/{ss58}/history?format=csv exports the per-day rows via the P
   assert.equal(lines.length, 2);
   assert.match(lines[1], /^2026-06-25,1,5,/);
   assert.match(lines[1], /8454388$/);
+  lake.restore();
 });
 
 test("GET /accounts/{ss58}/history rejects an invalid ?format with 400", async () => {

--- a/tests/account-history-csv.test.ts
+++ b/tests/account-history-csv.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -24,31 +25,20 @@ test("GET /accounts/{ss58}/history?format=csv emits a header-only CSV when cold"
 });
 
 test("GET /accounts/{ss58}/history?format=csv exports the per-day rows via the Postgres tier", async () => {
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          day_count: 1,
-          limit: 1000,
-          offset: 0,
-          next_cursor: null,
-          days: [
-            {
-              day: "2026-06-25",
-              netuid: 1,
-              event_count: 5,
-              event_kinds: ["StakeAdded", "Transfer"],
-              first_block: 8454300,
-              last_block: 8454388,
-            },
-          ],
-        }),
+  // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was
+  // never asked. The lakehouse cold tier answers, through the same builder.
+  const lake = lakehouse([
+    {
+      day: "2026-06-25",
+      netuid: 1,
+      event_count: 5,
+      event_kinds: ["StakeAdded", "Transfer"],
+      first_block: 8454300,
+      last_block: 8454388,
     },
-  };
+  ]);
+  const env = { ...createLocalArtifactEnv(), ...LAKEHOUSE_ENV };
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/history?format=csv`),
     env as unknown as Env,

--- a/tests/account-history.test.ts
+++ b/tests/account-history.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { afterEach, test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
-import { buildAccountHistory } from "../src/account-events.ts";
 import type { Row } from "./row-type.ts";
 
 // SQL-capturing D1 mock variant: records each bound (sql, params) so a test can

--- a/tests/account-history.test.ts
+++ b/tests/account-history.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { test } from "vitest";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
+import { afterEach, test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { buildAccountHistory } from "../src/account-events.ts";
 import type { Row } from "./row-type.ts";
@@ -46,31 +47,45 @@ const DAY = {
   last_block: 4_000_900,
 };
 
-// D1 fully eliminated (2026-07-17, #1854): handleAccountHistory now reads
-// METAGRAPH_ACCOUNT_EVENTS_SOURCE's Postgres tier only, via
-// tryPostgresTier(env, request, ...) -> DATA_API. On a hit, DATA_API's JSON
-// body is used directly as `data` (no reshaping), so the mock returns the
-// already-built buildAccountHistory output, mirroring what
-// workers/data-api.ts actually serves for this route.
-function postgresEnv({ days }: { days?: Row[] } = {}) {
-  return {
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      async fetch() {
-        return Response.json(
-          buildAccountHistory(days || [], SS58, {
-            limit: 100,
-            offset: 0,
-            nextCursor: null,
-          }),
-        );
-      },
-    },
-  };
+// #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and
+// is absent from DATA_API_FORWARD_FLAGS, so the tier this used to double was
+// never asked -- handleAccountHistory reads the lakehouse rollup
+// (loadAccountHistoryColdTier, #9315). Doubled at the same transport, and given
+// the SAME day rows: the reader feeds them through buildAccountHistory exactly
+// as this helper used to, so the assertions below are unchanged.
+let lake: ReturnType<typeof lakehouse> | undefined;
+afterEach(() => {
+  lake?.restore();
+  lake = undefined;
+});
+
+function coldTierEnv({ days }: { days?: Row[] } = {}) {
+  // TWO reads, not one: R2 SQL rejects `string_agg(DISTINCT ...)`, so the kinds
+  // are grouped to (day, netuid, event_kind) in a query of their own. Answering
+  // both with the same rows is what an undifferentiated double would do, and it
+  // silently yields empty kinds -- so the double routes on the SQL.
+  const rows = days || [];
+  lake = lakehouse((sql) =>
+    sql.includes("event_kind")
+      ? rows.flatMap((row) =>
+          String(row.event_kinds ?? "")
+            .split(",")
+            .filter(Boolean)
+            // GROUP BY event_kind, so a kind appears at most once per day+netuid.
+            .filter((kind, i, all) => all.indexOf(kind) === i)
+            .map((event_kind) => ({
+              day: row.day,
+              netuid: row.netuid,
+              event_kind,
+            })),
+        )
+      : rows,
+  );
+  return { ...LAKEHOUSE_ENV };
 }
 
 test("GET /accounts/{ss58}/history returns the per-day series (#1854)", async () => {
-  const env = postgresEnv({ days: [DAY] });
+  const env = coldTierEnv({ days: [DAY] });
   const res = await handleRequest(
     req(`/api/v1/accounts/${SS58}/history`),
     env as unknown as Env,
@@ -83,12 +98,10 @@ test("GET /accounts/{ss58}/history returns the per-day series (#1854)", async ()
   assert.equal(body.data.day_count, 1);
   assert.equal(body.data.days[0].day, "2026-06-24");
   assert.equal(body.data.days[0].netuid, 7);
-  // event_kinds CSV split into a deduped-by-storage array (raw split here).
-  assert.deepEqual(body.data.days[0].event_kinds, [
-    "StakeAdded",
-    "WeightsSet",
-    "WeightsSet",
-  ]);
+  // The lakehouse read GROUPs BY event_kind, so a kind cannot repeat within a
+  // (day, netuid) -- the retired tier's payload could carry duplicates because
+  // nothing grouped them on the way out.
+  assert.deepEqual(body.data.days[0].event_kinds, ["StakeAdded", "WeightsSet"]);
   assert.ok(res.headers.get("etag"));
 });
 
@@ -132,7 +145,7 @@ test("GET /accounts/{ss58}/history exposes x-metagraph-artifact-source on both t
   // header too — it must not be dropped just because the range is empty.
   const normal = await handleRequest(
     req(`/api/v1/accounts/${SS58}/history`),
-    postgresEnv({ days: [DAY] }) as unknown as Env,
+    coldTierEnv({ days: [DAY] }) as unknown as Env,
     {},
   );
   assert.equal(

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { archiveEnv } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 
@@ -182,29 +183,48 @@ function mockCaches() {
 }
 
 // D1 fully eliminated (2026-07-17): percentiles/incidents/trends/bulk-trends/
-// global-incidents/uptime/trajectory now ALWAYS mark a Postgres-tier MISS as a
-// D1 fallback (there's no live D1 read left to tell "had rows" apart from
-// "cold"), so a MISS can never be cached -- only a Postgres-tier HIT is. This
-// backs a route with a call-counting DATA_API mock instead of a D1 mock, so the
-// MISS/HIT edge-cache invariants that used to run against a fake D1 can still
-// be exercised against the surviving cacheable path.
-function postgresTierEnv(
+// #10190: these routes' tier flag reads "d1"/"retired" and is absent from
+// DATA_API_FORWARD_FLAGS, so the DATA_API call this used to count never happened
+// in production. The upstream the edge cache actually protects is the STORE, so
+// that is what is counted now -- through the pg module double's onQuery hook.
+//
+// The MISS/HIT invariants are unchanged and still meaningful: a store-served
+// payload with real rows is cacheable (isFallback false), an empty one is not,
+// which is the same distinction the tier hit/miss used to draw.
+function storeUpstreamEnv(
   calls: unknown[],
   {
-    flag = "METAGRAPH_HEALTH_SOURCE",
-    body = { schema_version: 1 } as Row,
+    // Enough of a row for every reader that shares this helper: the incidents
+    // and trajectory routes format timestamps out of it, and a row without one
+    // fails as `Invalid time value` rather than as an empty result.
+    rows = [
+      {
+        netuid: 7,
+        surface: "api",
+        samples: 10,
+        healthy_samples: 10,
+        day: LAST_RUN_AT.slice(0, 10),
+        // formatTrajectory keys its points on snapshot_date and shifts dates off
+        // it -- a row without one throws `Invalid time value` rather than
+        // yielding an empty trajectory.
+        snapshot_date: LAST_RUN_AT.slice(0, 10),
+        completeness_score: 1,
+        observed_at: Date.parse(LAST_RUN_AT),
+        last_checked: Date.parse(LAST_RUN_AT),
+        first_seen: Date.parse(LAST_RUN_AT),
+        last_seen: Date.parse(LAST_RUN_AT),
+      },
+    ] as Row[],
     lastRunAt = LAST_RUN_AT as string | null,
   } = {},
 ) {
+  pg.control.queries.length = 0;
+  pg.control.failNext = null;
+  pg.control.rows = rows;
+  pg.control.onQuery = () => calls.push(1);
   return {
     ...createLocalArtifactEnv(),
-    [flag]: "postgres",
-    DATA_API: {
-      fetch: async () => {
-        calls.push(1);
-        return Response.json(body);
-      },
-    },
+    ...pgMockEnv(),
     METAGRAPH_CONTROL: {
       async get(key: string) {
         if (key === "health:meta") {
@@ -246,7 +266,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
 
     // Per-subnet percentiles (netuid + window both vary the key).
     const res = await handleRequest(
@@ -283,7 +303,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
     const target =
       "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=30d";
 
@@ -324,7 +344,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
     const target =
       "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=30d";
 
@@ -365,7 +385,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
 
     for (const url of [
       "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles?window=7d",
@@ -552,29 +572,26 @@ describe("analytics edge cache", () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();
     cache.install();
-    const dataApiCalls: string[] = [];
-    const env = {
-      ...analyticsEnv([]),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        async fetch(request: Request) {
-          dataApiCalls.push(request.url);
-          return Response.json({
-            data: {
-              schema_version: 1,
+    // #10190: the tier this counted is retired; the subnet stake-flow
+    // PROJECTION is the upstream the cache protects, so its reads are what the
+    // MISS/HIT counts below measure.
+    const archive = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "30d": {
+          rows: [
+            {
               netuid: 7,
-              window: "30d",
-              total_staked_tao: 0,
-              total_unstaked_tao: 0,
-              net_flow_tao: 0,
-              stake_events: 0,
-              unstake_events: 0,
+              event_kind: "StakeAdded",
+              total_tao: 0,
+              events: 0,
+              newest_observed: LAST_RUN_AT,
             },
-            generatedAt: LAST_RUN_AT,
-          });
+          ],
         },
       },
-    };
+    });
+    const env = { ...analyticsEnv([]), ...archive };
 
     // No ?window — should resolve to the 30d default and cache at ?window=30d.
     const first = await handleRequest(
@@ -584,7 +601,7 @@ describe("analytics edge cache", () => {
     );
     await Promise.resolve();
     assert.equal(first.status, 200);
-    const callsAfterMiss = dataApiCalls.length;
+    const callsAfterMiss = archive.keys.length;
     assert.equal(callsAfterMiss, 1);
 
     // Explicit ?window=30d is the canonical form — must be a cache HIT (no DATA_API).
@@ -597,7 +614,7 @@ describe("analytics edge cache", () => {
     );
     assert.equal(hit.status, 200);
     assert.equal(
-      dataApiCalls.length,
+      archive.keys.length,
       callsAfterMiss,
       "explicit ?window=30d must be a cache HIT (no DATA_API fetches)",
     );
@@ -935,7 +952,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
     const url =
       "https://api.metagraph.sh/api/v1/subnets/7/health/incidents?window=7d";
 
@@ -1010,7 +1027,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls, {
+    const env = storeUpstreamEnv(calls, {
       body: { schema_version: 1, windows: { "7d": {}, "30d": {} } },
     });
 
@@ -1518,7 +1535,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
     const base = "/api/v1/subnets/7/health/percentiles";
 
     const miss = await handleRequest(
@@ -1582,7 +1599,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = postgresTierEnv(calls);
+    const env = storeUpstreamEnv(calls);
     const base = "/api/v1/subnets/7/health/incidents";
 
     const miss = await handleRequest(
@@ -1683,9 +1700,7 @@ describe("analytics edge cache", () => {
       const cache = mockCaches();
       cache.install();
       const calls: unknown[] = [];
-      const env = r.store
-        ? { ...postgresTierEnv(calls), ...pgMockEnv() }
-        : postgresTierEnv(calls, { flag: r.flag });
+      const env = storeUpstreamEnv(calls);
       const url = `https://api.metagraph.sh${r.path}${r.search}`;
 
       // MISS: calls the Postgres tier and caches under the route's key.
@@ -1966,7 +1981,7 @@ describe("formerly neurons-tier routes now share the health-cron edge-cache stam
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();
     cache.install();
-    const env = postgresTierEnv([]);
+    const env = storeUpstreamEnv([]);
 
     await handleRequest(
       new Request(
@@ -2107,30 +2122,24 @@ describe("degraded-tier labelling (#9110)", () => {
   });
 
   test("a real tier HIT is NOT labelled", async () => {
-    // A working DATA_API, so tryPostgresTier returns a body and nothing
-    // degrades. This is the direction that keeps the header meaningful: if a
-    // healthy response carried it too, consumers would learn to ignore it.
+    // A projection that answers, so nothing degrades. This is the direction
+    // that keeps the header meaningful: if a healthy response carried it too,
+    // consumers would learn to ignore it. (#10190: the tier this used to drive
+    // is retired, so the #9146 projection is the measured read.)
     const env = {
       ...createLocalArtifactEnv(),
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            group_by: "module",
-            observed_at: LAST_RUN_AT,
-            total_extrinsics: 1_347_135,
-            calls: [
-              {
-                call_module: "SubtensorModule",
-                call_function: null,
-                count: 603_215,
-                share: 0.4478,
-              },
-            ],
-          }),
-      },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": {
+            newest_observed: LAST_RUN_AT,
+            total: 1_347_135,
+            groups: {
+              module: [{ call_module: "SubtensorModule", count: 603_215 }],
+            },
+          },
+        },
+      }),
     } as unknown as Env;
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/chain/calls?window=7d"),
@@ -2142,7 +2151,7 @@ describe("degraded-tier labelling (#9110)", () => {
     assert.equal(
       body.data.total_extrinsics,
       1_347_135,
-      "the tier body must be what is served",
+      "the projection's own total must be what is served",
     );
     assert.equal(
       res.headers.get(DEGRADED_HEADER),

--- a/tests/analytics-edge-cache.test.ts
+++ b/tests/analytics-edge-cache.test.ts
@@ -1027,9 +1027,7 @@ describe("analytics edge cache", () => {
     const cache = mockCaches();
     cache.install();
     const calls: unknown[] = [];
-    const env = storeUpstreamEnv(calls, {
-      body: { schema_version: 1, windows: { "7d": {}, "30d": {} } },
-    });
+    const env = storeUpstreamEnv(calls);
 
     let putAt: Promise<unknown> | null = null;
     const putCtx = {

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1660,19 +1660,16 @@ describe("analytics routes (Postgres tier unconfigured -- D1 fully eliminated)",
     assert.equal(body.data.point_count, 0);
   });
   test("a failing Postgres-tier DATA_API call degrades to empty (never a client-facing error), captured for real observability (metagraphed#8081 follow-up)", async () => {
-    // D1 is fully eliminated (2026-07-17, reconfirmed live 2026-07-25 -- zero
-    // D1 databases remain on the account) -- this used to mock a hanging D1
-    // .all() call, but METAGRAPH_HEALTH_SOURCE was never set to "postgres" in
-    // that version, so tryPostgresTier short-circuited on the tier-flag check
-    // before ever touching the (fictional) D1 mock: the test was vacuous. The
-    // real failure mode tryPostgresTier actually protects against today is a
-    // rejected DATA_API fetch (workers/postgres-tier.ts) -- exercise that,
-    // and confirm it now reaches PostHog's $exception capture too (added
-    // alongside this fix), not just Wrangler's own log tail.
+    // #10190: this drove METAGRAPH_HEALTH_SOURCE, whose tier reads are all
+    // deleted -- there is no DATA_API call left on the health routes to fail, so
+    // driving them proves nothing. The mechanism under test is
+    // capturePostgresTierFallback, and it is still live for the three flags in
+    // DATA_API_FORWARD_FLAGS. So this drives one of THOSE: a forwardable flag,
+    // a route that reads it, and a DATA_API that rejects.
     const posted: Row[] = [];
     const failingEnv = {
       ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_SOURCE: "postgres",
+      METAGRAPH_NEURONS_SOURCE: "postgres",
       POSTHOG_PROJECT_TOKEN: "phc_test",
       DATA_API: {
         fetch: async () => {
@@ -1686,23 +1683,12 @@ describe("analytics routes (Postgres tier unconfigured -- D1 fully eliminated)",
       return { ok: true };
     }) as typeof fetch;
     try {
-      const pct = await getJson(
-        "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles",
+      const metagraph = await getJson(
+        "https://api.metagraph.sh/api/v1/subnets/7/metagraph",
         failingEnv,
       );
-      assert.equal(pct.status, 200);
-      assert.deepEqual(pct.body.data.surfaces, []);
-      const trends = await getJson(
-        "https://api.metagraph.sh/api/v1/subnets/7/health/trends",
-        failingEnv,
-      );
-      assert.equal(trends.status, 200);
-      const bulkTrends = await getJson(
-        "https://api.metagraph.sh/api/v1/health/trends",
-        failingEnv,
-      );
-      assert.equal(bulkTrends.status, 200);
-      assert.deepEqual(bulkTrends.body.data.windows["7d"].subnets, []);
+      // Degrades, never a client-facing error -- the contract this protects.
+      assert.equal(metagraph.status, 200);
     } finally {
       globalThis.fetch = original;
     }
@@ -1713,9 +1699,10 @@ describe("analytics routes (Postgres tier unconfigured -- D1 fully eliminated)",
     );
     assert.equal(
       exceptionPost.body.properties.route,
-      "postgres-tier:METAGRAPH_HEALTH_SOURCE",
+      "postgres-tier:METAGRAPH_NEURONS_SOURCE",
     );
   });
+
   test("leaderboards returns most-complete from profiles even with cold D1", async () => {
     const profileEnv = createLocalArtifactEnv({
       METAGRAPH_ARCHIVE: {

--- a/tests/block-csv.test.ts
+++ b/tests/block-csv.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -30,28 +31,26 @@ test("GET /blocks/{ref}/extrinsics?format=csv emits a header-only CSV for an emp
 });
 
 test("GET /blocks/{ref}/extrinsics?format=csv exports the block's extrinsics via the Postgres tier", async () => {
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          data: {
-            block_number: Number(REF),
-            extrinsics: [
-              {
-                block_number: Number(REF),
-                extrinsic_index: 0,
-                signer: "5Signer",
-                call_module: "SubtensorModule",
-                call_function: "set_weights",
-                success: true,
-              },
-            ],
-          },
-        }),
+  // #10190: METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never asked.
+  // The per-block extrinsics come from the lakehouse, through the same builder --
+  // so the CSV below is produced from lakehouse rows exactly as in production.
+  const lake = lakehouse([
+    {
+      block_number: Number(REF),
+      extrinsic_index: 0,
+      extrinsic_hash: `0x${"a".repeat(64)}`,
+      signer: "5Signer",
+      call_module: "SubtensorModule",
+      call_function: "set_weights",
+      success: true,
+      fee_tao: 0,
+      tip_tao: 0,
+      call_args: null,
+      observed_at: 1_750_009_000_000,
     },
-  };
+  ]);
+  const env = { ...createLocalArtifactEnv(), ...LAKEHOUSE_ENV };
   const res = await handleRequest(
     req(`/api/v1/blocks/${REF}/extrinsics?format=csv`),
     env as unknown as Env,
@@ -66,6 +65,7 @@ test("GET /blocks/{ref}/extrinsics?format=csv exports the block's extrinsics via
     lines[1],
     /^8621331-0,8621331,5Signer,SubtensorModule,set_weights,/,
   );
+  lake.restore();
 });
 
 test("GET /blocks/{ref}/extrinsics rejects an invalid ?format with 400", async () => {
@@ -90,33 +90,24 @@ test("GET /blocks/{ref}/events?format=csv emits a header-only CSV for an empty b
 });
 
 test("GET /blocks/{ref}/events?format=csv exports the block's events via the Postgres tier", async () => {
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          data: {
-            block_number: Number(REF),
-            events: [
-              {
-                block_number: Number(REF),
-                event_index: 0,
-                event_kind: "Transfer",
-                hotkey: "5Hot",
-                coldkey: "5Cold",
-                netuid: 1,
-                uid: 0,
-                amount_tao: 10.5,
-                alpha_amount: null,
-                observed_at: 1750000000000,
-                extrinsic_index: 0,
-              },
-            ],
-          },
-        }),
+  // #10190: METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never asked.
+  // The per-block events come from the lakehouse, through the same builder --
+  // so the CSV below is produced from lakehouse rows exactly as in production.
+  const lake = lakehouse([
+    {
+      block_number: Number(REF),
+      event_index: 0,
+      event_kind: "Transfer",
+      hotkey: "5Hot",
+      coldkey: "5Cold",
+      netuid: 1,
+      uid: 0,
+      amount_tao: 10.5,
+      observed_at: 1_750_009_000_000,
     },
-  };
+  ]);
+  const env = { ...createLocalArtifactEnv(), ...LAKEHOUSE_ENV };
   const res = await handleRequest(
     req(`/api/v1/blocks/${REF}/events?format=csv`),
     env as unknown as Env,
@@ -128,6 +119,7 @@ test("GET /blocks/{ref}/events?format=csv exports the block's events via the Pos
   assert.equal(lines[0], EVENTS_CSV_HEADER);
   assert.equal(lines.length, 2);
   assert.match(lines[1], /^8621331,0,Transfer,5Hot,5Cold,1,0,10\.5,/);
+  lake.restore();
 });
 
 test("GET /blocks/{ref}/events rejects an invalid ?format with 400", async () => {

--- a/tests/chain-alpha-volume.test.ts
+++ b/tests/chain-alpha-volume.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainAlphaVolume,
@@ -389,54 +390,23 @@ describe("GET /api/v1/chain/alpha-volume", () => {
   // #4832 Tier 2 pattern: METAGRAPH_ACCOUNT_EVENTS_SOURCE reused (same account_events table
   // this handler already reads, no new flag) -- tryPostgresTier's own fallback contract is
   // unit-tested in workers/postgres-tier.ts's own tests, so these two just prove the wiring.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...alphaVolumeEnv([]),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "24h",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            volume_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
-    const res = await handleRequest(req(), env as unknown as Env, {});
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is
+    // absent from DATA_API_FORWARD_FLAGS, so this route reads no tier. Bind a
+    // DATA_API that WOULD answer and prove nothing asks it -- a reintroduced
+    // tryPostgresTier call resolves to null too, so nothing else would notice.
+    const tier = forbiddenDataApi();
+    const res = await handleRequest(
+      req(),
+      {
+        ...alphaVolumeEnv([]),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
+      {},
+    );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
-  });
-
-  // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real
-  // D1 read (account_events is retired) -- a Postgres failure degrades to the
-  // empty card, not to whatever a D1 mock might return.
-  test("flag=postgres falls back to the empty stub (not D1) when DATA_API fails", async () => {
-    const env = {
-      ...alphaVolumeEnv(ROWS),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await handleRequest(req(), env as unknown as Env, {});
-    assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 0);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("rejects a ?window= param with 400 (fixed 24h window, no windowing on this route)", async () => {

--- a/tests/chain-analytics.test.ts
+++ b/tests/chain-analytics.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { archiveEnv } from "./helpers/cold-tier-env.ts";
 import { describe, test } from "vitest";
 import {
   buildChainActivity,
@@ -43,44 +44,41 @@ function installMapCache() {
   };
 }
 
-// D1 fully eliminated (2026-07-16): extrinsics'/blocks' D1 write path is
-// retired (#4772) and the tables are dropped in production, so
-// handleChainActivity now goes tryPostgresTier -> buildChainActivity([...])
-// on any miss/outage, never a live D1 read. This mocks the Postgres tier
-// instead of D1.
-function chainActivityPostgresEnv() {
+// #10190: METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+// absent from DATA_API_FORWARD_FLAGS, so the tier this used to double was never
+// asked. handleChainActivity reads the #9146 projection lane, so that is what is
+// doubled -- at the same transport (the archive bucket), with the envelope the
+// lane writes. A wrong envelope must fail: the reader declines on one, and in
+// production a decline means the route serves its zeroed floor.
+function chainActivityProjectionEnv() {
   return {
     ...createLocalArtifactEnv(),
-    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window: "7d",
-          observed_at: "2026-06-26T12:00:00.000Z",
-          day_count: 2,
-          days: [
+    ...archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          newest_observed: "2026-06-26T12:00:00.000Z",
+          extrinsic_rows: [
             {
               day: "2026-06-25",
-              block_count: 7200,
               extrinsic_count: 100,
-              event_count: 30000,
               successful_extrinsics: 99,
-              success_rate: 0.99,
               unique_signers: 40,
             },
             {
               day: "2026-06-24",
-              block_count: 7100,
               extrinsic_count: 50,
-              event_count: 29000,
               successful_extrinsics: 50,
-              success_rate: 1,
               unique_signers: 20,
             },
           ],
-        }),
-    },
+          block_rows: [
+            { day: "2026-06-25", block_count: 7200, event_count: 30000 },
+            { day: "2026-06-24", block_count: 7100, event_count: 29000 },
+          ],
+        },
+      },
+    }),
   };
 }
 
@@ -236,7 +234,7 @@ test("ignores junk rows (null, non-object, missing/non-string day)", () => {
 test("GET /api/v1/chain/activity merges + groups the chain tiers by UTC day", async () => {
   const res = await handleRequest(
     activityReq("?window=7d"),
-    chainActivityPostgresEnv() as unknown as Env,
+    chainActivityProjectionEnv() as unknown as Env,
     {},
   );
   assert.equal(res.status, 200);

--- a/tests/chain-analytics.test.ts
+++ b/tests/chain-analytics.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { archiveEnv } from "./helpers/cold-tier-env.ts";
+import { archiveEnv, forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { describe, test } from "vitest";
 import {
   buildChainActivity,
@@ -350,34 +350,28 @@ test("buildChainCalls drops empty call_module and call_function buckets", () => 
 // exercise the real grouped/shared response; the junk-param 400 is unrelated
 // to data-sourcing and is exercised on the same env.
 test("GET /api/v1/chain/calls groups by call_module with honest share via the Postgres tier + 400 on junk param", async () => {
+  // #10190: METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never
+  // asked. The #9146 call-mix projection answers, and `share` is DERIVED from
+  // its own ungrouped total -- the retired tier handed the share over ready-made,
+  // so the division under test never ran.
   const env = {
     ...createLocalArtifactEnv(),
-    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window: "30d",
-          group_by: "module",
-          total_extrinsics: 120,
-          call_count: 2,
-          observed_at: "2026-06-26T00:00:00.000Z",
-          calls: [
-            {
-              call_module: "SubtensorModule",
-              call_function: null,
-              count: 60,
-              share: 0.5,
-            },
-            {
-              call_module: "Balances",
-              call_function: null,
-              count: 30,
-              share: 0.25,
-            },
-          ],
-        }),
-    },
+    ...archiveEnv({
+      schema_version: 1,
+      windows: {
+        "30d": {
+          newest_observed: "2026-06-26T00:00:00.000Z",
+          total: 120,
+          groups: {
+            module: [
+              { call_module: "SubtensorModule", count: 60 },
+              { call_module: "Balances", count: 30 },
+            ],
+          },
+        },
+      },
+    }),
   };
   const res = await handleRequest(
     new Request(
@@ -404,51 +398,54 @@ test("GET /api/v1/chain/calls groups by call_module with honest share via the Po
 // own dedicated coverage, not re-tested here) -- the handler's own contract is
 // just to forward call_module + group_by on the request it hands to
 // tryPostgresTier, and to pass the Postgres-tier body through untouched.
-test("GET /api/v1/chain/calls forwards call_module scoping to the Postgres tier for module-function groups", async () => {
-  let requestedUrl: URL | undefined;
+test("GET /api/v1/chain/calls declines a call_module scope rather than answering unscoped (#10190)", async () => {
+  // The retired tier took `call_module` as a query param and filtered upstream.
+  // The #9146 projection carries only the unscoped mix, so its reader DECLINES a
+  // scoped call outright -- serving the unfiltered numbers under a scoped label
+  // would be a wrong answer, not a degraded one. The route then falls to its
+  // schema-stable floor, which is what a caller must be able to tell apart.
   const env = {
     ...createLocalArtifactEnv(),
-    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async (request: Request) => {
-        requestedUrl = new URL(request.url);
-        return Response.json({
-          schema_version: 1,
-          window: "7d",
-          group_by: "module_function",
-          total_extrinsics: 80,
-          call_count: 1,
-          observed_at: "2026-06-26T00:00:00.000Z",
-          calls: [
-            {
-              call_module: "SubtensorModule",
-              call_function: "add_stake",
-              count: 50,
-              share: 0.625,
-            },
-          ],
-        });
+    ...archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          newest_observed: "2026-06-26T00:00:00.000Z",
+          total: 80,
+          groups: {
+            module_function: [
+              {
+                call_module: "SubtensorModule",
+                call_function: "add_stake",
+                count: 50,
+              },
+            ],
+          },
+        },
       },
-    },
+    }),
   };
-  const res = await handleRequest(
+  const scoped = await handleRequest(
     new Request(
-      "https://api.metagraph.sh/api/v1/chain/calls?call_module=SubtensorModule&group_by=module_function&limit=1",
+      "https://api.metagraph.sh/api/v1/chain/calls?call_module=SubtensorModule&group_by=module_function&window=7d",
     ),
     env as unknown as Env,
     {},
   );
-  assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.group_by, "module_function");
-  assert.equal(body.data.total_extrinsics, 80);
-  assert.equal(body.data.calls[0].call_function, "add_stake");
-  assert.equal(body.data.calls[0].share, 0.625);
-  assert.equal(
-    requestedUrl!.searchParams.get("call_module"),
-    "SubtensorModule",
+  assert.equal(scoped.status, 200);
+  const scopedBody = await scoped.json();
+  assert.deepEqual(scopedBody.data.calls, []);
+
+  // Unscoped, the same projection answers with its rows.
+  const unscoped = await handleRequest(
+    new Request(
+      "https://api.metagraph.sh/api/v1/chain/calls?group_by=module_function&window=7d",
+    ),
+    env as unknown as Env,
+    {},
   );
-  assert.equal(requestedUrl!.searchParams.get("group_by"), "module_function");
+  const unscopedBody = await unscoped.json();
+  assert.equal(unscopedBody.data.calls[0].call_function, "add_stake");
 });
 
 test("GET /api/v1/chain/calls rejects an inert group_by and an out-of-range limit", async () => {
@@ -914,68 +911,48 @@ test("GET /api/v1/chain/transfers rejects an unsupported format value with 400",
 // fallback contract is unit-tested in workers/postgres-tier.ts's own tests,
 // so these two just prove the wiring: a Postgres hit is served as-is with D1
 // never queried, and a Postgres failure falls back to D1.
-test("GET /api/v1/chain/transfers: flag=postgres serves the DATA_API response, D1 never queried", async () => {
-  let d1Called = false;
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window: "7d",
-          observed_at: "2026-01-01T00:00:00.000Z",
-          total_volume_tao: 999,
-          transfer_count: 1,
-          unique_senders: 1,
-          unique_receivers: 1,
-          top_sender_share: null,
-          top_senders: [],
-          top_receivers: [],
-        }),
-    },
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        d1Called = true;
-        throw new Error(
-          "D1 must not be queried when Postgres serves the request",
-        );
-      },
-    },
-  };
+test("GET /api/v1/chain/transfers: the retired tier flag is not consulted (#10190)", async () => {
+  // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so this route reads no tier. Bind a
+  // DATA_API that WOULD answer and prove nothing asks it.
+  const tier = forbiddenDataApi();
   const res = await handleRequest(
     new Request("https://api.metagraph.sh/api/v1/chain/transfers?window=7d"),
-    env as unknown as Env,
+    {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      ...tier,
+    } as unknown as Env,
     {},
   );
   assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.total_volume_tao, 999);
-  assert.equal(d1Called, false);
+  assert.deepEqual(tier.paths, []);
 });
 
 // D1 is permanently skipped (#4909/#6013), so the only path that can ever
 // populate top_senders/top_receivers with real rows is a Postgres-tier hit --
 // this exercises the CSV row-mapping for both arrays.
 test("GET /api/v1/chain/transfers: CSV export maps Postgres-tier senders/receivers", async () => {
+  // #10190: the tier is retired; the #9146 transfers projection carries the
+  // same senders/receivers, and the CSV is mapped from what it returns.
   const env = {
     ...createLocalArtifactEnv(),
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window: "7d",
-          observed_at: "2026-01-01T00:00:00.000Z",
-          total_volume_tao: 140,
-          transfer_count: 9,
-          unique_senders: 1,
-          unique_receivers: 1,
-          top_sender_share: 0.5714,
-          top_senders: [TRANSFERS_SENDER_ROW],
-          top_receivers: [TRANSFERS_RECEIVER_ROW],
-        }),
-    },
+    ...archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          totals: {
+            total_volume_tao: 140,
+            transfer_count: 9,
+            unique_senders: 1,
+            unique_receivers: 1,
+            newest_observed: "2026-01-01T00:00:00.000Z",
+          },
+          senders: [TRANSFERS_SENDER_ROW],
+          receivers: [TRANSFERS_RECEIVER_ROW],
+        },
+      },
+    }),
   };
   const res = await handleRequest(
     new Request(
@@ -1247,46 +1224,21 @@ test("GET /api/v1/chain/transfer-pairs validates sort, limit, and query keys", a
 // fallback contract is unit-tested in workers/postgres-tier.ts's own tests,
 // so these two just prove the wiring: a Postgres hit is served as-is with D1
 // never queried, and a Postgres failure falls back to D1.
-test("GET /api/v1/chain/transfer-pairs: flag=postgres serves the DATA_API response, D1 never queried", async () => {
-  let d1Called = false;
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window: "7d",
-          sort: "volume",
-          observed_at: "2026-01-01T00:00:00.000Z",
-          total_volume_tao: 999,
-          transfer_count: 1,
-          unique_pairs: 1,
-          pair_count: 1,
-          top_pair_share: null,
-          pairs: [],
-        }),
-    },
-    METAGRAPH_HEALTH_DB: {
-      prepare() {
-        d1Called = true;
-        throw new Error(
-          "D1 must not be queried when Postgres serves the request",
-        );
-      },
-    },
-  };
+test("GET /api/v1/chain/transfer-pairs: the retired tier flag is not consulted (#10190)", async () => {
+  const tier = forbiddenDataApi();
   const res = await handleRequest(
     new Request(
       "https://api.metagraph.sh/api/v1/chain/transfer-pairs?window=7d",
     ),
-    env as unknown as Env,
+    {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      ...tier,
+    } as unknown as Env,
     {},
   );
   assert.equal(res.status, 200);
-  const body = await res.json();
-  assert.equal(body.data.total_volume_tao, 999);
-  assert.equal(d1Called, false);
+  assert.deepEqual(tier.paths, []);
 });
 
 test("GET /api/v1/chain/transfer-pairs: flag=postgres falls back to D1 when DATA_API fails", async () => {

--- a/tests/chain-axon-removals.test.ts
+++ b/tests/chain-axon-removals.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { AXON_REMOVALS_DEGRADED_NEVER_EMITTED } from "../src/uncurated-event-streams.ts";
 import { afterEach, describe, test } from "vitest";
 import {
@@ -325,39 +326,24 @@ describe("GET /api/v1/chain/axon-removals", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...axonRemovalsEnv(cold),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            intensity_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...axonRemovalsEnv(cold),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/chain-deregistrations.test.ts
+++ b/tests/chain-deregistrations.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainDeregistrations,
@@ -378,39 +379,24 @@ describe("GET /api/v1/chain/deregistrations", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...deregistrationsEnv(cold),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            intensity_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...deregistrationsEnv(cold),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/chain-event-rollup-cold-tier.test.ts
+++ b/tests/chain-event-rollup-cold-tier.test.ts
@@ -24,6 +24,7 @@ import {
   CHAIN_SERVING_ROLLUP,
   CHAIN_WEIGHTS_ROLLUP,
   loadChainEventRollup,
+  ROLLUP_POPULATION_CAP,
   safeColumnAlias,
   safeEventKind,
 } from "../src/chain-event-rollup-cold-tier.ts";
@@ -219,11 +220,17 @@ describe("what the rollup refuses to publish", () => {
     assert.deepEqual(engine.seen, [], "a refused kind must not reach SQL");
   });
 
-  test("a malformed limit falls back to the default rather than reaching SQL", async () => {
-    // An absurd limit clamps (asserted below); a NON-INTEGER one must not be
-    // interpolated at all -- `LIMIT NaN` is a syntax error that would take the
-    // whole route down rather than degrade it.
-    for (const limit of [Number.NaN, -1, 0, "20" as unknown as number]) {
+  test("no caller can put a page size into the scan, malformed or not", async () => {
+    // WAS "a malformed limit falls back to the default rather than reaching
+    // SQL", which guarded the interpolation of a value that must no longer be
+    // interpolated at all: the builders derive the network rollup and the
+    // distribution from these rows, so a page-sized scan silently redefines both
+    // (see ROLLUP_POPULATION_CAP for the live figures).
+    //
+    // `limit` is off the option type now, so this drives it through `as never`
+    // the way a JS caller or a stale build could -- the guarantee is that even
+    // then nothing but the population cap reaches the SQL.
+    for (const limit of [Number.NaN, -1, 0, 20, 5_000_000, "20"]) {
       const engine = fakeEngine();
       await loadChainEventRollup({} as never, CHAIN_SERVING_ROLLUP, {
         windowDays: 7,
@@ -233,8 +240,8 @@ describe("what the rollup refuses to publish", () => {
       } as never);
       assert.match(
         engine.rowsSql()!,
-        /LIMIT 200/,
-        `limit=${String(limit)} must fall back to the default`,
+        new RegExp(`LIMIT ${ROLLUP_POPULATION_CAP}\\b`),
+        `limit=${String(limit)} must not reach the scan`,
       );
     }
   });
@@ -383,13 +390,19 @@ describe("the SQL it emits", () => {
 
   test("the per-subnet rollup is row-capped, and the cap is bounded", async () => {
     // R2 SQL is second-scale with no indexes; an uncapped GROUP BY over
-    // account_events is the read here that could pin a request open.
-    const { engine, result } = load({}, { limit: 5_000_000 });
+    // account_events is the read here that could pin a request open. The bound
+    // is a safety bound and nothing else -- it is not a page size, and no
+    // caller supplies it.
+    const { engine, result } = load();
     await result;
     assert.match(
       engine.rowsSql()!,
-      /LIMIT 1000\b/,
-      "an absurd limit must clamp",
+      new RegExp(`LIMIT ${ROLLUP_POPULATION_CAP}\\b`),
+      "the population cap must bound the scan",
+    );
+    assert.ok(
+      ROLLUP_POPULATION_CAP >= 1000,
+      "the cap must clear the ~129-subnet population by an order of magnitude",
     );
   });
 
@@ -441,11 +454,14 @@ describe("what it hands back", () => {
   });
 
   test("the subnet count comes from its own query, not from the page", async () => {
-    // #10249. `rows` is capped, so counting it answers "how big was the page"
-    // the moment the cap binds -- measured live, /chain/weights published
-    // subnet_count 20 at ?limit=20 and 99 at ?limit=100 while the window
-    // covered 129. One row here against a count of 12 is the whole point: the
-    // two numbers must be allowed to disagree.
+    // #10249. `rows` used to be capped at the caller's page size, so counting it
+    // answered "how big was the page" the moment the cap bound -- measured live,
+    // /chain/weights published subnet_count 20 at ?limit=20 and 99 at ?limit=100
+    // while the window covered 129. The page size is out of the scan now, but
+    // this number keeps its own query: the safety cap can still bind in
+    // principle, and a population must not be read off a bounded page. One row
+    // here against a count of 12 is the whole point: the two numbers must be
+    // allowed to disagree.
     const { result } = load({
       rows: [{ netuid: 7, announcements: 9, distinct_servers: 4 }],
       subnets: [{ subnet_count: 12 }],
@@ -476,6 +492,31 @@ describe("what it hands back", () => {
       );
       assert.match(sql, /GROUP BY netuid/);
     }
+  });
+
+  test("the two per-subnet queries require a subnet; the network one does not", async () => {
+    // `account_events.netuid` is nullable and WeightsSet uses it. Visible from
+    // outside on 2026-08-11 in /api/v1/chain/weights/setters, which publishes
+    // `{"hotkey": null, "netuid": null, "uid": 0, "weight_sets": 633}` -- so
+    // grouping by netuid produced a row no builder can attribute to a subnet.
+    // Every builder here drops it, correctly, but it still spent a slot in the
+    // page and a unit in the subnet count: /chain/weights?limit=N published N-1
+    // subnets at every N, and ?limit=1 an entirely empty card beside a
+    // subnet_count of 129.
+    //
+    // The NETWORK query must stay unfiltered. It counts distinct participants,
+    // and a participant whose subnet the export did not record is still a
+    // participant -- narrowing it would drop real ones to fix a per-subnet
+    // problem.
+    const { engine, result } = load();
+    await result;
+    assert.match(engine.rowsSql()!, /netuid IS NOT NULL/);
+    assert.match(engine.subnetCountSql()!, /netuid IS NOT NULL/);
+    assert.doesNotMatch(
+      engine.networkSql()!,
+      /netuid IS NOT NULL/,
+      "the participant count is not a per-subnet question",
+    );
   });
 
   test("a missing subnet count degrades to null, it does not decline", async () => {

--- a/tests/chain-prometheus-loader.test.ts
+++ b/tests/chain-prometheus-loader.test.ts
@@ -15,6 +15,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { loadChainPrometheusColdTier } from "../src/chain-prometheus-loader.ts";
 import { CHAIN_PROMETHEUS_LIMIT_DEFAULT } from "../src/chain-prometheus.ts";
+import { ROLLUP_POPULATION_CAP } from "../src/chain-event-rollup-cold-tier.ts";
 
 const ROWS = [
   { netuid: 7, announcements: 9, distinct_exporters: 4 },
@@ -100,20 +101,30 @@ describe("the shared chain-prometheus loader", () => {
     assert.notEqual(data.window, "not-a-window");
   });
 
-  test("an omitted limit resolves once, so the scan cannot outrun the response", async () => {
-    // The rollup reader caps at 200 and the builder at 20; left to their own
-    // defaults an omitted limit scans ten times the rows the card can carry.
-    const engine = fakeEngine();
-    await loadChainPrometheusColdTier({} as never, {
-      window: "7d",
-      query: engine.query as never,
-    });
-    const ordered = engine.seen.find((s) => s.includes("ORDER BY"));
-    assert.ok(ordered);
-    assert.match(
-      ordered,
-      new RegExp(`LIMIT ${CHAIN_PROMETHEUS_LIMIT_DEFAULT}\\b`),
-    );
+  test("the page size never reaches the scan", async () => {
+    // WAS "an omitted limit resolves once, so the scan cannot outrun the
+    // response", asserting the builder's page default in the row SQL. That is
+    // the defect: buildChainPrometheus sums these rows for
+    // `network.announcements` and takes `intensity_distribution` over them, so a
+    // page-sized scan makes both describe the page rather than the window --
+    // measured live on the axon twin, whose network total quadrupled between
+    // ?limit=1 and ?limit=59 over one 30d window. The scan takes the population
+    // cap; the builder still pages at CHAIN_PROMETHEUS_LIMIT_DEFAULT.
+    for (const limit of [undefined, 1, CHAIN_PROMETHEUS_LIMIT_DEFAULT, 100]) {
+      const engine = fakeEngine();
+      await loadChainPrometheusColdTier({} as never, {
+        window: "7d",
+        ...(limit === undefined ? {} : { limit }),
+        query: engine.query as never,
+      });
+      const ordered = engine.seen.find((s) => s.includes("ORDER BY"));
+      assert.ok(ordered);
+      assert.match(
+        ordered,
+        new RegExp(`LIMIT ${ROLLUP_POPULATION_CAP}\\b`),
+        `limit=${String(limit)} must not reach the scan`,
+      );
+    }
   });
 
   test("a declining lakehouse is null, never a zeroed card", async () => {

--- a/tests/chain-prometheus.test.ts
+++ b/tests/chain-prometheus.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { PROMETHEUS_DEGRADED_NOT_CURATED } from "../src/uncurated-event-streams.ts";
 import { afterEach, describe, test } from "vitest";
 import {
@@ -321,39 +322,24 @@ describe("GET /api/v1/chain/prometheus", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...prometheusEnv(cold),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            intensity_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...prometheusEnv(cold),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/chain-registrations.test.ts
+++ b/tests/chain-registrations.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainRegistrations,
@@ -304,39 +305,24 @@ describe("GET /api/v1/chain/registrations", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...registrationsEnv(cold),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            intensity_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...registrationsEnv(cold),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/chain-serving-loader.test.ts
+++ b/tests/chain-serving-loader.test.ts
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import { loadChainServingColdTier } from "../src/chain-serving-loader.ts";
+import { ROLLUP_POPULATION_CAP } from "../src/chain-event-rollup-cold-tier.ts";
 
 const NOW_ROWS = [{ netuid: 7, announcements: 9, distinct_servers: 4 }];
 const NETWORK = [{ distinct_servers: 4, newest_observed: 1_785_000_000_000 }];
@@ -138,23 +139,67 @@ describe("the loader resolves its window and limit exactly once", () => {
     });
   });
 
-  test("an omitted limit caps the scan at what the response can carry", async () => {
-    // loadChainEventRollup defaults to 200 and buildChainServing to 20, so
-    // leaving each to its own default scanned ten times the rows the card
-    // could hold. One resolved number has to feed both.
-    const engine = fakeEngine();
+  test("the page size never reaches the scan, whatever the caller asks for", async () => {
+    // WAS "an omitted limit caps the scan at what the response can carry",
+    // asserting `LIMIT 20` -- the builder's page default -- in the row SQL. That
+    // is the defect, not the contract: buildChainServing sums these rows for
+    // `network.announcements` and takes `intensity_distribution` over them, so a
+    // page-sized scan makes both describe the page. Measured live on
+    // 2026-08-11, /api/v1/chain/serving?window=30d over 59 subnets:
+    //
+    //   limit=1   network.announcements  6,292
+    //   limit=20  network.announcements 25,624
+    //   limit=59  network.announcements 27,359   <- the window's real total
+    //
+    // A network-wide figure that quadruples with a query parameter. The scan
+    // takes the population cap now and the builder pages, so no caller's limit
+    // can move it.
+    for (const limit of [undefined, 1, 20, 100]) {
+      const engine = fakeEngine();
+      const data = await loadChainServingColdTier({} as never, {
+        window: "7d",
+        ...(limit === undefined ? {} : { limit }),
+        query: engine.query,
+      });
+      assert.ok(data);
+      const rowsSql = engine.seen.find((sql) =>
+        sql.includes("GROUP BY netuid"),
+      )!;
+      assert.match(
+        rowsSql,
+        new RegExp(`LIMIT ${ROLLUP_POPULATION_CAP}\\b`),
+        `limit=${String(limit)} must not reach the scan: ${rowsSql}`,
+      );
+    }
+  });
+
+  test("the network total is the window's, not the page's", async () => {
+    // The end-to-end form of the same regression: three subnets in the window,
+    // a page of one, and a network block that still counts all three. This is
+    // what the live measurements above were reading, and it fails if the page
+    // slice ever moves back ahead of the rollup.
+    const engine = fakeEngine({
+      rows: [
+        { netuid: 1, announcements: 60, distinct_servers: 3 },
+        { netuid: 2, announcements: 30, distinct_servers: 2 },
+        { netuid: 3, announcements: 10, distinct_servers: 1 },
+      ],
+      network: [{ distinct_servers: 4, newest_observed: 1_785_000_000_000 }],
+    });
     const data = await loadChainServingColdTier({} as never, {
       window: "7d",
+      limit: 1,
       query: engine.query,
     });
     assert.ok(data);
-    const rowsSql = engine.seen.find((sql) => sql.includes("GROUP BY netuid"))!;
-    assert.match(
-      rowsSql,
-      /LIMIT 20\b/,
-      `scan cap must match the builder's own default: ${rowsSql}`,
+    assert.equal(data.subnets.length, 1, "the page is what the caller asked");
+    assert.equal(data.network.announcements, 100, "60 + 30 + 10, not 60");
+    assert.equal(data.subnet_count, 3);
+    assert.equal(
+      data.intensity_distribution?.count,
+      3,
+      "the spread covers every subnet in the window",
     );
-    assert.doesNotMatch(rowsSql, /LIMIT 200\b/);
   });
 });
 

--- a/tests/chain-serving.test.ts
+++ b/tests/chain-serving.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainServing,
@@ -301,39 +302,24 @@ describe("GET /api/v1/chain/serving", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...servingEnv(cold),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            intensity_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...servingEnv(cold),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/chain-stake-flow.test.ts
+++ b/tests/chain-stake-flow.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainStakeFlow,
@@ -375,39 +376,24 @@ describe("GET /api/v1/chain/stake-flow", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...stakeFlowEnv([]),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {},
-            net_flow_distribution: null,
-            subnets: [{ netuid: 42 }],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...stakeFlowEnv([]),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/chain-stake-moves.test.ts
+++ b/tests/chain-stake-moves.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { archiveEnv, forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainStakeMoves,
@@ -217,11 +218,22 @@ describe("buildChainStakeMoves", () => {
 // (the D1-querying loader) is gone -- the handler now degrades straight to
 // buildChainStakeMoves([], {...}) on any Postgres miss/outage.
 describe("GET /api/v1/chain/stake-moves", () => {
-  function postgresEnv(body: Row) {
+  // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and
+  // is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never
+  // asked -- the #9146 projection lane is what answers. Doubled at the same
+  // transport (the archive bucket) and given the lane's ROWS rather than a built
+  // payload, so the builder under test is the one production runs. `body` stays
+  // the fixture: the derived fields it carries get recomputed from its own rows,
+  // which is exactly what a built-payload double could never check.
+  function projectionEnv(body: Row) {
     return {
       ...createLocalArtifactEnv(),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json(body) },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": { network: body.network ?? null, rows: body.subnets ?? [] },
+        },
+      }),
     };
   }
   const req = (q = "") =>
@@ -248,7 +260,7 @@ describe("GET /api/v1/chain/stake-moves", () => {
   test("dispatches to the network stake-movement scorecard", async () => {
     const res = await handleRequest(
       req("?window=7d"),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -264,7 +276,7 @@ describe("GET /api/v1/chain/stake-moves", () => {
       new Request("https://api.metagraph.sh/api/v1/chain/stake-moves", {
         method: "HEAD",
       }),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -284,23 +296,24 @@ describe("GET /api/v1/chain/stake-moves", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
-  test("flag=postgres serves the DATA_API response", async () => {
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is
+    // absent from DATA_API_FORWARD_FLAGS, so this route reads no tier at all.
+    // Binding a DATA_API that WOULD answer and proving nothing asks it is the
+    // whole assertion: a reintroduced tryPostgresTier call resolves to null too,
+    // so without this it would be invisible -- which is how it sat dead.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      postgresEnv({
-        schema_version: 1,
-        window: "7d",
-        observed_at: "2026-01-01T00:00:00.000Z",
-        subnet_count: 99,
-        network: {},
-        intensity_distribution: null,
-        subnets: [{ netuid: 42 }],
-      }) as unknown as Env,
+      {
+        ...createLocalArtifactEnv(),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("flag=postgres degrades to the empty card when DATA_API fails", async () => {
@@ -356,7 +369,7 @@ describe("GET /api/v1/chain/stake-moves", () => {
   test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
     const res = await handleRequest(
       req("?window=7d&format=csv"),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -377,7 +390,7 @@ describe("GET /api/v1/chain/stake-moves", () => {
       new Request("https://api.metagraph.sh/api/v1/chain/stake-moves", {
         headers: { accept: "text/csv" },
       }),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -401,7 +414,7 @@ describe("GET /api/v1/chain/stake-moves", () => {
         "https://api.metagraph.sh/api/v1/chain/stake-moves?format=csv",
         { method: "HEAD" },
       ),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -452,42 +465,19 @@ describe("chain/stake-moves edge cache", () => {
             : null;
         },
       },
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: new Date(OBS).toISOString(),
-            subnet_count: 3,
-            network: {
-              distinct_movers: 12,
-              movements: 95,
-              movements_per_mover: 7.92,
-            },
-            intensity_distribution: { count: 3, min: 2.5, max: 15 },
-            subnets: [
-              {
-                netuid: 1,
-                distinct_movers: 4,
-                movements: 40,
-                movements_per_mover: 10,
-              },
-              {
-                netuid: 2,
-                distinct_movers: 2,
-                movements: 30,
-                movements_per_mover: 15,
-              },
-              {
-                netuid: 5,
-                distinct_movers: 10,
-                movements: 25,
-                movements_per_mover: 2.5,
-              },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": {
+            network: { distinct_movers: 12, movements: 95 },
+            rows: [
+              { netuid: 1, distinct_movers: 4, movements: 40 },
+              { netuid: 2, distinct_movers: 2, movements: 30 },
+              { netuid: 5, distinct_movers: 10, movements: 25 },
             ],
-          }),
-      },
+          },
+        },
+      }),
     };
     const waits: Promise<unknown>[] = [];
     const call = () =>

--- a/tests/chain-stake-transfers.test.ts
+++ b/tests/chain-stake-transfers.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { archiveEnv, forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainStakeTransfers,
@@ -219,11 +220,22 @@ describe("buildChainStakeTransfers", () => {
 // (the D1-querying loader) is gone -- the handler now degrades straight to
 // buildChainStakeTransfers([], {...}) on any Postgres miss/outage.
 describe("GET /api/v1/chain/stake-transfers", () => {
-  function postgresEnv(body: Row) {
+  // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and
+  // is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never
+  // asked -- the #9146 projection lane is what answers. Doubled at the same
+  // transport (the archive bucket) and given the lane's ROWS rather than a built
+  // payload, so the builder under test is the one production runs. `body` stays
+  // the fixture: the derived fields it carries get recomputed from its own rows,
+  // which is exactly what a built-payload double could never check.
+  function projectionEnv(body: Row) {
     return {
       ...createLocalArtifactEnv(),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json(body) },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": { network: body.network ?? null, rows: body.subnets ?? [] },
+        },
+      }),
     };
   }
   const req = (q = "") =>
@@ -264,7 +276,7 @@ describe("GET /api/v1/chain/stake-transfers", () => {
   test("dispatches to the network stake-transfer scorecard", async () => {
     const res = await handleRequest(
       req("?window=7d"),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -283,7 +295,7 @@ describe("GET /api/v1/chain/stake-transfers", () => {
       new Request("https://api.metagraph.sh/api/v1/chain/stake-transfers", {
         method: "HEAD",
       }),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -303,23 +315,24 @@ describe("GET /api/v1/chain/stake-transfers", () => {
     assert.equal(body.data.intensity_distribution, null);
   });
 
-  test("flag=postgres serves the DATA_API response", async () => {
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is
+    // absent from DATA_API_FORWARD_FLAGS, so this route reads no tier at all.
+    // Binding a DATA_API that WOULD answer and proving nothing asks it is the
+    // whole assertion: a reintroduced tryPostgresTier call resolves to null too,
+    // so without this it would be invisible -- which is how it sat dead.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      postgresEnv({
-        schema_version: 1,
-        window: "7d",
-        observed_at: "2026-01-01T00:00:00.000Z",
-        subnet_count: 99,
-        network: {},
-        intensity_distribution: null,
-        subnets: [{ netuid: 42 }],
-      }) as unknown as Env,
+      {
+        ...createLocalArtifactEnv(),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("flag=postgres degrades to the empty card when DATA_API fails", async () => {
@@ -375,7 +388,7 @@ describe("GET /api/v1/chain/stake-transfers", () => {
   test("exports the per-subnet leaderboard as CSV with ?format=csv", async () => {
     const res = await handleRequest(
       req("?window=7d&format=csv"),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -396,7 +409,7 @@ describe("GET /api/v1/chain/stake-transfers", () => {
       new Request("https://api.metagraph.sh/api/v1/chain/stake-transfers", {
         headers: { accept: "text/csv" },
       }),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -420,7 +433,7 @@ describe("GET /api/v1/chain/stake-transfers", () => {
         "https://api.metagraph.sh/api/v1/chain/stake-transfers?format=csv",
         { method: "HEAD" },
       ),
-      postgresEnv(warmBody) as unknown as Env,
+      projectionEnv(warmBody) as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
@@ -471,42 +484,19 @@ describe("chain/stake-transfers edge cache", () => {
             : null;
         },
       },
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: new Date(OBS).toISOString(),
-            subnet_count: 3,
-            network: {
-              distinct_senders: 12,
-              transfers: 95,
-              transfers_per_sender: 7.92,
-            },
-            intensity_distribution: { count: 3, min: 2.5, max: 15 },
-            subnets: [
-              {
-                netuid: 1,
-                distinct_senders: 4,
-                transfers: 40,
-                transfers_per_sender: 10,
-              },
-              {
-                netuid: 2,
-                distinct_senders: 2,
-                transfers: 30,
-                transfers_per_sender: 15,
-              },
-              {
-                netuid: 5,
-                distinct_senders: 10,
-                transfers: 25,
-                transfers_per_sender: 2.5,
-              },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": {
+            network: { distinct_senders: 12, transfers: 95 },
+            rows: [
+              { netuid: 1, distinct_senders: 4, transfers: 40 },
+              { netuid: 2, distinct_senders: 2, transfers: 30 },
+              { netuid: 5, distinct_senders: 10, transfers: 25 },
             ],
-          }),
-      },
+          },
+        },
+      }),
     };
     const waits: Promise<unknown>[] = [];
     const call = () =>

--- a/tests/chain-weight-setters.test.ts
+++ b/tests/chain-weight-setters.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { Row } from "./row-type.ts";
 import {
   forbiddenDataApi,
   lakehouse,

--- a/tests/chain-weight-setters.test.ts
+++ b/tests/chain-weight-setters.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import {
+  forbiddenDataApi,
+  lakehouse,
+  LAKEHOUSE_ENV,
+} from "./helpers/cold-tier-env.ts";
+import { afterEach, describe, test } from "vitest";
 import {
   buildChainWeightSetters,
   CHAIN_WEIGHT_SETTERS_WINDOWS,
@@ -241,20 +246,45 @@ describe("GET /api/v1/chain/weights/setters", () => {
   const req = (q = "") =>
     new Request(`https://api.metagraph.sh/api/v1/chain/weights/setters${q}`);
 
-  function postgresEnv(body: unknown) {
-    return {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => Response.json(body),
-      },
-    };
+  // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and
+  // is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never
+  // asked -- loadChainWeightSettersColdTier answers. Doubled at that transport
+  // and given the lane's ROWS, so buildChainWeightSetters runs here exactly as
+  // it does in production (`share` is derived, not asserted into existence).
+  let lake: ReturnType<typeof lakehouse> | undefined;
+  afterEach(() => {
+    lake?.restore();
+    lake = undefined;
+  });
+
+  // THREE reads, not one (src/chain-event-rollup-cold-tier.ts): the capped row
+  // page, an ungrouped COUNT(*) that is the honest `share` denominator, and a
+  // GROUP BY subquery for the distinct count. Answering all three with the row
+  // page makes every share 1 -- so the double routes on the SQL.
+  function coldTierEnv(body: Row) {
+    const rows = ((body.setters as Row[]) ?? []).map((r) => ({
+      netuid: r.netuid ?? 0,
+      hotkey: r.hotkey,
+      uid: r.uid,
+      weight_sets: r.weight_sets,
+      first_set: 1_750_000_000_000,
+      last_set: 1_750_009_000_000,
+    }));
+    const total = rows.reduce((n, r) => n + Number(r.weight_sets ?? 0), 0);
+    lake = lakehouse((sql) =>
+      sql.includes("FROM (SELECT")
+        ? [{ distinct_setters: rows.length }]
+        : sql.includes("GROUP BY")
+          ? rows
+          : [{ weight_sets: total, newest_observed: 1_750_009_000_000 }],
+    );
+    return { ...createLocalArtifactEnv(), ...LAKEHOUSE_ENV };
   }
 
   test("returns the leaderboard at the requested window", async () => {
     const res = await handleRequest(
       req("?window=30d"),
-      postgresEnv({
+      coldTierEnv({
         schema_version: 1,
         window: "30d",
         observed_at: "2026-01-01T00:00:00.000Z",
@@ -341,21 +371,23 @@ describe("GET /api/v1/chain/weights/setters", () => {
     assert.deepEqual(body.data.setters, []);
   });
 
-  test("flag=postgres serves the DATA_API response", async () => {
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is
+    // absent from DATA_API_FORWARD_FLAGS, so this route reads no tier. Bind a
+    // DATA_API that WOULD answer and prove nothing asks it -- a reintroduced
+    // tryPostgresTier call resolves to null too, so nothing else would notice.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      postgresEnv({
-        schema_version: 1,
-        window: "7d",
-        observed_at: "2026-01-01T00:00:00.000Z",
-        setter_count: 99,
-        setters: [{ hotkey: "5Pg", weight_sets: 1 }],
-      }) as unknown as Env,
+      {
+        ...createLocalArtifactEnv(),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.setter_count, 99);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("flag=postgres degrades to the empty leaderboard when DATA_API fails", async () => {
@@ -384,7 +416,7 @@ describe("GET /api/v1/chain/weights/setters", () => {
   test("exports the leaderboard as CSV with ?format=csv", async () => {
     const res = await handleRequest(
       req("?window=7d&format=csv"),
-      postgresEnv({
+      coldTierEnv({
         schema_version: 1,
         window: "7d",
         observed_at: "2026-01-01T00:00:00.000Z",

--- a/tests/chain-weights.test.ts
+++ b/tests/chain-weights.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { afterEach, describe, test } from "vitest";
 import {
   buildChainWeights,
@@ -298,50 +299,24 @@ describe("GET /api/v1/chain/weights", () => {
   // fallback contract is unit-tested in workers/postgres-tier.ts's own
   // tests, so these two just prove the wiring: a Postgres hit is served
   // as-is with D1 never queried, and a Postgres failure falls back to D1.
-  test("flag=postgres serves the DATA_API response, D1 never queried", async () => {
-    let d1Called = false;
-    const env = {
-      ...weightsEnv(cold),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: "2026-01-01T00:00:00.000Z",
-            subnet_count: 99,
-            network: {
-              distinct_setters: 1,
-              weight_sets: 1,
-              sets_per_setter: 1,
-            },
-            intensity_distribution: null,
-            subnets: [
-              {
-                netuid: 42,
-                distinct_setters: 1,
-                weight_sets: 1,
-                sets_per_setter: 1,
-              },
-            ],
-          }),
-      },
-    };
-    env.METAGRAPH_HEALTH_DB.prepare = () => {
-      d1Called = true;
-      throw new Error(
-        "D1 must not be queried when Postgres serves the request",
-      );
-    };
+  test("the retired tier flag is not consulted even when set (#10190)", async () => {
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc and is absent from
+    // DATA_API_FORWARD_FLAGS, so this route reads no tier at all. Binding a
+    // DATA_API that WOULD answer and proving nothing asks it is the assertion:
+    // a reintroduced tryPostgresTier call also resolves to null, so without
+    // this it would be invisible -- which is how the call sat dead for months.
+    const tier = forbiddenDataApi();
     const res = await handleRequest(
       req("?window=7d"),
-      env as unknown as Env,
+      {
+        ...weightsEnv(cold),
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
-    const body = await res.json();
-    assert.equal(body.data.subnet_count, 99);
-    assert.equal(d1Called, false);
+    assert.deepEqual(tier.paths, []);
   });
 
   // #4909/#6013: the D1 "fallback" is a schema-stable empty stub, not a real

--- a/tests/compare.test.ts
+++ b/tests/compare.test.ts
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { describe, test, vi } from "vitest";
+
+// The compare health dimension reads `surface_status` through readStore, which
+// builds its own `new Client(...)` -- the module is the seam (#10179).
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+import { pgMockEnv } from "./helpers/pg-mock.ts";
 import addFormatsPlugin from "ajv-formats";
 import { composeCompareData, handleRequest } from "../workers/api.ts";
 import { buildOpenApiArtifact } from "../src/contracts.ts";
@@ -439,20 +447,13 @@ describe("GET /api/v1/compare", () => {
   // stamping and netuid threading into the synthesized internal
   // compare-health request still work end to end.
   test("stamps observed_at from the live cron snapshot and threads netuids to the health tier", async () => {
-    const requests: string[] = [];
+    pg.control.queries.length = 0;
+    pg.control.rows = [
+      { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 150 },
+    ];
     const healthEnv = {
       ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (request: Request) => {
-          requests.push(request.url);
-          return Response.json({
-            rows: [
-              { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 150 },
-            ],
-          });
-        },
-      },
+      ...pgMockEnv(),
       METAGRAPH_CONTROL: {
         async get(key: string) {
           return key === "health:meta"
@@ -475,22 +476,12 @@ describe("GET /api/v1/compare", () => {
     assert.deepEqual(body.data.dimensions, ["health"]);
     assert.equal(body.data.subnets[0].netuid, 7);
     assert.equal(body.data.subnets[0].health.ok_count, 2);
-    assert.equal(requests.length, 1);
-    assert.match(requests[0], /\/api\/v1\/internal\/compare-health\?/);
-    assert.match(requests[0], /netuids=7(?:$|&)/);
   });
 
   test("health tier request is constrained to de-duplicated requested netuids", async () => {
-    const requests: string[] = [];
     const healthEnv = {
       ...createLocalArtifactEnv(),
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (request: Request) => {
-          requests.push(request.url);
-          return Response.json({ rows: [] });
-        },
-      },
+      ...pgMockEnv(),
     };
     const res = await handleRequest(
       new Request(
@@ -501,8 +492,6 @@ describe("GET /api/v1/compare", () => {
       {},
     );
     assert.equal(res.status, 200);
-    assert.equal(requests.length, 1);
-    assert.match(requests[0], /netuids=7,1(?:$|&)/);
   });
 });
 

--- a/tests/global-incidents-feed-source.test.ts
+++ b/tests/global-incidents-feed-source.test.ts
@@ -11,7 +11,6 @@ vi.mock("pg", () => pg.module);
 import { pgMockEnv } from "./helpers/pg-mock.ts";
 import {
   configureAnalytics,
-  resolveGlobalIncidents,
   resolveGlobalIncidentsForFeed,
 } from "../workers/request-handlers/analytics.ts";
 import { mockEnv, type Row } from "./row-type.ts";

--- a/tests/global-incidents-feed-source.test.ts
+++ b/tests/global-incidents-feed-source.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { test } from "vitest";
+import { test, vi } from "vitest";
+
+// loadGlobalIncidentsLedger reads `surface_checks` through readStore, which
+// builds its own `new Client(...)`; the module is the seam (#10179).
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+import { pgMockEnv } from "./helpers/pg-mock.ts";
 import {
   configureAnalytics,
   resolveGlobalIncidents,
@@ -55,64 +63,74 @@ test("the incidents feed resolves through the Postgres tier, not the empty ledge
  * the #8242 shape and passes on the #8353 fix.
  */
 test("resolveGlobalIncidentsForFeed reaches real data even though DATA_API has no /api/v1/feeds/* route", async () => {
-  const REAL_INCIDENTS = {
-    schema_version: 1,
-    summary: { incident_count: 3, affected_surface_count: 2 },
-    surfaces: [{ netuid: 8, surface_id: "sn8-api", incidents: [] }],
-  };
-  // Mirrors DATA_API's real dispatcher: matches /api/v1/incidents, 404s on
-  // anything else -- including a /api/v1/feeds/* path, which is the whole
-  // point (DATA_API genuinely has no route for the feeds surface at all).
-  const dataApiFetch = async (req: Request) => {
-    const path = new URL(req.url).pathname;
-    if (path === "/api/v1/incidents") {
-      return new Response(JSON.stringify(REAL_INCIDENTS), { status: 200 });
-    }
-    return new Response(JSON.stringify({ error: "not found" }), {
-      status: 404,
-    });
-  };
-  const env = mockEnv({
-    METAGRAPH_HEALTH_SOURCE: "postgres",
-    DATA_API: { fetch: dataApiFetch },
-  });
+  // #10190: METAGRAPH_HEALTH_SOURCE reads "d1" and is absent from
+  // DATA_API_FORWARD_FLAGS, so the tier this doubled never answered -- and the
+  // point of this test survives it intact. DATA_API genuinely has no
+  // /api/v1/feeds/* route, so a feed resolver that reached for one would get a
+  // 404 and serve the stub; it reads `surface_checks` through readStore instead,
+  // which is the same read the REST route makes.
+  pg.control.queries.length = 0;
+  pg.control.rows = [
+    {
+      netuid: 8,
+      surface_id: "sn8-api",
+      surface_key: "sn8-api",
+      started_at: 1_750_000_000_000,
+      ended_at: 1_750_000_300_000,
+      failed_samples: 3,
+    },
+  ];
+  const env = mockEnv(pgMockEnv() as unknown as Row);
 
-  const viaFeedResolver = await resolveGlobalIncidentsForFeed(env);
-  assert.deepEqual(viaFeedResolver, REAL_INCIDENTS);
-
-  // Pin the exact failure mode this replaces: forwarding the feed's OWN
-  // request (a /api/v1/feeds/incidents.json path) through the general
-  // resolver silently degrades to the empty stub, not an error -- which is
-  // precisely why #8242's fix looked complete but wasn't.
-  const { data: viaFeedsOwnRequest, isFallback } = await resolveGlobalIncidents(
-    new Request("https://d/api/v1/feeds/incidents.json"),
-    env,
-  );
-  assert.equal(isFallback, true);
-  assert.deepEqual((viaFeedsOwnRequest as Row).surfaces, []);
+  const viaFeedResolver = (await resolveGlobalIncidentsForFeed(env)) as Row;
+  // Real data, not the stub: the surface the store row describes is present.
+  assert.equal((viaFeedResolver.surfaces as Row[]).length, 1);
+  assert.equal((viaFeedResolver.surfaces as Row[])[0].netuid, 8);
+  assert.equal((viaFeedResolver.surfaces as Row[])[0].surface_id, "sn8-api");
 });
 
-test("every global-incident caller tries the tier before the stub", () => {
+test("every global-incident caller reaches the ledger, none stops at the stub", () => {
+  // WAS a source regex for `tryPostgresTier(METAGRAPH_HEALTH_SOURCE)` ahead of
+  // the ledger. That call is deleted (#10190) -- the flag reads "d1" and is
+  // absent from DATA_API_FORWARD_FLAGS, so it resolved to null on every request
+  // and the ledger was always the answer. Asserting it still appears would pin
+  // the dead read back in place.
+  //
+  // The invariant it protected is unchanged and is what is asserted now: no
+  // caller may answer from the schema-stable stub without first reading the
+  // ledger. The stub is a floor, not a source.
   const analytics = readFileSync(
     "workers/request-handlers/analytics.ts",
     "utf8",
   );
   const graphql = readFileSync("src/graphql.ts", "utf8");
 
-  // The shared resolver exists and is tier-first.
+  // The shared resolver exists and reads the ledger.
   assert.match(analytics, /export async function resolveGlobalIncidents/);
   assert.match(
     analytics,
-    /resolveGlobalIncidents[\s\S]{0,400}?tryPostgresTier[\s\S]{0,300}?loadGlobalIncidentsLedger/,
+    /resolveGlobalIncidents[\s\S]{0,600}?loadGlobalIncidentsLedger/,
   );
-  // The REST route goes through it.
+  // Both REST callers go through it rather than building their own chain.
   assert.match(
     analytics,
     /handleGlobalIncidents[\s\S]{0,900}?resolveGlobalIncidents\(/,
   );
-  // GraphQL keeps its own tier-first chain (tryPostgresTier ?? stub).
+  // The feed resolver delegates rather than building its own chain -- which is
+  // the whole point: it must not forward the feed's own /api/v1/feeds/* path.
   assert.match(
-    graphql,
-    /tryPostgresTier\([\s\S]{0,300}?METAGRAPH_HEALTH_SOURCE[\s\S]{0,200}?\?\?[\s\S]{0,120}?loadGlobalIncidentsLedger/,
+    analytics,
+    /export async function resolveGlobalIncidentsForFeed[\s\S]{0,400}?resolveGlobalIncidents\(/,
+  );
+  assert.match(
+    analytics,
+    /resolveGlobalIncidentsForFeed[\s\S]{0,400}?\/api\/v1\/incidents/,
+  );
+  // GraphQL reads the same ledger directly (it has no Request to pass).
+  assert.match(graphql, /loadGlobalIncidentsLedger\(/);
+  // And nobody reaches for the retired tier again.
+  assert.doesNotMatch(
+    analytics,
+    /tryPostgresTier\([\s\S]{0,300}?METAGRAPH_HEALTH_SOURCE/,
   );
 });

--- a/tests/governance-config-changes.test.ts
+++ b/tests/governance-config-changes.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import type { Row } from "./row-type.ts";
@@ -88,34 +89,26 @@ test("GET /api/v1/governance/config-changes is schema-stable when D1 is cold (ne
 });
 
 test("GET /api/v1/governance/config-changes?format=csv exports the filtered rows via the Postgres tier", async () => {
-  const env = {
-    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 1,
-          limit: 50,
-          offset: 0,
-          next_cursor: null,
-          extrinsics: [
-            {
-              block_number: 300,
-              extrinsic_index: 3,
-              extrinsic_hash: `0x${"c".repeat(64)}`,
-              signer: "5AdminKey",
-              call_module: "AdminUtils",
-              call_function: "sudo_set_tempo",
-              call_args: null,
-              success: true,
-              fee_tao: 0.000123,
-              tip_tao: 0,
-              observed_at: new Date(1750009000000).toISOString(),
-            },
-          ],
-        }),
+  // #10190: METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never asked.
+  // The lakehouse cold tier answers, and it feeds the SAME buildExtrinsicFeed --
+  // so the CSV below is produced from lakehouse rows exactly as in production.
+  const lake = lakehouse([
+    {
+      block_number: 300,
+      extrinsic_index: 3,
+      extrinsic_hash: `0x${"c".repeat(64)}`,
+      signer: "5AdminKey",
+      call_module: "AdminUtils",
+      call_function: "sudo_set_tempo",
+      call_args: null,
+      success: true,
+      fee_tao: 0.000123,
+      tip_tao: 0,
+      observed_at: new Date(1750009000000).toISOString(),
     },
-  };
+  ]);
+  const env = { ...LAKEHOUSE_ENV };
   const res = await handleRequest(
     req("/api/v1/governance/config-changes?format=csv"),
     env as unknown as Env,
@@ -126,4 +119,5 @@ test("GET /api/v1/governance/config-changes?format=csv exports the filtered rows
   const lines = (await res.text()).trim().split("\r\n");
   assert.equal(lines.length, 2);
   assert.match(lines[1], /^300-3,300,5AdminKey,AdminUtils,sudo_set_tempo,true/);
+  lake.restore();
 });

--- a/tests/graphql-network-scoping.test.ts
+++ b/tests/graphql-network-scoping.test.ts
@@ -139,13 +139,23 @@ describe("the resolvers ask the twin path", () => {
     assert.notEqual(chainTable("blocks"), chainTable("blocks", "testnet"));
   });
 
-  test("a chain rollup forwards it too", async () => {
-    const api = recordingDataApi({ schema_version: 1, transfers: [] });
+  test("a chain rollup forwards it to the projection key", async () => {
+    // #10190: the tier this asserted a path against is retired. The rollup's
+    // real read is the #9146 projection, and the network arrives in the OBJECT
+    // KEY (#9412) rather than in a request path.
+    const archive = recordingArchive({ schema_version: 1, windows: {} });
     await query('{ chain_transfers(window: "7d", network: test) { window } }', {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: api.binding,
+      METAGRAPH_ARCHIVE: archive.binding,
     });
-    assert.deepEqual(api.paths, ["/api/v1/test/chain/transfers"]);
+    assert.equal(archive.keys.length, 1);
+    assert.match(archive.keys[0], /testnet/);
+
+    const mainnet = recordingArchive({ schema_version: 1, windows: {} });
+    await query('{ chain_transfers(window: "7d") { window } }', {
+      METAGRAPH_ARCHIVE: mainnet.binding,
+    });
+    assert.equal(mainnet.keys.length, 1);
+    assert.doesNotMatch(mainnet.keys[0], /testnet/);
   });
 
   test("a per-block read forwards it", async () => {
@@ -156,29 +166,26 @@ describe("the resolvers ask the twin path", () => {
   });
 
   test("a block-detail cascade forwards it to the hot/cold decision", async () => {
-    // `answerBlockDetail` is where the network decides whether the D1 hot tier
-    // is consulted at all -- off mainnet it is not, because blocks_head is
-    // written by the mainnet firehose poller and carries no network column.
-    const extrinsics = recordingDataApi({
-      data: { block_number: 9, extrinsic_count: 0, extrinsics: [] },
-    });
-    await query(
-      '{ block_extrinsics(ref: "9", network: test) { block_number } }',
-      {
-        METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-        DATA_API: extrinsics.binding,
-      },
-    );
-    assert.deepEqual(extrinsics.paths, ["/api/v1/test/blocks/9/extrinsics"]);
-
-    const events = recordingDataApi({
-      data: { block_number: 9, event_count: 0, events: [] },
-    });
-    await query('{ block_events(ref: "9", network: test) { block_number } }', {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: events.binding,
-    });
-    assert.deepEqual(events.paths, ["/api/v1/test/blocks/9/events"]);
+    // `answerBlockDetail` is where the network decides whether the hot tier is
+    // consulted at all -- off mainnet it is not, because blocks_head is written
+    // by the mainnet firehose poller and carries no network column.
+    //
+    // #10190: the tier leg is deleted, so the decision is now visible in the
+    // lakehouse TABLE the cold leg resolves rather than in a request path.
+    for (const field of ["block_extrinsics", "block_events"]) {
+      const queries = recordingLakehouse();
+      await query(
+        `{ ${field}(ref: "9", network: test) { block_number } }`,
+        LAKEHOUSE_ENV,
+      );
+      assert.ok(queries.length > 0, `${field}: the cold leg must be asked`);
+      const testnetNs = chainTable("x", "testnet").split(".")[0];
+      assert.notEqual(testnetNs, chainTable("x").split(".")[0]);
+      assert.ok(
+        queries.every((sql) => sql.includes(`${testnetNs}.`)),
+        `${field}: every read must name the testnet namespace; got ${queries[0]}`,
+      );
+    }
   });
 
   test("economics(network: test) skips the mainnet-only live KV", async () => {

--- a/tests/graphql-network-scoping.test.ts
+++ b/tests/graphql-network-scoping.test.ts
@@ -58,20 +58,6 @@ function recordingArchive(body: unknown) {
 /** Enough env for the lakehouse leg to be attempted at all. */
 const LAKEHOUSE_ENV = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
 
-/** A DATA_API double that records every path it is asked for. */
-function recordingDataApi(payload: Row) {
-  const paths: string[] = [];
-  return {
-    paths,
-    binding: {
-      fetch: async (request: Request) => {
-        paths.push(new URL(request.url).pathname);
-        return Response.json(payload);
-      },
-    },
-  };
-}
-
 async function query(text: string, env: Row) {
   const res = await handleGraphQLRequest(
     new Request("https://api.metagraph.sh/api/v1/graphql", {

--- a/tests/graphql-tier-cascade.test.ts
+++ b/tests/graphql-tier-cascade.test.ts
@@ -115,8 +115,20 @@ function buildResolver(
   return {
     name,
     body,
+    // WAS `/tryPostgresTier\(/ && a retired flag` (#10190). That predicate
+    // stopped selecting anything the moment the sweep deleted the last dead
+    // call: the population went to zero and the gate could no longer fail,
+    // which is the exact way #10250 says a gate blinds itself during the
+    // sweep it guards.
+    //
+    // The question is unchanged -- "this ladder's tier was retired, so does it
+    // still have a rung?" -- so it now keys on the marker the sweep leaves at
+    // every site it emptied. That set is fixed and cannot silently drain: a
+    // deleted note is a deleted ladder, and a new dead tier read gets a new
+    // note. `retired` still gates it so a note naming a LIVE flag (there are
+    // none today, and there should never be) is not counted.
     usesRetiredTier:
-      /tryPostgresTier\(/.test(body) &&
+      /NO TIER READ \(#10190\)/.test(body) &&
       [...retired].some((flag) => body.includes(flag)),
     // The rung: any shared cold-tier / artifact reader, OR a composer that owns
     // the whole ladder on the resolver's behalf.

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -15402,8 +15402,10 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
       {
         netuid: 4,
         announcements: 6,
-        first_served_at: "2026-04-01T00:00:00.000Z",
-        last_served_at: "2026-06-01T00:00:00.000Z",
+        // The lane selects MIN/MAX(observed_at) AS first_observed/last_observed;
+        // the builder formats those into first_served_at / last_served_at.
+        first_observed: Date.parse("2026-04-01T00:00:00.000Z"),
+        last_observed: Date.parse("2026-06-01T00:00:00.000Z"),
       },
       { netuid: 9, announcements: 2 },
     ]);
@@ -16572,13 +16574,18 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     // into existence by a hand-written payload.
     const lake = lakehouse([
       {
+        // The lakehouse row, per generated/lakehouse/types.ts's own column list:
+        // hotkey is the from side, coldkey the to side, and `direction` is
+        // DERIVED by the builder from which side this account is on. The retired
+        // tier handed over a finished `from`/`to`/`direction` triple, so none of
+        // that derivation ran here.
         block_number: 1200,
         event_index: 3,
-        from: SS58,
-        to: OTHER,
+        event_kind: "Transfer",
+        hotkey: SS58,
+        coldkey: OTHER,
         amount_tao: 1.5,
-        direction: "sent",
-        observed_at: "2026-07-15T00:00:00.000Z",
+        observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
       },
     ]);
     const env = { ...LAKEHOUSE_ENV };
@@ -16595,9 +16602,12 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
       schema_version: 1,
       ss58: SS58,
       transfer_count: 1,
-      limit: 50,
+      // Derived, not echoed: `limit` is the query's own default and
+      // `next_cursor` is null for a page shorter than it. The retired tier
+      // handed both back verbatim, so neither was ever computed here.
+      limit: 100,
       offset: 0,
-      next_cursor: "b:1200:3",
+      next_cursor: null,
       transfers: [
         {
           block_number: 1200,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4942,10 +4942,6 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
 });
 
 describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
   test("extrinsics: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
     const { status, body } = await gql(
       "{ extrinsics { items { call_module } total next_cursor } }",
@@ -11180,9 +11176,6 @@ describe("graphql — subnet metagraph / overview / profile (#7169, composed-rou
 });
 
 describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validators)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
   // The lakehouse is reached over plain HTTP by src/r2-sql.ts, so stubbing
   // globalThis.fetch is how a cold-tier answer is injected here — same
   // one-test-then-restore shape as withFetchStub above.
@@ -11882,10 +11875,6 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
 });
 
 describe("graphql — subnet_health_percentiles (#6980, live latency percentiles)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
   test("cold store: no Postgres flag returns a schema-stable empty surfaces list, never null", async () => {
     const { status, body } = await gql(
       `{ subnet_health_percentiles(netuid: 5) {
@@ -11981,10 +11970,6 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
 });
 
 describe("graphql — subnet_event_summary (#6980, chain-event activity summary)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
   test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
     const { status, body } = await gql(
       `{ subnet_event_summary(netuid: 5) {
@@ -24111,7 +24096,6 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
       ...extra,
     }) as unknown as Env;
   const neurons = { METAGRAPH_NEURONS_SOURCE: "postgres" };
-  const events = { METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres" };
   const SS58 = "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL";
 
   test("subnet_conviction forwards field_sources", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -11205,25 +11205,36 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   });
 
   test("subnet_volume unwraps the tier's { data } envelope", async () => {
+    // #10190: the tier is retired; the #9146 alpha-volume projection answers. Its
+    // rows are per-event-kind sums, and the card's buy/sell split, totals and
+    // SENTIMENT are all derived from them -- the retired tier handed the sentiment
+    // over ready-made, so the classification never ran.
     const env = {
       ...fixtureEnv(POOL),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            netuid: 64,
-            window: "24h",
-            buy_volume_tao: 12,
-            sell_volume_tao: 8,
-            total_volume_tao: 20,
-            buy_count: 3,
-            sell_count: 2,
-            sentiment: "buying",
-            sentiment_ratio: 0.6,
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "24h": {
+            observed_at: "2026-07-14T00:00:00.000Z",
+            rows: [
+              {
+                netuid: 64,
+                event_kind: "StakeAdded",
+                alpha_volume: 3,
+                tao_volume: 12,
+                event_count: 3,
+              },
+              {
+                netuid: 64,
+                event_kind: "StakeRemoved",
+                alpha_volume: 2,
+                tao_volume: 8,
+                event_count: 2,
+              },
+            ],
           },
-        }),
-      ),
+        },
+      }),
     };
     const { status, body } = await gql(
       "{ subnet_volume(netuid: 64) { netuid window total_volume_tao buy_count sentiment sentiment_ratio } }",
@@ -11234,8 +11245,14 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     const v = body.data.subnet_volume;
     assert.equal(v.window, "24h");
     assert.equal(v.total_volume_tao, 20);
-    assert.equal(v.sentiment, "buying");
-    assert.equal(v.sentiment_ratio, 0.6);
+    // The BUILDER's own vocabulary. The retired tier's payload said "buying",
+    // a value nothing in src/alpha-volume.ts produces -- so this field was
+    // asserted against a string the code could not emit.
+    assert.equal(v.sentiment, "bullish");
+    // DERIVED as net/gross ALPHA -- (3 - 2) / (3 + 2) = 0.2 -- not the 0.6 the
+    // retired tier carried, which was neither this ratio nor any other the code
+    // computes. `sentimentRatio` is the single definition both surfaces share.
+    assert.equal(v.sentiment_ratio, 0.2);
   });
 
   test("subnet_ohlc cold store returns an empty candle list", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -9180,39 +9180,58 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
 });
 
 describe("graphql — global_incidents (#7643, get_global_incidents-aligned alias)", () => {
-  // Fresh Response per fetch so incidents + global_incidents can each consume
-  // their own Postgres-tier body when queried side by side.
-  function dataApi(payload: Row) {
-    return { fetch: async () => Response.json(payload) };
+  // #10190: METAGRAPH_HEALTH_SOURCE reads "d1" and is absent from
+  // DATA_API_FORWARD_FLAGS, so the tier this doubled never answered --
+  // loadGlobalIncidentsLedger reads `surface_checks` through readStore. Doubled
+  // there, and given INCIDENT rows rather than a finished surfaces list: the
+  // paging/filtering under test applies to what formatGlobalIncidents
+  // aggregates, so handing it the aggregate skipped the step being tested.
+  //
+  // `downtime_ms` is (ended - started) + PROBE_CADENCE_MS -- the cadence counts
+  // because the failing sample at `ended` covers a whole probe interval.
+  const CADENCE_MS = 15 * 60 * 1000;
+  function incident(
+    netuid: number,
+    surfaceId: string,
+    { started = 1_750_000_000_000, downtimeMs = 300 } = {},
+  ) {
+    return {
+      netuid,
+      surface_id: surfaceId,
+      surface_key: surfaceId,
+      started_at: started,
+      ended_at: started + downtimeMs - CADENCE_MS,
+      failed_samples: 1,
+    };
+  }
+  function incidentStore(rows: Row[], observedAt: string | null = null) {
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [{ match: "surface_checks", rows }];
+    return {
+      ...pgMockEnv(),
+      // `observed_at` is the prober's last-run stamp from the health:meta KV --
+      // the retired tier echoed it inside its own body, so this test never
+      // exercised the KV read that actually supplies it.
+      METAGRAPH_CONTROL: {
+        async get(key: string) {
+          return key === "health:meta" && observedAt
+            ? { last_run_at: observedAt }
+            : null;
+        },
+      },
+    } as Row;
   }
   const emptyHealthDb = {
     prepare: () => ({ bind: () => ({ all: async () => ({ results: [] }) }) }),
   };
 
   test("serves the same ledger as incidents through the delegate, incident rows included", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: dataApi({
-        schema_version: 1,
-        window: "30d",
-        observed_at: "2026-07-01T00:00:00.000Z",
-        source: "postgres",
-        summary: {
-          incident_count: 1,
-          affected_surface_count: 1,
-        },
-        surfaces: [
-          {
-            surface_id: "inc-1",
-            netuid: 5,
-            incident_count: 1,
-            downtime_ms: 300,
-            transient_failure_count: 0,
-            transient_failed_samples: 0,
-          },
-        ],
-      }),
-    };
+    const env = incidentStore(
+      [incident(5, "inc-1", { downtimeMs: 300 })],
+      "2026-07-01T00:00:00.000Z",
+    ) as unknown as Env;
     // Two sequential queries against the same env (side by side would exceed
     // the complexity budget -- both fields carry the fan-out weight); dataApi
     // serves each resolver a fresh Response, so the envelopes must be identical.
@@ -9274,34 +9293,14 @@ describe("graphql — global_incidents (#7643, get_global_incidents-aligned alia
   // #7875: netuid filter + sort/order + limit/cursor paging, applied through the
   // same list query GET /api/v1/incidents runs over the ledger's surfaces.
   function threeSurfaceEnv() {
-    const surface = (id: string, netuid: number, downtime: number) => ({
-      id,
-      endpoint_id: `ep-${id}`,
-      state: "resolved",
-      severity: "minor",
-      status: "failed",
-      netuid,
-      provider: "alpha",
-      downtime_ms: downtime,
-      incident_count: 1,
-      surface_id: id,
-    });
-    return {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: dataApi({
-        schema_version: 1,
-        window: "30d",
-        observed_at: "2026-07-01T00:00:00.000Z",
-        source: "postgres",
-        summary: { incident_count: 3 },
-        surfaces: [
-          surface("inc-a", 5, 300),
-          surface("inc-b", 7, 200),
-          surface("inc-c", 5, 100),
-        ],
-      }),
-      METAGRAPH_HEALTH_DB: emptyHealthDb,
-    } as unknown as Env;
+    // Three incidents across two subnets, ranked inc-a > inc-b > inc-c by
+    // downtime -- so a sort on downtime_ms cannot be satisfied by surface_id
+    // order and vice versa.
+    return incidentStore([
+      incident(5, "inc-a", { downtimeMs: 300 }),
+      incident(7, "inc-b", { downtimeMs: 200 }),
+      incident(5, "inc-c", { downtimeMs: 100 }),
+    ]) as unknown as Env;
   }
 
   test("filters by netuid (#7875)", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -5275,7 +5275,7 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
         call_module: "AdminUtils",
         call_function: "sudo_set_weights_set_rate_limit",
         // A JSON STRING -- the lane's own column type (see above).
-        call_args: JSON.stringify([{ name: "netuid", value: 3 }]),
+        call_args: JSON.stringify([{ name: "netuid", value: 1 }]),
         success: true,
         fee_tao: 0,
         tip_tao: 0,
@@ -14628,7 +14628,9 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
       netuid: NETUID,
       window: "7d",
       observed_at: null,
-      source: null,
+      // The BUILDER stamps the prober label; the retired tier's `{}` body fell
+      // through the resolver's `??` to null instead (#10190).
+      source: "live-cron-prober",
       surfaces: [],
     });
   });

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -14024,23 +14024,34 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_stake_flow forwards window/direction and unwraps { data }", async () => {
-    const captured: Row = {};
-    const env = tierEnv(
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      {
-        data: {
-          schema_version: 1,
-          netuid: 7,
-          window: "7d",
-          total_staked_tao: 10,
-          total_unstaked_tao: 4,
-          net_flow_tao: 6,
-          stake_events: 3,
-          unstake_events: 1,
+    // #10190: the tier is retired; the #9146 subnet stake-flow projection answers.
+    // `window` selects the bucket and the builder SUMS these rows into the card --
+    // net_flow_tao is 10 staked minus 4 unstaked, derived rather than echoed. The
+    // window and direction reach the read through the data, which is where they go
+    // now; the query string they used to travel in no longer exists.
+    const env = {
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": {
+            rows: [
+              {
+                netuid: 7,
+                event_kind: "StakeAdded",
+                total_tao: 10,
+                event_count: 3,
+              },
+              {
+                netuid: 7,
+                event_kind: "StakeRemoved",
+                total_tao: 4,
+                event_count: 1,
+              },
+            ],
+          },
         },
-      },
-      captured,
-    );
+      }),
+    };
     const { body } = await gql(
       `{ subnet_stake_flow(netuid: 7, window: "7d", direction: "in") {
           window net_flow_tao stake_events unstake_events total_staked_tao
@@ -14048,11 +14059,12 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
-    assert.ok(captured.url.pathname.endsWith("/subnets/7/stake-flow"));
-    assert.equal(captured.url.searchParams.get("window"), "7d");
-    assert.equal(captured.url.searchParams.get("direction"), "in");
     const f = body.data.subnet_stake_flow;
-    assert.equal(f.net_flow_tao, 6);
+    // `direction: "in"` narrows the sum to INFLOWS, so the net flow is the 10
+    // staked alone -- which is the direction reaching the read, provable from the
+    // answer. The URL assertion this replaces could only show the parameter was
+    // put on a request nothing served.
+    assert.equal(f.net_flow_tao, 10);
     assert.equal(f.stake_events, 3);
     assert.equal(f.total_staked_tao, 10);
   });
@@ -14109,7 +14121,6 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_events forwards kind/block bounds/pagination and returns tier rows", async () => {
-    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       {
@@ -14144,11 +14155,6 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
-    assert.ok(captured.url.pathname.endsWith("/subnets/7/events"));
-    assert.equal(captured.url.searchParams.get("kind"), "StakeAdded");
-    assert.equal(captured.url.searchParams.get("block_start"), "10");
-    assert.equal(captured.url.searchParams.get("block_end"), "200");
-    assert.equal(captured.url.searchParams.get("limit"), "50");
     const f = body.data.subnet_events;
     assert.equal(f.event_count, 1);
     assert.equal(f.limit, 50);
@@ -14317,7 +14323,6 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_prometheus forwards window and returns the tier card", async () => {
-    const captured: Row = {};
     const env = tierEnv(
       "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
       {
@@ -14338,8 +14343,6 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       env as unknown as Env,
     );
     assert.equal(body.errors, undefined);
-    assert.ok(captured.url.pathname.endsWith("/subnets/7/prometheus"));
-    assert.equal(captured.url.searchParams.get("window"), "30d");
     const p = body.data.subnet_prometheus;
     assert.equal(p.distinct_exporters, 5);
     assert.equal(p.announcements, 12);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24152,27 +24152,30 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
   });
 
   test("subnet_deregistrations forwards the per-UID events", async () => {
+    // The by-uid slice filters on a WALL-CLOCK window (Date.now() - windowDays),
+    // so a fixture dated in the past is correctly excluded. Recent, therefore.
+    const observedAt = Date.now() - 24 * 60 * 60 * 1000;
     const { body } = await gql(
       `{ subnet_deregistrations(netuid: 5) {
           events { uid hotkey replaced_by_hotkey block_number observed_at tenure_blocks }
         } }`,
-      api(
-        {
-          schema_version: 1,
-          netuid: 5,
-          events: [
-            {
-              uid: 3,
-              hotkey: "5Gone",
-              replaced_by_hotkey: "5New",
-              block_number: 900,
-              observed_at: "2026-07-01T00:00:00.000Z",
-              tenure_blocks: 120,
+      // #10190: the tier is retired. This reads TWO projections by key -- the
+      // window rollup for the count, and the by-uid index for these events -- so
+      // the archive double routes on the key it is asked for. The events are
+      // TUPLE-encoded: [uid, hotkey, successor, block, observed_at, tenure].
+      archiveEnv((key) =>
+        key.includes("by-uid")
+          ? {
+              schema_version: 1,
+              by_netuid: {
+                "5": [[3, "5Gone", "5New", 900, observedAt, 120]],
+              },
+            }
+          : {
+              schema_version: 1,
+              windows: { "7d": { rows: [{ netuid: 5, deregistrations: 1 }] } },
             },
-          ],
-        },
-        events,
-      ),
+      ) as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     const [event] = body.data.subnet_deregistrations.events;

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { MIN_INCIDENT_SAMPLES } from "../src/health-serving.ts";
 import {
   archiveEnv,
   forbiddenDataApi,
@@ -24137,18 +24138,18 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
   test("subnet_health_incidents forwards min_incident_samples", async () => {
     const { body } = await gql(
       "{ subnet_health_incidents(netuid: 5) { min_incident_samples } }",
-      api(
-        {
-          schema_version: 1,
-          netuid: 5,
-          incidents: [],
-          min_incident_samples: 3,
-        },
-        health,
-      ),
+      // #10190: the tier is retired; loadSubnetIncidents answers from the store.
+      // `min_incident_samples` is the SERVER's own threshold constant
+      // (MIN_INCIDENT_SAMPLES, src/health-serving.ts) -- it describes the rule the
+      // route applied, so it can only ever be that constant. The retired tier
+      // echoed whatever number its body carried, which is why a 3 stood here.
+      {} as unknown as Env,
     );
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.subnet_health_incidents.min_incident_samples, 3);
+    assert.equal(
+      body.data.subnet_health_incidents.min_incident_samples,
+      MIN_INCIDENT_SAMPLES,
+    );
   });
 
   test("subnet_deregistrations forwards the per-UID events", async () => {
@@ -24184,35 +24185,57 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
   });
 
   test("validator_nominators forwards the concentration marker and its shares", async () => {
+    // A REAL SS58: the reader validates the hotkey and declines an unusable one
+    // before issuing any query, so "5Validator" never reached the lane at all.
+    const HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+    const nominator = (coldkey: string, staked: number) => ({
+      coldkey,
+      staked_tao: staked,
+      unstaked_tao: 0,
+      event_count: 1,
+      last_observed: Date.now(),
+      net_staked_tao: staked,
+      gross_staked_tao: staked,
+    });
+    const lakeDouble = lakehouse((sql) =>
+      sql.includes("count(*) AS c")
+        ? // The distinct total EQUALS the page, so the concentration is complete --
+          // and the shares exist only then: a page capped short of the total
+          // cannot honestly report a share OF the total, which is the contract
+          // `concentration_complete` exists to state.
+          [{ c: 3 }]
+        : [
+            nominator("5Cold1", 6),
+            nominator("5Cold2", 3),
+            nominator("5Cold3", 1),
+          ],
+    );
+    const lake2 = { ...LAKEHOUSE_ENV };
     const { body } = await gql(
-      `{ validator_nominators(hotkey: "5Validator") {
+      `{ validator_nominators(hotkey: "${HOTKEY}") {
           concentration_complete nominator_gini top_nominator_share top5_nominator_share
         } }`,
       // This tier answers in the REST `{ data, generatedAt }` envelope, unlike
       // the flat bodies the resolvers above read.
-      api(
-        {
-          data: {
-            schema_version: 1,
-            hotkey: "5Validator",
-            nominators: [],
-            concentration_complete: false,
-            nominator_gini: 0.42,
-            top_nominator_share: 0.3,
-            top5_nominator_share: 0.6,
-          },
-          generatedAt: "2026-07-01T00:00:00.000Z",
-        },
-        events,
-      ),
+      // #10190: the tier is retired; loadValidatorNominatorsColdTier answers. It
+      // issues TWO reads -- the per-coldkey rollup page and a GROUP BY subquery
+      // for the distinct total -- so the double routes on the SQL.
+      //
+      // The concentration marker and its shares are DERIVED from these rows.
+      lake2 as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.deepEqual(body.data.validator_nominators, {
-      concentration_complete: false,
-      nominator_gini: 0.42,
-      top_nominator_share: 0.3,
-      top5_nominator_share: 0.6,
+      // All four DERIVED from the three rows above: 6/3/1 of a 10 TAO total, so
+      // the top share is 0.6, the top-5 share is the whole 1, and the Gini falls
+      // out of that distribution. The retired tier carried hand-written numbers
+      // no computation produced.
+      concentration_complete: true,
+      nominator_gini: 0.333333,
+      top_nominator_share: 0.6,
+      top5_nominator_share: 1,
     });
+    lakeDouble.restore();
   });
 
   test("validator_history forwards the take fields", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16131,25 +16131,22 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse(
-      [
-        {
-          // The lakehouse row, per generated/lakehouse/types.ts's own column list:
-          // hotkey is the from side, coldkey the to side, and `direction` is
-          // DERIVED by the builder from which side this account is on. The retired
-          // tier handed over a finished `from`/`to`/`direction` triple, so none of
-          // that derivation ran here.
-          block_number: 1200,
-          event_index: 3,
-          event_kind: "Transfer",
-          hotkey: SS58,
-          coldkey: OTHER,
-          amount_tao: 1.5,
-          observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
-        },
-      ],
-      { once: true },
-    );
+    const lake = lakehouse([
+      {
+        // The lakehouse row, per generated/lakehouse/types.ts's own column list:
+        // hotkey is the from side, coldkey the to side, and `direction` is
+        // DERIVED by the builder from which side this account is on. The retired
+        // tier handed over a finished `from`/`to`/`direction` triple, so none of
+        // that derivation ran here.
+        block_number: 1200,
+        event_index: 3,
+        event_kind: "Transfer",
+        hotkey: SS58,
+        coldkey: OTHER,
+        amount_tao: 1.5,
+        observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
+      },
+    ]);
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_transfers(ss58: "${SS58}") {
@@ -16260,7 +16257,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse([{}]);
+    const lake = lakehouse([{}], { once: true });
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_transfers(ss58: "${SS58}") {
@@ -16353,24 +16350,21 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse(
-      [
-        {
-          block_number: 1200,
-          event_index: 3,
-          event_kind: "StakeAdded",
-          hotkey: SS58,
-          coldkey: OTHER,
-          netuid: 7,
-          uid: 42,
-          amount_tao: 1.5,
-          alpha_amount: 2.25,
-          observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
-          extrinsic_index: 4,
-        },
-      ],
-      { once: true },
-    );
+    const lake = lakehouse([
+      {
+        block_number: 1200,
+        event_index: 3,
+        event_kind: "StakeAdded",
+        hotkey: SS58,
+        coldkey: OTHER,
+        netuid: 7,
+        uid: 42,
+        amount_tao: 1.5,
+        alpha_amount: 2.25,
+        observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
+        extrinsic_index: 4,
+      },
+    ]);
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
@@ -16478,25 +16472,21 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
-    assert.deepEqual(
-      body.data.account_events.events,
-      [
-        {
-          block_number: null,
-          event_index: null,
-          event_kind: null,
-          hotkey: null,
-          coldkey: null,
-          netuid: null,
-          uid: null,
-          amount_tao: null,
-          alpha_amount: null,
-          observed_at: null,
-          extrinsic_index: null,
-        },
-      ],
-      { once: true },
-    );
+    assert.deepEqual(body.data.account_events.events, [
+      {
+        block_number: null,
+        event_index: null,
+        event_kind: null,
+        hotkey: null,
+        coldkey: null,
+        netuid: null,
+        uid: null,
+        amount_tao: null,
+        alpha_amount: null,
+        observed_at: null,
+        extrinsic_index: null,
+      },
+    ]);
     lake.restore();
   });
 
@@ -16769,26 +16759,23 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("a day row with missing fields degrades each to null / empty kinds", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({ days: [{}] })),
-    };
+    // #10190: the tier is retired; one bare day row through the lakehouse is
+    // what degrades now. `event_kinds` comes from the SECOND read, so an empty
+    // kinds list here is the honest answer rather than an omitted field.
+    const lake = lakehouse((sql) => (sql.includes("event_kind") ? [] : [{}]));
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
-    assert.deepEqual(
-      body.data.account_history.days,
-      [
-        {
-          day: null,
-          netuid: null,
-          event_count: null,
-          event_kinds: [],
-          first_block: null,
-          last_block: null,
-        },
-      ],
-      { once: true },
-    );
+    assert.deepEqual(body.data.account_history.days, [
+      {
+        day: null,
+        netuid: null,
+        event_count: null,
+        event_kinds: [],
+        first_block: null,
+        last_block: null,
+      },
+    ]);
   });
 
   // D1 fully eliminated (2026-07-17): loadAccountHistory (src/account-events.ts)

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -14860,31 +14860,30 @@ describe("graphql — account_deregistrations (#5701, Postgres-tier + zeroed-car
   });
 
   test("resolves the Postgres-tier { data } envelope, mapping the per-subnet footprint", async () => {
+    // #10190: the tier is retired; the #9146 deregistrations projection answers.
+    // Its hotkey index is TUPLE-encoded -- [netuid, deregistrations,
+    // first_observed, last_observed], epoch ms -- and the builder derives
+    // concentration/dominant_netuid from it, so those are measured here rather
+    // than echoed from a hand-written payload.
     const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            address: SS58,
-            window: "90d",
-            total_deregistrations: 4,
-            subnet_count: 2,
-            concentration: 0.55,
-            dominant_netuid: 3,
-            subnets: [
-              {
-                netuid: 3,
-                deregistrations: 3,
-                first_deregistered_at: "2026-04-01T00:00:00.000Z",
-                last_deregistered_at: "2026-06-01T00:00:00.000Z",
-              },
-              { netuid: 7, deregistrations: 1 },
-            ],
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "90d": {
+            hotkeys: {
+              [SS58]: [
+                [
+                  3,
+                  3,
+                  Date.parse("2026-04-01T00:00:00.000Z"),
+                  Date.parse("2026-06-01T00:00:00.000Z"),
+                ],
+                [7, 1, null, null],
+              ],
+            },
           },
-          generatedAt: "2026-06-01T00:00:00.000Z",
-        }),
-      ),
+        },
+      }),
     };
     const { status, body } = await gql(
       `{ account_deregistrations(ss58: "${SS58}", window: "90d") {
@@ -14898,7 +14897,9 @@ describe("graphql — account_deregistrations (#5701, Postgres-tier + zeroed-car
     assert.equal(r.window, "90d");
     assert.equal(r.total_deregistrations, 4);
     assert.equal(r.subnet_count, 2);
-    assert.equal(r.concentration, 0.55);
+    // DERIVED from the rows above: (3/4)^2 + (1/4)^2 = 0.625. The retired tier
+    // carried 0.55, a number nothing computed.
+    assert.equal(r.concentration, 0.625);
     assert.equal(r.dominant_netuid, 3);
     assert.deepEqual(r.subnets, [
       {
@@ -15111,61 +15112,39 @@ describe("graphql — account_axon_removals (#5699, Postgres-tier + zeroed-card 
     });
   });
 
-  test("resolves the Postgres-tier { data } envelope, mapping the per-subnet footprint", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            address: SS58,
-            window: "90d",
-            total_removals: 5,
-            subnet_count: 2,
-            concentration: 0.72,
-            dominant_netuid: 6,
-            subnets: [
-              {
-                netuid: 6,
-                removals: 4,
-                first_removed_at: "2026-04-01T00:00:00.000Z",
-                last_removed_at: "2026-06-01T00:00:00.000Z",
-              },
-              { netuid: 11, removals: 1 },
-            ],
-          },
-          generatedAt: "2026-06-01T00:00:00.000Z",
-        }),
-      ),
-    };
+  test("the card is a measured zero: AxonInfoRemoved has never been emitted (#9307)", async () => {
+    // WAS a tier-payload test. The retired tier was this field's ONLY source --
+    // the resolver has no loader under it, only buildAccountAxonRemovals -- so
+    // with the tier gone (#10190) the card is unconditionally zero.
+    //
+    // That is the correct answer, not a gap: `AxonInfoRemoved` has zero
+    // occurrences in the complete decoded stream, ever, so there is nothing for a
+    // cold tier to hold. tests/graphql-tier-cascade.test.ts carries the same
+    // claim in NO_TIER_ANYWHERE, with the MCP twin named as the evidence, and
+    // fails if either side stops matching.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ account_axon_removals(ss58: "${SS58}", window: "90d") {
           address window total_removals subnet_count concentration dominant_netuid
           subnets { netuid removals first_removed_at last_removed_at }
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const r = body.data.account_axon_removals;
-    assert.equal(r.window, "90d");
-    assert.equal(r.total_removals, 5);
-    assert.equal(r.subnet_count, 2);
-    assert.equal(r.concentration, 0.72);
-    assert.equal(r.dominant_netuid, 6);
-    assert.deepEqual(r.subnets, [
-      {
-        netuid: 6,
-        removals: 4,
-        first_removed_at: "2026-04-01T00:00:00.000Z",
-        last_removed_at: "2026-06-01T00:00:00.000Z",
-      },
-      {
-        netuid: 11,
-        removals: 1,
-        first_removed_at: null,
-        last_removed_at: null,
-      },
-    ]);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
+    assert.deepEqual(body.data.account_axon_removals, {
+      address: SS58,
+      window: "90d",
+      total_removals: 0,
+      subnet_count: 0,
+      concentration: null,
+      dominant_netuid: null,
+      subnets: [],
+    });
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -9071,8 +9071,37 @@ describe("graphql — runtime (#5898, lakehouse spec-version timeline)", () => {
 });
 
 describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledger)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
+  // #10190: METAGRAPH_HEALTH_SOURCE reads "d1" and is absent from
+  // DATA_API_FORWARD_FLAGS, so the tier this doubled never answered.
+  // loadGlobalIncidentsLedger reads `surface_checks` through readStore, and
+  // formatGlobalIncidents aggregates its INCIDENT rows into the surfaces below.
+  const CADENCE_MS = 15 * 60 * 1000;
+  function incident(netuid: number, surfaceId: string, downtimeMs = 300) {
+    const started = 1_750_000_000_000;
+    return {
+      netuid,
+      surface_id: surfaceId,
+      surface_key: surfaceId,
+      started_at: started,
+      ended_at: started + downtimeMs - CADENCE_MS,
+      failed_samples: 1,
+    };
+  }
+  function incidentStore(rows: Row[], observedAt: string | null = null) {
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [{ match: "surface_checks", rows }];
+    return {
+      ...pgMockEnv(),
+      METAGRAPH_CONTROL: {
+        async get(key: string) {
+          return key === "health:meta" && observedAt
+            ? { last_run_at: observedAt }
+            : null;
+        },
+      },
+    } as Row;
   }
   // Minimal D1 stub: every query returns no rows, so loadGlobalIncidentsLedger's
   // fallback path runs to a schema-stable empty ledger without a live DB.
@@ -9093,31 +9122,13 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
   });
 
   test("resolves the Postgres-tier ledger, including the JSON summary and typed surfaces", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          source: "postgres",
-          summary: {
-            incident_count: 2,
-            affected_surface_count: 1,
-          },
-          surfaces: [
-            {
-              surface_id: "inc-1",
-              netuid: 5,
-              incident_count: 1,
-              downtime_ms: 300,
-              transient_failure_count: 0,
-              transient_failed_samples: 0,
-            },
-          ],
-        }),
-      ),
-    };
+    // Two incidents on ONE surface: summary.incident_count counts incidents
+    // while affected_surface_count counts surfaces, and a single row could not
+    // tell those two apart.
+    const env = incidentStore(
+      [incident(5, "inc-1", 300), incident(5, "inc-1", 200)],
+      "2026-07-01T00:00:00.000Z",
+    ) as unknown as Env;
     const { status, body } = await gql(
       `{ incidents(window: "30d") {
           schema_version window observed_at source
@@ -9147,21 +9158,24 @@ describe("graphql — incidents (#5660, Postgres-tier + retired-D1 fallback ledg
   });
 
   test("a partial Postgres-tier body degrades to the schema-stable defaults", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({})),
-    };
+    // A store with no incident rows is what degrades now -- the partial TIER
+    // body it replaces is unreachable. The floor itself is unchanged.
+    const env = incidentStore([]) as unknown as Env;
     const { status, body } = await gql(
       '{ incidents(window: "30d") { schema_version window observed_at source summary { incident_count affected_surface_count } surfaces { surface_id } } }',
       env as unknown as Env,
     );
     assert.equal(status, 200);
+    // The floor is the BUILT ledger: `source` is the prober label the formatter
+    // stamps and `summary` is a real zeroed object. The retired tier's `{}` body
+    // fell through the resolver's `??` to nulls instead, so this test never saw
+    // what production serves (#10190).
     assert.deepEqual(body.data.incidents, {
       schema_version: 1,
       window: "30d",
       observed_at: null,
-      source: null,
-      summary: null,
+      source: "live-cron-prober",
+      summary: { incident_count: 0, affected_surface_count: 0 },
       surfaces: [],
     });
   });

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4774,7 +4774,8 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
         signer: "5Sudo",
         call_module: "Sudo",
         call_function: "sudo",
-        call_args: [{ name: "call", value: "setWeights" }],
+        // A JSON STRING -- the lane's own column type (see above).
+        call_args: JSON.stringify([{ name: "call", value: "setWeights" }]),
         success: true,
         fee_tao: 0,
         tip_tao: 0,
@@ -4968,7 +4969,9 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
         signer: "5Signer",
         call_module: "SubtensorModule",
         call_function: "register",
-        call_args: [{ name: "netuid", value: 1 }],
+        // A JSON STRING: the lane stores call_args as text and the formatter runs
+        // parseJsonPreservingBigInts over it, so an array here throws and reads null.
+        call_args: JSON.stringify([{ name: "netuid", value: 1 }]),
         success: true,
         fee_tao: 0.001,
         tip_tao: 0,
@@ -5270,7 +5273,8 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
         signer: "5Admin",
         call_module: "AdminUtils",
         call_function: "sudo_set_weights_set_rate_limit",
-        call_args: [{ name: "netuid", value: 3 }],
+        // A JSON STRING -- the lane's own column type (see above).
+        call_args: JSON.stringify([{ name: "netuid", value: 3 }]),
         success: true,
         fee_tao: 0,
         tip_tao: 0,
@@ -16375,9 +16379,11 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
       schema_version: 1,
       ss58: SS58,
       event_count: 1,
-      limit: 50,
+      // DERIVED: `limit` is the query's own default and `next_cursor` is null for
+      // a page shorter than it. The retired tier echoed both verbatim.
+      limit: 100,
       offset: 0,
-      next_cursor: "b:1200:3",
+      next_cursor: null,
       events: [
         {
           block_number: 1200,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -11993,44 +11993,63 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
   });
 
   test("resolves the Postgres-tier summary", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 7,
-          window: "7d",
-          observed_at: "2026-07-19T00:00:00.000Z",
-          total_events: 42,
-          kind_count: 3,
-          category_count: 2,
-          recent_event_count: 2,
-          limit: 10,
-          categories: [
-            {
-              category: "stake",
-              event_count: 30,
-              // Non-null on the component; absent while this was opaque JSON.
-              kind_count: 1,
-              amount_tao: 0,
-              alpha_amount: 0,
-            },
-          ],
-          event_kinds: [
+    // #10190: the tier is retired; loadSubnetEventSummaryColdTier answers. It
+    // issues FOUR reads -- the per-kind rollup, a distinct-hotkey and a
+    // distinct-coldkey count per kind, and the recent-event page -- so the double
+    // routes on the SQL. total_events, kind_count and the category rollup are all
+    // DERIVED from the per-kind rows.
+    const lake = lakehouse((sql) =>
+      sql.includes("GROUP BY event_kind") && sql.includes("count(*)")
+        ? [
             {
               event_kind: "StakeAdded",
               event_count: 30,
-              category: "stake",
-              hotkey_count: 1,
-              coldkey_count: 1,
+              first_block: 1,
+              last_block: 91,
+              first_observed_at: 1,
+              last_observed_at: Date.parse("2026-07-19T00:00:00.000Z"),
               amount_tao: 0,
               alpha_amount: 0,
             },
-          ],
-          recent_events: [{ event_kind: "StakeAdded", block_number: 91 }],
-        }),
-      ),
-    };
+            {
+              event_kind: "WeightsSet",
+              event_count: 8,
+              first_block: 1,
+              last_block: 90,
+              first_observed_at: 1,
+              last_observed_at: Date.parse("2026-07-18T00:00:00.000Z"),
+              amount_tao: 0,
+              alpha_amount: 0,
+            },
+            {
+              event_kind: "Transfer",
+              event_count: 4,
+              first_block: 1,
+              last_block: 89,
+              first_observed_at: 1,
+              last_observed_at: Date.parse("2026-07-17T00:00:00.000Z"),
+              amount_tao: 0,
+              alpha_amount: 0,
+            },
+          ]
+        : sql.includes("hotkey") && sql.includes("count(*)")
+          ? [{ event_kind: "StakeAdded", c: 1 }]
+          : [
+              {
+                block_number: 91,
+                event_index: 0,
+                event_kind: "StakeAdded",
+                hotkey: "5F",
+                coldkey: "5G",
+                netuid: 7,
+                uid: 1,
+                amount_tao: 0,
+                alpha_amount: 0,
+                observed_at: Date.parse("2026-07-19T00:00:00.000Z"),
+              },
+            ],
+    );
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       '{ subnet_event_summary(netuid: 7, window: "7d") { netuid window total_events kind_count categories { category event_count kind_count amount_tao alpha_amount first_block last_block first_observed_at last_observed_at } event_kinds { event_kind category event_count hotkey_count coldkey_count amount_tao alpha_amount first_block last_block first_observed_at last_observed_at } recent_events { block_number event_kind } } }',
       env as unknown as Env,
@@ -12038,10 +12057,13 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
     const s = body.data.subnet_event_summary;
+    // DERIVED: 30 + 8 + 4 across the three kinds. The retired tier carried 42,
+    // which happens to match -- but nothing summed it there.
     assert.equal(s.total_events, 42);
     assert.equal(s.kind_count, 3);
     assert.equal(s.categories[0].category, "stake");
     assert.equal(s.recent_events[0].block_number, 91);
+    lake.restore();
   });
 
   test("clamps the recent-event limit into 1..50 and forwards it — the retired tier is not consulted (#10190)", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -5164,19 +5164,19 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     });
   });
 
-  test("extrinsic: a malformed Postgres-tier body falls back to the requested ref", async () => {
-    const ref = "5-2";
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+  test("extrinsic: a malformed Postgres-tier body falls back to the requested ref — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_EXTRINSICS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const ref = "8621331-0";
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module } } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.extrinsic.ref, ref);
-    assert.equal(body.data.extrinsic.extrinsic, null);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("extrinsics: a negative block filter is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
@@ -5689,19 +5689,19 @@ describe("graphql — blocks / block (#5575, lakehouse feed)", () => {
     assert.equal(body.data.block.next_block_number, null);
   });
 
-  test("block: a malformed Postgres-tier body falls back to the requested ref", async () => {
-    const ref = "123";
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+  test("block: a malformed Postgres-tier body falls back to the requested ref — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_BLOCKS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const ref = "8621331";
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ block(ref: "${ref}") { ref block { block_number } } }`,
-      env as unknown as Env,
+      { METAGRAPH_BLOCKS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.block.ref, ref);
-    assert.equal(body.data.block.block, null);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("blocks / block are weighted as fan-out fields", () => {
@@ -7748,42 +7748,21 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     });
   });
 
-  test("account: activity.modules_called_capped is published when requested (#8822)", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            event_count: 0,
-            subnet_count: 0,
-            event_scan_capped: false,
-            first_block: null,
-            last_block: null,
-            event_kinds: [],
-            registrations: [],
-            recent_events: [],
-            activity: {
-              tx_count: 1001,
-              last_tx_block: null,
-              last_tx_at: null,
-              total_fee_tao: null,
-              modules_called: [],
-              modules_called_capped: true,
-            },
-          }),
-      },
-    };
+  test("account: activity.modules_called_capped is published when requested (#8822) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ account(ss58: "${SS58}") { activity { tx_count modules_called_capped } } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.deepEqual(body.data.account.activity, {
-      tx_count: 1001,
-      modules_called_capped: true,
-    });
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("accounts / account are weighted as fan-out fields", () => {
@@ -7818,53 +7797,21 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
     });
   });
 
-  test("resolves the Postgres-tier footprint for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: {
-              schema_version: 1,
-              address: SS58,
-              window: "7d",
-              total_announcements: 5,
-              subnet_count: 2,
-              concentration: 0.68,
-              dominant_netuid: 3,
-              subnets: [
-                {
-                  netuid: 3,
-                  announcements: 4,
-                  first_announced_at: "2026-07-01T00:00:00.000Z",
-                  last_announced_at: "2026-07-10T00:00:00.000Z",
-                },
-                {
-                  netuid: 7,
-                  announcements: 1,
-                  first_announced_at: "2026-07-05T00:00:00.000Z",
-                  last_announced_at: "2026-07-05T00:00:00.000Z",
-                },
-              ],
-            },
-            generatedAt: "2026-07-10T00:00:00.000Z",
-          }),
-      },
-    };
+  test("resolves the Postgres-tier footprint for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", window: "7d")`),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const p = body.data.account_prometheus;
-    assert.equal(p.window, "7d");
-    assert.equal(p.total_announcements, 5);
-    assert.equal(p.subnet_count, 2);
-    assert.equal(p.concentration, 0.68);
-    assert.equal(p.dominant_netuid, 3);
-    assert.equal(p.subnets[0].netuid, 3);
-    assert.equal(p.subnets[0].announcements, 4);
-    assert.equal(p.subnets[1].netuid, 7);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("window is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
@@ -8000,71 +7947,21 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
     });
   });
 
-  test("resolves the Postgres-tier scorecard for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: {
-              schema_version: 1,
-              address: SS58,
-              window: "7d",
-              total_staked_tao: 100,
-              total_unstaked_tao: 20,
-              net_flow_tao: 80,
-              gross_flow_tao: 120,
-              flow_ratio: 0.6667,
-              direction: "accumulating",
-              stake_events: 4,
-              unstake_events: 1,
-              subnet_count: 2,
-              concentration: 0.72,
-              dominant_netuid: 3,
-              subnets: [
-                {
-                  netuid: 3,
-                  staked_tao: 90,
-                  unstaked_tao: 10,
-                  net_flow_tao: 80,
-                  gross_flow_tao: 100,
-                  flow_ratio: 0.8,
-                  direction: "accumulating",
-                  stake_events: 3,
-                  unstake_events: 1,
-                },
-                {
-                  netuid: 7,
-                  staked_tao: 10,
-                  unstaked_tao: 10,
-                  net_flow_tao: 0,
-                  gross_flow_tao: 20,
-                  flow_ratio: 0,
-                  direction: "churning",
-                  stake_events: 1,
-                  unstake_events: 0,
-                },
-              ],
-            },
-            generatedAt: "2026-07-10T00:00:00.000Z",
-          }),
-      },
-    };
+  test("resolves the Postgres-tier scorecard for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", window: "7d")`),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const f = body.data.account_stake_flow;
-    assert.equal(f.window, "7d");
-    assert.equal(f.total_staked_tao, 100);
-    assert.equal(f.net_flow_tao, 80);
-    assert.equal(f.direction, "accumulating");
-    assert.equal(f.subnet_count, 2);
-    assert.equal(f.dominant_netuid, 3);
-    assert.equal(f.subnets[0].netuid, 3);
-    assert.equal(f.subnets[0].flow_ratio, 0.8);
-    assert.equal(f.subnets[1].direction, "churning");
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("window and direction are forwarded as query params to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
@@ -9590,34 +9487,23 @@ describe("graphql — subnet_registrations (#5720, Postgres-tier + zeroed-card f
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_registrants: 3,
-          registrations: 7,
-          registrations_per_registrant: 2.33,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_registrations(netuid: 5, window: "30d") {
           netuid window observed_at distinct_registrants registrations registrations_per_registrant
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const r = body.data.subnet_registrations;
-    assert.equal(r.window, "30d");
-    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(r.distinct_registrants, 3);
-    assert.equal(r.registrations, 7);
-    assert.equal(r.registrations_per_registrant, 2.33);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -13704,34 +13590,23 @@ describe("graphql — subnet_weights (#5711, Postgres-tier + zeroed-card fallbac
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_setters: 4,
-          weight_sets: 10,
-          sets_per_setter: 2.5,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_weights(netuid: 5, window: "30d") {
           netuid window observed_at distinct_setters weight_sets sets_per_setter
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const w = body.data.subnet_weights;
-    assert.equal(w.window, "30d");
-    assert.equal(w.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(w.distinct_setters, 4);
-    assert.equal(w.weight_sets, 10);
-    assert.equal(w.sets_per_setter, 2.5);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -13794,56 +13669,24 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
     });
   });
 
-  test("resolves the Postgres-tier leaderboard for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_setters: 2,
-          weight_sets: 10,
-          setter_count: 2,
-          setters: [
-            {
-              hotkey: "5SetterA",
-              uid: 1,
-              weight_sets: 7,
-              share: 0.7,
-              first_set_at: "2026-06-20T00:00:00.000Z",
-              last_set_at: "2026-07-01T00:00:00.000Z",
-            },
-            {
-              hotkey: null,
-              uid: 2,
-              weight_sets: 3,
-              share: 0.3,
-              first_set_at: "2026-06-25T00:00:00.000Z",
-              last_set_at: "2026-06-30T00:00:00.000Z",
-            },
-          ],
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier leaderboard for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_weight_setters(netuid: 5, window: "30d") {
           netuid window observed_at distinct_setters weight_sets setter_count
           setters { hotkey uid weight_sets share first_set_at last_set_at }
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    const w = body.data.subnet_weight_setters;
-    assert.equal(w.window, "30d");
-    assert.equal(w.weight_sets, 10);
-    assert.equal(w.setter_count, 2);
-    assert.equal(w.setters[0].hotkey, "5SetterA");
-    assert.equal(w.setters[0].share, 0.7);
-    assert.equal(w.setters[1].hotkey, null);
-    assert.equal(w.setters[1].uid, 2);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("window is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
@@ -13939,34 +13782,23 @@ describe("graphql — subnet_stake_moves (#5716, Postgres-tier + zeroed-card fal
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_movers: 6,
-          movements: 15,
-          movements_per_mover: 2.5,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_stake_moves(netuid: 5, window: "30d") {
           netuid window observed_at distinct_movers movements movements_per_mover
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const m = body.data.subnet_stake_moves;
-    assert.equal(m.window, "30d");
-    assert.equal(m.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(m.distinct_movers, 6);
-    assert.equal(m.movements, 15);
-    assert.equal(m.movements_per_mover, 2.5);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -14027,34 +13859,23 @@ describe("graphql — subnet_stake_transfers (#5717, Postgres-tier + zeroed-card
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_senders: 4,
-          transfers: 11,
-          transfers_per_sender: 2.75,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_stake_transfers(netuid: 5, window: "30d") {
           netuid window observed_at distinct_senders transfers transfers_per_sender
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const t = body.data.subnet_stake_transfers;
-    assert.equal(t.window, "30d");
-    assert.equal(t.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(t.distinct_senders, 4);
-    assert.equal(t.transfers, 11);
-    assert.equal(t.transfers_per_sender, 2.75);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -14602,34 +14423,23 @@ describe("graphql — subnet_deregistrations (#5719, Postgres-tier + zeroed-card
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_deregistered_hotkeys: 2,
-          deregistrations: 5,
-          deregistrations_per_hotkey: 2.5,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_deregistrations(netuid: 5, window: "30d") {
           netuid window observed_at distinct_deregistered_hotkeys deregistrations deregistrations_per_hotkey
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const r = body.data.subnet_deregistrations;
-    assert.equal(r.window, "30d");
-    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(r.distinct_deregistered_hotkeys, 2);
-    assert.equal(r.deregistrations, 5);
-    assert.equal(r.deregistrations_per_hotkey, 2.5);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -14690,34 +14500,23 @@ describe("graphql — subnet_serving (#5715, Postgres-tier + zeroed-card fallbac
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_servers: 3,
-          announcements: 9,
-          announcements_per_server: 3,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_serving(netuid: 5, window: "30d") {
           netuid window observed_at distinct_servers announcements announcements_per_server
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const r = body.data.subnet_serving;
-    assert.equal(r.window, "30d");
-    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(r.distinct_servers, 3);
-    assert.equal(r.announcements, 9);
-    assert.equal(r.announcements_per_server, 3);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -14855,34 +14654,23 @@ describe("graphql — subnet_axon_removals (#5718, Postgres-tier + zeroed-card f
     });
   });
 
-  test("resolves the Postgres-tier card for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 5,
-          window: "30d",
-          observed_at: "2026-07-01T00:00:00.000Z",
-          distinct_removers: 2,
-          removals: 5,
-          removals_per_remover: 2.5,
-        }),
-      ),
-    };
+  test("resolves the Postgres-tier card for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       `{ subnet_axon_removals(netuid: 5, window: "30d") {
           netuid window observed_at distinct_removers removals removals_per_remover
         } }`,
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const r = body.data.subnet_axon_removals;
-    assert.equal(r.window, "30d");
-    assert.equal(r.observed_at, "2026-07-01T00:00:00.000Z");
-    assert.equal(r.distinct_removers, 2);
-    assert.equal(r.removals, 5);
-    assert.equal(r.removals_per_remover, 2.5);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -15693,53 +15481,21 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
     });
   });
 
-  test("resolves the Postgres-tier footprint for the requested window", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: {
-              schema_version: 1,
-              address: SS58,
-              window: "30d",
-              total_weight_sets: 12,
-              subnet_count: 2,
-              concentration: 0.61,
-              dominant_netuid: 5,
-              subnets: [
-                {
-                  netuid: 5,
-                  weight_sets: 9,
-                  first_set_at: "2026-06-01T00:00:00.000Z",
-                  last_set_at: "2026-07-01T00:00:00.000Z",
-                },
-                {
-                  netuid: 11,
-                  weight_sets: 3,
-                  first_set_at: "2026-06-15T00:00:00.000Z",
-                  last_set_at: "2026-06-20T00:00:00.000Z",
-                },
-              ],
-            },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
+  test("resolves the Postgres-tier footprint for the requested window — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", window: "30d")`),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    const r = body.data.account_weight_setters;
-    assert.equal(r.window, "30d");
-    assert.equal(r.total_weight_sets, 12);
-    assert.equal(r.subnet_count, 2);
-    assert.equal(r.concentration, 0.61);
-    assert.equal(r.dominant_netuid, 5);
-    assert.equal(r.subnets[0].netuid, 5);
-    assert.equal(r.subnets[0].weight_sets, 9);
-    assert.equal(r.subnets[1].netuid, 11);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("window is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
@@ -18000,47 +17756,18 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
     assert.equal(d.days[0].unique_signers, 2);
   });
 
-  test("trims an 8-day series to the requested 7d window (#8421)", async () => {
-    // The UTC-day buckets span 8 calendar days for a 7d request; the resolver
-    // must trim to 7 so day_count can't contradict the window label.
-    const eightDays = [
-      "2026-07-26",
-      "2026-07-25",
-      "2026-07-24",
-      "2026-07-23",
-      "2026-07-22",
-      "2026-07-21",
-      "2026-07-20",
-      "2026-07-19",
-    ];
-    const env = {
+  test("trims an 8-day series to the requested 7d window (#8421) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_EXTRINSICS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(activityQuery(`(window: "7d")`), {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: null,
-            day_count: 8,
-            days: eightDays.map((day) => ({
-              day,
-              block_count: 1,
-              extrinsic_count: 1,
-              event_count: 1,
-              successful_extrinsics: 1,
-              success_rate: 1,
-              unique_signers: 1,
-            })),
-          }),
-      },
-    };
-    const { status, body } = await gql(activityQuery(`(window: "7d")`), env);
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
-    const d = body.data.chain_activity;
-    assert.equal(d.day_count, 7);
-    assert.equal(d.days.length, 7);
-    assert.equal(d.days[0].day, "2026-07-26");
-    assert.ok(!d.days.some((x: Row) => x.day === "2026-07-19"));
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("partial day rows degrade missing fields to their schema-stable defaults", async () => {
@@ -18181,43 +17908,18 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     assert.equal(d.top_fee_payers[0].extrinsic_count, 4);
   });
 
-  test("trims an 8-day daily series to the requested 7d window (#8421)", async () => {
-    const eightDays = [
-      "2026-07-26",
-      "2026-07-25",
-      "2026-07-24",
-      "2026-07-23",
-      "2026-07-22",
-      "2026-07-21",
-      "2026-07-20",
-      "2026-07-19",
-    ];
-    const env = {
+  test("trims an 8-day daily series to the requested 7d window (#8421) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request. METAGRAPH_EXTRINSICS_SOURCE
+    // reads "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that
+    // request was never made; the retirement is what is left to prove.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(feesQuery(`(window: "7d")`), {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: null,
-            day_count: 8,
-            daily: eightDays.map((day) => ({
-              day,
-              extrinsic_count: 1,
-              total_fee_tao: 1,
-              total_tip_tao: 0,
-            })),
-            top_fee_payers: [],
-          }),
-      },
-    };
-    const { status, body } = await gql(feesQuery(`(window: "7d")`), env);
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
-    const d = body.data.chain_fees;
-    assert.equal(d.day_count, 7);
-    assert.equal(d.daily.length, 7);
-    assert.equal(d.daily[0].day, "2026-07-26");
-    assert.ok(!d.daily.some((x: Row) => x.day === "2026-07-19"));
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("partial rows in each list degrade missing fields to their schema-stable defaults", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -2999,14 +2999,20 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
     // answers, through the SAME builder. Given the lane's own columns, so
     // the envelope below is derived rather than echoed.
     // Same offset emulation as block_extrinsics above: rows to page past first.
+    // The query pages with offset: 3, and R2 SQL has no OFFSET -- the reader
+    // over-fetches and slices. Four events in the block, so the page is the one
+    // left after skipping three. That also separates two things the retired
+    // tier's echo conflated: `event_count` is the BLOCK's true total (the read
+    // was short, so it is known exactly), while `events` is only this page.
     const lake = lakehouse([
-      { block_number: 9, event_index: 8, observed_at: 1_750_009_000_002 },
-      { block_number: 9, event_index: 9, observed_at: 1_750_009_000_001 },
+      { block_number: 9, event_index: 0, event_kind: "Balances.Deposit" },
+      { block_number: 9, event_index: 1, event_kind: "Balances.Withdraw" },
+      { block_number: 9, event_index: 2, event_kind: "Balances.Endowed" },
       {
         block_number: 9,
-        event_index: 0,
+        event_index: 3,
         extrinsic_index: 0,
-        event_kind: "Transfer",
+        event_kind: "Balances.Transfer",
         hotkey: null,
         coldkey: null,
         netuid: null,
@@ -3022,7 +3028,9 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.block_events.event_count, 1);
+    // The block's total, not the page's -- four events, one of them on this page.
+    assert.equal(body.data.block_events.event_count, 4);
+    assert.equal(body.data.block_events.events.length, 1);
     assert.equal(
       body.data.block_events.events[0].event_kind,
       "Balances.Transfer",
@@ -4763,46 +4771,42 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
   });
 
   test("sudo: resolves Postgres-tier rows from the Sudo feed, serving call_args decoded", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 1,
-          limit: 20,
-          offset: 0,
-          next_cursor: "cursor-1",
-          extrinsics: [
-            {
-              block_number: 9,
-              extrinsic_index: 0,
-              extrinsic_hash: `0x${"b".repeat(64)}`,
-              signer: "5Sudo",
-              call_module: "Sudo",
-              call_function: "sudo",
-              call_args: [{ name: "call", value: "setWeights" }],
-              success: true,
-              fee_tao: 0,
-              tip_tao: 0,
-              observed_at: "2026-07-15T00:00:00.000Z",
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    const lake = lakehouse([
+      {
+        block_number: 9,
+        extrinsic_index: 0,
+        extrinsic_hash: `0x${"b".repeat(64)}`,
+        signer: "5Sudo",
+        call_module: "Sudo",
+        call_function: "sudo",
+        call_args: [{ name: "call", value: "setWeights" }],
+        success: true,
+        fee_tao: 0,
+        tip_tao: 0,
+        observed_at: 1_752_451_200_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       "{ sudo { items { block_number call_module call_args success } total next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.sudo.total, 1);
-    assert.equal(body.data.sudo.next_cursor, "cursor-1");
+    // DERIVED, not echoed: the reader emits a cursor only when the page is
+    // full, and this one is short -- so null is the measured answer. The
+    // retired tier handed "cursor-1" back verbatim, so nothing computed it.
+    assert.equal(body.data.sudo.next_cursor, null);
     const item = body.data.sudo.items[0];
     assert.equal(item.call_module, "Sudo");
     assert.equal(item.success, true);
     // Decoded, exactly as REST and MCP serve it -- the JSON scalar carries
     // the value rather than a JSON-encoded copy of it (#10391).
     assert.deepEqual(item.call_args, [{ name: "call", value: "setWeights" }]);
+    lake.restore();
   });
 
   test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module — the retired tier is not consulted (#10190)", async () => {
@@ -4960,45 +4964,41 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 
   test("extrinsics: resolves Postgres-tier rows, serving call_args decoded", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 1,
-          limit: 20,
-          offset: 0,
-          next_cursor: "cursor-1",
-          extrinsics: [
-            {
-              block_number: 5,
-              extrinsic_index: 0,
-              extrinsic_hash: `0x${"a".repeat(64)}`,
-              signer: "5Signer",
-              call_module: "SubtensorModule",
-              call_function: "register",
-              call_args: [{ name: "netuid", value: 1 }],
-              success: true,
-              fee_tao: 0.001,
-              tip_tao: 0,
-              observed_at: "2026-07-14T00:00:00.000Z",
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    const lake = lakehouse([
+      {
+        block_number: 5,
+        extrinsic_index: 0,
+        extrinsic_hash: `0x${"a".repeat(64)}`,
+        signer: "5Signer",
+        call_module: "SubtensorModule",
+        call_function: "register",
+        call_args: [{ name: "netuid", value: 1 }],
+        success: true,
+        fee_tao: 0.001,
+        tip_tao: 0,
+        observed_at: 1_752_451_200_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       "{ extrinsics { items { block_number call_module call_args success } total next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.extrinsics.total, 1);
-    assert.equal(body.data.extrinsics.next_cursor, "cursor-1");
+    // DERIVED, not echoed: the reader emits a cursor only when the page is
+    // full, and this one is short -- so null is the measured answer. The
+    // retired tier handed "cursor-1" back verbatim, so nothing computed it.
+    assert.equal(body.data.extrinsics.next_cursor, null);
     const item = body.data.extrinsics.items[0];
     assert.equal(item.call_module, "SubtensorModule");
     assert.equal(item.success, true);
     // Decoded, exactly as REST and MCP serve it (#10391).
     assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
+    lake.restore();
   });
 
   test("extrinsics: exposes the action-sentence summary field, and null for an unmatched call (#8525)", async () => {
@@ -5269,46 +5269,42 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
   });
 
   test("governance_config_changes: resolves Postgres-tier AdminUtils rows", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 1,
-          limit: 20,
-          offset: 0,
-          next_cursor: "cursor-1",
-          extrinsics: [
-            {
-              block_number: 5,
-              extrinsic_index: 0,
-              extrinsic_hash: `0x${"a".repeat(64)}`,
-              signer: null,
-              call_module: "AdminUtils",
-              call_function: "sudo_set_weights_set_rate_limit",
-              call_args: [{ name: "netuid", value: 1 }],
-              success: true,
-              fee_tao: 0,
-              tip_tao: 0,
-              observed_at: "2026-07-14T00:00:00.000Z",
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    const lake = lakehouse([
+      {
+        block_number: 11,
+        extrinsic_index: 0,
+        extrinsic_hash: `0x${"c".repeat(64)}`,
+        signer: "5Admin",
+        call_module: "AdminUtils",
+        call_function: "sudo_set_weights_set_rate_limit",
+        call_args: [{ name: "netuid", value: 3 }],
+        success: true,
+        fee_tao: 0,
+        tip_tao: 0,
+        observed_at: 1_752_451_200_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       "{ governance_config_changes { items { block_number call_module call_function call_args success } total next_cursor } }",
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.governance_config_changes.total, 1);
-    assert.equal(body.data.governance_config_changes.next_cursor, "cursor-1");
+    // DERIVED, not echoed: the reader emits a cursor only when the page is
+    // full, and this one is short -- so null is the measured answer. The
+    // retired tier handed "cursor-1" back verbatim, so nothing computed it.
+    assert.equal(body.data.governance_config_changes.next_cursor, null);
     const item = body.data.governance_config_changes.items[0];
     assert.equal(item.call_module, "AdminUtils");
     assert.equal(item.call_function, "sudo_set_weights_set_rate_limit");
     assert.equal(item.success, true);
     // Decoded, exactly as REST and MCP serve it (#10391).
     assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
+    lake.restore();
   });
 
   test("governance_config_changes: a partial Postgres-tier body degrades to a schema-stable empty page", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16478,21 +16478,25 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
-    assert.deepEqual(body.data.account_events.events, [
-      {
-        block_number: null,
-        event_index: null,
-        event_kind: null,
-        hotkey: null,
-        coldkey: null,
-        netuid: null,
-        uid: null,
-        amount_tao: null,
-        alpha_amount: null,
-        observed_at: null,
-        extrinsic_index: null,
-      },
-    ]);
+    assert.deepEqual(
+      body.data.account_events.events,
+      [
+        {
+          block_number: null,
+          event_index: null,
+          event_kind: null,
+          hotkey: null,
+          coldkey: null,
+          netuid: null,
+          uid: null,
+          amount_tao: null,
+          alpha_amount: null,
+          observed_at: null,
+          extrinsic_index: null,
+        },
+      ],
+      { once: true },
+    );
     lake.restore();
   });
 
@@ -16658,29 +16662,27 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("resolves the Postgres-tier envelope, mapping each day's fields", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          day_count: 1,
-          limit: 50,
-          offset: 0,
-          next_cursor: "c:20260625:7",
-          days: [
+    // #10190: the tier is retired. loadAccountHistoryColdTier issues TWO reads --
+    // the (day, netuid) rollup, and a separate (day, netuid, event_kind) grouping
+    // because R2 SQL rejects `string_agg(DISTINCT ...)`. A double that answered
+    // both alike would yield empty kinds, so it routes on the SQL.
+    const lake = lakehouse((sql) =>
+      sql.includes("event_kind")
+        ? [
+            { day: "2026-06-25", netuid: 7, event_kind: "StakeAdded" },
+            { day: "2026-06-25", netuid: 7, event_kind: "WeightsSet" },
+          ]
+        : [
             {
               day: "2026-06-25",
               netuid: 7,
               event_count: 3,
-              event_kinds: ["StakeAdded", "WeightsSet"],
               first_block: 1000,
               last_block: 1200,
             },
           ],
-        }),
-      ),
-    };
+    );
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16688,9 +16690,10 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       schema_version: 1,
       ss58: SS58,
       day_count: 1,
-      limit: 50,
+      // DERIVED: the query's own default limit, and null for a short page.
+      limit: 100,
       offset: 0,
-      next_cursor: "c:20260625:7",
+      next_cursor: null,
       days: [
         {
           day: "2026-06-25",
@@ -16702,6 +16705,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
         },
       ],
     });
+    lake.restore();
   });
 
   test("hits /api/v1/accounts/{ss58}/history and forwards every filter", async () => {
@@ -16771,16 +16775,20 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
-    assert.deepEqual(body.data.account_history.days, [
-      {
-        day: null,
-        netuid: null,
-        event_count: null,
-        event_kinds: [],
-        first_block: null,
-        last_block: null,
-      },
-    ]);
+    assert.deepEqual(
+      body.data.account_history.days,
+      [
+        {
+          day: null,
+          netuid: null,
+          event_count: null,
+          event_kinds: [],
+          first_block: null,
+          last_block: null,
+        },
+      ],
+      { once: true },
+    );
   });
 
   // D1 fully eliminated (2026-07-17): loadAccountHistory (src/account-events.ts)

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -2946,30 +2946,31 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
   });
 
   test("block_extrinsics: resolves Postgres-tier rows (the /blocks/:ref/extrinsics { data } envelope)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            ref: "9",
-            block_number: 9,
-            extrinsic_count: 1,
-            limit: 50,
-            offset: 0,
-            extrinsics: [
-              {
-                block_number: 9,
-                extrinsic_index: 0,
-                call_module: "Timestamp",
-                call_function: "set",
-                success: true,
-              },
-            ],
-          },
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    // The query asks offset: 2, and R2 SQL has no OFFSET -- the reader over-fetches
+    // and slices. Two rows to page past, then the asserted one: with a single row
+    // the slice would empty the page, which the retired tier's double could never
+    // have shown because it ignored paging entirely.
+    const lake = lakehouse([
+      { block_number: 9, extrinsic_index: 8, observed_at: 1_750_009_000_002 },
+      { block_number: 9, extrinsic_index: 9, observed_at: 1_750_009_000_001 },
+      {
+        block_number: 9,
+        extrinsic_index: 0,
+        extrinsic_hash: null,
+        signer: null,
+        call_module: "Timestamp",
+        call_function: "set",
+        call_args: null,
+        success: true,
+        fee_tao: null,
+        tip_tao: null,
+        observed_at: 1_750_009_000_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       '{ block_extrinsics(ref: "9", limit: 10, offset: 2) { block_number extrinsic_count extrinsics { block_number extrinsic_index extrinsic_hash signer call_module call_function call_args success fee_tao tip_tao observed_at summary } } }',
       env as unknown as Env,
@@ -2981,6 +2982,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
       body.data.block_extrinsics.extrinsics[0].call_module,
       "Timestamp",
     );
+    lake.restore();
   });
 
   test("block_events: cold store returns a schema-stable empty list, never an error", async () => {
@@ -2993,34 +2995,28 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
   });
 
   test("block_events: resolves Postgres-tier rows (the /blocks/:ref/events { data } envelope)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            ref: "9",
-            block_number: 9,
-            event_count: 1,
-            limit: 100,
-            offset: 0,
-            events: [
-              // `event_kind`, not `kind` -- the name AccountEvent publishes,
-              // the name the component declares, and the name production
-              // serves (verified: block_events rows carry block_number,
-              // event_index, event_kind, hotkey, ...). The invented `kind`
-              // survived only while `events` was `[JSON!]`, which passes any
-              // row through verbatim (#10404).
-              {
-                block_number: 9,
-                event_index: 0,
-                event_kind: "Balances.Transfer",
-              },
-            ],
-          },
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    // Same offset emulation as block_extrinsics above: rows to page past first.
+    const lake = lakehouse([
+      { block_number: 9, event_index: 8, observed_at: 1_750_009_000_002 },
+      { block_number: 9, event_index: 9, observed_at: 1_750_009_000_001 },
+      {
+        block_number: 9,
+        event_index: 0,
+        extrinsic_index: 0,
+        event_kind: "Transfer",
+        hotkey: null,
+        coldkey: null,
+        netuid: null,
+        uid: null,
+        amount_tao: null,
+        alpha_amount: null,
+        observed_at: 1_750_009_000_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       '{ block_events(ref: "9", limit: 20, offset: 3) { block_number event_count events { block_number event_kind } } }',
       env as unknown as Env,
@@ -3031,6 +3027,7 @@ describe("graphql — block_extrinsics / block_events / block_chain_events (#697
       body.data.block_events.events[0].event_kind,
       "Balances.Transfer",
     );
+    lake.restore();
   });
 
   test("block_chain_events: resolves the all-events tier by block_number", async () => {
@@ -16133,22 +16130,25 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse([
-      {
-        // The lakehouse row, per generated/lakehouse/types.ts's own column list:
-        // hotkey is the from side, coldkey the to side, and `direction` is
-        // DERIVED by the builder from which side this account is on. The retired
-        // tier handed over a finished `from`/`to`/`direction` triple, so none of
-        // that derivation ran here.
-        block_number: 1200,
-        event_index: 3,
-        event_kind: "Transfer",
-        hotkey: SS58,
-        coldkey: OTHER,
-        amount_tao: 1.5,
-        observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
-      },
-    ]);
+    const lake = lakehouse(
+      [
+        {
+          // The lakehouse row, per generated/lakehouse/types.ts's own column list:
+          // hotkey is the from side, coldkey the to side, and `direction` is
+          // DERIVED by the builder from which side this account is on. The retired
+          // tier handed over a finished `from`/`to`/`direction` triple, so none of
+          // that derivation ran here.
+          block_number: 1200,
+          event_index: 3,
+          event_kind: "Transfer",
+          hotkey: SS58,
+          coldkey: OTHER,
+          amount_tao: 1.5,
+          observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
+        },
+      ],
+      { once: true },
+    );
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_transfers(ss58: "${SS58}") {
@@ -16351,21 +16351,24 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse([
-      {
-        block_number: 1200,
-        event_index: 3,
-        event_kind: "StakeAdded",
-        hotkey: SS58,
-        coldkey: OTHER,
-        netuid: 7,
-        uid: 42,
-        amount_tao: 1.5,
-        alpha_amount: 2.25,
-        observed_at: "2026-07-15T00:00:00.000Z",
-        extrinsic_index: 4,
-      },
-    ]);
+    const lake = lakehouse(
+      [
+        {
+          block_number: 1200,
+          event_index: 3,
+          event_kind: "StakeAdded",
+          hotkey: SS58,
+          coldkey: OTHER,
+          netuid: 7,
+          uid: 42,
+          amount_tao: 1.5,
+          alpha_amount: 2.25,
+          observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
+          extrinsic_index: 4,
+        },
+      ],
+      { once: true },
+    );
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -14121,33 +14121,28 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_events forwards kind/block bounds/pagination and returns tier rows", async () => {
-    const env = tierEnv(
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      {
-        schema_version: 1,
-        netuid: 7,
-        event_count: 1,
-        limit: 50,
-        offset: 0,
-        next_cursor: null,
-        events: [
-          {
-            block_number: 100,
-            event_index: 2,
-            event_kind: "StakeAdded",
-            hotkey: "5F",
-            coldkey: "5G",
-            netuid: 7,
-            uid: 3,
-            amount_tao: 1.5,
-            alpha_amount: 2.5,
-            observed_at: "2026-07-01T00:00:00.000Z",
-            extrinsic_index: 4,
-          },
-        ],
-      },
-      captured,
+    // #10190: the tier is retired; answerSubnetEvents composes over the lakehouse.
+    // The kind and block bounds become SQL PREDICATES rather than query params,
+    // which is where they actually go -- and the assertion below checks them there.
+    const lake = lakehouse(
+      [
+        {
+          block_number: 100,
+          event_index: 2,
+          event_kind: "StakeAdded",
+          hotkey: "5F",
+          coldkey: "5G",
+          netuid: 7,
+          uid: 3,
+          amount_tao: 1.5,
+          alpha_amount: 2.5,
+          observed_at: Date.parse("2026-07-01T00:00:00.000Z"),
+          extrinsic_index: 4,
+        },
+      ],
+      { once: true },
     );
+    const env = { ...LAKEHOUSE_ENV };
     const { body } = await gql(
       `{ subnet_events(netuid: 7, kind: "StakeAdded", block_start: 10, block_end: 200, limit: 50) {
           event_count limit events { event_kind amount_tao uid hotkey block_number }
@@ -14156,12 +14151,18 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
     );
     assert.equal(body.errors, undefined);
     const f = body.data.subnet_events;
+    const sql = lake.queries[0];
+    assert.match(sql, /netuid = 7/);
+    assert.match(sql, /event_kind = 'StakeAdded'/);
+    assert.match(sql, /block_number >= 10/);
+    assert.match(sql, /block_number <= 200/);
     assert.equal(f.event_count, 1);
     assert.equal(f.limit, 50);
     assert.equal(f.events[0].event_kind, "StakeAdded");
     assert.equal(f.events[0].amount_tao, 1.5);
     assert.equal(f.events[0].uid, 3);
     assert.equal(f.events[0].block_number, 100);
+    lake.restore();
   });
 
   test("subnet_events: a partial tier body degrades to the resolver defaults", async () => {
@@ -14323,19 +14324,23 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
   });
 
   test("subnet_prometheus forwards window and returns the tier card", async () => {
-    const env = tierEnv(
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      {
-        schema_version: 1,
-        netuid: 7,
-        window: "30d",
-        observed_at: "2026-07-01T00:00:00.000Z",
-        distinct_exporters: 5,
-        announcements: 12,
-        announcements_per_exporter: 2.4,
-      },
-      captured,
+    // #10190: the tier is retired; loadSubnetEventCardColdTier answers through the
+    // PrometheusServed rollup. That rollup issues THREE reads -- the row page, an
+    // ungrouped COUNT(*), and a GROUP BY subquery for the distinct count -- so the
+    // double routes on the SQL. `announcements_per_exporter` is DERIVED (12/5).
+    const lake = lakehouse((sql) =>
+      sql.includes("FROM (SELECT")
+        ? [{ distinct_exporters: 5 }]
+        : sql.includes("GROUP BY")
+          ? [{ netuid: 7, hotkey: "5Exporter", announcements: 12 }]
+          : [
+              {
+                announcements: 12,
+                newest_observed: Date.parse("2026-07-01T00:00:00.000Z"),
+              },
+            ],
     );
+    const env = { ...LAKEHOUSE_ENV };
     const { body } = await gql(
       `{ subnet_prometheus(netuid: 7, window: "30d") {
           window observed_at distinct_exporters announcements announcements_per_exporter
@@ -14348,6 +14353,7 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
     assert.equal(p.announcements, 12);
     assert.equal(p.announcements_per_exporter, 2.4);
     assert.equal(p.observed_at, "2026-07-01T00:00:00.000Z");
+    lake.restore();
   });
 
   test("subnet_prometheus: a partial tier body degrades to the resolver defaults", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16350,21 +16350,24 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse([
-      {
-        block_number: 1200,
-        event_index: 3,
-        event_kind: "StakeAdded",
-        hotkey: SS58,
-        coldkey: OTHER,
-        netuid: 7,
-        uid: 42,
-        amount_tao: 1.5,
-        alpha_amount: 2.25,
-        observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
-        extrinsic_index: 4,
-      },
-    ]);
+    const lake = lakehouse(
+      [
+        {
+          block_number: 1200,
+          event_index: 3,
+          event_kind: "StakeAdded",
+          hotkey: SS58,
+          coldkey: OTHER,
+          netuid: 7,
+          uid: 42,
+          amount_tao: 1.5,
+          alpha_amount: 2.25,
+          observed_at: Date.parse("2026-07-15T00:00:00.000Z"),
+          extrinsic_index: 4,
+        },
+      ],
+      { once: true },
+    );
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
@@ -16403,7 +16406,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse([]);
+    const lake = lakehouse([], { once: true });
     const env = { ...LAKEHOUSE_ENV };
     const { status } = await gql(
       query(
@@ -16429,7 +16432,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // lakehouse reader takes no params -- the clamped limit becomes the SQL LIMIT
     // (limit+offset, since R2 SQL has no OFFSET) and an absent filter simply
     // produces no predicate. Asserting the SQL is what the clamp actually reaches.
-    const lake = lakehouse([]);
+    const lake = lakehouse([], { once: true });
     const env = { ...LAKEHOUSE_ENV };
     await gql(query(`(ss58: "${SS58}", limit: 100000, offset: -5)`), env);
     const sql = lake.queries[0];
@@ -16468,7 +16471,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // was never asked. The cold tier answers, and it feeds the SAME builder
     // -- so the envelope below is derived from these rows, not asserted
     // into existence by a hand-written payload.
-    const lake = lakehouse([{}]);
+    const lake = lakehouse([{}], { once: true });
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
@@ -16762,13 +16765,19 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     // #10190: the tier is retired; one bare day row through the lakehouse is
     // what degrades now. `event_kinds` comes from the SECOND read, so an empty
     // kinds list here is the honest answer rather than an omitted field.
-    const lake = lakehouse((sql) => (sql.includes("event_kind") ? [] : [{}]));
+    // The rollup row must carry its `day` -- that is the reader's grouping key,
+    // and a row without one is not a day. Every OTHER field is omitted, which is
+    // the degradation under test.
+    const lake = lakehouse((sql) =>
+      sql.includes("event_kind") ? [] : [{ day: "2026-06-25" }],
+    );
     const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_history.days, [
       {
-        day: null,
+        // The grouping key survives; everything else degrades.
+        day: "2026-06-25",
         netuid: null,
         event_count: null,
         event_kinds: [],
@@ -16803,6 +16812,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       next_cursor: null,
       days: [],
     });
+    lake.restore();
   });
 
   test("rejects a malformed ss58 before hitting the Postgres tier", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -18009,15 +18009,20 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     const day = d.daily[0];
     assert.equal(day.extrinsic_count, 0);
     assert.equal(day.signed_extrinsic_count, 0);
-    assert.equal(day.total_fee_tao, null);
+    // `toTao` coerces a NULL fee to 0 by contract -- "NULL fees never leak into
+    // the payload" (src/chain-analytics.ts) -- while the MEDIANs keep null,
+    // because a median over no rows is genuinely unknown rather than zero. The
+    // retired tier echoed data-api's nulls for all of them, so neither rule was
+    // ever exercised here.
+    assert.equal(day.total_fee_tao, 0);
     assert.equal(day.avg_fee_tao, null);
     assert.equal(day.median_fee_tao, null);
-    assert.equal(day.total_tip_tao, null);
+    assert.equal(day.total_tip_tao, 0);
     assert.equal(day.avg_tip_tao, null);
     assert.equal(day.median_tip_tao, null);
     const payer = d.top_fee_payers[0];
-    assert.equal(payer.total_fee_tao, null);
-    assert.equal(payer.total_tip_tao, null);
+    assert.equal(payer.total_fee_tao, 0);
+    assert.equal(payer.total_tip_tao, 0);
     assert.equal(payer.extrinsic_count, 0);
   });
 

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -17578,27 +17578,28 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
   });
 
   test("resolves Postgres-tier call-mix rows", async () => {
+    // #10190: the tier this doubled is retired; the #9146 projection answers.
+    // Doubled at the archive transport with the envelope the LANE writes, so
+    // the derived fields below are recomputed rather than echoed.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "30d",
-            group_by: "module_function",
-            observed_at: "2026-07-14T00:00:00.000Z",
-            total_extrinsics: 8,
-            call_count: 1,
-            calls: [
-              {
-                call_module: "SubtensorModule",
-                call_function: "set_weights",
-                count: 6,
-                share: 0.75,
-              },
-            ],
-          }),
-      },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "30d": {
+            newest_observed: "2026-07-14T00:00:00.000Z",
+            total: 8,
+            groups: {
+              module_function: [
+                {
+                  call_module: "SubtensorModule",
+                  call_function: "set_weights",
+                  count: 6,
+                },
+              ],
+            },
+          },
+        },
+      }),
     };
     const { status, body } = await gql(
       callsQuery(`(window: "30d", group_by: "module_function")`),
@@ -17724,28 +17725,31 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
   });
 
   test("resolves the Postgres-tier per-day series", async () => {
+    // #10190: the tier this doubled is retired; the #9146 projection answers.
+    // Doubled at the archive transport with the envelope the LANE writes, so
+    // the derived fields below are recomputed rather than echoed.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-14T00:00:00.000Z",
-            day_count: 1,
-            days: [
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "30d": {
+            newest_observed: "2026-07-14T00:00:00.000Z",
+            // TWO row sets, merged by UTC day: the lane keeps the extrinsic and
+            // block aggregates separate because they come from different tables.
+            extrinsic_rows: [
               {
                 day: "2026-07-14",
-                block_count: 7,
                 extrinsic_count: 4,
-                event_count: 12,
                 successful_extrinsics: 3,
-                success_rate: 0.75,
                 unique_signers: 2,
               },
             ],
-          }),
-      },
+            block_rows: [
+              { day: "2026-07-14", block_count: 7, event_count: 12 },
+            ],
+          },
+        },
+      }),
     };
     const { status, body } = await gql(activityQuery(`(window: "30d")`), env);
     assert.equal(status, 200);
@@ -17864,29 +17868,28 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
   });
 
   test("resolves Postgres-tier daily series + top payers", async () => {
+    // #10190: the tier this doubled is retired; the #9146 projection answers.
+    // Doubled at the archive transport with the envelope the LANE writes, so
+    // the derived fields below are recomputed rather than echoed.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-14T00:00:00.000Z",
-            day_count: 1,
-            daily: [
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "30d": {
+            newest_observed: "2026-07-14T00:00:00.000Z",
+            daily_rows: [
               {
                 day: "2026-07-14",
                 extrinsic_count: 4,
                 signed_extrinsic_count: 3,
                 total_fee_tao: 0.4,
-                avg_fee_tao: 0.1,
-                median_fee_tao: 0.1,
                 total_tip_tao: 0.02,
-                avg_tip_tao: 0.005,
-                median_tip_tao: 0.004,
               },
             ],
-            top_fee_payers: [
+            median_rows: [
+              { day: "2026-07-14", median_fee_tao: 0.1, median_tip_tao: 0.004 },
+            ],
+            payer_rows: [
               {
                 signer: "5Signer",
                 total_fee_tao: 0.4,
@@ -17894,8 +17897,9 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
                 extrinsic_count: 4,
               },
             ],
-          }),
-      },
+          },
+        },
+      }),
     };
     const { status, body } = await gql(feesQuery(`(window: "30d")`), env);
     assert.equal(status, 200);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { Blob } from "node:buffer";
 import {
   buildSchema,
@@ -15139,32 +15140,24 @@ describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card 
   });
 
   test("resolves the Postgres-tier { data } envelope, mapping the per-subnet footprint", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            address: SS58,
-            window: "90d",
-            total_registrations: 7,
-            subnet_count: 2,
-            concentration: 0.63,
-            dominant_netuid: 1,
-            subnets: [
-              {
-                netuid: 1,
-                registrations: 5,
-                first_registered_at: "2026-04-01T00:00:00.000Z",
-                last_registered_at: "2026-06-01T00:00:00.000Z",
-              },
-              { netuid: 2, registrations: 2 },
-            ],
-          },
-          generatedAt: "2026-06-01T00:00:00.000Z",
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([
+      {
+        netuid: 1,
+        registrations: 5,
+        // The lane's own column names, and epoch ms: the reader selects
+        // MIN/MAX(observed_at) AS first_observed/last_observed, and the builder
+        // formats those into first_registered_at / last_registered_at.
+        first_observed: Date.parse("2026-04-01T00:00:00.000Z"),
+        last_observed: Date.parse("2026-06-01T00:00:00.000Z"),
+      },
+      { netuid: 2, registrations: 2 },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_registrations(ss58: "${SS58}", window: "90d") {
           address window total_registrations subnet_count concentration dominant_netuid
@@ -15177,7 +15170,9 @@ describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card 
     assert.equal(r.window, "90d");
     assert.equal(r.total_registrations, 7);
     assert.equal(r.subnet_count, 2);
-    assert.equal(r.concentration, 0.63);
+    // The builder DERIVES this from the rows above; the retired tier's
+    // hand-written envelope carried 0.63, a number nothing computed.
+    assert.equal(r.concentration, 0.5918);
     assert.equal(r.dominant_netuid, 1);
     assert.deepEqual(r.subnets, [
       {
@@ -15193,6 +15188,7 @@ describe("graphql — account_registrations (#5704, Postgres-tier + zeroed-card 
         last_registered_at: null,
       },
     ]);
+    lake.restore();
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -15397,32 +15393,21 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
   });
 
   test("resolves the Postgres-tier { data } envelope, mapping the per-subnet footprint", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            address: SS58,
-            window: "90d",
-            total_announcements: 8,
-            subnet_count: 2,
-            concentration: 0.68,
-            dominant_netuid: 4,
-            subnets: [
-              {
-                netuid: 4,
-                announcements: 6,
-                first_served_at: "2026-04-01T00:00:00.000Z",
-                last_served_at: "2026-06-01T00:00:00.000Z",
-              },
-              { netuid: 9, announcements: 2 },
-            ],
-          },
-          generatedAt: "2026-06-01T00:00:00.000Z",
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([
+      {
+        netuid: 4,
+        announcements: 6,
+        first_served_at: "2026-04-01T00:00:00.000Z",
+        last_served_at: "2026-06-01T00:00:00.000Z",
+      },
+      { netuid: 9, announcements: 2 },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_serving(ss58: "${SS58}", window: "90d") {
           address window total_announcements subnet_count concentration dominant_netuid
@@ -15435,7 +15420,9 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
     assert.equal(r.window, "90d");
     assert.equal(r.total_announcements, 8);
     assert.equal(r.subnet_count, 2);
-    assert.equal(r.concentration, 0.68);
+    // The builder DERIVES this from the rows above; the retired tier's
+    // hand-written envelope carried 0.68, a number nothing computed.
+    assert.equal(r.concentration, 0.625);
     assert.equal(r.dominant_netuid, 4);
     assert.deepEqual(r.subnets, [
       {
@@ -15451,6 +15438,7 @@ describe("graphql — account_serving (#5705, Postgres-tier + zeroed-card fallba
         last_served_at: null,
       },
     ]);
+    lake.restore();
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -15655,33 +15643,22 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
   });
 
   test("resolves the Postgres-tier { data } envelope, mapping the per-subnet footprint", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          data: {
-            schema_version: 1,
-            address: SS58,
-            window: "90d",
-            total_movements: 6,
-            subnet_count: 2,
-            concentration: 0.61,
-            dominant_netuid: 8,
-            subnets: [
-              {
-                netuid: 8,
-                movements: 5,
-                first_moved_at: "2026-04-01T00:00:00.000Z",
-                last_moved_at: "2026-06-01T00:00:00.000Z",
-                price_tao_at_last_move: 0.042,
-              },
-              { netuid: 12, movements: 1 },
-            ],
-          },
-          generatedAt: "2026-06-01T00:00:00.000Z",
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([
+      {
+        netuid: 8,
+        movements: 5,
+        first_moved_at: "2026-04-01T00:00:00.000Z",
+        last_moved_at: "2026-06-01T00:00:00.000Z",
+        price_tao_at_last_move: 0.042,
+      },
+      { netuid: 12, movements: 1 },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_stake_moves(ss58: "${SS58}", window: "90d") {
           address window total_movements subnet_count concentration dominant_netuid
@@ -15694,7 +15671,9 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
     assert.equal(r.window, "90d");
     assert.equal(r.total_movements, 6);
     assert.equal(r.subnet_count, 2);
-    assert.equal(r.concentration, 0.61);
+    // The builder DERIVES this from the rows above; the retired tier's
+    // hand-written envelope carried 0.61, a number nothing computed.
+    assert.equal(r.concentration, 0.7222);
     assert.equal(r.dominant_netuid, 8);
     assert.deepEqual(r.subnets, [
       {
@@ -15712,6 +15691,7 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
         price_tao_at_last_move: null,
       },
     ]);
+    lake.restore();
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -16585,30 +16565,23 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 
   test("resolves the flat Postgres-tier envelope, mapping each transfer's fields", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          transfer_count: 1,
-          limit: 50,
-          offset: 0,
-          next_cursor: "b:1200:3",
-          transfers: [
-            {
-              block_number: 1200,
-              event_index: 3,
-              from: SS58,
-              to: OTHER,
-              amount_tao: 1.5,
-              direction: "sent",
-              observed_at: "2026-07-15T00:00:00.000Z",
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([
+      {
+        block_number: 1200,
+        event_index: 3,
+        from: SS58,
+        to: OTHER,
+        amount_tao: 1.5,
+        direction: "sent",
+        observed_at: "2026-07-15T00:00:00.000Z",
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_transfers(ss58: "${SS58}") {
           schema_version ss58 transfer_count limit offset next_cursor
@@ -16637,25 +16610,18 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
         },
       ],
     });
+    lake.restore();
   });
 
   test("hits /api/v1/accounts/{ss58}/transfers and forwards every filter", async () => {
     const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          transfer_count: 0,
-          limit: 5,
-          offset: 2,
-          next_cursor: null,
-          transfers: [],
-        }),
-        capture,
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status } = await gql(
       `{ account_transfers(ss58: "${SS58}", limit: 5, offset: 2, cursor: "c:9:1", direction: "received", block_start: 10, block_end: 20) { transfer_count } }`,
       env as unknown as Env,
@@ -16668,6 +16634,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
     assert.equal(capture.url.searchParams.get("direction"), "received");
     assert.equal(capture.url.searchParams.get("block_start"), "10");
     assert.equal(capture.url.searchParams.get("block_end"), "20");
+    lake.restore();
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds before forwarding", async () => {
@@ -16715,18 +16682,13 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 
   test("a transfer row with missing fields degrades each to null", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          transfer_count: 1,
-          next_cursor: null,
-          transfers: [{}],
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([{}]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ account_transfers(ss58: "${SS58}") {
           transfers { block_number event_index from to amount_tao direction observed_at }
@@ -16745,6 +16707,7 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
         observed_at: null,
       },
     ]);
+    lake.restore();
   });
 
   test("an invalid ss58 is a GraphQL error and never reaches the Postgres tier", async () => {
@@ -16812,34 +16775,27 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
   });
 
   test("resolves the Postgres-tier envelope, mapping each event's fields", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          event_count: 1,
-          limit: 50,
-          offset: 0,
-          next_cursor: "b:1200:3",
-          events: [
-            {
-              block_number: 1200,
-              event_index: 3,
-              event_kind: "StakeAdded",
-              hotkey: SS58,
-              coldkey: OTHER,
-              netuid: 7,
-              uid: 42,
-              amount_tao: 1.5,
-              alpha_amount: 2.25,
-              observed_at: "2026-07-15T00:00:00.000Z",
-              extrinsic_index: 4,
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([
+      {
+        block_number: 1200,
+        event_index: 3,
+        event_kind: "StakeAdded",
+        hotkey: SS58,
+        coldkey: OTHER,
+        netuid: 7,
+        uid: 42,
+        amount_tao: 1.5,
+        alpha_amount: 2.25,
+        observed_at: "2026-07-15T00:00:00.000Z",
+        extrinsic_index: 4,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -16866,25 +16822,18 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
         },
       ],
     });
+    lake.restore();
   });
 
   test("hits /api/v1/accounts/{ss58}/events and forwards every filter", async () => {
     const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          event_count: 0,
-          limit: 5,
-          offset: 2,
-          next_cursor: null,
-          events: [],
-        }),
-        capture,
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status } = await gql(
       query(
         `(ss58: "${SS58}", kind: "StakeAdded", netuid: 7, block_start: 10, block_end: 20, limit: 5, offset: 2, cursor: "c:9:1")`,
@@ -16900,6 +16849,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     assert.equal(capture.url.searchParams.get("cursor"), "c:9:1");
     assert.equal(capture.url.searchParams.get("block_start"), "10");
     assert.equal(capture.url.searchParams.get("block_end"), "20");
+    lake.restore();
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {
@@ -16940,18 +16890,13 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
   });
 
   test("an event row with missing fields degrades each to null", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          event_count: 1,
-          next_cursor: null,
-          events: [{}],
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
+    // was never asked. The cold tier answers, and it feeds the SAME builder
+    // -- so the envelope below is derived from these rows, not asserted
+    // into existence by a hand-written payload.
+    const lake = lakehouse([{}]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_events.events, [
@@ -16969,6 +16914,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
         extrinsic_index: null,
       },
     ]);
+    lake.restore();
   });
 
   test("an invalid ss58 is a GraphQL error and never reaches the Postgres tier", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -11786,10 +11786,10 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   test("a partial tier body falls back to defaults on every market-data field", async () => {
     // Exercises the `?? default` branches: a tier that answers with an empty
     // body must still yield the schema-stable card, never nulls or an error.
-    const volumeEnv = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({ data: {} })),
-    };
+    // #10190: the tier is retired. What degrades now is a projection that cannot
+    // answer, and the floor is unchanged: the schema-stable card, never nulls or
+    // an error.
+    const volumeEnv = {} as unknown as Env;
     const vol = await gql(
       "{ subnet_volume(netuid: 9) { schema_version netuid window total_volume_alpha total_volume_tao buy_volume_alpha sell_volume_alpha buy_volume_tao sell_volume_tao buy_count sell_count net_volume_alpha sentiment sentiment_ratio vol_mcap_ratio } }",
       volumeEnv,
@@ -11798,7 +11798,10 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     assert.deepEqual(vol.body.data.subnet_volume, {
       schema_version: 1,
       netuid: 9,
-      window: null,
+      // The lane's single window, stamped by the reader rather than echoed from a
+      // body: this projection carries only 24h, so the card can name it even when
+      // there is nothing to report for it.
+      window: "24h",
       total_volume_alpha: 0,
       total_volume_tao: 0,
       buy_volume_alpha: 0,
@@ -11808,7 +11811,11 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
       buy_count: 0,
       sell_count: 0,
       net_volume_alpha: 0,
-      sentiment: null,
+      // "neutral" by design, not null: src/alpha-volume.ts documents a
+      // zero-volume window as "no signal either way", which is a reading rather
+      // than an absence. The retired tier's `{}` body fell through to null and so
+      // never showed the classifier's own answer.
+      sentiment: "neutral",
       sentiment_ratio: null,
       vol_mcap_ratio: null,
     });

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -17619,14 +17619,17 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
   });
 
   test("a partial Postgres-tier body degrades every missing field to its schema-stable default", async () => {
+    // #10190: the partial body was the TIER's; the projection lane is what
+    // answers now, so the partial row goes into its envelope. The subject is
+    // unchanged -- every omitted field must reach its schema-stable default
+    // through the builder rather than surfacing undefined.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      // Only a row's call_module present; envelope + row omit the rest, so
-      // every ?? default fallback must fire (not surface undefined).
-      DATA_API: {
-        fetch: async () =>
-          Response.json({ calls: [{ call_module: "Balances" }] }),
-      },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": { groups: { module: [{ call_module: "Balances" }] } },
+        },
+      }),
     };
     const { status, body } = await gql(callsQuery(""), env);
     assert.equal(status, 200);
@@ -17636,7 +17639,9 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
     assert.equal(d.group_by, "module");
     assert.equal(d.observed_at, null);
     assert.equal(d.total_extrinsics, 0);
-    assert.equal(d.call_count, 0);
+    // DERIVED from the row list now, not defaulted: the partial TIER body
+    // omitted this count, so the resolver's `?? 0` fired. The builder counts.
+    assert.equal(d.call_count, 1);
     const c = d.calls[0];
     assert.equal(c.call_module, "Balances");
     assert.equal(c.call_function, null);
@@ -17777,13 +17782,20 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
   });
 
   test("partial day rows degrade missing fields to their schema-stable defaults", async () => {
+    // #10190: the partial body was the TIER's; the projection lane is what
+    // answers now, so the partial row goes into its envelope. The subject is
+    // unchanged -- every omitted field must reach its schema-stable default
+    // through the builder rather than surfacing undefined.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      // The day row carries only its required key; every other field is omitted
-      // so the per-item ?? default fallbacks must fire.
-      DATA_API: {
-        fetch: async () => Response.json({ days: [{ day: "2026-07-14" }] }),
-      },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": {
+            extrinsic_rows: [{ day: "2026-07-14" }],
+            block_rows: [],
+          },
+        },
+      }),
     };
     const { status, body } = await gql(activityQuery(""), env);
     assert.equal(status, 200);
@@ -17791,7 +17803,9 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
     assert.equal(d.schema_version, 1);
     assert.equal(d.window, "7d");
     assert.equal(d.observed_at, null);
-    assert.equal(d.day_count, 0);
+    // DERIVED from the row list now, not defaulted: the partial TIER body
+    // omitted this count, so the resolver's `?? 0` fired. The builder counts.
+    assert.equal(d.day_count, 1);
     const day = d.days[0];
     assert.equal(day.block_count, 0);
     assert.equal(day.extrinsic_count, 0);
@@ -17930,17 +17944,21 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
   });
 
   test("partial rows in each list degrade missing fields to their schema-stable defaults", async () => {
+    // #10190: the partial body was the TIER's; the projection lane is what
+    // answers now, so the partial row goes into its envelope. The subject is
+    // unchanged -- every omitted field must reach its schema-stable default
+    // through the builder rather than surfacing undefined.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      // Each row carries only its required key; every other field is omitted so
-      // the per-item ?? default fallbacks (both lists) must fire.
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            daily: [{ day: "2026-07-14" }],
-            top_fee_payers: [{ signer: "5Signer" }],
-          }),
-      },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: {
+          "7d": {
+            daily_rows: [{ day: "2026-07-14" }],
+            median_rows: [],
+            payer_rows: [{ signer: "5Signer" }],
+          },
+        },
+      }),
     };
     const { status, body } = await gql(feesQuery(""), env);
     assert.equal(status, 200);
@@ -17948,7 +17966,9 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     assert.equal(d.schema_version, 1);
     assert.equal(d.window, "7d");
     assert.equal(d.observed_at, null);
-    assert.equal(d.day_count, 0);
+    // DERIVED from the row list now, not defaulted: the partial TIER body
+    // omitted this count, so the resolver's `?? 0` fired. The builder counts.
+    assert.equal(d.day_count, 1);
     const day = d.daily[0];
     assert.equal(day.extrinsic_count, 0);
     assert.equal(day.signed_extrinsic_count, 0);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16195,35 +16195,38 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/transfers`);
-    assert.equal(capture.url.searchParams.get("limit"), "5");
-    assert.equal(capture.url.searchParams.get("offset"), "2");
-    assert.equal(capture.url.searchParams.get("cursor"), "c:9:1");
-    assert.equal(capture.url.searchParams.get("direction"), "received");
-    assert.equal(capture.url.searchParams.get("block_start"), "10");
-    assert.equal(capture.url.searchParams.get("block_end"), "20");
+    const sql = lake.queries[0];
+    // `direction: received` narrows to the TO side -- coldkey, per data-api's own
+    // semantics -- so the predicate is one-sided rather than the (hotkey OR
+    // coldkey) disjunction an unfiltered read uses.
+    assert.match(sql, new RegExp(`coldkey = '${SS58}'`));
+    assert.doesNotMatch(sql, /OR coldkey/);
+    assert.match(sql, /event_kind = 'Transfer'/);
+    assert.match(sql, /block_number >= 10/);
+    assert.match(sql, /block_number <= 20/);
+    // limit + offset, since R2 SQL has no OFFSET.
+    assert.match(sql, /LIMIT 7\b/);
     lake.restore();
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds before forwarding", async () => {
-    const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({}), capture),
-    };
+    // #10190: the filters used to be read off the tier request's query string.
+    // The lakehouse reader takes none as params -- each becomes a SQL PREDICATE,
+    // which is where they actually go and a stronger thing to assert.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     await gql(
       `{ account_transfers(ss58: "${SS58}", limit: 100000, offset: -5) { transfer_count } }`,
       env as unknown as Env,
     );
-    const forwardedLimit = Number(capture.url.searchParams.get("limit"));
-    const forwardedOffset = Number(capture.url.searchParams.get("offset"));
-    assert.ok(forwardedLimit > 0 && forwardedLimit < 100000);
-    assert.equal(forwardedOffset, 0);
-    // No filter params were supplied, so none are forwarded.
-    assert.equal(capture.url.searchParams.get("cursor"), null);
-    assert.equal(capture.url.searchParams.get("direction"), null);
-    assert.equal(capture.url.searchParams.get("block_start"), null);
-    assert.equal(capture.url.searchParams.get("block_end"), null);
+    const sql = lake.queries[0];
+    const limitOut = Number(/LIMIT (\d+)/.exec(sql)?.[1]);
+    assert.ok(limitOut > 0 && limitOut < 100000);
+    // A negative offset clamps to 0, and no filters were supplied -- so the read
+    // is the unfiltered (hotkey OR coldkey) disjunction with no extra predicate.
+    assert.match(sql, /\(hotkey = '[^']+' OR coldkey = '[^']+'\)/);
+    assert.doesNotMatch(sql, /block_number [<>]/);
+    lake.restore();
   });
 
   test("a partial tier envelope degrades missing scalars to schema-stable defaults", async () => {
@@ -16593,19 +16596,22 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("well-formed from/to bounds are accepted and forwarded to the tier", async () => {
-    const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({ days: [] }), capture),
-    };
+    // #10190: the filters used to be read off the tier request's query string.
+    // The lakehouse reader takes none as params -- each becomes a SQL PREDICATE,
+    // which is where they actually go and a stronger thing to assert.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       query(`(ss58: "${SS58}", from: "2026-07-01", to: "2026-07-16")`),
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capture.url.searchParams.get("from"), "2026-07-01");
-    assert.equal(capture.url.searchParams.get("to"), "2026-07-16");
+    const sql = lake.queries[0];
+    assert.match(sql, new RegExp(`observed_at >= ${Date.parse("2026-07-01")}`));
+    // Inclusive of the ?to day, so the bound is the START of the NEXT day.
+    assert.match(sql, new RegExp(`observed_at < ${Date.parse("2026-07-17")}`));
+    lake.restore();
   });
 
   // The regression the issue describes predates D1 elimination (2026-07-17):
@@ -16696,22 +16702,11 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("hits /api/v1/accounts/{ss58}/history and forwards every filter", async () => {
-    const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          day_count: 0,
-          limit: 5,
-          offset: 2,
-          next_cursor: null,
-          days: [],
-        }),
-        capture,
-      ),
-    };
+    // #10190: the filters used to be read off the tier request's query string.
+    // The lakehouse reader takes none as params -- each becomes a SQL PREDICATE,
+    // which is where they actually go and a stronger thing to assert.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status } = await gql(
       query(
         `(ss58: "${SS58}", netuid: 7, from: "2026-06-01", to: "2026-06-30", limit: 5, offset: 2, cursor: "c:20260615:3")`,
@@ -16719,13 +16714,14 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/history`);
-    assert.equal(capture.url.searchParams.get("limit"), "5");
-    assert.equal(capture.url.searchParams.get("offset"), "2");
-    assert.equal(capture.url.searchParams.get("netuid"), "7");
-    assert.equal(capture.url.searchParams.get("from"), "2026-06-01");
-    assert.equal(capture.url.searchParams.get("to"), "2026-06-30");
-    assert.equal(capture.url.searchParams.get("cursor"), "c:20260615:3");
+    const sql = lake.queries[0];
+    assert.match(sql, new RegExp(`hotkey = '${SS58}'`));
+    assert.match(sql, /netuid = 7/);
+    // ?from/?to are UTC-day bounds, and ?to is INCLUSIVE of its day -- so the
+    // upper bound is that day's END, which the query string could never show.
+    assert.match(sql, /observed_at >= \d+/);
+    assert.match(sql, /observed_at < \d+/);
+    lake.restore();
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -11884,39 +11884,44 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
   });
 
   test("resolves the Postgres-tier per-surface percentiles", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          netuid: 7,
-          window: "30d",
-          observed_at: "2026-07-19T00:00:00.000Z",
-          source: "live-cron-prober",
-          // The shape /api/v1/subnets/{netuid}/health/percentiles actually
-          // serves: the percentiles nest under `latency_ms`. The flat
-          // `p95_ms`/`latency_sample_count` keys here were never the
-          // producer's, and nothing could say so while `surfaces` was JSON.
-          surfaces: [
-            {
-              surface_id: "s1",
-              samples: 120,
-              latency_ms: {
-                p50: 88,
-                p95: 280,
-                p99: 640,
-                avg: 120,
-                min: 40,
-                max: 900,
-              },
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: METAGRAPH_HEALTH_SOURCE reads "d1" and cannot forward, so
+    // loadSubnetPercentiles reads `surface_uptime_daily` through the store. The
+    // nested `latency_ms` block is the BUILDER's shape -- the flat p95_ms /
+    // latency_sample_count keys the retired tier carried were never the
+    // producer's, and nothing could say so while `surfaces` was opaque JSON.
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [
+      {
+        // The percentile query is a CTE over `surface_checks` that emits the
+        // order statistics itself, so these are the SELECT's own aliases -- p50 /
+        // p95 / p99 / latency_samples -- not raw samples and not the flat
+        // p95_ms keys the retired tier carried.
+        match: "FROM ranked",
+        rows: [
+          {
+            surface_id: "s1",
+            surface_key: "s1",
+            latency_samples: 120,
+            p50: 88,
+            p95: 280,
+            p99: 640,
+            avg_latency_ms: 120,
+            min_latency_ms: 40,
+            max_latency_ms: 900,
+          },
+        ],
+      },
+    ];
+    const env = pgMockEnv() as unknown as Env;
     const { status, body } = await gql(
       '{ subnet_health_percentiles(netuid: 7, window: "30d") { netuid window observed_at source surfaces { surface_id samples latency_ms { p50 p95 p99 avg min max } } } }',
       env as unknown as Env,
+      {},
+      // observationsReadDb needs a ctx to park its teardown on; without one it
+      // answers undefined and the card is a confident empty.
+      { waitUntil: (promise: Promise<unknown>) => void promise },
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4808,74 +4808,55 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     assert.deepEqual(item.call_args, [{ name: "call", value: "setWeights" }]);
   });
 
-  test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 5,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ sudo(limit: 5, offset: 2, block: 42, call_function: "sudo", success: true) { total } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
-    // The route fixes call_module=Sudo, so the field exposes neither arg.
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("sudo: a block_start/block_end height range is forwarded to the Postgres tier (#7874)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 50,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("sudo: a block_start/block_end height range is forwarded to the Postgres tier (#7874) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ sudo(block_start: 100, block_end: 500) { total } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("sudo: a from/to observed_at range is forwarded to the Postgres tier (#7874)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 50,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("sudo: a from/to observed_at range is forwarded to the Postgres tier (#7874) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ sudo(from: "1750000000000", to: "1760000000000") { total } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("introspection: sudo exposes block_start/block_end (Int) and from/to (String) args (#7874)", async () => {
@@ -4909,24 +4890,21 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
     }
   });
 
-  test("sudo: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
-    const env = {
+  test("sudo: a cursor arg is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(`{ sudo(cursor: "abc123") { total } }`, {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 20,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(`{ sudo(cursor: "abc123") { total } }`, env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("sudo: a negative block filter is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
@@ -5079,47 +5057,32 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     assert.equal(unmatched.summary, null);
   });
 
-  test("extrinsics: filter args are forwarded as query params to the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 5,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("extrinsics: filter args are forwarded as query params to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ extrinsics(limit: 5, block: 42, signer: "5Signer", call_module: "SubtensorModule", call_function: "register", success: true) { total } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("extrinsics: call_hash, block-range, and time-range filters are forwarded to the Postgres tier (#7872)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 50,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("extrinsics: call_hash, block-range, and time-range filters are forwarded to the Postgres tier (#7872) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ extrinsics(
           call_hash: "0x${"ab".repeat(32)}"
           block_start: 100
@@ -5127,12 +5090,11 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
           from: "1750000000000"
           to: "1760000000000"
         ) { total } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
-    // A REAL 64-hex hash. "0xabc" was accepted before #10316 because nothing
-    // checked it, and the route's published pattern
-    // (^0x[0-9a-fA-F]{64}$) has always forbidden it -- the dispatch parse now
-    // enforces what the contract says, so the fixture had to become valid.
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("introspection: extrinsics exposes call_hash/from/to (String) and block_start/block_end (Int) args (#7872)", async () => {
@@ -5168,24 +5130,21 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     }
   });
 
-  test("extrinsics: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 20,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(`{ extrinsics(cursor: "abc123") { total } }`, env);
+  test("extrinsics: a cursor arg is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      `{ extrinsics(cursor: "abc123") { total } }`,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("extrinsics: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -5374,94 +5333,77 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     });
   });
 
-  test("governance_config_changes: filter args are forwarded to the /governance/config-changes path (loader reuse, no signer/call_module)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 5,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("governance_config_changes: filter args are forwarded to the /governance/config-changes path (loader reuse, no signer/call_module) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ governance_config_changes(limit: 5, block: 42, call_function: "sudo_set_tempo", success: true) { total } }`,
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
-    // The worker fixes call_module=AdminUtils by path, so the resolver hits the
-    // governance route (not /extrinsics) and never forwards signer/call_module.
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  // #7873: block-range (block_start/block_end -> block_number) and time-range
-  // (from/to -> observed_at) bounds, matching REST + MCP
-  // get_governance_config_changes.
-  function capturingEnv(sink: { url?: URL }) {
-    return {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          sink.url = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 20,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    } as unknown as Env;
-  }
-
-  test("governance_config_changes: a block range is forwarded (#7873)", async () => {
-    const sink: { url?: URL } = {};
-    await gql(
+  test("governance_config_changes: a block range is forwarded (#7873) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request's query string.
+    // METAGRAPH_EXTRINSICS_SOURCE reads "retired" and is absent from
+    // DATA_API_FORWARD_FLAGS, so that request was never made.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       "{ governance_config_changes(block_start: 100, block_end: 200) { total } }",
-      capturingEnv(sink),
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
-    assert.equal(sink.url!.pathname, "/api/v1/governance/config-changes");
-    assert.equal(sink.url!.searchParams.get("block_start"), "100");
-    assert.equal(sink.url!.searchParams.get("block_end"), "200");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("governance_config_changes: a time range is forwarded (#7873)", async () => {
-    const sink: { url?: URL } = {};
-    await gql(
+  test("governance_config_changes: a time range is forwarded (#7873) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request's query string.
+    // METAGRAPH_EXTRINSICS_SOURCE reads "retired" and is absent from
+    // DATA_API_FORWARD_FLAGS, so that request was never made.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       "{ governance_config_changes(from: 1750000000, to: 1760000000) { total } }",
-      capturingEnv(sink),
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
-    assert.equal(sink.url!.searchParams.get("from"), "1750000000");
-    assert.equal(sink.url!.searchParams.get("to"), "1760000000");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("governance_config_changes: block and time bounds combine with the existing filters (#7873)", async () => {
-    const sink: { url?: URL } = {};
-    await gql(
+  test("governance_config_changes: block and time bounds combine with the existing filters (#7873) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request's query string.
+    // METAGRAPH_EXTRINSICS_SOURCE reads "retired" and is absent from
+    // DATA_API_FORWARD_FLAGS, so that request was never made.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       `{ governance_config_changes(limit: 5, call_function: "sudo_set_tempo", block_start: 10, block_end: 20, from: 1, to: 2) { total } }`,
-      capturingEnv(sink),
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
-    assert.equal(sink.url!.searchParams.get("limit"), "5");
-    assert.equal(sink.url!.searchParams.get("call_function"), "sudo_set_tempo");
-    assert.equal(sink.url!.searchParams.get("block_start"), "10");
-    assert.equal(sink.url!.searchParams.get("block_end"), "20");
-    assert.equal(sink.url!.searchParams.get("from"), "1");
-    assert.equal(sink.url!.searchParams.get("to"), "2");
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("governance_config_changes: omitted bounds are not forwarded (#7873)", async () => {
-    const sink: { url?: URL } = {};
-    await gql("{ governance_config_changes { total } }", capturingEnv(sink));
-    for (const p of ["block_start", "block_end", "from", "to"]) {
-      assert.equal(sink.url!.searchParams.get(p), null, `${p} must be absent`);
-    }
+  test("governance_config_changes: omitted bounds are not forwarded (#7873) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion over the tier request's query string.
+    // METAGRAPH_EXTRINSICS_SOURCE reads "retired" and is absent from
+    // DATA_API_FORWARD_FLAGS, so that request was never made.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      "{ governance_config_changes { total } }",
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("governance_config_changes: a negative bound is BAD_USER_INPUT (#7873)", async () => {
@@ -5479,24 +5421,21 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     }
   });
 
-  test("governance_config_changes: a cursor arg is forwarded as a query param", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            limit: 20,
-            offset: 0,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(`{ governance_config_changes(cursor: "abc123") { total } }`, env);
+  test("governance_config_changes: a cursor arg is forwarded as a query param — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      `{ governance_config_changes(cursor: "abc123") { total } }`,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("governance_config_changes: rejects a negative block with BAD_USER_INPUT", async () => {
@@ -7928,20 +7867,24 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
     assert.equal(p.subnets[1].netuid, 7);
   });
 
-  test("window is forwarded as a query param to the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            data: { schema_version: 1, address: SS58, subnets: [] },
-            generatedAt: null,
-          });
-        },
-      },
-    };
-    await gql(query(`(ss58: "${SS58}", window: "90d")`), env);
+  test("window is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "90d")`),
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed footprint", async () => {
@@ -8124,20 +8067,24 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
     assert.equal(f.subnets[1].direction, "churning");
   });
 
-  test("window and direction are forwarded as query params to the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            data: { schema_version: 1, address: SS58, subnets: [] },
-            generatedAt: null,
-          });
-        },
-      },
-    };
-    await gql(query(`(ss58: "${SS58}", window: "90d", direction: "in")`), env);
+  test("window and direction are forwarded as query params to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "90d", direction: "in")`),
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
@@ -8791,30 +8738,23 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
     assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
   });
 
-  test("ss58 + pagination/block-range args are forwarded on the Postgres-tier request path", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            extrinsic_count: 0,
-            limit: 5,
-            offset: 10,
-            next_cursor: null,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("ss58 + pagination/block-range args are forwarded on the Postgres-tier request path — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       query(
         `(ss58: "${SS58}", limit: 5, offset: 10, cursor: "abc123", block_start: 100, block_end: 200)`,
       ),
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -11423,53 +11363,26 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   // shape was a mock built from what the resolver assumed rather than from
   // what the producer sends, and it hid the resolver reading `candles` off the
   // envelope -- so every real tier answer became an empty series.
-  test("subnet_ohlc forwards interval + days and unwraps the tier's { data } envelope", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            data: {
-              schema_version: 1,
-              netuid: 7,
-              interval: "1d",
-              root_excluded: false,
-              candles: [
-                {
-                  bucket_start: 1770000000000,
-                  bucket_start_iso: "2026-02-02T00:00:00.000Z",
-                  open: 0.1,
-                  high: 0.2,
-                  low: 0.09,
-                  close: 0.15,
-                  volume_alpha: 100,
-                  volume_tao: 12,
-                  event_count: 4,
-                },
-              ],
-            },
-            generatedAt: "2026-02-02T01:00:00.000Z",
-          });
-        },
-      },
-    };
+  test("subnet_ohlc forwards interval + days and unwraps the tier's { data } envelope — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       '{ subnet_ohlc(netuid: 7, interval: "1d", days: 30) { interval candles { bucket_start close event_count } } }',
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    const o = body.data.subnet_ohlc;
-    assert.equal(o.interval, "1d");
-    assert.equal(o.candles[0].bucket_start, 1770000000000);
-    assert.equal(o.candles[0].event_count, 4);
+    assert.deepEqual(tier.paths, []);
   });
 
-  // The other side of the envelope contract: an ENVELOPE-LESS body is not an
-  // answer. Reading such a body as the payload is precisely the bug above, and
-  // this pins it -- a tier that returns a bare card contributes nothing and the
-  // resolver goes on to its next tier.
   test("subnet_ohlc does not read candles off an envelope-less tier body", async () => {
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
@@ -12098,20 +12011,21 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
     assert.equal(p.surfaces[0].latency_ms.p95, 280);
   });
 
-  test("forwards the window to the health/percentiles Postgres path", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(
+  test("forwards the window to the health/percentiles Postgres path — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_HEALTH_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       '{ subnet_health_percentiles(netuid: 3, window: "30d") { netuid } }',
-      env as unknown as Env,
+      { METAGRAPH_HEALTH_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("an unsupported window is a GraphQL error, not a silent card", async () => {
@@ -12209,33 +12123,44 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
     assert.equal(s.recent_events[0].block_number, 91);
   });
 
-  test("clamps the recent-event limit into 1..50 and forwards it", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(
+  test("clamps the recent-event limit into 1..50 and forwards it — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       '{ subnet_event_summary(netuid: 3, window: "90d", limit: 999) { netuid } }',
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("clamps a below-range limit up to 1", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql("{ subnet_event_summary(netuid: 3, limit: 0) { netuid } }", env);
+  test("clamps a below-range limit up to 1 — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      "{ subnet_event_summary(netuid: 3, limit: 0) { netuid } }",
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("an unsupported window is a GraphQL error, not a silent card", async () => {
@@ -13921,20 +13846,24 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
     assert.equal(w.setters[1].uid, 2);
   });
 
-  test("window is forwarded as a query param to the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(
+  test("window is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       '{ subnet_weight_setters(netuid: 3, window: "30d") { setter_count } }',
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -14852,54 +14781,21 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
     assert.deepEqual(d.surfaces, []);
   });
 
-  test("resolves Postgres-tier data, forwarding netuid in the path + window param", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            netuid: NETUID,
-            window: "30d",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            source: "live-cron-prober",
-            surfaces: [
-              {
-                surface_id: "srf-1",
-                samples: 100,
-                uptime_ratio: 0.98,
-                incident_count: 1,
-                downtime_ms: 60000,
-                transient_failure_count: 0,
-                transient_failed_samples: 0,
-                incidents: [
-                  {
-                    started_at: 1000,
-                    ended_at: 61000,
-                    duration_ms: 60000,
-                    failed_samples: 3,
-                  },
-                ],
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data, forwarding netuid in the path + window param — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_HEALTH_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       incidentsQuery(`(netuid: ${NETUID}, window: "30d")`),
-      env as unknown as Env,
+      { METAGRAPH_HEALTH_SOURCE: "postgres", ...tier } as unknown as Env,
     );
     assert.equal(status, 200);
-    const d = body.data.subnet_health_incidents;
-    assert.equal(d.window, "30d");
-    const s = d.surfaces[0];
-    assert.equal(s.surface_id, "srf-1");
-    assert.equal(s.uptime_ratio, 0.98);
-    assert.equal(s.incident_count, 1);
-    assert.equal(s.incidents[0].duration_ms, 60000);
-    assert.equal(s.incidents[0].failed_samples, 3);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("an empty Postgres-tier body degrades to schema-stable defaults with empty surfaces", async () => {
@@ -15846,20 +15742,24 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
     assert.equal(r.subnets[1].netuid, 11);
   });
 
-  test("window is forwarded as a query param to the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            data: { schema_version: 1, address: SS58, subnets: [] },
-            generatedAt: null,
-          });
-        },
-      },
-    };
-    await gql(query(`(ss58: "${SS58}", window: "30d")`), env);
+  test("window is forwarded as a query param to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", window: "30d")`),
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
@@ -17810,54 +17710,24 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
     });
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_setters: 4,
-              weight_sets: 40,
-              sets_per_setter: 10,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 10,
-              min: 10,
-              p25: 10,
-              median: 10,
-              p75: 10,
-              p90: 10,
-              max: 10,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                distinct_setters: 4,
-                weight_sets: 40,
-                sets_per_setter: 10,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       weightsQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_weights.window, "30d");
-    assert.equal(body.data.chain_weights.subnet_count, 1);
-    assert.equal(body.data.chain_weights.network.weight_sets, 40);
-    assert.equal(body.data.chain_weights.intensity_distribution.median, 10);
-    assert.equal(body.data.chain_weights.subnets[0].netuid, 3);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -18034,29 +17904,23 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
     });
   });
 
-  test("window/group_by/limit/call_module args are forwarded to the /chain/calls path", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            group_by: "module",
-            total_extrinsics: 0,
-            call_count: 0,
-            calls: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("window/group_by/limit/call_module args are forwarded to the /chain/calls path — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       callsQuery(
         `(window: "30d", group_by: "module", limit: 5, call_module: "SubtensorModule")`,
       ),
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -18220,22 +18084,21 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
     });
   });
 
-  test("the window arg is forwarded to the /chain/activity path", async () => {
-    const env = {
+  test("the window arg is forwarded to the /chain/activity path — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(activityQuery(`(window: "30d")`), {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            day_count: 0,
-            days: [],
-          });
-        },
-      },
-    };
-    await gql(activityQuery(`(window: "30d")`), env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -18409,26 +18272,21 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
     });
   });
 
-  test("window/limit/call_module args are forwarded to the /chain/fees path", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            day_count: 0,
-            daily: [],
-            top_fee_payers: [],
-          });
-        },
-      },
-    };
-    await gql(
+  test("window/limit/call_module args are forwarded to the /chain/fees path — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(
       feesQuery(`(window: "30d", limit: 5, call_module: "Balances")`),
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -18499,55 +18357,24 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
     });
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_servers: 4,
-              announcements: 40,
-              announcements_per_server: 10,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 10,
-              min: 10,
-              p25: 10,
-              median: 10,
-              p75: 10,
-              p90: 10,
-              max: 10,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                distinct_servers: 4,
-                announcements: 40,
-                announcements_per_server: 10,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       servingQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_serving.window, "30d");
-    assert.equal(body.data.chain_serving.subnet_count, 1);
-    assert.equal(body.data.chain_serving.network.distinct_servers, 4);
-    assert.equal(body.data.chain_serving.network.announcements_per_server, 10);
-    assert.equal(body.data.chain_serving.intensity_distribution.median, 10);
-    assert.equal(body.data.chain_serving.subnets[0].netuid, 3);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -18629,43 +18456,24 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
     });
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            distinct_setters: 2,
-            weight_sets: 40,
-            setter_count: 1,
-            setters: [
-              {
-                hotkey: "5Setter",
-                netuid: null,
-                uid: null,
-                weight_sets: 40,
-                share: 1,
-                first_set_at: "2026-06-20T00:00:00.000Z",
-                last_set_at: "2026-07-10T00:00:00.000Z",
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       weightSettersQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_weight_setters.window, "30d");
-    assert.equal(body.data.chain_weight_setters.setter_count, 1);
-    assert.equal(body.data.chain_weight_setters.setters[0].hotkey, "5Setter");
-    assert.equal(body.data.chain_weight_setters.setters[0].share, 1);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -18761,88 +18569,38 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
     });
   });
 
-  test("resolves Postgres-tier data for an explicit limit, forwarding it as a query param", async () => {
-    const env = {
+  test("resolves Postgres-tier data for an explicit limit, forwarding it as a query param — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(alphaVolumeQuery("(limit: 5)"), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "24h",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              buy_volume_alpha: 100,
-              sell_volume_alpha: 40,
-              total_volume_alpha: 140,
-              buy_volume_tao: 50,
-              sell_volume_tao: 20,
-              total_volume_tao: 70,
-              buy_count: 10,
-              sell_count: 5,
-              net_volume_alpha: 60,
-              sentiment_ratio: 0.4286,
-              sentiment: "bullish",
-            },
-            volume_distribution: {
-              count: 1,
-              mean: 70,
-              min: 70,
-              p25: 70,
-              median: 70,
-              p75: 70,
-              p90: 70,
-              max: 70,
-            },
-            subnets: [
-              {
-                schema_version: 1,
-                netuid: 3,
-                window: "24h",
-                buy_volume_alpha: 100,
-                sell_volume_alpha: 40,
-                total_volume_alpha: 140,
-                buy_volume_tao: 50,
-                sell_volume_tao: 20,
-                total_volume_tao: 70,
-                buy_count: 10,
-                sell_count: 5,
-                net_volume_alpha: 60,
-                sentiment_ratio: 0.4286,
-                sentiment: "bullish",
-                vol_mcap_ratio: null,
-              },
-            ],
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(alphaVolumeQuery("(limit: 5)"), env);
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
-    const card = body.data.chain_alpha_volume;
-    assert.equal(card.window, "24h");
-    assert.equal(card.subnet_count, 1);
-    assert.equal(card.observed_at, "2026-07-10T00:00:00.000Z");
-    assert.equal(card.network.total_volume_tao, 70);
-    assert.equal(card.network.sentiment, "bullish");
-    assert.equal(card.volume_distribution.median, 70);
-    assert.equal(card.subnets[0].netuid, 3);
-    assert.equal(card.subnets[0].vol_mcap_ratio, null);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("clamps an over-max limit before forwarding it to the Postgres tier", async () => {
-    const env = {
+  test("clamps an over-max limit before forwarding it to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(alphaVolumeQuery("(limit: 9999)"), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({});
-        },
-      },
-    };
-    const { status } = await gql(alphaVolumeQuery("(limit: 9999)"), env);
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -18953,42 +18711,21 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
     assert.deepEqual(body.data.health_trends.windows["30d"].subnets, []);
   });
 
-  test("resolves Postgres-tier data, forwarding the request unchanged", async () => {
-    const env = {
+  test("resolves Postgres-tier data, forwarding the request unchanged — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_HEALTH_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(trendsQuery(), {
       METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            observed_at: "2026-07-10T00:00:00.000Z",
-            source: "live-cron-prober",
-            windows: {
-              "7d": {
-                days: 7,
-                granularity: "1d",
-                subnet_count: 1,
-                subnets: [{ netuid: 3, samples: 10 }],
-              },
-              "30d": {
-                days: 30,
-                granularity: "1d",
-                subnet_count: 1,
-                subnets: [{ netuid: 3, samples: 40 }],
-              },
-            },
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(trendsQuery(), env);
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
-    assert.equal(
-      body.data.health_trends.observed_at,
-      "2026-07-10T00:00:00.000Z",
-    );
-    assert.equal(body.data.health_trends.windows["7d"].subnet_count, 1);
-    assert.equal(body.data.health_trends.windows["30d"].subnets[0].netuid, 3);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -19092,42 +18829,21 @@ describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallb
     assert.equal(d.windows["30d"].samples, 0);
   });
 
-  test("resolves Postgres-tier data, forwarding the netuid in the path", async () => {
-    const env = {
+  test("resolves Postgres-tier data, forwarding the netuid in the path — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_HEALTH_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(trendsQuery(NETUID), {
       METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            netuid: NETUID,
-            observed_at: "2026-07-10T00:00:00.000Z",
-            source: "live-cron-prober",
-            windows: {
-              "7d": {
-                samples: 20,
-                uptime_ratio: 0.95,
-                latency_sample_count: 18,
-                surfaces: [{ surface_id: "srf-1", samples: 20 }],
-              },
-              "30d": {
-                samples: 80,
-                uptime_ratio: 0.9,
-                latency_sample_count: 70,
-                surfaces: [{ surface_id: "srf-1", samples: 80 }],
-              },
-            },
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(trendsQuery(NETUID), env);
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
-    const d = body.data.subnet_health_trends;
-    assert.equal(d.netuid, NETUID);
-    assert.equal(d.observed_at, "2026-07-10T00:00:00.000Z");
-    assert.equal(d.windows["7d"].uptime_ratio, 0.95);
-    assert.equal(d.windows["30d"].surfaces[0].surface_id, "srf-1");
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -19445,56 +19161,21 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
     });
   });
 
-  test("resolves Postgres-tier data and forwards window + min_samples", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            netuid: NETUID,
-            window: "1y",
-            observed_at: "2026-07-10T00:00:00.000Z",
-            source: "live-cron-prober",
-            reliability: {
-              score: 99,
-              grade: "A",
-              uptime_ratio: 0.995,
-              sample_count: 100,
-              window: "1y",
-            },
-            surfaces: [
-              {
-                surface_id: "api-root",
-                day_count: 1,
-                samples: 100,
-                uptime_ratio: 0.995,
-                days: [
-                  {
-                    day: "2026-07-09",
-                    samples: 100,
-                    uptime_ratio: 0.995,
-                    status: "ok",
-                    avg_latency_ms: 80,
-                  },
-                ],
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data and forwards window + min_samples — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_HEALTH_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       uptimeQuery(`netuid: ${NETUID}, window: "1y", min_samples: 5`),
-      env as unknown as Env,
+      { METAGRAPH_HEALTH_SOURCE: "postgres", ...tier } as unknown as Env,
     );
     assert.equal(status, 200);
-    const d = body.data.subnet_uptime;
-    assert.equal(d.window, "1y");
-    assert.equal(d.reliability.score, 99);
-    assert.equal(d.surfaces[0].surface_id, "api-root");
-    assert.equal(d.surfaces[0].days[0].uptime_ratio, 0.995);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -20067,58 +19748,28 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     assert.deepEqual(body.data.validator_nominators.nominators, []);
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/sort, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            data: {
-              schema_version: 1,
-              hotkey: HOTKEY,
-              window: "7d",
-              sort: "gross_staked",
-              limit: 20,
-              offset: 0,
-              nominator_count: 1,
-              nominators: [
-                {
-                  coldkey: "5FNominatorColdkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-                  staked_tao: 12.5,
-                  unstaked_tao: 2.5,
-                  net_staked_tao: 10,
-                  gross_staked_tao: 15,
-                  event_count: 3,
-                  last_observed_at: "2026-07-10T00:00:00.000Z",
-                },
-              ],
-            },
-            generatedAt: "2026-07-10T00:00:00.000Z",
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/sort, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       nominatorsQuery(
         `(hotkey: "${HOTKEY}", window: "7d", sort: "gross_staked")`,
       ),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.validator_nominators.window, "7d");
-    assert.equal(body.data.validator_nominators.sort, "gross_staked");
-    assert.equal(body.data.validator_nominators.nominator_count, 1);
-    assert.equal(
-      body.data.validator_nominators.nominators[0].net_staked_tao,
-      10,
-    );
-    assert.equal(body.data.validator_nominators.nominators[0].event_count, 3);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
-  // #4772 D1 retirement: the `account_events` D1 table is dropped in
-  // production, so this resolver no longer queries D1 at all -- even a
-  // "warm" D1 mock (real rows) must not change the response.
   test("no Postgres tier flag: never queries D1, returns the schema-stable empty list (retired -- #4772)", async () => {
     const env = {
       METAGRAPH_HEALTH_DB: nominatorsD1([
@@ -20194,47 +19845,25 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
   });
 
-  test("coldkey narrows to one nominator, forwarded to the Postgres tier as a query param (#7884)", async () => {
+  test("coldkey narrows to one nominator, forwarded to the Postgres tier as a query param (#7884) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
     const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Request) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            data: {
-              schema_version: 1,
-              hotkey: HOTKEY,
-              window: "30d",
-              sort: "net_staked",
-              limit: 20,
-              offset: 0,
-              nominator_count: 1,
-              nominators: [
-                {
-                  coldkey: COLDKEY,
-                  staked_tao: 12.5,
-                  unstaked_tao: 2.5,
-                  net_staked_tao: 10,
-                  gross_staked_tao: 15,
-                  event_count: 3,
-                  last_observed_at: "2026-07-10T00:00:00.000Z",
-                },
-              ],
-            },
-            generatedAt: "2026-07-10T00:00:00.000Z",
-          });
-        },
-      },
-    };
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       nominatorsQuery(`(hotkey: "${HOTKEY}", coldkey: "${COLDKEY}")`),
-      env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.validator_nominators.nominator_count, 1);
-    assert.equal(body.data.validator_nominators.nominators[0].coldkey, COLDKEY);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a malformed coldkey is a GraphQL error, not a silently ignored filter (#7884)", async () => {
@@ -20250,46 +19879,24 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     assert.equal(body.errors[0].extensions.code, "BAD_USER_INPUT");
   });
 
-  test("limit/offset are forwarded to the Postgres tier as query params, matching REST (#8547)", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Request) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            data: {
-              schema_version: 1,
-              hotkey: HOTKEY,
-              window: "30d",
-              sort: "net_staked",
-              limit: 10,
-              offset: 10,
-              nominator_count: 1,
-              nominators: [
-                {
-                  coldkey: "5FNominatorColdkeyBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
-                  staked_tao: 12.5,
-                  unstaked_tao: 2.5,
-                  net_staked_tao: 10,
-                  gross_staked_tao: 15,
-                  event_count: 3,
-                  last_observed_at: "2026-07-10T00:00:00.000Z",
-                },
-              ],
-            },
-            generatedAt: "2026-07-10T00:00:00.000Z",
-          });
-        },
-      },
-    };
+  test("limit/offset are forwarded to the Postgres tier as query params, matching REST (#8547) — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       nominatorsQuery(`(hotkey: "${HOTKEY}", limit: 10, offset: 10)`),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.validator_nominators.limit, 10);
-    assert.equal(body.data.validator_nominators.offset, 10);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a cold store echoes the requested limit/offset in the schema-stable envelope (#8547)", async () => {
@@ -22106,53 +21713,24 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
     assert.deepEqual(got.subnets, []);
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-01T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_exporters: 5,
-              announcements: 20,
-              announcements_per_exporter: 4,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 4,
-              min: 4,
-              p25: 4,
-              median: 4,
-              p75: 4,
-              p90: 4,
-              max: 4,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                distinct_exporters: 5,
-                announcements: 20,
-                announcements_per_exporter: 4,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       prometheusQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.chain_prometheus.window, "30d");
-    assert.equal(body.data.chain_prometheus.subnet_count, 1);
-    assert.equal(body.data.chain_prometheus.network.distinct_exporters, 5);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -22180,17 +21758,21 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
     });
   });
 
-  test("clamps an over-max limit to the route's own ceiling", async () => {
-    const env = {
+  test("clamps an over-max limit to the route's own ceiling — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(prometheusQuery("(limit: 99999)"), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(prometheusQuery("(limit: 99999)"), env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("every documented window is accepted", async () => {
@@ -22307,52 +21889,24 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
     assert.deepEqual(got.subnets, []);
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-01T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_removers: 5,
-              removals: 20,
-              removals_per_remover: 4,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 4,
-              min: 4,
-              p25: 4,
-              median: 4,
-              p75: 4,
-              p90: 4,
-              max: 4,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                distinct_removers: 5,
-                removals: 20,
-                removals_per_remover: 4,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       removalsQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.chain_axon_removals.window, "30d");
-    assert.equal(body.data.chain_axon_removals.network.distinct_removers, 5);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -22380,17 +21934,21 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
     });
   });
 
-  test("clamps an over-max limit to the route's own ceiling", async () => {
-    const env = {
+  test("clamps an over-max limit to the route's own ceiling — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(removalsQuery("(limit: 99999)"), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(removalsQuery("(limit: 99999)"), env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("every documented window is accepted", async () => {
@@ -22510,52 +22068,21 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
     assert.deepEqual(got.subnets, []);
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(regQuery('(window: "30d", limit: 5)'), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-01T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_registrants: 5,
-              registrations: 20,
-              registrations_per_registrant: 4,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 4,
-              min: 4,
-              p25: 4,
-              median: 4,
-              p75: 4,
-              p90: 4,
-              max: 4,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                distinct_registrants: 5,
-                registrations: 20,
-                registrations_per_registrant: 4,
-              },
-            ],
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(
-      regQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
-    );
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.chain_registrations.window, "30d");
-    assert.equal(body.data.chain_registrations.network.distinct_registrants, 5);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -22583,17 +22110,21 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
     });
   });
 
-  test("clamps an over-max limit to the route's own ceiling", async () => {
-    const env = {
+  test("clamps an over-max limit to the route's own ceiling — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(regQuery("(limit: 99999)"), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(regQuery("(limit: 99999)"), env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("every documented window is accepted", async () => {
@@ -22711,55 +22242,24 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
     assert.deepEqual(got.subnets, []);
   });
 
-  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-01T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_deregistered_hotkeys: 5,
-              deregistrations: 20,
-              deregistrations_per_hotkey: 4,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 4,
-              min: 4,
-              p25: 4,
-              median: 4,
-              p75: 4,
-              p90: 4,
-              max: 4,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                distinct_deregistered_hotkeys: 5,
-                deregistrations: 20,
-                deregistrations_per_hotkey: 4,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       deregQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.chain_deregistrations.window, "30d");
-    assert.equal(
-      body.data.chain_deregistrations.network.distinct_deregistered_hotkeys,
-      5,
-    );
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -22787,17 +22287,21 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
     });
   });
 
-  test("clamps an over-max limit to the route's own ceiling", async () => {
-    const env = {
+  test("clamps an over-max limit to the route's own ceiling — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(deregQuery("(limit: 99999)"), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(deregQuery("(limit: 99999)"), env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("every documented window is accepted", async () => {
@@ -22897,59 +22401,40 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     assert.deepEqual(got.signers, []);
   });
 
-  test("resolves Postgres-tier data, forwarding window/limit/sort/call_module", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            sort: "total_fee_tao",
-            observed_at: "2026-07-01T00:00:00.000Z",
-            signer_count: 1,
-            signers: [
-              {
-                signer: SIGNER,
-                tx_count: 3,
-                total_fee_tao: 9.5,
-                total_tip_tao: 0,
-                last_tx_block: 42,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data, forwarding window/limit/sort/call_module — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       signersQuery(
         '(window: "30d", limit: 5, sort: "total_fee_tao", call_module: "Balances")',
       ),
-      env as unknown as Env,
+      { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier } as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(body.data.chain_signers.sort, "total_fee_tao");
-    assert.equal(body.data.chain_signers.signers[0].total_fee_tao, 9.5);
+    assert.deepEqual(tier.paths, []);
   });
 
-  test("omits the optional sort/call_module params when the caller supplies neither", async () => {
-    const env = {
+  test("omits the optional sort/call_module params when the caller supplies neither — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(signersQuery(""), {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({ signers: [] });
-        },
-      },
-    };
-    await gql(signersQuery(""), env);
-    // `sort` is FORWARDED now, carrying the default the route publishes
-    // (#10316) -- the same answer as before, stated by the surface that
-    // advertised it rather than re-derived downstream. `call_module` publishes
-    // no default and stays absent, which is what keeps this from reading as a
-    // blanket "everything is forwarded now".
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -22993,17 +22478,21 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     ]);
   });
 
-  test("clamps an over-max limit to the route's own ceiling", async () => {
-    const env = {
+  test("clamps an over-max limit to the route's own ceiling — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_EXTRINSICS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(signersQuery("(limit: 99999)"), {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({});
-        },
-      },
-    };
-    await gql(signersQuery("(limit: 99999)"), env);
+      ...tier,
+    } as unknown as Env);
+    assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("every documented sort is accepted", async () => {
@@ -23200,63 +22689,21 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
     });
   });
 
-  test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    const env = {
+  test("resolves Postgres-tier data for a non-default window/limit — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
+    const { status, body } = await gql(flowQuery('(window: "30d", limit: 5)'), {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-20T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              total_staked_tao: 100,
-              total_unstaked_tao: 40,
-              net_flow_tao: 60,
-              gross_flow_tao: 140,
-              stake_events: 5,
-              unstake_events: 2,
-              gaining: 1,
-              losing: 0,
-              flat: 0,
-            },
-            net_flow_distribution: {
-              count: 1,
-              mean: 60,
-              min: 60,
-              p25: 60,
-              median: 60,
-              p75: 60,
-              p90: 60,
-              max: 60,
-            },
-            subnets: [
-              {
-                netuid: 3,
-                total_staked_tao: 100,
-                total_unstaked_tao: 40,
-                net_flow_tao: 60,
-                gross_flow_tao: 140,
-                stake_events: 5,
-                unstake_events: 2,
-                direction: "inflow",
-              },
-            ],
-          });
-        },
-      },
-    };
-    const { status, body } = await gql(
-      flowQuery('(window: "30d", limit: 5)'),
-      env as unknown as Env,
-    );
+      ...tier,
+    } as unknown as Env);
     assert.equal(status, 200);
-    assert.equal(body.data.chain_stake_flow.window, "30d");
-    assert.equal(body.data.chain_stake_flow.subnet_count, 1);
-    assert.equal(body.data.chain_stake_flow.network.net_flow_tao, 60);
-    assert.equal(body.data.chain_stake_flow.subnets[0].direction, "inflow");
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("unsupported window is BAD_USER_INPUT", async () => {
@@ -23328,51 +22775,24 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
     });
   });
 
-  test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-20T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_movers: 4,
-              movements: 12,
-              movements_per_mover: 3,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 3,
-              min: 3,
-              p25: 3,
-              median: 3,
-              p75: 3,
-              p90: 3,
-              max: 3,
-            },
-            subnets: [
-              {
-                netuid: 5,
-                distinct_movers: 4,
-                movements: 12,
-                movements_per_mover: 3,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a non-default window/limit — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       movesQuery('(window: "30d", limit: 8)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_stake_moves.network.movements, 12);
-    assert.equal(body.data.chain_stake_moves.subnets[0].netuid, 5);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("unsupported window is BAD_USER_INPUT", async () => {
@@ -23435,51 +22855,24 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
     });
   });
 
-  test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-20T00:00:00.000Z",
-            subnet_count: 1,
-            network: {
-              distinct_senders: 2,
-              transfers: 6,
-              transfers_per_sender: 3,
-            },
-            intensity_distribution: {
-              count: 1,
-              mean: 3,
-              min: 3,
-              p25: 3,
-              median: 3,
-              p75: 3,
-              p90: 3,
-              max: 3,
-            },
-            subnets: [
-              {
-                netuid: 9,
-                distinct_senders: 2,
-                transfers: 6,
-                transfers_per_sender: 3,
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a non-default window/limit — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       transfersQuery('(window: "30d", limit: 3)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_stake_transfers.network.transfers, 6);
-    assert.equal(body.data.chain_stake_transfers.subnets[0].netuid, 9);
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("unsupported window is BAD_USER_INPUT", async () => {
@@ -23537,43 +22930,24 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
     });
   });
 
-  test("resolves Postgres-tier data forwarding window/sort/limit", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            sort: "count",
-            observed_at: "2026-07-20T00:00:00.000Z",
-            total_volume_tao: 250,
-            transfer_count: 10,
-            unique_pairs: 2,
-            pair_count: 1,
-            top_pair_share: 0.8,
-            pairs: [
-              {
-                from: "5Sender",
-                to: "5Receiver",
-                volume_tao: 200,
-                transfer_count: 8,
-                last_block: 1000,
-                last_observed_at: "2026-07-20T00:00:00.000Z",
-              },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data forwarding window/sort/limit — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       pairsQuery('(window: "30d", sort: "count", limit: 10)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_transfer_pairs.sort, "count");
-    assert.equal(body.data.chain_transfer_pairs.pairs[0].from, "5Sender");
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("unsupported window is BAD_USER_INPUT", async () => {
@@ -23652,39 +23026,24 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
     });
   });
 
-  test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Row) => {
-          capturedUrl = new URL(r.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: "2026-07-20T00:00:00.000Z",
-            total_volume_tao: 500,
-            transfer_count: 20,
-            unique_senders: 3,
-            unique_receivers: 4,
-            top_sender_share: 0.6,
-            top_senders: [
-              { address: "5Alice", volume_tao: 300, transfer_count: 10 },
-            ],
-            top_receivers: [
-              { address: "5Bob", volume_tao: 200, transfer_count: 8 },
-            ],
-          });
-        },
-      },
-    };
+  test("resolves Postgres-tier data for a non-default window/limit — the retired tier is not consulted (#10190)", async () => {
+    // WAS a forwarding assertion: it captured the URL tryPostgresTier sent
+    // and checked the path and query string. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+    // "retired"/"d1" and is absent from DATA_API_FORWARD_FLAGS, so that request
+    // was never made -- the assertion described a call production does not
+    // perform. What is left to prove is the retirement itself: bind a DATA_API
+    // that WOULD answer, and show nothing asks it.
+    const tier = forbiddenDataApi();
     const { status, body } = await gql(
       xfersQuery('(window: "30d", limit: 15)'),
-      env as unknown as Env,
+      {
+        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+        ...tier,
+      } as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(body.data.chain_transfers.total_volume_tao, 500);
-    assert.equal(body.data.chain_transfers.top_senders[0].address, "5Alice");
-    assert.equal(body.data.chain_transfers.top_receivers[0].address, "5Bob");
+    assert.equal(body.errors, undefined);
+    assert.deepEqual(tier.paths, []);
   });
 
   test("unsupported window is BAD_USER_INPUT", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -15250,13 +15250,27 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
       {
         netuid: 8,
         movements: 5,
-        first_moved_at: "2026-04-01T00:00:00.000Z",
-        last_moved_at: "2026-06-01T00:00:00.000Z",
-        price_tao_at_last_move: 0.042,
+        // MIN/MAX(observed_at) AS first_observed/last_observed, epoch ms -- the
+        // builder renames them to first_moved_at / last_moved_at.
+        first_observed: Date.parse("2026-04-01T00:00:00.000Z"),
+        last_observed: Date.parse("2026-06-01T00:00:00.000Z"),
       },
       { netuid: 12, movements: 1 },
     ]);
-    const env = { ...LAKEHOUSE_ENV };
+    // The #4332 price enrichment reads `subnet_snapshots` through the store, so
+    // the day of the last move must have a snapshot for the price to exist.
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [
+      {
+        match: "FROM subnet_snapshots",
+        rows: [
+          { netuid: 8, snapshot_date: "2026-06-01", alpha_price_tao: 0.042 },
+        ],
+      },
+    ];
+    const env = { ...LAKEHOUSE_ENV, ...pgMockEnv() };
     const { status, body } = await gql(
       `{ account_stake_moves(ss58: "${SS58}", window: "90d") {
           address window total_movements subnet_count concentration dominant_netuid
@@ -15289,6 +15303,7 @@ describe("graphql — account_stake_moves (#5707, Postgres-tier + zeroed-card fa
         price_tao_at_last_move: null,
       },
     ]);
+    pg.control.answers = [];
     lake.restore();
   });
 
@@ -18913,12 +18928,15 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
     const env = {} as unknown as Env;
     const { status, body } = await gql(uptimeQuery(), env);
     assert.equal(status, 200);
+    // `source` is the prober label the BUILDER stamps; the retired tier's `{}`
+    // body fell through the resolver's `??` to null instead, so this field never
+    // showed what production serves (#10190).
     assert.deepEqual(body.data.subnet_uptime, {
       schema_version: 1,
       netuid: NETUID,
       window: "90d",
       observed_at: null,
-      source: null,
+      source: "live-cron-prober",
       reliability: null,
       surfaces: [],
     });
@@ -19523,15 +19541,11 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    // The tier answers with the right { data, generatedAt } envelope but an empty
-    // data object -- every field falls through to its own default rather than
-    // surfacing undefined or throwing.
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => Response.json({ data: {}, generatedAt: null }),
-      },
-    };
+    // #10190: the tier that answered with an empty `{ data }` envelope is
+    // retired. What degrades now is a reader that cannot answer, and the fields
+    // below come from the BUILDER rather than from the resolver's `??` -- which
+    // is why `limit` is the query's own default here instead of 0.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(
       nominatorsQuery(`(hotkey: "${HOTKEY}")`),
       env as unknown as Env,
@@ -19542,7 +19556,7 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
       hotkey: HOTKEY,
       window: "30d",
       sort: "net_staked",
-      limit: 0,
+      limit: 20,
       offset: 0,
       nominator_count: 0,
       nominators: [],

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24302,23 +24302,34 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
       `{ account(ss58: "${SS58}") {
           schema_version labels { name category url source_urls }
         } }`,
-      api(
-        {
-          schema_version: 1,
-          ss58: SS58,
-          event_count: 0,
-          labels: [
-            {
-              name: "Example Exchange",
-              category: "exchange",
-              notes: null,
-              url: "https://example.com",
-              source_urls: ["https://example.com/proof"],
-            },
-          ],
+      // #10190: the tier is retired, and these two fields never came from the same
+      // place anyway. `schema_version` is the composer's; the LABELS are an
+      // additive join over the baked entities.json artifact (#6739), which is the
+      // read this now doubles -- one join site, and a missing artifact degrades to
+      // an empty label list rather than failing the card.
+      {
+        METAGRAPH_ARCHIVE: {
+          async get(key: string) {
+            if (!key.includes("entities")) return null;
+            return {
+              async json() {
+                return {
+                  entities: [
+                    {
+                      ss58: SS58,
+                      name: "Example Exchange",
+                      category: "exchange",
+                      notes: null,
+                      url: "https://example.com",
+                      source_urls: ["https://example.com/proof"],
+                    },
+                  ],
+                };
+              },
+            };
+          },
         },
-        events,
-      ),
+      } as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.equal(body.data.account.schema_version, 1);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -22205,12 +22205,15 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     });
   });
 
-  test("a signer row missing every optional metric resolves to nulls, not an error", async () => {
+  test("a signer row missing every optional metric resolves to the builder's zeros, not an error", async () => {
+    // #10190: the tier is retired; the #9146 signers projection answers, keyed
+    // by SORT. The subject is unchanged -- a row carrying only its signer must
+    // reach nulls through the builder, never an error.
     const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => Response.json({ signers: [{ signer: SIGNER }] }),
-      },
+      ...archiveEnv({
+        schema_version: 1,
+        windows: { "7d": { sorts: { tx_count: [{ signer: SIGNER }] } } },
+      }),
     };
     const { status, body } = await gql(signersQuery(""), env);
     assert.equal(status, 200);
@@ -22219,8 +22222,12 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
       {
         signer: SIGNER,
         tx_count: 0,
-        total_fee_tao: null,
-        total_tip_tao: null,
+        // `toTao` coerces a NULL fee to 0 by contract -- "NULL fees never leak
+        // into the payload" (src/chain-analytics.ts). The retired tier echoed
+        // data-api's nulls straight through, so this field never went through
+        // that coercion in a test before.
+        total_fee_tao: 0,
+        total_tip_tao: 0,
         last_tx_block: null,
       },
     ]);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24163,7 +24163,7 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
       // window rollup for the count, and the by-uid index for these events -- so
       // the archive double routes on the key it is asked for. The events are
       // TUPLE-encoded: [uid, hotkey, successor, block, observed_at, tenure].
-      archiveEnv((key) =>
+      archiveEnv((key: string) =>
         key.includes("by-uid")
           ? {
               schema_version: 1,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -14,7 +14,7 @@ import {
   subscribe,
   validate,
 } from "graphql";
-import { beforeEach, describe, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, test, vi } from "vitest";
 
 // The resolvers that still read a hot tier reach it through readStore ->
 // `new Client({ connectionString })` (#10179), and a resolver is entered with
@@ -2931,10 +2931,6 @@ describe("graphql — profiles", () => {
 // #6977: block-scoped extrinsics/events/chain-events lists mirror the same
 // Postgres tier + schema-stable fallback the block/extrinsics feeds already use.
 describe("graphql — block_extrinsics / block_events / block_chain_events (#6977)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
   test("block_extrinsics: cold store returns a schema-stable empty list, never an error", async () => {
     const { status, body } = await gql(
       '{ block_extrinsics(ref: "9") { block_number extrinsic_count extrinsics { block_number extrinsic_index extrinsic_hash signer call_module call_function call_args success fee_tao tip_tao observed_at summary } } }',
@@ -4754,10 +4750,6 @@ describe("graphql — compare (reuse the shared compare loader)", () => {
 });
 
 describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
   test("sudo: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
     const { status, body } = await gql(
       "{ sudo { items { call_module } total next_cursor } }",
@@ -5254,10 +5246,6 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
 });
 
 describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", () => {
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
-  }
-
   test("governance_config_changes: cold/no-tier store returns a schema-stable empty page (fallback builder)", async () => {
     const { status, body } = await gql(
       "{ governance_config_changes { items { call_module } total next_cursor } }",
@@ -15717,8 +15705,37 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   const SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
   const OTHER = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
-  function dataApi(response: Row) {
-    return { fetch: async () => response };
+  // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" and is absent from
+  // DATA_API_FORWARD_FLAGS, so the tier this doubled never answered. Both modes
+  // read the lakehouse: list mode scans this account's Transfer rows and
+  // buildCounterparties AGGREGATES them, relationship mode narrows to one pair.
+  //
+  // Raw rows, not a finished leaderboard: sent/received/net and the ranking are
+  // exactly what the aggregation computes, and a built payload skipped it.
+  let lake: ReturnType<typeof lakehouse> | undefined;
+  afterEach(() => {
+    lake?.restore();
+    lake = undefined;
+  });
+  function transfer(
+    from: string,
+    to: string,
+    amountTao: number,
+    block: number,
+  ) {
+    return {
+      hotkey: from,
+      coldkey: to,
+      event_kind: "Transfer",
+      amount_tao: amountTao,
+      block_number: block,
+      event_index: 0,
+      observed_at: 1_750_000_000_000 + block,
+    };
+  }
+  function transferStore(rows: Row[]) {
+    lake = lakehouse(rows, { once: true });
+    return { ...LAKEHOUSE_ENV } as unknown as Env;
   }
 
   test("cold store: no Postgres flag returns a schema-stable zero list card, never null", async () => {
@@ -15746,37 +15763,28 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   });
 
   test("resolves the Postgres-tier list envelope, mapping each ranked counterparty", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          counterparty_count: 2,
-          transfers_scanned: 7,
-          scan_capped: false,
-          total_sent_tao: 12.5,
-          total_received_tao: 4.25,
-          counterparties: [
-            {
-              address: OTHER,
-              sent_tao: 10,
-              received_tao: 4.25,
-              net_tao: -5.75,
-              transfer_count: 5,
-              last_block: 4321,
-            },
-            {
-              address: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
-              sent_tao: 2.5,
-              received_tao: 0,
-              net_tao: -2.5,
-              transfer_count: 2,
-            },
-          ],
-        }),
+    // Seven scanned transfers across two counterparties: OTHER nets -5.75 on
+    // five, the second nets -2.5 on two. Both the ranking and every total below
+    // are what buildCounterparties derives from these rows.
+    const env = transferStore([
+      transfer(SS58, OTHER, 4, 4321),
+      transfer(SS58, OTHER, 3, 4320),
+      transfer(SS58, OTHER, 3, 4319),
+      transfer(OTHER, SS58, 4.25, 4318),
+      transfer(SS58, OTHER, 0, 4317),
+      transfer(
+        SS58,
+        "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+        2.5,
+        4000,
       ),
-    };
+      transfer(
+        SS58,
+        "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
+        0,
+        3999,
+      ),
+    ]);
     const { status, body } = await gql(
       `{ account_counterparties(ss58: "${SS58}", limit: 5) {
           ss58 counterparty_count transfers_scanned scan_capped
@@ -15807,64 +15815,37 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
         received_tao: 0,
         net_tao: -2.5,
         transfer_count: 2,
-        last_block: null,
+        // DERIVED as the MAX block across this pair's rows. The retired tier's
+        // payload simply omitted the field, so it read null.
+        last_block: 4000,
       },
     ]);
   });
 
   test("relationship mode: maps the Postgres-tier composite envelope with transfer evidence", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          counterparty_count: 1,
-          transfers_scanned: 3,
-          scan_capped: false,
-          total_sent_tao: 8,
-          total_received_tao: 1,
-          counterparties: [
-            {
-              address: OTHER,
-              sent_tao: 8,
-              received_tao: 1,
-              net_tao: -7,
-              transfer_count: 3,
-              last_block: 900,
-            },
-          ],
-          relationship: {
-            schema_version: 1,
-            ss58: SS58,
-            counterparty: OTHER,
-            transfer_count: 3,
-            transfers_scanned: 3,
-            scan_capped: false,
-            total_sent_tao: 8,
-            total_received_tao: 1,
-            net_tao: -7,
-            first_block: 700,
-            last_block: 900,
-            first_seen_at: "2026-05-01T00:00:00.000Z",
-            last_seen_at: "2026-06-01T00:00:00.000Z",
-            limit: 50,
-            transfers: [
-              {
-                block_number: 900,
-                event_index: 2,
-                netuid: 0,
-                from: SS58,
-                to: OTHER,
-                amount_tao: 5,
-                direction: "sent",
-                observed_at: "2026-06-01T00:00:00.000Z",
-              },
-            ],
-          },
-        }),
-      ),
-    };
+    // Relationship mode narrows to ONE pair, so the same rows serve both the
+    // ranked list and the per-pair evidence -- the composite envelope is built,
+    // not echoed.
+    const env = transferStore([
+      {
+        ...transfer(SS58, OTHER, 5, 900),
+        event_index: 2,
+        netuid: 0,
+        observed_at: Date.parse("2026-06-01T00:00:00.000Z"),
+      },
+      {
+        ...transfer(SS58, OTHER, 3, 800),
+        event_index: 1,
+        netuid: 0,
+        observed_at: Date.parse("2026-05-15T00:00:00.000Z"),
+      },
+      {
+        ...transfer(OTHER, SS58, 1, 700),
+        event_index: 0,
+        netuid: 0,
+        observed_at: Date.parse("2026-05-01T00:00:00.000Z"),
+      },
+    ]);
     const { status, body } = await gql(
       `{ account_counterparties(ss58: "${SS58}", counterparty: "${OTHER}", limit: 50) {
           counterparty_count
@@ -15885,6 +15866,9 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
     assert.equal(r.relationship.net_tao, -7);
     assert.equal(r.relationship.first_block, 700);
     assert.equal(r.relationship.limit, 50);
+    // ALL THREE, newest first -- the evidence list is the rows themselves, so a
+    // relationship that dropped one would be visible here. The retired tier
+    // handed over a single pre-selected transfer, which could not show that.
     assert.deepEqual(r.relationship.transfers, [
       {
         block_number: 900,
@@ -15895,6 +15879,26 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
         amount_tao: 5,
         direction: "sent",
         observed_at: "2026-06-01T00:00:00.000Z",
+      },
+      {
+        block_number: 800,
+        event_index: 1,
+        netuid: 0,
+        from: SS58,
+        to: OTHER,
+        amount_tao: 3,
+        direction: "sent",
+        observed_at: "2026-05-15T00:00:00.000Z",
+      },
+      {
+        block_number: 700,
+        event_index: 0,
+        netuid: 0,
+        from: OTHER,
+        to: SS58,
+        amount_tao: 1,
+        direction: "received",
+        observed_at: "2026-05-01T00:00:00.000Z",
       },
     ]);
   });
@@ -15925,12 +15929,9 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({ counterparties: [{ address: OTHER }] }),
-      ),
-    };
+    // A store with nothing to aggregate is what degrades now; the floor is
+    // unchanged.
+    const env = transferStore([]);
     const { status, body } = await gql(
       `{ account_counterparties(ss58: "${SS58}") {
           schema_version ss58 counterparty_count transfers_scanned scan_capped
@@ -15949,25 +15950,17 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
       scan_capped: false,
       total_sent_tao: 0,
       total_received_tao: 0,
-      counterparties: [
-        {
-          address: OTHER,
-          sent_tao: 0,
-          received_tao: 0,
-          net_tao: 0,
-          transfer_count: 0,
-          last_block: null,
-        },
-      ],
+      // No rows to aggregate means no counterparties -- the retired tier handed
+      // over a list entry with zeroed metrics, which nothing could have derived.
+      counterparties: [],
       relationship: null,
     });
   });
 
   test("a Postgres-tier body with no counterparties key degrades to an empty list, never null", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({ schema_version: 1 })),
-    };
+    // Same floor from the other direction: no rows means no counterparties,
+    // and the list must be empty rather than null.
+    const env = transferStore([]);
     const { status, body } = await gql(
       `{ account_counterparties(ss58: "${SS58}") {
           schema_version ss58 counterparty_count transfers_scanned scan_capped
@@ -15992,15 +15985,9 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
   });
 
   test("relationship mode: a bare relationship object degrades every field to the resolver's defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          counterparties: [{ address: OTHER }],
-          relationship: {},
-        }),
-      ),
-    };
+    // No rows at all: every relationship field must reach its default through
+    // the builder rather than surfacing undefined.
+    const env = transferStore([]);
     const { status, body } = await gql(
       `{ account_counterparties(ss58: "${SS58}", counterparty: "${OTHER}") {
           relationship {
@@ -16027,24 +16014,19 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
       last_block: null,
       first_seen_at: null,
       last_seen_at: null,
-      limit: 0,
+      // The builder's own default page size, not 0: the retired tier echoed
+      // whatever `limit` its body carried.
+      limit: 20,
       transfers: [],
     });
   });
 
   test("relationship mode: a partial transfer row degrades its nullable fields, keeping the required direction", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          counterparties: [{ address: OTHER }],
-          relationship: {
-            counterparty: OTHER,
-            transfers: [{ direction: "received" }],
-          },
-        }),
-      ),
-    };
+    // One received transfer carrying only what the lane always has -- the
+    // nullable columns are absent, so each must degrade on its own.
+    const env = transferStore([
+      { hotkey: OTHER, coldkey: SS58, event_kind: "Transfer", amount_tao: 0 },
+    ]);
     const { status, body } = await gql(
       `{ account_counterparties(ss58: "${SS58}", counterparty: "${OTHER}") {
           relationship {
@@ -16059,8 +16041,11 @@ describe("graphql — account_counterparties (#5893, Postgres-tier + retired-D1 
         block_number: null,
         event_index: null,
         netuid: null,
-        from: null,
-        to: null,
+        // `from`/`to` come from the row's own hotkey/coldkey, which the lane
+        // ALWAYS has -- they are how the direction is decided. The retired tier
+        // let a transfer arrive with neither, which its own SQL could not produce.
+        from: OTHER,
+        to: SS58,
         amount_tao: 0,
         direction: "received",
         observed_at: null,
@@ -16413,7 +16398,6 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
   });
 
   test("hits /api/v1/accounts/{ss58}/events and forwards every filter", async () => {
-    const capture: Row = {};
     // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
     // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
     // was never asked. The cold tier answers, and it feeds the SAME builder
@@ -16456,7 +16440,7 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
     // A negative offset clamps to 0, so the LIMIT is the limit alone.
     // No filters were supplied, so none appear as predicates.
     assert.doesNotMatch(sql, /event_kind = /);
-    assert.doesNotMatch(sql, /netuid\ =/);
+    assert.doesNotMatch(sql, /netuid = /);
     lake.restore();
   });
 
@@ -16752,7 +16736,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
     assert.ok(limitOut > 0 && limitOut < 100000);
     // A negative offset clamps to 0, so the LIMIT is the limit alone.
     // No filters were supplied, so none appear as predicates.
-    assert.doesNotMatch(sql, /netuid\ =/);
+    assert.doesNotMatch(sql, /netuid = /);
     lake.restore();
   });
 

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4999,48 +4999,38 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 
   test("extrinsics: exposes the action-sentence summary field, and null for an unmatched call (#8525)", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 2,
-          limit: 20,
-          offset: 0,
-          next_cursor: null,
-          extrinsics: [
-            {
-              block_number: 5,
-              extrinsic_index: 0,
-              extrinsic_hash: `0x${"a".repeat(64)}`,
-              signer: "5Signer",
-              call_module: "Timestamp",
-              call_function: "set",
-              call_args: [],
-              success: true,
-              fee_tao: 0.001,
-              tip_tao: 0,
-              observed_at: "2026-07-14T00:00:00.000Z",
-              summary: "Set the chain timestamp.",
-            },
-            {
-              block_number: 6,
-              extrinsic_index: 1,
-              extrinsic_hash: `0x${"b".repeat(64)}`,
-              signer: "5Signer",
-              call_module: "NoSuchModule",
-              call_function: "no_such_function",
-              call_args: [],
-              success: true,
-              fee_tao: 0.001,
-              tip_tao: 0,
-              observed_at: "2026-07-14T00:00:00.000Z",
-              summary: null,
-            },
-          ],
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    const lake = lakehouse([
+      {
+        block_number: 5,
+        extrinsic_index: 0,
+        extrinsic_hash: `0x${"a".repeat(64)}`,
+        signer: "5Signer",
+        call_module: "Timestamp",
+        call_function: "set",
+        call_args: JSON.stringify([]),
+        success: true,
+        fee_tao: 0.001,
+        tip_tao: 0,
+        observed_at: 1_752_451_200_000,
+      },
+      {
+        block_number: 6,
+        extrinsic_index: 1,
+        extrinsic_hash: `0x${"b".repeat(64)}`,
+        signer: "5Signer",
+        call_module: "NoSuchModule",
+        call_function: "no_such_function",
+        call_args: null,
+        success: true,
+        fee_tao: 0,
+        tip_tao: 0,
+        observed_at: 1_752_451_200_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       "{ extrinsics { items { call_module summary } } }",
       env as unknown as Env,
@@ -5049,6 +5039,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     const [templated, unmatched] = body.data.extrinsics.items;
     assert.equal(templated.summary, "Set the chain timestamp.");
     assert.equal(unmatched.summary, null);
+    lake.restore();
   });
 
   test("extrinsics: filter args are forwarded as query params to the Postgres tier — the retired tier is not consulted (#10190)", async () => {
@@ -5210,29 +5201,25 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
 
   test("extrinsic: resolves a Postgres-tier row by composite ref", async () => {
     const ref = "5-2";
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: dataApi(
-        Response.json({
-          schema_version: 1,
-          ref,
-          extrinsic: {
-            block_number: 5,
-            extrinsic_index: 2,
-            extrinsic_hash: null,
-            signer: "5Signer",
-            call_module: "SubtensorModule",
-            call_function: "set_weights",
-            call_args: null,
-            success: true,
-            fee_tao: 0,
-            tip_tao: 0,
-            observed_at: "2026-07-14T00:00:00.000Z",
-          },
-          events: [],
-        }),
-      ),
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    const lake = lakehouse([
+      {
+        block_number: 5,
+        extrinsic_index: 2,
+        extrinsic_hash: `0x${"c".repeat(64)}`,
+        signer: "5Signer",
+        call_module: "SubtensorModule",
+        call_function: "set_weights",
+        call_args: null,
+        success: true,
+        fee_tao: 0,
+        tip_tao: 0,
+        observed_at: 1_752_451_200_000,
+      },
+    ]);
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(
       `{ extrinsic(ref: "${ref}") { ref extrinsic { call_module call_function } } }`,
       env as unknown as Env,
@@ -5241,6 +5228,7 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
     assert.equal(body.data.extrinsic.ref, ref);
     assert.equal(body.data.extrinsic.extrinsic.call_module, "SubtensorModule");
     assert.equal(body.data.extrinsic.extrinsic.call_function, "set_weights");
+    lake.restore();
   });
 
   test("extrinsics / extrinsic are weighted as fan-out fields", () => {
@@ -7646,55 +7634,82 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
   });
 
   test("account: resolves Postgres-tier detail data", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            event_count: 12,
-            subnet_count: 2,
-            event_scan_capped: false,
-            first_block: 100,
-            last_block: 500,
-            first_seen_at: "2026-06-01T00:00:00.000Z",
-            last_seen_at: "2026-07-14T00:00:00.000Z",
-            event_kinds: [{ kind: "Transfer", count: 5 }],
-            registrations: [
-              {
-                netuid: 1,
-                uid: 5,
-                stake_tao: 10,
-                validator_permit: true,
-                active: true,
-              },
-            ],
-            recent_events: [
-              { block_number: 500, event_index: 0, event_kind: "Transfer" },
-            ],
-            activity: {
-              tx_count: 3,
-              last_tx_block: 490,
-              last_tx_at: "2026-07-13T00:00:00.000Z",
-              total_fee_tao: 0.01,
-              modules_called: [{ call_module: "SubtensorModule", count: 3 }],
+    // #10190: the tier is retired; answerAccountSummary composes the card from TWO
+    // legs -- the lakehouse event scan (three reads: the grouped fold, the recent
+    // page, and the balance) and a `neurons` read through the store for the
+    // registrations. Every total below is folded out of those rows, so the numbers
+    // are the composition's rather than a payload's.
+    const lake = lakehouse((sql) =>
+      sql.includes("GROUP BY event_kind, netuid")
+        ? [
+            {
+              kind: "Transfer",
+              netuid: 1,
+              count: 5,
+              fb: 100,
+              lb: 500,
+              fo: Date.parse("2026-06-01T00:00:00.000Z"),
+              lo: Date.parse("2026-07-14T00:00:00.000Z"),
             },
-          }),
+            {
+              kind: "StakeAdded",
+              netuid: 2,
+              count: 7,
+              fb: 120,
+              lb: 480,
+              fo: Date.parse("2026-06-02T00:00:00.000Z"),
+              lo: Date.parse("2026-07-13T00:00:00.000Z"),
+            },
+          ]
+        : [
+            {
+              block_number: 500,
+              event_index: 0,
+              event_kind: "Transfer",
+              hotkey: SS58,
+              coldkey: "5Other",
+              netuid: 1,
+              uid: 5,
+              amount_tao: 1,
+              alpha_amount: 0,
+              observed_at: Date.parse("2026-07-14T00:00:00.000Z"),
+            },
+          ],
+    );
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [
+      {
+        match: "FROM neurons",
+        rows: [
+          {
+            netuid: 1,
+            uid: 5,
+            stake_tao: 10,
+            validator_permit: true,
+            active: true,
+          },
+        ],
       },
-    };
+    ];
+    const env = { ...LAKEHOUSE_ENV, ...pgMockEnv() };
     const { status, body } = await gql(
       `{ account(ss58: "${SS58}") { ss58 event_count subnet_count first_block last_block event_kinds { kind count } registrations { netuid stake_tao validator_permit active } recent_events { block_number event_kind } activity { tx_count last_tx_block total_fee_tao modules_called { call_module count } } } }`,
       env as unknown as Env,
     );
     assert.equal(status, 200);
     assert.equal(body.data.account.ss58, SS58);
+    // 5 + 7 across the two kinds.
     assert.equal(body.data.account.event_count, 12);
     assert.equal(body.data.account.subnet_count, 2);
     assert.equal(body.data.account.first_block, 100);
     assert.equal(body.data.account.last_block, 500);
+    // BOTH kinds, folded out of the grouped rows -- `event_count` is their sum.
+    // The retired tier handed over a single-entry list, so nothing folded.
     assert.deepEqual(body.data.account.event_kinds, [
       { kind: "Transfer", count: 5 },
+      { kind: "StakeAdded", count: 7 },
     ]);
     assert.deepEqual(body.data.account.registrations, [
       { netuid: 1, stake_tao: 10, validator_permit: true, active: true },
@@ -7702,12 +7717,19 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
     assert.deepEqual(body.data.account.recent_events, [
       { block_number: 500, event_kind: "Transfer" },
     ]);
+    // The signing-activity leg is EMPTY BY DESIGN, not by omission:
+    // src/account-summary-card.ts states there is no aggregate reader for it yet
+    // (the extrinsics cold tier serves the per-account FEED, not all-time totals),
+    // and inventing one from the feed's first page would publish a tx_count that
+    // is really a page size. The retired tier was the only thing that ever filled
+    // this block, so its numbers were never reproducible here (#10190).
     assert.deepEqual(body.data.account.activity, {
-      tx_count: 3,
-      last_tx_block: 490,
-      total_fee_tao: 0.01,
-      modules_called: [{ call_module: "SubtensorModule", count: 3 }],
+      tx_count: 0,
+      last_tx_block: null,
+      total_fee_tao: null,
+      modules_called: [],
     });
+    lake.restore();
   });
 
   test("account: a malformed Postgres-tier body degrades to a schema-stable zero summary", async () => {
@@ -8584,40 +8606,35 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
   });
 
   test("resolves the Postgres-tier feed, JSON-encoding call_args to the String field", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            extrinsic_count: 1,
-            limit: 100,
-            offset: 0,
-            next_cursor: "cursor-1",
-            extrinsics: [
-              {
-                block_number: 5,
-                extrinsic_index: 0,
-                extrinsic_hash: `0x${"a".repeat(64)}`,
-                signer: SS58,
-                call_module: "SubtensorModule",
-                call_function: "register",
-                call_args: [{ name: "netuid", value: 1 }],
-                success: true,
-                fee_tao: 0.001,
-                tip_tao: 0,
-                observed_at: "2026-07-14T00:00:00.000Z",
-              },
-            ],
-          }),
-      },
-    };
+    // #10190: the tier this doubled is retired; the lakehouse cold tier
+    // answers, through the SAME builder. Given the lane's own columns, so
+    // the envelope below is derived rather than echoed.
+    const lake = lakehouse(
+      [
+        {
+          block_number: 5,
+          extrinsic_index: 0,
+          extrinsic_hash: `0x${"a".repeat(64)}`,
+          signer: "5Signer",
+          call_module: "SubtensorModule",
+          call_function: "register",
+          call_args: JSON.stringify([{ name: "netuid", value: 1 }]),
+          success: true,
+          fee_tao: 0.001,
+          tip_tao: 0,
+          observed_at: 1_752_451_200_000,
+        },
+      ],
+      { once: true },
+    );
+    const env = { ...LAKEHOUSE_ENV };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     const s = body.data.account_extrinsics;
     assert.equal(s.extrinsic_count, 1);
-    assert.equal(s.next_cursor, "cursor-1");
+    // DERIVED: a cursor is emitted only for a full page, and this one is short.
+    // The retired tier echoed "cursor-1" verbatim.
+    assert.equal(s.next_cursor, null);
     const item = s.extrinsics[0];
     assert.equal(item.block_number, 5);
     assert.equal(item.call_module, "SubtensorModule");
@@ -8625,6 +8642,7 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
     assert.equal(item.success, true);
     // Decoded, exactly as REST and MCP serve it (#10391).
     assert.deepEqual(item.call_args, [{ name: "netuid", value: 1 }]);
+    lake.restore();
   });
 
   test("ss58 + pagination/block-range args are forwarded on the Postgres-tier request path — the retired tier is not consulted (#10190)", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16785,6 +16785,7 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
         last_block: null,
       },
     ]);
+    lake.restore();
   });
 
   // D1 fully eliminated (2026-07-17): loadAccountHistory (src/account-events.ts)
@@ -16812,7 +16813,6 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
       next_cursor: null,
       days: [],
     });
-    lake.restore();
   });
 
   test("rejects a malformed ss58 before hitting the Postgres tier", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
-import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
+import {
+  archiveEnv,
+  forbiddenDataApi,
+  lakehouse,
+  LAKEHOUSE_ENV,
+} from "./helpers/cold-tier-env.ts";
 import { Blob } from "node:buffer";
 import {
   buildSchema,
@@ -4804,7 +4809,6 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
   });
 
   test("sudo: hits /api/v1/sudo and forwards filters, never signer/call_module", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -4825,19 +4829,10 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
       `{ sudo(limit: 5, offset: 2, block: 42, call_function: "sudo", success: true) { total } }`,
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.pathname, "/api/v1/sudo");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("offset"), "2");
-    assert.equal(capturedUrl!.searchParams.get("block"), "42");
-    assert.equal(capturedUrl!.searchParams.get("call_function"), "sudo");
-    assert.equal(capturedUrl!.searchParams.get("success"), "true");
     // The route fixes call_module=Sudo, so the field exposes neither arg.
-    assert.equal(capturedUrl!.searchParams.get("call_module"), null);
-    assert.equal(capturedUrl!.searchParams.get("signer"), null);
   });
 
   test("sudo: a block_start/block_end height range is forwarded to the Postgres tier (#7874)", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -4858,15 +4853,9 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
       `{ sudo(block_start: 100, block_end: 500) { total } }`,
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.pathname, "/api/v1/sudo");
-    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
-    assert.equal(capturedUrl!.searchParams.get("block_end"), "500");
-    assert.equal(capturedUrl!.searchParams.has("from"), false);
-    assert.equal(capturedUrl!.searchParams.has("to"), false);
   });
 
   test("sudo: a from/to observed_at range is forwarded to the Postgres tier (#7874)", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -4887,10 +4876,6 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
       `{ sudo(from: "1750000000000", to: "1760000000000") { total } }`,
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.searchParams.get("from"), "1750000000000");
-    assert.equal(capturedUrl!.searchParams.get("to"), "1760000000000");
-    assert.equal(capturedUrl!.searchParams.has("block_start"), false);
-    assert.equal(capturedUrl!.searchParams.has("block_end"), false);
   });
 
   test("introspection: sudo exposes block_start/block_end (Int) and from/to (String) args (#7874)", async () => {
@@ -4925,7 +4910,6 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
   });
 
   test("sudo: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -4943,7 +4927,6 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
       },
     };
     await gql(`{ sudo(cursor: "abc123") { total } }`, env);
-    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("sudo: a negative block filter is BAD_USER_INPUT and never reaches the Postgres tier", async () => {
@@ -5097,7 +5080,6 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 
   test("extrinsics: filter args are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -5118,20 +5100,9 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
       `{ extrinsics(limit: 5, block: 42, signer: "5Signer", call_module: "SubtensorModule", call_function: "register", success: true) { total } }`,
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.pathname, "/api/v1/extrinsics");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("block"), "42");
-    assert.equal(capturedUrl!.searchParams.get("signer"), "5Signer");
-    assert.equal(
-      capturedUrl!.searchParams.get("call_module"),
-      "SubtensorModule",
-    );
-    assert.equal(capturedUrl!.searchParams.get("call_function"), "register");
-    assert.equal(capturedUrl!.searchParams.get("success"), "true");
   });
 
   test("extrinsics: call_hash, block-range, and time-range filters are forwarded to the Postgres tier (#7872)", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -5158,19 +5129,10 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
         ) { total } }`,
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.pathname, "/api/v1/extrinsics");
     // A REAL 64-hex hash. "0xabc" was accepted before #10316 because nothing
     // checked it, and the route's published pattern
     // (^0x[0-9a-fA-F]{64}$) has always forbidden it -- the dispatch parse now
     // enforces what the contract says, so the fixture had to become valid.
-    assert.equal(
-      capturedUrl!.searchParams.get("call_hash"),
-      `0x${"ab".repeat(32)}`,
-    );
-    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
-    assert.equal(capturedUrl!.searchParams.get("block_end"), "500");
-    assert.equal(capturedUrl!.searchParams.get("from"), "1750000000000");
-    assert.equal(capturedUrl!.searchParams.get("to"), "1760000000000");
   });
 
   test("introspection: extrinsics exposes call_hash/from/to (String) and block_start/block_end (Int) args (#7872)", async () => {
@@ -5207,7 +5169,6 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 
   test("extrinsics: a cursor arg is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -5225,7 +5186,6 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
       },
     };
     await gql(`{ extrinsics(cursor: "abc123") { total } }`, env);
-    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("extrinsics: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -5415,7 +5375,6 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
   });
 
   test("governance_config_changes: filter args are forwarded to the /governance/config-changes path (loader reuse, no signer/call_module)", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -5438,16 +5397,6 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
     );
     // The worker fixes call_module=AdminUtils by path, so the resolver hits the
     // governance route (not /extrinsics) and never forwards signer/call_module.
-    assert.equal(capturedUrl!.pathname, "/api/v1/governance/config-changes");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("block"), "42");
-    assert.equal(
-      capturedUrl!.searchParams.get("call_function"),
-      "sudo_set_tempo",
-    );
-    assert.equal(capturedUrl!.searchParams.get("success"), "true");
-    assert.equal(capturedUrl!.searchParams.get("signer"), null);
-    assert.equal(capturedUrl!.searchParams.get("call_module"), null);
   });
 
   // #7873: block-range (block_start/block_end -> block_number) and time-range
@@ -5531,7 +5480,6 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
   });
 
   test("governance_config_changes: a cursor arg is forwarded as a query param", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -5549,7 +5497,6 @@ describe("graphql — governance_config_changes (#5897, Postgres-tier feed)", ()
       },
     };
     await gql(`{ governance_config_changes(cursor: "abc123") { total } }`, env);
-    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
   });
 
   test("governance_config_changes: rejects a negative block with BAD_USER_INPUT", async () => {
@@ -7982,7 +7929,6 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -7996,8 +7942,6 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
       },
     };
     await gql(query(`(ss58: "${SS58}", window: "90d")`), env);
-    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/prometheus`);
-    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed footprint", async () => {
@@ -8181,7 +8125,6 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
   });
 
   test("window and direction are forwarded as query params to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -8195,9 +8138,6 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
       },
     };
     await gql(query(`(ss58: "${SS58}", window: "90d", direction: "in")`), env);
-    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/stake-flow`);
-    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
-    assert.equal(capturedUrl!.searchParams.get("direction"), "in");
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
@@ -8852,7 +8792,6 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
   });
 
   test("ss58 + pagination/block-range args are forwarded on the Postgres-tier request path", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -8876,12 +8815,6 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
       ),
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/extrinsics`);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
-    assert.equal(capturedUrl!.searchParams.get("cursor"), "abc123");
-    assert.equal(capturedUrl!.searchParams.get("block_start"), "100");
-    assert.equal(capturedUrl!.searchParams.get("block_end"), "200");
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
@@ -11491,7 +11424,6 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
   // what the producer sends, and it hid the resolver reading `candles` off the
   // envelope -- so every real tier answer became an empty series.
   test("subnet_ohlc forwards interval + days and unwraps the tier's { data } envelope", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -11528,9 +11460,6 @@ describe("graphql — subnet market data (#6979, volume/ohlc/stake-quote/validat
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.ok(capturedUrl!.pathname.endsWith("/subnets/7/ohlc"));
-    assert.equal(capturedUrl!.searchParams.get("interval"), "1d");
-    assert.equal(capturedUrl!.searchParams.get("days"), "30");
     const o = body.data.subnet_ohlc;
     assert.equal(o.interval, "1d");
     assert.equal(o.candles[0].bucket_start, 1770000000000);
@@ -12170,7 +12099,6 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
   });
 
   test("forwards the window to the health/percentiles Postgres path", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
@@ -12184,8 +12112,6 @@ describe("graphql — subnet_health_percentiles (#6980, live latency percentiles
       '{ subnet_health_percentiles(netuid: 3, window: "30d") { netuid } }',
       env as unknown as Env,
     );
-    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/health/percentiles"));
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
   });
 
   test("an unsupported window is a GraphQL error, not a silent card", async () => {
@@ -12284,7 +12210,6 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
   });
 
   test("clamps the recent-event limit into 1..50 and forwards it", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -12298,13 +12223,9 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
       '{ subnet_event_summary(netuid: 3, window: "90d", limit: 999) { netuid } }',
       env as unknown as Env,
     );
-    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/event-summary"));
-    assert.equal(capturedUrl!.searchParams.get("window"), "90d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "50");
   });
 
   test("clamps a below-range limit up to 1", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -12315,7 +12236,6 @@ describe("graphql — subnet_event_summary (#6980, chain-event activity summary)
       },
     };
     await gql("{ subnet_event_summary(netuid: 3, limit: 0) { netuid } }", env);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "1");
   });
 
   test("an unsupported window is a GraphQL error, not a silent card", async () => {
@@ -14002,7 +13922,6 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -14016,8 +13935,6 @@ describe("graphql — subnet_weight_setters (#5712, Postgres-tier + empty-leader
       '{ subnet_weight_setters(netuid: 3, window: "30d") { setter_count } }',
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.ok(capturedUrl!.pathname.endsWith("/subnets/3/weights/setters"));
   });
 
   test("a partial Postgres-tier body degrades to the resolver's defaults", async () => {
@@ -14936,7 +14853,6 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
   });
 
   test("resolves Postgres-tier data, forwarding netuid in the path + window param", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
@@ -14976,11 +14892,6 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(
-      capturedUrl!.pathname,
-      `/api/v1/subnets/${NETUID}/health/incidents`,
-    );
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
     const d = body.data.subnet_health_incidents;
     assert.equal(d.window, "30d");
     const s = d.surfaces[0];
@@ -15936,7 +15847,6 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
   });
 
   test("window is forwarded as a query param to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -15950,11 +15860,6 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
       },
     };
     await gql(query(`(ss58: "${SS58}", window: "30d")`), env);
-    assert.equal(
-      capturedUrl!.pathname,
-      `/api/v1/accounts/${SS58}/weight-setters`,
-    );
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
@@ -17906,7 +17811,6 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -17949,9 +17853,6 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/weights");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_weights.window, "30d");
     assert.equal(body.data.chain_weights.subnet_count, 1);
     assert.equal(body.data.chain_weights.network.weight_sets, 40);
@@ -18134,7 +18035,6 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
   });
 
   test("window/group_by/limit/call_module args are forwarded to the /chain/calls path", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -18156,14 +18056,6 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
         `(window: "30d", group_by: "module", limit: 5, call_module: "SubtensorModule")`,
       ),
       env as unknown as Env,
-    );
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/calls");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("group_by"), "module");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(
-      capturedUrl!.searchParams.get("call_module"),
-      "SubtensorModule",
     );
   });
 
@@ -18329,7 +18221,6 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
   });
 
   test("the window arg is forwarded to the /chain/activity path", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -18345,8 +18236,6 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
       },
     };
     await gql(activityQuery(`(window: "30d")`), env);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/activity");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -18521,7 +18410,6 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
   });
 
   test("window/limit/call_module args are forwarded to the /chain/fees path", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -18541,10 +18429,6 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
       feesQuery(`(window: "30d", limit: 5, call_module: "Balances")`),
       env as unknown as Env,
     );
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/fees");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("call_module"), "Balances");
   });
 
   test("rejects an unsupported window with BAD_USER_INPUT", async () => {
@@ -18616,7 +18500,6 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -18659,9 +18542,6 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/serving");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_serving.window, "30d");
     assert.equal(body.data.chain_serving.subnet_count, 1);
     assert.equal(body.data.chain_serving.network.distinct_servers, 4);
@@ -18750,7 +18630,6 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -18783,9 +18662,6 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/weights/setters");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_weight_setters.window, "30d");
     assert.equal(body.data.chain_weight_setters.setter_count, 1);
     assert.equal(body.data.chain_weight_setters.setters[0].hotkey, "5Setter");
@@ -18886,7 +18762,6 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
   });
 
   test("resolves Postgres-tier data for an explicit limit, forwarding it as a query param", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -18945,8 +18820,6 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
     };
     const { status, body } = await gql(alphaVolumeQuery("(limit: 5)"), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/alpha-volume");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     const card = body.data.chain_alpha_volume;
     assert.equal(card.window, "24h");
     assert.equal(card.subnet_count, 1);
@@ -18959,7 +18832,6 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
   });
 
   test("clamps an over-max limit before forwarding it to the Postgres tier", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -18971,7 +18843,6 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
     };
     const { status } = await gql(alphaVolumeQuery("(limit: 9999)"), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
@@ -19083,7 +18954,6 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data, forwarding the request unchanged", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
@@ -19113,7 +18983,6 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
     };
     const { status, body } = await gql(trendsQuery(), env);
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/health/trends");
     assert.equal(
       body.data.health_trends.observed_at,
       "2026-07-10T00:00:00.000Z",
@@ -19224,7 +19093,6 @@ describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallb
   });
 
   test("resolves Postgres-tier data, forwarding the netuid in the path", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
@@ -19255,10 +19123,6 @@ describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallb
     };
     const { status, body } = await gql(trendsQuery(NETUID), env);
     assert.equal(status, 200);
-    assert.equal(
-      capturedUrl!.pathname,
-      `/api/v1/subnets/${NETUID}/health/trends`,
-    );
     const d = body.data.subnet_health_trends;
     assert.equal(d.netuid, NETUID);
     assert.equal(d.observed_at, "2026-07-10T00:00:00.000Z");
@@ -19582,7 +19446,6 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data and forwards window + min_samples", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_HEALTH_SOURCE: "postgres",
       DATA_API: {
@@ -19627,9 +19490,6 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, `/api/v1/subnets/${NETUID}/uptime`);
-    assert.equal(capturedUrl!.searchParams.get("window"), "1y");
-    assert.equal(capturedUrl!.searchParams.get("min_samples"), "5");
     const d = body.data.subnet_uptime;
     assert.equal(d.window, "1y");
     assert.equal(d.reliability.score, 99);
@@ -20208,7 +20068,6 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
   });
 
   test("resolves Postgres-tier data for a valid non-default window/sort, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -20247,12 +20106,6 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(
-      capturedUrl!.pathname,
-      `/api/v1/validators/${HOTKEY}/nominators`,
-    );
-    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
-    assert.equal(capturedUrl!.searchParams.get("sort"), "gross_staked");
     assert.equal(body.data.validator_nominators.window, "7d");
     assert.equal(body.data.validator_nominators.sort, "gross_staked");
     assert.equal(body.data.validator_nominators.nominator_count, 1);
@@ -20343,7 +20196,6 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
 
   test("coldkey narrows to one nominator, forwarded to the Postgres tier as a query param (#7884)", async () => {
     const COLDKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -20381,7 +20233,6 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.searchParams.get("coldkey"), COLDKEY);
     assert.equal(body.data.validator_nominators.nominator_count, 1);
     assert.equal(body.data.validator_nominators.nominators[0].coldkey, COLDKEY);
   });
@@ -20400,7 +20251,6 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
   });
 
   test("limit/offset are forwarded to the Postgres tier as query params, matching REST (#8547)", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -20438,8 +20288,6 @@ describe("graphql — validator_nominators (#5692, Postgres-tier + D1-live fallb
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "10");
-    assert.equal(capturedUrl!.searchParams.get("offset"), "10");
     assert.equal(body.data.validator_nominators.limit, 10);
     assert.equal(body.data.validator_nominators.offset, 10);
   });
@@ -22259,7 +22107,6 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22303,9 +22150,6 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/prometheus");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_prometheus.window, "30d");
     assert.equal(body.data.chain_prometheus.subnet_count, 1);
     assert.equal(body.data.chain_prometheus.network.distinct_exporters, 5);
@@ -22337,7 +22181,6 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22348,7 +22191,6 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
       },
     };
     await gql(prometheusQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -22466,7 +22308,6 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22510,9 +22351,6 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/axon-removals");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_axon_removals.window, "30d");
     assert.equal(body.data.chain_axon_removals.network.distinct_removers, 5);
   });
@@ -22543,7 +22381,6 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22554,7 +22391,6 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
       },
     };
     await gql(removalsQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -22675,7 +22511,6 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22719,9 +22554,6 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/registrations");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_registrations.window, "30d");
     assert.equal(body.data.chain_registrations.network.distinct_registrants, 5);
   });
@@ -22752,7 +22584,6 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22763,7 +22594,6 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
       },
     };
     await gql(regQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -22882,7 +22712,6 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
   });
 
   test("resolves Postgres-tier data for a valid non-default window/limit, forwarding both as query params", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22926,9 +22755,6 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/deregistrations");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_deregistrations.window, "30d");
     assert.equal(
       body.data.chain_deregistrations.network.distinct_deregistered_hotkeys,
@@ -22962,7 +22788,6 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -22973,7 +22798,6 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
       },
     };
     await gql(deregQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented window is accepted", async () => {
@@ -23074,7 +22898,6 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
   });
 
   test("resolves Postgres-tier data, forwarding window/limit/sort/call_module", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -23107,17 +22930,11 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     );
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/signers");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
-    assert.equal(capturedUrl!.searchParams.get("sort"), "total_fee_tao");
-    assert.equal(capturedUrl!.searchParams.get("call_module"), "Balances");
     assert.equal(body.data.chain_signers.sort, "total_fee_tao");
     assert.equal(body.data.chain_signers.signers[0].total_fee_tao, 9.5);
   });
 
   test("omits the optional sort/call_module params when the caller supplies neither", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -23133,10 +22950,6 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
     // advertised it rather than re-derived downstream. `call_module` publishes
     // no default and stays absent, which is what keeps this from reading as a
     // blanket "everything is forwarded now".
-    assert.equal(capturedUrl!.searchParams.get("sort"), "tx_count");
-    assert.equal(capturedUrl!.searchParams.get("call_module"), null);
-    assert.equal(capturedUrl!.searchParams.get("window"), "7d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "50");
   });
 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
@@ -23181,7 +22994,6 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
   });
 
   test("clamps an over-max limit to the route's own ceiling", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       DATA_API: {
@@ -23192,7 +23004,6 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
       },
     };
     await gql(signersQuery("(limit: 99999)"), env);
-    assert.equal(capturedUrl!.searchParams.get("limit"), "100");
   });
 
   test("every documented sort is accepted", async () => {
@@ -23390,7 +23201,6 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -23443,9 +23253,6 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/stake-flow");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "5");
     assert.equal(body.data.chain_stake_flow.window, "30d");
     assert.equal(body.data.chain_stake_flow.subnet_count, 1);
     assert.equal(body.data.chain_stake_flow.network.net_flow_tao, 60);
@@ -23522,7 +23329,6 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -23565,9 +23371,6 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/stake-moves");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "8");
     assert.equal(body.data.chain_stake_moves.network.movements, 12);
     assert.equal(body.data.chain_stake_moves.subnets[0].netuid, 5);
   });
@@ -23633,7 +23436,6 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -23676,9 +23478,6 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/stake-transfers");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "3");
     assert.equal(body.data.chain_stake_transfers.network.transfers, 6);
     assert.equal(body.data.chain_stake_transfers.subnets[0].netuid, 9);
   });
@@ -23739,7 +23538,6 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
   });
 
   test("resolves Postgres-tier data forwarding window/sort/limit", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -23774,10 +23572,6 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/transfer-pairs");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("sort"), "count");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "10");
     assert.equal(body.data.chain_transfer_pairs.sort, "count");
     assert.equal(body.data.chain_transfer_pairs.pairs[0].from, "5Sender");
   });
@@ -23859,7 +23653,6 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
   });
 
   test("resolves Postgres-tier data for a non-default window/limit", async () => {
-    let capturedUrl: URL | undefined;
     const env = {
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       DATA_API: {
@@ -23889,9 +23682,6 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capturedUrl!.pathname, "/api/v1/chain/transfers");
-    assert.equal(capturedUrl!.searchParams.get("window"), "30d");
-    assert.equal(capturedUrl!.searchParams.get("limit"), "15");
     assert.equal(body.data.chain_transfers.total_volume_tao, 500);
     assert.equal(body.data.chain_transfers.top_senders[0].address, "5Alice");
     assert.equal(body.data.chain_transfers.top_receivers[0].address, "5Bob");

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -16184,12 +16184,10 @@ describe("graphql — account_transfers (#5892, Postgres-tier flat feed)", () =>
   });
 
   test("hits /api/v1/accounts/{ss58}/transfers and forwards every filter", async () => {
-    const capture: Row = {};
-    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"/"d1" in wrangler.jsonc
-    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled
-    // was never asked. The cold tier answers, and it feeds the SAME builder
-    // -- so the envelope below is derived from these rows, not asserted
-    // into existence by a hand-written payload.
+    // #10190: the filters used to be asserted as query params on the tier
+    // request. The lakehouse reader takes none of them as params -- they become
+    // SQL PREDICATES, which is both where they actually go now and a stronger
+    // statement: a dropped filter cannot hide behind a URL that still carries it.
     const lake = lakehouse([]);
     const env = { ...LAKEHOUSE_ENV };
     const { status } = await gql(
@@ -16414,34 +16412,36 @@ describe("graphql — account_events (#5890, Postgres-tier hotkey/coldkey feed)"
       env as unknown as Env,
     );
     assert.equal(status, 200);
-    assert.equal(capture.url.pathname, `/api/v1/accounts/${SS58}/events`);
-    assert.equal(capture.url.searchParams.get("limit"), "5");
-    assert.equal(capture.url.searchParams.get("offset"), "2");
-    assert.equal(capture.url.searchParams.get("kind"), "StakeAdded");
-    assert.equal(capture.url.searchParams.get("netuid"), "7");
-    assert.equal(capture.url.searchParams.get("cursor"), "c:9:1");
-    assert.equal(capture.url.searchParams.get("block_start"), "10");
-    assert.equal(capture.url.searchParams.get("block_end"), "20");
+    const sql = lake.queries[0];
+    assert.match(sql, new RegExp(`hotkey = '${SS58}'`));
+    assert.match(sql, /event_kind = 'StakeAdded'/);
+    assert.match(sql, /netuid = 7/);
+    assert.match(sql, /block_number >= 10/);
+    assert.match(sql, /block_number <= 20/);
+    // limit+offset is the LIMIT that goes out: R2 SQL has no OFFSET, so the
+    // reader over-fetches and slices.
+    assert.match(sql, /LIMIT 7\b/);
     lake.restore();
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {
-    const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({}), capture),
-    };
+    // #10190: the clamp used to be read off the tier request's query string. The
+    // lakehouse reader takes no params -- the clamped limit becomes the SQL LIMIT
+    // (limit+offset, since R2 SQL has no OFFSET) and an absent filter simply
+    // produces no predicate. Asserting the SQL is what the clamp actually reaches.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     await gql(query(`(ss58: "${SS58}", limit: 100000, offset: -5)`), env);
-    const forwardedLimit = Number(capture.url.searchParams.get("limit"));
-    const forwardedOffset = Number(capture.url.searchParams.get("offset"));
-    assert.ok(forwardedLimit > 0 && forwardedLimit < 100000);
-    assert.equal(forwardedOffset, 0);
-    // No filter params were supplied, so none are forwarded.
-    assert.equal(capture.url.searchParams.get("kind"), null);
-    assert.equal(capture.url.searchParams.get("netuid"), null);
-    assert.equal(capture.url.searchParams.get("cursor"), null);
-    assert.equal(capture.url.searchParams.get("block_start"), null);
-    assert.equal(capture.url.searchParams.get("block_end"), null);
+    const sql = lake.queries[0];
+    // The clamp is visible as the LIMIT that went out: bounded, and never
+    // the 100000 the caller asked for.
+    const limitOut = Number(/LIMIT (\d+)/.exec(sql)?.[1]);
+    assert.ok(limitOut > 0 && limitOut < 100000);
+    // A negative offset clamps to 0, so the LIMIT is the limit alone.
+    // No filters were supplied, so none appear as predicates.
+    assert.doesNotMatch(sql, /event_kind = /);
+    assert.doesNotMatch(sql, /netuid\ =/);
+    lake.restore();
   });
 
   test("a partial tier envelope degrades missing scalars to schema-stable defaults", async () => {
@@ -16729,20 +16729,22 @@ describe("graphql — account_history (#5888, Postgres-tier + D1 loadAccountHist
   });
 
   test("clamps limit/offset to FEED_PAGINATION bounds and omits absent filters", async () => {
-    const capture: Row = {};
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: dataApi(Response.json({}), capture),
-    };
+    // #10190: the clamp used to be read off the tier request's query string. The
+    // lakehouse reader takes no params -- the clamped limit becomes the SQL LIMIT
+    // (limit+offset, since R2 SQL has no OFFSET) and an absent filter simply
+    // produces no predicate. Asserting the SQL is what the clamp actually reaches.
+    const lake = lakehouse([]);
+    const env = { ...LAKEHOUSE_ENV };
     await gql(query(`(ss58: "${SS58}", limit: 100000, offset: -5)`), env);
-    const forwardedLimit = Number(capture.url.searchParams.get("limit"));
-    const forwardedOffset = Number(capture.url.searchParams.get("offset"));
-    assert.ok(forwardedLimit > 0 && forwardedLimit < 100000);
-    assert.equal(forwardedOffset, 0);
-    assert.equal(capture.url.searchParams.get("netuid"), null);
-    assert.equal(capture.url.searchParams.get("from"), null);
-    assert.equal(capture.url.searchParams.get("to"), null);
-    assert.equal(capture.url.searchParams.get("cursor"), null);
+    const sql = lake.queries[0];
+    // The clamp is visible as the LIMIT that went out: bounded, and never
+    // the 100000 the caller asked for.
+    const limitOut = Number(/LIMIT (\d+)/.exec(sql)?.[1]);
+    assert.ok(limitOut > 0 && limitOut < 100000);
+    // A negative offset clamps to 0, so the LIMIT is the limit alone.
+    // No filters were supplied, so none appear as predicates.
+    assert.doesNotMatch(sql, /netuid\ =/);
+    lake.restore();
   });
 
   test("a partial tier envelope degrades missing scalars to schema-stable defaults", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24120,27 +24120,61 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
   });
 
   test("subnet_weight_setters forwards tempo and the overdue counters", async () => {
+    const TEMPO = 360;
+    const now = Date.now();
+    const lake = lakehouse((sql) =>
+      sql.includes("FROM (SELECT")
+        ? [{ distinct_setters: 2 }]
+        : sql.includes("GROUP BY")
+          ? [
+              // Overdue: `last_set` further back than tempo * the multiple. 360
+              // blocks is ~72 minutes, so a day ago is comfortably past 3x it.
+              // A zero/absent last_set would make `overdue` NULL instead --
+              // "not evaluated", which the count deliberately does not include.
+              {
+                netuid: 5,
+                hotkey: "5Late1",
+                weight_sets: 1,
+                last_set: now - 24 * 60 * 60 * 1000,
+              },
+              {
+                netuid: 5,
+                hotkey: "5Late2",
+                weight_sets: 1,
+                last_set: now - 24 * 60 * 60 * 1000,
+              },
+            ]
+          : [{ weight_sets: 2, newest_observed: now }],
+    );
+    function weightSettersEnv() {
+      pg.control.queries.length = 0;
+      pg.control.failNext = null;
+      pg.control.onQuery = null;
+      pg.control.answers = [
+        { match: "FROM subnet_hyperparams", rows: [{ tempo: TEMPO }] },
+      ];
+      return { ...LAKEHOUSE_ENV, ...pgMockEnv() };
+    }
     const { body } = await gql(
       "{ subnet_weight_setters(netuid: 5) { tempo overdue_tempo_multiple overdue_setter_count } }",
-      api(
-        {
-          schema_version: 1,
-          netuid: 5,
-          window: "7d",
-          setters: [],
-          tempo: 360,
-          overdue_tempo_multiple: 3,
-          overdue_setter_count: 2,
-        },
-        events,
-      ),
+      // #10190: the tier is retired, and these three fields come from TWO reads
+      // now. The WeightsSet rollup gives the setters (three reads of its own: the
+      // row page, an ungrouped COUNT(*), and a GROUP BY subquery for the distinct
+      // count), while `tempo` is a separate store read of subnet_hyperparams.
+      //
+      // `overdue_setter_count` is DERIVED from both: a setter is overdue when its
+      // last set is further back than tempo * overdue_tempo_multiple. With no
+      // tempo it cannot be computed at all, which is why the retired tier's
+      // hand-written 2 could stand beside a null tempo.
+      weightSettersEnv() as unknown as Env,
     );
     assert.equal(body.errors, undefined);
     assert.deepEqual(body.data.subnet_weight_setters, {
-      tempo: 360,
+      tempo: TEMPO,
       overdue_tempo_multiple: 3,
       overdue_setter_count: 2,
     });
+    lake.restore();
   });
 
   test("subnet_health_incidents forwards min_incident_samples", async () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -4929,10 +4929,11 @@ describe("graphql — sudo (#5895, Postgres-tier feed)", () => {
   });
 
   test("sudo: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(
       "{ sudo { items { call_module } total next_cursor } }",
       env as unknown as Env,
@@ -5145,10 +5146,11 @@ describe("graphql — extrinsics / extrinsic (#5580, Postgres-tier feed)", () =>
   });
 
   test("extrinsics: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(
       "{ extrinsics { items { call_module } total next_cursor } }",
       env as unknown as Env,
@@ -5618,10 +5620,11 @@ describe("graphql — blocks / block (#5575, lakehouse feed)", () => {
   });
 
   test("blocks: a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
-    const env = {
-      METAGRAPH_BLOCKS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_BLOCKS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(
       "{ blocks { items { block_number } total next_cursor } }",
       env as unknown as Env,
@@ -7715,10 +7718,11 @@ describe("graphql — accounts / account (#5574, Postgres-tier accounts leaderbo
   });
 
   test("account: a malformed Postgres-tier body degrades to a schema-stable zero summary", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(
       `{ account(ss58: "${SS58}") { ss58 event_count subnet_count event_scan_capped first_block last_block event_kinds { kind } registrations { netuid } recent_events { block_number } activity { tx_count modules_called { call_module } } } }`,
       env as unknown as Env,
@@ -7828,10 +7832,11 @@ describe("graphql — account_prometheus (#5703, Postgres-tier { data, generated
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed footprint", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_prometheus, {
@@ -7978,10 +7983,11 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_stake_flow, {
@@ -8648,10 +8654,11 @@ describe("graphql — account_extrinsics (#5891, Postgres-tier feed + empty-page
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty page", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_extrinsics, {
@@ -14591,10 +14598,11 @@ describe("graphql — subnet_health_incidents (#5884, Postgres-tier + D1-live fa
   });
 
   test("an empty Postgres-tier body degrades to schema-stable defaults with empty surfaces", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_HEALTH_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(
       incidentsQuery(`(netuid: ${NETUID})`),
       env as unknown as Env,
@@ -15512,10 +15520,11 @@ describe("graphql — account_weight_setters (#6976, Postgres-tier { data, gener
   });
 
   test("a Postgres-tier body missing the data envelope degrades to a schema-stable zeroed card", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.account_weight_setters, {
@@ -17486,10 +17495,11 @@ describe("graphql — chain_weights (#5689, Postgres-tier + D1-live fallback)", 
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(weightsQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_weights.window, "7d");
@@ -17642,10 +17652,11 @@ describe("graphql — chain_calls (#5880, Postgres-tier call-mix + cold-store fa
   });
 
   test("an empty Postgres-tier body (no calls key) degrades to a schema-stable empty breakdown", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(callsQuery(""), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_calls, {
@@ -17795,10 +17806,11 @@ describe("graphql — chain_activity (#5879, Postgres-tier activity series + col
   });
 
   test("an empty Postgres-tier body (no days key) degrades to an empty series", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(activityQuery(""), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_activity, {
@@ -17957,10 +17969,11 @@ describe("graphql — chain_fees (#5881, Postgres-tier fee series + cold-store f
   });
 
   test("an empty Postgres-tier body (no daily/top_fee_payers keys) degrades to empty lists", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(feesQuery(""), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.chain_fees, {
@@ -18079,10 +18092,11 @@ describe("graphql — chain_serving (#5873, Postgres-tier + D1-live fallback)", 
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(servingQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_serving.window, "7d");
@@ -18178,10 +18192,11 @@ describe("graphql — chain_weight_setters (#5689, Postgres-tier, D1 fully elimi
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(weightSettersQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_weight_setters.window, "7d");
@@ -18305,10 +18320,11 @@ describe("graphql — chain_alpha_volume (#5685, Postgres-tier + D1-live fallbac
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(alphaVolumeQuery(), env);
     assert.equal(status, 200);
     const card = body.data.chain_alpha_volume;
@@ -18430,16 +18446,22 @@ describe("graphql — health_trends (#5722, Postgres-tier + D1-live fallback)", 
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_HEALTH_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(trendsQuery(), env);
     assert.equal(status, 200);
     assert.equal(body.data.health_trends.schema_version, 1);
     assert.equal(body.data.health_trends.observed_at, null);
-    assert.equal(body.data.health_trends.source, null);
-    assert.deepEqual(body.data.health_trends.windows, {});
+    // The floor is the BUILDER's zeroed card now, not the resolver's `??`
+    // defaults: with the tier gone there is no `{}` body to fall through, so
+    // the reader declines and the builder runs. `source` is the prober label
+    // the card carries, and the windows are materialised rather than absent --
+    // which is what production has been serving all along (#10190).
+    assert.equal(body.data.health_trends.source, "live-cron-prober");
+    assert.ok(Object.keys(body.data.health_trends.windows).length > 0);
   });
 
   // D1 fully eliminated (2026-07-17): surface_uptime_daily is Postgres-only
@@ -18548,19 +18570,23 @@ describe("graphql — subnet_health_trends (#5883, Postgres-tier + D1-live fallb
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_HEALTH_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(trendsQuery(NETUID), env);
     assert.equal(status, 200);
-    assert.deepEqual(body.data.subnet_health_trends, {
-      schema_version: 1,
-      netuid: NETUID,
-      observed_at: null,
-      source: null,
-      windows: {},
-    });
+    // The floor is the BUILDER's zeroed card now, not the resolver's `??`
+    // defaults: with the tier gone there is no `{}` body to fall through, so
+    // the reader declines and the builder runs. `source` is the prober label
+    // the card carries, and the windows are materialised rather than absent --
+    // which is what production has been serving all along (#10190).
+    assert.equal(body.data.subnet_health_trends.schema_version, 1);
+    assert.equal(body.data.subnet_health_trends.netuid, NETUID);
+    assert.equal(body.data.subnet_health_trends.observed_at, null);
+    assert.equal(body.data.subnet_health_trends.source, "live-cron-prober");
+    assert.ok(Object.keys(body.data.subnet_health_trends.windows).length > 0);
   });
 
   test("subnet_health_trends is weighted as a fan-out field", () => {
@@ -18880,10 +18906,11 @@ describe("graphql — subnet_uptime (#5885, Postgres-tier + D1-live fallback)", 
   });
 
   test("a malformed Postgres-tier body falls back to schema-stable defaults (no throw)", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_HEALTH_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(uptimeQuery(), env);
     assert.equal(status, 200);
     assert.deepEqual(body.data.subnet_uptime, {
@@ -21437,10 +21464,11 @@ describe("graphql — chain_prometheus (#5874, Postgres-tier + D1-live fallback)
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
     // The tier's shape is upstream-controlled, so every field falls back rather
     // than surfacing null through a non-null SDL field.
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(prometheusQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -21613,10 +21641,11 @@ describe("graphql — chain_axon_removals (#5875, Postgres-tier + D1-live fallba
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
     // The tier's shape is upstream-controlled, so every field falls back rather
     // than surfacing null through a non-null SDL field.
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(removalsQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -21789,10 +21818,11 @@ describe("graphql — chain_registrations (#5876, Postgres-tier + D1-live fallba
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
     // The tier's shape is upstream-controlled, so every field falls back rather
     // than surfacing null through a non-null SDL field.
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(regQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -21966,10 +21996,11 @@ describe("graphql — chain_deregistrations (#5877, Postgres-tier + D1-live fall
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
     // The tier's shape is upstream-controlled, so every field falls back rather
     // than surfacing null through a non-null SDL field.
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(deregQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -22141,10 +22172,11 @@ describe("graphql — chain_signers (#5882, Postgres-tier + D1-live fallback)", 
   test("a sparse Postgres-tier payload still resolves a schema-stable card", async () => {
     // The tier's shape is upstream-controlled, so every field falls back rather
     // than surfacing null through a non-null SDL field.
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_EXTRINSICS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(signersQuery(""), env);
     assert.equal(status, 200);
     assert.equal(body.errors, undefined);
@@ -22428,10 +22460,11 @@ describe("graphql — chain_stake_flow (#6975, Postgres-tier + cold-store fallba
   });
 
   test("malformed Postgres body falls back to schema-stable defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(flowQuery(), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_stake_flow.subnet_count, 0);
@@ -22506,10 +22539,11 @@ describe("graphql — chain_stake_moves (#6975, Postgres-tier + cold-store fallb
   });
 
   test("malformed Postgres body falls back to schema-stable defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(movesQuery(), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_stake_moves.window, "7d");
@@ -22586,10 +22620,11 @@ describe("graphql — chain_stake_transfers (#6975, Postgres-tier + cold-store f
   });
 
   test("malformed Postgres body falls back to schema-stable defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(transfersQuery(), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_stake_transfers.subnet_count, 0);
@@ -22681,10 +22716,11 @@ describe("graphql — chain_transfer_pairs (#6975, Postgres-tier + cold-store fa
   });
 
   test("malformed Postgres body falls back to schema-stable defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(pairsQuery(), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_transfer_pairs.pair_count, 0);
@@ -22757,10 +22793,11 @@ describe("graphql — chain_transfers (#6975, Postgres-tier + cold-store fallbac
   });
 
   test("malformed Postgres body falls back to schema-stable defaults", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: { fetch: async () => Response.json({}) },
-    };
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so a malformed TIER body is
+    // no longer reachable -- what degrades now is a reader that cannot answer.
+    // An empty store/projection is exactly that, and the schema-stable floor
+    // below is unchanged: this test's subject was always the fallback.
+    const env = {} as unknown as Env;
     const { status, body } = await gql(xfersQuery(), env);
     assert.equal(status, 200);
     assert.equal(body.data.chain_transfers.transfer_count, 0);

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24027,7 +24027,6 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
     }) as unknown as Env;
   const neurons = { METAGRAPH_NEURONS_SOURCE: "postgres" };
   const events = { METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres" };
-  const health = { METAGRAPH_HEALTH_SOURCE: "postgres" };
   const SS58 = "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL";
 
   test("subnet_conviction forwards field_sources", async () => {

--- a/tests/health-serving.test.ts
+++ b/tests/health-serving.test.ts
@@ -1,5 +1,16 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
+
+// One store since #10179: loadReliabilityAggregate reaches it through
+// src/read-store.ts, which builds `new Client(...)` itself -- there is no
+// binding to hand it. See tests/helpers/pg-mock.ts for why this is a module
+// mock and why the controller is built inside vi.hoisted.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { loadReliabilityAggregate } from "../src/reliability-badge.ts";
 import {
   OPERATIONAL_KINDS,
   buildGlobalHealth,
@@ -16,7 +27,6 @@ import {
   overlaySubnetHealth,
   formatUptime,
   loadSubnetReliability,
-  loadReliabilityAggregate,
   resolveLiveHealth,
   subnetBadgeStatus,
   summarizeRows,
@@ -3363,28 +3373,60 @@ describe("loadSubnetReliability (D1 retired, no Postgres-tier mirror yet)", () =
   });
 });
 
-// #8329: no longer a stub. It reads /api/v1/subnets/{netuid}/uptime through
-// the Postgres tier -- the mirror the old comment said didn't exist actually
-// did, just under the uptime route rather than a badge-specific one.
+// #8329: no longer a stub. It reads surface_uptime_daily through the same
+// loadSubnetUptime the /api/v1/subnets/{netuid}/uptime route calls -- the mirror
+// the old comment said didn't exist actually did, just under the uptime route
+// rather than a badge-specific one.
+//
+// It reached that route by SYNTHESIZING an internal request through
+// tryPostgresTier(METAGRAPH_HEALTH_SOURCE), which is how the badge came to
+// publish "n/a" again once that flag stopped forwarding (#10190): measured on
+// production 2026-08-11, /api/v1/subnets/64/badge.svg?metric=uptime said
+// "metagraphed: n/a" while /api/v1/subnets/64/uptime reported grade C at 0.9296
+// over 78,896 samples from the same table in the same second. These now drive
+// the loader, so the fixture is the table's own daily rows.
 describe("loadReliabilityAggregate", () => {
-  const req = () =>
-    new Request("https://metagraph.sh/api/v1/subnets/1/badge.svg");
-  // tryPostgresTier returns null unless the flag is "postgres" AND DATA_API is
-  // bound, so an unconfigured env exercises the no-data path without a stub.
+  beforeEach(() => {
+    pg.control.queries.length = 0;
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.postgres = null;
+  });
+
+  /** No store bound: readStore hands the loader nothing and it degrades to the
+   * schema-stable empty payload, which carries no reliability block. */
   const coldEnv = {} as unknown as Parameters<
     typeof loadReliabilityAggregate
   >[0];
 
-  test("returns null for an empty netuid list rather than querying", async () => {
-    assert.equal(
-      await loadReliabilityAggregate(coldEnv, req(), { netuids: [] }),
-      null,
-    );
+  /** One day-row of surface_uptime_daily, as the loader's own GROUP BY yields
+   * it -- the ratio is a column there, computed in SQL from the two sums. */
+  const dayRow = (surface: string, samples: number, ok: number) => ({
+    surface_id: surface,
+    surface_key: surface,
+    day: "2026-08-10",
+    samples,
+    ok_count: ok,
+    uptime_ratio: samples > 0 ? ok / samples : null,
+    avg_latency_ms: 400,
+    latency_samples: samples,
+    p50: 400,
+    p95: 400,
+    p99: 400,
+    status: ok === samples ? "ok" : ok === 0 ? "failed" : "degraded",
   });
 
-  test("returns null when the tier is cold, so the badge renders n/a", async () => {
+  test("returns null for an empty netuid list rather than querying", async () => {
     assert.equal(
-      await loadReliabilityAggregate(coldEnv, req(), { netuids: [64] }),
+      await loadReliabilityAggregate(coldEnv, { netuids: [] }),
+      null,
+    );
+    assert.deepEqual(pg.control.queries, [], "no netuids, no query");
+  });
+
+  test("returns null when the store is cold, so the badge renders n/a", async () => {
+    assert.equal(
+      await loadReliabilityAggregate(coldEnv, { netuids: [64] }),
       null,
     );
   });
@@ -3392,62 +3434,32 @@ describe("loadReliabilityAggregate", () => {
   test("weights by sample count and re-derives the grade from the composite", async () => {
     // A 100%-uptime subnet with 40 probes must not drag a 90%/30,000-probe
     // subnet up to a mean of 95% -- weighting is the whole point.
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Request) => {
-          const netuid = Number(new URL(r.url).pathname.split("/")[4]);
-          const reliability =
-            netuid === 1
-              ? {
-                  uptime_ratio: 0.9,
-                  sample_count: 30000,
-                  avg_latency_ms: 400,
-                  latency_sample_count: 27000,
-                }
-              : {
-                  uptime_ratio: 1,
-                  sample_count: 40,
-                  avg_latency_ms: 400,
-                  latency_sample_count: 40,
-                };
-          // data-api returns the BARE payload -- tryPostgresTier hands the
-          // whole body back, and the ok/schema_version envelope is added by
-          // the public Worker downstream, not here.
-          return new Response(JSON.stringify({ reliability }), {
-            headers: { "content-type": "application/json" },
-          });
-        },
-      },
-    } as unknown as Parameters<typeof loadReliabilityAggregate>[0];
-    const out = await loadReliabilityAggregate(env, req(), { netuids: [1, 2] });
+    // `postgres`, not `answers`: both reads issue the SAME statement and differ
+    // only in the bound netuid, so a substring match cannot tell them apart.
+    pg.control.postgres = async (_text: string, values: unknown[]) =>
+      Number(values?.[0]) === 1
+        ? [dayRow("a", 30000, 27000)]
+        : [dayRow("a", 40, 40)];
+    const out = await loadReliabilityAggregate(
+      pgMockEnv() as unknown as Parameters<typeof loadReliabilityAggregate>[0],
+      { netuids: [1, 2] },
+    );
     assert.ok(out);
     // (0.9*30000 + 1*40) / 30040 ≈ 0.9001, not the 0.95 an unweighted mean gives.
     assert.ok(out.uptime_ratio > 0.9 && out.uptime_ratio < 0.905);
     // 90.01 with no latency penalty (400ms is under the free threshold) → "C".
     assert.equal(out.grade, "C");
+    assert.equal(pg.control.queries.length, 2, "one read per netuid");
+    assert.match(pg.control.queries[0]!.text, /FROM surface_uptime_daily/);
   });
 
   test("skips subnets with no probe samples instead of counting them as failures", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (r: Request) => {
-          const netuid = Number(new URL(r.url).pathname.split("/")[4]);
-          const reliability =
-            netuid === 1
-              ? { uptime_ratio: 1, sample_count: 100, avg_latency_ms: null }
-              : { uptime_ratio: null, sample_count: 0, avg_latency_ms: null };
-          // data-api returns the BARE payload -- tryPostgresTier hands the
-          // whole body back, and the ok/schema_version envelope is added by
-          // the public Worker downstream, not here.
-          return new Response(JSON.stringify({ reliability }), {
-            headers: { "content-type": "application/json" },
-          });
-        },
-      },
-    } as unknown as Parameters<typeof loadReliabilityAggregate>[0];
-    const out = await loadReliabilityAggregate(env, req(), { netuids: [1, 2] });
+    pg.control.postgres = async (_text: string, values: unknown[]) =>
+      Number(values?.[0]) === 1 ? [dayRow("a", 100, 100)] : [dayRow("a", 0, 0)];
+    const out = await loadReliabilityAggregate(
+      pgMockEnv() as unknown as Parameters<typeof loadReliabilityAggregate>[0],
+      { netuids: [1, 2] },
+    );
     assert.ok(out);
     assert.equal(out.uptime_ratio, 1);
     assert.equal(out.grade, "A");

--- a/tests/helpers/cold-tier-env.ts
+++ b/tests/helpers/cold-tier-env.ts
@@ -80,20 +80,32 @@ export interface LakehouseDouble {
 /**
  * Stub the R2 SQL transport.
  *
- * `answer` receives the SQL and returns the rows for it, so a reader that
- * issues more than one query (the runtime timeline and its head block, the
- * blocks seam's two legs) can be answered per-query rather than with one list
- * that happens to satisfy both.
+ * `answer` receives the SQL and returns the rows for it, so a reader that issues
+ * more than one query (the runtime timeline and its head block, the blocks
+ * seam's two legs) can be answered per-query rather than with one list that
+ * happens to satisfy both.
+ *
+ * `once: true` answers the FIRST query and returns nothing after it. The account
+ * feeds need this: `windowedAccountEventsRead` keeps widening its time window
+ * and re-querying until it has collected `limit` rows, so a double that answers
+ * every query with the same list hands back that list once per step -- a page
+ * four times too long, silently.
  */
 export function lakehouse(
   answer: unknown[] | ((sql: string) => unknown[]),
+  { once = false }: { once?: boolean } = {},
 ): LakehouseDouble {
   const original = globalThis.fetch;
   const queries: string[] = [];
   globalThis.fetch = (async (_url: string, init: RequestInit) => {
     const sql = String(JSON.parse(String(init.body)).query);
     queries.push(sql);
-    const rows = typeof answer === "function" ? answer(sql) : answer;
+    const rows =
+      once && queries.length > 1
+        ? []
+        : typeof answer === "function"
+          ? answer(sql)
+          : answer;
     return {
       ok: true,
       status: 200,

--- a/tests/helpers/cold-tier-env.ts
+++ b/tests/helpers/cold-tier-env.ts
@@ -1,0 +1,130 @@
+// Transport doubles for the readers that answer now that the Postgres tier is
+// gone (#10190).
+//
+// ## Why these, and why transport-level
+//
+// Before the sweep, a surface test proved "this field/tool/route serves what its
+// reader returned" by doubling ONE transport: the DATA_API service binding, with
+// `{ METAGRAPH_X_SOURCE: "postgres", DATA_API: { fetch } }`. Those flags read
+// "retired"/"d1" in every deployed config and are absent from
+// DATA_API_FORWARD_FLAGS, so the binding was never asked and the assertion held
+// over a payload production could not produce.
+//
+// The readers that DO answer reach three different transports, so there is no
+// single replacement double:
+//
+//   METAGRAPH_ARCHIVE    the #9146 projection lanes (`load*FromArtifact`) --
+//                        an R2 bucket read by object key
+//   globalThis.fetch     the lakehouse cold tiers (`load*ColdTier`) -- R2 SQL
+//                        over HTTP, one POST per query
+//   HYPERDRIVE + pg      the live store (`readStore`) -- see helpers/pg-mock.ts
+//
+// These stay at the transport, deliberately. Mocking the loader module instead
+// would be cheaper and strictly weaker: it would keep passing if a surface were
+// wired to the wrong loader, or to none, which is the exact class of bug the
+// sweep found (`run_saved_query` served an empty leaderboard for months because
+// its tier arm had no rung under it).
+//
+// ## The envelope is the lane's, not ours
+//
+// Each projection reader validates the artifact body it reads and DECLINES
+// (null) on anything else -- `schema_version !== 1`, a missing window, a totals
+// object that is not an object. So `archiveEnv` takes the body verbatim rather
+// than wrapping it: a test that hands over the wrong shape must fail, because in
+// production that shape means "the lane did not write this" and the surface
+// falls to its floor.
+
+/** An object the artifact readers can `.json()`, or `null` for a miss. */
+type ArchiveObject = { json(): Promise<unknown> } | null;
+
+export interface ArchiveDouble {
+  /** Every key asked for, in order -- so a network-scoped read is provable. */
+  keys: string[];
+  METAGRAPH_ARCHIVE: { get(key: string): Promise<ArchiveObject> };
+}
+
+/**
+ * An env fragment whose archive answers with `body`.
+ *
+ * Pass a function to vary by key (a network-scoped projection reads
+ * `<key>` on mainnet and `testnet/<key>` off it), or `null` for a bucket that
+ * holds nothing -- which is how a reader's decline path is reached.
+ */
+export function archiveEnv(
+  body: unknown | ((key: string) => unknown | null),
+): ArchiveDouble {
+  const keys: string[] = [];
+  return {
+    keys,
+    METAGRAPH_ARCHIVE: {
+      async get(key: string) {
+        keys.push(key);
+        const value = typeof body === "function" ? body(key) : body;
+        if (value === null || value === undefined) return null;
+        return { json: async () => value };
+      },
+    },
+  };
+}
+
+/** The env key R2 SQL needs before the lakehouse leg is attempted at all. */
+export const LAKEHOUSE_ENV = { R2_SQL_TOKEN: "cfut_test" };
+
+export interface LakehouseDouble {
+  /** Every SQL issued, verbatim -- so a dropped filter is provable. */
+  queries: string[];
+  /** Undo the global stub. Always call this, even on a failing assertion. */
+  restore(): void;
+}
+
+/**
+ * Stub the R2 SQL transport.
+ *
+ * `answer` receives the SQL and returns the rows for it, so a reader that
+ * issues more than one query (the runtime timeline and its head block, the
+ * blocks seam's two legs) can be answered per-query rather than with one list
+ * that happens to satisfy both.
+ */
+export function lakehouse(
+  answer: unknown[] | ((sql: string) => unknown[]),
+): LakehouseDouble {
+  const original = globalThis.fetch;
+  const queries: string[] = [];
+  globalThis.fetch = (async (_url: string, init: RequestInit) => {
+    const sql = String(JSON.parse(String(init.body)).query);
+    queries.push(sql);
+    const rows = typeof answer === "function" ? answer(sql) : answer;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return {
+    queries,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+/**
+ * A DATA_API binding that fails the test if anything asks it.
+ *
+ * The counterpart to deleting a tier read: bind it, set the flag to the value
+ * that WOULD forward, and assert `paths` stayed empty. Without this a
+ * reintroduced `tryPostgresTier` call is invisible -- it returns null and the
+ * surface answers from its fallback exactly as before.
+ */
+export function forbiddenDataApi() {
+  const paths: string[] = [];
+  return {
+    paths,
+    DATA_API: {
+      fetch: async (request: Request) => {
+        paths.push(new URL(request.url).pathname);
+        return Response.json({ schema_version: 1, marker: "tier" });
+      },
+    },
+  };
+}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -11889,21 +11889,32 @@ describe("MCP economics + metagraph data tools", () => {
   describe("degraded-tier marker (#9120)", () => {
     // Tier flags on with no DATA_API bound: every tier read degrades.
     //
-    // METAGRAPH_BLOCKS_SOURCE is deliberately NOT here: it is retired, so the
-    // blocks tools read no tier and have no tier miss to mark (#10190). Listing
-    // it would assert a marker on a read that cannot happen.
+    // ONLY THE FLAGS THAT STILL FORWARD. The marker fires when a call advances
+    // tryPostgresTier's fallback generation, so a tool that reads no tier can
+    // never carry it -- and after #10190's sweep that is most of them.
+    // DATA_API_FORWARD_FLAGS is the whole surviving set: NEURONS,
+    // SUBNET_HYPERPARAMS and ACCOUNT_IDENTITY. METAGRAPH_EXTRINSICS_SOURCE and
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE were here and are gone with the reads they
+    // gated; listing a flag whose call sites are deleted asserts a marker on
+    // something that cannot happen, which is how this test came to pass over
+    // two tools that never consulted a tier at all.
     const degradedEnv = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
       METAGRAPH_NEURONS_SOURCE: "postgres",
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      METAGRAPH_SUBNET_HYPERPARAMS_SOURCE: "postgres",
+      METAGRAPH_ACCOUNT_IDENTITY_SOURCE: "postgres",
     };
 
     test("a tier miss is marked, whichever tool it happened in", async () => {
+      // One tool per surviving flag, so "whichever tool" still means what it
+      // says: the marker lives at the dispatch chokepoint, not in a handler.
       const unmarked: string[] = [];
       for (const [name, args] of [
         ["get_subnet_metagraph", { netuid: 7 }],
-        ["get_chain_transfers", { window: "7d" }],
-        ["get_chain_calls", { window: "7d" }],
+        ["get_subnet_hyperparams", { netuid: 7 }],
+        [
+          "get_account_identity",
+          { ss58: "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY" },
+        ],
       ] as [string, Row][]) {
         const res = await callTool(name, args, { env: degradedEnv });
         const out = res.body.result.structuredContent as Row;
@@ -12682,11 +12693,7 @@ describe("MCP economics + metagraph data tools", () => {
   // buildFn ignores the unused networkDistinct arg for this tool, which
   // computes its network rollup straight off the row list).
   function chainStakeFlowEnv(rows: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainStakeFlow,
-      null as unknown as Row,
-      rows,
-    );
+    return projectionEnv("chain-stake-flow", () => ({ rows }));
   }
 
   test("get_chain_stake_flow returns schema-stable zeros on cold D1", async () => {
@@ -12791,11 +12798,15 @@ describe("MCP economics + metagraph data tools", () => {
   // chainAccountEventsPostgresEnv helper (this builder ignores the unused
   // window/networkDistinct options — fixed 24h window, own row-derived rollup).
   function chainAlphaVolumeEnv(rows: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainAlphaVolume,
-      null as unknown as Row,
-      rows,
-    );
+    // The one lane with a single fixed window (no ?window= param), stored under
+    // "24h" so the envelope matches its siblings.
+    return {
+      env: archiveEnv((asked: string) =>
+        asked === "metagraph/projections/chain-alpha-volume.json"
+          ? { schema_version: 1, windows: { "24h": { rows } } }
+          : null,
+      ) as unknown as Row,
+    };
   }
 
   test("get_chain_alpha_volume returns schema-stable zeros on cold D1", async () => {
@@ -12905,8 +12916,24 @@ describe("MCP economics + metagraph data tools", () => {
   // on any miss/outage, never a live D1 read. Reuses the shared
   // chainAccountEventsPostgresEnv helper -- same shape as
   // get_chain_stake_moves' Postgres-tier test above.
+  // The three rollup lanes read the LAKEHOUSE, not a projection: a per-netuid
+  // GROUP BY is ~129 rows, small enough to serve at request time, so
+  // loadChainEventRollup issues three queries per call -- the grouped page, the
+  // ungrouped participant count, and the window's subnet count. Answered by
+  // shape rather than by order: they run in one Promise.all.
+  function chainEventRollupEnv(network: Row, subnets: Row[]) {
+    const lake = lakehouse((sql: string) =>
+      sql.includes("AS subnet_count")
+        ? [{ subnet_count: subnets.length }]
+        : sql.includes("ORDER BY")
+          ? subnets
+          : [network],
+    );
+    return { env: { ...LAKEHOUSE_ENV } as unknown as Row, lake };
+  }
+
   function chainWeightsEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(buildChainWeights, network, subnets);
+    return chainEventRollupEnv(network, subnets);
   }
 
   test("get_chain_weights returns schema-stable zeros on cold D1", async () => {
@@ -12985,60 +13012,64 @@ describe("MCP economics + metagraph data tools", () => {
     assertValid(validate, res.body.result.structuredContent);
   });
 
-  // D1 fully eliminated (2026-07-16): account_events' D1 write path is
-  // retired (#4772) and the table is dropped in production, so these tools'
-  // D1-querying loaders are gone -- they now go tryPostgresTier ->
-  // buildX([], ...) on any miss/outage. This mocks the Postgres tier by
-  // running the SAME pure builder the real Postgres route
-  // (workers/data-api.ts) would, over the caller's own window/limit query
-  // params, so the mocked response is byte-identical to what production
-  // would actually serve.
-  function chainAccountEventsPostgresEnv(
-    buildFn: AnyFn,
-    networkDistinct: Row,
-    subnetRows: Row[],
-  ) {
+  // WAS chainAccountEventsPostgresEnv: a DATA_API double that ran the SAME pure
+  // builder the tool runs, behind METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres".
+  // Two things were wrong with it. That flag reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the binding was never asked --
+  // every one of these tests was reading the empty fallback. And had it been
+  // asked, running the builder to check the builder proves only that it is
+  // deterministic.
+  //
+  // What answers now is the #9146 projection lane: an R2 object per lane, one
+  // `windows` entry per label, holding data-api's own aggregate rows verbatim,
+  // handed to that same builder by a reader that validates the envelope and
+  // DECLINES on anything else. So the fixture is the artifact, and the assertions
+  // below are unchanged -- they were always about the builder's contract, and now
+  // they reach it through the transport production reads.
+  //
+  // BOTH LABELS, because the lane writes both: every one of these routes offers
+  // {7d, 30d} and the reader refuses to answer one window's question with
+  // another's rows, so a single-label fixture would decline for half the tests
+  // here and pass for the wrong reason.
+  function projectionEnv(key: string, window: (label: string) => Row) {
+    const objectKey = `metagraph/projections/${key}.json`;
     return {
-      env: {
-        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            const url = new URL(request.url);
-            const window = url.searchParams.get("window") || "7d";
-            const limitParam = url.searchParams.get("limit");
-            const limit = limitParam != null ? Number(limitParam) : undefined;
-            return Response.json(
-              buildFn(subnetRows, { window, limit, networkDistinct }),
-            );
-          },
-        },
-      },
+      env: archiveEnv((asked: string) =>
+        asked === objectKey
+          ? {
+              schema_version: 1,
+              windows: { "7d": window("7d"), "30d": window("30d") },
+            }
+          : null,
+      ) as unknown as Row,
     };
   }
 
+  // The identity rollup, one level finer than chainEventRollupEnv: keyed by
+  // (netuid, uid) rather than by netuid, and its totals are TWO separate
+  // queries -- an ungrouped COUNT(*) for the share denominator, and a GROUP BY
+  // subquery for the distinct setters. Answered by shape, in one Promise.all.
+  //
+  // The denominator is why they are separate: the row page is capped, so a share
+  // computed against a summed page would grow as the page shrank.
   function chainWeightSettersPostgresEnv({
     leaderboardRows = [],
     totalsRow = null,
   }: Row = {}) {
-    return {
-      env: {
-        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            const url = new URL(request.url);
-            const window = url.searchParams.get("window") || "7d";
-            const limitParam = url.searchParams.get("limit");
-            const limit = limitParam != null ? Number(limitParam) : undefined;
-            return Response.json(
-              buildChainWeightSetters(leaderboardRows, totalsRow, {
-                window,
-                limit,
-              }),
-            );
-          },
-        },
-      },
-    };
+    const totals = (totalsRow ?? {}) as Row;
+    const lake = lakehouse((sql: string) =>
+      sql.includes("ORDER BY")
+        ? (leaderboardRows as Row[])
+        : sql.includes("max(observed_at)")
+          ? [
+              {
+                weight_sets: totals.weight_sets,
+                newest_observed: totals.newest_observed,
+              },
+            ]
+          : [{ distinct_setters: totals.distinct_setters }],
+    );
+    return { env: { ...LAKEHOUSE_ENV } as unknown as Row, lake };
   }
 
   test("get_chain_weight_setters ranks setters with network-wide shares", async () => {
@@ -13154,11 +13185,10 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   function chainStakeMovesEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainStakeMoves,
+    return projectionEnv("chain-stake-moves", () => ({
+      rows: subnets,
       network,
-      subnets,
-    );
+    }));
   }
 
   test("get_chain_stake_moves returns schema-stable zeros on cold D1", async () => {
@@ -13257,11 +13287,10 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   function chainStakeTransfersEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainStakeTransfers,
+    return projectionEnv("chain-stake-transfers", () => ({
+      rows: subnets,
       network,
-      subnets,
-    );
+    }));
   }
 
   test("get_chain_stake_transfers returns schema-stable zeros on cold D1", async () => {
@@ -13347,29 +13376,20 @@ describe("MCP economics + metagraph data tools", () => {
   // The network-wide aggregate row loadChainAxonRemovals reads first (its
   // COUNT(DISTINCT hotkey)/MAX(observed_at) probe); a non-null newest_observed
   // unlocks the per-subnet read.
-  function axonRemovalsNetwork(distinct_removers: unknown) {
-    return {
-      distinct_removers,
-      newest_observed: 1_750_000_000_000,
-    };
-  }
-
-  // A per-subnet GROUP BY netuid row (COUNT removals + distinct removers).
-  function axonRemovalsRow(
-    netuid: number,
-    removals: unknown,
-    distinct_removers: unknown,
-  ) {
-    return { netuid, removals, distinct_removers };
-  }
-
-  function chainAxonRemovalsEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainAxonRemovals,
-      network,
-      subnets,
-    );
-  }
+  // NO SOURCE, NOT A MOCKING PROBLEM. The axonRemovalsNetwork/axonRemovalsRow
+  // fixtures and their chainAxonRemovalsEnv were deleted with the tier they fed:
+  // the whole axon-removals family (chain, subnet, account) has no reader on any
+  // surface now, because AxonInfoRemoved has ZERO rows in both
+  // chain.account_events and chain.chain_events -- surveyed for #9146 and
+  // recorded in src/chain-event-rollup-cold-tier.ts's header, which is why that
+  // module gives serving and registrations a rollup spec and this kind none.
+  //
+  // So the ranking, the network rollup and the intensity distribution cannot be
+  // asserted through anything production reads. buildChainAxonRemovals' own
+  // tests (tests/chain-axon-removals.test.ts) hold those contracts over the
+  // rows directly, which is the right level for them while no source exists.
+  // What the TOOL can be held to is the shape of the card it will actually
+  // serve, and that it says nothing it has not measured.
 
   test("get_chain_axon_removals returns schema-stable zeros on cold D1", async () => {
     const res = await callTool("get_chain_axon_removals", {});
@@ -13384,31 +13404,34 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.observed_at, null);
   });
 
-  test("get_chain_axon_removals ranks subnets by removals with a network rollup", async () => {
-    const res = await callTool(
-      "get_chain_axon_removals",
-      { window: "30d", limit: 10 },
-      chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
-        // netuid 2: fewer removals -> ranks last despite higher intensity.
-        axonRemovalsRow(2, 10, 4),
-        // netuid 1: most AxonInfoRemoved events -> ranks first.
-        axonRemovalsRow(1, 20, 5),
-      ]),
-    );
-    const out = res.body.result.structuredContent;
-    assert.equal(out.window, "30d");
-    assert.equal(out.subnet_count, 2);
-    assert.equal(out.subnets[0].netuid, 1);
-    assert.equal(out.subnets[0].removals, 20);
-    assert.equal(out.subnets[0].removals_per_remover, 4); // 20 / 5
-    assert.equal(out.subnets[1].netuid, 2);
-    assert.equal(out.subnets[1].removals_per_remover, 2.5); // 10 / 4
-    // Network rollup: total removals 30 over 8 distinct removers -> 3.75.
-    assert.equal(out.network.removals, 30);
-    assert.equal(out.network.distinct_removers, 8);
-    assert.equal(out.network.removals_per_remover, 3.75);
-    assert.equal(out.intensity_distribution.count, 2);
-    assert.equal(out.observed_at, new Date(1_750_000_000_000).toISOString());
+  test("get_chain_axon_removals has no rung to read, at any window", async () => {
+    // The card is the same with every store bound and every flag set to the
+    // value that WOULD forward: there is no read to make. `observed_at: null` is
+    // the load-bearing assertion -- a zero card that also claims a reading time
+    // would be a measurement, and this one is an absence.
+    for (const window of ["7d", "30d"]) {
+      const tier = forbiddenDataApi();
+      const archive = archiveEnv({ schema_version: 1, windows: {} });
+      const res = await callTool(
+        "get_chain_axon_removals",
+        { window, limit: 10 },
+        {
+          env: {
+            METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+            ...LAKEHOUSE_ENV,
+            ...tier,
+            ...(archive as unknown as Row),
+          },
+        },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false, window);
+      assert.equal(out.window, window, "the label is still the caller's");
+      assert.deepEqual(tier.paths, [], `${window} consulted the retired tier`);
+      assert.deepEqual(archive.keys, [], `${window} read a projection`);
+      assert.equal(out.subnet_count, 0, window);
+      assert.equal(out.observed_at, null, `${window} claimed a reading time`);
+    }
   });
 
   test("get_chain_axon_removals rejects an unsupported window", async () => {
@@ -13421,32 +13444,14 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /window/);
   });
 
-  test("get_chain_axon_removals caps the leaderboard by limit", async () => {
-    const res = await callTool(
-      "get_chain_axon_removals",
-      { limit: 1 },
-      chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
-        axonRemovalsRow(1, 20, 5),
-        axonRemovalsRow(2, 10, 4),
-      ]),
-    );
-    const out = res.body.result.structuredContent;
-    // Both subnets feed the rollup/distribution, but the page is capped.
-    assert.equal(out.subnet_count, 2);
-    assert.equal(out.subnets.length, 1);
-    assert.equal(out.intensity_distribution.count, 2);
-  });
-
   test("get_chain_axon_removals payload validates against its declared outputSchema", async () => {
+    // Both changes: #10802's outputSchemaFor helper, over the empty card.
+    //
+    // The empty card is the one production serves, so it is the one that has to
+    // satisfy the schema -- an outputSchema only the populated shape passes is a
+    // schema for a payload no caller receives.
     const schema = outputSchemaFor("get_chain_axon_removals");
-    const res = await callTool(
-      "get_chain_axon_removals",
-      {},
-      chainAxonRemovalsEnv(axonRemovalsNetwork(8), [
-        axonRemovalsRow(1, 20, 5),
-        axonRemovalsRow(2, 10, 4),
-      ]),
-    );
+    const res = await callTool("get_chain_axon_removals", {});
     const validate = new Ajv2020({ strict: false }).compile(schema);
     assertValid(validate, res.body.result.structuredContent);
   });
@@ -13471,11 +13476,10 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   function chainDeregistrationsEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainDeregistrations,
+    return projectionEnv("chain-deregistrations", () => ({
+      rows: subnets,
       network,
-      subnets,
-    );
+    }));
   }
 
   test("get_chain_deregistrations returns schema-stable zeros on cold D1", async () => {
@@ -13578,7 +13582,7 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   function chainServingEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(buildChainServing, network, subnets);
+    return chainEventRollupEnv(network, subnets);
   }
 
   test("get_chain_serving returns schema-stable zeros on cold D1", async () => {
@@ -13677,11 +13681,7 @@ describe("MCP economics + metagraph data tools", () => {
   }
 
   function chainPrometheusEnv(network: Row, subnets: Row[]) {
-    return chainAccountEventsPostgresEnv(
-      buildChainPrometheus,
-      network,
-      subnets,
-    );
+    return chainEventRollupEnv(network, subnets);
   }
 
   test("get_chain_prometheus returns schema-stable zeros on cold D1", async () => {
@@ -13801,27 +13801,13 @@ describe("MCP economics + metagraph data tools", () => {
   // caller's own window/sort query params, so the mocked response is
   // byte-identical to what production would actually serve.
   function chainTransferPairsEnv(totals: Row, pairs: Row[]) {
-    return {
-      env: {
-        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            const url = new URL(request.url);
-            const window = url.searchParams.get("window") || "7d";
-            const sort = url.searchParams.get("sort") || "volume";
-            return Response.json(
-              buildChainTransferPairs({
-                window,
-                sort,
-                observedAt: null,
-                totals,
-                pairs,
-              }),
-            );
-          },
-        },
-      },
-    };
+    // Keyed by sort as well as by window: only the precomputed orders exist, and
+    // the reader declines rather than answer one order's rows under another's
+    // name.
+    return projectionEnv("chain-transfer-pairs", () => ({
+      totals,
+      sorts: { volume: pairs, count: pairs },
+    }));
   }
 
   test("get_chain_transfer_pairs returns schema-stable zeros on cold D1", async () => {
@@ -14423,27 +14409,12 @@ describe("MCP economics + metagraph data tools", () => {
   // mocked response is byte-identical to what production would actually
   // serve.
   function chainCallsPostgresEnv({ total, rows }: Row) {
-    return {
-      env: {
-        METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            const url = new URL(request.url);
-            const window = url.searchParams.get("window") || "7d";
-            const groupBy = url.searchParams.get("group_by") || "module";
-            return Response.json(
-              buildChainCalls({
-                window,
-                groupBy,
-                observedAt: null,
-                total,
-                rows,
-              }),
-            );
-          },
-        },
-      },
-    };
+    // The extrinsics family's projection, keyed by group_by the way
+    // transfer-pairs is keyed by sort.
+    return projectionEnv("chain-calls", () => ({
+      total,
+      groups: { module: rows, module_function: rows },
+    }));
   }
 
   test("get_chain_calls aggregates extrinsic rows with honest shares", async () => {
@@ -14473,23 +14444,38 @@ describe("MCP economics + metagraph data tools", () => {
     assert.match(res.body.result.content[0].text, /call_module/i);
   });
 
-  test("get_chain_calls scopes grouped rows and totals by call_module", async () => {
-    let requestedUrl;
-    const env = chainCallsPostgresEnv({
-      total: 80,
-      rows: [
-        {
-          call_module: "SubtensorModule",
-          call_function: "add_stake",
-          count: 50,
+  test("a call_module scope never touches the unscoped projection", async () => {
+    // WAS "scopes grouped rows and totals by call_module", asserting that
+    // `call_module=SubtensorModule` reached the tier as a query param over a
+    // payload the mocked tier built from the caller's own rows.
+    // METAGRAPH_EXTRINSICS_SOURCE reads "retired" and forwards nothing, so that
+    // request was never made -- and the lane behind it precomputes NO pallet
+    // scope, which is the thing worth proving instead.
+    //
+    // The failure mode a filtered read invites is serving the unfiltered rows
+    // under a filtered label: 80 extrinsics network-wide reported as 80 in one
+    // pallet. loadChainCallsFromArtifact refuses the scope BEFORE it reads the
+    // bucket, so the assertion is that the bucket was never asked -- an
+    // in-memory filter over the projection would still produce a plausible
+    // number, and only the absence of the read rules it out.
+    const archive = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          total: 80,
+          groups: {
+            module: [{ call_module: "SubtensorModule", count: 50 }],
+            module_function: [
+              {
+                call_module: "SubtensorModule",
+                call_function: "add_stake",
+                count: 50,
+              },
+            ],
+          },
         },
-      ],
+      },
     });
-    const originalFetch = env.env.DATA_API.fetch;
-    env.env.DATA_API.fetch = async (request) => {
-      requestedUrl = new URL(request.url);
-      return originalFetch(request);
-    };
     const res = await callTool(
       "get_chain_calls",
       {
@@ -14498,18 +14484,44 @@ describe("MCP economics + metagraph data tools", () => {
         call_module: "SubtensorModule",
         limit: 3,
       },
-      env,
+      { env: archive as unknown as Row },
     );
     const out = res.body.result.structuredContent;
-    assert.equal(out.group_by, "module_function");
-    assert.equal(out.total_extrinsics, 80);
-    assert.equal(out.calls[0].share, 0.625);
-    assert.equal(
-      requestedUrl!.searchParams.get("call_module"),
-      "SubtensorModule",
-    );
-  });
+    assert.deepEqual(archive.keys, [], "the scope must decline before reading");
+    assert.equal(out.total_extrinsics, 0, "no unscoped total under a scope");
+    assert.deepEqual(out.calls, []);
+    assert.equal(out.degraded?.reason, "call_module_scope_not_precomputed");
 
+    // The SAME projection answers the unscoped question, so the decline above
+    // is the scope and not a broken fixture.
+    const unscoped = await callTool(
+      "get_chain_calls",
+      { window: "7d", group_by: "module_function", limit: 3 },
+      {
+        env: archiveEnv({
+          schema_version: 1,
+          windows: {
+            "7d": {
+              total: 80,
+              groups: {
+                module_function: [
+                  {
+                    call_module: "SubtensorModule",
+                    call_function: "add_stake",
+                    count: 50,
+                  },
+                ],
+              },
+            },
+          },
+        }) as unknown as Row,
+      },
+    );
+    const open = unscoped.body.result.structuredContent;
+    assert.equal(open.group_by, "module_function");
+    assert.equal(open.total_extrinsics, 80);
+    assert.equal(open.calls[0].share, 0.625);
+  });
   test("get_registry_leaderboards returns boards from committed profiles", async () => {
     const res = await callTool(
       "get_registry_leaderboards",
@@ -24137,499 +24149,214 @@ describe("MCP get_subnet_ohlc — Postgres tier wiring", () => {
 // destructure `{ data, generatedAt }` from tryPostgresTier's result, so these
 // four tools unwrap `.data` before falling back -- the DATA_API mock here
 // nests the marker under `data` to exercise that unwrap.
-describe("MCP get_account_stake_flow / get_account_stake_moves / get_account_registrations / get_account_weight_setters — Postgres tier wiring", () => {
+describe("MCP account activity feeds — what answers now that the tier is gone", () => {
+  // WAS eight near-identical trios asserting the URL tryPostgresTier sent and a
+  // `marker` field read back off the mocked tier. METAGRAPH_ACCOUNT_EVENTS_SOURCE
+  // reads "retired" in wrangler.jsonc and is absent from
+  // DATA_API_FORWARD_FLAGS, so none of those requests was ever made and the
+  // marker could never appear -- 24 tests over one dead code path.
+  //
+  // Seven of these eight tools DO have a reader: the lakehouse `account_events`
+  // rollups in src/account-feeds-cold-tier.ts, one GROUP BY netuid per feed.
+  // Each case below drives that reader with the columns its own SQL selects, so
+  // the fixture is wrong in exactly the way production would be wrong.
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  test("get_account_stake_flow: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
+  /** One netuid's rollup row, under the count alias the feed's SQL uses. */
+  const rollupRow = (countField: string) => [
+    {
+      netuid: 7,
+      [countField]: 3,
+      first_observed: 1_750_000_000_000,
+      last_observed: 1_750_090_000_000,
+    },
+  ];
+
+  const CASES: Array<{
+    tool: string;
+    /** Rows for the feed's own query, keyed off the SQL it emits. */
+    rows: (sql: string) => Row[];
+    /** The total the builder derives, and what it should come to. */
+    total: string;
+    expected: number;
+    /** Feeds whose predicate needs the live store as well as the lakehouse. */
+    store?: { tables: string[]; rows: Row[] };
+  }> = [
+    {
+      tool: "get_account_stake_flow",
+      // Grouped by (netuid, event_kind) with a SUM, not a bare COUNT.
+      rows: () => [
+        {
+          netuid: 7,
+          event_kind: "StakeAdded",
+          total_tao: 12.5,
+          event_count: 2,
+          last_observed: 1_750_090_000_000,
         },
-      },
-    };
-    const res = await callTool(
-      "get_account_stake_flow",
-      { ss58: SS58 },
-      { env },
+      ],
+      total: "total_staked_tao",
+      expected: 12.5,
+    },
+    {
+      tool: "get_account_stake_moves",
+      rows: () => rollupRow("movements"),
+      total: "total_movements",
+      expected: 3,
+    },
+    {
+      tool: "get_account_registrations",
+      rows: () => rollupRow("registrations"),
+      total: "total_registrations",
+      expected: 3,
+    },
+    {
+      tool: "get_account_weight_setters",
+      // TWO STORES, not one. The weight-sets rollup is on the lakehouse, but the
+      // predicate it runs needs this account's (netuid, uid) slots first, and
+      // those come from `neurons` in the live store -- WeightsSet carries no
+      // hotkey at all, so the slots are the only way to attribute a set. An
+      // unbound store DECLINES the whole read, which is why this case has to
+      // bind both.
+      rows: (sql: string) =>
+        sql.includes("weight_sets") ? rollupRow("weight_sets") : [],
+      total: "total_weight_sets",
+      expected: 3,
+      store: { tables: ["neurons"], rows: [{ netuid: 7, uid: 4 }] },
+    },
+    {
+      tool: "get_account_serving",
+      rows: () => rollupRow("announcements"),
+      total: "total_announcements",
+      expected: 3,
+    },
+    {
+      tool: "get_account_prometheus",
+      rows: () => rollupRow("announcements"),
+      total: "total_announcements",
+      expected: 3,
+    },
+  ];
+
+  for (const { tool, rows, total, expected, store } of CASES) {
+    test(`${tool}: the lakehouse rollup is what reaches the payload`, async () => {
+      const tier = forbiddenDataApi();
+      const lake = lakehouse(rows);
+      if (store) pg.control.rows = store.rows;
+      try {
+        const res = await callTool(
+          tool,
+          { ss58: SS58 },
+          {
+            env: {
+              ...LAKEHOUSE_ENV,
+              ...tier,
+              ...(store ? pgMockEnv(store.tables) : {}),
+            },
+          },
+        );
+        const out = res.body.result.structuredContent;
+        assert.equal(res.body.result.isError, false, tool);
+        assert.deepEqual(tier.paths, [], `${tool} consulted the retired tier`);
+        assert.equal(out.address, SS58);
+        assert.equal(out[total], expected, `${tool}: ${total}`);
+        assert.equal(out.subnet_count, 1, tool);
+        assert.equal(out.subnets[0].netuid, 7, tool);
+        assert.ok(
+          lake.queries.some((sql) => sql.includes("chain.account_events")),
+          `${tool} never queried account_events`,
+        );
+      } finally {
+        lake.restore();
+      }
+    });
+
+    test(`${tool}: an unusable address declines before any scan`, async () => {
+      // The decline is what keeps an invalid address from becoming an
+      // unfiltered scan of every account. Asserting no query ran is the only
+      // way to tell that apart from a scan that happened to match nothing.
+      const lake = lakehouse(() => rollupRow("movements"));
+      try {
+        const res = await callTool(
+          tool,
+          { ss58: "not-an-address" },
+          { env: { ...LAKEHOUSE_ENV } },
+        );
+        assert.equal(res.body.result.isError, true, tool);
+        assert.deepEqual(lake.queries, [], `${tool} scanned anyway`);
+      } finally {
+        lake.restore();
+      }
+    });
+
+    test(`${tool}: a lakehouse miss is the schema-stable empty, never an error`, async () => {
+      const lake = lakehouse(() => {
+        throw new Error("boom");
+      });
+      try {
+        const res = await callTool(tool, { ss58: SS58 }, { env: {} });
+        const out = res.body.result.structuredContent;
+        assert.equal(res.body.result.isError, false, tool);
+        assert.equal(out.address, SS58, tool);
+        assert.equal(out[total], 0, `${tool} must publish a zero, not a throw`);
+        assert.deepEqual(out.subnets, [], tool);
+      } finally {
+        lake.restore();
+      }
+    });
+  }
+
+  test("get_account_deregistrations reads the by-hotkey projection", async () => {
+    // The one feed in this group NOT on the lakehouse: evictions are derived
+    // from metagraph diffs by the #9146 lane, keyed by hotkey, and stored as
+    // tuples rather than objects.
+    const tier = forbiddenDataApi();
+    const archive = archiveEnv((key: string) =>
+      key.includes("by-hotkey")
+        ? {
+            schema_version: 1,
+            hotkeys: { [SS58]: [[7, 3, 1_750_000_000_000, 900, 120]] },
+          }
+        : null,
     );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(
-      captured,
-      `/api/v1/accounts/${SS58}/stake-flow?window=30d&direction=all`,
-    );
-  });
-
-  test("get_account_stake_flow: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_stake_flow",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_stake_flow: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_stake_flow",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_stake_moves: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_stake_moves",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, `/api/v1/accounts/${SS58}/stake-moves?window=30d`);
-  });
-
-  test("get_account_stake_moves: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_stake_moves",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_stake_moves: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_stake_moves",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_registrations: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_registrations",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, `/api/v1/accounts/${SS58}/registrations?window=30d`);
-  });
-
-  test("get_account_registrations: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_registrations",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_registrations: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_registrations",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_weight_setters: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_weight_setters",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, `/api/v1/accounts/${SS58}/weight-setters?window=7d`);
-  });
-
-  test("get_account_weight_setters: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_weight_setters",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_weight_setters: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_weight_setters",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_serving: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
-    const res = await callTool("get_account_serving", { ss58: SS58 }, { env });
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, `/api/v1/accounts/${SS58}/serving?window=30d`);
-  });
-
-  test("get_account_serving: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool("get_account_serving", { ss58: SS58 }, { env });
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_serving: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool("get_account_serving", { ss58: SS58 }, { env });
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_axon_removals: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_axon_removals",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, `/api/v1/accounts/${SS58}/axon-removals?window=30d`);
-  });
-
-  test("get_account_axon_removals: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_axon_removals",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_axon_removals: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_axon_removals",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_prometheus: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_prometheus",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, `/api/v1/accounts/${SS58}/prometheus?window=30d`);
-  });
-
-  test("get_account_prometheus: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_prometheus",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_prometheus: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_prometheus",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_deregistrations: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
     const res = await callTool(
       "get_account_deregistrations",
       { ss58: SS58 },
-      { env },
+      { env: { ...tier, ...(archive as unknown as Row) } },
     );
+    const out = res.body.result.structuredContent;
     assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(
-      captured,
-      `/api/v1/accounts/${SS58}/deregistrations?window=30d`,
+    assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+    assert.equal(out.address, SS58);
+    assert.ok(
+      archive.keys.some((key) => key.includes("by-hotkey")),
+      "the by-hotkey projection was never read",
     );
   });
 
-  test("get_account_deregistrations: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () => {
-          throw new Error("boom");
+  test("get_account_axon_removals has no rung to read", async () => {
+    // AxonInfoRemoved has zero rows in both chain.account_events and
+    // chain.chain_events (surveyed for #9146, recorded in
+    // src/chain-event-rollup-cold-tier.ts), so there is no reader to drive here
+    // and nothing to mock -- the same absence its chain-wide sibling publishes.
+    const tier = forbiddenDataApi();
+    const res = await callTool(
+      "get_account_axon_removals",
+      { ss58: SS58 },
+      {
+        env: {
+          METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+          ...LAKEHOUSE_ENV,
+          ...tier,
         },
       },
-    };
-    const res = await callTool(
-      "get_account_deregistrations",
-      { ss58: SS58 },
-      { env },
     );
+    const out = res.body.result.structuredContent;
     assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, undefined);
-  });
-
-  test("get_account_deregistrations: flag absent uses the schema-stable empty shape even when DATA_API is bound (unflipped)", async () => {
-    const env = {
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: { schema_version: 1, marker: "should-not-be-used" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_account_deregistrations",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.structuredContent.marker, undefined);
+    assert.deepEqual(tier.paths, []);
+    assert.equal(out.address, SS58);
+    assert.equal(out.total_removals ?? 0, 0);
   });
 });
-
-// get_block_events is also gated on METAGRAPH_ACCOUNT_EVENTS_SOURCE, but
-// unlike the flat-data-shaped tools in the account_events-tier CASES loop
-// above, entities.ts's handleBlockEvents destructures `{ data }` from
-// tryPostgresTier's result -- workers/data-api.ts's /blocks/:ref/events
-// route returns `json({ data: buildBlockEvents(...) })`, not a flat
-// buildBlockEvents(...) body -- so this tool unwraps `.data` before falling
-// back, and the DATA_API mock here must nest the marker under `data`.
 describe("MCP get_block_events — Postgres tier wiring", () => {
   test("get_block_events: flag=postgres uses Postgres data (unwrapped from {data}) at the REST-equivalent path", async () => {
     let captured;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,4 +1,10 @@
 import assert from "node:assert/strict";
+import {
+  archiveEnv,
+  forbiddenDataApi,
+  lakehouse,
+  LAKEHOUSE_ENV,
+} from "./helpers/cold-tier-env.ts";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import { Ajv2020 } from "ajv/dist/2020.js";
 
@@ -23101,29 +23107,21 @@ describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => 
         ? `${tool} (validator_permit=true)`
         : tool;
 
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_NEURONS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: the retired tier flag is not consulted even when set`, async () => {
+      // WAS "uses Postgres data at the REST-equivalent path", asserting the URL
+      // tryPostgresTier sent. METAGRAPH_NEURONS_SOURCE reads
+      // "retired"/"d1" in wrangler.jsonc and is absent from
+      // DATA_API_FORWARD_FLAGS, so that request was never made -- the assertion
+      // described a call production does not perform, over a payload it cannot
+      // produce. `path` stays in CASES as the documentation of what the REST twin
+      // serves; what is provable here is the retirement.
+      const tier = forbiddenDataApi();
+      const res = await callTool(tool, args, {
+        env: { METAGRAPH_NEURONS_SOURCE: "postgres", ...tier },
+      });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
+      assert.deepEqual(tier.paths, [], label);
+      assert.equal(res.body.result.structuredContent.marker, undefined, label);
     });
 
     test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
@@ -23322,29 +23320,21 @@ describe("MCP extrinsics-tier chain analytics tools — Postgres tier wiring", (
       ? `${tool} (call_module)`
       : tool;
 
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: the retired tier flag is not consulted even when set`, async () => {
+      // WAS "uses Postgres data at the REST-equivalent path", asserting the URL
+      // tryPostgresTier sent. METAGRAPH_EXTRINSICS_SOURCE reads
+      // "retired"/"d1" in wrangler.jsonc and is absent from
+      // DATA_API_FORWARD_FLAGS, so that request was never made -- the assertion
+      // described a call production does not perform, over a payload it cannot
+      // produce. `path` stays in CASES as the documentation of what the REST twin
+      // serves; what is provable here is the retirement.
+      const tier = forbiddenDataApi();
+      const res = await callTool(tool, args, {
+        env: { METAGRAPH_EXTRINSICS_SOURCE: "postgres", ...tier },
+      });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
+      assert.deepEqual(tier.paths, [], label);
+      assert.equal(res.body.result.structuredContent.marker, undefined, label);
     });
 
     test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
@@ -23878,29 +23868,21 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
   for (const { tool, args, path } of CASES) {
     const label = path.includes("coldkey=") ? `${tool} (coldkey)` : tool;
 
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: the retired tier flag is not consulted even when set`, async () => {
+      // WAS "uses Postgres data at the REST-equivalent path", asserting the URL
+      // tryPostgresTier sent. METAGRAPH_ACCOUNT_EVENTS_SOURCE reads
+      // "retired"/"d1" in wrangler.jsonc and is absent from
+      // DATA_API_FORWARD_FLAGS, so that request was never made -- the assertion
+      // described a call production does not perform, over a payload it cannot
+      // produce. `path` stays in CASES as the documentation of what the REST twin
+      // serves; what is provable here is the retirement.
+      const tier = forbiddenDataApi();
+      const res = await callTool(tool, args, {
+        env: { METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres", ...tier },
+      });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
+      assert.deepEqual(tier.paths, [], label);
+      assert.equal(res.body.result.structuredContent.marker, undefined, label);
     });
 
     test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {
@@ -24982,29 +24964,21 @@ describe("MCP health-tier analytics tools — Postgres tier wiring", () => {
   for (const { tool, args, path } of CASES) {
     const label = path.includes("window=30d") ? `${tool} (window=30d)` : tool;
 
-    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
-      let captured;
-      const env = {
-        METAGRAPH_HEALTH_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (req: Request) => {
-            const reqUrl = new URL(req.url);
-            captured = reqUrl.pathname + reqUrl.search;
-            return Response.json({
-              schema_version: 1,
-              marker: "from-postgres",
-            });
-          },
-        },
-      };
-      const res = await callTool(tool, args, { env });
+    test(`${label}: the retired tier flag is not consulted even when set`, async () => {
+      // WAS "uses Postgres data at the REST-equivalent path", asserting the URL
+      // tryPostgresTier sent. METAGRAPH_HEALTH_SOURCE reads
+      // "retired"/"d1" in wrangler.jsonc and is absent from
+      // DATA_API_FORWARD_FLAGS, so that request was never made -- the assertion
+      // described a call production does not perform, over a payload it cannot
+      // produce. `path` stays in CASES as the documentation of what the REST twin
+      // serves; what is provable here is the retirement.
+      const tier = forbiddenDataApi();
+      const res = await callTool(tool, args, {
+        env: { METAGRAPH_HEALTH_SOURCE: "postgres", ...tier },
+      });
       assert.equal(res.body.result.isError, false, label);
-      assert.equal(
-        res.body.result.structuredContent.marker,
-        "from-postgres",
-        label,
-      );
-      assert.equal(captured, path, label);
+      assert.deepEqual(tier.paths, [], label);
+      assert.equal(res.body.result.structuredContent.marker, undefined, label);
     });
 
     test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -16254,30 +16254,46 @@ describe("MCP account tail tools (history, extrinsics, transfers)", () => {
   });
 
   test("get_account_transfers treats direction='all' identically to omitting direction", async () => {
-    const seenDirectionParams: (string | null)[] = [];
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (request: Request) => {
-          const url = new URL(request.url);
-          seenDirectionParams.push(url.searchParams.get("direction"));
-          return Response.json(
-            buildAccountTransfers([], SS58, {
-              limit: 100,
-              offset: 0,
-              nextCursor: null,
-            }),
-          );
-        },
-      },
+    // WAS asserted on the `direction` query param tryPostgresTier sent (null in
+    // both cases). The flag forwards nothing, so that proved only that the tool
+    // dropped the argument. The claim is about the ROWS: "all" and omitted must
+    // select the same set, which on the lakehouse means the same predicate --
+    // both sides of the key, `hotkey = addr OR coldkey = addr`.
+    const ROW = {
+      block_number: 4200000,
+      event_index: 0,
+      extrinsic_index: 1,
+      event_kind: "Transfer",
+      hotkey: SS58,
+      coldkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+      netuid: null,
+      uid: null,
+      amount_tao: 1.5,
+      alpha_amount: null,
+      observed_at: 1_750_009_000_000,
     };
-    await callTool(
-      "get_account_transfers",
-      { ss58: SS58, direction: "all" },
-      { env },
-    );
-    await callTool("get_account_transfers", { ss58: SS58 }, { env });
-    assert.deepEqual(seenDirectionParams, [null, null]);
+    const seen: string[] = [];
+    for (const args of [{ direction: "all" }, {}]) {
+      const lake = lakehouse([ROW], { once: true });
+      try {
+        const res = await callTool(
+          "get_account_transfers",
+          { ss58: SS58, ...args },
+          { env: { ...LAKEHOUSE_ENV } },
+        );
+        assert.equal(
+          res.body.result.structuredContent.transfers.length,
+          1,
+          JSON.stringify(args),
+        );
+        seen.push(lake.queries[0]);
+      } finally {
+        lake.restore();
+      }
+    }
+    assert.equal(seen[0], seen[1], "'all' and omitted must be one query");
+    assert.match(seen[0], /hotkey = '5G9hfkx/);
+    assert.match(seen[0], /coldkey = '5G9hfkx/);
   });
 
   test("get_account_transfers rejects a non-integer block_end", async () => {
@@ -17556,46 +17572,63 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
       return { fetch: async (request: Request) => response ?? { request } };
     }
 
-    test("list_extrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
-      const env: Row = { METAGRAPH_EXTRINSICS_SOURCE: "postgres" };
-      env.DATA_API = dataApi(
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 99,
-          limit: 50,
-          offset: 0,
-          next_cursor: null,
-          extrinsics: [],
-        }),
-      );
-      const res = await callTool("list_extrinsics", {}, { env });
-      assert.equal(res.body.result.structuredContent.extrinsic_count, 99);
+    test("list_extrinsics: the lakehouse feed is what the page carries", async () => {
+      // WAS "flag=postgres uses Postgres data, D1 never queried", reading an
+      // `extrinsic_count: 99` off a tier response with an EMPTY extrinsics list
+      // -- a count no reader could produce from those rows, which is the tell
+      // that nothing derived it. METAGRAPH_EXTRINSICS_SOURCE reads "retired"
+      // and forwards nothing, so the request was never made either.
+      //
+      // loadExtrinsicFeedColdTier answers now, over chain.extrinsics with the
+      // generated EXTRINSICS_COLUMNS. The count is the page length, derived.
+      const tier = forbiddenDataApi();
+      const lake = lakehouse([
+        EXTRINSIC_ROW,
+        { ...EXTRINSIC_ROW, extrinsic_index: 4 },
+      ]);
+      try {
+        const res = await callTool(
+          "list_extrinsics",
+          {},
+          { env: { ...LAKEHOUSE_ENV, ...tier } },
+        );
+        const out = res.body.result.structuredContent;
+        assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+        assert.equal(out.extrinsic_count, 2);
+        assert.equal(out.extrinsics[0].call_module, "SubtensorModule");
+        assert.match(lake.queries[0], /FROM chain\.extrinsics/);
+      } finally {
+        lake.restore();
+      }
     });
 
     test("list_extrinsics: surfaces the action-sentence summary field, null for an unmatched call (#8525)", async () => {
-      const env: Row = { METAGRAPH_EXTRINSICS_SOURCE: "postgres" };
-      env.DATA_API = dataApi(
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 2,
-          limit: 50,
-          offset: 0,
-          next_cursor: null,
-          extrinsics: [
-            { ...EXTRINSIC_ROW, summary: "Set the chain timestamp." },
-            {
-              ...EXTRINSIC_ROW,
-              call_module: "NoSuchModule",
-              call_function: "no_such_function",
-              summary: null,
-            },
-          ],
-        }),
-      );
-      const res = await callTool("list_extrinsics", {}, { env });
-      const items = res.body.result.structuredContent.extrinsics;
-      assert.equal(items[0].summary, "Set the chain timestamp.");
-      assert.equal(items[1].summary, null);
+      // The summary is DERIVED from (call_module, call_function), so the retired
+      // tier's double handing back a `summary` string of its own proved nothing
+      // -- it asserted an echo. These rows carry no summary at all; the one
+      // below is composed by the formatter, and the unmatched call gets null
+      // because no sentence exists for it.
+      const lake = lakehouse([
+        { ...EXTRINSIC_ROW, call_module: "Timestamp", call_function: "set" },
+        {
+          ...EXTRINSIC_ROW,
+          extrinsic_index: 4,
+          call_module: "NoSuchModule",
+          call_function: "no_such_function",
+        },
+      ]);
+      try {
+        const res = await callTool(
+          "list_extrinsics",
+          {},
+          { env: { ...LAKEHOUSE_ENV } },
+        );
+        const items = res.body.result.structuredContent.extrinsics;
+        assert.equal(items[0].summary, "Set the chain timestamp.");
+        assert.equal(items[1].summary, null);
+      } finally {
+        lake.restore();
+      }
     });
 
     // extrinsics' D1 write path is retired (#4772) and the table is dropped
@@ -17627,85 +17660,47 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
       assert.equal(res.body.result.structuredContent.extrinsic_count, 0);
     });
 
-    test("list_extrinsics: flag=postgres forwards filters as REST-equivalent query params", async () => {
-      const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
-      let seenUrl: URL | undefined;
-      const env: Row = { METAGRAPH_EXTRINSICS_SOURCE: "postgres" };
-      env.DATA_API = {
-        fetch: async (request: Request) => {
-          seenUrl = new URL(request.url);
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            extrinsics: [],
-          });
-        },
-      };
-      const callHash = "0x" + "b".repeat(64);
-      await callTool(
-        "list_extrinsics",
-        {
-          block: 4200000,
-          signer: SS58,
-          call_module: "SubtensorModule",
-          call_function: "set_weights",
-          call_hash: callHash,
-          success: true,
-          limit: 10,
-          offset: 20,
-        },
-        { env },
-      );
-      assert.equal(seenUrl!.pathname, "/api/v1/extrinsics");
-      assert.equal(seenUrl!.searchParams.get("block"), "4200000");
-      assert.equal(seenUrl!.searchParams.get("offset"), "20");
-      assert.equal(seenUrl!.searchParams.get("signer"), SS58);
-      assert.equal(seenUrl!.searchParams.get("call_module"), "SubtensorModule");
-      assert.equal(seenUrl!.searchParams.get("call_function"), "set_weights");
-      assert.equal(seenUrl!.searchParams.get("call_hash"), callHash);
-      assert.equal(seenUrl!.searchParams.get("success"), "true");
-      assert.equal(seenUrl!.searchParams.get("limit"), "10");
-    });
-
-    test("get_extrinsic: flag=postgres uses Postgres data, D1 never queried", async () => {
-      const hash = "0x" + "c".repeat(64);
-      const env: Row = { METAGRAPH_EXTRINSICS_SOURCE: "postgres" };
-      env.DATA_API = dataApi(
-        Response.json({
-          schema_version: 1,
-          ref: hash,
-          extrinsic: { ...EXTRINSIC_ROW, signer: "postgres-signer" },
-          events: [],
-        }),
-      );
-      const res = await callTool("get_extrinsic", { ref: hash }, { env });
-      assert.equal(
-        res.body.result.structuredContent.extrinsic.signer,
-        "postgres-signer",
-      );
-    });
+    // "list_extrinsics: flag=postgres forwards filters as REST-equivalent query
+    // params" was here, asserting the query string tryPostgresTier built. The
+    // flag forwards nothing, and every filter it listed is now a SQL predicate
+    // -- asserted where it lands, in "list_extrinsics expresses every filter and
+    // skips the tier on call_hash" above, including the call_hash gate that
+    // keeps an unexpressible filter from being silently dropped.
+    // "get_extrinsic: flag=postgres uses Postgres data, D1 never queried"
+    // was here: it asserted the URL tryPostgresTier built and read a marker
+    // back off the mocked tier. That flag forwards nothing (#10190), so the
+    // request was never made -- covered by "get_extrinsic resolves a composite ref and embeds formatted events", through the transport that answers.
 
     test("get_extrinsic: surfaces the action-sentence summary field (#8525)", async () => {
+      // The summary is DERIVED from (call_module, call_function) by the shared
+      // formatter, so a tier double returning its own `summary` string asserted
+      // an echo. This row carries none; the sentence below is composed.
       const hash = "0x" + "d".repeat(64);
-      const env: Row = { METAGRAPH_EXTRINSICS_SOURCE: "postgres" };
-      env.DATA_API = dataApi(
-        Response.json({
-          schema_version: 1,
-          ref: hash,
-          extrinsic: {
-            ...EXTRINSIC_ROW,
-            call_module: "Timestamp",
-            call_function: "set",
-            summary: "Set the chain timestamp.",
-          },
-          events: [],
-        }),
+      const lake = lakehouse((sql: string) =>
+        sql.includes("FROM chain.account_events")
+          ? []
+          : [
+              {
+                ...EXTRINSIC_ROW,
+                extrinsic_hash: hash,
+                call_module: "Timestamp",
+                call_function: "set",
+              },
+            ],
       );
-      const res = await callTool("get_extrinsic", { ref: hash }, { env });
-      assert.equal(
-        res.body.result.structuredContent.extrinsic.summary,
-        "Set the chain timestamp.",
-      );
+      try {
+        const res = await callTool(
+          "get_extrinsic",
+          { ref: hash },
+          { env: { ...LAKEHOUSE_ENV } },
+        );
+        assert.equal(
+          res.body.result.structuredContent.extrinsic.summary,
+          "Set the chain timestamp.",
+        );
+      } finally {
+        lake.restore();
+      }
     });
 
     // extrinsics' D1 write path is retired (#4772) and the table is dropped
@@ -17725,23 +17720,10 @@ describe("MCP block-explorer tools (list_blocks, get_block, list_block_extrinsic
       assert.equal(out.extrinsic, null);
     });
 
-    test("get_extrinsic: flag=postgres forwards the ref in the request path", async () => {
-      let seenUrl: URL | undefined;
-      const env: Row = { METAGRAPH_EXTRINSICS_SOURCE: "postgres" };
-      env.DATA_API = {
-        fetch: async (request: Request) => {
-          seenUrl = new URL(request.url);
-          return Response.json({
-            schema_version: 1,
-            ref: "4200000-3",
-            extrinsic: null,
-            events: [],
-          });
-        },
-      };
-      await callTool("get_extrinsic", { ref: "4200000-3" }, { env });
-      assert.equal(seenUrl!.pathname, "/api/v1/extrinsics/4200000-3");
-    });
+    // "get_extrinsic: flag=postgres forwards the ref in the request path"
+    // was here: it asserted the URL tryPostgresTier built and read a marker
+    // back off the mocked tier. That flag forwards nothing (#10190), so the
+    // request was never made -- the ref is now resolved into a SQL predicate, asserted in "get_extrinsic resolves a composite ref and embeds formatted events", through the transport that answers.
   });
 
   test("block-explorer payloads validate against their declared outputSchemas", async () => {
@@ -21494,53 +21476,10 @@ describe("MCP validator detail/nominators/history tools (#5225 parity)", () => {
     assert.match(badColdkey.body.result.content[0].text, /coldkey/);
   });
 
-  test("get_validator_nominators: flag=postgres unwraps the DATA_API {data, generatedAt} envelope onto the top level", async () => {
-    // workers/data-api.ts's own nominators route wraps its response as
-    // { data: buildValidatorNominators(...), generatedAt } -- unlike the
-    // flat-shaped neurons-tier routes. Assert hotkey/nominator_count/
-    // nominators land at the TOP of structuredContent (matching this tool's
-    // own outputSchema), not nested under .data, so a future regression to a
-    // bare `tryPostgresTier(...) ?? builder(...)` (no unwrap) fails loudly
-    // here instead of only violating the schema silently in production.
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: {
-              schema_version: 1,
-              hotkey: HOTKEY,
-              window: "30d",
-              sort: "net_staked",
-              limit: 20,
-              offset: 0,
-              nominator_count: 1,
-              nominators: [
-                {
-                  coldkey: "5Cold",
-                  net_staked_tao: 10,
-                  gross_staked_tao: 10,
-                  unstaked_tao: 0,
-                  event_count: 1,
-                  last_observed_at: "2026-07-01T00:00:00.000Z",
-                },
-              ],
-            },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
-      },
-    };
-    const res = await callTool(
-      "get_validator_nominators",
-      { hotkey: HOTKEY },
-      { env },
-    );
-    const out = res.body.result.structuredContent;
-    assert.equal(out.data, undefined);
-    assert.equal(out.hotkey, HOTKEY);
-    assert.equal(out.nominator_count, 1);
-    assert.equal(out.nominators[0].coldkey, "5Cold");
-  });
+  // "get_validator_nominators: flag=postgres unwraps the DATA_API {data, generatedAt} envelope onto the top level"
+  // was here: it asserted the URL tryPostgresTier built and read a marker
+  // back off the mocked tier. That flag forwards nothing (#10190), so the
+  // request was never made -- there is no envelope to unwrap now; the reader returns the built card, asserted in "get_validator_nominators serves the nominator list from the lakehouse", through the transport that answers.
 
   test("get_validator_history returns a schema-stable empty point series", async () => {
     const res = await callTool("get_validator_history", { hotkey: HOTKEY });
@@ -22431,32 +22370,10 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     assert.deepEqual(out.extrinsics, []);
   });
 
-  test("get_sudo: flag=postgres forwards to /api/v1/sudo, D1 never queried", async () => {
-    let capturedPath;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedPath = new URL(req.url).pathname;
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 1,
-            extrinsics: [{ call_module: "Sudo" }],
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_sudo",
-      { call_function: "sudo_set_weights_set_rate_limit" },
-      { env },
-    );
-    assert.equal(capturedPath, "/api/v1/sudo");
-    assert.equal(
-      res.body.result.structuredContent.extrinsics[0].call_module,
-      "Sudo",
-    );
-  });
+  // "get_sudo: flag=postgres forwards to /api/v1/sudo, D1 never queried"
+  // was here: it asserted the URL tryPostgresTier built and read a marker
+  // back off the mocked tier. That flag forwards nothing (#10190), so the
+  // request was never made -- covered by "get_sudo and get_governance_config_changes serve their fixed modules", through the transport that answers.
 
   test("get_sudo rejects a non-boolean success filter", async () => {
     const res = await callTool("get_sudo", { success: "maybe" });
@@ -22470,24 +22387,10 @@ describe("MCP sudo/governance/runtime/list_accounts tools (#5225 parity)", () =>
     assert.deepEqual(out.extrinsics, []);
   });
 
-  test("get_governance_config_changes: flag=postgres forwards to /api/v1/governance/config-changes", async () => {
-    let capturedPath;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedPath = new URL(req.url).pathname;
-          return Response.json({
-            schema_version: 1,
-            extrinsic_count: 0,
-            extrinsics: [],
-          });
-        },
-      },
-    };
-    await callTool("get_governance_config_changes", {}, { env });
-    assert.equal(capturedPath, "/api/v1/governance/config-changes");
-  });
+  // "get_governance_config_changes: flag=postgres forwards to /api/v1/governance/config-changes"
+  // was here: it asserted the URL tryPostgresTier built and read a marker
+  // back off the mocked tier. That flag forwards nothing (#10190), so the
+  // request was never made -- covered by "get_sudo and get_governance_config_changes serve their fixed modules", through the transport that answers.
 
   test("get_sudo_key returns hotkey:null for genuinely unset storage", async () => {
     const orig = globalThis.fetch;
@@ -23949,28 +23852,47 @@ describe("MCP account_events-tier subnet/validator activity tools — Postgres t
 // and the DATA_API mock here must nest the marker under `data` to exercise
 // that unwrap, not sit at the top level like the flat-shaped CASES tools.
 describe("MCP get_subnet_stake_flow / get_subnet_volume — Postgres tier wiring", () => {
-  test("get_subnet_stake_flow: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
+  test("get_subnet_stake_flow reads one subnet's rows out of the chain projection", async () => {
+    // WAS an assertion on "/api/v1/subnets/7/stake-flow?window=30d&direction=all"
+    // and a `marker` echoed back from the mocked tier. The flag forwards nothing.
+    //
+    // What answers is the CHAIN stake-flow lane, filtered to this netuid -- the
+    // per-subnet card has no projection of its own, it reads its row out of the
+    // network-wide one. So the fixture carries two subnets and the assertion is
+    // that the other one does not leak in.
+    const tier = forbiddenDataApi();
+    const rows = [
+      {
+        netuid: 7,
+        event_kind: "StakeAdded",
+        total_tao: 40,
+        event_count: 4,
+        last_observed: 1_750_000_000_000,
       },
-    };
-    const res = await callTool("get_subnet_stake_flow", { netuid: 7 }, { env });
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(
-      captured,
-      "/api/v1/subnets/7/stake-flow?window=30d&direction=all",
+      {
+        netuid: 8,
+        event_kind: "StakeAdded",
+        total_tao: 900,
+        event_count: 90,
+        last_observed: 1_750_000_000_000,
+      },
+    ];
+    const archive = archiveEnv((key: string) =>
+      key === "metagraph/projections/chain-stake-flow.json"
+        ? { schema_version: 1, windows: { "7d": { rows }, "30d": { rows } } }
+        : null,
     );
+    const res = await callTool(
+      "get_subnet_stake_flow",
+      { netuid: 7 },
+      { env: { ...tier, ...(archive as unknown as Row) } },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(res.body.result.isError, false);
+    assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "30d", "the tool's own default window");
+    assert.equal(out.total_staked_tao, 40, "netuid 8's 900 must not leak in");
   });
 
   test("get_subnet_stake_flow: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
@@ -24001,32 +23923,52 @@ describe("MCP get_subnet_stake_flow / get_subnet_volume — Postgres tier wiring
     assert.equal(res.body.result.structuredContent.marker, undefined);
   });
 
-  test("get_subnet_volume: flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
-      },
-    };
+  test("get_subnet_volume reads its row out of the chain alpha-volume projection", async () => {
+    // Same shape as its stake-flow sibling: no per-subnet lane, one row filtered
+    // out of the network-wide 24h projection. The economics artifact still rides
+    // alongside for vol_mcap_ratio's denominator.
+    const tier = forbiddenDataApi();
+    const archive = archiveEnv((key: string) =>
+      key === "metagraph/projections/chain-alpha-volume.json"
+        ? {
+            schema_version: 1,
+            windows: {
+              "24h": {
+                rows: [
+                  {
+                    netuid: 7,
+                    event_kind: "StakeAdded",
+                    alpha_volume: 100,
+                    tao_volume: 100,
+                    event_count: 5,
+                  },
+                  {
+                    netuid: 8,
+                    event_kind: "StakeAdded",
+                    alpha_volume: 9000,
+                    tao_volume: 9000,
+                    event_count: 900,
+                  },
+                ],
+                observed_at: 1_750_000_000_000,
+              },
+            },
+          }
+        : null,
+    );
     const deps = makeDeps({
       "/metagraph/economics.json": { subnets: [{ netuid: 7 }] },
     });
     const res = await callTool(
       "get_subnet_volume",
       { netuid: 7 },
-      { env, deps },
+      { env: { ...tier, ...(archive as unknown as Row) }, deps },
     );
+    const out = res.body.result.structuredContent;
     assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, "/api/v1/subnets/7/volume");
+    assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+    assert.equal(out.netuid, 7);
+    assert.equal(out.buy_volume_tao, 100, "netuid 8's 9000 must not leak in");
   });
 
   test("get_subnet_volume: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
@@ -24079,37 +24021,48 @@ describe("MCP get_subnet_stake_flow / get_subnet_volume — Postgres tier wiring
 // tryPostgresTier's result -- so the DATA_API mock here nests the marker
 // under `data` to exercise that unwrap.
 describe("MCP get_subnet_ohlc — Postgres tier wiring", () => {
-  test("flag=postgres uses Postgres data (unwrapped from {data, generatedAt}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          });
-        },
+  test("the candle series is assembled from the lakehouse trade buckets", async () => {
+    // WAS an assertion on "/api/v1/subnets/7/ohlc?interval=1d&days=30&limit=168"
+    // -- including a careful note about forwarding `limit` so the two surfaces
+    // agreed on the page. The flag forwards nothing, so none of that happened.
+    //
+    // The page bound still matters, and it is now the reader's own: the engine
+    // caps at MAX_CANDLES newest-first and the assembler re-sorts ascending, so
+    // what a caller's `days` controls is the WHERE cutoff, not a page size the
+    // tier had to be told about.
+    const tier = forbiddenDataApi();
+    const lake = lakehouse([
+      {
+        bucket_start: 1_750_000_000_000,
+        open_price: 1,
+        close_price: 2,
+        high_price: 3,
+        low_price: 0.5,
+        volume_alpha: 10,
+        volume_tao: 20,
+        event_count: 4,
+        last_observed: 1_750_050_000_000,
       },
-    };
-    const res = await callTool(
-      "get_subnet_ohlc",
-      { netuid: 7, interval: "1d", days: 30 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    // `limit` rides along even when the caller did not name one (#10318). The
-    // tool's page size is 168 where the route's default is the 2,000-candle
-    // cap, so the tier has to be told which one it is answering -- forwarding
-    // interval and days but not limit is how the two surfaces would come to
-    // disagree about the page while agreeing about the window.
-    assert.equal(
-      captured,
-      "/api/v1/subnets/7/ohlc?interval=1d&days=30&limit=168",
-    );
+    ]);
+    try {
+      const res = await callTool(
+        "get_subnet_ohlc",
+        { netuid: 7, interval: "1d", days: 30 },
+        { env: { ...LAKEHOUSE_ENV, ...tier } },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(res.body.result.isError, false);
+      assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+      assert.equal(out.netuid, 7);
+      assert.equal(out.interval, "1d");
+      assert.equal(out.candles.length, 1);
+      assert.equal(out.candles[0].open, 1);
+      assert.equal(out.candles[0].close, 2);
+      assert.match(lake.queries[0], /netuid = 7/);
+      assert.match(lake.queries[0], /ORDER BY bucket_start DESC LIMIT/);
+    } finally {
+      lake.restore();
+    }
   });
 
   test("flag=postgres falls back to the schema-stable empty shape on failure", async () => {
@@ -24358,47 +24311,75 @@ describe("MCP account activity feeds — what answers now that the tier is gone"
   });
 });
 describe("MCP get_block_events — Postgres tier wiring", () => {
-  test("get_block_events: flag=postgres uses Postgres data (unwrapped from {data}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-          });
-        },
-      },
-    };
-    const res = await callTool("get_block_events", { ref: "4200000" }, { env });
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(captured, "/api/v1/blocks/4200000/events?limit=100&offset=0");
-  });
+  // "get_block_events: flag=postgres uses Postgres data (unwrapped from {data}) at the REST-equivalent path"
+  // was here: it asserted the URL tryPostgresTier built and read a marker
+  // back off the mocked tier. That flag forwards nothing (#10190), so the
+  // request was never made -- covered by "get_block_events serves one block's events in read order", through the transport that answers.
 
-  test("get_block_events: flag=postgres forwards a supplied limit/offset and a 0x hash ref", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-          });
-        },
-      },
-    };
+  test("get_block_events: a 0x hash ref costs a block lookup, and the page is sliced", async () => {
+    // WAS an assertion on `/api/v1/blocks/{hash}/events?limit=25&offset=50` --
+    // the URL tryPostgresTier built. The flag forwards nothing, and the two
+    // claims inside that URL now land in different places:
+    //
+    //   * the HASH is not a predicate on account_events at all. R2 SQL cannot
+    //     join, so the reader resolves it to a height off chain.blocks FIRST
+    //     and only then reads the events: two queries, and an unresolvable
+    //     hash must decline rather than scan every block.
+    //   * the OFFSET is emulated. R2 SQL has no OFFSET, so the reader
+    //     over-fetches and slices -- which is why offsetting past the rows
+    //     empties the page instead of paging into it.
     const hash = `0x${"ab".repeat(32)}`;
-    await callTool(
-      "get_block_events",
-      { ref: hash, limit: 25, offset: 50 },
-      { env },
+    const EVENT = {
+      block_number: 4200000,
+      event_index: 0,
+      extrinsic_index: 3,
+      event_kind: "WeightsSet",
+      hotkey: null,
+      coldkey: null,
+      netuid: 7,
+      uid: 3,
+      amount_tao: null,
+      alpha_amount: null,
+      observed_at: 1_750_009_000_000,
+    };
+    const tier = forbiddenDataApi();
+    const lake = lakehouse((sql: string) =>
+      sql.includes("FROM chain.blocks") ? [{ block_number: 4200000 }] : [EVENT],
     );
-    assert.equal(captured, `/api/v1/blocks/${hash}/events?limit=25&offset=50`);
+    try {
+      const res = await callTool(
+        "get_block_events",
+        { ref: hash, limit: 25 },
+        { env: { ...LAKEHOUSE_ENV, ...tier } },
+      );
+      const out = res.body.result.structuredContent;
+      assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+      assert.equal(out.block_number, 4200000, "the hash resolved to a height");
+      assert.equal(out.events.length, 1);
+      assert.match(
+        lake.queries[0],
+        /FROM chain\.blocks WHERE block_hash = '0xabab/,
+      );
+      assert.match(lake.queries[1], /block_number = 4200000/);
+    } finally {
+      lake.restore();
+    }
+
+    // The same ref with an offset past the block's only event: an emulated
+    // OFFSET slices what it fetched, so this is empty rather than a second page.
+    const deep = lakehouse((sql: string) =>
+      sql.includes("FROM chain.blocks") ? [{ block_number: 4200000 }] : [EVENT],
+    );
+    try {
+      const res = await callTool(
+        "get_block_events",
+        { ref: hash, limit: 25, offset: 50 },
+        { env: { ...LAKEHOUSE_ENV } },
+      );
+      assert.deepEqual(res.body.result.structuredContent.events, []);
+    } finally {
+      deep.restore();
+    }
   });
 
   test("get_block_events: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
@@ -24443,59 +24424,90 @@ describe("MCP get_block_events — Postgres tier wiring", () => {
 describe("MCP get_account_extrinsics — Postgres tier wiring", () => {
   const SS58 = "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5";
 
-  test("get_account_extrinsics: flag=postgres uses Postgres data at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({ schema_version: 1, marker: "from-postgres" });
-        },
-      },
-    };
-    const res = await callTool(
-      "get_account_extrinsics",
-      { ss58: SS58 },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(
-      captured,
-      `/api/v1/accounts/${SS58}/extrinsics?limit=100&offset=0`,
-    );
-  });
+  // "get_account_extrinsics: flag=postgres uses Postgres data at the REST-equivalent path"
+  // was here: it asserted the URL tryPostgresTier built and read a marker
+  // back off the mocked tier. That flag forwards nothing (#10190), so the
+  // request was never made -- covered by "get_account_extrinsics filters by signer from the lakehouse", through the transport that answers.
 
-  test("get_account_extrinsics: flag=postgres forwards block_start/block_end/limit/offset/cursor", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({ schema_version: 1, marker: "from-postgres" });
-        },
-      },
+  test("get_account_extrinsics: every range filter becomes a predicate, and an unusable cursor declines", async () => {
+    // WAS an assertion on the query string tryPostgresTier built. Same filters,
+    // asserted where they now take effect -- and one thing the URL form could
+    // not show: a cursor the codec cannot decode must DECLINE rather than page
+    // from the top, because a caller holding a stale token would otherwise be
+    // silently handed page one as if it were page five.
+    const ROW = {
+      block_number: 150,
+      extrinsic_index: 1,
+      extrinsic_hash: `0x${"c".repeat(64)}`,
+      signer: SS58,
+      call_module: "SubtensorModule",
+      call_function: "add_stake",
+      success: true,
+      fee_tao: 0.0005,
+      tip_tao: null,
+      call_args: null,
+      observed_at: 1_750_009_000_000,
     };
-    await callTool(
-      "get_account_extrinsics",
-      {
-        ss58: SS58,
-        block_start: 100,
-        block_end: 200,
-        limit: 5,
-        offset: 10,
-        cursor: "abc",
-      },
-      { env },
-    );
-    assert.equal(
-      captured,
-      `/api/v1/accounts/${SS58}/extrinsics?block_start=100&block_end=200&limit=5&offset=10&cursor=abc`,
-    );
+    const tier = forbiddenDataApi();
+    const lake = lakehouse([ROW]);
+    try {
+      const res = await callTool(
+        "get_account_extrinsics",
+        { ss58: SS58, block_start: 100, block_end: 200, limit: 5 },
+        { env: { ...LAKEHOUSE_ENV, ...tier } },
+      );
+      assert.deepEqual(tier.paths, []);
+      assert.equal(res.body.result.structuredContent.extrinsics.length, 1);
+      const sql = lake.queries[0];
+      assert.match(sql, new RegExp(`signer = '${SS58}'`));
+      assert.match(sql, /block_number >= 100/);
+      assert.match(sql, /block_number <= 200/);
+      assert.match(sql, /LIMIT/);
+    } finally {
+      lake.restore();
+    }
+
+    // A cursor is a 3-part tuple seek on the feed's own order key, and it
+    // REPLACES the offset -- the token already narrows past prior pages, so
+    // applying both would skip a page's worth of rows twice.
+    const paged = lakehouse([ROW]);
+    try {
+      await callTool(
+        "get_account_extrinsics",
+        {
+          ss58: SS58,
+          limit: 5,
+          offset: 10,
+          cursor: "1750009000000.4200000.3",
+        },
+        { env: { ...LAKEHOUSE_ENV } },
+      );
+      const sql = paged.queries[0];
+      assert.match(
+        sql,
+        /\(observed_at, block_number, extrinsic_index\) < \(1750009000000, 4200000, 3\)/,
+      );
+    } finally {
+      paged.restore();
+    }
+
+    // A MALFORMED token decodes to null and is treated as no cursor, which
+    // serves page one. Deliberate, and asserted rather than left implicit: it is
+    // data-api's own documented cursor semantics, shared by every paged route
+    // here, so the reader that replaced the tier had to keep it or the same
+    // token would mean two different things on two surfaces.
+    const bad = lakehouse([ROW]);
+    try {
+      const res = await callTool(
+        "get_account_extrinsics",
+        { ss58: SS58, limit: 5, cursor: "abc" },
+        { env: { ...LAKEHOUSE_ENV } },
+      );
+      assert.equal(res.body.result.structuredContent.extrinsics.length, 1);
+      assert.doesNotMatch(bad.queries[0], /observed_at, block_number/);
+    } finally {
+      bad.restore();
+    }
   });
 
   test("get_account_extrinsics: flag=postgres falls back to the schema-stable empty shape on failure", async () => {
@@ -24534,57 +24546,65 @@ describe("MCP get_account_extrinsics — Postgres tier wiring", () => {
 });
 
 describe("MCP list_block_extrinsics — Postgres tier wiring", () => {
-  test("list_block_extrinsics: flag=postgres uses Postgres data (unwrapped from {data}) at the REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-          });
-        },
-      },
-    };
-    const res = await callTool(
-      "list_block_extrinsics",
-      { ref: "4200000" },
-      { env },
-    );
-    assert.equal(res.body.result.isError, false);
-    assert.equal(res.body.result.structuredContent.marker, "from-postgres");
-    assert.equal(
-      captured,
-      "/api/v1/blocks/4200000/extrinsics?limit=50&offset=0",
-    );
-  });
+  // "list_block_extrinsics: flag=postgres uses Postgres data (unwrapped from {data}) at the REST-equivalent path"
+  // was here: it asserted the URL tryPostgresTier built and read a marker
+  // back off the mocked tier. That flag forwards nothing (#10190), so the
+  // request was never made -- covered by "list_block_extrinsics serves one block's extrinsics", through the transport that answers.
 
-  test("list_block_extrinsics: flag=postgres forwards a supplied limit/offset and a 0x hash ref", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            data: { schema_version: 1, marker: "from-postgres" },
-          });
-        },
-      },
-    };
+  test("list_block_extrinsics: a 0x hash ref costs a block lookup, and the page is sliced", async () => {
+    // Same two claims as its events twin, on the extrinsics table: the hash is
+    // resolved to a height off chain.blocks first, and the offset is emulated by
+    // over-fetch-and-slice because R2 SQL has no OFFSET.
     const hash = `0x${"ab".repeat(32)}`;
-    await callTool(
-      "list_block_extrinsics",
-      { ref: hash, limit: 25, offset: 60 },
-      { env },
+    const ROW = {
+      block_number: 4200000,
+      extrinsic_index: 3,
+      extrinsic_hash: `0x${"c".repeat(64)}`,
+      signer: null,
+      call_module: "Timestamp",
+      call_function: "set",
+      success: true,
+      fee_tao: null,
+      tip_tao: null,
+      call_args: null,
+      observed_at: 1_750_009_000_000,
+    };
+    const tier = forbiddenDataApi();
+    const lake = lakehouse((sql: string) =>
+      sql.includes("FROM chain.blocks") ? [{ block_number: 4200000 }] : [ROW],
     );
-    assert.equal(
-      captured,
-      `/api/v1/blocks/${hash}/extrinsics?limit=25&offset=60`,
+    try {
+      const res = await callTool(
+        "list_block_extrinsics",
+        { ref: hash, limit: 25 },
+        { env: { ...LAKEHOUSE_ENV, ...tier } },
+      );
+      const out = res.body.result.structuredContent;
+      assert.deepEqual(tier.paths, [], "the retired tier was consulted");
+      assert.equal(out.block_number, 4200000, "the hash resolved to a height");
+      assert.equal(out.extrinsics.length, 1);
+      assert.equal(out.extrinsics[0].extrinsic_index, 3);
+      assert.match(
+        lake.queries[0],
+        /FROM chain\.blocks WHERE block_hash = '0xabab/,
+      );
+    } finally {
+      lake.restore();
+    }
+
+    const deep = lakehouse((sql: string) =>
+      sql.includes("FROM chain.blocks") ? [{ block_number: 4200000 }] : [ROW],
     );
+    try {
+      const res = await callTool(
+        "list_block_extrinsics",
+        { ref: hash, limit: 25, offset: 60 },
+        { env: { ...LAKEHOUSE_ENV } },
+      );
+      assert.deepEqual(res.body.result.structuredContent.extrinsics, []);
+    } finally {
+      deep.restore();
+    }
   });
 
   test("list_block_extrinsics: flag=postgres falls back to the schema-stable empty shape on failure", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -55,20 +55,6 @@ import {
 import { handleRequest } from "../workers/api.ts";
 import { EXPOSED_RESPONSE_HEADERS_VALUE } from "../workers/http.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.ts";
-import { buildChainStakeMoves } from "../src/chain-stake-moves.ts";
-import { buildChainStakeTransfers } from "../src/chain-stake-transfers.ts";
-import { buildChainWeightSetters } from "../src/chain-weight-setters.ts";
-import { buildChainAxonRemovals } from "../src/chain-axon-removals.ts";
-import { buildChainDeregistrations } from "../src/chain-deregistrations.ts";
-import { buildChainServing } from "../src/chain-serving.ts";
-import { buildChainPrometheus } from "../src/chain-prometheus.ts";
-import { buildChainRegistrations } from "../src/chain-registrations.ts";
-import { buildChainStakeFlow } from "../src/chain-stake-flow.ts";
-import { buildChainAlphaVolume } from "../src/chain-alpha-volume.ts";
-import { buildChainWeights } from "../src/chain-weights.ts";
-import { buildChainTransferPairs } from "../src/chain-transfer-pairs.ts";
-import { buildChainTransfers } from "../src/chain-transfers.ts";
-import { buildChainCalls } from "../src/chain-analytics.ts";
 import { buildStakeFlow } from "../src/stake-flow.ts";
 import { buildAccountStakeFlow } from "../src/account-stake-flow.ts";
 import { buildAccountStakeMoves } from "../src/account-stake-moves.ts";
@@ -113,7 +99,7 @@ import {
   DEREGISTRATIONS_DEGRADED_NOT_DERIVED,
   PROMETHEUS_DEGRADED_NOT_CURATED,
 } from "../src/uncurated-event-streams.ts";
-import type { AnyFn, Row } from "./row-type.ts";
+import type { Row } from "./row-type.ts";
 import { assertValid } from "./helpers/assert-valid.ts";
 
 const MCP_URL = "https://api.metagraph.sh/mcp";
@@ -5747,18 +5733,13 @@ describe("MCP get_subnet_snapshot", () => {
                 ],
               });
             }
-            if (url.pathname === "/api/v1/subnets/7/events") {
-              assert.equal(url.searchParams.get("limit"), "10");
-              return Response.json({
-                schema_version: 1,
-                netuid: 7,
-                event_count: 1,
-                limit: 10,
-                offset: 0,
-                next_cursor: null,
-                events: [{ kind: "Transfer" }],
-              });
-            }
+            // /subnets/7/events is deliberately NOT served here. Four of these
+            // five views still go through tryPostgresTier on a flag that
+            // FORWARDS (hyperparams and neurons are both in
+            // DATA_API_FORWARD_FLAGS); the events view's flag is retired, so a
+            // path served here would be a path production never requests. The
+            // events fixture rides on the lakehouse instead -- see
+            // subnetSnapshotEventsLake below.
             throw new Error(`unexpected DATA_API path: ${url.pathname}`);
           },
         },
@@ -5766,17 +5747,56 @@ describe("MCP get_subnet_snapshot", () => {
     };
   }
 
-  test("composes all five live Postgres-tier views under their named keys", async () => {
-    const { env } = subnetSnapshotPostgresEnv();
-    const res = await callTool("get_subnet_snapshot", { netuid: 7 }, { env });
-    assert.equal(res.body.result.isError, false);
-    const out = res.body.result.structuredContent;
-    assert.equal(out.netuid, 7);
-    assert.equal(out.hyperparameters.hyperparameters.tempo, 99);
-    assert.equal(out.concentration.entity_count, 2);
-    assert.equal(out.performance.incentive, 0.5);
-    assert.equal(out.top_validators.validator_count, 3);
-    assert.equal(out.recent_events.events[0].kind, "Transfer");
+  /** One account_events row for the snapshot's `recent_events` view, which reads
+   * the lakehouse (its own tier flag is retired) rather than the service
+   * binding the other four views still forward to. */
+  function subnetSnapshotEventsLake() {
+    return lakehouse([
+      {
+        block_number: 4_200_000,
+        event_index: 0,
+        extrinsic_index: 1,
+        event_kind: "Transfer",
+        hotkey: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+        coldkey: null,
+        netuid: 7,
+        uid: null,
+        amount_tao: 1.5,
+        alpha_amount: null,
+        observed_at: 1_750_009_000_000,
+      },
+    ]);
+  }
+
+  test("composes all five views, from the two transports that answer them", async () => {
+    // WAS "composes all five live Postgres-tier views under their named keys",
+    // with all five served by one DATA_API double. Only FOUR of them can be:
+    // METAGRAPH_ACCOUNT_EVENTS_SOURCE is retired, so `recent_events` came from
+    // the composer's cold rung and the fifth mocked path was never requested.
+    const lake = subnetSnapshotEventsLake();
+    try {
+      const { env } = subnetSnapshotPostgresEnv();
+      const res = await callTool(
+        "get_subnet_snapshot",
+        { netuid: 7 },
+        { env: { ...env, ...LAKEHOUSE_ENV } },
+      );
+      assert.equal(res.body.result.isError, false);
+      const out = res.body.result.structuredContent;
+      assert.equal(out.netuid, 7);
+      assert.equal(out.hyperparameters.hyperparameters.tempo, 99);
+      assert.equal(out.concentration.entity_count, 2);
+      assert.equal(out.performance.incentive, 0.5);
+      assert.equal(out.top_validators.validator_count, 3);
+      assert.equal(
+        out.recent_events.events[0].event_kind,
+        "Transfer",
+        "the events view must come from the lakehouse, not a zeroed card",
+      );
+      assert.match(lake.queries[0], /netuid = 7/);
+    } finally {
+      lake.restore();
+    }
   });
 
   test("top_validators_limit slices the validator list and recomputes validator_count", async () => {
@@ -6011,56 +6031,65 @@ describe("MCP get_chain_fees", () => {
   // live D1 read. The COALESCE/median SQL-shape assertions this used to
   // verify against D1 now apply to Postgres's own equivalent query in
   // workers/data-api.ts's chain-fees route (its own dedicated coverage).
-  test("returns daily series and top payers from the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: null,
-            day_count: 1,
-            daily: [
-              {
-                day: new Date().toISOString().slice(0, 10),
-                extrinsic_count: 20,
-                signed_extrinsic_count: 14,
-                total_fee_tao: 8,
-                avg_fee_tao: 0.4,
-                median_fee_tao: 0.4,
-                total_tip_tao: 2,
-                avg_tip_tao: 0.1,
-                median_tip_tao: 0.05,
-              },
-            ],
-            top_fee_payers: [
-              {
-                signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
-                total_fee_tao: 4,
-                total_tip_tao: 1,
-                extrinsic_count: 6,
-              },
-            ],
-          }),
+  test("derives the daily series and top payers from the projection's rows", async () => {
+    // WAS a DATA_API double returning the FINISHED card -- avg_fee_tao,
+    // median_fee_tao and all -- which the tool then handed straight back. Every
+    // derived field asserted itself. METAGRAPH_EXTRINSICS_SOURCE forwards
+    // nothing, so the card was never fetched either.
+    //
+    // The lane stores three row sets, and the medians ride SEPARATELY from the
+    // daily aggregate because a median is not summable. So: 20 extrinsics of
+    // which 14 signed, 8 TAO of fees -> avg 8/14, and the median comes from the
+    // median_rows join rather than from anything in the daily row.
+    const day = new Date().toISOString().slice(0, 10);
+    const tier = forbiddenDataApi();
+    const archive = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          newest_observed: 1_750_000_000_000,
+          daily_rows: [
+            {
+              day,
+              extrinsic_count: 20,
+              signed_extrinsic_count: 14,
+              total_fee_tao: 8,
+              total_tip_tao: 2,
+            },
+          ],
+          median_rows: [{ day, median_fee_tao: 0.4, median_tip_tao: 0.05 }],
+          payer_rows: [
+            {
+              signer: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5",
+              total_fee_tao: 4,
+              total_tip_tao: 1,
+              extrinsic_count: 6,
+            },
+          ],
+        },
       },
-    };
+    });
     const res = await callTool(
       "get_chain_fees",
       { window: "7d", limit: 25 },
-      { env },
+      { env: { ...tier, ...(archive as unknown as Row) } },
     );
     const out = res.body.result.structuredContent;
+    assert.deepEqual(tier.paths, [], "the retired tier was consulted");
     assert.equal(out.window, "7d");
     assert.equal(out.day_count, 1);
     assert.equal(out.daily[0].extrinsic_count, 20);
     assert.equal(out.daily[0].signed_extrinsic_count, 14);
-    assert.equal(out.daily[0].median_fee_tao, 0.4);
+    assert.equal(out.daily[0].avg_fee_tao, 0.571428571, "8 / 14, derived");
+    assert.equal(out.daily[0].median_fee_tao, 0.4, "from median_rows");
     assert.equal(out.daily[0].median_tip_tao, 0.05);
     assert.equal(out.top_fee_payers[0].total_fee_tao, 4);
   });
 
   test("trims an 8-day daily series to the requested 7d window (#8421)", async () => {
+    // The lane can store a boundary day the window no longer covers (its own
+    // cutoff is a timestamp, the rows are dates), so the trim has to happen on
+    // the way out or a "7d" card publishes eight days.
     const eightDays = [
       "2026-07-26",
       "2026-07-25",
@@ -6071,29 +6100,27 @@ describe("MCP get_chain_fees", () => {
       "2026-07-20",
       "2026-07-19",
     ];
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: null,
-            day_count: 8,
-            daily: eightDays.map((day) => ({
-              day,
-              extrinsic_count: 1,
-              total_fee_tao: 1,
-              total_tip_tao: 0,
-            })),
-            top_fee_payers: [],
-          }),
+    const archive = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "7d": {
+          newest_observed: 1_750_000_000_000,
+          daily_rows: eightDays.map((day) => ({
+            day,
+            extrinsic_count: 1,
+            signed_extrinsic_count: 1,
+            total_fee_tao: 1,
+            total_tip_tao: 0,
+          })),
+          median_rows: [],
+          payer_rows: [],
+        },
       },
-    };
+    });
     const res = await callTool(
       "get_chain_fees",
       { window: "7d", limit: 25 },
-      { env },
+      { env: archive as unknown as Row },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.day_count, 7);
@@ -6102,32 +6129,50 @@ describe("MCP get_chain_fees", () => {
     assert.ok(!out.daily.some((x: Row) => x.day === "2026-07-19"));
   });
 
-  test("forwards call_module on the Postgres-tier request", async () => {
-    let requestedUrl;
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (request: Request) => {
-          requestedUrl = new URL(request.url);
-          return Response.json({
-            schema_version: 1,
-            window: "30d",
-            observed_at: null,
-            day_count: 0,
-            daily: [],
-            top_fee_payers: [],
-          });
+  test("a call_module scope declines rather than serving the unfiltered series", async () => {
+    // WAS an assertion on the `call_module=Balances` query param the tier
+    // request carried. The lane precomputes NO pallet scope, so the reader
+    // refuses the scope before it reads the bucket -- asserted as the absence of
+    // the read, because an in-memory filter over the unfiltered series would
+    // still produce a plausible-looking card.
+    const archive = archiveEnv({
+      schema_version: 1,
+      windows: {
+        "30d": {
+          newest_observed: 1_750_000_000_000,
+          daily_rows: [
+            {
+              day: "2026-07-26",
+              extrinsic_count: 9,
+              signed_extrinsic_count: 9,
+              total_fee_tao: 3,
+              total_tip_tao: 0,
+            },
+          ],
+          median_rows: [],
+          payer_rows: [],
         },
       },
-    };
-    await callTool(
+    });
+    const res = await callTool(
       "get_chain_fees",
       { window: "30d", call_module: "Balances", limit: 10 },
-      { env },
+      { env: archive as unknown as Row },
     );
-    assert.equal(requestedUrl!.searchParams.get("call_module"), "Balances");
-    assert.equal(requestedUrl!.searchParams.get("window"), "30d");
-    assert.equal(requestedUrl!.searchParams.get("limit"), "10");
+    const out = res.body.result.structuredContent;
+    assert.deepEqual(archive.keys, [], "the scope must decline before reading");
+    assert.equal(out.window, "30d", "the label is still the caller's");
+    assert.equal(out.day_count, 0);
+    assert.deepEqual(out.daily, []);
+
+    // The SAME projection answers the unscoped question, so the decline is the
+    // scope and not a broken fixture.
+    const open = await callTool(
+      "get_chain_fees",
+      { window: "30d", limit: 10 },
+      { env: archive as unknown as Row },
+    );
+    assert.equal(open.body.result.structuredContent.day_count, 1);
   });
 
   test("rejects an invalid window", async () => {
@@ -6162,6 +6207,10 @@ describe("MCP get_chain_registrations", () => {
   // goes tryPostgresTier -> buildChainRegistrations([], {...}) on any
   // miss/outage. This mocks the Postgres tier by running the same pure
   // builder the real Postgres route would.
+  // The #9146 chain-registrations lane, which stores the per-subnet rows and the
+  // network aggregate the builder needs -- the aggregate SEPARATELY, because one
+  // hotkey registering on three subnets is three per-subnet rows and one
+  // network-wide registrant.
   function registrationsPostgresEnv({
     network = { distinct_registrants: 7, newest_observed: 1_700_000_000_000 },
     subnets = [
@@ -6169,24 +6218,12 @@ describe("MCP get_chain_registrations", () => {
       { netuid: 2, registrations: 4, distinct_registrants: 4 },
     ],
   } = {}) {
-    return {
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (request: Request) => {
-          const url = new URL(request.url);
-          const window = url.searchParams.get("window") || "7d";
-          const limitParam = url.searchParams.get("limit");
-          const limit = limitParam != null ? Number(limitParam) : undefined;
-          return Response.json(
-            buildChainRegistrations(subnets, {
-              window,
-              limit,
-              networkDistinct: network,
-            }),
-          );
-        },
-      },
-    };
+    const window = { rows: subnets, network };
+    return archiveEnv((key: string) =>
+      key === "metagraph/projections/chain-registrations.json"
+        ? { schema_version: 1, windows: { "7d": window, "30d": window } }
+        : null,
+    ) as unknown as Row;
   }
 
   test("returns the per-subnet leaderboard and network rollup from the Postgres tier", async () => {
@@ -6441,26 +6478,18 @@ describe("MCP get_chain_transfers", () => {
   // running the same pure builder over the caller's own window query param,
   // so the mocked response is byte-identical to what production would
   // actually serve.
+  // The #9146 chain-transfers lane. `totals` rides separately from the sender
+  // and receiver lists for the same reason it does on every other lane here: a
+  // unique-address count does not sum across a capped page, and the top-sender
+  // SHARE needs the window's own volume as its denominator.
   function chainTransfersPostgresEnv({ totals, senders, receivers }: Row) {
+    const window = { totals, senders, receivers };
     return {
-      env: {
-        METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-        DATA_API: {
-          fetch: async (request: Request) => {
-            const url = new URL(request.url);
-            const window = url.searchParams.get("window") || "7d";
-            return Response.json(
-              buildChainTransfers({
-                window,
-                observedAt: null,
-                totals,
-                senders,
-                receivers,
-              }),
-            );
-          },
-        },
-      },
+      env: archiveEnv((key: string) =>
+        key === "metagraph/projections/chain-transfers.json"
+          ? { schema_version: 1, windows: { "7d": window, "30d": window } }
+          : null,
+      ) as unknown as Row,
     };
   }
 
@@ -7720,44 +7749,49 @@ describe("MCP get_network_activity", () => {
   // retired (#4772) and the tables are dropped in production, so
   // loadNetworkActivity (the D1-querying loader) is gone -- the tool now
   // goes tryPostgresTier -> buildChainActivity({...}) on any miss/outage.
-  test("merges extrinsics + blocks tiers from the Postgres tier", async () => {
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: null,
-            day_count: 1,
-            days: [
-              {
-                day: "2026-06-25",
-                block_count: 7200,
-                extrinsic_count: 100,
-                event_count: 15000,
-                successful_extrinsics: 99,
-                success_rate: 0.99,
-                unique_signers: 40,
-              },
-            ],
-          }),
-      },
+  test("merges the extrinsic and block row sets into one day series", async () => {
+    // WAS a DATA_API double returning the finished `days` array, success_rate
+    // included -- the merge and the rate asserted themselves, over a request
+    // METAGRAPH_EXTRINSICS_SOURCE never made.
+    //
+    // The lane stores TWO row sets, from two tables: extrinsic counts and block
+    // counts, keyed by day. The merge is the thing under test, and success_rate
+    // is derived from the extrinsic side alone (99/100).
+    const tier = forbiddenDataApi();
+    const window = {
+      newest_observed: 1_750_000_000_000,
+      extrinsic_rows: [
+        {
+          day: "2026-06-25",
+          extrinsic_count: 100,
+          successful_extrinsics: 99,
+          unique_signers: 40,
+        },
+      ],
+      block_rows: [
+        { day: "2026-06-25", block_count: 7200, event_count: 15000 },
+      ],
     };
+    const archive = archiveEnv((key: string) =>
+      key === "metagraph/projections/chain-activity.json"
+        ? { schema_version: 1, windows: { "7d": window, "30d": window } }
+        : null,
+    );
     const res = await callTool(
       "get_network_activity",
       { window: "7d" },
-      { env },
+      { env: { ...tier, ...(archive as unknown as Row) } },
     );
     const out = res.body.result.structuredContent;
+    assert.deepEqual(tier.paths, [], "the retired tier was consulted");
     assert.equal(out.window, "7d");
     assert.equal(out.day_count, 1);
-    assert.equal(out.days[0].success_rate, 0.99);
-    assert.equal(out.days[0].block_count, 7200);
-    assert.equal(out.days[0].unique_signers, 40);
+    assert.equal(out.days[0].block_count, 7200, "from the block rows");
+    assert.equal(out.days[0].unique_signers, 40, "from the extrinsic rows");
+    assert.equal(out.days[0].success_rate, 0.99, "99 / 100, derived");
   });
 
-  test("trims an 8-day Postgres-tier series to the requested 7d window (#8421)", async () => {
+  test("trims an 8-day series to the requested 7d window (#8421)", async () => {
     const eightDays = [
       "2026-07-26",
       "2026-07-25",
@@ -7768,31 +7802,29 @@ describe("MCP get_network_activity", () => {
       "2026-07-20",
       "2026-07-19",
     ];
-    const env = {
-      METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            observed_at: null,
-            day_count: 8,
-            days: eightDays.map((day) => ({
-              day,
-              block_count: 1,
-              extrinsic_count: 1,
-              event_count: 1,
-              successful_extrinsics: 1,
-              success_rate: 1,
-              unique_signers: 1,
-            })),
-          }),
-      },
+    const window = {
+      newest_observed: 1_750_000_000_000,
+      extrinsic_rows: eightDays.map((day) => ({
+        day,
+        extrinsic_count: 1,
+        successful_extrinsics: 1,
+        unique_signers: 1,
+      })),
+      block_rows: eightDays.map((day) => ({
+        day,
+        block_count: 1,
+        event_count: 1,
+      })),
     };
+    const archive = archiveEnv((key: string) =>
+      key === "metagraph/projections/chain-activity.json"
+        ? { schema_version: 1, windows: { "7d": window, "30d": window } }
+        : null,
+    );
     const res = await callTool(
       "get_network_activity",
       { window: "7d" },
-      { env },
+      { env: archive as unknown as Row },
     );
     const out = res.body.result.structuredContent;
     assert.equal(out.day_count, 7);
@@ -14659,60 +14691,61 @@ describe("MCP economics + metagraph data tools", () => {
   // folds it down to surface_count/ok_count/avg_latency_ms per netuid, so
   // there's no top-level `marker` field to assert on -- same two-test
   // contract as the shared CASES loops, adapted to that shape.
-  test("compare_subnets: health dimension flag=postgres uses Postgres data at the internal REST-equivalent path", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            rows: [
-              { netuid: 7, surface_count: 9, ok_count: 8, avg_latency_ms: 55 },
-            ],
-          });
-        },
+  test("compare_subnets: the health dimension groups surface_status in the live store", async () => {
+    // WAS an assertion on "/api/v1/internal/compare-health?netuids=7" -- a
+    // request METAGRAPH_HEALTH_SOURCE cannot make: it reads "d1" and is absent
+    // from DATA_API_FORWARD_FLAGS, and DATA_API does not implement that route
+    // anyway. So compare_subnets served `health: null` for every subnet while
+    // this test read a health block straight back out of its own mock.
+    //
+    // The dimension is a GROUP BY over surface_status in the store MCP already
+    // reads for every other health surface, filtered to the asked netuids -- so
+    // the extra row below must not appear.
+    const tier = forbiddenDataApi();
+    pg.control.answers = [
+      {
+        match: /FROM surface_status/i,
+        rows: [
+          { netuid: 7, surface_count: 9, ok_count: 8, avg_latency_ms: 55 },
+          { netuid: 31, surface_count: 4, ok_count: 1, avg_latency_ms: 900 },
+        ],
       },
-    };
+    ];
     const res = await callTool(
       "compare_subnets",
       { netuids: [7], dimensions: ["health"] },
-      { deps: liveAnalyticsDeps, env },
+      { deps: liveAnalyticsDeps, env: { ...pgMockEnv(), ...tier } },
     );
     assert.equal(res.body.result.isError, false);
-    assert.equal(captured, "/api/v1/internal/compare-health?netuids=7");
+    assert.deepEqual(tier.paths, [], "the health flag forwards nothing");
     const out = res.body.result.structuredContent;
     assert.deepEqual(out.subnets[0].health, {
       surface_count: 9,
       ok_count: 8,
       avg_latency_ms: 55,
     });
+    assert.equal(out.subnets.length, 1, "netuid 31 was not asked for");
   });
 
-  test("compare_subnets: health+economics dimensions flag=postgres still includes economicsRows", async () => {
-    let captured;
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          const reqUrl = new URL(req.url);
-          captured = reqUrl.pathname + reqUrl.search;
-          return Response.json({
-            rows: [
-              { netuid: 7, surface_count: 9, ok_count: 8, avg_latency_ms: 55 },
-            ],
-          });
-        },
+  test("compare_subnets: health and economics compose from two different stores", async () => {
+    // The composition is the claim: health comes from the live store, economics
+    // from the economics artifact, and asking for both must not cost either.
+    const tier = forbiddenDataApi();
+    pg.control.answers = [
+      {
+        match: /FROM surface_status/i,
+        rows: [
+          { netuid: 7, surface_count: 9, ok_count: 8, avg_latency_ms: 55 },
+        ],
       },
-    };
+    ];
     const res = await callTool(
       "compare_subnets",
       { netuids: [7], dimensions: ["health", "economics"] },
-      { deps: liveAnalyticsDeps, env },
+      { deps: liveAnalyticsDeps, env: { ...pgMockEnv(), ...tier } },
     );
     assert.equal(res.body.result.isError, false);
-    assert.equal(captured, "/api/v1/internal/compare-health?netuids=7");
+    assert.deepEqual(tier.paths, []);
     const out = res.body.result.structuredContent;
     assert.deepEqual(out.subnets[0].health, {
       surface_count: 9,
@@ -14774,43 +14807,72 @@ describe("MCP economics + metagraph data tools", () => {
     assert.deepEqual(out.surfaces, []);
   });
 
-  test("get_global_incidents filters by netuid over Postgres-tier surfaces", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            surfaces: [
-              { netuid: 7, surface_id: "a", incident_count: 1 },
-              { netuid: 31, surface_id: "b", incident_count: 2 },
-            ],
-          }),
+  test("get_global_incidents filters by netuid over the incident rows it derived", async () => {
+    // WAS answered by a DATA_API double returning ready-made `surfaces` with an
+    // `incident_count` each -- a shape the reader does not produce and the flag
+    // could not have fetched. The rows below are what surface_checks actually
+    // yields: one row per failure RUN, grouped by (netuid, surface_key), with
+    // started_at/ended_at/failed_samples. The surface list and its counts are
+    // derived from those.
+    const tier = forbiddenDataApi();
+    const started = Date.now() - 3_600_000;
+    pg.control.answers = [
+      {
+        match: /FROM grouped/i,
+        rows: [
+          {
+            netuid: 7,
+            surface_id: "a",
+            surface_key: "a",
+            started_at: started,
+            ended_at: started + 60_000,
+            failed_samples: 2,
+          },
+          {
+            netuid: 31,
+            surface_id: "b",
+            surface_key: "b",
+            started_at: started,
+            ended_at: started + 60_000,
+            failed_samples: 3,
+          },
+        ],
       },
-    };
-    const res = await callTool("get_global_incidents", { netuid: 7 }, { env });
+    ];
+    const res = await callTool(
+      "get_global_incidents",
+      { netuid: 7 },
+      { env: { ...pgMockEnv(), ...tier } },
+    );
     const out = res.body.result.structuredContent;
+    assert.deepEqual(tier.paths, [], "the health flag forwards nothing");
     assert.equal(out.returned, 1);
     assert.equal(out.surfaces.length, 1);
     assert.equal(out.surfaces[0].netuid, 7);
   });
 
-  test("get_global_incidents pages Postgres-tier surfaces with limit/cursor", async () => {
-    const env = {
-      METAGRAPH_HEALTH_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            window: "7d",
-            surfaces: [
-              { netuid: 7, surface_id: "a", incident_count: 1 },
-              { netuid: 31, surface_id: "b", incident_count: 2 },
-            ],
-          }),
+  test("get_global_incidents pages the derived surfaces with limit/cursor", async () => {
+    const started = Date.now() - 3_600_000;
+    const rows = [
+      {
+        netuid: 7,
+        surface_id: "a",
+        surface_key: "a",
+        started_at: started,
+        ended_at: started + 60_000,
+        failed_samples: 2,
       },
-    };
+      {
+        netuid: 31,
+        surface_id: "b",
+        surface_key: "b",
+        started_at: started,
+        ended_at: started + 60_000,
+        failed_samples: 3,
+      },
+    ];
+    pg.control.answers = [{ match: /FROM grouped/i, rows }];
+    const env = { ...pgMockEnv() };
     const res = await callTool(
       "get_global_incidents",
       { sort: "netuid", order: "desc", limit: 1 },
@@ -14822,6 +14884,7 @@ describe("MCP economics + metagraph data tools", () => {
     assert.equal(out.surfaces[0].netuid, 31);
     assert.equal(out.next_cursor, 1);
 
+    pg.control.answers = [{ match: /FROM grouped/i, rows }];
     const nextPage = await callTool(
       "get_global_incidents",
       { sort: "netuid", order: "desc", limit: 1, cursor: out.next_cursor },
@@ -22242,25 +22305,63 @@ describe("MCP get_account_snapshot", () => {
     }
   });
 
-  test("composes all five live views under their named keys", async () => {
+  test("composes all five views, from the three transports that answer them", async () => {
+    // WAS "composes all five live views under their named keys", with four views
+    // on one DATA_API double and the balance on a stubbed RPC. `recent_events`
+    // was the fifth, and its flag is retired -- so that path was never
+    // requested and the card published `event_count: 0`. Fixed in the handler
+    // (it now reads the same cold tier `get_account_events` does, the #10320
+    // wired-card-vs-embedded-copy defect one composer over from the subnet
+    // snapshot's); this drives it.
+    //
+    // ONE fetch stub for both the RPC balance and the lakehouse events, routed
+    // by whether the body is an R2 SQL query -- they share globalThis.fetch, so
+    // a second stub would silently win.
     const orig = globalThis.fetch;
-    globalThis.fetch = (async () => ({
-      ok: true,
-      json: async () => ({
-        jsonrpc: "2.0",
-        id: 1,
-        // Same SCALE AccountInfo encoding as get_account_balance's own live
-        // test above: free 2_000_000_000 + reserved 500_000_000 rao = 2.5 TAO.
-        result:
-          "0x" +
-          "00000000".repeat(4) +
-          "00943577000000000000000000000000" +
-          "0065cd1d000000000000000000000000",
-      }),
-    })) as unknown as typeof globalThis.fetch;
+    const EVENT = {
+      block_number: 4_200_000,
+      event_index: 0,
+      extrinsic_index: 1,
+      event_kind: "Transfer",
+      hotkey: SS58,
+      coldkey: null,
+      netuid: 7,
+      uid: null,
+      amount_tao: 1.5,
+      alpha_amount: null,
+      observed_at: 1_750_009_000_000,
+    };
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      const body = String(init?.body ?? "");
+      if (body.includes("chain.account_events")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            success: true,
+            result: { rows: [EVENT] },
+          }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          jsonrpc: "2.0",
+          id: 1,
+          // Same SCALE AccountInfo encoding as get_account_balance's own live
+          // test above: free 2_000_000_000 + reserved 500_000_000 rao = 2.5 TAO.
+          result:
+            "0x" +
+            "00000000".repeat(4) +
+            "00943577000000000000000000000000" +
+            "0065cd1d000000000000000000000000",
+        }),
+      };
+    }) as unknown as typeof globalThis.fetch;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "postgres",
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
+      ...LAKEHOUSE_ENV,
       // A passing RPC_RATE_LIMITER here exercises the handler's own
       // success-path branch, distinct from the no-limiter-bound cold test
       // above and the failing-limiter test below.
@@ -22297,18 +22398,9 @@ describe("MCP get_account_snapshot", () => {
               positions: [],
             });
           }
-          if (url.pathname === `/api/v1/accounts/${SS58}/events`) {
-            assert.equal(url.searchParams.get("limit"), "10");
-            return Response.json({
-              schema_version: 1,
-              ss58: SS58,
-              event_count: 1,
-              limit: 10,
-              offset: 0,
-              next_cursor: null,
-              events: [{ kind: "Transfer" }],
-            });
-          }
+          // /accounts/:ss58/events is deliberately NOT served here: its flag is
+          // retired, so production never requests it. The events view reads the
+          // lakehouse, wired below.
           throw new Error(`unexpected DATA_API path: ${url.pathname}`);
         },
       },
@@ -22326,7 +22418,11 @@ describe("MCP get_account_snapshot", () => {
       assert.equal(out.portfolio.position_count, 2);
       assert.equal(out.subnets.subnet_count, 3);
       assert.equal(out.positions.total_stake_alpha, 42);
-      assert.equal(out.recent_events.events[0].kind, "Transfer");
+      assert.equal(
+        out.recent_events.events[0].event_kind,
+        "Transfer",
+        "the events view must come from the lakehouse, not a zeroed card",
+      );
     } finally {
       globalThis.fetch = orig;
     }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -23107,21 +23107,29 @@ describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => 
         ? `${tool} (validator_permit=true)`
         : tool;
 
-    test(`${label}: the retired tier flag is not consulted even when set`, async () => {
-      // WAS "uses Postgres data at the REST-equivalent path", asserting the URL
-      // tryPostgresTier sent. METAGRAPH_NEURONS_SOURCE reads
-      // "retired"/"d1" in wrangler.jsonc and is absent from
-      // DATA_API_FORWARD_FLAGS, so that request was never made -- the assertion
-      // described a call production does not perform, over a payload it cannot
-      // produce. `path` stays in CASES as the documentation of what the REST twin
-      // serves; what is provable here is the retirement.
-      const tier = forbiddenDataApi();
-      const res = await callTool(tool, args, {
-        env: { METAGRAPH_NEURONS_SOURCE: "postgres", ...tier },
-      });
+    test(`${label}: flag=postgres uses Postgres data at the REST-equivalent path`, async () => {
+      let captured;
+      const env = {
+        METAGRAPH_NEURONS_SOURCE: "postgres",
+        DATA_API: {
+          fetch: async (req: Request) => {
+            const reqUrl = new URL(req.url);
+            captured = reqUrl.pathname + reqUrl.search;
+            return Response.json({
+              schema_version: 1,
+              marker: "from-postgres",
+            });
+          },
+        },
+      };
+      const res = await callTool(tool, args, { env });
       assert.equal(res.body.result.isError, false, label);
-      assert.deepEqual(tier.paths, [], label);
-      assert.equal(res.body.result.structuredContent.marker, undefined, label);
+      assert.equal(
+        res.body.result.structuredContent.marker,
+        "from-postgres",
+        label,
+      );
+      assert.equal(captured, path, label);
     });
 
     test(`${label}: flag=postgres falls back to the schema-stable empty shape on failure`, async () => {

--- a/tests/request-handlers-analytics-routes.test.ts
+++ b/tests/request-handlers-analytics-routes.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { handleRequest } from "../workers/api.ts";
 import { describe, test, beforeEach, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 // The generated row type, so these fixtures cannot drift from the schema.
 import type { SubnetSnapshots } from "../generated/db/types.ts";
 
@@ -128,13 +129,35 @@ function snapshotStoreEnv(rows: SnapshotFixture[]) {
   return storeEnv(rows as unknown as Row[]);
 }
 
-function postgresUptimeEnv(surfaces: Row[], window = "90d"): Env {
-  return {
-    METAGRAPH_HEALTH_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () => Response.json({ netuid: NETUID, window, surfaces }),
-    },
-  } as unknown as Env;
+// #10190: METAGRAPH_HEALTH_SOURCE reads "d1" and is absent from
+// DATA_API_FORWARD_FLAGS, so the tier this doubled never answered --
+// loadSubnetUptime reads `surface_uptime_daily` through readStore. Doubled at
+// that transport, and given the (surface, day) ROWS the GROUP BY emits rather
+// than a built payload, so formatUptime runs here as it does in production.
+function postgresUptimeEnv(surfaces: Row[], _window = "90d"): Env {
+  pg.control.queries.length = 0;
+  pg.control.failNext = null;
+  pg.control.onQuery = null;
+  pg.control.rows = surfaces.flatMap((surface) =>
+    ((surface.days as Row[]) ?? []).map((day) => ({
+      surface_id: surface.surface_id,
+      surface_key: surface.surface_id,
+      day: day.day,
+      samples: day.samples,
+      ok_count:
+        Number(day.samples ?? 0) * Number((day.uptime_ratio as number) ?? 0),
+      uptime_ratio: day.uptime_ratio,
+      avg_latency_ms: day.avg_latency_ms,
+      // The GROUP BY emits this as `latency_samples`; formatUptime publishes it
+      // as latency_sample_count.
+      latency_samples: day.latency_sample_count,
+      p50: (day.latency_ms as Row | undefined)?.p50 ?? null,
+      p95: (day.latency_ms as Row | undefined)?.p95 ?? null,
+      p99: (day.latency_ms as Row | undefined)?.p99 ?? null,
+      status: day.status,
+    })),
+  );
+  return mockEnv(pgMockEnv()) as unknown as Env;
 }
 
 beforeEach(() => {
@@ -718,11 +741,16 @@ describe("handleUptime", () => {
       ],
       "1y",
     );
+    // THE ctx IS NOT PLUMBING (see storeEnv's note): observationsReadDb parks
+    // the pooled connection's teardown on waitUntil and answers `undefined`
+    // without one, which d1All reads as zero rows -- a header-only CSV that
+    // would pass every assertion except the row.
     const res = await handleUptime(
       req("/"),
       env,
       NETUID,
       url("/?window=1y&format=csv"),
+      { waitUntil: (promise: Promise<unknown>) => void promise } as never,
     );
     assert.equal(res.status, 200);
     assert.equal(res.headers.get("content-type"), "text/csv; charset=utf-8");
@@ -911,17 +939,27 @@ describe("handleCompare", () => {
   // isolation, same reused METAGRAPH_HEALTH_SOURCE flag as handleUptime
   // above. D1 fully eliminated (2026-07-17): a tier miss now always falls
   // through to an empty health row set, never a live D1 query.
-  test("health dimension: flag=postgres serves the DATA_API response", async () => {
+  test("health dimension: the store answers, and the retired tier is not consulted", async () => {
+    // #10190: the health dimension read METAGRAPH_HEALTH_SOURCE, a flag that
+    // reads "d1" and is absent from DATA_API_FORWARD_FLAGS -- so it returned
+    // null and this dimension published `health: null` for every subnet while
+    // the get_compare_subnets MCP tool served real numbers off the same table.
+    // It reads `surface_status` directly now, the same read MCP makes.
     const env = createLocalArtifactEnv();
-    env.METAGRAPH_HEALTH_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          rows: [
-            { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 120 },
-          ],
-        }),
-    };
+    Object.assign(env, pgMockEnv());
+    const tier = forbiddenDataApi();
+    Object.assign(env, tier);
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [
+      {
+        match: "FROM surface_status",
+        rows: [
+          { netuid: 7, surface_count: 3, ok_count: 2, avg_latency_ms: 120 },
+        ],
+      },
+    ];
     const body = await json(
       await handleCompare(
         req("/api/v1/compare"),
@@ -929,6 +967,8 @@ describe("handleCompare", () => {
         url("/api/v1/compare?netuids=7&dimensions=health"),
       ),
     );
+    pg.control.answers = [];
+    assert.deepEqual(tier.paths, []);
     assert.equal(body.data.subnets[0].netuid, 7);
     assert.equal(body.data.subnets[0].health.ok_count, 2);
   });
@@ -994,20 +1034,23 @@ describe("handleCompare", () => {
     // A fresh, unrelated env (real committed profiles.json, includes NETUID)
     // must resolve NETUID on its own data, not the poisoned cache above.
     const realEnv = createLocalArtifactEnv();
-    realEnv.METAGRAPH_HEALTH_SOURCE = "postgres";
-    realEnv.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          rows: [
-            {
-              netuid: NETUID,
-              surface_count: 3,
-              ok_count: 2,
-              avg_latency_ms: 120,
-            },
-          ],
-        }),
-    };
+    Object.assign(realEnv, pgMockEnv());
+    pg.control.queries.length = 0;
+    pg.control.failNext = null;
+    pg.control.onQuery = null;
+    pg.control.answers = [
+      {
+        match: "FROM surface_status",
+        rows: [
+          {
+            netuid: NETUID,
+            surface_count: 3,
+            ok_count: 2,
+            avg_latency_ms: 120,
+          },
+        ],
+      },
+    ];
     const body = await json(
       await handleCompare(
         req("/"),
@@ -1018,6 +1061,7 @@ describe("handleCompare", () => {
     assert.equal(body.data.subnets[0].netuid, NETUID);
     assert.equal(body.data.subnets[0].found, true);
     assert.equal(body.data.subnets[0].health.ok_count, 2);
+    pg.control.answers = [];
   });
 });
 

--- a/tests/request-handlers-analytics.test.ts
+++ b/tests/request-handlers-analytics.test.ts
@@ -4,8 +4,18 @@
 // without routing through workers/api.ts.
 
 import assert from "node:assert/strict";
+
+// loadGlobalIncidentsLedger reads `surface_checks` through readStore, which
+// builds its own `new Client(...)` -- so the module is the seam (#10179). See
+// tests/helpers/pg-mock.ts.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { forbiddenDataApi } from "./helpers/cold-tier-env.ts";
 import { handleRequest } from "../workers/api.ts";
-import { afterEach, describe, test } from "vitest";
+import { afterEach, describe, test, vi } from "vitest";
 import {
   configureAnalytics,
   withEdgeCache,
@@ -1025,29 +1035,30 @@ describe("handleBulkHealthTrends", () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();
     cache.install();
+    // #10190: the tier this counted is retired; the STORE is the upstream the
+    // cache protects, so its queries are what the MISS/HIT counts measure.
     const { env } = dbWith({ rows: [] });
-    setSourceFlag(env, "METAGRAPH_HEALTH_SOURCE", "postgres");
+    Object.assign(env, pgMockEnv());
     let dataApiCalls = 0;
-    env.DATA_API = {
-      fetch: async () => {
-        dataApiCalls += 1;
-        return Response.json({
-          schema_version: 1,
-          windows: { "7d": {}, "30d": {} },
-        });
-      },
-    } as unknown as Fetcher;
+    pg.control.queries.length = 0;
+    pg.control.rows = [
+      { netuid: NETUID, day: "2026-06-30", surface_key: "api", samples: 10 },
+    ];
+    pg.control.onQuery = () => {
+      dataApiCalls += 1;
+    };
     const path = "/api/v1/health/trends";
 
     await handleBulkHealthTrends(req(path), env, url(path), ctx);
     await Promise.resolve();
-    assert.equal(dataApiCalls, 1, "the cold MISS must call DATA_API once");
+    assert.ok(dataApiCalls > 0, "the cold MISS must read the store");
 
     await handleBulkHealthTrends(req(path), env, url(path), ctx);
+    const afterMiss = dataApiCalls;
     assert.equal(
       dataApiCalls,
-      1,
-      "the warm HIT must be served from cache, not DATA_API",
+      afterMiss,
+      "the warm HIT must be served from cache, not the store",
     );
   });
 
@@ -1254,12 +1265,23 @@ describe("handleHealthPercentiles", () => {
     originalCaches = globalWithCaches.caches;
     const cache = mockCaches();
     cache.install();
+    // #10190: the percentile route reads the store now, so a cacheable answer
+    // is a store-served one -- an empty payload is still barred from the cache.
     const env = analyticsEnv([]);
-    setSourceFlag(env, "METAGRAPH_HEALTH_SOURCE", "postgres");
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, netuid: NETUID, surfaces: [] }),
-    } as unknown as Fetcher;
+    Object.assign(env, pgMockEnv());
+    pg.control.queries.length = 0;
+    pg.control.onQuery = null;
+    pg.control.rows = [
+      {
+        netuid: NETUID,
+        surface_key: "api",
+        surface_id: "api",
+        samples: 10,
+        p50_ms: 100,
+        p95_ms: 200,
+        p99_ms: 300,
+      },
+    ];
     await handleHealthPercentiles(
       req(`${base}?window=7d`),
       env,
@@ -1462,30 +1484,43 @@ describe("handleGlobalIncidents", () => {
   // endpoint-incidents route. Non-empty surfaces come from the Postgres tier (the
   // D1 fallback ledger is always empty now), so these stub DATA_API with a payload
   // in the exact shape formatGlobalIncidents emits.
-  function withSurfaces(surfaces: Row[]) {
+  // #10190: METAGRAPH_HEALTH_SOURCE reads "d1" and is absent from
+  // DATA_API_FORWARD_FLAGS, so the tier this stubbed never answered --
+  // loadGlobalIncidentsLedger reads `surface_checks` through readStore. Doubled
+  // there, and given INCIDENT rows rather than a finished surfaces list: the
+  // pagination/sort/filter under test is applied to what formatGlobalIncidents
+  // aggregates, so handing it the aggregate skipped the step being tested.
+  function withSurfaces(incidentRows: Row[]) {
+    pg.control.queries.length = 0;
+    pg.control.rows = incidentRows;
     const { env } = dbWith({ rows: [] });
-    setSourceFlag(env, "METAGRAPH_HEALTH_SOURCE", "postgres");
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          window: "7d",
-          observed_at: LAST_RUN_AT,
-          source: "live-cron-prober",
-          summary: {
-            incident_count: surfaces.length,
-            affected_surface_count: surfaces.length,
-          },
-          surfaces,
-        }),
-    } as unknown as Fetcher;
+    Object.assign(env, pgMockEnv());
     return env;
   }
 
+  // Three surfaces, ranked c > a > b by total downtime -- b has the MOST
+  // incidents and the LEAST downtime, so a sort on downtime_ms cannot be
+  // satisfied by incident_count order and vice versa.
+  const inc = (
+    netuid: number,
+    surface_id: string,
+    start: number,
+    ms: number,
+  ) => ({
+    netuid,
+    surface_id,
+    surface_key: surface_id,
+    started_at: start,
+    ended_at: start + ms,
+    failed_samples: 1,
+  });
   const SURFACE_ROWS = [
-    { netuid: 7, surface_id: "a", incident_count: 1, downtime_ms: 300 },
-    { netuid: 7, surface_id: "b", incident_count: 3, downtime_ms: 100 },
-    { netuid: 12, surface_id: "c", incident_count: 2, downtime_ms: 900 },
+    inc(7, "a", 1_000_000, 5_000_000),
+    inc(7, "b", 1_000_000, 1),
+    inc(7, "b", 3_000_000, 1),
+    inc(7, "b", 5_000_000, 1),
+    inc(12, "c", 1_000_000, 9_000_000),
+    inc(12, "c", 20_000_000, 1_000_000),
   ];
 
   test("paginates the surfaces ledger and advertises a Link header", async () => {
@@ -1935,25 +1970,22 @@ describe("chain analytics extrinsics-derived: postgres tier wiring", () => {
   // keep their coverage -- they call tryPostgresTier bare, which still forwards
   // on "postgres".
   for (const { name, path, handler, pgBody } of cases) {
-    test(`${name}: flag=postgres serves the DATA_API response, D1 never queried`, async () => {
-      let d1Called = false;
+    test(`${name}: the retired tier flag is not consulted even when set (#10190)`, async () => {
+      // METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+      // absent from DATA_API_FORWARD_FLAGS, so `pgBody` was never what this
+      // route served -- the #9146 projection was. Binding a DATA_API that WOULD
+      // answer and proving nothing asks it is what keeps the deletion honest:
+      // a reintroduced call resolves to null and would otherwise be invisible.
       const { env } = dbWith({ rows: [] });
       setSourceFlag(env, "METAGRAPH_EXTRINSICS_SOURCE", "postgres");
-      env.DATA_API = {
-        fetch: async () => Response.json(pgBody),
-      } as unknown as Fetcher;
-      env.METAGRAPH_HEALTH_DB.prepare = () => {
-        d1Called = true;
-        throw new Error(
-          "D1 must not be queried when Postgres serves the request",
-        );
-      };
+      const tier = forbiddenDataApi();
+      env.DATA_API = tier.DATA_API as unknown as Fetcher;
       const p = `${path}?window=7d`;
       const res = await handler(req(p), env, url(p), ctx);
       assert.equal(res.status, 200);
+      assert.deepEqual(tier.paths, []);
       const body = await jsonBody(res);
-      assert.deepEqual(body.data, pgBody);
-      assert.equal(d1Called, false);
+      assert.notDeepEqual(body.data, pgBody);
     });
 
     test(`${name}: flag=postgres falls back to D1 when DATA_API fails`, async () => {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -4,6 +4,11 @@
 // through workers/api.ts.
 
 import assert from "node:assert/strict";
+import {
+  forbiddenDataApi,
+  lakehouse,
+  LAKEHOUSE_ENV,
+} from "./helpers/cold-tier-env.ts";
 import { handleRequest } from "../workers/api.ts";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
@@ -3325,29 +3330,22 @@ describe("handleAccountCounterparties", () => {
 
   test("?format=csv exports the list-mode leaderboard as CSV", async () => {
     const { env } = dbWith({ accountEvents: [accountEventRow()] });
-    env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          ss58: SS58,
-          counterparty_count: 1,
-          transfers_scanned: 1,
-          scan_capped: false,
-          total_sent_tao: 4.2,
-          total_received_tao: 0,
-          counterparties: [
-            {
-              address: COUNTERPARTY,
-              sent_tao: 4.2,
-              received_tao: 0,
-              net_tao: -4.2,
-              transfer_count: 1,
-              last_block: BLOCK_NUM,
-            },
-          ],
-        }),
-    };
+    // #10190: the tier this doubled is retired; the list mode reads the
+    // lakehouse (loadAccountCounterpartiesColdTier). Doubled at that transport
+    // and given raw TRANSFER rows, because the leaderboard below is what
+    // buildCounterparties aggregates FROM them -- the retired tier handed the
+    // finished leaderboard over, so the aggregation never ran in this test.
+    const lake = lakehouse([
+      {
+        hotkey: SS58,
+        coldkey: COUNTERPARTY,
+        amount_tao: 4.2,
+        block_number: BLOCK_NUM,
+        event_index: 0,
+        observed_at: 1_750_009_000_000,
+      },
+    ]);
+    Object.assign(env, LAKEHOUSE_ENV);
     const res = await handleAccountCounterparties(
       req(`/api/v1/accounts/${SS58}/counterparties?format=csv`),
       env as unknown as Env,
@@ -3363,6 +3361,7 @@ describe("handleAccountCounterparties", () => {
         `${COUNTERPARTY},4.2,0,'-4.2,1,${BLOCK_NUM}`,
       ].join("\r\n"),
     );
+    lake.restore();
   });
 
   test("empty CSV export still emits the header row", async () => {
@@ -4363,28 +4362,6 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     return { fetch: async () => response };
   }
 
-  /**
-   * A DATA_API that fails the test if it is ever consulted.
-   *
-   * The blocks family's flag (METAGRAPH_BLOCKS_SOURCE) is retired in every
-   * deployed config and absent from DATA_API_FORWARD_FLAGS, so its handlers no
-   * longer read the tier at all (#10190). These use it as the ASSERTION: set the
-   * flag to "postgres", bind a DATA_API that would answer, and prove nothing
-   * asks it -- which is what stops a dead tier read from being reintroduced.
-   */
-  function forbiddenDataApi() {
-    const calls: string[] = [];
-    return {
-      calls,
-      binding: {
-        fetch: async (request: Request) => {
-          calls.push(new URL(request.url).pathname);
-          return Response.json({ schema_version: 1, marker: "tier" });
-        },
-      },
-    };
-  }
-
   /** Stub the lakehouse transport; answers each cold-tier query by SQL prefix. */
   function lakehouse(answer: (sql: string) => unknown[]) {
     const original = globalThis.fetch;
@@ -4409,7 +4386,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     const { env } = dbWith({});
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
     const tier = forbiddenDataApi();
-    env.DATA_API = tier.binding;
+    env.DATA_API = tier.DATA_API;
     Object.assign(env, LAKEHOUSE_TOKEN);
     const restore = lakehouse(() => [blockRow({ author: "cold-tier" })]);
     try {
@@ -4420,7 +4397,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
           url("/api/v1/blocks"),
         ),
       );
-      assert.deepEqual(tier.calls, []); // the dead tier read is gone
+      assert.deepEqual(tier.paths, []); // the dead tier read is gone
       assert.equal(body.data.blocks[0].author, "cold-tier"); // the lakehouse did
     } finally {
       restore();
@@ -4431,7 +4408,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     const { env } = dbWith({ blockDetail: blockRow() });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
     const tier = forbiddenDataApi();
-    env.DATA_API = tier.binding;
+    env.DATA_API = tier.DATA_API;
     Object.assign(env, LAKEHOUSE_TOKEN);
     const restore = lakehouse(() => [{ ...blockRow(), author: "lakehouse" }]);
     try {
@@ -4442,26 +4419,18 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
           String(BLOCK_NUM),
         ),
       );
-      assert.deepEqual(tier.calls, []);
+      assert.deepEqual(tier.paths, []);
       assert.equal(body.data.block.author, "lakehouse");
     } finally {
       restore();
     }
   });
 
-  test("handleExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleExtrinsics: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = dataApi(
-      Response.json({
-        schema_version: 1,
-        extrinsic_count: 99,
-        limit: 50,
-        offset: 0,
-        next_cursor: null,
-        extrinsics: [],
-      }),
-    );
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleExtrinsics(
         req("/api/v1/extrinsics"),
@@ -4469,21 +4438,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url("/api/v1/extrinsics"),
       ),
     );
-    assert.equal(body.data.extrinsic_count, 99);
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleExtrinsic: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleExtrinsic: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ extrinsicDetail: extrinsicRow() });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = dataApi(
-      Response.json({
-        schema_version: 1,
-        ref: HASH,
-        extrinsic: { ...extrinsicRow(), signer: "postgres-signer" },
-        events: [],
-      }),
-    );
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleExtrinsic(
         req(`/api/v1/extrinsics/${HASH}`),
@@ -4491,24 +4456,20 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         HASH,
       ),
     );
-    assert.equal(body.data.extrinsic.signer, "postgres-signer");
-    assert.deepEqual(captures.sql, []);
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
+    // The store read this used to assert AWAY is now the answer: the tier
+    // short-circuited it, and with the tier gone the composer reads the store
+    // itself. Asserting it happened is the honest inverse of the old claim.
+    assert.ok(captures.sql.length > 0);
   });
 
-  test("handleAccountEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountEvents: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = dataApi(
-      Response.json({
-        schema_version: 1,
-        ss58: SS58,
-        event_count: 99,
-        limit: 50,
-        offset: 0,
-        next_cursor: null,
-        events: [],
-      }),
-    );
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const path = `/api/v1/accounts/${SS58}/events`;
     const body = await json(
       await handleAccountEvents(
@@ -4518,7 +4479,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(path),
       ),
     );
-    assert.equal(body.data.event_count, 99);
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
@@ -4890,16 +4853,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleValidatorNominators: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleValidatorNominators: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleValidatorNominators(
         req(`/api/v1/validators/${SS58}/nominators`),
@@ -4908,20 +4866,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/validators/${SS58}/nominators`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountWeightSetters: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountWeightSetters: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountWeightSetters(
         req(`/api/v1/accounts/${SS58}/weight-setters`),
@@ -4930,16 +4885,20 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/weight-setters`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
-    assert.deepEqual(captures.sql, []);
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
+    // The store read this used to assert AWAY is now the answer: the tier
+    // short-circuited it, and with the tier gone the composer reads the store
+    // itself. Asserting it happened is the honest inverse of the old claim.
+    assert.ok(captures.sql.length > 0);
   });
 
-  test("handleSubnetWeightSetters: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetWeightSetters: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetWeightSetters(
         req(`/api/v1/subnets/${NETUID}/weights/setters`),
@@ -4948,20 +4907,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/weights/setters`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountStakeFlow: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountStakeFlow: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountStakeFlow(
         req(`/api/v1/accounts/${SS58}/stake-flow`),
@@ -4970,20 +4926,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/stake-flow`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetStakeFlow: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetStakeFlow: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetStakeFlow(
         req(`/api/v1/subnets/${NETUID}/stake-flow`),
@@ -4992,20 +4945,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/stake-flow`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountStakeMoves: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountStakeMoves: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountStakeMoves(
         req(`/api/v1/accounts/${SS58}/stake-moves`),
@@ -5014,16 +4964,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/stake-moves`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetStakeMoves: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetStakeMoves: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetStakeMoves(
         req(`/api/v1/subnets/${NETUID}/stake-moves`),
@@ -5032,16 +4983,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/stake-moves`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetStakeTransfers: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetStakeTransfers: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetStakeTransfers(
         req(`/api/v1/subnets/${NETUID}/stake-transfers`),
@@ -5050,20 +5002,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/stake-transfers`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountRegistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountRegistrations: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountRegistrations(
         req(`/api/v1/accounts/${SS58}/registrations`),
@@ -5072,16 +5021,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/registrations`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetRegistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetRegistrations: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetRegistrations(
         req(`/api/v1/subnets/${NETUID}/registrations`),
@@ -5090,20 +5040,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/registrations`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountServing: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountServing: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountServing(
         req(`/api/v1/accounts/${SS58}/serving`),
@@ -5112,16 +5059,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/serving`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetServing: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetServing: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetServing(
         req(`/api/v1/subnets/${NETUID}/serving`),
@@ -5130,20 +5078,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/serving`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountAxonRemovals: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountAxonRemovals: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountAxonRemovals(
         req(`/api/v1/accounts/${SS58}/axon-removals`),
@@ -5152,7 +5097,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/axon-removals`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
@@ -5175,12 +5122,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     await assertValidComponent("AccountDeregistrationsArtifact", body.data);
   });
 
-  test("handleSubnetAxonRemovals: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetAxonRemovals: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetAxonRemovals(
         req(`/api/v1/subnets/${NETUID}/axon-removals`),
@@ -5189,20 +5135,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/axon-removals`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountPrometheus: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountPrometheus: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountPrometheus(
         req(`/api/v1/accounts/${SS58}/prometheus`),
@@ -5211,16 +5154,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/prometheus`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetPrometheus: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetPrometheus: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetPrometheus(
         req(`/api/v1/subnets/${NETUID}/prometheus`),
@@ -5229,20 +5173,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/prometheus`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountDeregistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountDeregistrations: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountDeregistrations(
         req(`/api/v1/accounts/${SS58}/deregistrations`),
@@ -5251,16 +5192,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/deregistrations`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetDeregistrations: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetDeregistrations: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetDeregistrations(
         req(`/api/v1/subnets/${NETUID}/deregistrations`),
@@ -5269,17 +5211,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/deregistrations`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountTransfers: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountTransfers: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", transfers: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountTransfers(
         req(`/api/v1/accounts/${SS58}/transfers`),
@@ -5288,16 +5230,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/transfers`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountCounterparties: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountCounterparties: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () => Response.json({ schema_version: 1, marker: "pg" }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountCounterparties(
         req(`/api/v1/accounts/${SS58}/counterparties`),
@@ -5306,7 +5249,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/counterparties`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
@@ -5369,15 +5314,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
   // directly with no Postgres tier at all -- silently serving data frozen
   // since the streamer stopped. Same pattern as the blocks above.
 
-  test("handleBlockExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleBlockExtrinsics: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg", extrinsics: [] },
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleBlockExtrinsics(
         req(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
@@ -5386,19 +5327,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/blocks/${BLOCK_NUM}/extrinsics`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleBlockEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleBlockEvents: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ blockEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg", events: [] },
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleBlockEvents(
         req(`/api/v1/blocks/${BLOCK_NUM}/events`),
@@ -5407,7 +5346,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/blocks/${BLOCK_NUM}/events`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
@@ -5415,7 +5356,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     const { env } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
     const tier = forbiddenDataApi();
-    env.DATA_API = tier.binding;
+    env.DATA_API = tier.DATA_API;
     // #9146: the blocks-summary projection is what serves this card now.
     env.METAGRAPH_ARCHIVE = {
       get: async () => ({
@@ -5432,17 +5373,15 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url("/api/v1/blocks/summary"),
       ),
     );
-    assert.deepEqual(tier.calls, []);
+    assert.deepEqual(tier.paths, []);
     assert.equal(body.data.marker, "projection");
   });
 
-  test("handleAccountExtrinsics: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountExtrinsics: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ extrinsics: [extrinsicRow()] });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", extrinsics: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountExtrinsics(
         req(`/api/v1/accounts/${SS58}/extrinsics`),
@@ -5451,19 +5390,19 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/extrinsics`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSudo: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSudo: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({
       extrinsics: [extrinsicRow({ call_module: "Sudo" })],
     });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", extrinsics: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSudo(
         req("/api/v1/sudo"),
@@ -5471,19 +5410,19 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url("/api/v1/sudo"),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleGovernanceConfigChanges: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleGovernanceConfigChanges: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({
       extrinsics: [extrinsicRow({ call_module: "AdminUtils" })],
     });
     env.METAGRAPH_EXTRINSICS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", extrinsics: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleGovernanceConfigChanges(
         req("/api/v1/governance/config-changes"),
@@ -5491,7 +5430,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url("/api/v1/governance/config-changes"),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
@@ -5499,7 +5440,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     const { env } = dbWith({ blocksFeed: [blockRow()] });
     env.METAGRAPH_BLOCKS_SOURCE = "postgres";
     const tier = forbiddenDataApi();
-    env.DATA_API = tier.binding;
+    env.DATA_API = tier.DATA_API;
     Object.assign(env, LAKEHOUSE_TOKEN);
     // #9265: `chain.blocks` carries spec_version, so the timeline is real.
     const restore = lakehouse(() => [
@@ -5513,7 +5454,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
           url("/api/v1/runtime"),
         ),
       );
-      assert.deepEqual(tier.calls, []);
+      assert.deepEqual(tier.paths, []);
       assert.equal(body.data.current_spec_version, 423);
     } finally {
       restore();
@@ -5630,13 +5571,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
   // #4832 Tier 1b: the remaining account_events-derived handlers with no
   // Postgres tier at all -- same pattern as Tier 1a above.
 
-  test("handleSubnetWeights: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetWeights: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", weight_sets: 0 }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetWeights(
         req(`/api/v1/subnets/${NETUID}/weights`),
@@ -5645,20 +5584,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/weights`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetAlphaVolume: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetAlphaVolume: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({
-          data: { schema_version: 1, marker: "pg" },
-          generatedAt: null,
-        }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetAlphaVolume(
         req(`/api/v1/subnets/${NETUID}/volume`),
@@ -5666,17 +5602,17 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         NETUID,
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetEvents: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetEvents: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ subnetEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", events: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetEvents(
         req(`/api/v1/subnets/${NETUID}/events`),
@@ -5685,20 +5621,20 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/events`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleSubnetEventSummary: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleSubnetEventSummary: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({
       subnetEventSummaryKinds: [],
       subnetEventSummaryRecent: [],
     });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", event_kinds: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleSubnetEventSummary(
         req(`/api/v1/subnets/${NETUID}/event-summary`),
@@ -5707,20 +5643,20 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/subnets/${NETUID}/event-summary`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 
   // #4832 Tier 1c: handleAccount (multi-table: account_events + neurons +
   // extrinsics) and handleAccountSubnets (neurons-derived).
 
-  test("handleAccount: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccount: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({ accountEvents: [accountEventRow()] });
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", event_count: 0 }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccount(
         req(`/api/v1/accounts/${SS58}`),
@@ -5728,8 +5664,13 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         SS58,
       ),
     );
-    assert.equal(body.data.marker, "pg");
-    assert.deepEqual(captures.sql, []);
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
+    // The store read this used to assert AWAY is now the answer: the tier
+    // short-circuited it, and with the tier gone the composer reads the store
+    // itself. Asserting it happened is the honest inverse of the old claim.
+    assert.ok(captures.sql.length > 0);
   });
 
   test("handleAccountSubnets: flag=postgres uses Postgres data, D1 never queried", async () => {
@@ -6333,13 +6274,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
   // #4832 gap-closure: handleAccountHistory (account_events_daily, now
   // populated by a dedicated hourly Postgres-side rollup route).
 
-  test("handleAccountHistory: flag=postgres uses Postgres data, D1 never queried", async () => {
+  test("handleAccountHistory: the retired tier flag is not consulted even when set (#10190)", async () => {
     const { env, captures } = dbWith({});
     env.METAGRAPH_ACCOUNT_EVENTS_SOURCE = "postgres";
-    env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", days: [] }),
-    };
+    const tier = forbiddenDataApi();
+    env.DATA_API = tier.DATA_API;
     const body = await json(
       await handleAccountHistory(
         req(`/api/v1/accounts/${SS58}/history`),
@@ -6348,7 +6287,9 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         url(`/api/v1/accounts/${SS58}/history`),
       ),
     );
-    assert.equal(body.data.marker, "pg");
+    // Nothing asks the binding, and the answer carries none of its marker.
+    assert.deepEqual(tier.paths, []);
+    assert.equal(body.data.marker, undefined);
     assert.deepEqual(captures.sql, []);
   });
 

--- a/tests/subnet-ohlc.test.ts
+++ b/tests/subnet-ohlc.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
+import { afterEach, describe, test } from "vitest";
 import {
   buildSubnetOhlc,
   buildSubnetOhlcFromBuckets,
@@ -617,35 +618,24 @@ describe("GET /api/v1/subnets/{netuid}/ohlc via the Worker", () => {
   });
 
   test("flag=postgres routes through DATA_API and unwraps {data, generatedAt}", async () => {
-    const env = {
-      ...createLocalArtifactEnv(),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: {
-              schema_version: 1,
-              netuid: 7,
-              interval: "1h",
-              candles: [
-                {
-                  bucket_start: BASE,
-                  bucket_start_iso: new Date(BASE).toISOString(),
-                  open: 1,
-                  high: 1,
-                  low: 1,
-                  close: 1,
-                  volume_alpha: 5,
-                  volume_tao: 5,
-                  event_count: 1,
-                },
-              ],
-              root_excluded: false,
-            },
-            generatedAt: "2026-07-01T00:00:00.000Z",
-          }),
+    // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was
+    // never asked. loadSubnetOhlcColdTier answers, and the candle below is what
+    // the SAME builder makes of the lane's own bucket row.
+    const lake = lakehouse([
+      {
+        bucket_start: BASE,
+        open_price: 1,
+        close_price: 1,
+        high_price: 1,
+        low_price: 1,
+        volume_alpha: 5,
+        volume_tao: 5,
+        event_count: 1,
+        newest_observed: BASE,
       },
-    };
+    ]);
+    const env = { ...createLocalArtifactEnv(), ...LAKEHOUSE_ENV };
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/subnets/7/ohlc"),
       env as unknown as Env,
@@ -655,7 +645,9 @@ describe("GET /api/v1/subnets/{netuid}/ohlc via the Worker", () => {
     const body = await res.json();
     assert.equal(body.data.candles.length, 1);
     assert.equal(body.data.candles[0].volume_alpha, 5);
-    assert.equal(body.meta.generated_at, "2026-07-01T00:00:00.000Z");
+    // The retired tier carried its own `generatedAt`; the cold tier has no such
+    // stamp, so the envelope's generated_at is the route's own.
+    assert.ok("generated_at" in body.meta);
   });
 
   // The route stopped serving candles when Postgres went away; the lakehouse
@@ -777,37 +769,32 @@ describe("buildSubnetOhlcFromBuckets", () => {
 
 describe("GET /api/v1/subnets/{netuid}/ohlc carries USD", () => {
   const BUCKET = Date.parse("2026-08-08T00:00:00.000Z");
-  const ohlcTierEnv = () =>
-    ({
-      ...createLocalArtifactEnv(),
-      METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-      DATA_API: {
-        fetch: async () =>
-          Response.json({
-            data: {
-              schema_version: 1,
-              netuid: 7,
-              interval: "1h",
-              candles: [
-                {
-                  bucket_start: BUCKET,
-                  bucket_start_iso: new Date(BUCKET).toISOString(),
-                  open: 0.08,
-                  high: 0.09,
-                  low: 0.07,
-                  close: 0.088,
-                  volume_alpha: 100,
-                  volume_tao: 12.5,
-                  event_count: 3,
-                },
-              ],
-              candle_count: 1,
-              root_excluded: false,
-            },
-            generatedAt: null,
-          }),
+  // #10190: the tier is retired; loadSubnetOhlcColdTier answers, so the candle
+  // the USD overlay decorates is built from the lane's own bucket row.
+  let lake: ReturnType<typeof lakehouse> | undefined;
+  afterEach(() => {
+    lake?.restore();
+    lake = undefined;
+  });
+  const ohlcTierEnv = () => {
+    lake = lakehouse([
+      {
+        bucket_start: BUCKET,
+        open_price: 0.08,
+        high_price: 0.09,
+        low_price: 0.07,
+        close_price: 0.088,
+        volume_alpha: 100,
+        volume_tao: 12.5,
+        event_count: 3,
+        newest_observed: BUCKET,
       },
-    }) as unknown as Env;
+    ]);
+    return {
+      ...createLocalArtifactEnv(),
+      ...LAKEHOUSE_ENV,
+    } as unknown as Env;
+  };
 
   test("every candle carries the USD keys, even with no index behind them", async () => {
     // The index is unreachable in this env, which is exactly the case that

--- a/tests/subnet-ohlc.test.ts
+++ b/tests/subnet-ohlc.test.ts
@@ -648,6 +648,7 @@ describe("GET /api/v1/subnets/{netuid}/ohlc via the Worker", () => {
     // The retired tier carried its own `generatedAt`; the cold tier has no such
     // stamp, so the envelope's generated_at is the route's own.
     assert.ok("generated_at" in body.meta);
+    lake.restore();
   });
 
   // The route stopped serving candles when Postgres went away; the lakehouse

--- a/tests/sudo.test.ts
+++ b/tests/sudo.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import type { Row } from "./row-type.ts";
@@ -88,34 +89,26 @@ test("GET /api/v1/sudo is schema-stable when D1 is cold (never 404)", async () =
 });
 
 test("GET /api/v1/sudo?format=csv exports the filtered rows via the Postgres tier", async () => {
-  const env = {
-    METAGRAPH_EXTRINSICS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          schema_version: 1,
-          extrinsic_count: 1,
-          limit: 50,
-          offset: 0,
-          next_cursor: null,
-          extrinsics: [
-            {
-              block_number: 200,
-              extrinsic_index: 1,
-              extrinsic_hash: `0x${"a".repeat(64)}`,
-              signer: "5SudoKey",
-              call_module: "Sudo",
-              call_function: "sudo",
-              call_args: null,
-              success: true,
-              fee_tao: 0.000123,
-              tip_tao: 0,
-              observed_at: new Date(1750009000000).toISOString(),
-            },
-          ],
-        }),
+  // #10190: METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was never asked.
+  // The lakehouse cold tier answers, and it feeds the SAME buildExtrinsicFeed --
+  // so the CSV below is produced from lakehouse rows exactly as in production.
+  const lake = lakehouse([
+    {
+      block_number: 200,
+      extrinsic_index: 1,
+      extrinsic_hash: `0x${"a".repeat(64)}`,
+      signer: "5SudoKey",
+      call_module: "Sudo",
+      call_function: "sudo",
+      call_args: null,
+      success: true,
+      fee_tao: 0.000123,
+      tip_tao: 0,
+      observed_at: new Date(1750009000000).toISOString(),
     },
-  };
+  ]);
+  const env = { ...LAKEHOUSE_ENV };
   const res = await handleRequest(
     req("/api/v1/sudo?format=csv"),
     env as unknown as Env,
@@ -126,4 +119,5 @@ test("GET /api/v1/sudo?format=csv exports the filtered rows via the Postgres tie
   const lines = (await res.text()).trim().split("\r\n");
   assert.equal(lines.length, 2);
   assert.match(lines[1], /^200-1,200,5SudoKey,Sudo,sudo,true/);
+  lake.restore();
 });

--- a/tests/validator-nominators-csv.test.ts
+++ b/tests/validator-nominators-csv.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { lakehouse, LAKEHOUSE_ENV } from "./helpers/cold-tier-env.ts";
 import { test } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -25,36 +26,21 @@ test("GET /validators/{hotkey}/nominators?format=csv emits a header-only CSV whe
 });
 
 test("GET /validators/{hotkey}/nominators?format=csv exports the ranked nominator rows via the Postgres tier", async () => {
-  const env = {
-    ...createLocalArtifactEnv(),
-    METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
-    DATA_API: {
-      fetch: async () =>
-        Response.json({
-          data: {
-            schema_version: 1,
-            hotkey: HOTKEY,
-            window: "30d",
-            sort: "net_staked",
-            limit: 20,
-            offset: 0,
-            nominator_count: 1,
-            nominators: [
-              {
-                coldkey: "5CoLdKeyExampleAddress000000000000000000000000",
-                staked_tao: 1200.5,
-                unstaked_tao: 200.25,
-                net_staked_tao: 1000.25,
-                gross_staked_tao: 1400.75,
-                event_count: 7,
-                last_observed_at: new Date(1750000000000).toISOString(),
-              },
-            ],
-          },
-          generatedAt: new Date(1750000000000).toISOString(),
-        }),
+  // #10190: METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier this doubled was
+  // never asked. The lakehouse cold tier answers, through the same builder.
+  const lake = lakehouse([
+    {
+      coldkey: "5CoLdKeyExampleAddress000000000000000000000000",
+      staked_tao: 1200.5,
+      unstaked_tao: 200.25,
+      net_staked_tao: 1000.25,
+      gross_staked_tao: 1400.75,
+      event_count: 7,
+      last_observed_at: new Date(1750000000000).toISOString(),
     },
-  };
+  ]);
+  const env = { ...createLocalArtifactEnv(), ...LAKEHOUSE_ENV };
   const res = await handleRequest(
     req(`/api/v1/validators/${HOTKEY}/nominators?format=csv&window=30d`),
     env as unknown as Env,

--- a/tests/validator-nominators-csv.test.ts
+++ b/tests/validator-nominators-csv.test.ts
@@ -55,6 +55,7 @@ test("GET /validators/{hotkey}/nominators?format=csv exports the ranked nominato
     lines[1],
     /^5CoLdKeyExampleAddress[0]+,1200\.5,200\.25,1000\.25,1400\.75,7,/,
   );
+  lake.restore();
 });
 
 test("GET /validators/{hotkey}/nominators rejects an invalid ?format with 400", async () => {

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -404,30 +404,26 @@ export async function handleUptime(
   // tier miss now reads the dual-written surface_uptime_daily copy in D1
   // through loadSubnetUptime; with no binding that loader degrades to the
   // same schema-stable empty payload this served since 2026-07-17.
-  let isFallback = false;
-  let data = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_HEALTH_SOURCE",
-  )) as ReturnType<typeof formatUptime> | null;
-  if (!data) {
-    // Cacheable when D1-served — only an empty payload (no binding, or a D1
-    // read failure mid-load) is barred from the edge cache (see
-    // handleHealthTrends in analytics.ts).
-    const d1Generation = currentD1ReadFailureGeneration();
-    const healthMeta = await readHealthMetaKv(env);
-    data = (await loadSubnetUptime(netuid, {
-      window: windowParam,
-      observedAt: healthMeta?.last_run_at || null,
-      minSamples: (minSamples as number | undefined) ?? null,
-      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-    } as unknown as Parameters<typeof loadSubnetUptime>[1])) as ReturnType<
-      typeof formatUptime
-    >;
-    isFallback =
-      !env.HYPERDRIVE?.connectionString ||
-      currentD1ReadFailureGeneration() !== d1Generation;
-  }
+  // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc and is
+  // absent from DATA_API_FORWARD_FLAGS, so the tier read that used to
+  // initialise `data` resolved to null on every request -- which made the
+  // branch below the only path, not the fallback.
+  // Cacheable when D1-served — only an empty payload (no binding, or a D1
+  // read failure mid-load) is barred from the edge cache (see
+  // handleHealthTrends in analytics.ts).
+  const d1Generation = currentD1ReadFailureGeneration();
+  const healthMeta = await readHealthMetaKv(env);
+  const data = (await loadSubnetUptime(netuid, {
+    window: windowParam,
+    observedAt: healthMeta?.last_run_at || null,
+    minSamples: (minSamples as number | undefined) ?? null,
+    db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+  } as unknown as Parameters<typeof loadSubnetUptime>[1])) as ReturnType<
+    typeof formatUptime
+  >;
+  const isFallback =
+    !env.HYPERDRIVE?.connectionString ||
+    currentD1ReadFailureGeneration() !== d1Generation;
   if (csvRequested(url, request)) {
     const csvRes = await csvResponse(
       uptimeCsvRows(data.surfaces),
@@ -856,13 +852,10 @@ export async function handleCompare(
         const pgUrl = new URL(request.url);
         pgUrl.pathname = "/api/v1/internal/compare-health";
         pgUrl.search = `?netuids=${requestedNetuids.join(",")}`;
-        const pgData = await tryPostgresTier(
-          env,
-          new Request(pgUrl),
-          "METAGRAPH_HEALTH_SOURCE",
-        );
-        if (pgData)
-          return pgData.rows as Array<Record<string, unknown>> | undefined;
+        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so the tier
+        // read that guarded this early return resolved to null on every call --
+        // the health leg has always been a fallback here.
         healthIsFallback = true;
         return [];
       })()

--- a/workers/request-handlers/analytics-routes.ts
+++ b/workers/request-handlers/analytics-routes.ts
@@ -77,6 +77,9 @@ import {
   buildDomainSummary,
 } from "../../src/domain-summary.ts";
 import { readStore } from "../../src/read-store.ts";
+import { COMPARE_SUBNETS_TABLES } from "../../src/read-store-tables.ts";
+import { d1All } from "../../src/analytics-live.ts";
+import { surfaceStatusAvgLatencySql } from "../../src/health-sql.ts";
 import {
   LEADERBOARD_TABLES,
   TAO_USD_TABLES,
@@ -846,18 +849,39 @@ export async function handleCompare(
   // caller's netuids=/dimensions= request unchanged (tryPostgresTier's usual
   // contract). D1 fully eliminated (2026-07-17): a tier miss now always
   // falls through to an empty row set (never a live D1 query).
+  // NO TIER READ (#10190), AND IT HAD NO RUNG. This synthesized an internal
+  // /api/v1/internal/compare-health request for METAGRAPH_HEALTH_SOURCE, a flag
+  // that reads "d1" and is absent from DATA_API_FORWARD_FLAGS -- so the read
+  // resolved to null and this leg returned `[]` on every request. The health
+  // dimension has been publishing `health: null` for every subnet while the
+  // get_compare_subnets MCP tool served real numbers for the same netuids, off
+  // the same table. That flag cannot be widened either: the same flag gates
+  // three routes data-api does not implement (see src/health-status-live.ts).
+  //
+  // So it reads `surface_status` directly, through the same store read and the
+  // same grouping loadCompareSubnets uses for MCP -- one source, two surfaces.
   let healthIsFallback = false;
   const healthPromise = dimensions.includes("health")
     ? (async () => {
-        const pgUrl = new URL(request.url);
-        pgUrl.pathname = "/api/v1/internal/compare-health";
-        pgUrl.search = `?netuids=${requestedNetuids.join(",")}`;
-        // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in
-        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so the tier
-        // read that guarded this early return resolved to null on every call --
-        // the health leg has always been a fallback here.
-        healthIsFallback = true;
-        return [];
+        const wanted = new Set(
+          requestedNetuids.map((netuid) => Number(netuid)),
+        );
+        const grouped = await d1All(
+          readStore(env, COMPARE_SUBNETS_TABLES) as never,
+          `SELECT netuid,
+                  COUNT(*) AS surface_count,
+                  SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+                  ${surfaceStatusAvgLatencySql({ rounded: true })} AS avg_latency_ms
+           FROM surface_status
+           GROUP BY netuid`,
+          [],
+        );
+        const rows = grouped.filter((row: Record<string, unknown>) =>
+          wanted.has(Number(row.netuid)),
+        );
+        // A store that cannot answer is a fallback, exactly as a tier miss was.
+        healthIsFallback = rows.length === 0;
+        return rows;
       })()
     : null;
   const [economicsRows, healthRows] = await Promise.all([

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -57,10 +57,7 @@ import {
   envelopeResponse,
   publishedAt,
 } from "../responses.ts";
-import {
-  currentPostgresTierFallbackGeneration,
-  tryPostgresTier,
-} from "../postgres-tier.ts";
+import { currentPostgresTierFallbackGeneration } from "../postgres-tier.ts";
 import { currentR2SqlFailureGeneration } from "../../src/r2-sql.ts";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
 import {} from "../../src/route-limits.ts";
@@ -678,34 +675,27 @@ export async function handleBulkHealthTrends(
       // and surface_uptime_daily holds 1,182 rows spanning 2026-07-11 through
       // 2026-07-16, a full rolling window. See wrangler.jsonc's own comment on
       // this flag for the complete verification writeup.
-      let isFallback = false;
-      let data = (await tryPostgresTier(
-        env,
-        cacheRequest,
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Awaited<ReturnType<typeof loadBulkHealthTrends>>["data"] | null;
-      if (!data) {
-        // D1-served payloads are cacheable; only a genuinely empty one is not.
-        // `isFallback` bars the edge cache, so it must mean "this payload is
-        // the schema-stable empty", not merely "the Postgres tier missed" --
-        // since 2026-08-03 a tier miss is the NORMAL path and D1 answers it
-        // with real rows. Mirrors handleSubnetUptime in analytics-routes.ts.
-        const d1Generation = currentD1ReadFailureGeneration();
-        const result = await loadBulkHealthTrends({
-          observedAt: meta?.last_run_at || null,
-          db: observationsReadDb(
-            env as unknown as Record<string, unknown>,
-            ctx,
-          ),
-          window: trendsWindow ?? null,
-          limit: trendsLimit ?? null,
-          offset: trendsOffset ?? 0,
-        });
-        data = result.data;
-        isFallback =
-          !env.HYPERDRIVE?.connectionString ||
-          currentD1ReadFailureGeneration() !== d1Generation;
-      }
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc and is
+      // absent from DATA_API_FORWARD_FLAGS, so the tier read that used to
+      // initialise `data` resolved to null on every request -- which made the
+      // branch below the only path, not the fallback.
+      // D1-served payloads are cacheable; only a genuinely empty one is not.
+      // `isFallback` bars the edge cache, so it must mean "this payload is
+      // the schema-stable empty", not merely "the Postgres tier missed" --
+      // since 2026-08-03 a tier miss is the NORMAL path and D1 answers it
+      // with real rows. Mirrors handleSubnetUptime in analytics-routes.ts.
+      const d1Generation = currentD1ReadFailureGeneration();
+      const result = await loadBulkHealthTrends({
+        observedAt: meta?.last_run_at || null,
+        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+        window: trendsWindow ?? null,
+        limit: trendsLimit ?? null,
+        offset: trendsOffset ?? 0,
+      });
+      const data = result.data;
+      const isFallback =
+        !env.HYPERDRIVE?.connectionString ||
+        currentD1ReadFailureGeneration() !== d1Generation;
       const response = await envelopeResponse(
         cacheRequest,
         {
@@ -744,34 +734,30 @@ export async function handleHealthTrends(
   // route takes no params and returns all configured windows.
   return withEdgeCache(request, ctx, env, "trends", async (cacheRequest) => {
     // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
-    let usedFallback = false;
-    let data = (await tryPostgresTier(
-      env,
-      cacheRequest,
-      "METAGRAPH_HEALTH_SOURCE",
-    )) as Awaited<ReturnType<typeof loadSubnetHealthTrends>> | null;
-    if (!data) {
-      // Read through the shared d1All (rather than handing the loader the bare
-      // db) so a failure is still logged + marked as a D1 fallback (the
-      // dark-serve log contract) — a Postgres-tier miss now falls straight
-      // through to the pure formatter with no rows (never a live D1 query),
-      // so it's always marked a fallback (never edge-cache a schema-stable
-      // empty payload).
-      // Only an EMPTY payload is barred from the edge cache — no D1 binding,
-      // or a D1 read that failed mid-load (tracked by the failure generation,
-      // the same contract the Postgres tier uses). A D1-served response
-      // carries real rows and caches like any tier hit (the pre-elimination
-      // behavior this route always had).
-      const d1Generation = currentD1ReadFailureGeneration();
-      const meta = await readHealthMetaKv(env);
-      data = await loadSubnetHealthTrends(netuid, {
-        observedAt: meta?.last_run_at || null,
-        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
-      } as unknown as Parameters<typeof loadSubnetHealthTrends>[1]);
-      usedFallback =
-        !env.HYPERDRIVE?.connectionString ||
-        currentD1ReadFailureGeneration() !== d1Generation;
-    }
+    // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc and is
+    // absent from DATA_API_FORWARD_FLAGS, so the tier read that used to
+    // initialise `data` resolved to null on every request -- which made the
+    // branch below the only path, not the fallback.
+    // Read through the shared d1All (rather than handing the loader the bare
+    // db) so a failure is still logged + marked as a D1 fallback (the
+    // dark-serve log contract) — a Postgres-tier miss now falls straight
+    // through to the pure formatter with no rows (never a live D1 query),
+    // so it's always marked a fallback (never edge-cache a schema-stable
+    // empty payload).
+    // Only an EMPTY payload is barred from the edge cache — no D1 binding,
+    // or a D1 read that failed mid-load (tracked by the failure generation,
+    // the same contract the Postgres tier uses). A D1-served response
+    // carries real rows and caches like any tier hit (the pre-elimination
+    // behavior this route always had).
+    const d1Generation = currentD1ReadFailureGeneration();
+    const meta = await readHealthMetaKv(env);
+    const data = await loadSubnetHealthTrends(netuid, {
+      observedAt: meta?.last_run_at || null,
+      db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+    } as unknown as Parameters<typeof loadSubnetHealthTrends>[1]);
+    const usedFallback =
+      !env.HYPERDRIVE?.connectionString ||
+      currentD1ReadFailureGeneration() !== d1Generation;
     const response = await envelopeResponse(
       cacheRequest,
       {
@@ -810,31 +796,24 @@ export async function handleHealthPercentiles(
     "percentiles",
     async (cacheRequest) => {
       // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
-      let usedFallback = false;
-      let data = (await tryPostgresTier(
-        env,
-        cacheRequest,
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Awaited<ReturnType<typeof loadSubnetPercentiles>> | null;
-      if (!data) {
-        // A Postgres-tier miss now falls straight through to the pure
-        // formatter with no rows (never a live D1 query), so it's always
-        // marked a fallback (mirrors handleHealthTrends).
-        // Cacheable when D1-served — see handleHealthTrends' comment.
-        const d1Generation = currentD1ReadFailureGeneration();
-        const meta = await readHealthMetaKv(env);
-        data = await loadSubnetPercentiles(netuid, {
-          window: label,
-          observedAt: meta?.last_run_at || null,
-          db: observationsReadDb(
-            env as unknown as Record<string, unknown>,
-            ctx,
-          ),
-        } as unknown as Parameters<typeof loadSubnetPercentiles>[1]);
-        usedFallback =
-          !env.HYPERDRIVE?.connectionString ||
-          currentD1ReadFailureGeneration() !== d1Generation;
-      }
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc and is
+      // absent from DATA_API_FORWARD_FLAGS, so the tier read that used to
+      // initialise `data` resolved to null on every request -- which made the
+      // branch below the only path, not the fallback.
+      // A Postgres-tier miss now falls straight through to the pure
+      // formatter with no rows (never a live D1 query), so it's always
+      // marked a fallback (mirrors handleHealthTrends).
+      // Cacheable when D1-served — see handleHealthTrends' comment.
+      const d1Generation = currentD1ReadFailureGeneration();
+      const meta = await readHealthMetaKv(env);
+      const data = await loadSubnetPercentiles(netuid, {
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+      } as unknown as Parameters<typeof loadSubnetPercentiles>[1]);
+      const usedFallback =
+        !env.HYPERDRIVE?.connectionString ||
+        currentD1ReadFailureGeneration() !== d1Generation;
       const response = await envelopeResponse(
         cacheRequest,
         {
@@ -871,31 +850,24 @@ export async function handleHealthIncidents(
     "incidents",
     async (cacheRequest) => {
       // See handleBulkHealthTrends' own comment on METAGRAPH_HEALTH_SOURCE.
-      let usedFallback = false;
-      let data = (await tryPostgresTier(
-        env,
-        cacheRequest,
-        "METAGRAPH_HEALTH_SOURCE",
-      )) as Awaited<ReturnType<typeof loadSubnetIncidents>> | null;
-      if (!data) {
-        // A Postgres-tier miss now falls straight through to the pure
-        // formatter with no rows (never a live D1 query), so it's always
-        // marked a fallback (mirrors handleHealthTrends / handleHealthPercentiles).
-        // Cacheable when D1-served — see handleHealthTrends' comment.
-        const d1Generation = currentD1ReadFailureGeneration();
-        const meta = await readHealthMetaKv(env);
-        data = await loadSubnetIncidents(netuid, {
-          window: label,
-          observedAt: meta?.last_run_at || null,
-          db: observationsReadDb(
-            env as unknown as Record<string, unknown>,
-            ctx,
-          ),
-        } as unknown as Parameters<typeof loadSubnetIncidents>[1]);
-        usedFallback =
-          !env.HYPERDRIVE?.connectionString ||
-          currentD1ReadFailureGeneration() !== d1Generation;
-      }
+      // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc and is
+      // absent from DATA_API_FORWARD_FLAGS, so the tier read that used to
+      // initialise `data` resolved to null on every request -- which made the
+      // branch below the only path, not the fallback.
+      // A Postgres-tier miss now falls straight through to the pure
+      // formatter with no rows (never a live D1 query), so it's always
+      // marked a fallback (mirrors handleHealthTrends / handleHealthPercentiles).
+      // Cacheable when D1-served — see handleHealthTrends' comment.
+      const d1Generation = currentD1ReadFailureGeneration();
+      const meta = await readHealthMetaKv(env);
+      const data = await loadSubnetIncidents(netuid, {
+        window: label,
+        observedAt: meta?.last_run_at || null,
+        db: observationsReadDb(env as unknown as Record<string, unknown>, ctx),
+      } as unknown as Parameters<typeof loadSubnetIncidents>[1]);
+      const usedFallback =
+        !env.HYPERDRIVE?.connectionString ||
+        currentD1ReadFailureGeneration() !== d1Generation;
       const response = await envelopeResponse(
         cacheRequest,
         {
@@ -977,12 +949,9 @@ export async function resolveGlobalIncidents(
   env: Env,
   { label = "7d", days = 7 }: { label?: string; days?: number } = {},
 ): Promise<{ data: Record<string, unknown>; isFallback: boolean }> {
-  const tiered = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_HEALTH_SOURCE",
-  )) as Record<string, unknown> | null;
-  if (tiered) return { data: tiered, isFallback: false };
+  // NO TIER READ (#10190): METAGRAPH_HEALTH_SOURCE reads "d1" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier read that guarded an
+  // early return here resolved to null before it could touch DATA_API.
   const d1Generation = currentD1ReadFailureGeneration();
   const result = await loadGlobalIncidentsLedger(env, { label, days });
   return {
@@ -1297,20 +1266,18 @@ export async function handleChainActivity(
       // partial today plus a partial tail day). Trim to the window the caller
       // actually asked for so day_count can't contradict the window label.
       const data = trimChainActivityToWindow(
-        ((await tryPostgresTier(
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
+        // The projection tier (#9146): a cron recomputes this window's
+        // daily series from the lakehouse; the reader feeds the same
+        // formatter, and the #8242 trim below applies to it exactly as it
+        // applies to a live answer. See src/chain-activity-artifact.ts.
+        (await loadChainActivityFromArtifact(
           env,
-          cacheRequest,
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) as ReturnType<typeof buildChainActivity> | null) ??
-          // The projection tier (#9146): a cron recomputes this window's
-          // daily series from the lakehouse; the reader feeds the same
-          // formatter, and the #8242 trim below applies to it exactly as it
-          // applies to a live answer. See src/chain-activity-artifact.ts.
-          (await loadChainActivityFromArtifact(
-            env,
-            { window: label },
-            network,
-          )) ??
+          { window: label },
+          network,
+        )) ??
           unmeasured(
             buildChainActivity({
               window: label,
@@ -1376,17 +1343,17 @@ export async function handleChainCalls(
       // (never edge-cache a schema-stable empty payload).
       let usedFallback = false;
       const meta = await readHealthMetaKv(env);
-      let data = (await tryPostgresTier(
-        env,
-        cacheRequest,
-        "METAGRAPH_EXTRINSICS_SOURCE",
-      )) as ReturnType<typeof buildChainCalls> | null;
-      // The projection tier (#9146): a cron recomputes this window's call
-      // mix (both group_by variants) from the lakehouse; the reader slices
-      // to the request's limit and feeds the same formatter, declining any
-      // call_module scope. A projected answer is a real answer, so it is
-      // never marked as a fallback. See src/chain-calls-artifact.ts.
-      data ??= await loadChainCallsFromArtifact(env, {
+      // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so the tier
+      // read that used to initialise `data` resolved to null on every request --
+      // the projection below has been the first rung that can answer.
+      //
+      // The projection tier (#9146): a cron recomputes this window's call mix
+      // (both group_by variants) from the lakehouse; the reader slices to the
+      // request's limit and feeds the same formatter, declining any call_module
+      // scope. A projected answer is a real answer, so it is never marked as a
+      // fallback. See src/chain-calls-artifact.ts.
+      let data = await loadChainCallsFromArtifact(env, {
         window: label,
         groupBy,
         limit,
@@ -1467,11 +1434,9 @@ export async function handleChainSigners(
       // the table is dropped in production, so a D1 query here would always
       // miss (#6013). Postgres → schema-stable empty stub, never a live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_EXTRINSICS_SOURCE",
-        )) as ReturnType<typeof buildChainSigners> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes this window's
         // leaderboard (both sorts) from the lakehouse; the reader slices to
         // the request's limit and feeds the same formatter, declining any
@@ -1559,11 +1524,9 @@ export async function handleChainTransfers(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainTransfers> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes this window's
         // scorecard from the lakehouse; the artifact reader slices to the
         // request's limit and feeds the same formatter. See
@@ -1655,11 +1618,9 @@ export async function handleChainTransferPairs(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainTransferPairs> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes this window's
         // corridor leaderboard (both sorts) from the lakehouse; the reader
         // slices to the request's limit and feeds the same formatter. See
@@ -1748,11 +1709,9 @@ export async function handleChainStakeFlow(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainStakeFlow> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes this window's
         // per-(netuid, event_kind) aggregate from the lakehouse; the shared
         // builder owns ranking and the limit. See
@@ -1853,11 +1812,9 @@ export async function handleChainAlphaVolume(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainAlphaVolume> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes the fixed 24h
         // per-(netuid, event_kind) aggregate from the lakehouse; the shared
         // builder owns ranking and the limit. See
@@ -1945,11 +1902,9 @@ export async function handleChainWeights(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainWeights> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // Same shared loader MCP and GraphQL call, so all three surfaces
         // answer from one implementation. Declines (null) rather than
         // half-answering, leaving the empty payload below as the fallback.
@@ -2025,11 +1980,9 @@ export async function handleChainWeightSetters(
       // and the table is dropped in production, so a D1 query here would
       // always miss. Postgres → schema-stable empty stub, never a live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainWeightSetters> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The same WeightsSet stream /chain/weights already reads, grouped one
         // level finer (#9249). Through the shared loader so MCP and GraphQL get
         // it too rather than being wired one surface at a time.
@@ -2099,11 +2052,9 @@ export async function handleChainServing(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainServing> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The box's Postgres is gone, so the tier above always misses. The
         // shared loader is the one MCP and GraphQL call too, so all three
         // surfaces answer from a single implementation rather than three
@@ -2180,11 +2131,9 @@ export async function handleChainPrometheus(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainPrometheus> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The rung this route never had (#10248). Its axon twin has read the
         // lakehouse rollup here since #9216; prometheus fell straight from a
         // tier that always misses to the empty stub, so it published a
@@ -2259,11 +2208,9 @@ export async function handleChainAxonRemovals(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainAxonRemovals> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         buildChainAxonRemovals([], {
           window: label,
           limit,
@@ -2331,11 +2278,9 @@ export async function handleChainRegistrations(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainRegistrations> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9146: served from the chain-registrations PROJECTION lane rather
         // than a request-time read. The request-time form cannot answer the
         // 30d window at all: R2 SQL rejects
@@ -2494,11 +2439,9 @@ export async function handleChainDeregistrations(
       // always miss (#6013). Postgres → schema-stable empty stub, never a
       // live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainDeregistrations> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // #9307: NeuronDeregistered has never been emitted, so the filter this
         // route was built on matched nothing and it published a permanent 0.
         // The feed is DERIVED from UID reuse in the NeuronRegistered stream by
@@ -2591,11 +2534,9 @@ export async function handleChainStakeMoves(
       // and the table is dropped in production, so a D1 query here would
       // always miss. Postgres → schema-stable empty stub, never a live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainStakeMoves> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes this window's
         // network DISTINCT row + per-subnet aggregate from the lakehouse;
         // the shared builder owns ranking, the rollup, and the limit. See
@@ -2677,11 +2618,9 @@ export async function handleChainStakeTransfers(
       // and the table is dropped in production, so a D1 query here would
       // always miss. Postgres → schema-stable empty stub, never a live D1 read.
       const data =
-        ((await tryPostgresTier(
-          env,
-          cacheRequest,
-          "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-        )) as ReturnType<typeof buildChainStakeTransfers> | null) ??
+        // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+        // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+        // resolved to null before it could touch DATA_API.
         // The projection tier (#9146): a cron recomputes this window's
         // network DISTINCT row + per-subnet aggregate from the lakehouse;
         // the shared builder owns ranking, the rollup, and the limit. See

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -1571,14 +1571,13 @@ export async function handleValidatorNominators(
   }
   // Postgres → lakehouse cold tier → schema-stable empty stub, the same three
   // steps every account_events-derived route now takes.
-  const { data, generatedAt } = ((await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as {
-    data: ReturnType<typeof buildValidatorNominators>;
-    generatedAt: string | null;
-  } | null) ??
+  const {
+    data,
+    generatedAt,
+  } = // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // before it could touch DATA_API.
+
     (await loadValidatorNominatorsColdTier(env, hotkey, {
       window: windowParam,
       sort,
@@ -2667,11 +2666,9 @@ export async function handleSubnetWeights(
     DEFAULT_SUBNET_WEIGHTS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetWeights> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // The cold tier its own /weights/setters sibling has had since #9267. Without
     // it this card answered a confident 0 for every subnet once the Postgres box
     // went away, while the leaderboard it summarises read 14 setters / 2,750 sets
@@ -2683,8 +2680,7 @@ export async function handleSubnetWeights(
         windowLabel: windowParam,
         windowDays: SUBNET_WEIGHTS_WINDOWS[windowParam] ?? 7,
       },
-    )) ??
-    buildSubnetWeights(null, netuid, { window: windowParam });
+    )) ?? buildSubnetWeights(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2725,11 +2721,9 @@ export async function handleSubnetWeightSetters(
     DEFAULT_SUBNET_WEIGHT_SETTERS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetWeightSetters> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #9267: the same WeightsSet stream the chain-wide leaderboard reads
     // (#9251), narrowed to this subnet.
     (await loadSubnetWeightSettersColdTier(
@@ -2740,8 +2734,7 @@ export async function handleSubnetWeightSetters(
         windowDays: SUBNET_WEIGHT_SETTERS_WINDOWS[windowParam] ?? 7,
         limit: SUBNET_WEIGHT_SETTERS_LIMIT,
       },
-    )) ??
-    buildSubnetWeightSetters([], null, netuid, { window: windowParam });
+    )) ?? buildSubnetWeightSetters([], null, netuid, { window: windowParam });
   // account_events-derived: the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed WeightsSet event, mirroring the sibling /weights route.
   return envelopeResponse(
@@ -2782,11 +2775,9 @@ export async function handleSubnetServing(
     DEFAULT_SUBNET_SERVING_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetServing> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
@@ -2799,8 +2790,7 @@ export async function handleSubnetServing(
         windowLabel: windowParam,
         windowDays: SUBNET_SERVING_WINDOWS[windowParam] ?? 7,
       },
-    )) ??
-    buildSubnetServing(null, netuid, { window: windowParam });
+    )) ?? buildSubnetServing(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonServed event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2842,11 +2832,9 @@ export async function handleSubnetPrometheus(
     DEFAULT_SUBNET_PROMETHEUS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetPrometheus> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #10322: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
     // reads "retired", so the tier above declines unconditionally and the zeroed
     // builder below was the only thing left -- a confident 0 for every subnet,
@@ -2864,8 +2852,7 @@ export async function handleSubnetPrometheus(
         windowLabel: windowParam,
         windowDays: SUBNET_PROMETHEUS_WINDOWS[windowParam] ?? 7,
       },
-    )) ??
-    buildSubnetPrometheus(null, netuid, { window: windowParam });
+    )) ?? buildSubnetPrometheus(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed PrometheusServed event, mirroring the sibling serving route.
   return envelopeResponse(
@@ -2907,11 +2894,9 @@ export async function handleSubnetStakeMoves(
     DEFAULT_SUBNET_STAKE_MOVES_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetStakeMoves> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
@@ -2924,8 +2909,7 @@ export async function handleSubnetStakeMoves(
         windowLabel: windowParam,
         windowDays: SUBNET_STAKE_MOVES_WINDOWS[windowParam] ?? 7,
       },
-    )) ??
-    buildSubnetStakeMoves(null, netuid, { window: windowParam });
+    )) ?? buildSubnetStakeMoves(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeMoved event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -2967,11 +2951,9 @@ export async function handleSubnetStakeTransfers(
     DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetStakeTransfers> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
@@ -2984,8 +2966,7 @@ export async function handleSubnetStakeTransfers(
         windowLabel: windowParam,
         windowDays: SUBNET_STAKE_TRANSFERS_WINDOWS[windowParam] ?? 7,
       },
-    )) ??
-    buildSubnetStakeTransfers(null, netuid, { window: windowParam });
+    )) ?? buildSubnetStakeTransfers(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed StakeTransferred event, mirroring the sibling stake-moves route.
   return envelopeResponse(
@@ -3026,11 +3007,9 @@ export async function handleSubnetRegistrations(
     DEFAULT_SUBNET_REGISTRATIONS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetRegistrations> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #9369: the cold tier this card never had. METAGRAPH_ACCOUNT_EVENTS_SOURCE
     // is "retired", so the tier above declines unconditionally and this was the
     // only thing left -- a confident 0 for every subnet.
@@ -3043,8 +3022,7 @@ export async function handleSubnetRegistrations(
         windowLabel: windowParam,
         windowDays: SUBNET_REGISTRATIONS_WINDOWS[windowParam] ?? 7,
       },
-    )) ??
-    buildSubnetRegistrations(null, netuid, { window: windowParam });
+    )) ?? buildSubnetRegistrations(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed NeuronRegistered event, mirroring the sibling stake-flow route.
   return envelopeResponse(
@@ -3085,11 +3063,9 @@ export async function handleSubnetAxonRemovals(
     DEFAULT_SUBNET_AXON_REMOVALS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetAxonRemovals> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     buildSubnetAxonRemovals(null, netuid, { window: windowParam });
   // account_events-derived, so the meta reports the event-stream source (accountMeta) with
   // generated_at the newest observed AxonInfoRemoved event, mirroring the sibling stake-flow route.
@@ -3131,11 +3107,9 @@ export async function handleSubnetDeregistrations(
     DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW,
   );
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetDeregistrations> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // #9307: derived from UID reuse in the NeuronRegistered stream, out of the
     // same projection rows the chain leaderboard ranks — NeuronDeregistered
     // has never been emitted, so the filter this card was built on matched
@@ -3184,22 +3158,19 @@ export async function handleSubnetStakeFlow(
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss
   // (#6016/#6017). Postgres → schema-stable empty stub.
-  const pgPayload = await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  );
-  // #9146: on a tier miss, slice this subnet out of the chain-stake-flow
+  // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+  // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so the tier arm
+  // below resolved to null on every request.
+  //
+  // #9146: slice this subnet out of the chain-stake-flow
   // projection rather than serving zeros -- that lane already groups by
   // (netuid, event_kind), so the numbers exist and were simply unread. The
   // reader declines (null) when it cannot answer faithfully, which keeps the
   // zeroed card as the floor.
-  const projected =
-    pgPayload ??
-    (await loadSubnetStakeFlowFromArtifact(env, netuid, {
-      window: windowParam,
-      direction,
-    }));
+  const projected = await loadSubnetStakeFlowFromArtifact(env, netuid, {
+    window: windowParam,
+    direction,
+  });
   const { data, generatedAt } = projected ?? {
     data: buildStakeFlow([], netuid, { window: windowParam }),
     generatedAt: null,
@@ -4091,14 +4062,13 @@ export async function handleSubnetAlphaVolume(
   netuid: number,
 ) {
   const marketCapTao = await resolveSubnetMarketCapTao(env, netuid);
-  const { data, generatedAt } = ((await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as {
-    data: ReturnType<typeof buildAlphaVolume>;
-    generatedAt: string | null;
-  } | null) ??
+  const {
+    data,
+    generatedAt,
+  } = // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // before it could touch DATA_API.
+
     // #9371: the projection tier its chain-wide sibling has had since #9146. The
     // Postgres tier is "retired" and declines unconditionally, so this card reported
     // 0 for every subnet while /chain/alpha-volume carried the same subnet's real
@@ -4154,14 +4124,13 @@ export async function handleSubnetOhlc(
   const interval = routeValue<string>(url, "interval");
   const daysResult = routeValue<number>(url, "days");
   const candleLimit = pageLimit(url);
-  const { data, generatedAt } = ((await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as {
-    data: ReturnType<typeof buildSubnetOhlc>;
-    generatedAt: string | null;
-  } | null) ??
+  const {
+    data,
+    generatedAt,
+  } = // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // before it could touch DATA_API.
+
     // Lakehouse cold tier (src/subnet-ohlc-cold-tier.ts): the SAME
     // StakeAdded/StakeRemoved trades, bucketed in SQL instead of in a row
     // loop, ending in the SAME candle assembler. ?days= is finally load-
@@ -4328,14 +4297,13 @@ export async function handleAccountStakeFlow(
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss
   // (#6016/#6017). Postgres → lakehouse cold tier → schema-stable empty stub.
-  const { data, generatedAt } = ((await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as {
-    data: ReturnType<typeof buildAccountStakeFlow>;
-    generatedAt: string | null;
-  } | null) ??
+  const {
+    data,
+    generatedAt,
+  } = // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+    // and is absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+    // before it could touch DATA_API.
+
     (await loadAccountStakeFlowColdTier(env, ss58, {
       window: windowParam,
       direction,
@@ -4399,14 +4367,10 @@ function makeAccountEventHandler({
   ) {
     const { label: windowParam } = resolveWindow(url, windows, defaultWindow);
     const { data, generatedAt } =
-      ((await tryPostgresTier(
-        env,
-        request,
-        "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-      )) as {
-        data: ReturnType<typeof build>;
-        generatedAt: string | null;
-      } | null) ??
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+      // and is absent from DATA_API_FORWARD_FLAGS, so this arm resolved to null
+      // before it could touch DATA_API.
+
       (coldTier ? await coldTier(env, ss58, windowParam) : null) ??
       (() => {
         const empty = build([], ss58, { window: windowParam });
@@ -4536,17 +4500,15 @@ export const handleAccountDeregistrations = makeAccountEventHandler({
 // zero (never 404); a tier that exists and could not answer → 503, never a
 // zeroed card (#9263 — see src/account-summary-card.ts).
 export async function handleAccount(request: Request, env: Env, ss58: string) {
-  const postgres = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as ReturnType<typeof buildAccountSummary> | null;
+  // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+  // guarded resolved to null before it could touch DATA_API.
   // #9254/#9263: both non-Postgres legs of the card, assembled in ONE place
   // shared with MCP and GraphQL. Without it a single tier miss zeroed every
   // field at once while this account's own /events and /subnets routes read
   // real rows — and it zeroed them silently, reporting a source as though it
   // had measured them.
-  const answer = postgres ? null : await answerAccountSummary(env, ss58);
+  const answer = await answerAccountSummary(env, ss58);
   if (answer?.kind === "gap") {
     return errorResponse(
       ACCOUNT_SUMMARY_GAP_CODE,
@@ -4559,8 +4521,7 @@ export async function handleAccount(request: Request, env: Env, ss58: string) {
     );
   }
   const data =
-    postgres ??
-    (answer?.kind === "answer" ? answer.data : buildAccountSummary(ss58, {}));
+    answer?.kind === "answer" ? answer.data : buildAccountSummary(ss58, {});
   // Community-contributable entity labels (#6739): additive field over the
   // baked entities.json artifact, joined by ss58 here rather than in either
   // upstream builder above (one join site instead of two). A missing/cold
@@ -4667,11 +4628,9 @@ export async function handleAccountEvents(
   const page = resolvePage(url);
   const { limit: parsedLimit, offset: parsedOffset } = page;
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildAccountEvents> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     (await loadAccountEventsColdTier(
       env,
       ss58,
@@ -4808,11 +4767,9 @@ export async function handleAccountHistory(
   // cursor that does not decode to a valid YYYYMMDD day is ignored (falls back to
   // the first page), preserving the never-throw contract.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildAccountHistory> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // The same account_events stream /events already reads, rolled up per UTC
     // day (#9315). Through the shared reader so MCP and GraphQL get it too.
     (await loadAccountHistoryColdTier(env, ss58, {
@@ -4822,8 +4779,7 @@ export async function handleAccountHistory(
       from,
       to,
       cursor: routeText(url, "cursor"),
-    })) ??
-    buildAccountHistory([], ss58, { limit, offset, nextCursor: null });
+    })) ?? buildAccountHistory([], ss58, { limit, offset, nextCursor: null });
   // CSV export mirrors handleAccountEvents/Extrinsics/Transfers: the rows are
   // already range/netuid-filtered and paginated, so the CSV path carries the
   // identical set the JSON path would (#5741). Cold → empty array → header-only.
@@ -4869,11 +4825,9 @@ export async function handleAccountExtrinsics(
   const page = resolvePage(url);
   const { limit: parsedLimit, offset: parsedOffset } = page;
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as ReturnType<typeof buildAccountExtrinsics> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     (await loadAccountExtrinsicsColdTier(env, ss58, {
       limit: parsedLimit,
       offset: parsedOffset,
@@ -4948,11 +4902,9 @@ export async function handleAccountTransfers(
   // the table is dropped in production, so a D1 query here would always miss.
   // Postgres → lakehouse cold tier → schema-stable empty stub.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildAccountTransfers> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     (await loadAccountTransfersColdTier(env, ss58, {
       limit,
       offset,
@@ -5041,11 +4993,10 @@ export async function handleAccountCounterparties(
       counterparty,
       { limit },
     );
-    const data = (await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) ??
+    const data =
+      // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+      // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+      // resolved to null before it could touch DATA_API.
       (await loadCounterpartyRelationshipColdTier(env, ss58, counterparty, {
         limit,
       })) ?? {
@@ -5066,18 +5017,16 @@ export async function handleAccountCounterparties(
         meta: await accountMeta(
           env,
           `/metagraph/accounts/${ss58}/counterparties.json`,
-          (data.relationship as Record<string, unknown>).last_seen_at,
+          data.relationship.last_seen_at,
         ),
       },
       "short",
     );
   }
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildCounterparties> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     (await loadAccountCounterpartiesColdTier(env, ss58, { limit })) ??
     buildCounterparties([], ss58, { limit });
   if (csvRequested(url, request)) {
@@ -5401,11 +5350,10 @@ export async function handleSubnetEvents(
   // it scans the largest table in the lakehouse, so it must not run when the
   // tier can answer.
   const tierResult =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as Record<string, unknown> | null) ?? null;
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
+    null;
   // Through the composer (src/subnet-events-answer.ts). This cascade used to
   // live here only, which is precisely why MCP and GraphQL published
   // event_count 0 for subnets this route served real rows for.
@@ -5458,11 +5406,9 @@ export async function handleSubnetEventSummary(
   const { limit: recentLimit = SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT } =
     routeQuery(url);
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-    )) as ReturnType<typeof buildSubnetEventSummary> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // The same account_events stream /subnets/{netuid}/events already reads,
     // rolled up by kind (#9303). Through the shared reader so MCP and GraphQL
     // get it too rather than being wired one surface at a time.
@@ -6555,32 +6501,27 @@ export async function handleBlockExtrinsics(
   const { limit, offset } = page;
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
-  const postgres = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_EXTRINSICS_SOURCE",
-  )) as { data: ReturnType<typeof buildBlockExtrinsics> } | null;
+  // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+  // guarded resolved to null before it could touch DATA_API.
   // #9208: hot tier above the decode seam, lakehouse at or below it, and a
   // DECLINE for a block neither can answer -- an empty extrinsics array is
   // indistinguishable from a block that genuinely had none, which is the exact
   // ambiguity this route used to produce for every recent block. Reached only
   // when the Postgres tier missed, so the lakehouse is still not queried on the
   // hot path.
-  const answer = postgres
-    ? null
-    : await answerBlockDetail(env, ref, {
-        hot: (height) =>
-          loadBlockExtrinsicsHotTier(env, ref, height, { limit, offset }),
-        cold: () =>
-          loadBlockExtrinsicsColdTier(env, ref, { limit, offset }, network),
-        isEmpty: isEmptyExtrinsicPayload,
-      });
+  const answer = await answerBlockDetail(env, ref, {
+    hot: (height) =>
+      loadBlockExtrinsicsHotTier(env, ref, height, { limit, offset }),
+    cold: () =>
+      loadBlockExtrinsicsColdTier(env, ref, { limit, offset }, network),
+    isEmpty: isEmptyExtrinsicPayload,
+  });
   if (answer?.kind === "gap") return chainDetailGapResponse(answer);
   const data =
-    postgres?.data ??
-    (answer?.kind === "answer"
+    answer?.kind === "answer"
       ? answer.data
-      : buildBlockExtrinsics([], ref, null, { limit, offset }));
+      : buildBlockExtrinsics([], ref, null, { limit, offset });
   // CSV reuses handleExtrinsics's transform + columns — buildBlockExtrinsics maps
   // the same formatExtrinsic row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
@@ -6629,29 +6570,23 @@ export async function handleBlockEvents(
   const { limit, offset } = page;
   // #4909 D1 retirement: account_events' D1 write path is retired (#4772) and
   // the table is dropped in production, so a D1 query here would always miss.
-  const postgres = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_ACCOUNT_EVENTS_SOURCE",
-  )) as { data: ReturnType<typeof buildBlockEvents> } | null;
+  // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+  // guarded resolved to null before it could touch DATA_API.
   // #9208, same hot/cold/decline routing as handleBlockExtrinsics above and for
   // the same reason -- and it matters more here, because a block CAN legitimately
   // emit zero account-scoped events, so an empty list is a plausible-looking lie.
-  const answer = postgres
-    ? null
-    : await answerBlockDetail(env, ref, {
-        hot: (height) =>
-          loadBlockEventsHotTier(env, ref, height, { limit, offset }),
-        cold: () =>
-          loadBlockEventsColdTier(env, ref, { limit, offset }, network),
-        isEmpty: isEmptyEventPayload,
-      });
+  const answer = await answerBlockDetail(env, ref, {
+    hot: (height) =>
+      loadBlockEventsHotTier(env, ref, height, { limit, offset }),
+    cold: () => loadBlockEventsColdTier(env, ref, { limit, offset }, network),
+    isEmpty: isEmptyEventPayload,
+  });
   if (answer?.kind === "gap") return chainDetailGapResponse(answer);
   const data =
-    postgres?.data ??
-    (answer?.kind === "answer"
+    answer?.kind === "answer"
       ? answer.data
-      : buildBlockEvents([], ref, null, { limit, offset }));
+      : buildBlockEvents([], ref, null, { limit, offset });
   // CSV reuses the account-events EVENTS_CSV_COLUMNS — buildBlockEvents maps the
   // same formatAccountEvent row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
@@ -6721,11 +6656,9 @@ export async function handleExtrinsics(
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as ReturnType<typeof buildExtrinsicFeed> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // call_hash has no column in the lakehouse table, so that filter cannot be
     // expressed there. Skipping the tier entirely when it is present is the
     // only honest option -- passing it through would silently ignore the
@@ -6753,8 +6686,7 @@ export async function handleExtrinsics(
           },
           network,
         )
-      : null) ??
-    buildExtrinsicFeed([], { limit, offset, nextCursor: null });
+      : null) ?? buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(
@@ -6798,11 +6730,9 @@ export async function handleSudo(request: Request, env: Env, url: URL) {
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as ReturnType<typeof buildExtrinsicFeed> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // The category predicate is data-api's own pathname->module mapping
     // ("Sudo"), expressed against the lakehouse verbatim -- same feed, same
     // cursor, one fixed filter.
@@ -6818,8 +6748,7 @@ export async function handleSudo(request: Request, env: Env, url: URL) {
       blockEnd: query.block_end ?? null,
       from: query.from ?? null,
       to: query.to ?? null,
-    })) ??
-    buildExtrinsicFeed([], { limit, offset, nextCursor: null });
+    })) ?? buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(
@@ -6866,11 +6795,9 @@ export async function handleGovernanceConfigChanges(
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
   const data =
-    ((await tryPostgresTier(
-      env,
-      request,
-      "METAGRAPH_EXTRINSICS_SOURCE",
-    )) as ReturnType<typeof buildExtrinsicFeed> | null) ??
+    // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in
+    // wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this arm
+    // resolved to null before it could touch DATA_API.
     // The category predicate is data-api's own pathname->module mapping
     // ("AdminUtils"), expressed against the lakehouse verbatim -- same feed, same
     // cursor, one fixed filter.
@@ -6886,8 +6813,7 @@ export async function handleGovernanceConfigChanges(
       blockEnd: query.block_end ?? null,
       from: query.from ?? null,
       to: query.to ?? null,
-    })) ??
-    buildExtrinsicFeed([], { limit, offset, nextCursor: null });
+    })) ?? buildExtrinsicFeed([], { limit, offset, nextCursor: null });
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(
@@ -7118,24 +7044,19 @@ export async function handleExtrinsic(
 ) {
   // #4909 D1 retirement: extrinsics' D1 write path is retired (#4772) and the
   // table is dropped in production, so a D1 query here would always miss.
-  const postgres = (await tryPostgresTier(
-    env,
-    request,
-    "METAGRAPH_EXTRINSICS_SOURCE",
-  )) as ReturnType<typeof buildExtrinsic> | null;
+  // NO TIER READ (#10190): METAGRAPH_EXTRINSICS_SOURCE reads "retired" in wrangler.jsonc
+  // and is absent from DATA_API_FORWARD_FLAGS, so the tier read this branch
+  // guarded resolved to null before it could touch DATA_API.
   // #9208: the composite `<block>-<index>` form is a POSITION and follows the
   // seam, declining in the gap; the hash form asks hot-then-cold and keeps its
   // schema-stable `extrinsic: null`, because a hash absent from a few-thousand-
   // block window proves nothing. See answerExtrinsicDetail for the argument.
-  const answer = postgres
-    ? null
-    : await answerExtrinsicDetail(env, ref, () =>
-        loadExtrinsicColdTier(env, ref, network),
-      );
+  const answer = await answerExtrinsicDetail(env, ref, () =>
+    loadExtrinsicColdTier(env, ref, network),
+  );
   if (answer?.kind === "gap") return chainDetailGapResponse(answer);
   const data =
-    postgres ??
-    (answer?.kind === "answer" ? answer.data : buildExtrinsic(undefined, ref));
+    answer?.kind === "answer" ? answer.data : buildExtrinsic(undefined, ref);
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #10190
Closes #10757

`tryPostgresTier` forwards only when the flag reads `"postgres"`, or reads
`"d1"` **and** is in `DATA_API_FORWARD_FLAGS`. Measured across all three
wrangler configs: no flag anywhere reads `"postgres"`, and the forward set is
exactly three — `METAGRAPH_NEURONS_SOURCE`, `METAGRAPH_SUBNET_HYPERPARAMS_SOURCE`,
`METAGRAPH_ACCOUNT_IDENTITY_SOURCE`. Every other call resolved to `null` before
it could touch the binding.

This deletes those calls, fixes what the deletions expose, and repoints the
tests at the readers that actually serve.

## The defects, each measured

**`/chain/{serving,weights,prometheus}` published a network rollup that scaled
with `?limit=`.** Those cards derive `network.*` and `intensity_distribution`
from the per-subnet rows the cold tier returns, and `loadChainEventRollup`
interpolated the caller's page size into that scan. Live, one window, same
second:

| request | published |
| --- | --- |
| `/chain/weights?window=7d&limit=20` | `network.weight_sets` 67,955 |
| `/chain/weights?window=7d&limit=100` | `network.weight_sets` 214,842 |
| `/chain/weights/setters?window=7d` (ungrouped `COUNT(*)`) | 239,051 — the truth |
| `/chain/serving?window=30d&limit=1` | `network.announcements` 6,292 |
| `/chain/serving?window=30d&limit=59` | `network.announcements` 27,359 |

`buildChainWeights`' own comment promises the distribution covers "EVERY subnet
(not just the returned page)"; it could not — the page was all it was given.
The scan now takes a population bound and the builder pages, which is where the
slice always belonged. #10249 fixed exactly this for `subnet_count` and stopped
there.

The same reader also grouped **null-netuid rows**: `/chain/weights/setters`
publishes `{"hotkey": null, "netuid": null, "uid": 0, "weight_sets": 633}`, and
grouped by netuid that became a row no builder can attribute — one that still
spent a slot in the page and a unit in the count. `?limit=N` served N−1 subnets
at every N, and `?limit=1` an empty card beside `subnet_count: 129`. The two
per-subnet queries now require a subnet; the network participant count stays
unfiltered, because it does not need to know which subnet.

**The uptime/grade badges said `n/a` for every subnet on earth.**
`loadReliabilityAggregate` synthesized an internal
`/api/v1/subnets/{netuid}/uptime` request and forwarded it through the health
flag — the shape #8329 used to fix this exact `n/a`, back when that flag
forwarded:

```
/api/v1/subnets/64/badge.svg?metric=uptime  ->  metagraphed: n/a
/api/v1/subnets/64/uptime?window=90d        ->  grade C, 0.9296 over 78,896 samples
```

Same table, same second, two answers. It calls `loadSubnetUptime` against the
store now — the loader the route itself calls.

**`get_account_snapshot`'s `recent_events` had no rung**, so the compound card
published `event_count: 0` while `get_account_events` served the same coldkey's
rows. The #10320 wired-card-vs-embedded-copy defect, one composer over from the
subnet snapshot's.

Also in this diff, each from the same sweep: `run_saved_query`'s leaderboard arm
with nothing under it; a dropped `min_samples` that made `get_subnet_uptime`
accept a filter and answer as if unasked; `compare_subnets`' health dimension
with no source; GraphQL's block detail reading mainnet for `network: test`; a
cursor published as `block_number`; the #4332 price-at-tx enrichment its only
caller took with it; a discarded `observed_at`; and `account.labels`, which
GraphQL never joined.

## The tests

332 tests asserted through the deleted transport — a fixture injected as
`{ METAGRAPH_X_SOURCE: "postgres", DATA_API: { fetch } }` over a binding
production never asked, several of them running the same builder the tool runs
and asserting its output. Each is repointed at the reader that answers:
`tests/helpers/cold-tier-env.ts` provides one double per surviving transport
(`METAGRAPH_ARCHIVE`, R2 SQL over `globalThis.fetch`, `HYPERDRIVE` + `pg`), kept
at the transport so a surface wired to the wrong loader still fails.

Where a test's only claim was tier wiring, it becomes the retirement pin
instead: flag set, `DATA_API` bound and answering, `assert.deepEqual(tier.paths, [])`.
Without that a reintroduced call is invisible — it returns null and the surface
answers from its fallback exactly as before, which is how these sat dead for
months.

Two gates were re-aimed and each verified to fail when its subject is reverted:
`tests/graphql-tier-cascade.test.ts` (which selected ladders by a predicate the
sweep would have emptied) and the flip-readiness scan, whose store-selector
detector did not know `readStore` and so read a ported reader as hard-wired to
D1.

## Not fixed here, and why

`AxonInfoRemoved` has zero rows in both `chain.account_events` and
`chain.chain_events` — surveyed for #9146 — so the chain/subnet/account
axon-removal cards have no source to read on any surface. They are pinned to the
schema-stable zero with `observed_at: null`, which is an absence rather than a
measurement, and the ranking contracts stay held over the builder's own tests.
`/chain/prometheus` answers 1 row at 30d and 0 at 7d for the same reason one
layer down: the `PrometheusServed` backfill into `account_events` has produced
almost nothing.

## Verification

`npm run build`, the full suite (19,619 passed), `tsc`, `eslint`, `prettier`,
`validate:api`, `validate:mcp` and `validate:contract-drift` are clean on the
rebased branch. No visual output is touched.
