### PR TITLE
fix(neon): file a flush's lane verdict under the key the write path uses

### DIFF
--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -521,6 +521,36 @@ export function shouldWriteNeonWriteVerdict(
 }
 
 /**
+ * The `lane_health` key a Neon write verdict is filed under, for one lane.
+ *
+ * ONE FUNCTION BECAUSE TWO WRITERS SHARE THE KEY, and until #10851 they did not
+ * agree on it. `recordNeonWriteVerdict` spelled `neon:${lane}` here; the buffer
+ * hub's flush spelled the BARE lane name, taken from the tag on the buffered
+ * statement. Two literals, two files, no test that could see the difference.
+ *
+ * WHAT THAT COST. A buffered SUCCESS records nothing here (see `buffered`
+ * below) on the stated assumption that the flush will file an honest verdict
+ * for the lane later. The flush does file one -- under the other key. So a
+ * buffered FAILURE, which does record here, could never be cleared: the only
+ * writer that could clear it is the one that just suppressed itself. Measured
+ * on production 2026-08-11, `neon:validator-nominator-counts` held `stale` from
+ * 10:15 UTC ("Durable Object reset because its code was updated", from a
+ * deploy) while its table wrote 112,250 rows at 11:30 and the lane alarm
+ * escalated over it for twelve hours.
+ *
+ * The bare name was not free either: the poller reports its OWN lane outcome
+ * under it ("558009 scanned, 366107 written"), so the flush's rows landed in
+ * the same bucket as the scan's. Freshness on that key could mean the lane ran
+ * or merely that the buffer drained on some other lane's behalf.
+ *
+ * So the prefix is applied HERE, once, and both callers ask for it rather than
+ * spelling it. A lane name is what a caller has; the key is this module's.
+ */
+export function neonLaneKey(lane: string): string {
+  return `neon:${lane}`;
+}
+
+/**
  * Record one Neon write's outcome as a lane verdict.
  *
  * THIS IS THE INVARIANT THE PILOT WAS MISSING. A store with no lane is
@@ -580,9 +610,15 @@ export async function recordNeonWriteVerdict(
    *
    * The suppression above assumes the flush will record an honest verdict for
    * this lane later. That holds for a row lane, whose statements carry its
-   * name -- and it is FALSE for the `-pass` and `-prune` sub-lanes, which share
-   * the base lane's buffered runner and so never appear in the flush's own
-   * per-lane tally. Nothing can ever write them again once buffering is on.
+   * name -- SINCE #10851, which is what made it true: the flush filed those
+   * verdicts under the bare lane name while this path files `neon:`-prefixed
+   * ones, so the assumption was false for row lanes too until both writers were
+   * put on `neonLaneKey`.
+   *
+   * It remains FALSE for the `-pass` and `-prune` sub-lanes, which share the
+   * base lane's buffered runner and so never appear in the flush's per-lane
+   * tally under any key. Nothing can ever write them again once buffering is
+   * on, which is what `oncePerPass` exists for.
    *
    * Measured on production 2026-08-11: `neon:nominator-positions-prune` and
    * `neon:nominator-positions-pass` held a `stale` verdict from 10:23 UTC --
@@ -602,7 +638,7 @@ export async function recordNeonWriteVerdict(
    */
   oncePerPass = false,
 ): Promise<boolean> {
-  const key = `neon:${lane}`;
+  const key = neonLaneKey(lane);
   const verdict: LaneVerdict = result.ok ? "ok" : "stale";
   if (buffered && result.ok && !oncePerPass) return true;
   if (!shouldWriteNeonWriteVerdict(lastWrittenVerdict.get(key), verdict, nowMs))

--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -27,6 +27,7 @@ import {
   FLUSH_INTERVAL_MS,
   MAX_BUFFERED_STATEMENTS,
 } from "../src/neon-write-buffer.ts";
+import { neonLaneKey, recordNeonWriteVerdict } from "../src/neon-write.ts";
 
 const NOW = 1_785_800_000_000;
 
@@ -236,9 +237,58 @@ describe("flushBuffer", () => {
       },
     });
     const byLane = Object.fromEntries(spy.rows.map((r) => [r.lane, r.verdict]));
-    assert.equal(byLane["blocks-head"], "ok");
-    assert.equal(byLane["chain-detail"], "ok");
+    // `neon:`-PREFIXED (#10851). The tag on a buffered statement is the bare
+    // lane name; the verdict has to be filed under the key the write path uses,
+    // or it clears nothing it was meant to clear.
+    assert.equal(byLane["neon:blocks-head"], "ok");
+    assert.equal(byLane["neon:chain-detail"], "ok");
     assert.equal(byLane[BUFFER_FLUSH_LANE], "ok");
+    // And NOT under the bare name, which is the poller's own report for the
+    // same lane -- the collision half of #10851.
+    assert.equal(byLane["blocks-head"], undefined);
+    assert.equal(byLane["chain-detail"], undefined);
+  });
+
+  test("the flush clears a failure the write path recorded for the same lane", async () => {
+    // THE REGRESSION #10851 EXISTS FOR, asserted as the two writers meeting on
+    // one key rather than as a string.
+    //
+    // A buffered failure is recorded by recordNeonWriteVerdict (the enqueue was
+    // refused); buffered successes are suppressed there on the assumption the
+    // flush files an honest verdict later. That only holds if both agree on the
+    // key. Measured in production when they did not:
+    // `neon:validator-nominator-counts` held `stale` from 10:15 UTC while its
+    // table wrote 112,250 rows at 11:30, and nothing could clear it.
+    const failSpy = laneSpy();
+    await recordNeonWriteVerdict(
+      failSpy.db as never,
+      "chain-detail",
+      { ok: false, rows: 0, statements: 0, reason: "buffer full" },
+      NOW,
+      true,
+    );
+    const failure = failSpy.rows.at(-1);
+    assert.equal(failure?.lane, neonLaneKey("chain-detail"));
+    assert.equal(failure?.verdict, "stale");
+
+    const storage = fakeStorage();
+    await enqueueStatement(storage, stmt("chain-detail", "A"), NOW);
+    const spy = laneSpy();
+    await flushBuffer(storage, {}, CTX, {
+      laneHealthDb: spy.db,
+      now: () => NOW,
+      sql: {
+        async unsafe() {
+          return [];
+        },
+      },
+    });
+    const cleared = spy.rows.find((r) => r.lane === failure?.lane);
+    assert.equal(
+      cleared?.verdict,
+      "ok",
+      "the flush must write the SAME key the failure landed on, or the lane alarms forever",
+    );
   });
 
   test("an unreadable entry is discarded, never left to wedge the backlog", async () => {

--- a/workers/neon-write-buffer-hub.ts
+++ b/workers/neon-write-buffer-hub.ts
@@ -17,7 +17,8 @@
 //
 // A lane's `record()` reports `ok` when its statement did not throw. Against
 // this buffer that means "durably enqueued", which is a weaker claim than "in
-// Neon", so the flush records its OWN verdict per lane and a
+// Neon", so the flush records its OWN verdict per lane -- under `neon:<lane>`,
+// the same key that path uses (#10851), or it clears nothing -- and a
 // `neon:buffer-flush` verdict for the drain itself. A flush that fails leaves
 // the backlog in place and says so; and because every buffered table is held to
 // `2 * HOUR` by src/table-freshness-watchdog.ts, a flush that stays broken
@@ -51,6 +52,7 @@ import {
 import { createPgSql, type HyperdriveLike } from "../src/pg-sql.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "../src/lane-health.ts";
+import { neonLaneKey } from "../src/neon-write.ts";
 import { recordExceptionEvent } from "../src/usage-telemetry.ts";
 
 /** The lane the drain itself reports under. */
@@ -410,7 +412,12 @@ async function recordFlushVerdicts(
 ): Promise<void> {
   for (const [lane, tally] of perLane) {
     await recordLaneVerdict(laneDb, {
-      lane,
+      // `neon:`-PREFIXED, matching recordNeonWriteVerdict (#10851). The tag on
+      // a buffered statement is the bare lane name, and filing the verdict
+      // under it put this in the wrong bucket twice over: it never cleared the
+      // failure that path records, and it collided with the poller's own report
+      // for the same lane. See neonLaneKey for the measurement.
+      lane: neonLaneKey(lane),
       verdict: tally.failed > 0 ? "stale" : "ok",
       age_ms: null,
       detail:


### PR DESCRIPTION
`neon:validator-nominator-counts` has held a `stale` verdict since **10:15 UTC**, from one Durable
Object reset during a deploy. Its table wrote **112,250 rows at 11:30** and is healthy. The lane alarm
escalated over it for twelve hours, and nothing could clear it — because nothing could write it.

## Two writers, one lane, two keys

| writer | key | file |
|---|---|---|
| `recordNeonWriteVerdict` | `` `neon:${lane}` `` | `src/neon-write.ts` |
| `recordFlushVerdicts` | `` `${lane}` `` | `workers/neon-write-buffer-hub.ts` |

The flush takes its key from the lane tag on the buffered statement, which is the bare name. Two
string literals in two files, and no test that could see the difference.

## Why the failure was permanent

A buffered **success** records nothing in `recordNeonWriteVerdict` — deliberately, since "durably
enqueued" is a weaker claim than "in Neon" — on the stated assumption that the flush files an honest
verdict later. It does, under the other key. A buffered **failure** does record, because a refused
enqueue is backpressure nobody else reports.

So after a deploy reset the DO mid-flush, the only writer that could clear that lane was the one that
had just suppressed itself.

#10826 hit exactly this for the `-pass` and `-prune` sub-lanes and gave them `oncePerPass`. Its
comment reasons that row lanes are safe:

> That holds for a row lane, whose statements carry its name

That half was false too, for the same reason — just less visibly, because a row lane usually has a
recent unbuffered verdict to mask it.

## The bare name was not free either

The poller reports its **own** lane outcome under it, so the flush's rows landed in the same bucket
as the scan's:

```
account-balances  20:05:57  ok  20 statement(s) flushed           <- flush (Worker)
account-balances  19:55:34  ok  558009 scanned, 366107 written    <- poller (container)
```

Freshness on that key could mean the lane ran, or merely that the buffer drained on some *other*
lane's behalf — precisely the distinction a staleness watchdog exists to make. Same on `hotkey-alpha`,
`nominator-positions`, `validator-nominator-counts`.

## The change

The prefix moves into `neonLaneKey(lane)` and both callers ask for it rather than spelling it. A lane
name is what a caller has; the key belongs to the module that owns the verdict.

## Test

The regression test asserts the two writers **meet** — it records a buffered failure through
`recordNeonWriteVerdict`, then requires the flush to clear *that same key* — rather than asserting a
string, so it fails if either side drifts:

```ts
const cleared = spy.rows.find((r) => r.lane === failure?.lane);
assert.equal(cleared?.verdict, "ok",
  "the flush must write the SAME key the failure landed on, or the lane alarms forever");
```

Both new assertions were confirmed to **fail with the fix reverted** and pass with it:

```
FAIL  records a per-lane verdict that means the rows LANDED
FAIL  the flush clears a failure the write path recorded for the same lane
Tests  2 failed | 45 passed (47)
```

## Verification

`npm run typecheck`, `lint`, `format:check`, `scan:public-safety`, `validate:module-state-resets`,
`validate:contract-drift`, `validate:no-hand-written-mjs` all pass. Test suites:
`neon-write-buffer-hub` (47), plus `neon-write`, `neon-write-buffer`, `lane-alarm`,
`ledger-neon-write`, `nominator-positions-neon-write`, `producer-cadence` — 215 passed, 0 failed.

## Note on the existing data

The stale rows already in `lane_health` are historical and will be superseded by the next flush on
each affected lane once this deploys. No backfill needed — only the newest row per lane is ever read.

Closes #10851
