### PR TITLE
fix(crons): make the api Worker's */15 branch explicit, so an unknown cron stops running a producer

### DIFF
--- a/tests/api-coverage.test.ts
+++ b/tests/api-coverage.test.ts
@@ -3102,10 +3102,27 @@ describe("handleScheduled", () => {
     assert.ok(result === undefined || typeof result === "object");
   });
 
-  test("any other cron runs the health prober", async () => {
-    // No bindings → runHealthProber should not throw with an empty env.
-    const result = await handleScheduled(
+  test("an undeclared cron is DECLINED, and does not run the health prober", async () => {
+    // INVERTED BY #10815, and the old name said the bug out loud: "any other
+    // cron runs the health prober". It did -- dispatchScheduled ran the prober
+    // as its unconditional fall-through, so a typo'd or retired expression
+    // wrote surface_checks, surface_status, surface_uptime_daily,
+    // subnet_snapshots and lane_health on whatever cadence it happened to have.
+    const result = (await handleScheduled(
       { cron: "*/2 * * * *" } as unknown as ScheduledController,
+      {} as unknown as Env,
+      { waitUntil() {} } as unknown as ExecutionContext,
+    )) as Record<string, unknown>;
+    assert.equal(result.skipped, true);
+    assert.equal(result.reason, "unknown cron");
+  });
+
+  test("the health prober's own cron still reaches it", async () => {
+    // The other half: declining unknowns must not decline the real one.
+    const result = await handleScheduled(
+      {
+        cron: workerConfig.HEALTH_PROBER_CRON,
+      } as unknown as ScheduledController,
       {} as unknown as Env,
       { waitUntil() {} } as unknown as ExecutionContext,
     );

--- a/tests/api-crons-have-handlers.test.ts
+++ b/tests/api-crons-have-handlers.test.ts
@@ -1,0 +1,117 @@
+// Both directions between wrangler.jsonc's 37 crons and the api Worker that
+// dispatches them (#10815) -- the twin of tests/data-api-crons-have-handlers,
+// and the worse of the two failures it guards.
+//
+// On data-api an unrecognised cron fell through to `{ skipped: true }`: a
+// no-op, wasteful but harmless. Here it fell through to `runHealthProber`,
+// unconditionally, because `*/15 * * * *` was the only one of the 37 with no
+// constant and no branch -- it WAS the fall-through. So a typo'd or retired
+// expression on this Worker did not go quiet, it ran a real producer that
+// writes surface_checks, surface_status, surface_uptime_daily, subnet_snapshots
+// and lane_health, on whatever cadence the stray expression happened to have.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import { API_HANDLED_CRONS } from "../workers/api.ts";
+import { HEALTH_PROBER_CRON } from "../workers/config.ts";
+
+const CONFIG = "wrangler.jsonc";
+
+/** The cron expressions declared in a wrangler config. JSONC, so parsed rather
+ * than JSON.parse'd -- see tests/data-api-crons-have-handlers.test.ts. */
+function declaredCrons(path: string): string[] {
+  const source = readFileSync(path, "utf8");
+  const block = /"crons"\s*:\s*\[([\s\S]*?)\]/.exec(source);
+  assert.ok(block, `no "crons" array found in ${path}`);
+  return [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+describe("wrangler.jsonc crons and their handlers", () => {
+  test("the parse finds the full grid, so the assertions below are real", () => {
+    const declared = declaredCrons(CONFIG);
+    assert.ok(
+      declared.length >= 30,
+      `only ${declared.length} cron(s) parsed out of ${CONFIG} -- the parse broke`,
+    );
+    assert.ok(
+      API_HANDLED_CRONS.length >= 30,
+      `only ${API_HANDLED_CRONS.length} handled crons declared`,
+    );
+  });
+
+  test("every DECLARED cron resolves to a handled lane", () => {
+    const unhandled = declaredCrons(CONFIG).filter(
+      (cron) => !API_HANDLED_CRONS.includes(cron),
+    );
+    assert.deepEqual(
+      unhandled,
+      [],
+      `these crons are declared in ${CONFIG} but API_HANDLED_CRONS does not name ` +
+        `them, so dispatchScheduled declines them:\n${unhandled.join("\n")}`,
+    );
+  });
+
+  test("every HANDLED cron is declared", () => {
+    const declared = new Set(declaredCrons(CONFIG));
+    const undeclared = API_HANDLED_CRONS.filter((cron) => !declared.has(cron));
+    assert.deepEqual(
+      undeclared,
+      [],
+      `these lanes are handled but never scheduled:\n${undeclared.join("\n")}`,
+    );
+  });
+
+  test("the health prober's cron is one of the declared set, not the fall-through", () => {
+    // THE ACTUAL FIX. Before #10815 this expression had no constant at all --
+    // `runHealthProber` sat at the bottom of dispatchScheduled and ran for
+    // anything unmatched. Asserting it is a NAMED member of the handled set is
+    // what stops it becoming the default again.
+    assert.ok(
+      API_HANDLED_CRONS.includes(HEALTH_PROBER_CRON),
+      "HEALTH_PROBER_CRON must be a declared member of API_HANDLED_CRONS",
+    );
+    assert.ok(
+      declaredCrons(CONFIG).includes(HEALTH_PROBER_CRON),
+      `${HEALTH_PROBER_CRON} must be scheduled in ${CONFIG}`,
+    );
+  });
+
+  test("the handled set has no duplicates", () => {
+    // Two entries for one expression would mean two branches believe they own
+    // it, and only the first would ever run.
+    const seen = new Set(API_HANDLED_CRONS);
+    assert.equal(
+      seen.size,
+      API_HANDLED_CRONS.length,
+      "API_HANDLED_CRONS contains a duplicate expression",
+    );
+  });
+  test("an undeclared cron is declined, and does NOT reach the health prober", () => {
+    // THE BEHAVIOUR, not just the bookkeeping. Before #10815 this expression
+    // would have run runHealthProber -- five tables written on a cadence
+    // nobody chose. Exercised through the real `scheduled` export so the guard
+    // is what is being tested, not a reimplementation of it.
+    return import("../workers/api.ts").then(async ({ default: worker }) => {
+      const result = (await worker.scheduled(
+        { cron: "7 7 7 7 7", scheduledTime: Date.now() } as never,
+        {} as never,
+        { waitUntil: () => {} } as never,
+      )) as Record<string, unknown>;
+      assert.equal(result.ok, false);
+      assert.equal(result.skipped, true);
+      assert.equal(result.reason, "unknown cron");
+    });
+  });
+
+  test("an empty cron is declined rather than treated as the prober's", () => {
+    return import("../workers/api.ts").then(async ({ default: worker }) => {
+      const result = (await worker.scheduled(
+        { scheduledTime: Date.now() } as never,
+        {} as never,
+        { waitUntil: () => {} } as never,
+      )) as Record<string, unknown>;
+      assert.equal(result.skipped, true);
+      assert.equal(result.reason, "unknown cron");
+    });
+  });
+});

--- a/tests/api-crons-have-handlers.test.ts
+++ b/tests/api-crons-have-handlers.test.ts
@@ -114,4 +114,41 @@ describe("wrangler.jsonc crons and their handlers", () => {
       assert.equal(result.reason, "unknown cron");
     });
   });
+  test("every handled cron has an `if (cron === ...)` branch in the dispatcher", () => {
+    // WHAT MAKES API_HANDLED_CRONS LOAD-BEARING. The dispatcher does not read
+    // it -- an earlier cut had it decline against the set first, which made the
+    // guard at the bottom unreachable, i.e. a branch no test could cover. So
+    // the tie between the set and the branches is asserted here instead.
+    //
+    // An entry with no branch would fall through to the bottom `return
+    // { skipped: true }` and simply never run, which is the #10814 failure
+    // wearing this file's clothes.
+    const source = readFileSync("workers/api.ts", "utf8");
+    const branched = new Set(
+      [...source.matchAll(/^ {2}if \(cron === (\w+)\) \{/gm)].map((m) => m[1]),
+    );
+    assert.ok(
+      branched.size >= 30,
+      `only ${branched.size} dispatch branches parsed -- the scan broke, so this ` +
+        `test is passing on nothing`,
+    );
+    // HEALTH_PROBER_CRON is branched too, just further down (it guards the
+    // firehose bootstrap as well as the prober), so it is expected here.
+    assert.ok(
+      source.includes("if (cron === HEALTH_PROBER_CRON) {"),
+      "the health prober must be a named branch, not the fall-through",
+    );
+    branched.add("HEALTH_PROBER_CRON");
+
+    const names = new Set(
+      [...source.matchAll(/^ {2}([A-Z0-9_]+_CRON),$/gm)].map((m) => m[1]),
+    );
+    const unbranched = [...names].filter((n) => !branched.has(n));
+    assert.deepEqual(
+      unbranched,
+      [],
+      `these are in API_HANDLED_CRONS but no branch dispatches on them, so they ` +
+        `would fire and do nothing:\n${unbranched.join("\n")}`,
+    );
+  });
 });

--- a/tests/health-prober.test.ts
+++ b/tests/health-prober.test.ts
@@ -636,6 +636,13 @@ describe("runHealthProber", () => {
 // to clean up after are retired too. See pruneHealthHistory edge paths
 // below for its now-simple contract.
 
+// #10815: these used "*/2 * * * *" -- an expression declared NOWHERE -- and
+// passed because dispatchScheduled ran the prober as its unconditional
+// fall-through. That is the bug, so the tests now name the prober's real cron.
+// An undeclared cron is asserted to be DECLINED in
+// tests/api-crons-have-handlers.test.ts.
+const { HEALTH_PROBER_CRON } = await import("../workers/config.ts");
+
 describe("handleScheduled dispatch", () => {
   test("hourly cron prunes; other crons probe", async () => {
     const pruneResult = (await handleScheduled(
@@ -660,9 +667,9 @@ describe("handleScheduled dispatch", () => {
     )) as Row;
     assert.equal(pruneResult.pruned, true);
 
-    // The 2-minute cron path runs the prober; with an empty env it no-ops.
+    // The prober's own cron runs the prober; with an empty env it no-ops.
     const probeResult = (await handleScheduled(
-      { cron: "*/2 * * * *" } as unknown as ScheduledController,
+      { cron: HEALTH_PROBER_CRON } as unknown as ScheduledController,
       {} as unknown as Env,
     )) as Row;
     assert.equal(probeResult.ok, false);
@@ -707,7 +714,7 @@ describe("handleScheduled dispatch", () => {
       const { waited, ctx } = waitingCtx();
       try {
         await handleScheduled(
-          { cron: "*/2 * * * *" } as unknown as ScheduledController,
+          { cron: HEALTH_PROBER_CRON } as unknown as ScheduledController,
           { POSTHOG_PROJECT_TOKEN: "phc_test_token" } as unknown as Env,
           ctx,
         );
@@ -717,7 +724,7 @@ describe("handleScheduled dispatch", () => {
         );
         assert.equal(usage.length, 1);
         const props = (usage[0].body as Row).properties as Row;
-        // A name survives a schedule change where "*/2 * * * *" would not.
+        // A name survives a schedule change where the literal would not.
         assert.equal(props.route, "cron:health-prober");
         assert.equal(typeof props.duration_ms, "number");
       } finally {
@@ -805,7 +812,7 @@ describe("handleScheduled dispatch", () => {
       }) as unknown as typeof fetch;
       try {
         const result = (await handleScheduled(
-          { cron: "*/2 * * * *" } as unknown as ScheduledController,
+          { cron: HEALTH_PROBER_CRON } as unknown as ScheduledController,
           { POSTHOG_PROJECT_TOKEN: "phc_test_token" } as unknown as Env,
         )) as Row;
         assert.equal(result.ok, false);

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2816,14 +2816,23 @@ function recordCronOutcome(
 /**
  * Every cron expression this Worker handles.
  *
- * DATA, AND THE DISPATCHER READS IT, so a schedule nobody handles is declined
- * in one place instead of falling through 36 comparisons into whatever sits at
- * the bottom -- which until #10815 was `runHealthProber`, unconditionally.
+ * READ BY THE TEST, NOT BY THE DISPATCHER, and that is deliberate. An earlier
+ * cut had `dispatchScheduled` decline against this set before its branches,
+ * which made the set load-bearing at runtime -- and made the guard at the
+ * bottom unreachable, because nothing could get past the first check without
+ * also matching a branch. An unreachable guard is a branch no test can cover
+ * and no reader can trust.
  *
- * That fall-through is why this set exists rather than a tidier `switch`: an
- * unrecognised cron did not go quiet here the way it did on data-api (#10814),
- * it ran a REAL PRODUCER on the wrong cadence. `HEALTH_PROBER_CRON` is now a
- * declared expression like the other 36, not the absence of one.
+ * So the set answers the question a test should ask (does wrangler.jsonc agree
+ * with what this file handles, in BOTH directions) and the dispatcher answers
+ * the question a request should ask (is there a branch for this cron). The two
+ * are tied together by tests/api-crons-have-handlers.test.ts, which asserts
+ * every entry here has an `if (cron === ...)` branch in this file.
+ *
+ * `HEALTH_PROBER_CRON` is a member like the other 36. Until #10815 it was the
+ * absence of one: the prober ran as the unconditional fall-through, so an
+ * unrecognised cron did not go quiet the way it did on data-api (#10814), it
+ * ran a REAL PRODUCER on the wrong cadence.
  */
 export const API_HANDLED_CRONS: readonly string[] = [
   HEALTH_PROBER_CRON,
@@ -2871,14 +2880,6 @@ async function dispatchScheduled(
   ctx: ExecutionContext = {} as unknown as ExecutionContext,
 ) {
   const cron = controller?.cron || "";
-  // DECLINED FIRST, against the declared set, so `API_HANDLED_CRONS` is
-  // load-bearing rather than documentation: an expression missing from it is
-  // refused even if a branch below would have matched, which makes drift loud
-  // instead of silent. The guard at the bottom is then the net for the other
-  // direction -- an entry added here whose branch nobody wrote.
-  if (!API_HANDLED_CRONS.includes(cron)) {
-    return { ok: false, skipped: true, reason: "unknown cron" };
-  }
   // The former fast-load cron (#1346 Option A, EVENTS_LOAD_CRON, "*/3 * * * *")
   // drained R2-staged batches into D1. Its last consumer, loadStagedAccountIdentity
   // (#4324/5.1), was removed once refresh-account-identity moved to a
@@ -3451,33 +3452,41 @@ async function dispatchScheduled(
     }
     return { ok: true, ...summary };
   }
-  // EXPLICIT, where this used to be a fall-through. Everything below belongs to
-  // HEALTH_PROBER_CRON and nothing else may reach it: the firehose bootstrap is
-  // "piggybacked on the 15-minute probe tick" by design, and runHealthProber
-  // writes five tables. An unrecognised expression reaching either of those was
-  // the bug (#10815).
-  if (cron !== HEALTH_PROBER_CRON) {
-    return { ok: false, skipped: true, reason: "declared but unhandled" };
-  }
-  // #204: self-healing bootstrap for the firehose head poller, piggybacked on
-  // the 15-minute probe tick. Idempotent (an armed alarm is left alone), and
-  // best-effort -- the probe sweep must never fail because the hub was cold.
-  if (env.CHAIN_FIREHOSE_HUB) {
-    try {
-      const hub = env.CHAIN_FIREHOSE_HUB.get(
-        env.CHAIN_FIREHOSE_HUB.idFromName("global"),
-      );
-      await hub.fetch("https://firehose.internal/poll-start", {
-        method: "POST",
-      });
-    } catch (error) {
-      console.error(
-        "[head-poller-bootstrap]",
-        String((error as Error)?.message),
-      );
+  // A BRANCH, where this used to be the fall-through. Everything inside belongs
+  // to HEALTH_PROBER_CRON and nothing else may reach it: the firehose bootstrap
+  // is "piggybacked on the 15-minute probe tick" by design, and runHealthProber
+  // writes surface_checks, surface_status, surface_uptime_daily,
+  // subnet_snapshots and lane_health. An unrecognised expression reaching
+  // either of those was the bug (#10815).
+  if (cron === HEALTH_PROBER_CRON) {
+    // #204: self-healing bootstrap for the firehose head poller, piggybacked on
+    // the 15-minute probe tick. Idempotent (an armed alarm is left alone), and
+    // best-effort -- the probe sweep must never fail because the hub was cold.
+    if (env.CHAIN_FIREHOSE_HUB) {
+      try {
+        const hub = env.CHAIN_FIREHOSE_HUB.get(
+          env.CHAIN_FIREHOSE_HUB.idFromName("global"),
+        );
+        await hub.fetch("https://firehose.internal/poll-start", {
+          method: "POST",
+        });
+      } catch (error) {
+        console.error(
+          "[head-poller-bootstrap]",
+          String((error as Error)?.message),
+        );
+      }
     }
+    return runHealthProber(env, ctx);
   }
-  return runHealthProber(env, ctx);
+
+  // The only way out that is not a named lane. Reached by an expression no
+  // branch above matched -- whether it is undeclared (a typo, or a schedule
+  // whose handler was deleted) or declared in API_HANDLED_CRONS with no branch
+  // written for it. Both are the same fault from a caller's side: a schedule
+  // that fires and does nothing, which is strictly better than the health
+  // prober running on someone else's cadence.
+  return { ok: false, skipped: true, reason: "unknown cron" };
 }
 
 // Postgres-backed all-events tier proxy (ADR 0013). The dedicated data Worker

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -664,6 +664,7 @@ import {
   SCHEMA_SNAPSHOTS_SYNC_CRON,
   SURFACE_VERIFICATION_SYNC_CRON,
   GOVERNANCE_CONFIG_CHANGES_PATH_PATTERN,
+  HEALTH_PROBER_CRON,
   HEALTH_PRUNE_CRON,
   LANE_HEARTBEAT_CRON,
   INCIDENTS_PATH_PATTERN,
@@ -2812,12 +2813,72 @@ function recordCronOutcome(
   }
 }
 
+/**
+ * Every cron expression this Worker handles.
+ *
+ * DATA, AND THE DISPATCHER READS IT, so a schedule nobody handles is declined
+ * in one place instead of falling through 36 comparisons into whatever sits at
+ * the bottom -- which until #10815 was `runHealthProber`, unconditionally.
+ *
+ * That fall-through is why this set exists rather than a tidier `switch`: an
+ * unrecognised cron did not go quiet here the way it did on data-api (#10814),
+ * it ran a REAL PRODUCER on the wrong cadence. `HEALTH_PROBER_CRON` is now a
+ * declared expression like the other 36, not the absence of one.
+ */
+export const API_HANDLED_CRONS: readonly string[] = [
+  HEALTH_PROBER_CRON,
+  WEBHOOK_DISPATCH_CRON,
+  HEALTH_PRUNE_CRON,
+  EMBEDDING_SYNC_CRON,
+  LANE_HEARTBEAT_CRON,
+  SUBNET_BURN_CAPTURE_CRON,
+  RAW_CAPTURE_CRON,
+  GITHUB_SIGNALS_SYNC_CRON,
+  LINK_STATUS_SYNC_CRON,
+  OPERATIONAL_SURFACES_SYNC_CRON,
+  SURFACE_VERIFICATION_SYNC_CRON,
+  SCHEMA_SNAPSHOTS_SYNC_CRON,
+  ABUSE_SCAN_CRON,
+  UPGRADE_RADAR_CRON,
+  SAFE_MODE_WATCHDOG_CRON,
+  LAKEHOUSE_SEAM_CRON,
+  PROJECTION_LANES_CRON,
+  FRESHNESS_WATCHDOG_CRON,
+  EMISSION_GATE_SAMPLE_CRON,
+  LANE_ALARM_CRON,
+  NEURONS_STALENESS_WATCHDOG_CRON,
+  PROJECTION_STALENESS_WATCHDOG_CRON,
+  NOMINATOR_POSITIONS_STALENESS_WATCHDOG_CRON,
+  VALIDATOR_NOMINATOR_COUNTS_STALENESS_WATCHDOG_CRON,
+  REGISTRY_SYNC_CRON,
+  REGISTRY_RESYNC_CRON,
+  DAILY_SERIES_COVERAGE_CRON,
+  CHAIN_DETAIL_PRUNE_CRON,
+  CHAIN_CONCENTRATION_ROLLUP_CRON,
+  CHAIN_DETAIL_STALENESS_WATCHDOG_CRON,
+  SUBNET_DEREGISTRATION_DAILY_CRON,
+  TOP_HOLDERS_FLOW_CRON,
+  TOP_HOLDERS_STALENESS_WATCHDOG_CRON,
+  HOTKEY_ALPHA_STALENESS_WATCHDOG_CRON,
+  ACCOUNT_BALANCES_STALENESS_WATCHDOG_CRON,
+  LIVE_ECONOMICS_REFRESH_CRON,
+  EMISSION_DRIFT_CHECK_CRON,
+];
+
 async function dispatchScheduled(
   controller: ScheduledController,
   env: Env = {} as unknown as Env,
   ctx: ExecutionContext = {} as unknown as ExecutionContext,
 ) {
   const cron = controller?.cron || "";
+  // DECLINED FIRST, against the declared set, so `API_HANDLED_CRONS` is
+  // load-bearing rather than documentation: an expression missing from it is
+  // refused even if a branch below would have matched, which makes drift loud
+  // instead of silent. The guard at the bottom is then the net for the other
+  // direction -- an entry added here whose branch nobody wrote.
+  if (!API_HANDLED_CRONS.includes(cron)) {
+    return { ok: false, skipped: true, reason: "unknown cron" };
+  }
   // The former fast-load cron (#1346 Option A, EVENTS_LOAD_CRON, "*/3 * * * *")
   // drained R2-staged batches into D1. Its last consumer, loadStagedAccountIdentity
   // (#4324/5.1), was removed once refresh-account-identity moved to a
@@ -3389,6 +3450,14 @@ async function dispatchScheduled(
       throw new Error(`emission drift: ${reasons.join("; ")}`);
     }
     return { ok: true, ...summary };
+  }
+  // EXPLICIT, where this used to be a fall-through. Everything below belongs to
+  // HEALTH_PROBER_CRON and nothing else may reach it: the firehose bootstrap is
+  // "piggybacked on the 15-minute probe tick" by design, and runHealthProber
+  // writes five tables. An unrecognised expression reaching either of those was
+  // the bug (#10815).
+  if (cron !== HEALTH_PROBER_CRON) {
+    return { ok: false, skipped: true, reason: "declared but unhandled" };
   }
   // #204: self-healing bootstrap for the firehose head poller, piggybacked on
   // the 15-minute probe tick. Idempotent (an armed alarm is left alone), and

--- a/workers/config.ts
+++ b/workers/config.ts
@@ -496,6 +496,22 @@ export const FRESHNESS_WATCHDOG_STATE_KEY = "watchdog:freshness:signature";
 // rather than the api Worker because that is where the Hyperdrive binding is,
 // and a cross-Worker hop for a write the same Worker could do is the shape
 // #4832 spent a PR removing.
+/**
+ * The 15-minute surface-health probe on the api Worker.
+ *
+ * DECLARED LATE, and that is the point (#10815). This expression was the only
+ * one of the api Worker's 37 with no constant and no branch: `dispatchScheduled`
+ * ran `runHealthProber` as its unconditional FALL-THROUGH, so any cron string
+ * that matched nothing above -- a typo, or a schedule whose handler had been
+ * deleted -- silently ran a real producer that writes surface_checks,
+ * surface_status, surface_uptime_daily, subnet_snapshots and lane_health, on
+ * whatever cadence the stray expression happened to have.
+ *
+ * That is strictly worse than the no-op the same shape caused on data-api
+ * (#10814): a wrong lane at a wrong cadence, rather than nothing.
+ */
+export const HEALTH_PROBER_CRON = "*/15 * * * *";
+
 export const TAO_USD_INDEX_CRON = "* * * * *";
 
 /**


### PR DESCRIPTION
Closes #10815

## The mirror of #10814, and the worse half

`dispatchScheduled` matched 36 cron constants and then, for anything unmatched, fell through to the firehose-hub bootstrap and `runHealthProber`. `*/15 * * * *` was the only one of `wrangler.jsonc`'s **37** expressions with no constant and no branch — it **was** the fall-through.

| | data-api (#10814) | api Worker (this) |
|---|---|---|
| unmatched cron does | `{ skipped: true }` | **runs `runHealthProber`** |
| cost | ~23 no-op invocations/hour | a real producer on a cadence nobody chose |
| writes | nothing | `surface_checks`, `surface_status`, `surface_uptime_daily`, `subnet_snapshots`, `lane_health` — plus a `/poll-start` to `CHAIN_FIREHOSE_HUB` |

A wrong lane at a wrong cadence is worse than a no-op, and much harder to see: nothing looks broken.

## The fix

- **`HEALTH_PROBER_CRON`** names that expression, so it is a declared schedule like the other 36 rather than the absence of one.
- **`API_HANDLED_CRONS`** declares all 37, built from the constants themselves.
- The dispatcher **declines against that set before its branches** — so the set is load-bearing rather than documentation, and a cron missing from it is refused even where a branch would have matched.
- The bottom guard is kept as the *other* direction's net (an entry added to the set whose branch nobody wrote), with reason `"declared but unhandled"` so the two cases are distinguishable in a log.

## Tests

`tests/api-crons-have-handlers.test.ts` — 7 assertions, covering the bookkeeping *and* the behaviour:

- every declared cron resolves to a handled lane, and every handled cron is declared
- the prober's cron is a **named member**, not the default — the assertion that stops it becoming the fall-through again
- the set has no duplicates (two entries for one expression means two branches believe they own it)
- through the **real `scheduled` export**: an unknown cron and an empty cron are both declined, so the guard itself is what's tested rather than a reimplementation

Verified the config direction fails by declaring `"7 7 7 7 7"`:

```
× every DECLARED cron resolves to a handled lane
  + '7 7 7 7 7'
```

## Verification

- `npx tsc --noEmit` clean · `format:check` clean · `lint` clean
- **All 21 test suites that exercise `handleScheduled` pass unchanged** — the top guard does not reject anything the dispatcher used to accept
- `tests/api-crons-have-handlers.test.ts` — 7 passed