### PR TITLE
fix(neon): a buffered lane's -pass/-prune verdict can never be cleared

### DIFF
--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -267,6 +267,13 @@ export async function mirrorLedgerToNeon(
       },
       now(),
       buffered,
+      // ONCE PER PASS (#10826): this sub-lane shares the base lane's buffered
+      // runner, so the flush's per-lane tally never names it -- a suppressed
+      // success here can never be recorded by anything else, and a `stale`
+      // verdict then outlives its own recovery. Measured on
+      // neon:validator-nominator-counts-pass, stale from 10:15 UTC while its
+      // table wrote 112,250 rows at 11:30.
+      true,
     );
   }
   return { attempted: true, result };

--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -433,10 +433,36 @@ export async function recordNeonWriteVerdict(
    * it matters.
    */
   buffered = false,
+  /**
+   * This lane writes ONCE PER PASS, not once per batch of rows (#10826).
+   *
+   * The suppression above assumes the flush will record an honest verdict for
+   * this lane later. That holds for a row lane, whose statements carry its
+   * name -- and it is FALSE for the `-pass` and `-prune` sub-lanes, which share
+   * the base lane's buffered runner and so never appear in the flush's own
+   * per-lane tally. Nothing can ever write them again once buffering is on.
+   *
+   * Measured on production 2026-08-11: `neon:nominator-positions-prune` and
+   * `neon:nominator-positions-pass` held a `stale` verdict from 10:23 UTC --
+   * "prune did not land; tally withheld", from one Durable Object reset during
+   * a deploy -- while `nominator_positions` itself wrote 123,057 rows at 11:30
+   * and `neon:nominator-positions` went `ok`. The failure verdict outlived its
+   * own recovery by eight hours and counting, and the lane alarm escalated over
+   * it the whole time. A verdict that cannot be cleared is not a health signal.
+   *
+   * #10690's cost argument does not reach here: these fire once per PASS --
+   * daily for the nominator lanes -- so recording them is ~4 rows a day against
+   * the ~758/hr that argument was about.
+   *
+   * The verdict says ENQUEUED rather than landed, because that is what is true
+   * at this point. If the flush then fails, it records `stale` for the base
+   * lane and for `neon:buffer-flush`, so the failure still surfaces.
+   */
+  oncePerPass = false,
 ): Promise<boolean> {
   const key = `neon:${lane}`;
   const verdict: LaneVerdict = result.ok ? "ok" : "stale";
-  if (buffered && result.ok) return true;
+  if (buffered && result.ok && !oncePerPass) return true;
   if (!shouldWriteNeonWriteVerdict(lastWrittenVerdict.get(key), verdict, nowMs))
     // TRUE, not false. `false` is this function's word for "the verdict is NOT
     // on record", and a coalesced verdict IS on record -- an identical row
@@ -449,7 +475,14 @@ export async function recordNeonWriteVerdict(
     verdict,
     age_ms: null,
     detail: result.ok
-      ? `${result.rows} row(s) in ${result.statements} statement(s)`
+      ? // "enqueued" when it is enqueued. A buffered once-per-pass verdict
+        // (see oncePerPass) is recorded before the flush runs, and saying
+        // "in N statement(s)" there would claim Neon holds rows that are
+        // still in the buffer -- the exact overclaim #10690 refused, which
+        // this keeps refusing while still clearing the lane.
+        buffered
+        ? `${result.rows} row(s) enqueued in ${result.statements} statement(s)`
+        : `${result.rows} row(s) in ${result.statements} statement(s)`
       : `${result.rows} row(s) written before failure: ${result.reason ?? "unknown"}`,
     checked_at: nowMs,
   });

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -166,6 +166,10 @@ export async function mirrorNominatorPositionsToNeon(
     prune,
     now(),
     buffered,
+    // ONCE PER PASS (#10826): this sub-lane shares the base lane's buffered
+    // runner, so the flush's per-lane tally never names it and a suppressed
+    // success here can never be recorded by anything else.
+    true,
   );
 
   // AFTER THE PRUNE, not just after the upsert. This lane's pass is only
@@ -198,6 +202,8 @@ export async function mirrorNominatorPositionsToNeon(
       },
       now(),
       buffered,
+      // ONCE PER PASS (#10826) -- see the prune's own note.
+      true,
     );
   }
   return { attempted: true, write, prune, pass: passResult };

--- a/tests/neon-write.test.ts
+++ b/tests/neon-write.test.ts
@@ -711,6 +711,73 @@ describe("a buffered lane's enqueue-time verdict", () => {
     assert.deepEqual(s.rows, []);
   });
 
+  test("a buffered ONCE-PER-PASS success records, so its verdict can be cleared", async () => {
+    // #10826. The suppression above is safe only because the flush records an
+    // honest verdict for that lane later. It does not for `-pass` and `-prune`:
+    // they share the base lane's buffered runner, so the flush's per-lane tally
+    // NEVER names them, and a suppressed success here can be recorded by
+    // nothing at all.
+    //
+    // Measured on production 2026-08-11: `neon:nominator-positions-prune` and
+    // `-pass` held "prune did not land; tally withheld" from 10:23 UTC -- one
+    // Durable Object reset during a deploy -- while nominator_positions wrote
+    // 123,057 rows at 11:30 and the base lane went ok. The failure verdict
+    // outlived its own recovery by eight hours and the lane alarm escalated
+    // over it the whole time.
+    const s = countingDb();
+    const landed = await recordNeonWriteVerdict(
+      s.db,
+      "nominator-positions-pass",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+      true,
+      true,
+    );
+    assert.equal(landed, true);
+    assert.deepEqual(
+      s.rows,
+      [{ lane: "neon:nominator-positions-pass", verdict: "ok" }],
+      "a once-per-pass success must reach lane_health, or nothing can clear it",
+    );
+  });
+
+  test("...and it says ENQUEUED, because that is what is true at that point", async () => {
+    // The reason #10690 suppressed these in the first place: at enqueue time
+    // the rows are in the buffer, not in Neon. Recording the verdict is what
+    // makes the lane clearable; claiming the rows LANDED would be the overclaim
+    // that argument correctly refused. Both can hold at once, and the detail is
+    // where the distinction lives.
+    const details: string[] = [];
+    const db = {
+      prepare(sql: string) {
+        return {
+          bind(...values: unknown[]) {
+            return {
+              async run() {
+                if (sql.startsWith("INSERT")) details.push(String(values[3]));
+              },
+            };
+          },
+        };
+      },
+    };
+    await recordNeonWriteVerdict(
+      db,
+      "nominator-positions-prune",
+      { ok: true, rows: 1, statements: 1 },
+      NOW,
+      true,
+      true,
+    );
+    assert.equal(details.length, 1);
+    assert.match(details[0]!, /enqueued/);
+    assert.doesNotMatch(
+      details[0]!,
+      /^1 row\(s\) in /,
+      "an enqueued write must not be reported as landed",
+    );
+  });
+
   test("a buffered FAILURE still records -- nothing else reports backpressure", async () => {
     // ok:false here is the ENQUEUE being refused (buffer full, DO unreachable).
     // The flush cannot report it: those rows never reached the flush. This is


### PR DESCRIPTION
Closes #10830
Refs #10807, #10809

Part of #10807. Found while root-causing #10809.

A `-pass` / `-prune` lane verdict cannot be cleared once buffering is on, so a
failure verdict outlives its own recovery indefinitely and the lane alarm
escalates over data that is fine.

## Measured

Production, 2026-08-11. `lane_health`:

```
neon:nominator-positions        ok     "409 row(s) in 1 statement(s)"                  08:47 UTC
neon:nominator-positions-prune  stale  "Internal error in Durable Object storage ..."  10:23 UTC
neon:nominator-positions-pass   stale  "prune did not land; tally withheld"            10:23 UTC
neon:validator-nominator-counts stale  "Durable Object reset because its code ..."     10:15 UTC
neon:validator-nominator-counts-pass stale "rows did not land; tally withheld"         10:15 UTC
```

The tables those lanes feed, at the same moment:

```
validator_nominator_counts  112,250 rows  newest captured_at 11:30 UTC
nominator_positions         123,057 rows  newest captured_at 11:30 UTC
hotkey_alpha_passes         complete: received 47,167 of 47,167 expected
```

The data is an hour NEWER than the failure verdict, and the public surface was
never degraded — `/api/v1/validators/{hotkey}/nominators` serves
`concentration_complete: true` with a real `top_nominator_share`. The lane alarm
had nonetheless been escalating for eight hours.

## Mechanism

`recordNeonWriteVerdict` suppresses a buffered success:

```ts
if (buffered && result.ok) return true;
```

That is correct for a ROW lane — #10690's reasoning holds, ~758 writes/hour
saying "ok" about rows that are enqueued and not yet in Neon, and the flush
records the honest per-lane verdict once it has written them.

**It does not hold for the sub-lanes.** `-pass` and `-prune` share the base
lane's buffered runner, so every statement they enqueue carries the BASE lane's
name. `recordFlushVerdicts` builds its tally from `statement.lane`, so those two
names never appear in it. With buffering on, the only way either can be written
again is a FAILURE — which means:

> once a `-pass` or `-prune` lane goes stale, nothing can ever make it ok again.

Both nominator lanes are in `NEON_WRITE_BUFFER_LANES`, so both are in that
state now.

## Fix

`recordNeonWriteVerdict` takes `oncePerPass`, and the three sub-lane call sites
set it. #10690's cost argument does not reach them: these fire once per PASS —
daily for the nominator lanes — so it is ~4 rows a day against the ~758/hour
that argument was about.

The verdict says **enqueued**, not landed, because that is what is true at that
point; if the flush then fails it records `stale` for the base lane and for
`neon:buffer-flush`, so the failure still surfaces. Both halves are asserted,
and the test is verified to fail against the old behaviour.

## Why it matters beyond the noise

This is the #9301 failure the whole lane-alarm design exists to prevent — "an
alarm which fires on a working lane stops being read". Four of the five lanes in
#10809's original table were healthy, and the escalating figures are what made
them look like an outage.