### PR TITLE
fix(revenue): ack a probe failure a retry cannot change

### DIFF
--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -61,10 +61,28 @@ export async function persistRevenueProbe(
   ok: boolean;
   written: number;
   failed: number;
+  /**
+   * Whether redelivering this work could produce a different answer (#10855).
+   *
+   * SEPARATE FROM `ok`, because `ok` answers "did this pass produce anything"
+   * -- a lane-verdict question -- and the queue needs a different one: "is
+   * asking again worth a round trip against somebody else's API". Conflating
+   * them is what dead-lettered a deterministic extraction failure hourly.
+   */
+  retryable: boolean;
   reason?: string;
 }> {
   if (!db?.prepare) {
-    return { ok: false, written: 0, failed: 0, reason: "no_store_binding" };
+    // Nothing was recorded, so the next delivery is the only chance this work
+    // gets. Retryable even though a missing binding will not fix itself: the
+    // alternative is acking work that left no trace anywhere.
+    return {
+      ok: false,
+      written: 0,
+      failed: 0,
+      retryable: true,
+      reason: "no_store_binding",
+    };
   }
   const { observations, failures } = result;
   try {
@@ -120,6 +138,8 @@ export async function persistRevenueProbe(
       ok: false,
       written: 0,
       failed: failures.length,
+      // The rows did NOT land, so this is the one failure a retry can fix.
+      retryable: true,
       reason: `write_failed: ${String((error as Error)?.message ?? error)}`,
     };
   }
@@ -131,6 +151,9 @@ export async function persistRevenueProbe(
     ok: observations.length > 0 || failures.length === 0,
     written: observations.length,
     failed: failures.length,
+    // The rows ARE on disk by here. Only a transient failure is worth another
+    // delivery; a terminal one would re-fetch and rewrite the identical row.
+    retryable: failures.some((failure) => !failure.terminal),
     ...(observations.length === 0 && failures.length === 0
       ? { reason: "no_eligible_surfaces" }
       : {}),
@@ -147,6 +170,8 @@ export async function runRevenueProbeLane(
   written: number;
   failed: number;
   skipped: number;
+  /** See persistRevenueProbe: whether another delivery could answer differently. */
+  retryable: boolean;
   reason?: string;
 }> {
   const result = await runRevenueProbe(surfaces, deps);
@@ -373,6 +398,19 @@ export async function handleRevenueProbeBatch(
       if (typeof id !== "string" || !id) return null;
       return deps.surfaceFor(id);
     },
-    run: async (surface) => (await runRevenueProbeLane([surface], db, deps)).ok,
+    run: async (surface) => {
+      const outcome = await runRevenueProbeLane([surface], db, deps);
+      // ACKED WHEN THERE IS NOTHING LEFT TO ASK (#10855). `consumeBatch` retries
+      // on a falsy return, so returning `ok` alone sent every deterministic
+      // extraction failure round the retry loop and then to
+      // `revenue-probes-dlq` -- hourly, for as long as the declaration and the
+      // payload disagreed. The failure row is already written by then, so the
+      // retry bought a second identical row and a second request against
+      // somebody else's API.
+      //
+      // A transient failure still retries: `retryable` is true for a fetch that
+      // threw and for a write that did not land.
+      return outcome.ok || !outcome.retryable;
+    },
   });
 }

--- a/src/revenue-probe.ts
+++ b/src/revenue-probe.ts
@@ -63,6 +63,29 @@ export interface RevenueFailureRow {
   netuid: number;
   reason: string;
   observed_at: number;
+  /**
+   * Whether redelivering this message could ever produce a different answer.
+   *
+   * NOT PERSISTED -- the insert names its columns, and this is a routing fact
+   * about the queue rather than something a reader of
+   * `revenue_probe_failures` needs. It exists because the two failures this
+   * lane records are opposites:
+   *
+   *   a FETCH failure is transient. The endpoint was slow, throttling, or
+   *   briefly 5xx, and the next delivery may well succeed.
+   *
+   *   an EXTRACTION failure is deterministic. `expected an array payload`
+   *   depends on the declaration and the payload's shape, neither of which a
+   *   redelivery changes, so every retry re-fetches somebody else's API to
+   *   write the identical row and then dead-letters.
+   *
+   * Measured 2026-08-11 (#10855): `sn-64-chutes-payments-list` declares
+   * `flat-array` against a paginated envelope, failed extraction on every tick
+   * for twelve hours, and held `revenue-probes-dlq` at `stale` the whole time.
+   * The failure row was already on disk each time -- the retry added nothing
+   * but load.
+   */
+  terminal: boolean;
 }
 
 export interface RevenueProbeResult {
@@ -152,6 +175,9 @@ export async function runRevenueProbe(
         netuid: surface.netuid,
         reason: `fetch failed: ${error instanceof Error ? error.message : String(error)}`,
         observed_at,
+        // Transient: a slow, throttling or briefly-5xx endpoint is worth
+        // asking again.
+        terminal: false,
       });
       continue;
     }
@@ -162,6 +188,9 @@ export async function runRevenueProbe(
         netuid: surface.netuid,
         reason: extracted.reason,
         observed_at,
+        // Deterministic: the declaration and the payload's shape decide this,
+        // and a redelivery changes neither.
+        terminal: true,
       });
       continue;
     }

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -107,6 +107,7 @@ describe("persistRevenueProbe", () => {
           netuid: 51,
           reason: "fetch failed: HTTP 503",
           observed_at: 1786320000000,
+          terminal: false,
         },
       ],
       skipped: [],
@@ -131,6 +132,7 @@ describe("persistRevenueProbe", () => {
           netuid: 1,
           reason: "fetch failed",
           observed_at: 1786320000000,
+          terminal: false,
         },
       ],
       skipped: [],
@@ -814,6 +816,49 @@ describe("the queue lane (#10715)", () => {
     const out = await handleRevenueProbeBatch([m], null, deps() as never);
     assert.equal(out.retried, 1);
     assert.equal(m.calls.retried, 1);
+  });
+
+  test("an EXTRACTION failure is ACKED, because the payload's shape will not change", async () => {
+    // #10855, measured on production: sn-64-chutes-payments-list declares
+    // `flat-array` and its endpoint returns a paginated envelope, so extraction
+    // failed identically on every tick for twelve hours and held
+    // `revenue-probes-dlq` at `stale` the whole time. The failure row is
+    // written before we get here; a retry buys a duplicate row and a second
+    // request against somebody else's API.
+    const m = message({ surface_id: surface.id });
+    const out = await handleRevenueProbeBatch(
+      [m],
+      store(),
+      deps({
+        fetchPayload: async () => ({
+          payload: { total: 18943, page: 0, limit: 25, items: [] },
+          raw: '{"total":18943,"page":0,"limit":25,"items":[]}',
+        }),
+      }) as never,
+    );
+    assert.equal(m.calls.retried, 0, "a deterministic failure must not retry");
+    assert.equal(m.calls.acked, 1);
+    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
+  });
+
+  test("a FETCH failure still RETRIES, because that one is transient", async () => {
+    // The other half of the same rule: a slow or briefly-5xx endpoint is worth
+    // asking again, and acking it would lose the observation entirely. If this
+    // ever passes for the same reason the test above does, the distinction has
+    // collapsed and every failure is being acked.
+    const m = message({ surface_id: surface.id });
+    const out = await handleRevenueProbeBatch(
+      [m],
+      store(),
+      deps({
+        fetchPayload: async () => {
+          throw new Error("HTTP 503");
+        },
+      }) as never,
+    );
+    assert.equal(m.calls.retried, 1, "a transient failure must retry");
+    assert.equal(m.calls.acked, 0);
+    assert.equal(out.retried, 1);
   });
 
   test("re-reads the eligible set at DELIVERY", async () => {


### PR DESCRIPTION
## The bug

`handleRevenueProbeBatch` returned `runRevenueProbeLane(...).ok`, and `consumeBatch` calls
`message.retry()` on a falsy return. Since

```ts
ok: observations.length > 0 || failures.length === 0
```

a single-surface message whose extraction failed had `observations = 0, failures = 1` → `ok: false` →
retried → `revenue-probes-dlq`. **The failure row was already written**, so each retry bought a
duplicate row and another request against somebody else's API.

## Measured on production

`revenue-probes-dlq` held a `stale` verdict for 12+ hours on 2026-08-11, alarming hourly, with
`sn-64-chutes-payments-list` failing `expected an array payload` on every tick — it declares
`flat-array` against a paginated envelope. I ran the live payload through `extractRevenue` itself to
confirm the failure is deterministic, and the sibling in the same DLQ
(`sn-51-lium-revenue-for-validators`) through it too:

| surface | result |
| --- | --- |
| `sn-51-lium-revenue-for-validators` | **OK — 20 observations**, first `{"period":"2025-01","amount":11590.562697311232,"currency":"USD"}` |
| `sn-64-chutes-payments-list` | **FAIL: `expected an array payload`**, every time |

Twelve hours of retries produced no new information and no possibility of any.

## The fix

`ok` was answering the wrong question. It means *"did this pass produce anything"* — what the lane
verdict needs. The queue needs *"is asking again worth a round trip"*, and those differ by failure, so
`retryable` is reported **alongside** `ok` rather than folded into it:

| failure | retryable | why |
| --- | --- | --- |
| `fetch failed: …` | yes | slow, throttling, briefly 5xx |
| extraction failed | **no** | neither the declaration nor the payload shape changes on redelivery |
| `write_failed: …` | yes | the rows did not land — the one a retry genuinely fixes |
| `no_store_binding` | yes | nothing was recorded, so acking would lose it |

`terminal` on the failure row is deliberately **not persisted** — the insert names its columns, and
this is a routing fact about the queue, not something a reader of `revenue_probe_failures` needs.

## Verification

- 71 tests green across `revenue-observations` + `revenue-probe`; 111 including
  `revenue-observation` and `dead-letter`
- **100%** statements / branches / functions / lines on both changed files
- `tsc`, `lint`, `format:check`, `validate`, `validate:no-hand-written-mjs`,
  `validate:unreferenced-exports` all pass
- **Proved the tests can fail, and independently**: reverting the ack to `return outcome.ok` fails the
  extraction test *alone* and leaves the fetch test green — so the distinction cannot silently collapse
  into "ack everything", which is the way this fix would otherwise rot
- Rebased onto `0e3bbd755` and re-verified after the rebase

## Not fixed here

The declaration problem is separate and stays open in #10855: a declaration can say *what* shape its
rows are but not *where* they live. That one needs care rather than a path — page 0 of 18,943 payments
would otherwise be published as a subnet's revenue, which is worse than the current honest failure.

Closes #10856