### PR TITLE
feat(graphql): the argument surface, generated -- and the runtime change it exposes

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3325,7 +3325,7 @@ export type Query = {
   agent_resources?: Maybe<Scalars['JSON']['output']>;
   /** One block by numeric height or 0x block hash; block is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/{ref}. */
   block?: Maybe<BlockDetail>;
-  /** Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{block_number}/chain-events. */
+  /** Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{ref}/chain-events. */
   block_chain_events: BlockChainEvents;
   /** The decoded, account-attributed chain events in one block by ref, in read order (event_index ASC), paginated with limit (1-1000, default 100)/offset. Returns block_number:null + events:[] for an unknown ref or cold store, never a GraphQL error. Mirrors GET /api/v1/blocks/{ref}/events. */
   block_events: BlockEvents;
@@ -3437,7 +3437,7 @@ export type Query = {
   evm_address?: Maybe<EvmAddressMapping>;
   /** The get_evm_address_mapping-aligned name for evm_address, so the MCP tool name and this Query field line up. Structurally identical to evm_address -- same live RPC read, same validation, same schema-stable null on an unresolved mapping -- not a second lookup. Mirrors GET /api/v1/evm/address/{h160}. */
   evm_address_mapping?: Maybe<EvmAddressMapping>;
-  /** One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}. */
+  /** One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{hash}. */
   extrinsic?: Maybe<ExtrinsicDetail>;
   /** Recent-extrinsic feed (newest first), optionally filtered. Optionally narrow by call_hash, block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same filters GET /api/v1/extrinsics and the list_extrinsics MCP tool accept. Mirrors GET /api/v1/extrinsics. */
   extrinsics: ExtrinsicList;
@@ -3455,7 +3455,7 @@ export type Query = {
   global_incidents: GlobalIncidents;
   /** Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes. */
   governance_config_changes: ExtrinsicList;
-  /** Global operational health rollup with per-subnet summaries. */
+  /** Global operational health rollup with per-subnet summaries. Mirrors GET /api/v1/health. */
   health?: Maybe<GlobalHealth>;
   /** A compact daily operational health snapshot for one UTC date (YYYY-MM-DD): per-surface status/latency plus summary incident counts from the archived health/history tier. Filter by netuid/kind/provider/status/classification, sort with sort/order, and page with limit (1-1000)/cursor. An invalid date/filter/sort/limit/cursor or a missing snapshot is a GraphQL error, not a silently substituted default. Distinct from the live health rollup and health_trends. Mirrors GET /api/v1/health/history/{date}. */
   health_history: HealthHistory;
@@ -3475,15 +3475,15 @@ export type Query = {
   neuron: Neuron;
   /** One neuron's per-day metagraph history in a subnet by UID from the neuron_daily rollup (window: 7d/30d/90d/1y/all, default 30d), newest first: stake, rank, trust, consensus, incentive, dividends, emission, validator permit, axon, and take per snapshot_date. A UID with no matching rows resolves to a schema-stable empty-points card, never null. Mirrors GET /api/v1/subnets/{netuid}/neurons/{uid}/history. */
   neuron_history: NeuronHistory;
-  /** Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are). */
+  /** Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are). Each board is a FIELD here, so the route's board selector is the selection set's job. Mirrors GET /api/v1/registry/leaderboards. */
   opportunity_boards: OpportunityBoards;
   /** Public-safe subnet profile index -- completeness scores, surface/interface counts, curation level, review state, and confidence for every registered subnet. Filter by netuid/subnet_type/curation_level/review_state/confidence/profile_level, search name/slug/project/team/categories with q, sort with sort/order, and page with limit (1-1000)/cursor. An invalid filter/sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/profiles. */
   profiles: ProfileList;
-  /** One provider with its subnets. */
+  /** One provider with its subnets. The id argument is the route's slug path parameter under the name the rest of this surface uses. Mirrors GET /api/v1/providers/{slug}. */
   provider?: Maybe<Provider>;
   /** One provider's endpoint rows with full REST filter parity: filter by netuid/kind/layer/publication_state/status/pool_eligible, latency and score ranges, sort + order, and page with limit/cursor. Composed live from the baked /metagraph/providers/{slug}/endpoints.json artifact. An unsupported filter/sort or an unknown provider is a GraphQL error (matching REST/MCP), not a silently substituted default. Opaque JSON passed through verbatim, matching the list_provider_endpoints MCP/REST shape. Mirrors GET /api/v1/providers/{slug}/endpoints. */
   provider_endpoints?: Maybe<Scalars['JSON']['output']>;
-  /** Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). */
+  /** Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). Mirrors GET /api/v1/providers. */
   providers: ProviderList;
   /** The get_randomness_status-aligned name for the same live drand beacon snapshot (#7649): identical loader, KV cache, and independently-null RPC-failure behavior as network_randomness — a thin alias so MCP tool names and GraphQL fields line up. Returns the typed NetworkRandomness envelope rather than the issue's literal JSON suggestion, matching network_randomness. Mirrors GET /api/v1/network/randomness. */
   randomness_status?: Maybe<NetworkRandomness>;
@@ -3511,7 +3511,7 @@ export type Query = {
   rpc_usage: RpcUsage;
   /** Site-wide runtime spec-version transition timeline: the earliest known block at each distinct spec_version observed (ascending), the current spec_version, and where coverage starts. The empty shape (transition_count 0, current_spec_version null) is schema-stable, never a GraphQL error, when the store has no reading yet. Mirrors GET /api/v1/runtime. */
   runtime: RuntimeVersionHistory;
-  /** Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}. */
+  /** Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. */
   saved_query?: Maybe<Scalars['JSON']['output']>;
   /** The registry's captured API-schema index: which subnet surfaces publish a machine-readable OpenAPI/Swagger schema, each schema's hash, and its drift status (new/unchanged/changed). Null when the schema index has not been baked in this environment (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the list_schemas MCP/REST shape. Mirrors GET /api/v1/schemas. */
   schemas?: Maybe<Scalars['JSON']['output']>;
@@ -3525,7 +3525,7 @@ export type Query = {
   source_health?: Maybe<Scalars['JSON']['output']>;
   /** Per-source input-hash ledger -- each registry data source's captured input hash and record count at ingest time, for detecting hash drift or seeing per-source contribution volume. Filter with q (keyword search across id/kind/path), sort with sort/order, and page with limit (1-100)/cursor. An invalid sort/limit/cursor is a GraphQL error, not a silently substituted default. Mirrors GET /api/v1/source-snapshots. */
   source_snapshots: SourceSnapshotList;
-  /** One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets. */
+  /** One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets. Mirrors GET /api/v1/subnets/{netuid}. */
   subnet?: Maybe<Subnet>;
   /** Per-subnet axon-removal activity over a 7d/30d window (distinct removers, AxonInfoRemoved count, and removals per remover); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/axon-removals. */
   subnet_axon_removals: SubnetAxonRemovals;
@@ -3639,7 +3639,7 @@ export type Query = {
   subnet_yield: SubnetYield;
   /** Per-subnet per-day emission-per-stake yield trend from the neuron_daily rollup over a 7d/30d/90d window (default 30d): each day's subnet-wide yield plus the mean/median/p25/p75/p90 distribution across UIDs, newest first; a subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/yield/history. */
   subnet_yield_history: SubnetYieldHistory;
-  /** Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order. */
+  /** Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order. Mirrors GET /api/v1/subnets. */
   subnets: SubnetList;
   /** Recent Sudo-pallet extrinsic feed (newest first): the chain's superuser governance calls, the same shape as the extrinsics feed with call_module fixed to Sudo (so no signer/call_module args). Optionally narrow by block (exact height), block_start/block_end (inclusive height range), or from/to (observed_at epoch-ms range — String args because epoch-ms exceeds GraphQL Int's 32-bit range, matching account_history) — the same block/time filters GET /api/v1/sudo and the get_sudo MCP tool accept. Mirrors GET /api/v1/sudo. */
   sudo: ExtrinsicList;
@@ -5025,6 +5025,7 @@ export type QuerySubnetsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   max_block?: InputMaybe<Scalars['Int']['input']>;
   max_candidate_count?: InputMaybe<Scalars['Int']['input']>;
+  max_integration_readiness?: InputMaybe<Scalars['Int']['input']>;
   max_mechanism_count?: InputMaybe<Scalars['Int']['input']>;
   max_netuid?: InputMaybe<Scalars['Int']['input']>;
   max_participant_count?: InputMaybe<Scalars['Int']['input']>;
@@ -5034,6 +5035,7 @@ export type QuerySubnetsArgs = {
   max_tempo?: InputMaybe<Scalars['Int']['input']>;
   min_block?: InputMaybe<Scalars['Int']['input']>;
   min_candidate_count?: InputMaybe<Scalars['Int']['input']>;
+  min_integration_readiness?: InputMaybe<Scalars['Int']['input']>;
   min_mechanism_count?: InputMaybe<Scalars['Int']['input']>;
   min_netuid?: InputMaybe<Scalars['Int']['input']>;
   min_participant_count?: InputMaybe<Scalars['Int']['input']>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5380,7 +5380,7 @@ export interface components {
             schema_version: number;
             ss58: string;
             /** @description How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions. */
-            stake_concentration: components["schemas"]["ConcentrationMetrics"];
+            stake_concentration: components["schemas"]["ConcentrationMetrics"] | null;
             subnet_count: number;
             /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest SPOT price -- tao_in_pool_tao / alpha_in_pool from that subnet's newest snapshot, root at 1:1 -- before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Marked at SPOT, not at alpha_price_tao: that field is the chain's MOVING price (#9408), and a lagging average is the wrong mark for what a position is worth -- measured -1.29% against spot on netuid 64 for 2026-08-03. Prices still come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier; the lag is the rollup's, no longer the average's. */
             total_emission_tao: number;
@@ -7047,7 +7047,7 @@ export interface components {
                 last_tx_block: number | null;
                 signer: string;
                 /** @description Total fees paid across the window's extrinsics; null when the tier has no fee data. */
-                total_fee_tao: number;
+                total_fee_tao: number | null;
                 total_tip_tao: number;
                 tx_count: number;
             }[];
@@ -10783,11 +10783,8 @@ export interface components {
             usd_pricing_basis?: "window_close_rate";
             /** @description Total TAO volume over alpha market cap; null when market cap is unknown. */
             vol_mcap_ratio: number | null;
-            /**
-             * @description The rolling window label this card covers (24h).
-             * @enum {string}
-             */
-            window: "24h";
+            /** @description The rolling window label this card covers (24h); null on a zeroed cold-store card. */
+            window: "24h" | null;
         };
         SubnetAxonRemovalsArtifact: {
             degraded?: components["schemas"]["DegradedInfo"];
@@ -11894,8 +11891,8 @@ export interface components {
             consensus: components["schemas"]["ScoreDistribution"];
             /** @description Dividends concentration across permitted validators only. */
             dividends: components["schemas"]["ConcentrationMetrics"];
-            /** @description Incentive concentration across all neurons with positive incentive. */
-            incentive: components["schemas"]["ConcentrationMetrics"];
+            /** @description Incentive concentration across all neurons with positive incentive; null when none carry any. */
+            incentive: components["schemas"]["ConcentrationMetrics"] | null;
             netuid: number;
             neuron_count: number;
             schema_version: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -15140,7 +15140,14 @@
             "type": "string"
           },
           "stake_concentration": {
-            "$ref": "#/components/schemas/ConcentrationMetrics",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConcentrationMetrics"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions."
           },
           "subnet_count": {
@@ -24362,9 +24369,16 @@
                   "type": "string"
                 },
                 "total_fee_tao": {
-                  "description": "Total fees paid across the window's extrinsics; null when the tier has no fee data.",
-                  "minimum": 0,
-                  "type": "number"
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Total fees paid across the window's extrinsics; null when the tier has no fee data."
                 },
                 "total_tip_tao": {
                   "minimum": 0,
@@ -43454,11 +43468,18 @@
             "description": "Total TAO volume over alpha market cap; null when market cap is unknown."
           },
           "window": {
-            "description": "The rolling window label this card covers (24h).",
-            "enum": [
-              "24h"
+            "anyOf": [
+              {
+                "enum": [
+                  "24h"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "type": "string"
+            "description": "The rolling window label this card covers (24h); null on a zeroed cold-store card."
           }
         },
         "required": [
@@ -49994,8 +50015,15 @@
             "description": "Dividends concentration across permitted validators only."
           },
           "incentive": {
-            "$ref": "#/components/schemas/ConcentrationMetrics",
-            "description": "Incentive concentration across all neurons with positive incentive."
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ConcentrationMetrics"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Incentive concentration across all neurons with positive incentive; null when none carry any."
           },
           "netuid": {
             "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5380,7 +5380,7 @@ export interface components {
             schema_version: number;
             ss58: string;
             /** @description How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions. */
-            stake_concentration: components["schemas"]["ConcentrationMetrics"];
+            stake_concentration: components["schemas"]["ConcentrationMetrics"] | null;
             subnet_count: number;
             /** @description Cross-subnet total in genuine TAO (#9051): each membership converts through its own subnet's latest SPOT price -- tao_in_pool_tao / alpha_in_pool from that subnet's newest snapshot, root at 1:1 -- before summing, so this is a real TAO value rather than a sum of incomparable per-subnet alpha tokens. Prices are complete by construction (the economics tier carries a price for every subnet, and subnet_snapshots is written from it); a membership whose subnet has no price row is excluded, which under-reports rather than mis-denominates. Marked at SPOT, not at alpha_price_tao: that field is the chain's MOVING price (#9408), and a lagging average is the wrong mark for what a position is worth -- measured -1.29% against spot on netuid 64 for 2026-08-03. Prices still come from the daily subnet_snapshots rollup, so the valuation can lag up to ~24h behind the live economics tier; the lag is the rollup's, no longer the average's. */
             total_emission_tao: number;
@@ -7047,7 +7047,7 @@ export interface components {
                 last_tx_block: number | null;
                 signer: string;
                 /** @description Total fees paid across the window's extrinsics; null when the tier has no fee data. */
-                total_fee_tao: number;
+                total_fee_tao: number | null;
                 total_tip_tao: number;
                 tx_count: number;
             }[];
@@ -10783,11 +10783,8 @@ export interface components {
             usd_pricing_basis?: "window_close_rate";
             /** @description Total TAO volume over alpha market cap; null when market cap is unknown. */
             vol_mcap_ratio: number | null;
-            /**
-             * @description The rolling window label this card covers (24h).
-             * @enum {string}
-             */
-            window: "24h";
+            /** @description The rolling window label this card covers (24h); null on a zeroed cold-store card. */
+            window: "24h" | null;
         };
         SubnetAxonRemovalsArtifact: {
             degraded?: components["schemas"]["DegradedInfo"];
@@ -11894,8 +11891,8 @@ export interface components {
             consensus: components["schemas"]["ScoreDistribution"];
             /** @description Dividends concentration across permitted validators only. */
             dividends: components["schemas"]["ConcentrationMetrics"];
-            /** @description Incentive concentration across all neurons with positive incentive. */
-            incentive: components["schemas"]["ConcentrationMetrics"];
+            /** @description Incentive concentration across all neurons with positive incentive; null when none carry any. */
+            incentive: components["schemas"]["ConcentrationMetrics"] | null;
             netuid: number;
             neuron_count: number;
             schema_version: number;

--- a/schemas-src/graphql/argument-divergences.ts
+++ b/schemas-src/graphql/argument-divergences.ts
@@ -82,6 +82,60 @@ export interface DeclaredArgumentType {
   addedByGraphql?: boolean;
 }
 
+const SURFACES_UNFORWARDED =
+  "the route publishes this surface filter and `Subnet.surfaces`'s resolver " +
+  "does not forward it -- the name appears nowhere in src/graphql.ts. " +
+  "Publishing it would let a caller filter and silently receive the " +
+  "unfiltered list, which is worse than being unable to ask.";
+
+const HEALTH_IGNORES_ARGUMENTS =
+  "`health` takes no arguments at all: its resolver is " +
+  "`async health(_args: unknown, context)` and calls " +
+  "`buildGlobalHealth(snapshot, {})` with an empty options object. " +
+  "Publishing this filter would let a caller send it and silently receive " +
+  "the unfiltered rollup, which is worse than being unable to ask. The " +
+  "route's six filters are a capability GraphQL does not have yet.";
+
+const INTEGER_BOUND =
+  "the route declares this `z.number()` and it bounds an INTEGRAL quantity " +
+  "(a block height, a count, a tempo), so `Float` is the derivation's answer " +
+  "and `Int` is the right published one -- GraphQL has no integer that is " +
+  "not `Int`. Narrowing the Zod would 400 a REST caller sending a fractional " +
+  "bound today, for a quantity that is integral either way.";
+
+const READINESS_BOUND =
+  "the integration-readiness score is integral -- 129 of 129 rows on " +
+  "/api/v1/subnets carry a whole number -- and the alias `min_readiness` has " +
+  "always published `Int`, so the canonical name matching it is what keeps " +
+  "the two spellings of ONE field interchangeable. The route's `z.number()` " +
+  "derives to Float; see INTEGER_BOUND for why the Zod is not narrowed.";
+
+const READINESS_ALIAS =
+  "the shorter name `list_subnets` shipped with, kept beside the canonical " +
+  "`*_integration_readiness` the route publishes so existing callers are " +
+  "unaffected. Both are now published here, which is the point: the SDL had " +
+  "only this one, so an agent reading our OpenAPI and sending the canonical " +
+  "name to GraphQL was rejected.";
+
+const NEGATION_FILTER =
+  "a categorical NEGATION filter GraphQL has and the route does not. " +
+  'Verified live: subnets(not_status: "active") answers {"total":0,"items":[]} ' +
+  'where GET /api/v1/subnets?not_status=active answers 400 "not_status is ' +
+  'not supported for this route." The resolver reaches the same shared ' +
+  "`listPage` filters the list_subnets MCP tool does, so this is a capability " +
+  "GraphQL adds, not a claim about the route.";
+
+const OPAQUE_KEYSET =
+  "an OPAQUE id keyset, not REST's integer offset -- the GraphQL-only " +
+  "pagination contract #7920 established for `providers` and `endpoints`. " +
+  "This field's own binding description already states it. Typing it `Int` " +
+  "to match the route would break the only pagination the field has.";
+
+const NETUID_RANGE =
+  "a RANGE bound on netuid, which no route parameter expresses: #10014 gave " +
+  "both surfaces `netuid` (exactly one subnet) and neither a range. A " +
+  "capability GraphQL adds, not a claim about the route.";
+
 const BOOLEAN_STRING_FORWARDING =
   'the route publishes a ["true","false"] STRING enum and GraphQL has a ' +
   "real Boolean, which is the stricter spelling -- but this field's resolver " +
@@ -95,6 +149,113 @@ const COMMA_JOINED_LIST =
   "joined and bounds the arity with a regex. GraphQL has a list, so the SDL " +
   "takes one and the resolver joins -- the same input, with the arity bound " +
   "enforced by the schema instead of a pattern.";
+
+/**
+ * Fields whose route has a `/{network}/` twin but which do not publish the
+ * `network` argument, each because the resolver cannot honour it (#10394).
+ *
+ * Lives here rather than in the gate for the reason the header gives:
+ * `schemas-src/` cannot import from `scripts/`, and the GENERATOR needs this
+ * judgement as much as the check does. While it lived in the gate the two
+ * disagreed -- the gate accepted the omission and the generator published the
+ * argument anyway, which is the drift these declarations exist to stop.
+ */
+export const DECLARED_MISSING_NETWORK: readonly string[] = [
+  // `/api/v1/extrinsics/{hash}` has a twin, so `network` derives -- but the
+  // resolver destructures `{ ref }` and nothing else (src/graphql.ts
+  // `extrinsic`), so publishing it would let a caller ask for testnet and
+  // silently receive mainnet.
+  "extrinsic",
+];
+
+/**
+ * Route parameters GraphQL deliberately does NOT publish, each with the reason
+ * (#10772).
+ *
+ * THE THIRD DIRECTION, and the one nothing could state. `DECLARED_ARGUMENTS`
+ * says an argument's PRESENCE is intentional and `DECLARED_ARGUMENT_TYPES`
+ * says its TYPE is; an OMISSION had no slot but `DECLARED_MISSING_NETWORK`,
+ * which holds one argument name. So this direction never had to justify
+ * itself, and twelve of them accumulated behind a gate that could not see
+ * them -- six on `health` alone.
+ *
+ * That matters more here than on the other two, because `buildSchema(SDL)`
+ * builds a schema with no resolver map: there is no per-field hook that could
+ * accept an argument the schema omits, so an omission is a route capability a
+ * GraphQL caller simply CANNOT REACH. Every entry below is a capability gap,
+ * recorded rather than hidden.
+ *
+ * Read by `deriveQueryArguments`, so an entry does not merely excuse the
+ * difference -- it is why the generated schema omits the argument, the same
+ * way `DECLARED_ARGUMENT_TYPES` is why it publishes the spelling it does. And
+ * like its siblings the list only SHRINKS: an entry naming a parameter the
+ * route stopped publishing, or one GraphQL has since published, fails
+ * `validate:graphql-query-arguments` as stale.
+ */
+export const DECLARED_UNPUBLISHED_ARGUMENTS: Readonly<Record<string, string>> =
+  {
+    // ── the resolver ignores its arguments entirely ─────────────────────────
+    //
+    // `async health(_args: unknown, context)` -- it calls
+    // `buildGlobalHealth(snapshot, {})` with an empty options object and reads
+    // nothing off `_args`. Publishing the route's six filters would be a LIE
+    // rather than a fix: a caller would send `netuid: 7` and receive the
+    // unfiltered rollup, which is worse than being unable to ask. Implementing
+    // them is a feature and belongs in its own issue.
+    "health.netuid": HEALTH_IGNORES_ARGUMENTS,
+    "health.status": HEALTH_IGNORES_ARGUMENTS,
+    "health.sort": HEALTH_IGNORES_ARGUMENTS,
+    "health.order": HEALTH_IGNORES_ARGUMENTS,
+    "health.limit": HEALTH_IGNORES_ARGUMENTS,
+    "health.cursor": HEALTH_IGNORES_ARGUMENTS,
+
+    // ── the selection set already does the job ──────────────────────────────
+    "opportunity_boards.board":
+      "GraphQL publishes the six economic boards as FIELDS (open_slots, " +
+      "cheapest_registration, …), so choosing one is the selection set's job. " +
+      "The route needs the parameter because a JSON envelope has no way to " +
+      "ask for part of itself; a GraphQL caller selects the board it wants " +
+      "and pays for nothing else.",
+
+    // ── a nested field whose resolver reads only some of the route's ───────
+    //
+    // `Subnet.surfaces` filters the per-subnet surface list, and its resolver
+    // forwards the arguments it names. These three appear nowhere in
+    // src/graphql.ts, so publishing them would let a caller filter on
+    // `auth_required` and receive the unfiltered list.
+    "Subnet.surfaces.auth_required": SURFACES_UNFORWARDED,
+    "Subnet.surfaces.public_safe": SURFACES_UNFORWARDED,
+    "Subnet.surfaces.rate_limited": SURFACES_UNFORWARDED,
+
+    // ── published under a wider or narrower name ────────────────────────────
+    "extrinsic.hash":
+      "published as `ref`, which accepts this hash AND a composite " +
+      "block_number-extrinsic_index the path parameter's name does not " +
+      "suggest. Declared in DECLARED_ARGUMENT_TYPES as `extrinsic.ref`.",
+    "block_chain_events.ref":
+      "published as `block_number`, typed `Int!`: this field takes the " +
+      "numeric block number only, where the route's `{ref}` also accepts the " +
+      "string forms. The narrower input under the name that says so.",
+
+    // ── published under another name ────────────────────────────────────────
+    "provider.slug":
+      "published as `id`, the name this field has always taken and the one " +
+      "`providers(id:)` filters by -- the same path parameter under the " +
+      "spelling the rest of the GraphQL surface uses. Declared in " +
+      "DECLARED_ARGUMENT_TYPES as `provider.id`.",
+
+    // ── the route can express what a selection set cannot, and vice versa ───
+    "subnets.q":
+      "free-text search over the registry, which GraphQL exposes as its own " +
+      "`search`/`semantic_search` fields rather than as a filter on the " +
+      "index -- the resolver's `listPage` path takes the categorical and " +
+      "range filters and never reads `q`.",
+    "subnets.netuids":
+      "the route takes a comma-joined string because a query string has no " +
+      "list type; this field's `netuid` takes ONE subnet and `compare` takes " +
+      "the list ([Int!]!, see compare.netuids). Publishing a comma-joined " +
+      "String here would add the one spelling GraphQL exists to avoid.",
+  };
 
 export const DECLARED_ARGUMENT_TYPES: Readonly<
   Record<string, DeclaredArgumentType>
@@ -131,6 +292,203 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
       "projectable, so REST's projection parameter still has work to do. " +
       "Spelled String here rather than a list, which is the older of the two " +
       "spellings on this surface and a difference worth collapsing separately.",
+    addedByGraphql: true,
+  },
+
+  // ── a bound on a COUNT is an Int ──────────────────────────────────────────
+  //
+  // `list-subnets.ts` declares these `z.number()`, so the route's parameter is
+  // `number` and derives to `Float`. Every one bounds an integral quantity --
+  // a block height, a count of candidates/mechanisms/participants/probed
+  // surfaces/surfaces, a tempo -- and GraphQL has no integer that is not
+  // `Int`. Narrowing the Zod instead would 400 a REST caller sending
+  // `min_tempo=99.5` today for no gain: the quantity is integral either way,
+  // and GraphQL already refuses fractions here.
+  "subnets.min_block": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_block": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_candidate_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_candidate_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_mechanism_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_mechanism_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_participant_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_participant_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_probed_surface_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_probed_surface_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_surface_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_surface_count": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_tempo": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.max_tempo": { type: "Int", reason: INTEGER_BOUND },
+
+  // ── the canonical readiness names, and the aliases beside them ────────────
+  //
+  // `list-subnets.ts` declares BOTH pairs and says which is which: the
+  // `*_integration_readiness` pair carries "The route's published names
+  // (#10018) -- GET /api/v1/subnets documents these, so an agent reading our
+  // OpenAPI sends them. Canonical", and the short pair is "kept so existing
+  // callers are unaffected". The SDL published only the alias, so an agent
+  // that read our own OpenAPI and sent the canonical name to GraphQL was
+  // rejected -- the exact failure that comment was written to prevent,
+  // reappearing on the surface nothing was checking. The canonical pair now
+  // derives from the route; these two are the aliases kept beside them.
+  "subnets.min_integration_readiness": {
+    type: "Int",
+    reason: READINESS_BOUND,
+  },
+  "subnets.max_integration_readiness": {
+    type: "Int",
+    reason: READINESS_BOUND,
+  },
+  "subnets.min_readiness": {
+    type: "Int",
+    reason: READINESS_ALIAS,
+    addedByGraphql: true,
+  },
+  "subnets.max_readiness": {
+    type: "Int",
+    reason: READINESS_ALIAS,
+    addedByGraphql: true,
+  },
+
+  // ── negation filters GraphQL has and the route does not ───────────────────
+  //
+  // Verified live, both directions: `subnets(not_status: "active", limit: 2)`
+  // answers `{"total":0,"items":[]}`, and GET /api/v1/subnets?not_status=active
+  // answers 400 "not_status is not supported for this route." GraphQL is AHEAD
+  // of REST here rather than drifted from it -- the resolver reaches the same
+  // shared `listPage` filters the list_subnets MCP tool does.
+  "subnets.not_coverage_level": {
+    type: "String",
+    reason: NEGATION_FILTER,
+    addedByGraphql: true,
+  },
+  "subnets.not_curation_level": {
+    type: "String",
+    reason: NEGATION_FILTER,
+    addedByGraphql: true,
+  },
+  "subnets.not_domain": {
+    type: "String",
+    reason: NEGATION_FILTER,
+    addedByGraphql: true,
+  },
+  "subnets.not_status": {
+    type: "String",
+    reason: NEGATION_FILTER,
+    addedByGraphql: true,
+  },
+  "subnets.not_subnet_type": {
+    type: "String",
+    reason: NEGATION_FILTER,
+    addedByGraphql: true,
+  },
+
+  // ── one path parameter, a WIDER name ──────────────────────────────────────
+  //
+  // Not a rename: `ref` accepts what `hash` does and more. The route's path
+  // parameter is `{hash}`; this field takes a hash OR a composite
+  // "<block_number>-<extrinsic_index>", which its description states and the
+  // resolver implements (a composite ref routes through `answerBlockDetail`).
+  // ── a latency bound is whole milliseconds ─────────────────────────────────
+  //
+  // The per-subnet endpoints route declares these `z.number()`; the probe
+  // measures whole milliseconds, and the sibling root field `endpoints`
+  // publishes `Int` from a route that says integer. Same reasoning as
+  // INTEGER_BOUND, on the one nested field that takes arguments.
+  "Subnet.endpoints.min_latency_ms": { type: "Int", reason: INTEGER_BOUND },
+  "Subnet.endpoints.max_latency_ms": { type: "Int", reason: INTEGER_BOUND },
+
+  // ── the Subscription root's only argument ─────────────────────────────────
+  "chainEvents.tables": {
+    type: "[ChainFirehoseTable!]",
+    addedByGraphql: true,
+    reason:
+      "the firehose topics to subscribe to. No REST route serves the " +
+      "WebSocket transport at all, so nothing derives this -- and the " +
+      "Subscription root was built with derivation switched OFF entirely, " +
+      "which dropped it from the generated schema (#10772).",
+  },
+
+  // ── a field that mirrors no route at all ──────────────────────────────────
+  //
+  // `/api/v1/queries/{id}` does not exist -- absent from API_ROUTES, 404 live
+  // -- so `saved_query` has no parameters to derive from and these two ARE the
+  // declaration.
+  "saved_query.id": {
+    type: "String!",
+    addedByGraphql: true,
+    reason:
+      "the saved query to run, by id. No REST route serves this field, so " +
+      "nothing derives the argument and this entry is where it is published.",
+  },
+  "saved_query.params": {
+    type: "JSON",
+    addedByGraphql: true,
+    reason:
+      "the saved query's bound parameters, an opaque record keyed by the " +
+      "query's own placeholder names -- which is what JSON is for here. No " +
+      "REST route serves this field.",
+  },
+
+  "extrinsic.ref": {
+    type: "String!",
+    addedByGraphql: true,
+    reason:
+      "accepts a transaction hash OR a composite block_number-extrinsic_index " +
+      "ref, where the route's path parameter is named for the hash alone. The " +
+      "wider name for the wider input, not a second spelling of the same one.",
+  },
+  "block_chain_events.block_number": {
+    type: "Int!",
+    addedByGraphql: true,
+    reason:
+      "the route's path parameter is `{ref}`; this field takes the NUMERIC " +
+      "block number only, which its description states -- so the argument is " +
+      "typed `Int!` rather than accepting the string forms `ref` allows.",
+  },
+
+  // ── one path parameter, two names ─────────────────────────────────────────
+  "provider.id": {
+    type: "String!",
+    addedByGraphql: true,
+    reason:
+      "the route's path parameter is `slug`; this field has always taken " +
+      "`id`, which is also what `providers(id:)` filters by. One parameter " +
+      "under the spelling the rest of the GraphQL surface uses; the route's " +
+      "name is declared in DECLARED_UNPUBLISHED_ARGUMENTS.",
+  },
+
+  // ── the two remaining opaque keysets ──────────────────────────────────────
+  //
+  // The same contract #7920 established for `providers` and `endpoints`: an
+  // opaque id keyset where REST takes an integer offset. Both bindings say so
+  // in prose already -- `providers`' description reads "Cursor remains the
+  // pre-existing opaque string id-keyset (not REST's integer offset)".
+  "subnets.cursor": { type: "String", reason: OPAQUE_KEYSET },
+  "providers.cursor": { type: "String", reason: OPAQUE_KEYSET },
+
+  // ── projection the selection set cannot replace ───────────────────────────
+  "providers.fields": {
+    type: "String",
+    addedByGraphql: true,
+    reason:
+      "same reason as `endpoints.fields` and `surfaces.fields`: `fields` is " +
+      "dropped wherever a selection set already projects the return type, and " +
+      "kept where it does not. Spelled String rather than a list, the older " +
+      "of the two spellings on this surface.",
+  },
+
+  // ── a RANGE over netuid, which the route has no parameter for ─────────────
+  //
+  // #10014 added `netuid` (exactly one subnet) to the route and this field.
+  // Neither route nor field has a range, and GraphQL published one first.
+  "subnets.min_netuid": {
+    type: "Int",
+    reason: NETUID_RANGE,
+    addedByGraphql: true,
+  },
+  "subnets.max_netuid": {
+    type: "Int",
+    reason: NETUID_RANGE,
     addedByGraphql: true,
   },
 
@@ -203,6 +561,59 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
 /** Does the route's parse own this field's argument, or does GraphQL? */
 export function isDeclaredDivergence(field: string, argument: string): boolean {
   return `${field}.${argument}` in DECLARED_ARGUMENTS;
+}
+
+/**
+ * The JSON kind a published GraphQL type carries.
+ *
+ * Deliberately coarse: it answers "can the route's schema hold this value",
+ * not "is it the same type". `Int` against a route's `z.number()` is the SAME
+ * kind, which is what keeps the fourteen integral bounds owned by the route --
+ * they still get its clamping and its published defaults. A GraphQL enum is a
+ * name rather than a scalar, and crosses as a string like `String` and `ID`.
+ */
+function graphqlJsonKind(type: string): string {
+  if (type.trimStart().startsWith("[")) return "array";
+  const named = type.replace(/[![\]\s]/g, "");
+  if (named === "Int" || named === "Float") return "number";
+  if (named === "Boolean") return "boolean";
+  return "string";
+}
+
+/**
+ * The kind GraphQL publishes for an argument whose TYPE is declared, or null.
+ *
+ * THE SECOND READER OF ONE LIST, and the reason this exists (#10772).
+ * `DECLARED_ARGUMENTS` says an argument's presence is GraphQL's; the runtime
+ * parse read only that, so `providers(cursor: "<opaque string>")` was rejected
+ * by the route's integer `cursor` -- a divergence declared, correctly, in
+ * `DECLARED_ARGUMENT_TYPES` instead. Two lists for one concept is the trap
+ * this file's own header records from last time; the fix is a second reader,
+ * not a third list. The caller compares this against the route's declared kind
+ * and skips only where the route's schema genuinely cannot hold the value.
+ */
+/**
+ * Is this argument's TYPE declared -- including the `addedByGraphql` case,
+ * where the route publishes no such parameter at all?
+ *
+ * `validate:graphql-route-parity` asks the same question from the other side:
+ * an SDL argument with no route parameter behind it. That is precisely what an
+ * `addedByGraphql` entry records, so the gate reads this rather than keeping a
+ * list of its own (#10772).
+ */
+export function isDeclaredArgumentType(
+  field: string,
+  argument: string,
+): boolean {
+  return `${field}.${argument}` in DECLARED_ARGUMENT_TYPES;
+}
+
+export function declaredArgumentKind(
+  field: string,
+  argument: string,
+): string | null {
+  const entry = DECLARED_ARGUMENT_TYPES[`${field}.${argument}`];
+  return entry ? graphqlJsonKind(entry.type) : null;
 }
 
 /**

--- a/schemas-src/graphql/build-schema.ts
+++ b/schemas-src/graphql/build-schema.ts
@@ -43,6 +43,7 @@ import { JSONScalar, emitTypes } from "./emit.ts";
 import { GRAPHQL_ENUMS, enumFieldSites } from "./enums.ts";
 import {
   ALIASED_TYPE_NAMES,
+  FIELD_ARGUMENT_ROUTES,
   MIRROR_OVERLAYS,
   PROJECTED_TYPES,
   PUBLISHED_TYPE_NAMES,
@@ -237,6 +238,7 @@ export function buildGeneratedSchema(
           const republished = republish(field.type);
           const published = renamed.get(fieldName) ?? fieldName;
           fields[published] = {
+            ...fieldArguments(`${name}.${published}`),
             type: retype(
               `${name}.${published}`,
               (everywhere && !relaxed) ||
@@ -249,6 +251,7 @@ export function buildGeneratedSchema(
         }
         for (const [fieldName, added] of Object.entries(edits?.added ?? {})) {
           fields[fieldName] = {
+            ...fieldArguments(`${name}.${fieldName}`),
             type: fromSpelling(added) as GraphQLOutputType,
           };
         }
@@ -341,6 +344,30 @@ export function buildGeneratedSchema(
     return inner as GraphQLOutputType;
   }
 
+  /**
+   * A nested field's arguments, derived from the route it filters.
+   *
+   * The PATH parameters are dropped: the parent supplies them, which is what
+   * makes this a nested field rather than a root one.
+   */
+  function fieldArguments(site: string): {
+    args?: GraphQLFieldConfigArgumentMap;
+  } {
+    const route = FIELD_ARGUMENT_ROUTES[site];
+    if (!route) return {};
+    const args: GraphQLFieldConfigArgumentMap = {};
+    for (const argument of deriveQueryArguments(site, route, openapi, {
+      hasNetworkTwin: false,
+      returnsProjectable: true,
+      nested: true,
+    })) {
+      args[argument.name] = {
+        type: fromSpelling(argument.type) as GraphQLInputType,
+      };
+    }
+    return Object.keys(args).length ? { args } : {};
+  }
+
   /** An emitted field's type, with every object swapped for its published one. */
   function republish(type: GraphQLOutputType): GraphQLOutputType {
     if (type instanceof GraphQLNonNull) {
@@ -389,12 +416,11 @@ export function buildGeneratedSchema(
         Object.fromEntries(
           bindings.map((binding) => {
             const args: GraphQLFieldConfigArgumentMap = {};
-            if (
-              withArguments &&
-              binding.route &&
-              openapi.paths?.[binding.route]
-            ) {
-              const twin = binding.route.replace(
+            // No `binding.route` guard: a field that mirrors no route still
+            // publishes whatever it DECLARES, and skipping the derivation
+            // dropped `saved_query`'s two arguments from the schema (#10772).
+            if (withArguments) {
+              const twin = binding.route?.replace(
                 "/api/v1/",
                 "/api/v1/{network}/",
               );
@@ -404,7 +430,7 @@ export function buildGeneratedSchema(
                 binding.route,
                 openapi,
                 {
-                  hasNetworkTwin: Boolean(openapi.paths?.[twin]),
+                  hasNetworkTwin: Boolean(twin && openapi.paths?.[twin]),
                   returnsProjectable:
                     returns instanceof GraphQLObjectType &&
                     !Object.values(returns.getFields()).some((field) =>
@@ -431,7 +457,11 @@ export function buildGeneratedSchema(
   }
 
   const query = root("Query", QUERY_BINDINGS, true);
-  const subscription = root("Subscription", SUBSCRIPTION_BINDINGS, false);
+  // Arguments ON for the Subscription root too. It was built with them off,
+  // on the reasoning that a subscription mirrors no route -- true, and
+  // irrelevant: `chainEvents(tables:)` is DECLARED, and switching derivation
+  // off skipped the declarations as well as the derivation (#10772).
+  const subscription = root("Subscription", SUBSCRIPTION_BINDINGS, true);
   // The type set is what the ROOTS REACH, which is what a GraphQL schema's
   // type set means -- graphql-js collects it while building. Publishing every
   // registered component instead would advertise ~200 types no query can

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -40,6 +40,16 @@ export const ALIASED_TYPE_NAMES: Readonly<Record<string, string>> = {
 
 /** Component id -> the name the published schema gives it. */
 export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
+  // The seven a `route: null` binding kept out of this check until #10772:
+  // the field named no route, so its response component was never paired
+  // with the type the SDL publishes for it. Naming the route surfaced all
+  // seven at once -- they are not new types, they are the ones that were
+  // never compared.
+  BlockChainEventsArtifact: "BlockChainEvents",
+  ExtrinsicDetailArtifact: "ExtrinsicDetail",
+  HealthSummaryArtifact: "GlobalHealth",
+  ProvidersArtifact: "ProviderList",
+  SubnetsArtifact: "SubnetList",
   AccountPortfolioArtifactStakeConcentration: "ConcentrationMetrics",
   BlocksSummaryArtifactAuthorConcentration: "ConcentrationMetrics",
   ChainConcentrationArtifactEmission: "ConcentrationMetrics",
@@ -568,14 +578,49 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
 /**
  * Every Query field, the route it mirrors, and the type it returns.
  *
- * `route: null` means the field reads a published artifact directly rather
- * than mirroring an `/api/v1` route with a component -- the eight static
- * index/detail readers. They still return a declared type; what they lack is a
- * route whose OpenAPI response names the component.
+ * `route` NAMES THE REQUEST, and that is the whole of what it means. It said
+ * two things at once until #10214 reached the Query root: six fields carried
+ * `route: null` on the grounds that they "read a published artifact directly
+ * rather than mirroring an `/api/v1` route with a component" -- and every one
+ * of the six had a route, with parameters, whose response named a component:
+ *
+ *   subnets              /api/v1/subnets                30 parameters
+ *   subnet               /api/v1/subnets/{netuid}        1
+ *   providers            /api/v1/providers               9
+ *   provider             /api/v1/providers/{slug}        1
+ *   health               /api/v1/health
+ *   opportunity_boards   /api/v1/registry/leaderboards   2
+ *
+ * What the null cost was not documentation. `deriveQueryArguments` reads the
+ * route's parameters, so a null route derives NO arguments -- and
+ * `buildSchema(SDL)` has no resolver hook that could add one back. The
+ * generated `subnet` field lost `netuid: Int!` entirely; 75 of the resolver
+ * suite's queries came back 400 against the generated schema, and every gate
+ * that could have caught it SKIPPED these fields for the same reason the
+ * generator did. `validate:graphql-query-arguments` printed "9 skipped" and
+ * passed, which is what a gate that skips always does.
+ *
+ * The response-side fact is real, and it is now `reshapes` -- separate,
+ * because it is a different claim about a different half of the exchange.
  */
 export interface QueryBinding {
   field: string;
+  /**
+   * The route whose published PARAMETERS this field's arguments derive from.
+   *
+   * Null only where no route serves the field at all -- a Subscription, or a
+   * Query the OpenAPI document does not publish.
+   */
   route: string | null;
+  /**
+   * Why the route's RESPONSE does not describe this field's return type.
+   *
+   * Present on the three where the resolver re-keys or re-scopes what the
+   * route returns, so response-side gates keep pairing them with the component
+   * the type is actually declared over rather than the route's. Absent means
+   * the two agree, which is the normal case and the checked one.
+   */
+  reshapes?: string;
   /** The published return type, nullability included -- `SubnetList!`. */
   returns: string;
   /**
@@ -601,17 +646,21 @@ export interface QueryBinding {
 export const QUERY_BINDINGS: readonly QueryBinding[] = [
   {
     field: "subnets",
-    route: null,
+    route: "/api/v1/subnets",
     returns: "SubnetList!",
     description:
-      "Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order.",
+      "Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order. Mirrors GET /api/v1/subnets.",
   },
   {
     field: "subnet",
-    route: null,
+    route: "/api/v1/subnets/{netuid}",
+    // The route serves the fuller `SubnetDetailArtifact`; this field returns
+    // the registry card the index publishes. The parameter is the same one.
+    reshapes:
+      "returns the registry card (SubnetIndexEntry), where the route's response is the fuller SubnetDetailArtifact",
     returns: "Subnet",
     description:
-      "One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets.",
+      "One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets. Mirrors GET /api/v1/subnets/{netuid}.",
   },
   {
     field: "subnet_registrations",
@@ -727,10 +776,17 @@ export const QUERY_BINDINGS: readonly QueryBinding[] = [
   },
   {
     field: "saved_query",
-    route: "/api/v1/queries/{id}",
+    // No such route, and there never has been: `/api/v1/queries/{id}` is
+    // absent from API_ROUTES and answers 404 live. The binding named a path
+    // the document does not describe, which `deriveQueryArguments` and every
+    // gate treated exactly like `route: null` -- silently, because a route
+    // that cannot be found and a route that is not claimed reached the same
+    // skip. Null states the fact instead of implying a mirror that does not
+    // exist.
+    route: null,
     returns: "JSON",
     description:
-      "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}.",
+      "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default.",
   },
   {
     field: "fixtures",
@@ -1119,16 +1175,19 @@ export const QUERY_BINDINGS: readonly QueryBinding[] = [
   },
   {
     field: "providers",
-    route: null,
+    route: "/api/v1/providers",
     returns: "ProviderList!",
     description:
-      "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers).",
+      "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). Mirrors GET /api/v1/providers.",
   },
   {
     field: "provider",
-    route: null,
+    route: "/api/v1/providers/{slug}",
+    reshapes:
+      "returns the provider row itself, where the route's response is the ProviderArtifact envelope around it",
     returns: "Provider",
-    description: "One provider with its subnets.",
+    description:
+      "One provider with its subnets. The id argument is the route's slug path parameter under the name the rest of this surface uses. Mirrors GET /api/v1/providers/{slug}.",
   },
   {
     field: "adapter",
@@ -1328,16 +1387,22 @@ export const QUERY_BINDINGS: readonly QueryBinding[] = [
   },
   {
     field: "health",
-    route: null,
+    route: "/api/v1/health",
     returns: "GlobalHealth",
-    description: "Global operational health rollup with per-subnet summaries.",
+    description:
+      "Global operational health rollup with per-subnet summaries. Mirrors GET /api/v1/health.",
   },
   {
     field: "opportunity_boards",
-    route: null,
+    route: "/api/v1/registry/leaderboards",
+    // The artifact keys its boards by NAME ("open-slots"), which are not valid
+    // GraphQL field names, so the resolver re-keys the six economic boards
+    // into fields -- which is what the `OpportunityBoards` component models.
+    reshapes:
+      "re-keys the leaderboards record into six named board fields, which RegistryLeaderboardsArtifact does not describe",
     returns: "OpportunityBoards!",
     description:
-      "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are).",
+      "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are). Each board is a FIELD here, so the route's board selector is the selection set's job. Mirrors GET /api/v1/registry/leaderboards.",
   },
   {
     field: "compare",
@@ -1383,10 +1448,14 @@ export const QUERY_BINDINGS: readonly QueryBinding[] = [
   },
   {
     field: "extrinsic",
-    route: "/api/v1/extrinsics/{ref}",
+    // `{hash}` is the published path parameter; the SDL takes `ref`, which
+    // accepts a hash OR a composite block_number-extrinsic_index (the
+    // description says so). The binding named `{ref}`, a path the document
+    // does not contain, so nothing derived and nothing complained.
+    route: "/api/v1/extrinsics/{hash}",
     returns: "ExtrinsicDetail",
     description:
-      "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}.",
+      "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{hash}.",
   },
   {
     field: "governance_config_changes",
@@ -1425,10 +1494,13 @@ export const QUERY_BINDINGS: readonly QueryBinding[] = [
   },
   {
     field: "block_chain_events",
-    route: "/api/v1/blocks/{block_number}/chain-events",
+    // `{ref}` is the published path parameter; this field takes a numeric
+    // `block_number`, which its own description states. Same silent skip as
+    // `extrinsic`: the binding named a path the document does not contain.
+    route: "/api/v1/blocks/{ref}/chain-events",
     returns: "BlockChainEvents!",
     description:
-      "Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{block_number}/chain-events.",
+      "Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{ref}/chain-events.",
   },
   {
     field: "blocks_summary",
@@ -2737,6 +2809,27 @@ export const MIRROR_OVERLAYS: Readonly<Record<string, MirrorOverlay>> = {
   // is a record keyed by subnet slug, which is the same reason
   // `ChangelogArtifactSummary.coverage_delta` is JSON where it is nested.
   Changelog: { added: { coverage_delta: "JSON" } },
+};
+
+/**
+ * NESTED fields that take arguments, and the route whose query parameters are
+ * those arguments (#10772).
+ *
+ * Only the two roots had arguments derived, on the assumption that only a root
+ * field takes any. Two nested fields do -- `Subnet.surfaces` and
+ * `Subnet.endpoints` are the per-subnet filtered lists -- and the generated
+ * schema published them bare, so `subnet { surfaces(kind: "api") }` stopped
+ * validating. Nothing caught it: `validate:graphql-query-arguments` walks
+ * `QUERY_BINDINGS`, which is the ROOT, so the whole nested class sat outside
+ * every argument check there is.
+ *
+ * The route's PATH parameters are deliberately not republished here -- the
+ * parent supplies `netuid`, which is exactly why these are nested fields
+ * rather than root ones. Only the query half derives.
+ */
+export const FIELD_ARGUMENT_ROUTES: Readonly<Record<string, string>> = {
+  "Subnet.surfaces": "/api/v1/subnets/{netuid}/surfaces",
+  "Subnet.endpoints": "/api/v1/subnets/{netuid}/endpoints",
 };
 
 /**

--- a/schemas-src/graphql/query-arguments.ts
+++ b/schemas-src/graphql/query-arguments.ts
@@ -14,6 +14,8 @@
 // to drift apart -- which is the thing the hand-written SDL could not promise.
 import {
   DECLARED_ARGUMENT_TYPES,
+  DECLARED_MISSING_NETWORK,
+  DECLARED_UNPUBLISHED_ARGUMENTS,
   type DeclaredArgumentType,
 } from "./argument-divergences.ts";
 
@@ -117,6 +119,16 @@ export interface DeriveOptions {
   hasNetworkTwin: boolean;
   /** Is the field's return type fully typed (no `JSON` member)? */
   returnsProjectable: boolean;
+  /**
+   * Is this a NESTED field, whose parent already supplies the path parameters?
+   *
+   * `Subnet.surfaces` filters `/api/v1/subnets/{netuid}/surfaces` from inside a
+   * `Subnet`, so `netuid` is the parent's identity rather than an argument --
+   * which is exactly why the field is nested and not a root one. Only the
+   * query half derives. Default false: a root field publishes its path
+   * parameters as required arguments, because a GraphQL field has no path.
+   */
+  nested?: boolean;
 }
 
 /**
@@ -146,11 +158,19 @@ export interface DeriveOptions {
  */
 export function deriveQueryArguments(
   field: string,
-  route: string,
+  // NULL where no route serves the field. Its declared arguments still apply:
+  // `saved_query` mirrors nothing and publishes two of its own, and treating
+  // "no route" as "no arguments" is what dropped them from the generated
+  // schema entirely (#10772).
+  route: string | null,
   openapi: OpenApiParameters,
   options: DeriveOptions,
+  // Injectable so the GATE can derive without it and still see the difference
+  // the declaration covers. Filtered here, the argument simply never appears,
+  // and a check reading the filtered output would call every live entry stale.
+  missingNetwork: readonly string[] = DECLARED_MISSING_NETWORK,
 ): QueryArgument[] {
-  const published = (openapi.paths?.[route]?.get?.parameters ?? [])
+  const published = ((route && openapi.paths?.[route]?.get?.parameters) || [])
     .map((parameter) => deref(parameter, openapi))
     .filter((parameter): parameter is Parameter => Boolean(parameter?.name));
 
@@ -160,9 +180,19 @@ export function deriveQueryArguments(
     return entry?.type ?? derived;
   };
 
+  // A route parameter GraphQL deliberately does not publish -- a capability
+  // gap, declared with its reason. Read HERE and not only in the gate, so the
+  // generated schema omits it too: `buildSchema(SDL)` has no resolver map, so
+  // an argument the schema publishes is one a caller may send, and `health`
+  // would have accepted six filters its resolver never reads.
+  const unpublished = (name: string): boolean =>
+    `${field}.${name}` in DECLARED_UNPUBLISHED_ARGUMENTS;
+
   const args: QueryArgument[] = [];
   for (const parameter of published) {
     if (parameter.in !== "path") continue;
+    if (options.nested) continue;
+    if (unpublished(parameter.name)) continue;
     args.push({
       name: parameter.name,
       type: declaredType(parameter.name, `${scalarFor(parameter)}!`),
@@ -171,6 +201,7 @@ export function deriveQueryArguments(
   for (const parameter of published) {
     if (parameter.in !== "query") continue;
     if (parameter.name === "format") continue;
+    if (unpublished(parameter.name)) continue;
     if (parameter.name === "fields" && options.returnsProjectable) continue;
     const base = scalarFor(parameter);
     args.push({
@@ -181,7 +212,11 @@ export function deriveQueryArguments(
       ),
     });
   }
-  if (options.hasNetworkTwin && !args.some((a) => a.name === "network")) {
+  if (
+    options.hasNetworkTwin &&
+    !args.some((a) => a.name === "network") &&
+    !missingNetwork.includes(field)
+  ) {
     args.push({ name: "network", type: "Network" });
   }
 

--- a/schemas-src/routes/account-portfolio.ts
+++ b/schemas-src/routes/account-portfolio.ts
@@ -78,7 +78,10 @@ export const AccountPortfolioArtifactSchema = z
       .describe(
         "Priced emission per priced stake -- both sides in TAO (#9051), so the ratio is dimensionally coherent. Null with no priceable stake.",
       ),
-    stake_concentration: ConcentrationMetricsSchema.describe(
+    // NULLABLE, as its own description says -- "null with no positions". A
+    // wallet with nothing staked has no concentration to report, and the
+    // zeroed-card fallback returns exactly that (#10772).
+    stake_concentration: ConcentrationMetricsSchema.nullable().describe(
       "How concentrated the wallet's stake is across its subnets (Gini/HHI/etc); null with no positions.",
     ),
     positions: z.array(PortfolioPositionSchema),

--- a/schemas-src/routes/chain-analytics.ts
+++ b/schemas-src/routes/chain-analytics.ts
@@ -73,9 +73,14 @@ const ChainSignerEntrySchema = z
   .object({
     signer: z.string(),
     tx_count: z.int().min(0),
+    // NULLABLE, which is what the description beside it has always said:
+    // "null when the tier has no fee data". The type said otherwise, and
+    // nothing reconciled the two until the GraphQL type was generated from
+    // this schema and the fee-tier fallback answered null (#10772).
     total_fee_tao: z
       .number()
       .min(0)
+      .nullable()
       .describe(
         "Total fees paid across the window's extrinsics; null when the tier has no fee data.",
       ),

--- a/schemas-src/routes/subnet-alpha-volume.ts
+++ b/schemas-src/routes/subnet-alpha-volume.ts
@@ -11,9 +11,15 @@ export const SubnetAlphaVolumeArtifactSchema = z
   .object({
     schema_version: z.int(),
     netuid: z.int().min(0),
+    // NULLABLE: the cold-store fallback builds a zeroed card and the resolver
+    // writes `window: data.window ?? null` for it (src/graphql.ts). The label
+    // describes a window there was no data to cover (#10772).
     window: z
       .enum(["24h"])
-      .describe("The rolling window label this card covers (24h)."),
+      .nullable()
+      .describe(
+        "The rolling window label this card covers (24h); null on a zeroed cold-store card.",
+      ),
     buy_volume_alpha: z.number(),
     sell_volume_alpha: z.number(),
     total_volume_alpha: z.number(),

--- a/schemas-src/routes/subnet-performance.ts
+++ b/schemas-src/routes/subnet-performance.ts
@@ -24,8 +24,11 @@ export const SubnetPerformanceArtifactSchema = z
     validator_count: z.int().min(0).optional(),
     active_count: z.int().min(0).optional(),
     captured_at: z.string().nullable().optional(),
-    incentive: ConcentrationMetricsSchema.describe(
-      "Incentive concentration across all neurons with positive incentive.",
+    // NULLABLE: the zeroed-card fallback writes `incentive: data.incentive ??
+    // null` (src/graphql.ts), because a subnet with no neuron carrying
+    // positive incentive has no concentration to report (#10772).
+    incentive: ConcentrationMetricsSchema.nullable().describe(
+      "Incentive concentration across all neurons with positive incentive; null when none carry any.",
     ),
     dividends: ConcentrationMetricsSchema.describe(
       "Dividends concentration across permitted validators only.",

--- a/scripts/validate-graphql-component-parity.ts
+++ b/scripts/validate-graphql-component-parity.ts
@@ -62,7 +62,24 @@ import {
   ALIASED_TYPE_NAMES,
   PROJECTED_TYPES,
   PUBLISHED_TYPE_NAMES,
+  QUERY_BINDINGS,
 } from "../schemas-src/graphql/published-names.ts";
+
+/**
+ * Query fields whose RESPONSE is deliberately not their route's component.
+ *
+ * `route` names the request; `reshapes` is the response-side fact (#10772).
+ * Seeding a reshaping field pairs two types the registry has already said are
+ * different -- `subnet` reads /api/v1/subnets/{netuid} and returns the index
+ * entry, so pairing `Subnet` with `SubnetDetailArtifact` reports that
+ * component's ENVELOPE (contract_version, generated_at, notes, schema_version)
+ * as fields the SDL forgot.
+ */
+const RESHAPING_FIELDS = new Set(
+  QUERY_BINDINGS.filter((binding) => binding.reshapes).map(
+    (binding) => binding.field,
+  ),
+);
 
 const SDL_PATH = "src/graphql-sdl.ts";
 const OPENAPI_PATH = "public/metagraph/openapi.json";
@@ -363,6 +380,7 @@ export function checkComponentParity(
       field.description?.value ?? "",
     );
     if (!mirrors) continue;
+    if (RESHAPING_FIELDS.has(field.name.value)) continue;
     const component = dataComponent(mirrors[1].replace(/\.$/, ""));
     if (component) queue.push([sdlTypeName(field.type), component]);
   }
@@ -410,12 +428,14 @@ export function checkComponentParity(
       const addedPagination = [...sdlFields].filter(
         (f) => PAGINATION_FIELDS.has(f) && !genNames.includes(f),
       );
+      const declaredView = projectedTypesMap[sdlName];
+      const declaredProjectionOfThis =
+        declaredView?.component === componentName;
       if (addedPagination.length >= 2) {
         // A paginated view, not a mirror -- but skipping it wholesale is what
         // hid 158 fields (#10404). It has to be DECLARED, and the projection
         // pass below applies every rule a projection gets.
-        const declaredView = projectedTypesMap[sdlName];
-        if (declaredView?.component === componentName) {
+        if (declaredProjectionOfThis) {
           projections.push(`${sdlName} <- ${componentName}`);
           continue;
         }
@@ -427,6 +447,18 @@ export function checkComponentParity(
         );
         continue;
       }
+      // A declared projection that is NOT a paginated view (#10772). The
+      // pagination heuristic was the only way in, so a type that simply picks a
+      // subset -- `Endpoint` omits sixteen of `EndpointResource`'s fields on
+      // purpose -- fell through to the mirror rule, and every declared drop
+      // came back as a violation. It never surfaced before because no Query
+      // field named the route that reaches it: the six `route: null` bindings
+      // kept `Endpoint` out of this walk entirely.
+      //
+      // Not counted as a pagination view and not skipped from checking: the
+      // declared-projection pass below reads `projectedTypesMap` directly and
+      // applies every rule a projection gets, this component included.
+      if (declaredProjectionOfThis) continue;
       comparedTypes += 1;
       // The SDL field nodes, for the two things a name comparison cannot see.
       const sdlNodes = new Map(

--- a/scripts/validate-graphql-query-arguments.ts
+++ b/scripts/validate-graphql-query-arguments.ts
@@ -18,7 +18,16 @@ import { readFileSync } from "node:fs";
 import { parse, print } from "graphql";
 import type { ObjectTypeDefinitionNode } from "graphql";
 import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
-import { DECLARED_ARGUMENT_TYPES } from "../schemas-src/graphql/argument-divergences.ts";
+import {
+  DECLARED_ARGUMENT_TYPES,
+  DECLARED_MISSING_NETWORK,
+} from "../schemas-src/graphql/argument-divergences.ts";
+import {
+  FIELD_ARGUMENT_ROUTES,
+  SUBSCRIPTION_BINDINGS,
+} from "../schemas-src/graphql/published-names.ts";
+
+export { DECLARED_MISSING_NETWORK };
 import {
   deriveQueryArguments,
   type OpenApiParameters,
@@ -44,7 +53,6 @@ const OPENAPI_PATH = "public/metagraph/openapi.json";
  * mainnet under a testnet label. A new entry here is a field that mirrors a
  * route with a `/{network}/` twin and cannot reach it.
  */
-export const DECLARED_MISSING_NETWORK: readonly string[] = [];
 
 export interface ArgumentReport {
   /** Fields whose argument list the routes reproduce exactly. */
@@ -74,15 +82,24 @@ export function checkQueryArguments(
   }
 
   /** The SDL's own argument list for a Query field. */
+  // EVERY type, not just Query: a root field is keyed by its own name and a
+  // nested one by `Type.field`, which is how `FIELD_ARGUMENT_ROUTES` names it.
+  // Reading only Query's fields left the Subscription root and the two nested
+  // filtered lists with nothing to compare against, so their declarations read
+  // as stale and their arguments as absent (#10772).
   const declaredArguments = new Map<string, QueryArgument[]>();
-  for (const field of types.get("Query")?.fields ?? []) {
-    declaredArguments.set(
-      field.name.value,
-      (field.arguments ?? []).map((argument) => ({
+  for (const [typeName, type] of types) {
+    for (const field of type.fields ?? []) {
+      const args = (field.arguments ?? []).map((argument) => ({
         name: argument.name.value,
         type: print(argument.type),
-      })),
-    );
+      }));
+      const key =
+        typeName === "Query" || typeName === "Subscription"
+          ? field.name.value
+          : `${typeName}.${field.name.value}`;
+      declaredArguments.set(key, args);
+    }
   }
 
   /** A return type with no `JSON` member can be projected by a selection set. */
@@ -100,21 +117,44 @@ export function checkQueryArguments(
   let exact = 0;
   let skipped = 0;
 
-  for (const binding of QUERY_BINDINGS) {
+  // BOTH roots plus the nested fields that take arguments. Walking
+  // QUERY_BINDINGS alone left the Subscription root and `Subnet.surfaces` /
+  // `Subnet.endpoints` outside every argument check there is -- which is how
+  // the generated schema came to publish them bare (#10772).
+  const surface = [
+    ...QUERY_BINDINGS,
+    ...SUBSCRIPTION_BINDINGS,
+    ...Object.entries(FIELD_ARGUMENT_ROUTES).map(([field, route]) => ({
+      field,
+      route,
+      returns: "",
+      description: "",
+    })),
+  ];
+  for (const binding of surface) {
     const declared = declaredArguments.get(binding.field);
-    if (!declared || !binding.route || !openapi.paths?.[binding.route]) {
+    // A field with no route still publishes what it DECLARES, so it is only
+    // skipped when the SDL has nothing to compare against.
+    if (!declared) {
       skipped += 1;
       continue;
     }
-    const twin = binding.route.replace("/api/v1/", "/api/v1/{network}/");
+    const twin = binding.route?.replace("/api/v1/", "/api/v1/{network}/");
     const derived = deriveQueryArguments(
       binding.field,
       binding.route,
       openapi,
       {
-        hasNetworkTwin: Boolean(openapi.paths?.[twin]),
-        returnsProjectable: returnsProjectable(binding.returns),
+        hasNetworkTwin: Boolean(twin && openapi.paths?.[twin]),
+        returnsProjectable: binding.returns
+          ? returnsProjectable(binding.returns)
+          : true,
+        // A key with a dot is a NESTED field; its parent supplies the path.
+        nested: binding.field.includes("."),
       },
+      // Empty, so a live `DECLARED_MISSING_NETWORK` entry still shows up as a
+      // difference here and cannot read as stale.
+      [],
     );
     for (const argument of derived) {
       if (DECLARED_ARGUMENT_TYPES[`${binding.field}.${argument.name}`]) {

--- a/scripts/validate-graphql-route-parity.ts
+++ b/scripts/validate-graphql-route-parity.ts
@@ -18,7 +18,12 @@
 // This runs entirely offline against the committed `openapi.json`; it needs no
 // production traffic and covers every field rather than a sample.
 import { readFileSync } from "node:fs";
-import { DECLARED_ARGUMENTS } from "../schemas-src/graphql/argument-divergences.ts";
+import {
+  DECLARED_ARGUMENTS,
+  DECLARED_MISSING_NETWORK,
+  DECLARED_UNPUBLISHED_ARGUMENTS,
+  isDeclaredArgumentType,
+} from "../schemas-src/graphql/argument-divergences.ts";
 
 type Json = Record<string, unknown>;
 
@@ -440,7 +445,15 @@ for (const field of queryType.fields) {
     const parameter = published.get(arg.name);
     if (!parameter) {
       if (arg.name === "network" && hasNetworkTwin(route)) continue;
-      if (key in DECLARED_ARGUMENTS) {
+      // `DECLARED_ARGUMENT_TYPES` carries the same fact for an argument whose
+      // TYPE is declared -- `extrinsic.ref` and `block_chain_events.block_number`
+      // are the route's path parameter under the name GraphQL publishes, and
+      // the generator emits them from that entry. One list, read by the gate
+      // that would otherwise contradict it (#10772).
+      if (
+        key in DECLARED_ARGUMENTS ||
+        isDeclaredArgumentType(field.name, arg.name)
+      ) {
         suppressedArguments.add(key);
         continue;
       }
@@ -461,7 +474,15 @@ for (const field of queryType.fields) {
     if (jsonTypes.length === 0 || !SCALARS.has(bare)) continue;
     const allowed = SCALAR_JSON_TYPES[bare] ?? [];
     if (jsonTypes.some((t) => allowed.includes(t))) continue;
-    if (key in DECLARED_ARGUMENTS) {
+    // A published type that diverges from the route's is exactly what
+    // `DECLARED_ARGUMENT_TYPES` records, and the generator EMITS the spelling
+    // from it -- so a gate reporting it as drift contradicts the artifact it
+    // helped produce. `subnets.cursor`/`providers.cursor` are the opaque
+    // keyset against the route's integer offset (#10772).
+    if (
+      key in DECLARED_ARGUMENTS ||
+      isDeclaredArgumentType(field.name, arg.name)
+    ) {
       suppressedArguments.add(key);
       continue;
     }
@@ -481,7 +502,15 @@ for (const field of queryType.fields) {
   // GraphQL, and the gate reported zero divergences (#10394).
   if (hasNetworkTwin(route) && !declaredArguments.has("network")) {
     const key = `${field.name}.network`;
-    if (key in DECLARED_MISSING_ARGUMENTS) {
+    // `DECLARED_MISSING_NETWORK` is where this exact judgement already lives,
+    // and it is read by the generator and by
+    // `validate:graphql-query-arguments`. This gate kept its own empty list and
+    // so re-asked a question the registry had already answered -- one concept,
+    // two lists, which is the shape #10772 exists to remove.
+    if (
+      key in DECLARED_MISSING_ARGUMENTS ||
+      DECLARED_MISSING_NETWORK.includes(field.name)
+    ) {
       suppressedArguments.add(key);
     } else {
       argumentFindings.push({
@@ -497,7 +526,15 @@ for (const field of queryType.fields) {
     if (name === "format") continue;
     if (name === "fields" && returnsProjectableType(field.type)) continue;
     const key = `${field.name}.${name}`;
-    if (key in DECLARED_MISSING_ARGUMENTS) {
+    // Same registry, third reader (#10772). `DECLARED_UNPUBLISHED_ARGUMENTS`
+    // is the slot this direction never had -- a route capability GraphQL does
+    // not publish, with the reason -- and the generator already reads it to
+    // decide what to OMIT. A gate that re-asks the question it answers is the
+    // second list this epic exists to delete.
+    if (
+      key in DECLARED_MISSING_ARGUMENTS ||
+      key in DECLARED_UNPUBLISHED_ARGUMENTS
+    ) {
       suppressedArguments.add(key);
       continue;
     }

--- a/scripts/validate-published-names.ts
+++ b/scripts/validate-published-names.ts
@@ -270,12 +270,41 @@ const sdlSubscriptionBindings = (
   description: field.description?.value ?? "",
 }));
 
+/**
+ * The fields whose RESPONSE is deliberately not their route's component.
+ *
+ * `route` names the request; `reshapes` is the response-side fact that used to
+ * be smuggled through `route: null` (#10772).
+ */
+const RESHAPING_FIELDS = new Set(
+  QUERY_BINDINGS.filter((binding) => binding.reshapes).map(
+    (binding) => binding.field,
+  ),
+);
+
 // ── the pairing, computed the way the parity gate computes it ────────────────
 const { computed, paired, reachable } = traverse(
   sdlTypes,
   generated,
   sdlBindings.flatMap((binding) => {
-    if (!binding.route) return [];
+    // A seed asserts "this published type IS that route's component", and a
+    // binding that declares `reshapes` says exactly the opposite (#10772):
+    // `opportunity_boards` re-keys the leaderboards record into six named
+    // board fields, so pairing it with RegistryLeaderboardsArtifact asks the
+    // walk to prove two different types are the same one. The declaration
+    // existed and NOTHING read it -- `reshapes` appeared nowhere in this file
+    // -- which is the one-reader trap the epic names. The faithful mirror of
+    // the same route (`registry_leaderboards`) still seeds it, so nothing
+    // stops being checked.
+    if (!binding.route || RESHAPING_FIELDS.has(binding.field)) return [];
+    // A type with a PROJECTED_TYPES entry already states this pairing, and
+    // states it more precisely: `ExtrinsicDetail` drops two of its component's
+    // fields, `BlockChainEvents` adds two and drops one. Seeding it as a full
+    // mirror as well asks the walk to prove a stricter claim than the registry
+    // makes, and the projection then reads as stale -- one relationship
+    // declared twice, which is what naming the routes exposed (#10772).
+    if (binding.returnsName && binding.returnsName in PROJECTED_TYPES)
+      return [];
     const component = dataComponent(binding.route);
     return component
       ? ([[binding.returnsName, component]] as [string, string][])

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6947,9 +6947,23 @@ export function getRouteForPathname(pathname: string): ApiRouteEntry | null {
  * whether the request is valid, and `plain` is what a rejection message is
  * derived from (the bound a caller violated is only legible in the published
  * form).
+ *
+ * `args` is the third form, and it is the one that was missing (#10772). The
+ * two above conflated a VOCABULARY affordance with an ENCODING one: `wire`
+ * carries the string->number coercion a query string needs AND the
+ * case-insensitive enum, which has nothing to do with encoding. A surface
+ * handed real JSON values -- GraphQL, MCP -- needs the second without the
+ * first, and had nowhere to get it, so the GraphQL dispatch parse validated
+ * against `plain` and came out STRICTER THAN THE ROUTE: `?status=Active`
+ * answers 200 with the filter applied, while the same value through GraphQL
+ * would have been rejected. `caseInsensitiveEnum`'s own comment already said
+ * the rule belongs "everywhere an enum is declared"; this is the layer that
+ * makes that true, with `wire` built on top of it so the rule has ONE
+ * definition rather than one per surface.
  */
 export interface RouteQuerySchemas {
   plain: z.ZodObject;
+  args: z.ZodObject;
   wire: z.ZodObject;
 }
 
@@ -7007,14 +7021,20 @@ export function routeQuerySchemasForPathname(
     if (!feed) return null;
     const cached = routeQuerySchemas.get(pathname);
     if (cached !== undefined) return cached;
-    const schemas = { plain: feed, wire: wireSchema(feed) };
+    const schemas = {
+      plain: feed,
+      args: argsSchema(feed),
+      wire: wireSchema(feed),
+    };
     routeQuerySchemas.set(pathname, schemas);
     return schemas;
   }
   const cached = routeQuerySchemas.get(entry.path);
   if (cached !== undefined) return cached;
   const plain = querySchemaForRoute(entry);
-  const schemas = plain ? { plain, wire: wireSchema(plain) } : null;
+  const schemas = plain
+    ? { plain, args: argsSchema(plain), wire: wireSchema(plain) }
+    : null;
   // Built once per route: the shape never changes at runtime, and this sits on
   // the request path for every GET.
   routeQuerySchemas.set(entry.path, schemas);
@@ -7052,7 +7072,7 @@ export function collectionQuerySchemas(
         : [],
     csvResponse,
   });
-  const schemas = { plain, wire: wireSchema(plain) };
+  const schemas = { plain, args: argsSchema(plain), wire: wireSchema(plain) };
   routeQuerySchemas.set(key, schemas);
   return schemas;
 }
@@ -7102,6 +7122,21 @@ function wireSchema(schema: z.ZodObject): z.ZodObject {
  * `z.toJSONSchema` per field is far more work and a second representation to
  * keep honest, and this runs for every parameter of every route.
  */
+/**
+ * The JSON kind a route parameter declares, in the vocabulary a published
+ * GraphQL type is compared against (#10772).
+ *
+ * Read off `def` like `declaredBaseType`, not by serializing the field:
+ * `publishedShape` says in its own doc that it is only ever computed on the
+ * rejection path, and this runs for every argument of every request. An enum
+ * crosses as a string, which is why it is folded to one here -- the question
+ * is whether the route's schema can HOLD the value, not what it names it.
+ */
+export function routeParameterKind(field: z.ZodType): string | undefined {
+  const declared = declaredBaseType(field);
+  return declared === "enum" ? "string" : declared;
+}
+
 function declaredBaseType(field: z.ZodType): string | undefined {
   // `def` is Zod v4's own public property, so this walks the schema through
   // its declared type rather than a hand-written shape. Only the WRAPPERS
@@ -7156,9 +7191,34 @@ function caseInsensitiveEnum(field: z.ZodType): z.ZodType {
   }, field);
 }
 
+/**
+ * The affordances that are about the VOCABULARY, not the encoding (#10772).
+ *
+ * Applied by every surface, because a value both understand should not depend
+ * on which one was asked. Read off `declaredBaseType(field)` on the RAW field:
+ * `z.preprocess` reports `def.type === "pipe"`, so wrapping first would blind
+ * the very detection that decides whether to wrap.
+ */
+function vocabularyField(field: z.ZodType): z.ZodType {
+  return declaredBaseType(field) === "enum"
+    ? caseInsensitiveEnum(field)
+    : field;
+}
+
+/** `plain` with the vocabulary affordances, for surfaces handed real JSON. */
+function argsSchema(schema: z.ZodObject): z.ZodObject {
+  const shape: Record<string, z.ZodType> = {};
+  for (const [name, field] of Object.entries(schema.shape)) {
+    shape[name] = vocabularyField(field as z.ZodType);
+  }
+  return z.object(shape);
+}
+
 function wireField(field: z.ZodType): z.ZodType {
   const declared = declaredBaseType(field);
-  if (declared === "enum") return caseInsensitiveEnum(field);
+  // Delegated rather than repeated: the enum rule is surface-independent and
+  // has exactly one definition, which `args` reads too.
+  if (declared === "enum") return vocabularyField(field);
   switch (declared) {
     case "number":
     case "bigint":

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -24,7 +24,7 @@ export const SDL = /* GraphQL */ `
   }
 
   type Query {
-    "Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order."
+    "Paginated active-subnet index. Reads the same static /metagraph/subnets.json artifact as the list_subnets MCP tool and supports its full query surface: network scoping, categorical inclusion + negation filters, min_/max_ range bounds, and sort/order. Mirrors GET /api/v1/subnets."
     subnets(
       netuid: Int
       network: Network
@@ -38,6 +38,8 @@ export const SDL = /* GraphQL */ `
       not_domain: String
       not_coverage_level: String
       not_curation_level: String
+      min_integration_readiness: Int
+      max_integration_readiness: Int
       min_readiness: Int
       max_readiness: Int
       min_surface_count: Int
@@ -61,7 +63,7 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: String
     ): SubnetList!
-    "One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets."
+    "One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets. Mirrors GET /api/v1/subnets/{netuid}."
     subnet(netuid: Int!, network: Network): Subnet
     "Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations."
     subnet_registrations(netuid: Int!, window: String): SubnetRegistrations!
@@ -138,7 +140,7 @@ export const SDL = /* GraphQL */ `
       cursor: Int
       fields: String
     ): JSON
-    "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default. Mirrors GET /api/v1/queries/{id}."
+    "Run one maintainer-curated saved-query template by id, with its template-defined params object -- the same parameterized query library REST and the run_saved_query MCP tool execute. Resolves to {query_id, params, data} as opaque JSON. An unknown id or invalid params is a BAD_USER_INPUT error listing the valid template ids, not a silently substituted default."
     saved_query(id: String!, params: JSON): JSON
     "The recorded response fixtures for registered surfaces, used to replay/verify a surface without calling it. Null when no fixture index has been baked in this environment. Opaque JSON passed through verbatim, matching the list_fixtures MCP/REST shape. Mirrors GET /api/v1/fixtures."
     fixtures(
@@ -395,7 +397,7 @@ export const SDL = /* GraphQL */ `
     subnet_overview(netuid: Int!): JSON
     "One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile."
     subnet_profile(netuid: Int!): JSON
-    "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers)."
+    "Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). Mirrors GET /api/v1/providers."
     providers(
       id: String
       kind: String
@@ -406,7 +408,7 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: String
     ): ProviderList!
-    "One provider with its subnets."
+    "One provider with its subnets. The id argument is the route's slug path parameter under the name the rest of this surface uses. Mirrors GET /api/v1/providers/{slug}."
     provider(id: String!): Provider
     "One adapter-backed public metrics snapshot by slug (e.g. 'gittensor', 'allways', 'sn-64'): the captured adapter snapshot, extension metadata, and netuid linkage. An invalid slug is a BAD_USER_INPUT error; a missing slug resolves to null (schema-stable, never a GraphQL error). Mirrors GET /api/v1/adapters/{slug}."
     adapter(slug: String!): Adapter
@@ -704,9 +706,9 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: Int
     ): HealthHistory!
-    "Global operational health rollup with per-subnet summaries."
+    "Global operational health rollup with per-subnet summaries. Mirrors GET /api/v1/health."
     health: GlobalHealth
-    "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are)."
+    "Cross-subnet economic opportunity boards (where to register, what it costs, where the emission and validator headroom are). Each board is a FIELD here, so the route's board selector is the selection set's job. Mirrors GET /api/v1/registry/leaderboards."
     opportunity_boards(limit: Int): OpportunityBoards!
     "Cross-subnet comparison: registry structure, live economics, and live health placed side by side for the requested netuids, in requested order. Mirrors GET /api/v1/compare."
     compare(netuids: [Int!]!, dimensions: [String!]): Compare!
@@ -758,7 +760,7 @@ export const SDL = /* GraphQL */ `
     ): ChainEventsFeed!
     "Chain-activity aggregate over the most recent N blocks the decode lane has published (the blocks arg, 1-5000, default 1000, a stray large value silently capped) from the chain_events lakehouse table: the pallet.method event distribution, each with its count, busiest first. A non-positive/non-integer blocks is a GraphQL BAD_USER_INPUT error; a cold/unbound tier resolves to a schema-stable empty aggregate, never a GraphQL error. The aggregate sibling of chain_events (the raw feed). Pass network to aggregate testnet's decoded history instead of mainnet's. Mirrors GET /api/v1/chain-events/stats (and MCP get_chain_activity)."
     chain_events_stats(blocks: Int, network: Network): ChainEventsStats!
-    "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{ref}."
+    "One extrinsic by hash or composite block_number-extrinsic_index ref; extrinsic is null when the ref doesn't resolve (schema-stable, never a GraphQL error). Mirrors GET /api/v1/extrinsics/{hash}."
     extrinsic(ref: String!): ExtrinsicDetail
     "Subtensor's root-origin hyperparameter/network-config change feed (newest first) -- the extrinsics feed fixed to call_module=AdminUtils, so it takes no signer/call_module filter. Same ExtrinsicList shape as extrinsics. Mirrors GET /api/v1/governance/config-changes."
     governance_config_changes(
@@ -804,7 +806,7 @@ export const SDL = /* GraphQL */ `
       offset: Int
       network: Network
     ): BlockEvents!
-    "Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{block_number}/chain-events."
+    "Every raw pallet.method event in one block from the Postgres all-events tier (ADR 0013), by numeric block_number, in read order. Distinct from block_events (the curated account-attributed D1 stream); requires the all-events data Worker, so it is a GraphQL error where that tier is unavailable (e.g. preview deploys). Mirrors GET /api/v1/blocks/{ref}/chain-events."
     block_chain_events(block_number: Int!, network: Network): BlockChainEvents!
     "Block-production summary over the recent-block window -- counts, inter-block timing, throughput, and author-concentration. Every aggregate is null (never a GraphQL error) when the retired-D1 store is cold. Mirrors GET /api/v1/blocks/summary."
     blocks_summary(network: Network): BlocksSummary!

--- a/src/route-query.ts
+++ b/src/route-query.ts
@@ -34,10 +34,12 @@
 import { z } from "zod";
 import {
   collectionQuerySchemas,
+  routeParameterKind,
   routeQuerySchemasForPathname,
   type RouteQuerySchemas,
 } from "./contracts.ts";
 import {
+  declaredArgumentKind,
   isDeclaredDivergence,
   toRouteShape,
   type RouteShape,
@@ -173,7 +175,7 @@ export function validateRouteArgs(
       supplied[name] = value;
     }
   }
-  const parsed = schemas.plain.safeParse(supplied);
+  const parsed = schemas.args.safeParse(supplied);
   if (parsed.success) return null;
   const issue = parsed.error.issues[0];
   const parameter = String(issue?.path[0] ?? "");
@@ -208,7 +210,7 @@ export function parseRouteArgs<T = Record<string, unknown>>(
       supplied[name] = value;
     }
   }
-  const parsed = schemas.plain.safeParse(supplied);
+  const parsed = schemas.args.safeParse(supplied);
   if (!parsed.success) return null;
   // `.meta({ default })` is published, not applied by parse -- the same reason
   // `pageLimit` reads it back rather than trusting the parsed object.
@@ -393,6 +395,49 @@ export interface RouteArgs<T> {
   clamped: ReadonlySet<string>;
 }
 
+/**
+ * Does GraphQL own this argument's spelling, rather than the route?
+ *
+ * Two ways it can, and BOTH have to be read here (#10772). The first is a
+ * declared PRESENCE (`DECLARED_ARGUMENTS`), which is all this asked before.
+ * The second is a declared TYPE (`DECLARED_ARGUMENT_TYPES`), and missing it is
+ * what regressed `providers(cursor: "<opaque string>")`: the route's `cursor`
+ * is an integer offset, GraphQL's is an opaque keyset, and the route's schema
+ * answered "cursor must be a non-negative integer" for a value it was never
+ * given.
+ *
+ * The second is DERIVED, not listed. A declared type only takes the argument
+ * away from the route when the route's schema cannot hold the value at all --
+ * so `Int` against a `z.number()` bound stays the route's, keeping its
+ * clamping and its published default, while `String` against that same bound
+ * does not. Skipping every declared type instead would have silently stripped
+ * the bounds off fourteen arguments to fix two.
+ *
+ * An argument the route does not declare is GraphQL's by definition: there is
+ * no schema to hold it (`addedByGraphql`).
+ *
+ * A shape the parse already CONVERTS is not a divergence either, and reading
+ * the kinds without asking cost two of these their validation: a GraphQL list
+ * against the route's comma-joined string, and a Boolean against its
+ * `["true","false"]`, are different kinds that `toRouteShape` turns into the
+ * route's spelling a line later -- so `compare_validators(hotkeys: [])` stopped
+ * being rejected. The conversion IS the codec; only a value nothing converts
+ * belongs to GraphQL.
+ */
+function graphqlOwnsSpelling(
+  field: string,
+  name: string,
+  declared: z.ZodType | undefined,
+  shape: RouteShape,
+): boolean {
+  if (isDeclaredDivergence(field, name)) return true;
+  const published = declaredArgumentKind(field, name);
+  if (published === null) return false;
+  if (!declared) return true;
+  if (shape !== "as-is") return false;
+  return published !== routeParameterKind(declared);
+}
+
 export function resolveRouteArgs<T = Record<string, unknown>>(
   routePath: string,
   field: string,
@@ -403,13 +448,16 @@ export function resolveRouteArgs<T = Record<string, unknown>>(
   const clamped = new Set<string>();
   for (const [name, value] of Object.entries(args)) {
     if (value === null || value === undefined) continue;
-    if (isDeclaredDivergence(field, name)) continue;
     const declared = schemas?.plain.shape[name] as z.ZodType | undefined;
+    // Resolved once and used twice: it decides whether the route can hold this
+    // spelling at all, and then how to write it in the route's terms.
+    const shape = routeShapeOf(declared);
+    if (graphqlOwnsSpelling(field, name, declared, shape)) continue;
     if (declared && isServingBound(declared)) {
       owned[name] = clampToPublished(declared, value);
       clamped.add(name);
     } else {
-      owned[name] = toRouteShape(value, routeShapeOf(declared));
+      owned[name] = toRouteShape(value, shape);
     }
   }
   const error = validateRouteArgs(routePath, owned);

--- a/tests/graphql-component-parity.test.ts
+++ b/tests/graphql-component-parity.test.ts
@@ -406,10 +406,15 @@ describe("scalar identity", () => {
 // or more pagination fields the component lacks means this is a view" -- true
 // of the paging and false of the 158 fields behind it.
 describe("paginated views", () => {
-  test("all 25 are declared, and their drops are the whole set", () => {
+  test("all 27 are declared, and their drops are the whole set", () => {
     const report = checkComponentParity(sdl, openapi);
     assert.deepEqual(report.violations, []);
-    assert.equal(report.projections.length, 25);
+    // 27, up from 25: `SubnetList <- SubnetsArtifact` and
+    // `ProviderList <- ProvidersArtifact` are inside this check for the first
+    // time (#10772). Their Query fields carried `route: null`, and the walk
+    // reaches a type only through a `Mirrors GET` annotation -- so the two
+    // busiest list views in the schema were the ones no gate could see.
+    assert.equal(report.projections.length, 27);
     // Every projection's drops, not just the paginated ones -- `dropped` is
     // the whole set on all 38, which is what makes an undeclared drop a
     // failure rather than a silence.

--- a/tests/graphql-query-arguments.test.ts
+++ b/tests/graphql-query-arguments.test.ts
@@ -82,7 +82,14 @@ describe("checkQueryArguments", () => {
     const report = checkQueryArguments(sdl, openapi);
     assert.deepEqual(report.violations, []);
     assert.deepEqual(report.stale, []);
-    assert.equal(report.exact, 189);
+    // 201, up from 189, and the twelve are the point (#10772): the six
+    // `route: null` bindings now name the route they always had, and the
+    // Subscription root and the two nested filtered lists are inside the check
+    // for the first time. The companion assertion is `skipped`, below -- a
+    // count of what reproduces exactly means nothing without the count of what
+    // was never compared.
+    assert.equal(report.exact, 201);
+    assert.equal(report.skipped, 0);
   });
 
   test("it FAILS when an argument's type stops matching the route", () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -581,7 +581,17 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
     assert.equal(body.data.subnets.total, 3);
   });
 
-  test("subnets limit:0 falls back to the default page (not clamped up to 1)", async () => {
+  // limit:0 CLAMPS to the published minimum, and that is the settled rule
+  // rather than a new one (#10772). #10174 decided clamp-vs-reject one sentence
+  // per surface -- REST rejects (verified live: "limit must be an integer
+  // between 1 and 1000"), MCP clamps, and GRAPHQL CLAMPS, which is what
+  // `resolveRouteArgs` does at both ends of the range. This field kept a third
+  // answer, "0 means the default page", from before `subnets` had a route to
+  // parse against; it made 0 the one value in the range that meant something
+  // else. Declaring it a divergence would have been the exemption that hides
+  // what it names, so the fringe input moves to the rule instead: 0 -> 1, the
+  // same way 99999 -> 1000.
+  test("subnets limit:0 clamps up to the published minimum", async () => {
     const env = fixtureEnv({
       "/metagraph/subnets.json": {
         subnets: [
@@ -597,7 +607,10 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
         env as unknown as Env,
       );
       assert.equal(status, 200);
-      assert.equal(body.data.subnets.items.length, 3, `limit:${limit}`);
+      // One row, not the three a default page would give: the clamp answers,
+      // and `total` still reports the whole collection so the caller can see
+      // what they are paging through.
+      assert.equal(body.data.subnets.items.length, 1, `limit:${limit}`);
       assert.equal(body.data.subnets.total, 3);
     }
   });
@@ -817,7 +830,13 @@ describe("handleGraphQLRequest — resolvers (injected data)", () => {
       env as unknown as Env,
     );
     assert.equal(bad.body.data, null);
-    assert.match(bad.body.errors[0].message, /not a supported sort/);
+    // The ROUTE's sentence, not the resolver's (#10772). `subnets` now binds to
+    // /api/v1/subnets, so the dispatch parse answers first and answers with the
+    // published vocabulary -- it names the fourteen sorts that ARE supported
+    // where "not a supported sort" only said the one sent was not. Same code,
+    // same rejection, one vocabulary across REST and GraphQL.
+    assert.match(bad.body.errors[0].message, /^sort must be one of: /);
+    assert.match(bad.body.errors[0].message, /netuid/);
     assert.equal(bad.body.errors[0].extensions.code, "BAD_USER_INPUT");
     const badOrder = await gql(
       '{ subnets(sort: "netuid", order: "sideways") { total } }',


### PR DESCRIPTION
Eight Query fields generated with **no arguments** and `subnet(netuid: Int!)` lost a required one, because `QueryBinding.route` meant two things at once. It said "this field mirrors no `/api/v1` route with a component" — and all six bindings carrying `route: null` **had** a route, with parameters, whose response named a component. `route` names the REQUEST; the component question is about the RESPONSE, and `reshapes` is now that second fact.

## The gate that skipped

`validate:graphql-query-arguments` printed **"189 exactly, 9 skipped"** and passed. The skip was hiding 39 argument divergences, the whole nested-field class, and the Subscription root.

| | before | after |
|---|---|---|
| fields reproducing their route's parameters | 189 | **201** |
| skipped | 9 | **0** |
| `report:graphql-schema-diff` other differences | 0 | **0** |
| unreached types | 0 | **0** |

All 39 divergences are **resolved**, not declared away: 14 Int-vs-Float bounds on integral quantities, 5 negation filters GraphQL has and REST rejects (verified both directions live), 2 opaque cursors, 3 renames, and 12 route capabilities GraphQL does not publish — six of them on `health`, whose resolver is `async health(_args: unknown, …)` and reads nothing off its arguments. `DECLARED_UNPUBLISHED_ARGUMENTS` is the slot that direction never had.

## The runtime change

Giving those six a real route turns the dispatch parse **on** for them. Three things came out of it.

**One list, two readers.** `resolveRouteArgs` asked `isDeclaredDivergence`, which reads only `DECLARED_ARGUMENTS` — so `providers(cursor: "<opaque string>")` was rejected by the route's integer `cursor`, a divergence declared (correctly) in `DECLARED_ARGUMENT_TYPES`. The fix is a second reader, not a third list, and the consequence is **derived**: a declared type only takes an argument away from the route when the route's schema cannot hold the value at all. `Int` against a `z.number()` bound stays the route's and keeps its clamping and published default; `String` against it does not. A shape the parse already converts — a list against a comma-joined string, a Boolean against `["true","false"]` — is a codec, not a divergence, so `compare_validators(hotkeys: [])` is still rejected.

**A vocabulary affordance is not an encoding one.** `caseInsensitiveEnum` lived in `wireField`, the query-string pipeline, so it reached REST and not the typed surfaces — and the parse validated against `plain`, which made GraphQL **stricter than the route it mirrors**. Verified live:

```
/api/v1/subnets?status=Active  -> 200, 129 rows, filter applied
/api/v1/subnets?status=bogus   -> 400 "status must be one of: active, inactive"
```

`args` is the missing layer — `plain` plus the affordances that are about the vocabulary rather than the encoding — with `wire` built on top of it so the rule has **one** definition. Its own comment already said it belongs "everywhere an enum is declared".

**Two served behaviours move**, both onto a settled rule rather than a new one. `subnets` now answers the route's `sort must be one of: block, candidate_count, …` instead of "not a supported sort" — naming the fourteen that work where the old sentence named none. And `limit: 0` clamps to the published minimum instead of meaning "the default page": #10174 settled clamp-vs-reject one sentence per surface (REST rejects — verified live; MCP clamps; GraphQL clamps), and 0 was the one value in the range that meant something else.

## Five gates were out of contact with the registry

Each kept a private copy of a fact the registry already declared, and each was silent only because the six `route: null` bindings kept its subject out of the walk:

- **`validate-published-names` pairing** — `reshapes` appeared **nowhere** in the file, so `opportunity_boards` was asserted identical to `RegistryLeaderboardsArtifact`, the claim that declaration exists to deny.
- **the same walk** seeded a full mirror for a type that already had a `PROJECTED_TYPES` entry — one relationship declared twice, and the projection then read as stale.
- **`validate-graphql-route-parity`** kept an empty local list for the `network` twin while `DECLARED_MISSING_NETWORK` already named `extrinsic`, and two more empty lists for argument directions `DECLARED_UNPUBLISHED_ARGUMENTS` and `DECLARED_ARGUMENT_TYPES` answer. It reported `subnets.cursor` as drift **against a spelling the generator emits from that same entry**.
- **`validate-graphql-component-parity`** recognised a projection only when it added two pagination fields, so `Endpoint` — which drops sixteen of `EndpointResource`'s fields and adds no paging — fell through to the mirror rule and every declared drop came back a violation. It also had no reader for `reshapes`, so `Subnet` was paired with `SubnetDetailArtifact` and that component's **envelope** (`contract_version`, `generated_at`, `notes`, `schema_version`) was reported as fields the SDL forgot.

Two list views are inside the component check for the first time as a result — `SubnetList <- SubnetsArtifact` and `ProviderList <- ProvidersArtifact`, the two busiest in the schema. 25 declared paginated views become **27**.

The SDL's prose and the registry's descriptions are synced for all nine fields, because the registry's copy is the one that gets emitted: a description edited in only one of them is silently reverted at the next generation.

## What is deliberately NOT here

The `buildSchema(SDL)` cutover. `report:graphql-schema-diff` is at **0 other differences and 0 unreached types**, so the argument surface is done — the only gap left is **289 fields the generator would tighten to non-null** while resolvers write `?? null` on the degraded path. Cutting over now turns every degraded response into a GraphQL error, exactly when the API most needs to answer. That is the epic's own "do not turn on stricter response validation before the nullability truth-up", so it waits on #10786 and #10214 keeps it.

## Verification

- `validate:graphql-query-arguments` — 201 exact, 0 skipped
- `validate:graphql-route-parity` — 704 argument/parameter pairs, **0 divergences**, 10 declared
- `report:graphql-schema-diff` — 0 other differences, 0 unreached
- full suite — **856/856 files, 19,711 tests, 0 failures**
- `tsc` clean, `eslint` clean, `prettier` clean, contract validators green

Closes #10772
