### PR TITLE
fix(observability): the four live fault classes the PostHog sweep found

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -134,6 +134,34 @@ export const LANE_ALARM_MIN_SILENCE_MS = 90 * 60 * 1000;
  */
 export const LANE_ALARM_MAX_VERDICT_AGE_MS = LANE_ALARM_CADENCE_WINDOW_MS;
 
+/**
+ * The one-line summary a capture carries, with the CADENCE that makes its
+ * duration readable (#10809).
+ *
+ * "lane neon:validator-nominator-counts is stale: 7.9h" is unreadable on its
+ * own, and was read wrongly in production: that lane's producer runs every 24
+ * hours, so 7.9h is a third of ONE cycle after a single failed flush -- not
+ * eight hours of a worsening outage. Measured 2026-08-11, the figure climbed
+ * 1h per hour from 1.4h to 7.9h while nothing new failed, because a stale
+ * verdict simply ages until the next pass overwrites it.
+ *
+ * The alarm already RESOLVES the cadence -- `cadence_ms` is on every alarm, for
+ * the silence bound -- so this is the number it had all along and did not say.
+ * Stating it is the whole fix: a reader can then tell "less than one cycle,
+ * one failure" from "several cycles missed, the producer is gone", which is the
+ * distinction the bare duration erases.
+ *
+ * Silence is left alone: its bound IS the cadence (three intervals), so its
+ * duration is already expressed in the unit that matters.
+ */
+export function laneAlarmSummary(alarm: LaneAlarm, nowMs: number): string {
+  const elapsed = humanDuration(nowMs - alarm.since);
+  const base = `lane ${alarm.lane} is ${alarm.kind}: ${elapsed}`;
+  return alarm.kind === "stale" && alarm.cadence_ms
+    ? `${base} (producer cadence ${humanDuration(alarm.cadence_ms)})`
+    : base;
+}
+
 /** Title prefix. The dedup key: stable across ticks, and greppable by a human. */
 export const LANE_ALARM_TITLE_PREFIX = "alarm(lane): ";
 
@@ -826,9 +854,7 @@ export async function runLaneAlarm(
     // consecutive hours, while this watchdog's own verdict read "4 alarming".
     // The lane set is declared and small, so per-lane windows are bounded.
     await record(env as never, {
-      error: new Error(
-        `lane ${alarm.lane} is ${alarm.kind}: ${humanDuration(nowMs - alarm.since)}`,
-      ),
+      error: new Error(laneAlarmSummary(alarm, nowMs)),
       route: "watchdog:lane-alarm",
       fingerprintDetail: alarm.lane,
       errorCode: alarm.kind === "stale" ? "lane_stale" : "lane_silent",

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -10459,17 +10459,27 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       ctx: McpCtx,
     ) {
       const ss58 = requireSs58(args);
-      // Shaped on the way out because the first arm forwards an upstream
-      // payload verbatim (#9804). Every locally-built decline already carries
-      // the full `degraded` block, so this is a no-op for them -- it exists for
-      // the one arm this file does not build.
+      // NO TIER ARM (#10808). The forward was real -- METAGRAPH_NEURONS_SOURCE
+      // reads "d1" and IS in DATA_API_FORWARD_FLAGS, so unlike #10190's
+      // deletions this request was genuinely sent. DATA_API just has no handler
+      // for it: matchNeuronsD1Route covers /portfolio, /subnets and
+      // /subnets/:netuid/history, and every unmatched GET falls through to the
+      // gone-tier 503. Measured 36 times in 4 days, and doubled by #10767's
+      // retry, which is right for a transient and wasted on a route that will
+      // never exist.
+      //
+      // Nothing was user-visible, which is the point: the ladder below caught
+      // every one. A fallback ladder hiding a dead dependency is the exact shape
+      // #10190 exists to remove -- and REST's account-positions handler and
+      // GraphQL's account_positions both start at loadAccountPositionsD1 with no
+      // tier arm at all, so this only ever made MCP the odd surface out.
+      //
+      // shapeForwardedPositions stays: it normalised the payload the tier arm
+      // forwarded verbatim (#9804), and every locally-built decline already
+      // carries the full `degraded` block, so it is a no-op for them -- but it
+      // is the one thing keeping this tool's shape identical to its REST twin's.
       return shapeForwardedPositions(
-        (await tryPostgresTier(
-          ctx.env,
-          mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
-          "METAGRAPH_NEURONS_SOURCE",
-        )) ??
-          (await loadAccountPositionsD1(ctx.env, ss58)) ??
+        (await loadAccountPositionsD1(ctx.env, ss58)) ??
           (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
           unavailableAccountPositions(ss58),
       );
@@ -10542,24 +10552,19 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/subnets`),
             "METAGRAPH_NEURONS_SOURCE",
           ).then((data) => data ?? buildAccountSubnets([], ss58)),
-          // Same Postgres → lakehouse → empty-card chain get_account_positions
-          // resolves through, so the compound card and the single-facet tool
-          // cannot disagree about what this coldkey holds.
-          tryPostgresTier(
-            ctx.env,
-            mcpNeuronsTierRequest(`/api/v1/accounts/${ss58}/positions`),
-            "METAGRAPH_NEURONS_SOURCE",
-          ).then(async (data) =>
-            // Same shaping as the single-facet tool above, for the same reason:
-            // this arm can forward a payload this file never built (#9804), and
-            // the compound card must not disagree with the tool it mirrors.
+          // The same hot → cold → empty-card chain get_account_positions resolves
+          // through, so the compound card and the single-facet tool cannot
+          // disagree about what this coldkey holds -- including the tier arm
+          // BOTH of them dropped in #10808, which had no handler behind it.
+          //
+          // Same shaping as the single-facet tool above, for the same reason:
+          // the compound card must not disagree with the tool it mirrors.
+          (async () =>
             shapeForwardedPositions(
-              data ??
-                (await loadAccountPositionsD1(ctx.env, ss58)) ??
+              (await loadAccountPositionsD1(ctx.env, ss58)) ??
                 (await loadAccountPositionsColdTier(ctx.env, ss58)) ??
                 unavailableAccountPositions(ss58),
-            ),
-          ),
+            ))(),
           // NO TIER READ (#10190): METAGRAPH_ACCOUNT_EVENTS_SOURCE reads "retired"
           // in wrangler.jsonc and is absent from DATA_API_FORWARD_FLAGS, so this
           // promise resolved to null on every call.

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -212,6 +212,7 @@ import {
   recordUsageEvent,
   parseUserAgentClient,
 } from "./usage-telemetry.ts";
+import { maskRouteParams } from "./route-label.ts";
 import {
   newSpanId,
   newTraceId,
@@ -8532,7 +8533,18 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       }
       if (!upstream.ok) {
         throw toolError(
-          upstream.status === 404 ? "not_found" : "alert_trigger_error",
+          // CLASSIFIED BY STATUS (#10810). Every non-404 used to collapse into
+          // `alert_trigger_error`, which classifyMcpErrorType buckets as
+          // `internal` -- "our bug". A 401/403 from a wrong or missing owner
+          // token is the CALLER'S, and it made this the only server-fault-classed
+          // MCP error in a 7-day window: a floor that could never reach zero, on
+          // the one signal that answers "is anything broken server-side".
+          //
+          // The codes are the vocabulary's existing ones, so they bucket without
+          // a new mapping: auth_required/forbidden -> permission,
+          // not_found -> missing_context, provider_error -> api_5xx. Only a
+          // genuinely unclassifiable status keeps the catch-all.
+          alertTriggerErrorCode(upstream.status),
           typeof (body as Row | null)?.error === "string"
             ? ((body as Row).error as string)
             : "The alert triggers tier returned an error.",
@@ -17364,6 +17376,57 @@ export function mcpRefusalReason(response: Response): string | null {
 }
 
 /**
+ * The path a refusal arrived on, bounded (#10810).
+ *
+ * `workers/api.ts` routes BOTH `/mcp` and `/mcp/*` here, so the tail is
+ * whatever the caller sent -- and this rides on an event that is never sampled.
+ * `maskRouteParams` alone is not enough: it recognises digits, hex hashes,
+ * UUIDs and SS58 by shape, which covers an id a client of ours would send and
+ * not `/mcp/sess-abc123` or a scanner walking `/mcp/aaa`, `/mcp/bbb`.
+ *
+ * So masking runs first -- keeping this label consistent with every other route
+ * label in the codebase, `:uuid` and all -- and anything it did not recognise
+ * under `/mcp/` collapses to `:seg`. The property can then only ever be `/mcp`
+ * or `/mcp/` plus a fixed vocabulary of placeholders, whatever a caller sends.
+ *
+ * The same bounding decision `$mcp_tool_name` already takes for an
+ * unregistered tool, for the same reason: an unknown value is worth one bucket,
+ * not one bucket per attacker.
+ */
+export function mcpRefusalPath(pathname: string): string {
+  const masked = maskRouteParams(pathname).split("/");
+  // 0 is the empty string before the leading slash and 1 is the mount point
+  // itself; both are ours. Everything after is the caller's.
+  const tail = masked.slice(2).filter((segment) => segment !== "");
+  if (tail.length === 0) return masked.slice(0, 2).join("/");
+  // ONE bucket at ANY depth for anything masking did not recognise. Mapping
+  // each segment independently would still leave the DEPTH caller-controlled --
+  // `/mcp/a/b/c` and `/mcp/a/b` are different labels -- so a scanner walking
+  // deeper paths shards the property anyway, just more slowly.
+  return tail.every((segment) => segment.startsWith(":"))
+    ? [...masked.slice(0, 2), ...tail].join("/")
+    : `${masked.slice(0, 2).join("/")}/:seg`;
+}
+
+/**
+ * The alert-triggers tier's HTTP status, as an MCP error code (#10810).
+ *
+ * Kept a function rather than inlined so the mapping is testable on its own:
+ * the statuses that matter here are produced by another Worker, and driving
+ * each one through a full tool call to assert its bucket would mean standing up
+ * four DATA_API doubles to check four constants.
+ */
+export function alertTriggerErrorCode(status: number): string {
+  if (status === 404) return "not_found";
+  if (status === 401) return "auth_required";
+  if (status === 403) return "forbidden";
+  // Somebody else's 5xx, from the caller's side -- the same reading
+  // provider_error already carries for an adapter's upstream.
+  if (status >= 500) return "provider_error";
+  return "alert_trigger_error";
+}
+
+/**
  * Record a refusal that never reached a handler, without ever touching the
  * response.
  *
@@ -17468,6 +17531,14 @@ export function scheduleMcpRefusalEvent(
           ),
           clientNameSource: "user_agent",
           sessionId: request.headers.get("mcp-session-id"),
+          // WHAT was refused (#10810). The usage_event above has carried the
+          // method all along; the $mcp_tool_call family -- the one MCP
+          // Analytics actually reads -- had neither, which left the largest
+          // refusal class (36 `method_not_allowed` in two days) with no way to
+          // tell a client using an unimplemented verb from a scanner. Masked,
+          // so a session id in the path cannot shard the property.
+          requestMethod: request.method,
+          requestPath: mcpRefusalPath(new URL(request.url).pathname),
           serverName: MCP_SERVER_INFO.name,
           serverVersion: MCP_SERVER_VERSION,
         },

--- a/src/safe-mode-watchdog.ts
+++ b/src/safe-mode-watchdog.ts
@@ -268,6 +268,16 @@ export async function runSafeModeWatchdog(
       await record(env as never, {
         error: new Error(`SafeMode watchdog: ${reasons.join(", ")}`),
         route: "watchdog:safe-mode",
+        // fingerprintDetail (#10813). This route reports TWO independent
+        // subjects: the chain being paused, and this monitor's own read failing.
+        // Both fingerprinted `watchdog:safe-mode:Error`, which is also the storm
+        // guard's throttle key -- so a `safe_mode_active`, the single condition
+        // this watchdog exists to report, could be dropped as a repeat of a
+        // routine `extrinsics: HTTP 522` that fired minutes earlier. Measured
+        // 2026-08-11: 16 `watchdog_unreachable` captures in four days, every one
+        // of them holding that window open. Same fix #10673 made for lane-alarm,
+        // for the same reason.
+        fingerprintDetail: "safe_mode_active",
         errorCode: "safe_mode_active",
       }).catch(() => false);
     }
@@ -282,6 +292,8 @@ export async function runSafeModeWatchdog(
           historyError ??
           new Error("SafeMode history: the extrinsics tier declined the read"),
         route: "watchdog:safe-mode",
+        // See above: the two subjects must not share a throttle window.
+        fingerprintDetail: "watchdog_unreachable",
         errorCode: "watchdog_unreachable",
       }).catch(() => false);
     }
@@ -302,6 +314,8 @@ export async function runSafeModeWatchdog(
     await record(env as never, {
       error: err,
       route: "watchdog:safe-mode",
+      // See above: the two subjects must not share a throttle window.
+      fingerprintDetail: "watchdog_unreachable",
       errorCode: "watchdog_unreachable",
     }).catch(() => false);
     return {

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -935,6 +935,26 @@ export interface McpToolCallEvent extends McpServerIdentity {
   /** Mcp-Session-Id header value; omitted from the payload when absent. */
   sessionId?: string | null;
   /**
+   * The HTTP method and masked path a PRE-DISPATCH REFUSAL arrived on
+   * (#10810).
+   *
+   * Only refusals set these, and only refusals need them: a dispatched call
+   * names its tool, so the request that produced it is never in question. A
+   * refusal has no tool by construction -- the gate runs in front of the
+   * dispatcher -- so `$mcp_tool_name` is null and the error code is all there
+   * is. That was not enough to triage the largest refusal class on the surface:
+   * 36 `method_not_allowed` in two days, with no way to tell a spec-compliant
+   * client hitting a verb the transport does not implement from a scanner
+   * probing paths. One is a compatibility bug worth fixing and the other is
+   * noise worth ignoring, and the event could not distinguish them.
+   *
+   * The path is MASKED with the same maskRouteParams every other route label
+   * uses, so a session id or an ss58 in the URL cannot turn one recurring
+   * refusal into thousands of distinct property values.
+   */
+  requestMethod?: string;
+  requestPath?: string;
+  /**
    * The tool call's raw arguments / result. Redacted (redactMcpSensitiveFields)
    * and size-capped (boundedMcpPayload) before ever being included in the
    * posted event — this module owns that, callers pass the raw value through.
@@ -1039,6 +1059,18 @@ export async function recordMcpToolCallEvent(
     if (intent !== undefined) {
       properties["$mcp_intent"] = intent;
       properties["$mcp_intent_source"] = "context_parameter";
+    }
+
+    // What a refusal arrived on (#10810). Only set by scheduleMcpRefusalEvent,
+    // so a dispatched call never carries them -- see the doc comment on
+    // McpToolCallEvent.requestMethod for why the refusal class alone needs it.
+    const requestMethod = sanitizeLabel(event.requestMethod);
+    if (requestMethod !== undefined) {
+      properties["$mcp_request_method"] = requestMethod;
+    }
+    const requestPath = sanitizeLabel(event.requestPath);
+    if (requestPath !== undefined) {
+      properties["$mcp_request_path"] = requestPath;
     }
 
     // Failure classification (#8963). Emitted only on failure: an

--- a/tests/exception-fingerprints-are-per-fault.test.ts
+++ b/tests/exception-fingerprints-are-per-fault.test.ts
@@ -1,0 +1,140 @@
+// A route that reports several INDEPENDENT faults must fingerprint them apart.
+//
+// THE FAILURE THIS EXISTS TO STOP, which no unit test of a single watchdog can
+// reach. `recordExceptionEvent` throttles on `route:fingerprintDetail:type` --
+// the same key PostHog groups by -- so two unrelated faults filed under one
+// route share a storm-guard window. The louder one holds it open and the
+// quieter one is dropped as a repeat.
+//
+// It is not hypothetical, and it is not cheap when it happens:
+//
+//   * #10673: `lane-alarm` fingerprinted every lane the same, so the first
+//     alarming lane consumed the window and the other three in the same tick
+//     vanished. Measured: exactly one event per tick for six consecutive hours
+//     while the watchdog's own verdict read "4 alarming".
+//   * #10813: `watchdog:safe-mode` filed `safe_mode_active` -- the chain
+//     halting, the one condition that monitor exists for -- under the same
+//     fingerprint as `watchdog_unreachable`, its own probe failing with an
+//     HTTP 522. Sixteen of those 522s in four days, every one holding the
+//     window open against the signal that matters.
+//
+// So this reads the capture sites back out of the source and holds the rule
+// structurally: more than one `errorCode` on a `route` means each site must
+// carry a `fingerprintDetail`. Nothing is listed here that the modules do not
+// already state themselves -- a list in this file would be one more copy to
+// forget.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { describe, test } from "vitest";
+
+/** Every tracked source file that could hold a capture site. */
+function sourceFiles(): string[] {
+  return execFileSync("git", ["ls-files", "src/*.ts", "workers/*.ts"], {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+}
+
+interface Site {
+  file: string;
+  errorCode: string;
+  hasDetail: boolean;
+}
+
+/**
+ * The capture sites in one module, keyed by route.
+ *
+ * Matched on the OBJECT LITERAL rather than on the call, because these are
+ * written as `record(env, { route, errorCode })` through half a dozen different
+ * local aliases (`record`, `capture`, `deps.recordExceptionEvent`) and a matcher
+ * keyed on the callee name would silently miss whichever alias came next.
+ */
+function captureSites(source: string, file: string): Map<string, Site[]> {
+  const byRoute = new Map<string, Site[]>();
+  // POSITION-BASED, not one sweeping regex. The obvious form --
+  // `/route:\s*"([^"]+)"([\s\S]{0,N}?)errorCode:\s*"([^"]+)"/g` -- looks
+  // equivalent and is not: `matchAll` resumes from the END of each match, so a
+  // match that ran past its own literal into a LATER site consumes that site
+  // too, and skipping the bad match silently drops the good one. That is how
+  // the first draft of this gate found one of safe-mode's two codes and
+  // reported the route as single-fault, i.e. compliant.
+  for (const match of source.matchAll(/route:\s*"([^"]+)"/g)) {
+    const from = match.index! + match[0].length;
+    const codeAt = source.indexOf("errorCode:", from);
+    if (codeAt === -1) continue;
+    const between = source.slice(from, codeAt);
+    // Another `route:` in between means this literal has no errorCode of its
+    // own -- the one we found belongs to a later site, which gets its own turn.
+    if (/route:\s*"/.test(between)) continue;
+    const code = /errorCode:\s*"([^"]+)"/.exec(source.slice(codeAt));
+    if (!code) continue;
+    const sites = byRoute.get(match[1]!) ?? [];
+    sites.push({
+      file,
+      errorCode: code[1]!,
+      hasDetail: between.includes("fingerprintDetail:"),
+    });
+    byRoute.set(match[1]!, sites);
+  }
+  return byRoute;
+}
+
+describe("a route with several faults fingerprints them apart", () => {
+  test("no multi-fault route leaves its sites sharing one throttle window", () => {
+    // Routes are collected ACROSS files: a route reported from two modules is
+    // still one fingerprint, and that is exactly the case a per-file check
+    // would miss.
+    const byRoute = new Map<string, Site[]>();
+    for (const file of sourceFiles()) {
+      for (const [route, sites] of captureSites(
+        readFileSync(file, "utf8"),
+        file,
+      )) {
+        byRoute.set(route, [...(byRoute.get(route) ?? []), ...sites]);
+      }
+    }
+
+    const offenders: string[] = [];
+    for (const [route, sites] of byRoute) {
+      const codes = new Set(sites.map((site) => site.errorCode));
+      if (codes.size < 2) continue;
+      const undetailed = sites.filter((site) => !site.hasDetail);
+      if (undetailed.length === 0) continue;
+      offenders.push(
+        `${route} reports ${[...codes].sort().join(", ")} but ` +
+          `${undetailed.length} site(s) carry no fingerprintDetail ` +
+          `(${[...new Set(undetailed.map((site) => site.file))].join(", ")})`,
+      );
+    }
+
+    assert.deepEqual(
+      offenders,
+      [],
+      "these routes let one fault throttle another:\n  " +
+        offenders.join("\n  "),
+    );
+  });
+
+  test("the scan actually finds the sites it is checking", () => {
+    // A structural gate that matches nothing passes forever. Anchored on a
+    // route known to report two subjects -- if this stops finding them, the
+    // matcher has drifted from how these sites are written and the check above
+    // is vacuous.
+    const sites = captureSites(
+      readFileSync("src/safe-mode-watchdog.ts", "utf8"),
+      "src/safe-mode-watchdog.ts",
+    );
+    const safeMode = sites.get("watchdog:safe-mode");
+    assert.ok(safeMode, "watchdog:safe-mode has capture sites");
+    assert.ok(
+      safeMode.length >= 2,
+      `expected several capture sites, found ${safeMode.length}`,
+    );
+    assert.deepEqual(
+      new Set(safeMode.map((site) => site.errorCode)),
+      new Set(["safe_mode_active", "watchdog_unreachable"]),
+    );
+  });
+});

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -31,6 +31,7 @@ const { pg } = await vi.hoisted(async () => ({
 vi.mock("pg", () => pg.module);
 
 import {
+  laneAlarmSummary,
   LANE_ALARM_MAX_OPENS_PER_TICK,
   LANE_ALARM_MIN_STALE_MS,
   LANE_SILENCE_EXEMPT,
@@ -1216,5 +1217,51 @@ describe("laneAlarmTitle", () => {
       laneAlarmTitle("neurons-staleness"),
       `${LANE_ALARM_TITLE_PREFIX}neurons-staleness`,
     );
+  });
+});
+
+describe("the summary a capture carries (#10809)", () => {
+  const NOW = 1_760_000_000_000;
+  const staleFor = (hours: number, cadenceMs: number | null) => ({
+    lane: "neon:validator-nominator-counts",
+    kind: "stale" as const,
+    since: NOW - hours * 3_600_000,
+    ticks: 1,
+    detail: "1 statement(s) flushed, 1 failed",
+    age_ms: null,
+    cadence_ms: cadenceMs,
+  });
+
+  test("a stale duration is stated against the cadence that makes it readable", () => {
+    // Measured on production 2026-08-11: this lane's figure climbed 1h per hour
+    // from 1.4h to 7.9h while NOTHING new failed -- a stale verdict simply ages
+    // until the next pass overwrites it. Its producer runs every 24 hours, so
+    // 7.9h is a third of one cycle after a single failed flush. The bare
+    // duration read as eight hours of a worsening outage, and it was not.
+    const summary = laneAlarmSummary(staleFor(7.9, 86_400_000), NOW);
+    assert.match(summary, /is stale: /);
+    assert.match(
+      summary,
+      /producer cadence 24\.0h/,
+      `the duration needs its unit: ${summary}`,
+    );
+  });
+
+  test("an uncalibrated lane says only what it measured", () => {
+    // No declared producer and too little history to estimate one: inventing a
+    // cadence here would be exactly the false precision the alarm's own
+    // LANE_ALARM_MIN_CADENCE_SAMPLES rule refuses.
+    const summary = laneAlarmSummary(staleFor(7.9, null), NOW);
+    assert.match(summary, /is stale: /);
+    assert.doesNotMatch(summary, /cadence/);
+  });
+
+  test("silence is left alone -- its bound already IS the cadence", () => {
+    const summary = laneAlarmSummary(
+      { ...staleFor(4, 86_400_000), kind: "silent" as const },
+      NOW,
+    );
+    assert.match(summary, /is silent: /);
+    assert.doesNotMatch(summary, /cadence/);
   });
 });

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -24,6 +24,8 @@ import {
   handleMcpRequest,
   listToolDefinitions,
   mcpRefusalReason,
+  alertTriggerErrorCode,
+  mcpRefusalPath,
   scheduleMcpRefusalEvent,
 } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
@@ -162,6 +164,69 @@ describe("pre-dispatch refusals reach the $mcp_* family", () => {
     });
   }
 
+  test("a refusal names the method and the masked path it arrived on", async () => {
+    // #10810. A refusal has no tool by construction -- the gate runs in front of
+    // the dispatcher -- so `$mcp_tool_name` is null and the error code was all
+    // there was. That could not triage the largest refusal class on the surface:
+    // 36 `method_not_allowed` in two days, with no way to separate a client
+    // using a verb the transport does not implement from a scanner.
+    const events: Row[] = [];
+    scheduleMcpRefusalEvent(
+      new Request("https://api.metagraph.sh/mcp/sess-abc123", {
+        method: "DELETE",
+      }),
+      CONFIGURED_ENV as unknown as Env,
+      {
+        recordUsageEvent: () => true,
+        recordMcpToolCallEvent: (_e: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+        executionCtx: { waitUntil: () => {} },
+      },
+      new Response("no", { status: 405 }),
+    );
+    assert.equal(events.length, 1);
+    assert.equal(events[0].requestMethod, "DELETE");
+    assert.equal(events[0].toolName, undefined, "a refusal names no tool");
+    // MASKED. An unmasked path would shard one recurring refusal across every
+    // session id that produced it -- the same cardinality argument every other
+    // route label in this codebase already makes.
+    assert.equal(
+      events[0].requestPath,
+      "/mcp/:seg",
+      `expected the session segment masked, got ${String(events[0].requestPath)}`,
+    );
+  });
+
+  test("the refusal path is bounded whatever the caller sends", () => {
+    // /mcp AND /mcp/* both route to the MCP handler, so the tail is caller
+    // input on an event that is never sampled. maskRouteParams recognises ids
+    // by SHAPE, which covers a UUID and not a scanner walking /mcp/aaa,
+    // /mcp/bbb -- so anything it does not recognise gets one bucket, not one
+    // bucket per probe.
+    assert.equal(mcpRefusalPath("/mcp"), "/mcp");
+    // A trailing slash is the SAME endpoint, so it must not be a second label.
+    assert.equal(mcpRefusalPath("/mcp/"), "/mcp");
+    assert.equal(
+      mcpRefusalPath("/mcp/019fc81a-5c37-7012-970b-7871a621c410"),
+      "/mcp/:uuid",
+      "a recognised id keeps its own placeholder",
+    );
+    assert.equal(mcpRefusalPath("/mcp/4200000"), "/mcp/:n");
+    // The whole point: unbounded caller input cannot shard the property -- and
+    // DEPTH is caller input too, so a deeper probe must not buy a new label.
+    const probes = [
+      "aaa",
+      "bbb",
+      "sess-1",
+      "../etc/passwd",
+      "%00",
+      "a/b/c/d/e/f",
+    ].map((tail) => mcpRefusalPath(`/mcp/${tail}`));
+    assert.deepEqual(new Set(probes), new Set(["/mcp/:seg"]));
+  });
+
   test("a 2xx is not a refusal and records nothing", async () => {
     const events: Row[] = [];
     assert.equal(mcpRefusalReason(new Response("ok", { status: 200 })), null);
@@ -197,6 +262,36 @@ describe("pre-dispatch refusals reach the $mcp_* family", () => {
         Date.now() + 99 * 3_600_000,
       ),
     );
+  });
+});
+
+describe("the alert-triggers tier's status, classified (#10810)", () => {
+  test("a caller's bad token is a permission failure, not a server fault", () => {
+    // Every non-404 used to collapse into `alert_trigger_error`, which
+    // classifyMcpErrorType buckets as `internal` -- "our bug". It was the ONLY
+    // server-fault-classed MCP error in a 7-day production window, which put a
+    // floor under the one signal that answers "is anything broken server-side"
+    // and made that floor unreachable.
+    for (const [status, code, type] of [
+      [401, "auth_required", "permission"],
+      [403, "forbidden", "permission"],
+      [404, "not_found", "missing_context"],
+      // Somebody else's 5xx, from the caller's side -- the reading
+      // provider_error already carries for an adapter's upstream.
+      [500, "provider_error", "api_5xx"],
+      [503, "provider_error", "api_5xx"],
+    ] as [number, string, string][]) {
+      assert.equal(alertTriggerErrorCode(status), code, `HTTP ${status}`);
+      assert.equal(classifyMcpErrorType(code), type, code);
+    }
+  });
+
+  test("an unclassifiable status keeps the catch-all, and it still reads as internal", () => {
+    // The point is not that nothing is `internal` any more -- a status we
+    // cannot attribute genuinely is ours until proven otherwise. The point is
+    // that the ones we CAN attribute no longer arrive there.
+    assert.equal(alertTriggerErrorCode(418), "alert_trigger_error");
+    assert.equal(classifyMcpErrorType("alert_trigger_error"), "internal");
   });
 });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -21251,13 +21251,17 @@ describe("MCP webhook/alert-trigger read tools (2026-07-14/15 audit follow-up)",
       { env },
     );
     assert.equal(res.body.result.isError, true);
-    assert.equal(
-      res.body.result.structuredContent.error.code,
-      "alert_trigger_error",
-    );
+    // The MESSAGE fallback is this test's claim -- an upstream `error` field
+    // that is not a string must not reach the caller as "[object Object]".
     assert.equal(
       res.body.result.structuredContent.error.message,
       "The alert triggers tier returned an error.",
+    );
+    // The CODE now follows the status (#10810): a 500 is somebody else's 5xx,
+    // which classifies as api_5xx rather than as our own `internal`.
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "provider_error",
     );
   });
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -22280,6 +22280,43 @@ describe("MCP account identity/position-history tools (#5225 parity)", () => {
     assert.deepEqual(out.positions, []);
   });
 
+  test("get_account_positions never asks DATA_API, on either tool", async () => {
+    // #10808. The tier arm here was a REAL forward -- METAGRAPH_NEURONS_SOURCE
+    // is in DATA_API_FORWARD_FLAGS -- to a route DATA_API does not implement:
+    // matchNeuronsD1Route covers /portfolio, /subnets and
+    // /subnets/:netuid/history, and /positions fell through to the gone-tier
+    // 503 on all 36 occurrences measured in 4 days.
+    //
+    // Asserting the ABSENCE of the request, not the shape of the answer: the
+    // ladder below always caught the 503, so the card was correct throughout
+    // and no assertion over its payload could have found this. A reintroduced
+    // forward would be invisible the same way.
+    for (const [tool, args] of [
+      ["get_account_positions", { ss58: SS58 }],
+      ["get_account_snapshot", { ss58: SS58 }],
+    ] as [string, Row][]) {
+      const paths: string[] = [];
+      const res = await callTool(tool, args, {
+        env: {
+          // The value that WOULD forward, on the flag that genuinely forwards.
+          METAGRAPH_NEURONS_SOURCE: "d1",
+          DATA_API: {
+            fetch: async (request: Request) => {
+              paths.push(new URL(request.url).pathname);
+              return Response.json({ schema_version: 1, marker: "tier" });
+            },
+          },
+        },
+      });
+      assert.equal(res.body.result.isError, false, tool);
+      assert.deepEqual(
+        paths.filter((path) => path.endsWith("/positions")),
+        [],
+        `${tool} forwarded /positions to a handler that does not exist`,
+      );
+    }
+  });
+
   test("get_account_positions rejects a malformed ss58", async () => {
     const res = await callTool("get_account_positions", {
       ss58: "not-an-address",
@@ -22441,7 +22478,33 @@ describe("MCP get_account_snapshot", () => {
         }),
       };
     }) as unknown as typeof globalThis.fetch;
+    // The positions view's own store (#10808). THREE reads, not one, and the
+    // order matters -- `answers` is first-match. The loader issues the position
+    // page and the ledger stamp together (an empty stamp is the pre-cutover
+    // state and DECLINES), then side-loads the hotkeys' stake off `neurons` to
+    // price the shares. Miss any of the three and it falls through to the cold
+    // tier and then to the unavailable card.
+    const POSITION_HOTKEY = "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3";
+    pg.control.answers = [
+      { match: /MAX\(captured_at\)/i, rows: [{ latest: 1_750_000_000_000 }] },
+      {
+        match: /FROM neurons/i,
+        rows: [{ hotkey: POSITION_HOTKEY, netuid: 7, stake_tao: 100 }],
+      },
+      {
+        match: /FROM nominator_positions/i,
+        rows: [
+          {
+            hotkey: POSITION_HOTKEY,
+            netuid: 7,
+            share_fraction: 0.25,
+            captured_at: 1_750_000_000_000,
+          },
+        ],
+      },
+    ];
     const env = {
+      ...pgMockEnv(["nominator_positions", "neurons"]),
       METAGRAPH_NEURONS_SOURCE: "postgres",
       METAGRAPH_ACCOUNT_EVENTS_SOURCE: "postgres",
       ...LAKEHOUSE_ENV,
@@ -22472,18 +22535,12 @@ describe("MCP get_account_snapshot", () => {
               subnets: [],
             });
           }
-          if (url.pathname === `/api/v1/accounts/${SS58}/positions`) {
-            return Response.json({
-              schema_version: 1,
-              ss58: SS58,
-              position_count: 1,
-              total_stake_alpha: 42,
-              positions: [],
-            });
-          }
-          // /accounts/:ss58/events is deliberately NOT served here: its flag is
-          // retired, so production never requests it. The events view reads the
-          // lakehouse, wired below.
+          // NEITHER /positions nor /events is served here. #10808 removed the
+          // positions forward (DATA_API has no handler for it, so it 503'd every
+          // time) and #10190 retired the events flag -- so a path served here is
+          // one production never gets an answer from. Positions reads
+          // nominator_positions in the live store, events reads the lakehouse;
+          // both are wired above.
           throw new Error(`unexpected DATA_API path: ${url.pathname}`);
         },
       },
@@ -22500,7 +22557,11 @@ describe("MCP get_account_snapshot", () => {
       assert.equal(out.balance.balance_tao, 2.5);
       assert.equal(out.portfolio.position_count, 2);
       assert.equal(out.subnets.subnet_count, 3);
-      assert.equal(out.positions.total_stake_alpha, 42);
+      assert.equal(
+        out.positions.position_count,
+        1,
+        "the positions view must come from the store, not a tier that 503s",
+      );
       assert.equal(
         out.recent_events.events[0].event_kind,
         "Transfer",
@@ -23178,11 +23239,11 @@ describe("MCP chain-*/subnet-* analytics tools — Postgres tier wiring", () => 
       args: { ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" },
       path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/portfolio",
     },
-    {
-      tool: "get_account_positions",
-      args: { ss58: "5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5" },
-      path: "/api/v1/accounts/5G9hfkx9wGB1CLMT9WXkpHSAiYzjZb5o1Boyq4KAdDhjwrc5/positions",
-    },
+    // get_account_positions is NOT here (#10808). Every other entry names a path
+    // matchNeuronsD1Route actually implements; /positions was the one that did
+    // not, so this loop asserted a forward that answered 503 every time in
+    // production. Its replacement asserts the absence of the request --
+    // "get_account_positions never asks DATA_API, on either tool" above.
     {
       tool: "get_account_position_history",
       args: {

--- a/tests/safe-mode-watchdog.test.ts
+++ b/tests/safe-mode-watchdog.test.ts
@@ -440,3 +440,62 @@ test("a capture that fails on the BLIND-HALF report never breaks the tick", asyn
   assert.equal(result.ok, true);
   assert.equal(result.history_read, false);
 });
+
+// #10813: the two subjects this route reports must not share a throttle window.
+describe("the chain-paused signal cannot be throttled by our own probe", () => {
+  function captureSpy() {
+    const captures: Record<string, unknown>[] = [];
+    return {
+      captures,
+      recordExceptionEvent: (async (_env: unknown, event: unknown) => {
+        captures.push(event as Record<string, unknown>);
+        return true;
+      }) as never,
+    };
+  }
+
+  const pausedChain = (async () =>
+    new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1234" }), {
+      status: 200,
+    })) as unknown as typeof fetch;
+
+  test("a paused chain and a blind history fingerprint separately", async () => {
+    // recordExceptionEvent throttles on `route:fingerprintDetail:type`, which is
+    // also what PostHog groups by. Without the detail BOTH of these were
+    // `watchdog:safe-mode:Error` -- so a SafeMode pause, the one condition this
+    // watchdog exists to report, could be dropped as a repeat of a routine
+    // `extrinsics: HTTP 522`. Measured 2026-08-11: 16 of those 522s in four
+    // days, every one holding the window open.
+    //
+    // Both faults in ONE tick, which is the case that matters: a chain that
+    // pauses while our own history read is failing is exactly when the wrong
+    // one must not win.
+    const spy = captureSpy();
+    const result = await runSafeModeWatchdog(null, {
+      fetchImpl: pausedChain,
+      readExtrinsics: async () => null,
+      recordExceptionEvent: spy.recordExceptionEvent,
+    });
+    assert.equal(result.alerted, true);
+    assert.equal(spy.captures.length, 2, "both subjects reported");
+
+    const byCode = new Map(
+      spy.captures.map((capture) => [capture.errorCode, capture]),
+    );
+    assert.equal(
+      byCode.get("safe_mode_active")?.fingerprintDetail,
+      "safe_mode_active",
+    );
+    assert.equal(
+      byCode.get("watchdog_unreachable")?.fingerprintDetail,
+      "watchdog_unreachable",
+    );
+    // The property under test, stated as the thing it prevents: two DIFFERENT
+    // throttle keys, so neither can suppress the other.
+    assert.equal(
+      new Set(spy.captures.map((capture) => capture.fingerprintDetail)).size,
+      2,
+      "the two subjects share a throttle window",
+    );
+  });
+});


### PR DESCRIPTION
Closes #10808
Closes #10810
Refs #10807, #10809, #10813

Four fixes from the 2026-08-11 PostHog sweep, each measured against production
before and after.

## A tier forward to a route that does not exist (#10808)

`/api/v1/accounts/{ss58}/positions` was forwarded through
`METAGRAPH_NEURONS_SOURCE` — a flag that genuinely forwards — to a route
`matchNeuronsD1Route` does not implement. It covers `/portfolio`, `/subnets`
and `/subnets/:netuid/history`; every unmatched GET falls through to the
gone-tier 503. **The top production exception: 36 in 4 days**, and doubled
since #10767 began retrying 5xx — correct for a transient, wasted on a route
that will never exist.

This is not what #10190 swept. That sweep deleted calls whose FLAG cannot
forward; here the flag forwards and the ROUTE is missing, which no static read
of the flags can see.

Nothing was user-visible, which is the point — the hot/cold ladder caught every
one, so no assertion over the payload could have found it. REST and GraphQL
both start at `loadAccountPositionsD1` with no tier arm, so this only ever made
MCP the odd surface out. The test asserts the **absence** of the request, on
both tools, with the flag set to the value that would forward.

## Refusals that could not be triaged (#10810)

36 `method_not_allowed` and 33 `stream_taken`/`status_409` in two days carried
the error code and nothing else — no method, no path — so a spec-compliant
client hitting an unimplemented verb was indistinguishable from a scanner.

The path is **bounded**, not merely masked. `workers/api.ts` routes `/mcp` and
`/mcp/*` alike, so the tail is caller input on an event that is never sampled;
`maskRouteParams` recognises ids by shape, which covers a UUID and not
`/mcp/sess-abc123`. Mapping segments independently would still leave the DEPTH
caller-controlled, so anything unrecognised collapses to one bucket at any
depth — the same decision `$mcp_tool_name` already takes for an unregistered
tool.

## An auth failure filed as a server fault (#10810)

`get_alert_trigger` mapped every non-404 upstream status to
`alert_trigger_error`, which classifies as `internal` — "our bug". A 401/403
from a wrong owner token is the caller's. It was the **only**
server-fault-classed MCP error in a 7-day window, so it put a floor under the
one signal that answers whether anything is broken server-side. Statuses now
map to the vocabulary's existing codes; an unattributable status keeps the
catch-all, because a status we cannot attribute genuinely is ours until proven
otherwise.

## A routine 522 throttling the chain-paused signal (#10813)

`watchdog:safe-mode` reports two independent subjects — the chain halting, and
this monitor's own read failing — and both fingerprinted
`watchdog:safe-mode:Error`. That string is the storm guard's throttle key, so
`safe_mode_active`, the one condition the watchdog exists for, could be dropped
as a repeat of an HTTP 522 that fired minutes earlier. **16 of those 522s in
four days**, every one holding the window open.

Same fix #10673 made for lane-alarm, plus a **structural gate** so the next
multi-fault route cannot repeat it: more than one `errorCode` on a route means
every site must carry a `fingerprintDetail`. It reads the capture sites out of
the source, collects routes across files, and is verified to fail when the
detail is removed. Its scan is position-based rather than one sweeping regex —
`matchAll` resumes past a match that overran its own literal, which made the
first draft find one of safe-mode's two codes and call the route compliant.

## An alarm that could not be read (#10809)

`lane neon:validator-nominator-counts is stale: 7.9h` was read as eight hours
of a worsening outage. That lane's producer runs every 24 hours, so it was a
third of ONE cycle after a single failed flush — the figure climbed 1h per hour
from 1.4h to 7.9h while nothing new failed, because a stale verdict ages until
the next pass overwrites it. The alarm already resolved `cadence_ms` for its
silence bound; it simply never said it.

That misreading is what put four healthy lanes in #10809's original table.
Root cause and the producer-side half are recorded there.

## Verification

`npm run build`, the full suite (19,710 passed), `tsc`, `eslint`, `prettier`,
`validate:api` and `validate:contract-drift` clean on the rebased branch. Each
new guard was verified to fail against the code it guards. No visual output is
touched.
