### PR TITLE
fix(mcp): pass the live lanes to /freshness, so two healthy ones stop reading missing

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1508,7 +1508,7 @@ import {
   withinRateLimit,
 } from "./ai-search.ts";
 import { keywordScore, queryTerms } from "./keyword-search.ts";
-import { KV_HEALTH_META } from "./kv-keys.ts";
+import { KV_ECONOMICS_CURRENT, KV_HEALTH_META } from "./kv-keys.ts";
 import {
   buildAccountsList,
   ACCOUNTS_LIST_SORTS,
@@ -1653,7 +1653,10 @@ import {
   subnetOwnershipHistoryNode,
 } from "./subnet-ownership-answer.ts";
 import { loadSudoKey } from "./sudo-key.ts";
-import { loadNetworkParameters } from "./network-parameters.ts";
+import {
+  loadNetworkParameters,
+  readCachedNetworkParametersSnapshot,
+} from "./network-parameters.ts";
 import { loadSweepRecord, type SweepStoreDb } from "./attribution-sweep.ts";
 import { loadUpgradeRadar } from "./upgrade-radar.ts";
 import { buildNetworksPayload } from "./network-capabilities.ts";
@@ -3751,11 +3754,41 @@ async function loadProviderDetail(
 // freshness artifact overlaid with the live 15-minute prober's last_run_at
 // (mergeFreshness) so the surface-health source reads `current` like the REST
 // route. With no live meta the committed artifact passes through unchanged.
+//
+// ALL THREE LIVE ARGUMENTS, not just the prober's. `mergeFreshness` appends two
+// lanes the built artifact structurally cannot carry -- `economics-live` and
+// `chain-parameters`, both KV-backed and moving on their own schedules -- and
+// it takes their timestamps from its THIRD parameter. Passing `(base, meta)`
+// and stopping left that parameter at its `{}` default, so both lanes parsed
+// `undefined`, and `liveFreshnessSource` reported them `missing` with a null
+// timestamp on every MCP call while REST reported them `current` from the same
+// KV. A field that is permanently wrong for two of its rows teaches people to
+// ignore the field (#10816).
+//
+// The reads are the SAME ONES the REST route makes, deliberately:
+//   - `KV_ECONOMICS_CURRENT` raw, NOT `resolveLiveEconomics` -- that helper
+//     drops a blob built under an older contract, which is right for serving
+//     economics and wrong here. Freshness reports how old the lane is; a blob
+//     being off-contract does not make it ageless, and dropping it would
+//     reintroduce exactly the `missing` this fixes.
+//   - `readCachedNetworkParametersSnapshot`, which reads the cache and never
+//     refreshes it -- see its own header: a freshness probe that triggered the
+//     work it measures could never report anything but `current`.
 async function loadFreshness(ctx: McpCtx) {
   const base = await loadArtifactData(ctx, "/metagraph/freshness.json");
   if (!ctx.readHealthKv) return base;
-  const meta = await ctx.readHealthKv(ctx.env, KV_HEALTH_META);
-  return mergeFreshness(base, meta) ?? base;
+  const [meta, economics, parameters] = await Promise.all([
+    ctx.readHealthKv(ctx.env, KV_HEALTH_META),
+    ctx.readHealthKv(ctx.env, KV_ECONOMICS_CURRENT),
+    readCachedNetworkParametersSnapshot(ctx.env),
+  ]);
+  return (
+    mergeFreshness(base, meta, {
+      economicsCapturedAt: (economics as { captured_at?: unknown } | null)
+        ?.captured_at,
+      parametersQueriedAt: parameters?.queried_at,
+    }) ?? base
+  );
 }
 
 async function loadEconomicsSubnetRows(ctx: McpCtx) {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -20967,6 +20967,89 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     const out = res.body.result.structuredContent;
     assert.equal(out.sources[0].status, "stale");
   });
+
+  // #10816. `mergeFreshness` appends `economics-live` and `chain-parameters`
+  // from its THIRD argument, which MCP was not passing -- so both reported
+  // `missing` with a null timestamp on every call while REST reported them
+  // `current` off the same KV. These three pin the parameter, not the shape:
+  // the first two fail if either argument is dropped again, the third fails if
+  // one is invented.
+  const FRESHNESS_ARTIFACT = {
+    schema_version: 1,
+    sources: [{ id: "surface-health", status: "stale" }],
+    summary: {},
+  };
+  const parametersEnv = (queriedAt: string | null) => ({
+    METAGRAPH_CONTROL: {
+      get: (key: string) =>
+        Promise.resolve(
+          key.includes("network:parameters") && queriedAt
+            ? { queried_at: queriedAt }
+            : null,
+        ),
+    },
+  });
+
+  test("get_freshness reports economics-live from the KV blob, not missing", async () => {
+    const deps = makeDeps(
+      { "/metagraph/freshness.json": FRESHNESS_ARTIFACT },
+      { "health:meta": { last_run_at: FRESH_RUN } },
+    );
+    // Raw KV, so no contract_version: the freshness lane reports how OLD the
+    // blob is, and an off-contract blob is not an ageless one.
+    (deps as Row).readHealthKv = (_env: unknown, key: string) =>
+      Promise.resolve(
+        key === "health:meta"
+          ? { last_run_at: FRESH_RUN }
+          : key === "economics:current"
+            ? { captured_at: FRESH_RUN }
+            : null,
+      );
+    const res = await callTool("get_freshness", {}, { deps });
+    const econ = res.body.result.structuredContent.sources.find(
+      (s: Row) => s.id === "economics-live",
+    );
+    assert.equal(econ.status, "current");
+    assert.equal(econ.timestamp, FRESH_RUN);
+  });
+
+  test("get_freshness reports chain-parameters from the cached snapshot", async () => {
+    const deps = makeDeps(
+      { "/metagraph/freshness.json": FRESHNESS_ARTIFACT },
+      { "health:meta": { last_run_at: FRESH_RUN } },
+    );
+    const res = await callTool(
+      "get_freshness",
+      {},
+      { deps, env: parametersEnv(FRESH_RUN) },
+    );
+    const rpcLane = res.body.result.structuredContent.sources.find(
+      (s: Row) => s.id === "chain-parameters",
+    );
+    assert.equal(rpcLane.status, "current");
+    assert.equal(rpcLane.timestamp, FRESH_RUN);
+  });
+
+  test("get_freshness still reports both live lanes missing when their stores are cold", async () => {
+    // The honest case, and the one that must survive the fix: a cold store has
+    // no age, and inventing one would be worse than the bug being fixed.
+    const deps = makeDeps(
+      { "/metagraph/freshness.json": FRESHNESS_ARTIFACT },
+      { "health:meta": { last_run_at: FRESH_RUN } },
+    );
+    const res = await callTool(
+      "get_freshness",
+      {},
+      { deps, env: parametersEnv(null) },
+    );
+    for (const id of ["economics-live", "chain-parameters"]) {
+      const lane = res.body.result.structuredContent.sources.find(
+        (s: Row) => s.id === id,
+      );
+      assert.equal(lane.status, "missing", `${id} should report missing`);
+      assert.equal(lane.timestamp, null, `${id} should carry no timestamp`);
+    }
+  });
 });
 
 // Read-only MCP tools for webhook subscriptions + chain alert triggers, added


### PR DESCRIPTION
Closes #10816

## What was wrong

`mergeFreshness` appends two lanes the committed artifact structurally *cannot* carry — they move on their own schedules, not the publish's — and it takes their timestamps from its **third** parameter:

```ts
// src/mcp-server.ts
return mergeFreshness(base, meta) ?? base;   // third parameter left at its {} default
```

```ts
// workers/api.ts — REST, for contrast
data = mergeFreshness(staticData, meta, {
  economicsCapturedAt: economicsBlob?.captured_at,
  parametersQueriedAt: parameters?.queried_at,
});
```

So `liveFreshnessSource` parsed `undefined` for both and hit its `missing` branch:

| lane | max age | REST | MCP (before) |
|---|---|---|---|
| `economics-live` | 8 h | `current` | **`missing`, timestamp null** |
| `chain-parameters` | 20 min | `current` | **`missing`, timestamp null** |

Both lanes are healthy — `/economics` returns `source: "live-kv"` captured minutes earlier. A field that is permanently wrong for two of its rows teaches people to ignore the field, which is what the flip-readiness gate was retired for in #10799.

## Why these two reads specifically

Not the nearest available equivalents — the ones REST actually makes:

- **`KV_ECONOMICS_CURRENT` raw, not `resolveLiveEconomics`.** That helper drops a blob built under an older contract. Correct when *serving* economics; wrong here — freshness reports how **old** a lane is, and an off-contract blob is not an ageless one. Routing through it would have reintroduced the same `missing` through a different door.
- **`readCachedNetworkParametersSnapshot`,** which reads the cache and never refreshes it. Its own header explains why that matters: a freshness probe that triggers the work it measures could only ever report `current`, i.e. a lane that cannot go stale and therefore cannot be gated on.

## Tests

Three added, and I verified the first two **fail** with the third argument removed rather than assuming they would:

```
× get_freshness reports economics-live from the KV blob, not missing
× get_freshness reports chain-parameters from the cached snapshot
✓ get_freshness still reports both live lanes missing when their stores are cold
```

The third is the guard on the fix, not the bug: a cold store has no age, and inventing one would be worse than what this replaces. It passes both before and after, deliberately.

## Verification

- `npx tsc --noEmit` clean
- `tests/mcp-server.test.ts` — 1371 passed
- `tests/health-serving.test.ts` + `tests/freshness-watchdog.test.ts` — 187 passed