### PR TITLE
test(flake): prove the SafeMode cron wiring in-process, not through a socket

### DIFF
--- a/tests/safe-mode-watchdog.test.ts
+++ b/tests/safe-mode-watchdog.test.ts
@@ -142,18 +142,50 @@ describe("SafeMode alerting rule (#8696)", () => {
   test("the cron is wired: the schedule reaches the watchdog", async () => {
     // A cron entry with no dispatch branch falls through to the health prober
     // and checks nothing -- silently.
-    const { default: worker } = await import("../workers/api.ts");
-    const { SAFE_MODE_WATCHDOG_CRON } = await import("../workers/config.ts");
-    const result = (await worker.scheduled(
-      { cron: SAFE_MODE_WATCHDOG_CRON, scheduledTime: Date.now() } as never,
-      { SAFE_MODE_RPC_URL: "http://127.0.0.1:1/unreachable" } as never,
-      { waitUntil: () => {} } as never,
-    )) as Record<string, unknown>;
+    //
+    // The dispatch calls `runSafeModeWatchdog(env)` with NO deps, so the only
+    // seam reachable from `scheduled` is the global `fetch` the watchdog falls
+    // back to. This used to point SAFE_MODE_RPC_URL at 127.0.0.1:1 and rely on
+    // a real connect refusing quickly, which made a wiring assertion depend on
+    // the runner's network stack: on a loaded runner the refusal can arrive as
+    // a timeout instead, and the test then reports the wiring as broken (the
+    // #10831 flake). The failure is now produced in-process, so no socket is
+    // opened and there is no timing to lose. The sentinel rides the catch's
+    // `detail` back out, which is what proves the fetch that failed was the
+    // watchdog's own and not some other read on the fallthrough path.
+    //
+    // Belt and braces on the URL: with the global stubbed, env could be `{}`
+    // and the watchdog's default RPC URL would never be dialled -- but that
+    // default is a REAL endpoint, so a future edit that drops the stub would
+    // start calling production from a unit test. A reserved `.invalid` host
+    // (RFC 2606) cannot resolve, so neither layer alone can reach the network.
+    const sentinel = "safe-mode cron wiring probe: no network in this test";
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.reject(new Error(sentinel))) as typeof fetch;
+    let result: Record<string, unknown>;
+    try {
+      const { default: worker } = await import("../workers/api.ts");
+      const { SAFE_MODE_WATCHDOG_CRON } = await import("../workers/config.ts");
+      result = (await worker.scheduled(
+        { cron: SAFE_MODE_WATCHDOG_CRON, scheduledTime: Date.now() } as never,
+        { SAFE_MODE_RPC_URL: "http://safe-mode-wiring.invalid/" } as never,
+        { waitUntil: () => {} } as never,
+      )) as Record<string, unknown>;
+    } finally {
+      globalThis.fetch = realFetch;
+    }
     assert.equal(
       result.reason,
       "unreachable",
       "the SafeMode cron did not reach runSafeModeWatchdog -- an unmatched " +
         "cron falls through to the health prober and checks nothing",
+    );
+    assert.equal(
+      result.detail,
+      sentinel,
+      "the tick failed on something other than the watchdog's own RPC read, " +
+        "so this proves nothing about where the cron landed",
     );
   });
 


### PR DESCRIPTION
## The problem

`tests/safe-mode-watchdog.test.ts` → *"the cron is wired: the schedule reaches the watchdog"*
asserted two things at once:

1. the cron reaches `runSafeModeWatchdog` — the property under test; and
2. a real TCP connect to `127.0.0.1:1` fails in the particular way that yields `reason: "unreachable"`.

On a loaded runner the second clause can resolve as a timeout rather than a refusal, and the test
then reports the *first* as broken. It cost two unrelated PRs a re-run (#10826, #10827).

## The fix

The dispatch calls `runSafeModeWatchdog(env)` with **no deps**, so the only seam reachable through
`worker.scheduled` is the global `fetch` the watchdog falls back to. Stubbing that global produces
the same failure in-process — no socket, no timing — and the assertion keeps its end-to-end reach.

The sentinel message is what makes it *evidence*: it rides the watchdog's `catch` back out through
`detail`, so the test proves the fetch that failed was the watchdog's own read and not some other
read on the fallthrough path. Asserting `reason: "unreachable"` alone would not distinguish them.

`SAFE_MODE_RPC_URL` is also pointed at a reserved `.invalid` host (RFC 2606). With the global stubbed
the URL is never dialled, but the watchdog's default is a **real endpoint** — so an edit that later
drops the stub would leave a unit test calling production. Neither layer alone can now reach the
network.

## Two corrections to the issue's analysis

**Membership in `API_HANDLED_CRONS` would be weaker, not equivalent.**
`tests/api-crons-have-handlers.test.ts` does already tie that set to the dispatcher — but by scanning
source text for `` if (cron === X) { ``. That goes blind on a reformat, and it proves only that a
*branch exists*, not that the branch calls this watchdog. The behavioural assertion is kept for that
reason.

**The ~2.3s is not the connect timeout.** Measured on this tree:

| what | time |
| --- | --- |
| importing `workers/api.ts` alone (empty test) | ~3.2s |
| the test, dispatch branch disabled, no connect attempted | ~2.2s |
| the test, after this change (no socket at all) | ~2.1s |

The cost is the module import, not a connect. So suite time does not drop and there was no timeout to
remove — acceptance criterion 3 rests on a misattribution. Criteria 1 and 2 are met: the wiring
assertion no longer depends on network behaviour, and the watchdog's `unreachable` path keeps its own
tests (*"a failed PRIMARY read reports unreachable, never 'quiet'"* and the degraded-tier case), which
were always the real coverage for that behaviour.

## Verification

- `tests/safe-mode-watchdog.test.ts` (26) + `tests/api-crons-have-handlers.test.ts` (8) — 34 passed
- **Proved the gate can fail**: with the dispatch branch disabled the test fails on its own message,
  so it is not passing on nothing
- 5×5 repeat runs green; `tsc --noEmit` clean; prettier clean
- Test-only diff, so no `src/**` / `workers/**` patch-coverage surface

Closes #10831
