### PR TITLE
feat(schemas): one canonical input schema, three codecs, one table

### DIFF
--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3545,7 +3545,7 @@ export type Query = {
   subnet_deregistrations: SubnetDeregistrations;
   /** One subnet's emission-pipeline decomposition OVER TIME: emission share, the TAO split (pool-liquidity injection vs chain buys), alpha in/out emission, miner burned fraction and whether emission is enabled, one point per day, each pinned to the block it was captured at. chain_emission_pipeline answers ONE BLOCK for every subnet; this answers one subnet across days. READ THE DEPTH: the pipeline columns began on 2026-08-02, so a wide window returns the days that EXIST -- first_captured_day says where the series starts. READ distinct_observations, NOT point_count, when claiming a value moved: the snapshot writer carries the last capture forward when a fresh one has not landed, so two consecutive points can be THE SAME OBSERVATION, flagged per point as repeats_previous_observation. Treating one as an independent sample reports a value as FLAT when it was simply not re-measured. window is 7d, 30d (default), 90d or 180d. An empty series is a measurement. Mainnet only. Mirrors GET /api/v1/subnets/{netuid}/emission-pipeline/history. */
   subnet_emission_pipeline_history: SubnetPipelineHistory;
-  /** One subnet's endpoint/resource registry as a filtered/sorted/paged list — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, provider, publication_state, status, and pool_eligible (a true/false string); threshold with min_/max_latency_ms and min_/max_score; project with fields; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the filterable network-wide endpoint registry). Mirrors GET /api/v1/subnets/{netuid}/endpoints. */
+  /** One subnet's endpoint/resource registry as a filtered/sorted/paged list — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, provider, publication_state, status, and pool_eligible; threshold with min_/max_latency_ms and min_/max_score; project with fields; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the filterable network-wide endpoint registry). Mirrors GET /api/v1/subnets/{netuid}/endpoints. */
   subnet_endpoints?: Maybe<Scalars['JSON']['output']>;
   /** One subnet's chain-event activity summary over a 7d/30d/90d window (default 30d): total events, the per-kind and per-category breakdowns with hotkey/coldkey participation and TAO/alpha amounts, and a bounded newest-first recent-event list (limit 1-50, default 10). A subnet with no events resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/event-summary. */
   subnet_event_summary: SubnetEventSummary;
@@ -4486,7 +4486,7 @@ export type QueryReview_Enrichment_QueueArgs = {
   identity_level?: InputMaybe<Scalars['String']['input']>;
   lane?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
-  manual_review_required?: InputMaybe<Scalars['String']['input']>;
+  manual_review_required?: InputMaybe<Scalars['Boolean']['input']>;
   missing_kinds?: InputMaybe<Scalars['String']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4499,14 +4499,14 @@ export type QueryReview_Enrichment_QueueArgs = {
 
 
 export type QueryReview_Enrichment_TargetsArgs = {
-  auto_review_candidate?: InputMaybe<Scalars['String']['input']>;
+  auto_review_candidate?: InputMaybe<Scalars['Boolean']['input']>;
   cursor?: InputMaybe<Scalars['Int']['input']>;
   evidence_action?: InputMaybe<Scalars['String']['input']>;
   identity_level?: InputMaybe<Scalars['String']['input']>;
   kind?: InputMaybe<Scalars['String']['input']>;
   lane?: InputMaybe<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
-  manual_review_required?: InputMaybe<Scalars['String']['input']>;
+  manual_review_required?: InputMaybe<Scalars['Boolean']['input']>;
   missing_kinds?: InputMaybe<Scalars['String']['input']>;
   netuid?: InputMaybe<Scalars['Int']['input']>;
   order?: InputMaybe<Scalars['String']['input']>;
@@ -4704,7 +4704,7 @@ export type QuerySubnet_EndpointsArgs = {
   min_score?: InputMaybe<Scalars['Float']['input']>;
   netuid: Scalars['Int']['input'];
   order?: InputMaybe<Scalars['String']['input']>;
-  pool_eligible?: InputMaybe<Scalars['String']['input']>;
+  pool_eligible?: InputMaybe<Scalars['Boolean']['input']>;
   provider?: InputMaybe<Scalars['String']['input']>;
   publication_state?: InputMaybe<Scalars['String']['input']>;
   sort?: InputMaybe<Scalars['String']['input']>;

--- a/schemas-src/graphql/argument-divergences.ts
+++ b/schemas-src/graphql/argument-divergences.ts
@@ -32,54 +32,48 @@ const EPOCH_MS_BOUND =
   "The route's `integer` and the SDL's `String` are the same value in the two " +
   "type systems that can each hold it.";
 
-/** SDL arguments the mirrored route does not publish, each with the reason. */
-export const DECLARED_ARGUMENTS: Readonly<Record<string, string>> = {
-  "agent_catalog.netuid":
-    "the field merges TWO routes: netuid absent reads /api/v1/agent-catalog, " +
-    "netuid present reads the sibling detail route /api/v1/agent-catalog/{netuid} " +
-    "(src/graphql.ts `agent_catalog`), where it is a path parameter. The doc " +
-    "annotation can only name one of the two.",
-  "validators.cursor":
-    "GraphQL-only pagination. /api/v1/validators publishes sort+limit and 400s " +
-    "on cursor (verified live: 'cursor is not supported for this route'); the " +
-    "resolver fetches GLOBAL_VALIDATOR_LIMIT_MAX once and paginates in-process, " +
-    "keyed by hotkey, the way providers/economics do. A capability GraphQL adds, " +
-    "not a claim about the route.",
-  "endpoints.cursor":
-    "an OPAQUE id keyset, not REST's integer offset -- the same GraphQL-only " +
-    "pagination contract #7920 established for `providers`. Verified live: " +
-    'endpoints(limit:1) answers next_cursor "endpoint-srf-2d3306d2cfa2223e" ' +
-    'and endpoints(cursor:"abc") is accepted, where the four sibling list ' +
-    'fields answer "cursor must be a non-negative integer". Typing this Int ' +
-    "to match the route would break the only pagination the field has.",
-  "compare.netuids":
-    "/api/v1/compare takes a comma-joined string (pattern ^\\d{1,5}(,\\d{1,5}){0,127}$) " +
-    "because a query string has no list type. GraphQL does, so the SDL takes " +
-    "[Int!]! and the resolver joins -- the stricter spelling of the same input, " +
-    "with the arity bound enforced by the schema instead of a regex.",
-  "extrinsics.from": EPOCH_MS_BOUND,
-  "extrinsics.to": EPOCH_MS_BOUND,
-  "blocks.from": EPOCH_MS_BOUND,
-  "blocks.to": EPOCH_MS_BOUND,
-  "sudo.from": EPOCH_MS_BOUND,
-  "sudo.to": EPOCH_MS_BOUND,
-};
-
 /**
- * The published GraphQL type for an argument the route's parameter does not
- * derive to (#10214).
+ * ONE argument's codec: the spelling GraphQL publishes, and who validates it.
  *
- * `DECLARED_ARGUMENTS` above says an argument's PRESENCE is intentional; this
- * says its TYPE is. The generator reads it, so an entry here is not an
- * exemption from a check -- it is the spelling that gets published.
+ * ── Why this is one table and was two ──────────────────────────────────────
+ *
+ * `DECLARED_ARGUMENTS` said an argument's PRESENCE was GraphQL's and
+ * `DECLARED_ARGUMENT_TYPES` said its TYPE was, and they were the same fact
+ * written twice: every one of the ten keys in the first list was already in
+ * the second. #10772 shipped the failure that shape guarantees -- the runtime
+ * parse read one list while the generator and the gate read the other, so
+ * `providers(cursor: "<opaque string>")` was rejected by a route parameter it
+ * was never given. A list not consumed by every acting component will be
+ * half-fed; a list that restates a sibling will be half-fed by construction.
+ *
+ * ── Why `owner` is almost never written ────────────────────────────────────
+ *
+ * Ownership is DERIVED, from this entry against the route's own schema: the
+ * route keeps the argument when its schema can hold the published value, and
+ * GraphQL takes it when it cannot. Measured against the ten declarations that
+ * list held, the derivation already answered NINE -- the six epoch-ms bounds
+ * (`String` over an `integer`), both opaque cursors, and `agent_catalog.netuid`
+ * (a path parameter on a sibling route, so there is no query parameter at all).
+ *
+ * The tenth is `compare.netuids`, and it is declared because the CODEC is what
+ * hides it: the array is joined into the route's comma-joined string a line
+ * later, so the route's schema can hold it and the derivation says so. See its
+ * entry for why the route must not be the one to reject it.
  */
-export interface DeclaredArgumentType {
-  /** The published GraphQL spelling. */
-  type: string;
+export interface ArgumentCodec {
+  /** The spelling the SDL publishes. */
+  graphql: string;
   /** Why the route's own parameter does not derive to it. */
   reason: string;
   /** True when the route publishes no such parameter at all. */
   addedByGraphql?: boolean;
+  /**
+   * Declared only where the derivation cannot see the divergence.
+   *
+   * One entry uses it. An entry that merely restates what the derivation
+   * already answers is the second list coming back under a new name.
+   */
+  owner?: "graphql";
 }
 
 const SURFACES_UNFORWARDED =
@@ -135,14 +129,6 @@ const NETUID_RANGE =
   "a RANGE bound on netuid, which no route parameter expresses: #10014 gave " +
   "both surfaces `netuid` (exactly one subnet) and neither a range. A " +
   "capability GraphQL adds, not a claim about the route.";
-
-const BOOLEAN_STRING_FORWARDING =
-  'the route publishes a ["true","false"] STRING enum and GraphQL has a ' +
-  "real Boolean, which is the stricter spelling -- but this field's resolver " +
-  "hands the argument to an MCP loader that validates it with " +
-  "`optionalEnum(args, name, BOOLEAN_STRINGS)`, so a JS boolean is rejected " +
-  "where the string is accepted. Moving the spelling means moving the " +
-  "forwarding with it.";
 
 const COMMA_JOINED_LIST =
   "a query string has no list type, so the route takes the values comma-" +
@@ -257,27 +243,41 @@ export const DECLARED_UNPUBLISHED_ARGUMENTS: Readonly<Record<string, string>> =
       "String here would add the one spelling GraphQL exists to avoid.",
   };
 
-export const DECLARED_ARGUMENT_TYPES: Readonly<
-  Record<string, DeclaredArgumentType>
-> = {
+export const ARGUMENT_CODECS: Readonly<Record<string, ArgumentCodec>> = {
   // ── an epoch-ms bound cannot be an Int ────────────────────────────────────
-  "blocks.from": { type: "String", reason: EPOCH_MS_BOUND },
-  "blocks.to": { type: "String", reason: EPOCH_MS_BOUND },
-  "extrinsics.from": { type: "String", reason: EPOCH_MS_BOUND },
-  "extrinsics.to": { type: "String", reason: EPOCH_MS_BOUND },
-  "sudo.from": { type: "String", reason: EPOCH_MS_BOUND },
-  "sudo.to": { type: "String", reason: EPOCH_MS_BOUND },
+  "blocks.from": { graphql: "String", reason: EPOCH_MS_BOUND },
+  "blocks.to": { graphql: "String", reason: EPOCH_MS_BOUND },
+  "extrinsics.from": { graphql: "String", reason: EPOCH_MS_BOUND },
+  "extrinsics.to": { graphql: "String", reason: EPOCH_MS_BOUND },
+  "sudo.from": { graphql: "String", reason: EPOCH_MS_BOUND },
+  "sudo.to": { graphql: "String", reason: EPOCH_MS_BOUND },
 
   // ── a comma-joined string is a list ───────────────────────────────────────
-  "compare.netuids": { type: "[Int!]!", reason: COMMA_JOINED_LIST },
-  "compare.dimensions": { type: "[String!]", reason: COMMA_JOINED_LIST },
-  "compare_validators.hotkeys": {
-    type: "[String!]!",
+  //
+  // THE ONE DECLARED OWNER (#10787). Every other entry's ownership derives from
+  // this table against the route's schema; this one cannot, because the codec
+  // is what hides it -- the array is joined into the route's comma-joined
+  // string a line later, so the route's schema CAN hold the value and the
+  // derivation says the route keeps it.
+  //
+  // It must not. The route's parameter is a regex over a comma-joined string,
+  // and its rejection message describes a spelling a GraphQL caller cannot
+  // send. `parseCompareNetuidList` in the resolver bounds the same arity (1-128
+  // distinct, non-negative) and says so in the caller's own terms, which is why
+  // `compare(netuids: [])` and `compare(netuids: [-1])` answer what they do.
+  "compare.netuids": {
+    graphql: "[Int!]!",
+    owner: "graphql",
     reason: COMMA_JOINED_LIST,
   },
-  "rpc_endpoints.fields": { type: "[String!]", reason: COMMA_JOINED_LIST },
+  "compare.dimensions": { graphql: "[String!]", reason: COMMA_JOINED_LIST },
+  "compare_validators.hotkeys": {
+    graphql: "[String!]!",
+    reason: COMMA_JOINED_LIST,
+  },
+  "rpc_endpoints.fields": { graphql: "[String!]", reason: COMMA_JOINED_LIST },
   "endpoints.fields": {
-    type: "[String!]",
+    graphql: "[String!]",
     reason:
       COMMA_JOINED_LIST +
       " Kept at all -- unlike the fields whose `fields` is dropped -- because " +
@@ -286,7 +286,7 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
     addedByGraphql: true,
   },
   "surfaces.fields": {
-    type: "String",
+    graphql: "String",
     reason:
       "same reason as `endpoints.fields`: the return type is not fully " +
       "projectable, so REST's projection parameter still has work to do. " +
@@ -304,20 +304,20 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // `Int`. Narrowing the Zod instead would 400 a REST caller sending
   // `min_tempo=99.5` today for no gain: the quantity is integral either way,
   // and GraphQL already refuses fractions here.
-  "subnets.min_block": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_block": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.min_candidate_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_candidate_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.min_mechanism_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_mechanism_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.min_participant_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_participant_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.min_probed_surface_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_probed_surface_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.min_surface_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_surface_count": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.min_tempo": { type: "Int", reason: INTEGER_BOUND },
-  "subnets.max_tempo": { type: "Int", reason: INTEGER_BOUND },
+  "subnets.min_block": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_block": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.min_candidate_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_candidate_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.min_mechanism_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_mechanism_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.min_participant_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_participant_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.min_probed_surface_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_probed_surface_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.min_surface_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_surface_count": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.min_tempo": { graphql: "Int", reason: INTEGER_BOUND },
+  "subnets.max_tempo": { graphql: "Int", reason: INTEGER_BOUND },
 
   // ── the canonical readiness names, and the aliases beside them ────────────
   //
@@ -331,20 +331,20 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // reappearing on the surface nothing was checking. The canonical pair now
   // derives from the route; these two are the aliases kept beside them.
   "subnets.min_integration_readiness": {
-    type: "Int",
+    graphql: "Int",
     reason: READINESS_BOUND,
   },
   "subnets.max_integration_readiness": {
-    type: "Int",
+    graphql: "Int",
     reason: READINESS_BOUND,
   },
   "subnets.min_readiness": {
-    type: "Int",
+    graphql: "Int",
     reason: READINESS_ALIAS,
     addedByGraphql: true,
   },
   "subnets.max_readiness": {
-    type: "Int",
+    graphql: "Int",
     reason: READINESS_ALIAS,
     addedByGraphql: true,
   },
@@ -357,27 +357,27 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // of REST here rather than drifted from it -- the resolver reaches the same
   // shared `listPage` filters the list_subnets MCP tool does.
   "subnets.not_coverage_level": {
-    type: "String",
+    graphql: "String",
     reason: NEGATION_FILTER,
     addedByGraphql: true,
   },
   "subnets.not_curation_level": {
-    type: "String",
+    graphql: "String",
     reason: NEGATION_FILTER,
     addedByGraphql: true,
   },
   "subnets.not_domain": {
-    type: "String",
+    graphql: "String",
     reason: NEGATION_FILTER,
     addedByGraphql: true,
   },
   "subnets.not_status": {
-    type: "String",
+    graphql: "String",
     reason: NEGATION_FILTER,
     addedByGraphql: true,
   },
   "subnets.not_subnet_type": {
-    type: "String",
+    graphql: "String",
     reason: NEGATION_FILTER,
     addedByGraphql: true,
   },
@@ -394,12 +394,12 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // measures whole milliseconds, and the sibling root field `endpoints`
   // publishes `Int` from a route that says integer. Same reasoning as
   // INTEGER_BOUND, on the one nested field that takes arguments.
-  "Subnet.endpoints.min_latency_ms": { type: "Int", reason: INTEGER_BOUND },
-  "Subnet.endpoints.max_latency_ms": { type: "Int", reason: INTEGER_BOUND },
+  "Subnet.endpoints.min_latency_ms": { graphql: "Int", reason: INTEGER_BOUND },
+  "Subnet.endpoints.max_latency_ms": { graphql: "Int", reason: INTEGER_BOUND },
 
   // ── the Subscription root's only argument ─────────────────────────────────
   "chainEvents.tables": {
-    type: "[ChainFirehoseTable!]",
+    graphql: "[ChainFirehoseTable!]",
     addedByGraphql: true,
     reason:
       "the firehose topics to subscribe to. No REST route serves the " +
@@ -414,14 +414,14 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // -- so `saved_query` has no parameters to derive from and these two ARE the
   // declaration.
   "saved_query.id": {
-    type: "String!",
+    graphql: "String!",
     addedByGraphql: true,
     reason:
       "the saved query to run, by id. No REST route serves this field, so " +
       "nothing derives the argument and this entry is where it is published.",
   },
   "saved_query.params": {
-    type: "JSON",
+    graphql: "JSON",
     addedByGraphql: true,
     reason:
       "the saved query's bound parameters, an opaque record keyed by the " +
@@ -430,7 +430,7 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   },
 
   "extrinsic.ref": {
-    type: "String!",
+    graphql: "String!",
     addedByGraphql: true,
     reason:
       "accepts a transaction hash OR a composite block_number-extrinsic_index " +
@@ -438,7 +438,7 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
       "wider name for the wider input, not a second spelling of the same one.",
   },
   "block_chain_events.block_number": {
-    type: "Int!",
+    graphql: "Int!",
     addedByGraphql: true,
     reason:
       "the route's path parameter is `{ref}`; this field takes the NUMERIC " +
@@ -448,7 +448,7 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
 
   // ── one path parameter, two names ─────────────────────────────────────────
   "provider.id": {
-    type: "String!",
+    graphql: "String!",
     addedByGraphql: true,
     reason:
       "the route's path parameter is `slug`; this field has always taken " +
@@ -463,12 +463,12 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // opaque id keyset where REST takes an integer offset. Both bindings say so
   // in prose already -- `providers`' description reads "Cursor remains the
   // pre-existing opaque string id-keyset (not REST's integer offset)".
-  "subnets.cursor": { type: "String", reason: OPAQUE_KEYSET },
-  "providers.cursor": { type: "String", reason: OPAQUE_KEYSET },
+  "subnets.cursor": { graphql: "String", reason: OPAQUE_KEYSET },
+  "providers.cursor": { graphql: "String", reason: OPAQUE_KEYSET },
 
   // ── projection the selection set cannot replace ───────────────────────────
   "providers.fields": {
-    type: "String",
+    graphql: "String",
     addedByGraphql: true,
     reason:
       "same reason as `endpoints.fields` and `surfaces.fields`: `fields` is " +
@@ -482,19 +482,19 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // #10014 added `netuid` (exactly one subnet) to the route and this field.
   // Neither route nor field has a range, and GraphQL published one first.
   "subnets.min_netuid": {
-    type: "Int",
+    graphql: "Int",
     reason: NETUID_RANGE,
     addedByGraphql: true,
   },
   "subnets.max_netuid": {
-    type: "Int",
+    graphql: "Int",
     reason: NETUID_RANGE,
     addedByGraphql: true,
   },
 
   // ── pagination GraphQL owns ───────────────────────────────────────────────
   "endpoints.cursor": {
-    type: "String",
+    graphql: "String",
     reason:
       "an OPAQUE id keyset, not REST's integer offset -- the GraphQL-only " +
       "pagination contract #7920 established for `providers`. Verified live: " +
@@ -503,7 +503,7 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
       "field has.",
   },
   "validators.cursor": {
-    type: "String",
+    graphql: "String",
     reason:
       "GraphQL-only pagination. /api/v1/validators publishes sort+limit and " +
       "400s on cursor; the resolver fetches GLOBAL_VALIDATOR_LIMIT_MAX once " +
@@ -514,7 +514,7 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
 
   // ── one field, two routes ─────────────────────────────────────────────────
   "agent_catalog.netuid": {
-    type: "Int",
+    graphql: "Int",
     reason:
       "the field merges TWO routes: netuid absent reads /api/v1/agent-catalog, " +
       "netuid present reads the sibling detail route " +
@@ -523,32 +523,21 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
     addedByGraphql: true,
   },
 
-  // ── a true/false enum the resolver's forwarding still expects as text ─────
+  // ── the four true/false arguments that are gone from here (#10787) ────────
   //
-  // `Boolean` is the honest spelling and ~20 sibling arguments already use it
-  // -- but these four reach an MCP loader that validates with
-  // `optionalEnum(args, name, BOOLEAN_STRINGS)`, which wants the STRING
-  // "true". `endpoints.pool_eligible` is Boolean and safe only because ITS
-  // resolver takes a different path (`endpointsListQueryUrl`'s `set()`, which
-  // does `String(value)`). So the spelling cannot move without moving the
-  // forwarding with it, per field -- an input-type change that needs its own
-  // verification rather than a rename inside a generator change.
-  "subnet_endpoints.pool_eligible": {
-    type: "String",
-    reason: BOOLEAN_STRING_FORWARDING,
-  },
-  "review_enrichment_queue.manual_review_required": {
-    type: "String",
-    reason: BOOLEAN_STRING_FORWARDING,
-  },
-  "review_enrichment_targets.auto_review_candidate": {
-    type: "String",
-    reason: BOOLEAN_STRING_FORWARDING,
-  },
-  "review_enrichment_targets.manual_review_required": {
-    type: "String",
-    reason: BOOLEAN_STRING_FORWARDING,
-  },
+  // `subnet_endpoints.pool_eligible` and the three review filters published
+  // `String` while ~20 siblings published `Boolean`, and the reason was not a
+  // divergence at all: their resolvers hand the argument to an MCP loader that
+  // validated it with `optionalEnum(args, name, ["true","false"])`, so a JS
+  // boolean was rejected where the string was accepted. NOTHING PREVENTED THAT
+  // BUT THIS PARAGRAPH, which said "the spelling cannot move without moving
+  // the forwarding with it" and left both where they were.
+  //
+  // The forwarding moved. `withBooleanWords` in src/mcp-list-query.ts is the
+  // one decoder for the route's query-string spelling of a boolean, the four
+  // arguments publish `Boolean` like their siblings, and `scalarFor` derives
+  // that from the route's own `["true","false"]` enum -- so there is nothing
+  // left to declare.
 
   // `subnet_stake_quote.amount` was declared here as `Float!` while the route
   // called it optional and rejected every request without it. #10401 fixed the
@@ -558,9 +547,25 @@ export const DECLARED_ARGUMENT_TYPES: Readonly<
   // closes is a lie that validate:graphql-query-arguments would fail on.
 };
 
-/** Does the route's parse own this field's argument, or does GraphQL? */
-export function isDeclaredDivergence(field: string, argument: string): boolean {
-  return `${field}.${argument}` in DECLARED_ARGUMENTS;
+/** The codec declared for one field's argument, or null. */
+export function argumentCodec(
+  field: string,
+  argument: string,
+): ArgumentCodec | null {
+  return ARGUMENT_CODECS[`${field}.${argument}`] ?? null;
+}
+
+/**
+ * Is this argument's spelling declared -- including the `addedByGraphql` case,
+ * where the route publishes no such parameter at all?
+ *
+ * `validate:graphql-route-parity` asks the same question from the other side:
+ * an SDL argument with no route parameter behind it. That is precisely what an
+ * `addedByGraphql` entry records, so the gate reads this rather than keeping a
+ * list of its own (#10772).
+ */
+export function hasArgumentCodec(field: string, argument: string): boolean {
+  return `${field}.${argument}` in ARGUMENT_CODECS;
 }
 
 /**
@@ -581,81 +586,30 @@ function graphqlJsonKind(type: string): string {
 }
 
 /**
- * The kind GraphQL publishes for an argument whose TYPE is declared, or null.
+ * The kind GraphQL publishes for an argument whose spelling is declared, or
+ * null.
  *
- * THE SECOND READER OF ONE LIST, and the reason this exists (#10772).
- * `DECLARED_ARGUMENTS` says an argument's presence is GraphQL's; the runtime
- * parse read only that, so `providers(cursor: "<opaque string>")` was rejected
- * by the route's integer `cursor` -- a divergence declared, correctly, in
- * `DECLARED_ARGUMENT_TYPES` instead. Two lists for one concept is the trap
- * this file's own header records from last time; the fix is a second reader,
- * not a third list. The caller compares this against the route's declared kind
- * and skips only where the route's schema genuinely cannot hold the value.
+ * The caller compares this against the route's declared kind and takes the
+ * argument away from the route only where the route's schema genuinely cannot
+ * hold the value -- so `Int` over a `z.number()` bound stays the route's,
+ * keeping its clamping and its published default, while `String` over that
+ * same bound does not. Skipping every declared spelling instead would strip
+ * the bounds off fourteen arguments to fix two.
  */
-/**
- * Is this argument's TYPE declared -- including the `addedByGraphql` case,
- * where the route publishes no such parameter at all?
- *
- * `validate:graphql-route-parity` asks the same question from the other side:
- * an SDL argument with no route parameter behind it. That is precisely what an
- * `addedByGraphql` entry records, so the gate reads this rather than keeping a
- * list of its own (#10772).
- */
-export function isDeclaredArgumentType(
-  field: string,
-  argument: string,
-): boolean {
-  return `${field}.${argument}` in DECLARED_ARGUMENT_TYPES;
-}
-
-export function declaredArgumentKind(
+export function publishedArgumentKind(
   field: string,
   argument: string,
 ): string | null {
-  const entry = DECLARED_ARGUMENT_TYPES[`${field}.${argument}`];
-  return entry ? graphqlJsonKind(entry.type) : null;
+  const codec = argumentCodec(field, argument);
+  return codec ? graphqlJsonKind(codec.graphql) : null;
 }
 
 /**
- * The two shape conversions a resolver performs before it calls the route, and
- * the reason each is a SPELLING rather than a divergence.
+ * Does this entry take the argument away from the route outright?
  *
- * `validate-graphql-route-parity.ts` documents both and deliberately does not
- * flag them:
- *
- *   BOOLEAN against a published ["true","false"] string enum. A query string
- *   can only carry those two words as text; GraphQL has a real Boolean, so the
- *   SDL is the stricter and more honest of the two spellings. Every resolver on
- *   this shape normalises the same way -- `if (changes === true)
- *   params.set("changes", "true")`.
- *
- *   LIST against a comma-joined string. `/api/v1/compare` takes a bounded
- *   comma-joined pattern because a query string has no list type. GraphQL does,
- *   so the SDL takes [Int!]! and the resolver joins.
- *
- * A dispatch-level parse sees the GraphQL-shaped value while the route's Zod
- * object describes the route-shaped one. Converting first is what lets ONE
- * parse serve both spellings; without it the parse rejects `changes: true`
- * against a string enum and a list against a string -- the parse being wrong
- * about the field rather than the field being wrong.
- *
- * ── It must ask the schema, not the value ──────────────────────────────────
- *
- * The first version of this converted every boolean it saw, which is wrong
- * whenever the route's own parameter is a real boolean rather than the
- * two-word enum: `validator_economics(emission_gate_open: true)` became
- * `"true"` and the parse answered `emission_gate_open must be true or false`.
- * A conversion is only correct when the DESTINATION is the other spelling, so
- * the target type decides, and a value the route already accepts is left alone.
+ * Declared, not derived, and used ONCE -- see `ArgumentCodec.owner` and the
+ * `compare.netuids` entry for why that one cannot be derived.
  */
-export type RouteShape = "string-enum" | "delimited-string" | "as-is";
-
-export function toRouteShape(value: unknown, target: RouteShape): unknown {
-  if (target === "string-enum" && typeof value === "boolean") {
-    return value ? "true" : "false";
-  }
-  if (target === "delimited-string" && Array.isArray(value)) {
-    return value.join(",");
-  }
-  return value;
+export function codecOwnsArgument(field: string, argument: string): boolean {
+  return argumentCodec(field, argument)?.owner === "graphql";
 }

--- a/schemas-src/graphql/query-arguments.ts
+++ b/schemas-src/graphql/query-arguments.ts
@@ -13,10 +13,10 @@
 // simply cannot reach. Deriving both from the route makes the two impossible
 // to drift apart -- which is the thing the hand-written SDL could not promise.
 import {
-  DECLARED_ARGUMENT_TYPES,
+  ARGUMENT_CODECS,
   DECLARED_MISSING_NETWORK,
   DECLARED_UNPUBLISHED_ARGUMENTS,
-  type DeclaredArgumentType,
+  type ArgumentCodec,
 } from "./argument-divergences.ts";
 
 /** One published argument, written the way the SDL writes it. */
@@ -154,7 +154,7 @@ export interface DeriveOptions {
  *
  * Anything else the published parameter cannot express -- a comma-joined list
  * GraphQL spells as a real list, an epoch-ms bound that overflows `Int` --
- * comes from `DECLARED_ARGUMENT_TYPES`, whose entries must stay live.
+ * comes from `ARGUMENT_CODECS`, whose entries must stay live.
  */
 export function deriveQueryArguments(
   field: string,
@@ -175,9 +175,9 @@ export function deriveQueryArguments(
     .filter((parameter): parameter is Parameter => Boolean(parameter?.name));
 
   const declaredType = (name: string, derived: string): string => {
-    const entry: DeclaredArgumentType | undefined =
-      DECLARED_ARGUMENT_TYPES[`${field}.${name}`];
-    return entry?.type ?? derived;
+    const codec: ArgumentCodec | undefined =
+      ARGUMENT_CODECS[`${field}.${name}`];
+    return codec?.graphql ?? derived;
   };
 
   // A route parameter GraphQL deliberately does not publish -- a capability
@@ -223,11 +223,11 @@ export function deriveQueryArguments(
   // Arguments the route does not publish at all -- a capability GraphQL adds,
   // like `validators(cursor:)`'s in-process pagination. Appended last so the
   // derived order stays the route's.
-  for (const [key, entry] of Object.entries(DECLARED_ARGUMENT_TYPES)) {
+  for (const [key, codec] of Object.entries(ARGUMENT_CODECS)) {
     const [owner, name] = key.split(".");
-    if (owner !== field || !entry.addedByGraphql) continue;
+    if (owner !== field || !codec.addedByGraphql) continue;
     if (args.some((a) => a.name === name)) continue;
-    args.push({ name, type: entry.type });
+    args.push({ name, type: codec.graphql });
   }
   return args;
 }

--- a/scripts/validate-graphql-query-arguments.ts
+++ b/scripts/validate-graphql-query-arguments.ts
@@ -19,7 +19,7 @@ import { parse, print } from "graphql";
 import type { ObjectTypeDefinitionNode } from "graphql";
 import { QUERY_BINDINGS } from "../schemas-src/graphql/published-names.ts";
 import {
-  DECLARED_ARGUMENT_TYPES,
+  ARGUMENT_CODECS,
   DECLARED_MISSING_NETWORK,
 } from "../schemas-src/graphql/argument-divergences.ts";
 import {
@@ -157,7 +157,7 @@ export function checkQueryArguments(
       [],
     );
     for (const argument of derived) {
-      if (DECLARED_ARGUMENT_TYPES[`${binding.field}.${argument.name}`]) {
+      if (ARGUMENT_CODECS[`${binding.field}.${argument.name}`]) {
         usedDeclared.add(`${binding.field}.${argument.name}`);
       }
     }
@@ -202,9 +202,7 @@ export function checkQueryArguments(
     violations,
     stale: [
       ...missingNetwork.filter((field) => !usedNetwork.has(field)),
-      ...Object.keys(DECLARED_ARGUMENT_TYPES).filter(
-        (key) => !usedDeclared.has(key),
-      ),
+      ...Object.keys(ARGUMENT_CODECS).filter((key) => !usedDeclared.has(key)),
     ],
   };
 }
@@ -233,7 +231,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     for (const line of report.violations.sort()) console.error(`  - ${line}`);
     console.error(
       "\nFix the SDL to match the route, or declare the spelling in " +
-        "DECLARED_ARGUMENT_TYPES with the reason.",
+        "ARGUMENT_CODECS with the reason.",
     );
   }
   if (report.stale.length) {

--- a/scripts/validate-graphql-route-parity.ts
+++ b/scripts/validate-graphql-route-parity.ts
@@ -19,10 +19,9 @@
 // production traffic and covers every field rather than a sample.
 import { readFileSync } from "node:fs";
 import {
-  DECLARED_ARGUMENTS,
   DECLARED_MISSING_NETWORK,
   DECLARED_UNPUBLISHED_ARGUMENTS,
-  isDeclaredArgumentType,
+  hasArgumentCodec,
 } from "../schemas-src/graphql/argument-divergences.ts";
 
 type Json = Record<string, unknown>;
@@ -445,15 +444,12 @@ for (const field of queryType.fields) {
     const parameter = published.get(arg.name);
     if (!parameter) {
       if (arg.name === "network" && hasNetworkTwin(route)) continue;
-      // `DECLARED_ARGUMENT_TYPES` carries the same fact for an argument whose
-      // TYPE is declared -- `extrinsic.ref` and `block_chain_events.block_number`
-      // are the route's path parameter under the name GraphQL publishes, and
-      // the generator emits them from that entry. One list, read by the gate
-      // that would otherwise contradict it (#10772).
-      if (
-        key in DECLARED_ARGUMENTS ||
-        isDeclaredArgumentType(field.name, arg.name)
-      ) {
+      // `ARGUMENT_CODECS` carries this fact for an argument whose spelling is
+      // declared -- `extrinsic.ref` and `block_chain_events.block_number` are
+      // the route's path parameter under the name GraphQL publishes, and the
+      // generator emits them from that entry. ONE table, read by the gate that
+      // would otherwise contradict it (#10772, merged in #10787).
+      if (hasArgumentCodec(field.name, arg.name)) {
         suppressedArguments.add(key);
         continue;
       }
@@ -475,14 +471,11 @@ for (const field of queryType.fields) {
     const allowed = SCALAR_JSON_TYPES[bare] ?? [];
     if (jsonTypes.some((t) => allowed.includes(t))) continue;
     // A published type that diverges from the route's is exactly what
-    // `DECLARED_ARGUMENT_TYPES` records, and the generator EMITS the spelling
-    // from it -- so a gate reporting it as drift contradicts the artifact it
-    // helped produce. `subnets.cursor`/`providers.cursor` are the opaque
-    // keyset against the route's integer offset (#10772).
-    if (
-      key in DECLARED_ARGUMENTS ||
-      isDeclaredArgumentType(field.name, arg.name)
-    ) {
+    // `ARGUMENT_CODECS` records, and the generator EMITS the spelling from it
+    // -- so a gate reporting it as drift contradicts the artifact it helped
+    // produce. `subnets.cursor`/`providers.cursor` are the opaque keyset
+    // against the route's integer offset (#10772).
+    if (hasArgumentCodec(field.name, arg.name)) {
       suppressedArguments.add(key);
       continue;
     }
@@ -548,10 +541,12 @@ for (const field of queryType.fields) {
 // --- report ----------------------------------------------------------------
 
 const declaredKeys = Object.keys(DECLARED);
-const argumentDeclaredKeys = [
-  ...Object.keys(DECLARED_ARGUMENTS),
-  ...Object.keys(DECLARED_MISSING_ARGUMENTS),
-];
+// The codec table's own staleness is `validate:graphql-query-arguments`', and
+// deliberately so: it checks all 55 entries against what the GENERATOR emits,
+// which is why an entry exists at all. Checking the ten this gate happened to
+// suppress would be a strict subset of that, computed a second way -- the
+// two-lists-for-one-concept shape #10787 merged away.
+const argumentDeclaredKeys = [...Object.keys(DECLARED_MISSING_ARGUMENTS)];
 const stale = [
   ...declaredKeys.filter((key) => !suppressed.has(key)),
   ...argumentDeclaredKeys.filter((key) => !suppressedArguments.has(key)),
@@ -611,7 +606,7 @@ if (argumentFindings.length > 0) {
   }
   console.error(
     "\nAdd the argument to the SDL and forward it in the resolver, or declare it in\n" +
-      "DECLARED_ARGUMENTS / DECLARED_MISSING_ARGUMENTS with the reason.",
+      "ARGUMENT_CODECS / DECLARED_MISSING_ARGUMENTS with the reason.",
   );
 }
 

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -6965,6 +6965,7 @@ export interface RouteQuerySchemas {
   plain: z.ZodObject;
   args: z.ZodObject;
   wire: z.ZodObject;
+  graphql: z.ZodObject;
 }
 
 const routeQuerySchemas = new Map<string, RouteQuerySchemas | null>();
@@ -7025,6 +7026,7 @@ export function routeQuerySchemasForPathname(
       plain: feed,
       args: argsSchema(feed),
       wire: wireSchema(feed),
+      graphql: graphqlSchema(feed),
     };
     routeQuerySchemas.set(pathname, schemas);
     return schemas;
@@ -7033,7 +7035,12 @@ export function routeQuerySchemasForPathname(
   if (cached !== undefined) return cached;
   const plain = querySchemaForRoute(entry);
   const schemas = plain
-    ? { plain, args: argsSchema(plain), wire: wireSchema(plain) }
+    ? {
+        plain,
+        args: argsSchema(plain),
+        wire: wireSchema(plain),
+        graphql: graphqlSchema(plain),
+      }
     : null;
   // Built once per route: the shape never changes at runtime, and this sits on
   // the request path for every GET.
@@ -7072,7 +7079,12 @@ export function collectionQuerySchemas(
         : [],
     csvResponse,
   });
-  const schemas = { plain, args: argsSchema(plain), wire: wireSchema(plain) };
+  const schemas = {
+    plain,
+    args: argsSchema(plain),
+    wire: wireSchema(plain),
+    graphql: graphqlSchema(plain),
+  };
   routeQuerySchemas.set(key, schemas);
   return schemas;
 }
@@ -7210,6 +7222,115 @@ function argsSchema(schema: z.ZodObject): z.ZodObject {
   const shape: Record<string, z.ZodType> = {};
   for (const [name, field] of Object.entries(schema.shape)) {
     shape[name] = vocabularyField(field as z.ZodType);
+  }
+  return z.object(shape);
+}
+
+/**
+ * Is this parameter's published enum the QUERY-STRING SPELLING of a boolean?
+ *
+ * Answers for ANY field, not only an enum -- a caller that had to establish
+ * that first would be asking the same question twice, and the second ask is
+ * where the two drift.
+ *
+ * EVERY value being a boolean word, not exactly two of them.
+ * `/subnets/{netuid}/metagraph` publishes `validator_permit` as `["true"]`
+ * alone -- absent means "both", so "false" would be a third answer rather than
+ * the other half of a pair. It is still the spelling a query string has for a
+ * boolean, and requiring arity 2 read it as an ordinary enum.
+ *
+ * Read off `def` for the reason `declaredBaseType` gives: serializing every
+ * field to JSON Schema is far more work and a second representation to keep
+ * honest.
+ */
+export function isBooleanWordEnum(field: z.ZodType): boolean {
+  type Wrapper = { innerType?: { def?: z.core.$ZodTypeDef } };
+  type EnumDef = { entries?: Record<string, unknown> };
+  let current: z.core.$ZodTypeDef = field.def;
+  for (let hops = 0; hops < 10; hops += 1) {
+    const inner = (current as Wrapper).innerType?.def;
+    if (!inner) break;
+    current = inner;
+  }
+  const values = Object.values((current as EnumDef).entries ?? {});
+  return (
+    values.length > 0 &&
+    values.every((value) => value === "true" || value === "false")
+  );
+}
+
+/**
+ * Re-type one field for the shape GRAPHQL carries (#10787).
+ *
+ * THE THIRD LAYER, and it was the missing one. `wire` is REST's codec and
+ * `args` is MCP's, both derived from the field's own declared type -- while
+ * GraphQL's lived in `src/route-query.ts` as a hand-written switch over a
+ * `RouteShape` union, reached through a second table nothing else read. One
+ * canonical schema with two codecs beside it and a third somewhere else is how
+ * a surface comes to decode differently from the gate that checks it, which is
+ * the failure #10772 shipped and this issue exists to close.
+ *
+ * Two conversions, and each is a SPELLING rather than a divergence:
+ *
+ *   a GraphQL Boolean against a published `["true","false"]` enum. A query
+ *   string can carry those two words only as text; GraphQL has a real Boolean,
+ *   so the SDL publishes the stricter of the two spellings and this writes it
+ *   back in the route's terms.
+ *
+ *   a GraphQL list against a comma-joined string. `/api/v1/compare` bounds its
+ *   arity with a regex because a query string has no list type; GraphQL has
+ *   one, so the SDL takes a list and this joins it.
+ *
+ * The DESTINATION decides, never the value. Converting every boolean seen is
+ * wrong wherever the route's own parameter is a real boolean:
+ * `validator_economics(emission_gate_open: true)` became `"true"` and the parse
+ * answered `emission_gate_open must be true or false` (#10772).
+ */
+function graphqlField(field: z.ZodType): z.ZodType {
+  const declared = declaredBaseType(field);
+  if (declared === "enum") {
+    const vocabulary = vocabularyField(field);
+    return isBooleanWordEnum(field)
+      ? z.preprocess(booleanWord, vocabulary)
+      : vocabulary;
+  }
+  if (declared === "string") {
+    return z.preprocess(
+      (value) => (Array.isArray(value) ? value.join(",") : value),
+      field,
+    );
+  }
+  return field;
+}
+
+/**
+ * Does the GraphQL codec RESHAPE this parameter, rather than pass it through?
+ *
+ * Asked by the argument boundary, and the answer decides ownership: a spelling
+ * the codec converts is one the route can still validate a line later, so the
+ * route keeps its bounds and its published default. Reading the two kinds and
+ * comparing them without asking this cost two arguments their validation --
+ * a GraphQL list against a comma-joined string and a Boolean against a
+ * `["true","false"]` enum are different KINDS that the codec turns into the
+ * route's spelling, so `compare_validators(hotkeys: [])` was rejected by a
+ * parse that was right about the route and wrong about the field (#10772).
+ */
+export function graphqlReshapes(field: z.ZodType): boolean {
+  return declaredBaseType(field) === "string" || isBooleanWordEnum(field);
+}
+
+/** A GraphQL Boolean in the words a query string spells it with. */
+function booleanWord(value: unknown): unknown {
+  if (value === true) return "true";
+  if (value === false) return "false";
+  return value;
+}
+
+/** `plain` with the two shape conversions GraphQL's type system forces. */
+function graphqlSchema(schema: z.ZodObject): z.ZodObject {
+  const shape: Record<string, z.ZodType> = {};
+  for (const [name, field] of Object.entries(schema.shape)) {
+    shape[name] = graphqlField(field as z.ZodType);
   }
   return z.object(shape);
 }

--- a/src/enrichment-queue-mcp.ts
+++ b/src/enrichment-queue-mcp.ts
@@ -3,7 +3,12 @@
 // /metagraph/review/enrichment-queue.json artifact.
 
 import { clampToolLimit } from "../workers/request-params.ts";
-import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
+import {
+  applyMcpQueryFilters,
+  BOOLEAN_WORDS,
+  withBooleanWords,
+  type Row,
+} from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -35,7 +40,6 @@ const LANES = [
   "monitoring-followup",
   "baseline-monitoring",
 ];
-const BOOLEAN_STRINGS = ["true", "false"];
 
 export interface EnrichmentQueueMcpError extends Error {
   toolError: true;
@@ -127,9 +131,9 @@ export function enrichmentQueueQueryUrl(
   const missingKinds = optionalEnum(args, "missing_kinds", SURFACE_KINDS);
   if (missingKinds) url.searchParams.set("missing_kinds", missingKinds);
   const manualReviewRequired = optionalEnum(
-    args,
+    withBooleanWords(args, ["manual_review_required"]),
     "manual_review_required",
-    BOOLEAN_STRINGS,
+    BOOLEAN_WORDS,
   );
   if (manualReviewRequired) {
     url.searchParams.set("manual_review_required", manualReviewRequired);

--- a/src/graphql-sdl.ts
+++ b/src/graphql-sdl.ts
@@ -278,7 +278,7 @@ export const SDL = /* GraphQL */ `
       limit: Int
       cursor: Int
     ): JSON
-    "One subnet's endpoint/resource registry as a filtered/sorted/paged list — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, provider, publication_state, status, and pool_eligible (a true/false string); threshold with min_/max_latency_ms and min_/max_score; project with fields; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the filterable network-wide endpoint registry). Mirrors GET /api/v1/subnets/{netuid}/endpoints."
+    "One subnet's endpoint/resource registry as a filtered/sorted/paged list — the baked per-subnet /metagraph/endpoints/{netuid}.json artifact the REST route and list_subnet_endpoints MCP tool read. Filter with kind, layer, provider, publication_state, status, and pool_eligible; threshold with min_/max_latency_ms and min_/max_score; project with fields; sort with sort + order; and page with limit (1-100) / cursor, exactly as REST does — an unsupported filter/sort value is a GraphQL error, not a silently substituted default. The envelope carries the same pagination meta REST returns (total, returned, limit, cursor, next_cursor, sort, order) alongside the endpoints rows. Null when no endpoint artifact has been baked for the netuid (rather than a GraphQL error). Distinct from endpoints(...) (the filterable network-wide endpoint registry). Mirrors GET /api/v1/subnets/{netuid}/endpoints."
     subnet_endpoints(
       netuid: Int!
       kind: String
@@ -286,7 +286,7 @@ export const SDL = /* GraphQL */ `
       provider: String
       publication_state: String
       status: String
-      pool_eligible: String
+      pool_eligible: Boolean
       min_latency_ms: Float
       max_latency_ms: Float
       min_score: Float
@@ -597,7 +597,7 @@ export const SDL = /* GraphQL */ `
       profile_level: String
       direct_submission_kinds: String
       missing_kinds: String
-      manual_review_required: String
+      manual_review_required: Boolean
       reason_codes: String
       review_state: String
       sort: String
@@ -617,8 +617,8 @@ export const SDL = /* GraphQL */ `
       identity_level: String
       profile_level: String
       submission_route: String
-      auto_review_candidate: String
-      manual_review_required: String
+      auto_review_candidate: Boolean
+      manual_review_required: Boolean
       missing_kinds: String
       reason_codes: String
       sort: String

--- a/src/mcp-list-query.ts
+++ b/src/mcp-list-query.ts
@@ -46,6 +46,48 @@ import { MCP_LIST_LIMIT_DEFAULT } from "./route-limits.ts";
  * same validation, same errors. An explicit `limit` in the query string still
  * wins; this only supplies one when the caller gave none.
  */
+/**
+ * The query-string spelling of a boolean, and the one decoder for it (#10787).
+ *
+ * A route that publishes a filter as a `["true","false"]` STRING enum is
+ * spelling a boolean the only way a query string can. GraphQL has a real
+ * `Boolean` and publishes it, which is the stricter and more honest of the two
+ * spellings -- but four fields could not, because their resolvers hand the
+ * argument straight to an MCP loader that validated it with
+ * `optionalEnum(args, name, ["true","false"])`. A JS boolean was rejected
+ * there where the string was accepted, and NOTHING PREVENTED IT BUT A COMMENT:
+ * the divergence table carried a paragraph saying "moving the spelling means
+ * moving the forwarding with it", and nobody moved either.
+ *
+ * This is that forwarding, once. It is a LENIENT codec in the sense #8942
+ * measured -- MCP's decoder accepts what REST's would reject, over the same
+ * canonical vocabulary -- and it is declared here rather than hand-written at
+ * each site, so a loader written next month gets it by importing the decoder
+ * it already needs.
+ */
+export const BOOLEAN_WORDS = ["true", "false"] as const;
+
+/**
+ * `args` with the named boolean filters rewritten in the route's spelling.
+ *
+ * Returns the SAME object when nothing needed rewriting, so a loader whose
+ * caller already sent the string form allocates nothing.
+ */
+export function withBooleanWords(
+  args: Record<string, unknown> | null | undefined,
+  keys: readonly string[],
+): Record<string, unknown> | null | undefined {
+  if (!args) return args;
+  let decoded: Record<string, unknown> | null = null;
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value !== "boolean") continue;
+    decoded ??= { ...args };
+    decoded[key] = value ? "true" : "false";
+  }
+  return decoded ?? args;
+}
+
 export function applyMcpQueryFilters(
   data: Record<string, unknown> | null | undefined,
   url: URL,

--- a/src/review-enrichment-targets-mcp.ts
+++ b/src/review-enrichment-targets-mcp.ts
@@ -4,7 +4,12 @@
 // /metagraph/review/enrichment-targets.json artifact.
 
 import { clampToolLimit } from "../workers/request-params.ts";
-import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
+import {
+  applyMcpQueryFilters,
+  BOOLEAN_WORDS,
+  withBooleanWords,
+  type Row,
+} from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -36,7 +41,6 @@ const LANES = [
   "monitoring-followup",
   "baseline-monitoring",
 ];
-const BOOLEAN_STRINGS = ["true", "false"];
 const SUBMISSION_ROUTES = [
   "direct-candidate-pr",
   "adapter-request",
@@ -149,18 +153,25 @@ export function reviewEnrichmentTargetsQueryUrl(
   );
   if (submissionRoute)
     url.searchParams.set("submission_route", submissionRoute);
-  const autoReviewCandidate = optionalEnum(
-    args,
+  // Both filters are spelled `["true","false"]` by the route because a query
+  // string has no boolean; GraphQL publishes real Booleans and this decodes
+  // them, in the one place the decoding is written (#10787).
+  const booleans = withBooleanWords(args, [
     "auto_review_candidate",
-    BOOLEAN_STRINGS,
+    "manual_review_required",
+  ]);
+  const autoReviewCandidate = optionalEnum(
+    booleans,
+    "auto_review_candidate",
+    BOOLEAN_WORDS,
   );
   if (autoReviewCandidate) {
     url.searchParams.set("auto_review_candidate", autoReviewCandidate);
   }
   const manualReviewRequired = optionalEnum(
-    args,
+    booleans,
     "manual_review_required",
-    BOOLEAN_STRINGS,
+    BOOLEAN_WORDS,
   );
   if (manualReviewRequired) {
     url.searchParams.set("manual_review_required", manualReviewRequired);

--- a/src/route-query.ts
+++ b/src/route-query.ts
@@ -34,15 +34,14 @@
 import { z } from "zod";
 import {
   collectionQuerySchemas,
+  graphqlReshapes,
   routeParameterKind,
   routeQuerySchemasForPathname,
   type RouteQuerySchemas,
 } from "./contracts.ts";
 import {
-  declaredArgumentKind,
-  isDeclaredDivergence,
-  toRouteShape,
-  type RouteShape,
+  codecOwnsArgument,
+  publishedArgumentKind,
 } from "../schemas-src/graphql/argument-divergences.ts";
 import { SERVING_BOUND } from "../schemas-src/query-params.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
@@ -175,7 +174,7 @@ export function validateRouteArgs(
       supplied[name] = value;
     }
   }
-  const parsed = schemas.args.safeParse(supplied);
+  const parsed = schemas.graphql.safeParse(supplied);
   if (parsed.success) return null;
   const issue = parsed.error.issues[0];
   const parameter = String(issue?.path[0] ?? "");
@@ -210,7 +209,7 @@ export function parseRouteArgs<T = Record<string, unknown>>(
       supplied[name] = value;
     }
   }
-  const parsed = schemas.args.safeParse(supplied);
+  const parsed = schemas.graphql.safeParse(supplied);
   if (!parsed.success) return null;
   // `.meta({ default })` is published, not applied by parse -- the same reason
   // `pageLimit` reads it back rather than trusting the parsed object.
@@ -280,31 +279,6 @@ function isServingBound(field: z.ZodType | undefined): boolean {
 function unwrapOptional(field: z.ZodType | undefined): z.ZodType | undefined {
   if (!field) return undefined;
   return field instanceof z.ZodOptional ? (field.unwrap() as z.ZodType) : field;
-}
-
-/**
- * Which spelling the route wants for this parameter.
- *
- * A published `["true","false"]` enum is the query-string spelling of a
- * boolean; a published string with a delimited pattern is the query-string
- * spelling of a list. Anything else already matches what GraphQL sends.
- */
-function routeShapeOf(field: z.ZodType | undefined): RouteShape {
-  const inner = unwrapOptional(field);
-  if (!inner) return "as-is";
-  const json = publishedShape(inner);
-  if (Array.isArray(json.enum)) {
-    // EVERY value being a boolean word, not exactly two of them.
-    // `/subnets/{netuid}/metagraph` publishes `validator_permit` as `["true"]`
-    // alone -- absent means "both", so "false" would be a third answer rather
-    // than the other half of a pair. It is still the query-string spelling of
-    // a boolean, and requiring arity 2 read it as an ordinary enum and rejected
-    // the SDL's `Boolean`.
-    return json.enum.every((value) => value === "true" || value === "false")
-      ? "string-enum"
-      : "as-is";
-  }
-  return json.type === "string" ? "delimited-string" : "as-is";
 }
 
 /**
@@ -428,13 +402,12 @@ function graphqlOwnsSpelling(
   field: string,
   name: string,
   declared: z.ZodType | undefined,
-  shape: RouteShape,
 ): boolean {
-  if (isDeclaredDivergence(field, name)) return true;
-  const published = declaredArgumentKind(field, name);
+  if (codecOwnsArgument(field, name)) return true;
+  const published = publishedArgumentKind(field, name);
   if (published === null) return false;
   if (!declared) return true;
-  if (shape !== "as-is") return false;
+  if (graphqlReshapes(declared)) return false;
   return published !== routeParameterKind(declared);
 }
 
@@ -449,15 +422,15 @@ export function resolveRouteArgs<T = Record<string, unknown>>(
   for (const [name, value] of Object.entries(args)) {
     if (value === null || value === undefined) continue;
     const declared = schemas?.plain.shape[name] as z.ZodType | undefined;
-    // Resolved once and used twice: it decides whether the route can hold this
-    // spelling at all, and then how to write it in the route's terms.
-    const shape = routeShapeOf(declared);
-    if (graphqlOwnsSpelling(field, name, declared, shape)) continue;
+    if (graphqlOwnsSpelling(field, name, declared)) continue;
     if (declared && isServingBound(declared)) {
       owned[name] = clampToPublished(declared, value);
       clamped.add(name);
     } else {
-      owned[name] = toRouteShape(value, shape);
+      // NOT converted here. The `graphql` codec layer both parse entries below
+      // read does it, so the conversion has ONE definition rather than a
+      // hand-written switch beside the schema that already describes it.
+      owned[name] = value;
     }
   }
   const error = validateRouteArgs(routePath, owned);

--- a/src/subnet-endpoints-mcp.ts
+++ b/src/subnet-endpoints-mcp.ts
@@ -4,7 +4,12 @@
 // /metagraph/endpoints/{netuid}.json artifact.
 
 import { clampToolLimit } from "../workers/request-params.ts";
-import { applyMcpQueryFilters, type Row } from "./mcp-list-query.ts";
+import {
+  applyMcpQueryFilters,
+  BOOLEAN_WORDS,
+  withBooleanWords,
+  type Row,
+} from "./mcp-list-query.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
 import { API_QUERY_COLLECTIONS, QUERY_ENUMS } from "./contracts.ts";
 import {
@@ -18,7 +23,6 @@ const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
 const ENDPOINT_LAYERS = QUERY_ENUMS.endpointLayer;
 const PUBLICATION_STATES = QUERY_ENUMS.endpointPublicationState;
 const HEALTH_STATUSES = QUERY_ENUMS.healthStatus;
-const BOOLEAN_STRINGS = ["true", "false"];
 const SUBNET_ENDPOINTS_QUERY_FILTER_NAMES = [
   "kind",
   "layer",
@@ -118,7 +122,10 @@ export function subnetEndpointsQueryUrl(
   if (kind) url.searchParams.set("kind", kind);
   const layer = optionalEnum(args, "layer", ENDPOINT_LAYERS);
   if (layer) url.searchParams.set("layer", layer);
-  const poolEligible = optionalEnum(args, "pool_eligible", BOOLEAN_STRINGS);
+  // The route spells this filter `["true","false"]` because a query string
+  // has no boolean; GraphQL publishes a real `Boolean` and this decodes it.
+  const decoded = withBooleanWords(args, ["pool_eligible"]);
+  const poolEligible = optionalEnum(decoded, "pool_eligible", BOOLEAN_WORDS);
   if (poolEligible) url.searchParams.set("pool_eligible", poolEligible);
   const provider = optionalString(args, "provider");
   if (provider) url.searchParams.set("provider", provider);

--- a/tests/argument-codecs.test.ts
+++ b/tests/argument-codecs.test.ts
@@ -1,0 +1,177 @@
+// The three codecs over one canonical schema (#10787).
+//
+// A route publishes ONE parameter set. Each surface carries it in the shape its
+// transport can hold, and each of those shapes is a LAYER over the same Zod
+// object rather than a conversion written beside it:
+//
+//   wire     REST -- everything arrives as text off a query string
+//   args     MCP  -- real JSON, plus the vocabulary affordances
+//   graphql  GraphQL -- real JSON, plus the two conversions its type system
+//            forces: a `Boolean` where a query string can only spell the words,
+//            and a list where a query string can only spell a delimited string
+//
+// `graphql` is the one that was missing. It lived in `src/route-query.ts` as a
+// hand-written switch over a `RouteShape` union, reached through a second table
+// nothing else read -- which is how the surface came to decode differently from
+// the gate that checks it (#10772).
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  graphqlReshapes,
+  routeQuerySchemasForPathname,
+} from "../src/contracts.ts";
+import { withBooleanWords } from "../src/mcp-list-query.ts";
+
+describe("the graphql codec layer", () => {
+  test("a real Boolean is accepted where the route publishes the words", () => {
+    // `/subnets/{netuid}/endpoints` spells `pool_eligible` `["true","false"]`
+    // because a query string has no boolean. GraphQL has one and publishes it.
+    const schemas = routeQuerySchemasForPathname(
+      "/api/v1/subnets/{netuid}/endpoints",
+    );
+    assert.ok(schemas, "the route must publish a query schema");
+    const parsed = schemas.graphql.safeParse({ pool_eligible: true });
+    assert.equal(parsed.success, true);
+    assert.equal(
+      (parsed.data as Record<string, unknown>).pool_eligible,
+      "true",
+    );
+  });
+
+  test("`false` converts too, not only `true`", () => {
+    // Both arms, because a codec that only ever handled the truthy one would
+    // pass every test written the obvious way and drop the filter that says
+    // "exclude these".
+    const schemas = routeQuerySchemasForPathname(
+      "/api/v1/subnets/{netuid}/endpoints",
+    );
+    const parsed = schemas!.graphql.safeParse({ pool_eligible: false });
+    assert.equal(parsed.success, true);
+    assert.equal(
+      (parsed.data as Record<string, unknown>).pool_eligible,
+      "false",
+    );
+  });
+
+  test("and the route's own spelling still parses, unchanged", () => {
+    const schemas = routeQuerySchemasForPathname(
+      "/api/v1/subnets/{netuid}/endpoints",
+    );
+    const parsed = schemas!.graphql.safeParse({ pool_eligible: "false" });
+    assert.equal(parsed.success, true);
+    assert.equal(
+      (parsed.data as Record<string, unknown>).pool_eligible,
+      "false",
+    );
+  });
+
+  test("`args` does NOT convert -- the codec is per surface", () => {
+    // The layers are not interchangeable, and a test that only ever checked the
+    // permissive one would not notice them collapsing into each other. MCP's
+    // spelling is the route's; its leniency is declared where it applies
+    // (`withBooleanWords`), not by widening every surface at once.
+    const schemas = routeQuerySchemasForPathname(
+      "/api/v1/subnets/{netuid}/endpoints",
+    );
+    assert.equal(
+      schemas!.args.safeParse({ pool_eligible: true }).success,
+      false,
+    );
+  });
+
+  test("a list is joined into the route's delimited string", () => {
+    // `/api/v1/compare` bounds its arity with a regex because a query string
+    // has no list type; GraphQL has one, so the SDL takes `[Int!]!`.
+    const schemas = routeQuerySchemasForPathname("/api/v1/compare");
+    assert.ok(schemas, "the route must publish a query schema");
+    const parsed = schemas.graphql.safeParse({ netuids: [1, 7, 64] });
+    assert.equal(parsed.success, true);
+    assert.equal((parsed.data as Record<string, unknown>).netuids, "1,7,64");
+  });
+
+  test("a boolean the route ALREADY declares as one is left alone", () => {
+    // The destination decides, never the value. Converting every boolean seen
+    // is wrong wherever the route's own parameter is a real boolean:
+    // `validator_economics(emission_gate_open: true)` became `"true"` and the
+    // parse answered `emission_gate_open must be true or false` (#10772).
+    const schemas = routeQuerySchemasForPathname(
+      "/api/v1/validators/economics",
+    );
+    assert.ok(
+      schemas?.plain.shape.emission_gate_open,
+      "the route must still declare a REAL boolean parameter, or this test " +
+        "passes by checking nothing",
+    );
+    const parsed = schemas.graphql.safeParse({ emission_gate_open: true });
+    assert.equal(parsed.success, true);
+    assert.equal(
+      (parsed.data as Record<string, unknown>).emission_gate_open,
+      true,
+    );
+  });
+});
+
+describe("graphqlReshapes", () => {
+  // The predicate the argument boundary asks before deciding ownership: a
+  // spelling the codec CONVERTS is one the route can still validate a line
+  // later, so the route keeps its bounds and its published default. Reading
+  // the two kinds and comparing them without asking this cost
+  // `compare_validators(hotkeys: [])` its validation (#10772).
+  const shapeOf = (path: string, name: string) => {
+    const field = routeQuerySchemasForPathname(path)?.plain.shape[name];
+    assert.ok(field, `${path} must still publish ${name}`);
+    return graphqlReshapes(field as never);
+  };
+
+  test("a delimited string and a boolean-word enum reshape", () => {
+    assert.equal(shapeOf("/api/v1/compare", "netuids"), true);
+    assert.equal(
+      shapeOf("/api/v1/subnets/{netuid}/endpoints", "pool_eligible"),
+      true,
+    );
+  });
+
+  test("a number and a REAL boolean pass through", () => {
+    assert.equal(shapeOf("/api/v1/validators/economics", "limit"), false);
+    assert.equal(
+      shapeOf("/api/v1/validators/economics", "emission_gate_open"),
+      false,
+    );
+  });
+});
+
+describe("withBooleanWords", () => {
+  test("rewrites a JS boolean into the route's word spelling", () => {
+    assert.deepEqual(
+      withBooleanWords({ pool_eligible: true, kind: "subnet-api" }, [
+        "pool_eligible",
+      ]),
+      { pool_eligible: "true", kind: "subnet-api" },
+    );
+    assert.deepEqual(
+      withBooleanWords({ manual_review_required: false }, [
+        "manual_review_required",
+      ]),
+      { manual_review_required: "false" },
+    );
+  });
+
+  test("leaves the string form, and every other argument, untouched", () => {
+    const args = { pool_eligible: "true", provider: "alpha" };
+    assert.equal(withBooleanWords(args, ["pool_eligible"]), args);
+  });
+
+  test("only the NAMED keys are rewritten", () => {
+    // A blanket "convert every boolean" is the bug this decoder exists to
+    // avoid: a route with a real boolean filter would have its value rewritten
+    // into a string it does not accept.
+    assert.deepEqual(withBooleanWords({ other: true }, ["pool_eligible"]), {
+      other: true,
+    });
+  });
+
+  test("a null/undefined argument bag passes through", () => {
+    assert.equal(withBooleanWords(null, ["pool_eligible"]), null);
+    assert.equal(withBooleanWords(undefined, ["pool_eligible"]), undefined);
+  });
+});

--- a/tests/graphql-route-parity.test.ts
+++ b/tests/graphql-route-parity.test.ts
@@ -10,6 +10,7 @@
 // resolve, and it prints a clean bill of health forever.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { ARGUMENT_CODECS } from "../schemas-src/graphql/argument-divergences.ts";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -24,19 +25,17 @@ function run() {
 /**
  * Each declared-exemption map and the file that owns it.
  *
- * `DECLARED_ARGUMENTS` moved to `schemas-src/` (#10316) because the runtime
- * needs it too: the GraphQL dispatch parse has to skip an argument the two
+ * The argument half moved to `schemas-src/` (#10316) because the runtime needs
+ * it too: the GraphQL argument boundary has to skip an argument the two
  * surfaces legitimately spell differently, and `src/` cannot import from
- * `scripts/`. This test follows it rather than pinning it to the gate -- what
- * matters is that every entry carries a written reason, not which file it
- * sits in.
+ * `scripts/`. It is `ARGUMENT_CODECS` since #10787, which merged the two lists
+ * that had said the same thing about one argument -- its presence and its type
+ * -- and were read by different components. This test follows the table rather
+ * than pinning it to a file: what matters is that every entry carries a written
+ * reason.
  */
 const DECLARED_MAPS = [
   { name: "DECLARED", file: SCRIPT },
-  {
-    name: "DECLARED_ARGUMENTS",
-    file: "schemas-src/graphql/argument-divergences.ts",
-  },
   { name: "DECLARED_MISSING_ARGUMENTS", file: SCRIPT },
 ] as const;
 
@@ -126,6 +125,37 @@ describe("graphql route parity gate", () => {
         .length;
       assert.equal(reasons, keys, `every ${name} entry needs a reason`);
     }
+  });
+
+  test("every argument codec carries a written reason", () => {
+    // Read as a VALUE, not as source text. The two maps above still have to be
+    // regexed because they are private to the gate script, but the codec table
+    // is exported for the runtime -- and a gate that regexes source goes blind
+    // the moment a formatter rewraps it, which is the failure mode this table
+    // is least able to afford now that three components read it.
+    const entries = Object.entries(ARGUMENT_CODECS);
+    assert.ok(entries.length > 40, `only ${entries.length} codecs declared`);
+    for (const [key, codec] of entries) {
+      assert.ok(
+        codec.graphql.length > 0,
+        `${key} declares no GraphQL spelling`,
+      );
+      assert.ok(
+        codec.reason.trim().length > 40,
+        `${key} needs a reason, not a marker`,
+      );
+    }
+  });
+
+  test("`owner` is declared only where the derivation cannot see it", () => {
+    // The bit that survived the merge, and the whole point of merging: nine of
+    // the ten presence declarations were restating what the derivation already
+    // answers. An entry that adds `owner` back for one of those is the second
+    // list returning under a new name.
+    const declared = Object.entries(ARGUMENT_CODECS)
+      .filter(([, codec]) => codec.owner === "graphql")
+      .map(([key]) => key);
+    assert.deepEqual(declared, ["compare.netuids"]);
   });
 
   test("the SDL still annotates the routes it mirrors", () => {

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -12675,8 +12675,13 @@ describe("graphql — subnet_endpoints (#7869, baked per-subnet endpoint artifac
   });
 
   test("filters by provider, pool_eligible, and score range (#7869)", async () => {
+    // `pool_eligible` is a real `Boolean` since #10787. It published `String`
+    // only because this field's resolver hands the argument to an MCP loader
+    // that validated it with `optionalEnum(args, name, ["true","false"])` --
+    // the forwarding moved to `withBooleanWords`, so the spelling could move
+    // with it and match the ~20 sibling arguments that always had it.
     const { body } = await gql(
-      '{ subnet_endpoints(netuid: 5, provider: "alpha", pool_eligible: "true") }',
+      '{ subnet_endpoints(netuid: 5, provider: "alpha", pool_eligible: true) }',
       FILTER_ENV(),
     );
     assert.equal(body.errors, undefined);


### PR DESCRIPTION
The three surfaces differ in input **shape** where the contract is identical, and those differences are permanent transport affordances — a query string has no list and no boolean, GraphQL has both, MCP is handed real JSON. What was wrong was where those affordances lived.

## The layer that was missing

`RouteQuerySchemas` already carried two codecs over one canonical `plain` schema:

| layer | surface | what it decodes |
|---|---|---|
| `wire` | REST | everything arrives as text off a query string |
| `args` | MCP | real JSON, plus the vocabulary affordances |
| **`graphql`** | GraphQL | **did not exist** |

GraphQL's codec lived across the tree instead: a hand-written switch over a `RouteShape` union in `src/route-query.ts`, fed by a second declaration table nothing else read. One canonical schema with two codecs beside it and a third somewhere else is how a surface comes to decode differently from the gate that checks it — which is exactly what #10772 shipped.

`graphql` is the third layer now, built the same way from the field's own declared type: a real `Boolean` where the route publishes `["true","false"]`, a list where the route publishes a delimited string. **`toRouteShape`, `routeShapeOf` and `RouteShape` are deleted** — the schema that describes the parameter now performs the conversion.

## The two lists that were one

`DECLARED_ARGUMENTS` said an argument's PRESENCE was GraphQL's; `DECLARED_ARGUMENT_TYPES` said its TYPE was. Measured:

- **all ten keys of the first were already in the second**
- of those ten declarations, **nine are answered by deriving ownership** from the table against the route's own schema — the six epoch-ms bounds (`String` over an `integer`), both opaque cursors, and `agent_catalog.netuid`, whose route publishes no such query parameter at all

They are `ARGUMENT_CODECS` now: one table, read by the generator, both gates, and the runtime argument boundary.

The tenth survives as `owner: "graphql"` on `compare.netuids`, and only because **the codec is what hides it**: the array is joined into the route's comma-joined string a line later, so the route's schema *can* hold the value and the derivation says the route keeps it. It must not — the route's rejection message describes a spelling a GraphQL caller cannot send, while `parseCompareNetuidList` bounds the same arity (1–128 distinct, non-negative) in the caller's own terms. `tests/graphql-route-parity.test.ts` pins that list at exactly one entry.

That test also stops regexing the table's source and reads it as a **value**. A gate that regexes source goes blind the moment a formatter rewraps it, and three components read this table now.

## The mismatch a comment was holding shut

`BOOLEAN_STRING_FORWARDING` documented that four arguments published `String` while ~20 siblings published `Boolean`, because their resolvers hand the value to an MCP loader validating with `optionalEnum(args, name, ["true","false"])` — a JS boolean rejected where the string was accepted. The paragraph said *"the spelling cannot move without moving the forwarding with it"*, and neither moved.

The forwarding moved. `withBooleanWords` in `src/mcp-list-query.ts` is the one decoder for the query-string spelling of a boolean — MCP leniency declared once, in the sense #8942 measured, rather than hand-written per loader — and the three local `BOOLEAN_STRINGS` copies are gone. The four arguments now publish `Boolean`, which `scalarFor` already derives from the route's own enum, so **nothing is left to declare**.

⚠️ **Input-type change.** `subnet_endpoints.pool_eligible`, `review_enrichment_queue.manual_review_required` and both `review_enrichment_targets` filters no longer accept the string `"true"` over GraphQL. Their ~20 siblings never did. REST and MCP are unaffected: the route's spelling is unchanged, and the MCP loaders now accept **both** forms.

## What is deliberately kept

Every permanent affordance — comma-joined lists, the integer-offset cursor against the opaque keyset, `format=csv`. `DECLARED_UNPUBLISHED_ARGUMENTS` keeps its capability gaps with their reasons; `health`'s six filters are still a resolver that reads none of them. **No dispatch-level `safeParse` was added to MCP** — #8942 measured that, built it, and deleted it.

## Verification

```
validate:graphql-query-arguments   201 fields exact, 0 skipped, 0 divergences
```

Nineteen contract validators green, `tsc` clean, `format:check` and `lint` clean, 2,671 tests across the twelve affected suites. Patch coverage on every changed `src/**` line is 100% statements and 100% branches by diff intersection — including both arms of the boolean codec, which is why there is a test for `false` as well as `true`.

Closes #10787
