### PR TITLE
fix(crons): delete three data-api crons whose handlers were deleted with D1

### DIFF
--- a/tests/data-api-crons-have-handlers.test.ts
+++ b/tests/data-api-crons-have-handlers.test.ts
@@ -32,7 +32,10 @@ const CONFIG = "wrangler.data.jsonc";
 function declaredCrons(path: string): string[] {
   const source = readFileSync(path, "utf8");
   const block = /"crons"\s*:\s*\[([^\]]*)\]/.exec(source);
-  assert.ok(block, `no "crons" array found in ${path} -- this test parses nothing`);
+  assert.ok(
+    block,
+    `no "crons" array found in ${path} -- this test parses nothing`,
+  );
   return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
 }
 
@@ -81,11 +84,10 @@ describe("wrangler.data.jsonc crons and their handlers", () => {
     // A map built from string literals would drift silently the moment a
     // constant changed. Asserting the three constants are its keys is what ties
     // it to them.
-    assert.deepEqual(Object.keys(DATA_API_CRON_LANES).sort(), [
-      NEON_PRUNE_CRON,
-      TABLE_FRESHNESS_CRON,
-      TAO_USD_INDEX_CRON,
-    ].sort());
+    assert.deepEqual(
+      Object.keys(DATA_API_CRON_LANES).sort(),
+      [NEON_PRUNE_CRON, TABLE_FRESHNESS_CRON, TAO_USD_INDEX_CRON].sort(),
+    );
   });
 
   test("the three retired D1-era crons are gone", () => {

--- a/tests/data-api-crons-have-handlers.test.ts
+++ b/tests/data-api-crons-have-handlers.test.ts
@@ -102,4 +102,31 @@ describe("wrangler.data.jsonc crons and their handlers", () => {
       );
     }
   });
+  test("an undeclared cron is declined by the dispatcher itself", async () => {
+    // THE BEHAVIOUR, not just the bookkeeping. Exercised through the real
+    // `scheduled` export so the guard is what is being tested rather than a
+    // reimplementation of it.
+    const { default: worker } = await import("../workers/data-api.ts");
+    const result = (await worker.scheduled(
+      { cron: "7 7 7 7 7", scheduledTime: Date.now() } as never,
+      {} as never,
+      { waitUntil: () => {} } as never,
+    )) as Record<string, unknown>;
+    assert.equal(result.ok, false);
+    assert.equal(result.skipped, true);
+    assert.equal(result.reason, "unknown cron");
+  });
+
+  test("an empty cron is declined too", async () => {
+    // `controller?.cron` is optional in the type, and an empty string is not a
+    // member of the lane map -- both paths reach the same decline.
+    const { default: worker } = await import("../workers/data-api.ts");
+    const result = (await worker.scheduled(
+      { scheduledTime: Date.now() } as never,
+      {} as never,
+      { waitUntil: () => {} } as never,
+    )) as Record<string, unknown>;
+    assert.equal(result.skipped, true);
+    assert.equal(result.reason, "unknown cron");
+  });
 });

--- a/tests/data-api-crons-have-handlers.test.ts
+++ b/tests/data-api-crons-have-handlers.test.ts
@@ -1,0 +1,103 @@
+// Both directions between wrangler.data.jsonc's crons and the Worker that
+// dispatches them (#10814).
+//
+// Every cron gate in this repo ran ONE direction: a constant exists, therefore
+// assert it appears in the config. That can only catch a handler whose schedule
+// was never declared. It cannot catch the reverse -- a declared schedule whose
+// handler was deleted -- because the deleted handler exports no constant to
+// start the assertion from. A test whose starting point disappears along with
+// the bug passes hardest exactly when it should fail.
+//
+// Three expressions had been in that state since D1 was retired:
+// "*/3 * * * *" (NEON_BACKFILL_CRON), "26 * * * *" (mirror-lag) and
+// "38 * * * *" (D1<->Neon parity). All three producers were deleted; the
+// expressions stayed, fell through to `{ skipped: true }`, and cost roughly 23
+// no-op Worker invocations an hour with nothing reporting it.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { DATA_API_CRON_LANES } from "../workers/data-api.ts";
+import { TABLE_FRESHNESS_CRON, TAO_USD_INDEX_CRON } from "../workers/config.ts";
+import { NEON_PRUNE_CRON } from "../src/neon-prune.ts";
+
+const CONFIG = "wrangler.data.jsonc";
+
+/**
+ * The cron expressions declared in a wrangler config.
+ *
+ * Parsed rather than `JSON.parse`d because these files are JSONC -- comments
+ * and trailing commas -- and the block is a flat array of string literals, so
+ * lifting the quoted strings out of it is exact rather than approximate.
+ */
+function declaredCrons(path: string): string[] {
+  const source = readFileSync(path, "utf8");
+  const block = /"crons"\s*:\s*\[([^\]]*)\]/.exec(source);
+  assert.ok(block, `no "crons" array found in ${path} -- this test parses nothing`);
+  return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe("wrangler.data.jsonc crons and their handlers", () => {
+  test("the parse finds a non-trivial set, so the assertions below are real", () => {
+    // Guards the regex, not the config: an empty match would make every
+    // assertion in this file vacuously true.
+    const declared = declaredCrons(CONFIG);
+    assert.ok(
+      declared.length >= 3,
+      `only ${declared.length} cron(s) parsed out of ${CONFIG} -- the parse broke`,
+    );
+    assert.ok(Object.keys(DATA_API_CRON_LANES).length >= 3);
+  });
+
+  test("every DECLARED cron resolves to a handled lane", () => {
+    // THE DIRECTION THAT WAS MISSING. Removing a producer without removing its
+    // schedule fails here.
+    const unhandled = declaredCrons(CONFIG).filter(
+      (cron) => !(cron in DATA_API_CRON_LANES),
+    );
+    assert.deepEqual(
+      unhandled,
+      [],
+      `these crons are declared in ${CONFIG} but no branch in workers/data-api.ts ` +
+        `handles them, so each one is a no-op Worker invocation on its schedule:\n` +
+        unhandled.join("\n"),
+    );
+  });
+
+  test("every HANDLED lane has a declared cron", () => {
+    // The original direction, kept: a handler whose schedule was never declared
+    // simply never runs.
+    const declared = new Set(declaredCrons(CONFIG));
+    const undeclared = Object.keys(DATA_API_CRON_LANES).filter(
+      (cron) => !declared.has(cron),
+    );
+    assert.deepEqual(
+      undeclared,
+      [],
+      `these lanes are handled but never scheduled:\n${undeclared.join("\n")}`,
+    );
+  });
+
+  test("the lane map names the constants, not copies of their values", () => {
+    // A map built from string literals would drift silently the moment a
+    // constant changed. Asserting the three constants are its keys is what ties
+    // it to them.
+    assert.deepEqual(Object.keys(DATA_API_CRON_LANES).sort(), [
+      NEON_PRUNE_CRON,
+      TABLE_FRESHNESS_CRON,
+      TAO_USD_INDEX_CRON,
+    ].sort());
+  });
+
+  test("the three retired D1-era crons are gone", () => {
+    // Named explicitly so re-adding one is a deliberate act with a test to
+    // argue with, rather than a paste that quietly resumes ~23 no-ops an hour.
+    const declared = new Set(declaredCrons(CONFIG));
+    for (const retired of ["*/3 * * * *", "26 * * * *", "38 * * * *"]) {
+      assert.ok(
+        !declared.has(retired),
+        `${retired} was NEON_BACKFILL/mirror-lag/parity -- all three producers ` +
+          `were deleted with D1, so declaring it schedules a no-op`,
+      );
+    }
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8332,6 +8332,24 @@ export async function ingestTaoUsdIndex(
   }
 }
 
+/**
+ * Every cron expression this Worker handles, and the lane each one runs.
+ *
+ * DATA, AND THE DISPATCHER READS IT -- so the set cannot drift from the
+ * branches below, and tests/data-api-crons-have-handlers.test.ts can compare it
+ * against wrangler.data.jsonc in BOTH directions.
+ *
+ * The reverse direction is the one that was missing. Every cron gate in tests/
+ * asserted constant -> declared-in-wrangler; a declared expression whose
+ * constant had been deleted could not fail any of them. Three had been in that
+ * state since D1 was retired (#10814), firing ~23 no-op invocations an hour.
+ */
+export const DATA_API_CRON_LANES: Readonly<Record<string, string>> = {
+  [TAO_USD_INDEX_CRON]: "tao-usd-index",
+  [NEON_PRUNE_CRON]: "neon-prune",
+  [TABLE_FRESHNESS_CRON]: "table-freshness + tao-usd-index watchdog",
+};
+
 export default {
   // #8600: the data-api Worker's first cron. It lives here rather than on the
   // api Worker for the same locality reason it always has -- this Worker owns
@@ -8343,6 +8361,12 @@ export default {
     env: Env,
     ctx: ExecutionContext,
   ) {
+    // Declined BEFORE the branches, against the declared set, so an expression
+    // nobody handles is refused in one place rather than falling through three
+    // comparisons to a default that looks deliberate.
+    if (!controller?.cron || !(controller.cron in DATA_API_CRON_LANES)) {
+      return { ok: false, skipped: true, reason: "unknown cron" };
+    }
     if (controller?.cron === TABLE_FRESHNESS_CRON) {
       // Reads MAX(<timestamp>) per table and writes one verdict, all on Neon
       // through Hyperdrive. This line read "D1 only" until #10223 -- which is
@@ -8370,8 +8394,13 @@ export default {
       // the moment the producer breaks.
       return runNeonPrune(env as unknown as Record<string, unknown>, ctx);
     }
-    if (controller?.cron !== TAO_USD_INDEX_CRON) {
-      return { ok: false, skipped: true, reason: "unknown cron" };
+    // Unreachable for anything DECLARED and branched, and deliberately kept:
+    // it is the net under `DATA_API_CRON_LANES` gaining an entry whose branch
+    // nobody wrote. Without it that expression would fall through to
+    // `ingestTaoUsdIndex` and run the wrong lane on the wrong schedule, which
+    // is a worse failure than the no-op this whole issue is about.
+    if (controller.cron !== TAO_USD_INDEX_CRON) {
+      return { ok: false, skipped: true, reason: "declared but unhandled" };
     }
     return ingestTaoUsdIndex(env, ctx);
   },

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -464,18 +464,27 @@
   // No committed default either: unset, the tick is a recorded no-op rather
   // than a silent fallback to somebody's public node. See
   // workers/env-extra.d.ts for why that is a choice and not an oversight.
-  // "* * * * *" = TAO_USD_INDEX_CRON; "*/3 * * * *" = NEON_BACKFILL_CRON, the
-  // D1 -> Neon reconciler (workers/config.ts documents both cadences). The
-  // second is a SUBSET of the first by the clock and still a separate entry:
+  // EVERY EXPRESSION HERE RESOLVES TO A BRANCH in this Worker's `scheduled`,
+  // and tests/data-api-crons-have-handlers.test.ts asserts it. Three did not
+  // until #10814: "*/3 * * * *" (NEON_BACKFILL_CRON), "26 * * * *" (the
+  // mirror-lag watchdog) and "38 * * * *" (D1<->Neon row-count parity). All
+  // three producers were deleted with D1 -- `src/neon-backfill.ts`,
+  // `src/neon-mirror-lag.ts`, `src/neon-parity.ts` are gone and their lanes are
+  // in RETIRED_LANES -- so the expressions fell through to
+  // `{ skipped: true, reason: "unknown cron" }` roughly 23 times an hour.
+  //
+  // Nothing caught that because every cron gate in tests/ ran one direction:
+  // constant -> declared here. A constant that no longer exists cannot fail
+  // that test, which is precisely the shape of a check that passes hardest
+  // when there is nothing to check.
+  //
   // Cloudflare delivers one event per matching expression with its own
   // `controller.cron`, so the handler dispatches on the string rather than on
-  // what minute it happens to be.
+  // what minute it happens to be -- which is why a subset expression like
+  // "*/3 * * * *" was a separate entry rather than folded into "* * * * *".
   "triggers": {
     "crons": [
       "* * * * *",
-      "*/3 * * * *",
-      "26 * * * *",
-      "38 * * * *",
       "52 * * * *",
       "46 * * * *",
     ],

--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -483,11 +483,7 @@
   // what minute it happens to be -- which is why a subset expression like
   // "*/3 * * * *" was a separate entry rather than folded into "* * * * *".
   "triggers": {
-    "crons": [
-      "* * * * *",
-      "52 * * * *",
-      "46 * * * *",
-    ],
+    "crons": ["* * * * *", "52 * * * *", "46 * * * *"],
   },
 
   // HYPERDRIVE is gone with the box (2026-08-03): the Postgres it fronted was


### PR DESCRIPTION
Closes #10814

## What was wrong

`wrangler.data.jsonc` declared six cron expressions. Three had no branch in `workers/data-api.ts`:

| cron | was | producer | state |
|---|---|---|---|
| `*/3 * * * *` | `NEON_BACKFILL_CRON` | `src/neon-backfill.ts` | **deleted** |
| `26 * * * *` | mirror-lag watchdog | `src/neon-mirror-lag.ts` | **deleted** |
| `38 * * * *` | D1↔Neon row-count parity | `src/neon-parity.ts` | **deleted** |

All three fell through to `{ ok: false, skipped: true, reason: "unknown cron" }` — roughly **23 no-op Worker invocations an hour**. Their lanes are already in `RETIRED_LANES` / `RETIRED_LANE_PREFIXES`, so nothing downstream expected them.

The live `26 * * * *` handler is on the *api* Worker, which is part of why this read as harmless in a grep.

## Why no test caught it

Every cron gate in `tests/` runs **one** direction: a constant exists, therefore assert it appears in the config. That can only catch a handler whose schedule was never declared.

It cannot catch the reverse — a declared schedule whose handler was deleted — because **the deleted handler exports no constant to start the assertion from**. The test's own starting point disappears along with the bug. `tests/neon-prune.test.ts:127` and `tests/table-freshness-watchdog.test.ts` are both that shape.

## So the fix is not only the deletion

- `DATA_API_CRON_LANES` declares the handled set **as data**, keyed by the three constants themselves rather than copies of their values.
- The dispatcher declines against that set **before** its branches, instead of after them.
- The trailing `!== TAO_USD_INDEX_CRON` check is **kept** and re-commented. It is now unreachable for anything declared and branched, and it is the net under `DATA_API_CRON_LANES` gaining an entry whose branch nobody wrote — which would otherwise run tao-usd-index on someone else's schedule. Its reason string changed from `"unknown cron"` to `"declared but unhandled"` so the two cases are distinguishable in a log.
- `tests/data-api-crons-have-handlers.test.ts` asserts **both** directions, that the lane map is keyed by the constants, that the parse itself found something (so the assertions can't pass vacuously), and that the three retired expressions stay gone.

## Proven able to fail

Re-adding `"38 * * * *"` to the config turns two assertions red:

```
× every DECLARED cron resolves to a handled lane
× the three retired D1-era crons are gone
✓ every HANDLED lane has a declared cron
✓ the lane map names the constants, not copies of their values
✓ the parse finds a non-trivial set
```

## Verification

- `npx tsc --noEmit` clean
- full CI validator set (all 39 `validate:*` steps, derived from `.github/workflows/`) passes
- `tests/{data-api-crons-have-handlers,neon-prune,table-freshness-watchdog}.test.ts` — 73 passed
- rebased onto `73c87f17b`; verified the crons block and `DATA_API_CRON_LANES` survived the rebase

Note the api Worker has the mirror-image problem — its `*/15` branch is the *unconditional default*, so an unrecognised cron there silently runs the health prober rather than being declined. That is #10815, deliberately not in this diff.