### PR TITLE
feat(neon): store the shares the chain gives us, and normalise in SQL

### DIFF
--- a/migrations/neon/0025_nominator_positions_shares.sql
+++ b/migrations/neon/0025_nominator_positions_shares.sql
@@ -1,0 +1,38 @@
+-- metagraphed-infra#414: store the shares the chain gives us, not only the
+-- fraction we derive from them.
+--
+-- WHY THIS COLUMN IS THE FIX FOR A PRODUCER PROBLEM. `share_fraction` is
+-- normalised across every row sharing a (hotkey, netuid) -- this coldkey's
+-- shares over ALL delegators' shares for that pool. No single row can produce
+-- it, so the poller buffers the WHOLE 762,577-row Alpha keyspace in memory
+-- before it may write anything. Its own header says so.
+--
+-- Every difficulty in metagraphed-infra#414 follows from that one decision: a
+-- chunk boundary cannot fall mid-pool without computing a fraction against a
+-- partial denominator, a failed pass at minute 9 of 10 discards all nine
+-- minutes, and the container holds the keyspace on its heap to do it.
+--
+-- Storing the raw value moves the normalisation to one SQL statement after the
+-- prune, which the database does over the complete table. The producer then
+-- streams rows as it walks them.
+--
+-- NUMERIC, NOT BIGINT. Shares are a u128 (`Shares.bits`), whose maximum is
+-- ~3.4e38 against bigint's ~9.2e18. `numeric` is the only exact type that
+-- holds it. It also travels as a STRING on the sync route, because a u128 does
+-- not survive JSON's double: 2^53 is the last integer a JSON number represents
+-- exactly, and these values run far past it.
+--
+-- NULLABLE, deliberately. The producer that sends it does not exist yet
+-- (metagraphed-infra#414 step 2), so every existing row has no shares and the
+-- normalisation below skips them. That makes this migration inert until the
+-- poller changes, which is the property that lets it ship first.
+ALTER TABLE nominator_positions
+  ADD COLUMN IF NOT EXISTS shares numeric;
+
+-- The normalisation reads (hotkey, netuid) and sums over it. The existing
+-- primary-key-ish access pattern is per-coldkey (the prune) and per-hotkey (the
+-- serve path), so the group this statement aggregates has no index behind it.
+-- 123,057 rows makes a sequential scan cheap today; this keeps it cheap as the
+-- table grows, and it is the same shape top-holders already groups by.
+CREATE INDEX IF NOT EXISTS nominator_positions_hotkey_netuid_idx
+  ON nominator_positions (hotkey, netuid);

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -49,20 +49,6 @@ export const NOMINATOR_POSITION_INSERT_COLUMNS = [
   "captured_at",
 ];
 
-/** The type `shares` must be cast to in the FILTERED upsert form.
- *
- * Only that form needs it: a plain `INSERT INTO t (cols) VALUES (...)` takes
- * its types from the target columns, while `FROM (VALUES ...) AS src (cols)`
- * is a standalone relation whose untyped parameters fall back to TEXT -- the
- * exact failure that took the hotkey_alpha mirror down twice (see
- * buildPgUpsert's own `columnTypes` note). `shares` arrives as a decimal
- * STRING, because a u128 does not survive JSON's double past 2^53, so it is
- * precisely the column that would land as text.
- */
-export const NOMINATOR_POSITION_COLUMN_TYPES = {
-  shares: "numeric",
-} as const;
-
 // A finite, non-negative TAO cell, or null when absent/blank/non-numeric.
 // Blank Postgres cells coerce via Number("") -> 0; skip those rather than
 // joining a phantom zero-stake hotkey (mirrors buildGlobalValidators/

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -35,8 +35,33 @@ export const NOMINATOR_POSITION_INSERT_COLUMNS = [
   "hotkey",
   "netuid",
   "share_fraction",
+  // The raw u128 the chain holds, added so `share_fraction` stops being the
+  // ONLY thing we keep (metagraphed-infra#414). A fraction is normalised across
+  // every row in a (hotkey, netuid) pool, so no single row can produce it --
+  // which is why the poller buffers the whole 762,577-row keyspace before it
+  // may write anything. Keeping the raw value moves that normalisation to one
+  // statement after the prune and lets the producer stream.
+  //
+  // Optional on the wire: the producer that sends it does not exist yet, and
+  // the normalisation skips a row without it. That is what makes this shippable
+  // ahead of the poller.
+  "shares",
   "captured_at",
 ];
+
+/** The type `shares` must be cast to in the FILTERED upsert form.
+ *
+ * Only that form needs it: a plain `INSERT INTO t (cols) VALUES (...)` takes
+ * its types from the target columns, while `FROM (VALUES ...) AS src (cols)`
+ * is a standalone relation whose untyped parameters fall back to TEXT -- the
+ * exact failure that took the hotkey_alpha mirror down twice (see
+ * buildPgUpsert's own `columnTypes` note). `shares` arrives as a decimal
+ * STRING, because a u128 does not survive JSON's double past 2^53, so it is
+ * precisely the column that would land as text.
+ */
+export const NOMINATOR_POSITION_COLUMN_TYPES = {
+  shares: "numeric",
+} as const;
 
 // A finite, non-negative TAO cell, or null when absent/blank/non-numeric.
 // Blank Postgres cells coerce via Number("") -> 0; skip those rather than

--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -302,6 +302,72 @@ export async function pruneKeysInNeon(
 }
 
 /**
+ * Recompute `share_fraction` from the raw `shares` of one pass, in SQL
+ * (metagraphed-infra#414).
+ *
+ * WHAT THIS REPLACES. `share_fraction` is this coldkey's shares over ALL
+ * delegators' shares for the same (hotkey, netuid) pool, so no single row can
+ * produce it -- which is why the poller buffers the whole 762,577-row Alpha
+ * keyspace before it may write anything, and why a chunk boundary could not
+ * fall mid-pool. A window over the table answers the same question exactly,
+ * once, and the producer is then free to stream rows as it walks them.
+ *
+ * AFTER THE PRUNE, and the caller enforces that order. Normalising while
+ * superseded rows are still present divides by a denominator that includes
+ * them -- the same reasoning the pass tally already follows, and the reason
+ * this takes a `capturedAt` rather than running over everything.
+ *
+ * SKIPS ROWS WITHOUT SHARES, which is what makes this inert until the poller
+ * sends them: `WHERE shares IS NOT NULL` matches nothing today, so the
+ * statement is a no-op and the fraction the producer computed stands. It becomes
+ * load-bearing the moment a pass carries shares, with no second deploy.
+ *
+ * `numeric` throughout, cast to double only on assignment: shares are u128 and
+ * the ratio of two of them is exact in numeric. The Rust side computed this as
+ * u128 -> f64 division, so this is at least as accurate and does not round the
+ * denominator before dividing.
+ */
+export async function normalizeShareFractionsInNeon(
+  sql: PgUnsafe | null | undefined,
+  capturedAt: number,
+): Promise<NeonWriteResult> {
+  if (!sql?.unsafe)
+    return { ok: false, rows: 0, statements: 0, reason: "unbound" };
+  if (!Number.isSafeInteger(capturedAt) || capturedAt <= 0) {
+    return {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: `unusable captured_at: ${capturedAt}`,
+    };
+  }
+  try {
+    await sql.unsafe(
+      `UPDATE nominator_positions AS p
+          SET share_fraction = (p.shares / t.total)::double precision
+         FROM (SELECT hotkey, netuid, SUM(shares) AS total
+                 FROM nominator_positions
+                WHERE captured_at = $1 AND shares IS NOT NULL
+             GROUP BY hotkey, netuid) AS t
+        WHERE p.hotkey = t.hotkey
+          AND p.netuid = t.netuid
+          AND p.captured_at = $1
+          AND p.shares IS NOT NULL
+          AND t.total > 0`,
+      [capturedAt],
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+  }
+  return { ok: true, rows: 1, statements: 1 };
+}
+
+/**
  * How long an UNCHANGED `ok` verdict may be re-asserted without writing again.
  *
  * TEN MINUTES, against a bound of two hours. `lane_health`'s own freshness

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -25,6 +25,7 @@
 // tick -- never delete a position without having written its replacement first.
 
 import { laneHealthStore } from "./lane-health-store.ts";
+import { normalizeShareFractionsInNeon } from "./neon-write.ts";
 import {
   writePassTallyToNeon,
   type PassTallyInput,
@@ -172,10 +173,41 @@ export async function mirrorNominatorPositionsToNeon(
     true,
   );
 
-  // AFTER THE PRUNE, not just after the upsert. This lane's pass is only
-  // whole once the stale rows are gone: a tally written between the two would
-  // declare a complete pass over a table that still holds superseded
-  // positions, which is the state the prune exists to end.
+  // AFTER THE PRUNE, BEFORE THE TALLY (metagraphed-infra#414). Recomputes
+  // share_fraction from the raw shares of this pass, which is what lets the
+  // producer stop buffering the whole keyspace to compute a pool-normalised
+  // value it cannot derive one row at a time.
+  //
+  // The ordering is the same argument the tally below makes: normalising while
+  // superseded rows are still present would divide by a denominator that
+  // includes them. So it runs after the prune, and the tally -- which declares
+  // the pass whole -- runs after this.
+  //
+  // NOT FATAL, and deliberately unlike the prune. A failure here leaves the
+  // fraction the producer computed in place, which is the value this lane has
+  // always served; the rows are correct, just not re-derived. Failing the pass
+  // over it would trade a served-and-correct table for no pass at all. It rides
+  // on the same lane verdict so a persistent failure is still visible.
+  //
+  // A no-op until the poller sends shares: the statement matches no rows.
+  if (prune.ok && input.pass?.capturedAt) {
+    const normalized = await normalizeShareFractionsInNeon(
+      sql,
+      Number(input.pass.capturedAt),
+    );
+    await recordNeonWriteVerdict(
+      laneDb,
+      `${NOMINATOR_POSITIONS_NEON_LANE}-normalize`,
+      normalized,
+      now(),
+      buffered,
+      // ONCE PER PASS, same reason as the prune and the tally: this sub-lane
+      // shares the base lane's buffered runner, so the flush never names it and
+      // a suppressed success could never be cleared (#10830).
+      true,
+    );
+  }
+
   let passResult: NeonWriteResult | undefined;
   if (input.pass) {
     const tally = prune.ok

--- a/src/sync-row-schemas.ts
+++ b/src/sync-row-schemas.ts
@@ -318,6 +318,22 @@ export function nominatorPositionSyncRowSchema({
         .finite("must be finite")
         .min(0)
         .max(1, "must be a fraction between 0 and 1"),
+      // A STRING, not a number (metagraphed-infra#414). Shares are a u128 whose
+      // maximum is ~3.4e38; JSON represents integers exactly only to 2^53, so a
+      // numeric field here would silently round the value it exists to preserve.
+      // Validated as digits rather than parsed: nothing in this Worker needs its
+      // magnitude, Postgres does the arithmetic, and `Number()` on it would
+      // reintroduce the loss the string avoids.
+      //
+      // OPTIONAL, because the producer that sends it does not exist yet. A row
+      // without it is accepted and simply not normalised.
+      shares: z
+        .string()
+        .regex(
+          /^\d{1,39}$/,
+          "must be a non-negative integer of at most 39 digits",
+        )
+        .optional(),
       captured_at: capturedAtMs(minCapturedAtMs),
     })
     .superRefine((row, ctx) => onlyKnownColumns(columns)(row as Row, ctx));

--- a/tests/account-nominator-positions.test.ts
+++ b/tests/account-nominator-positions.test.ts
@@ -537,12 +537,23 @@ describe("buildAccountPositions", () => {
 });
 
 describe("NOMINATOR_POSITION_INSERT_COLUMNS", () => {
-  test("is the exact five-column shape the migration/sync endpoint expect", () => {
+  test("is the exact column shape the migration/sync endpoint expect", () => {
+    // `shares` joined in metagraphed-infra#414. It is the raw u128 the chain
+    // holds, and it exists so `share_fraction` -- which is normalised across a
+    // whole (hotkey, netuid) pool and therefore unproducible one row at a time --
+    // stops being the only thing kept. That is what lets the producer stream
+    // instead of buffering the entire 762,577-row keyspace.
+    //
+    // ORDER MATTERS, which is why this is deepEqual and not a set comparison:
+    // coerceNominatorPositionSyncRow projects onto this list positionally and
+    // buildPgUpsert numbers its placeholders from it, so a reordering binds
+    // values to the wrong columns without failing anything.
     assert.deepEqual(NOMINATOR_POSITION_INSERT_COLUMNS, [
       "coldkey",
       "hotkey",
       "netuid",
       "share_fraction",
+      "shares",
       "captured_at",
     ]);
   });

--- a/tests/nominator-positions-neon-write.test.ts
+++ b/tests/nominator-positions-neon-write.test.ts
@@ -12,13 +12,17 @@
 //     rows that did not land deletes live positions and leaves nothing in
 //     their place, and no retry undoes a delete
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test } from "vitest";
 import {
   mirrorNominatorPositionsToNeon,
   NOMINATOR_POSITIONS_CONFLICT,
   NOMINATOR_POSITIONS_NEON_LANE,
 } from "../src/nominator-positions-neon-write.ts";
-import { pruneKeysInNeon } from "../src/neon-write.ts";
+import {
+  normalizeShareFractionsInNeon,
+  pruneKeysInNeon,
+  resetNeonWriteVerdictMemo,
+} from "../src/neon-write.ts";
 
 const NOW = 1_785_800_000_000;
 
@@ -73,6 +77,13 @@ const rows = [
 ];
 const cutoffs = new Map([["5A", 9]]);
 const on = { NEON_DUAL_WRITE_LANES: NOMINATOR_POSITIONS_NEON_LANE };
+
+// recordNeonWriteVerdict coalesces an unchanged `ok` for ten minutes, keyed per
+// lane in MODULE state. Without this reset a test's verdicts depend on which
+// tests ran before it in the same file -- the base and prune rows vanish from
+// the middle of the suite and reappear when the test is run alone, which is
+// exactly how this was found.
+beforeEach(resetNeonWriteVerdictMemo);
 
 describe("pruneKeysInNeon", () => {
   test("deletes per key against that key's own cutoff, in ONE statement", () => {
@@ -163,6 +174,78 @@ describe("mirrorNominatorPositionsToNeon", () => {
     assert.deepEqual(
       spy.rows.map((r) => r.lane),
       ["neon:nominator-positions", "neon:nominator-positions-prune"],
+    );
+  });
+
+  test("normalises AFTER the prune and BEFORE the tally (metagraphed-infra#414)", async () => {
+    // The order is the correctness claim, not tidiness. Normalising before the
+    // prune divides by a denominator that still includes superseded rows;
+    // tallying before the normalisation declares a pass whole whose fractions
+    // have not been re-derived.
+    const sql = fakeSql();
+    const spy = laneSpy();
+    const out = await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      {
+        rows,
+        coldkeyMaxCapturedAt: cutoffs,
+        pass: {
+          capturedAt: NOW,
+          expectedRows: rows.length,
+          receivedRows: rows.length,
+          nowMs: NOW,
+        },
+      },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.prune?.ok, true);
+    const kinds = sql.calls.map((call) => call.text.split(" ")[0]);
+    assert.deepEqual(
+      kinds,
+      ["INSERT", "DELETE", "UPDATE", "INSERT"],
+      `expected upsert, prune, normalise, tally -- got ${kinds.join(", ")}`,
+    );
+    assert.deepEqual(
+      spy.rows.map((r) => r.lane),
+      [
+        "neon:nominator-positions",
+        "neon:nominator-positions-prune",
+        "neon:nominator-positions-normalize",
+        "neon:nominator-positions-pass",
+      ],
+    );
+  });
+
+  test("does NOT normalise when the prune failed", async () => {
+    // Same reason the tally is withheld: the table still holds superseded rows,
+    // so any pool total computed over it is wrong. Recomputing fractions there
+    // would overwrite correct producer-side values with ones divided by a
+    // denominator that includes rows the prune was supposed to remove.
+    const sql = fakeSql("delete");
+    const spy = laneSpy();
+    await mirrorNominatorPositionsToNeon(
+      on,
+      ctx,
+      {
+        rows,
+        coldkeyMaxCapturedAt: cutoffs,
+        pass: {
+          capturedAt: NOW,
+          expectedRows: rows.length,
+          receivedRows: rows.length,
+          nowMs: NOW,
+        },
+      },
+      { sql, laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(
+      sql.calls.filter((call) => call.text.startsWith("UPDATE")).length,
+      0,
+      "a failed prune must not be followed by a normalisation",
+    );
+    assert.ok(
+      !spy.rows.some((r) => r.lane === "neon:nominator-positions-normalize"),
     );
   });
 
@@ -323,4 +406,82 @@ test("no declared pass leaves the result undefined", async () => {
     { sql, laneHealthDb: null },
   );
   assert.equal(out.pass, undefined);
+});
+
+// metagraphed-infra#414: the normalisation that lets the producer stop buffering
+// the whole 762,577-row Alpha keyspace to compute a pool-relative fraction.
+describe("normalizeShareFractionsInNeon", () => {
+  test("divides each row's shares by its own (hotkey, netuid) pool total", async () => {
+    const sql = fakeSql();
+    const result = await normalizeShareFractionsInNeon(sql, NOW);
+    assert.deepEqual(result, { ok: true, rows: 1, statements: 1 });
+    assert.equal(sql.calls.length, 1);
+    const text = sql.calls[0].text;
+    // The GROUP BY is the whole correctness claim: share_fraction is this
+    // coldkey's shares over ALL delegators' shares for the SAME pool, so a
+    // denominator grouped on anything else publishes a plausible wrong number.
+    assert.match(text, /GROUP BY hotkey, netuid/);
+    assert.match(text, /SUM\(shares\) AS total/);
+    assert.match(text, /p\.hotkey = t\.hotkey/);
+    assert.match(text, /p\.netuid = t\.netuid/);
+    // Scoped to ONE pass on both sides of the join. Without it the denominator
+    // would include superseded rows the prune has not reached yet.
+    assert.equal(sql.calls[0].values[0], NOW);
+    assert.match(text, /p\.captured_at = \$1/);
+    assert.match(text, /WHERE captured_at = \$1/);
+  });
+
+  test("skips rows with no shares, which is what makes it inert today", async () => {
+    // The producer that sends shares does not exist yet. Until it does this
+    // statement must match nothing and leave the fraction the producer computed
+    // standing -- that property is what lets this ship ahead of the poller.
+    const sql = fakeSql();
+    await normalizeShareFractionsInNeon(sql, NOW);
+    const text = sql.calls[0].text;
+    assert.match(text, /AND shares IS NOT NULL/);
+    assert.match(text, /AND p\.shares IS NOT NULL/);
+  });
+
+  test("never divides by zero", async () => {
+    // A pool whose every delegator holds zero shares has no meaningful
+    // fraction. Postgres raises on numeric division by zero, which would fail
+    // the statement for every OTHER pool in the same pass.
+    const sql = fakeSql();
+    await normalizeShareFractionsInNeon(sql, NOW);
+    assert.match(sql.calls[0].text, /t\.total > 0/);
+  });
+
+  test("an unusable captured_at is refused before it reaches SQL", async () => {
+    // `captured_at = NaN` would match no rows and report success, which reads as
+    // "normalised" for a pass that was not.
+    const sql = fakeSql();
+    for (const bad of [0, -1, Number.NaN, 1.5]) {
+      const result = await normalizeShareFractionsInNeon(sql, bad);
+      assert.equal(result.ok, false, String(bad));
+      assert.match(String(result.reason), /unusable captured_at/);
+    }
+    assert.deepEqual(sql.calls, [], "nothing may reach the database");
+  });
+
+  test("an unbound store declines rather than throwing", async () => {
+    assert.deepEqual(await normalizeShareFractionsInNeon(null, NOW), {
+      ok: false,
+      rows: 0,
+      statements: 0,
+      reason: "unbound",
+    });
+  });
+
+  test("a failed statement is a reason, not an exception", async () => {
+    // The caller treats this as non-fatal: the rows are correct, just not
+    // re-derived. It must therefore report rather than throw.
+    const sql = {
+      async unsafe() {
+        throw new Error("deadlock detected");
+      },
+    };
+    const result = await normalizeShareFractionsInNeon(sql, NOW);
+    assert.equal(result.ok, false);
+    assert.match(String(result.reason), /deadlock detected/);
+  });
 });


### PR DESCRIPTION
Step 1 of metagraphed-infra#414. Inert on merge; it becomes load-bearing when the poller changes.

## The problem is the schema, not the chain

`nominator_positions` keeps only the derived value:

```sql
share_fraction double precision   -- normalised across a whole (hotkey, netuid) pool
```

The chain hands us **raw shares** per `(hotkey, coldkey, netuid)`. We discard that and store a number no single row can produce — so the poller must hold all **762,577** rows in memory to compute it. Its own header says so:

> this job buffers the WHOLE scan in memory before writing anything

Every difficulty in #414 follows from that one decision:

| difficulty | cause |
| --- | --- |
| chunks must align to `(hotkey, netuid)` groups | normalisation at write time |
| 762k rows on a container's heap | normalisation at write time |
| a failed pass discards everything | nothing may be written until the walk ends |
| resume needs an exact cursor | there is only one indivisible unit of work |

## What this does

Adds `shares numeric` and recomputes `share_fraction` in **one statement after the prune**, over the complete table. The producer is then free to stream — which is step 2, in the infra repo.

- **`numeric`, not `bigint`** — shares are a u128 (max ~3.4e38 against bigint's ~9.2e18).
- **A decimal STRING on the wire** — 2^53 is the last integer JSON represents exactly, and these run far past it. Validated as digits rather than parsed; Postgres does the arithmetic, and `Number()` on it would reintroduce exactly the loss the string avoids.
- **More accurate than today**, not less: the Rust side computes u128 → f64 division, this divides in `numeric` and casts once at the end.
- **A column we did not have** — absolute stake weight. `share_fraction` can only answer "what proportion", never "how much", from data we already fetch and throw away.

## Why it is safe to merge before the producer exists

The column is nullable, the wire field optional, and the statement carries `shares IS NOT NULL`. It matches no rows today, so the fraction the producer computes stands unchanged. Nothing observable moves until a pass carries shares — and then it does, with no second deploy.

## Ordering, which is the correctness claim

**After the prune** — normalising while superseded rows are present divides by a denominator that includes them. **Before the tally** — which declares the pass whole. **Skipped entirely when the prune failed**, for the same reason the tally is withheld.

**Non-fatal on its own failure.** The rows are correct, just not re-derived; failing the pass over that would trade a served-and-correct table for no pass at all. It rides its own `-normalize` sub-lane verdict so a persistent failure is still visible — carrying the `oncePerPass` flag from #10830, without which a buffered success could never be cleared.

All four properties are asserted, including the statement order (`INSERT, DELETE, UPDATE, INSERT`).

## Also in here

`tests/nominator-positions-neon-write.test.ts` never reset the verdict memo. `recordNeonWriteVerdict` coalesces an unchanged `ok` for ten minutes in **module** state, so a test's verdict rows depended on which tests ran before it — the base and prune rows vanished mid-suite and reappeared when the test ran alone. That is how it was found, and the reset is now a `beforeEach`.

## Not in here

`db/schema.sql` and `generated/db/*`. `neon-migrate.yml` applies `migrations/neon/**` on merge to main and `refresh-neon-schema.yml` snapshots the result on the same push — both own those artifacts, and hand-applying the DDL is what #9867 warns about.

## Verification

Full suite 19,761 passed, `tsc`, `eslint`, `prettier`, `validate:migrations` clean. No visual output touched.
