### PR TITLE
refactor(schemas): one object vocabulary, and a report that cannot agree about fields it never found

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5235,19 +5235,19 @@ export interface components {
             extrinsic_count: number;
             extrinsics: {
                 block_number: number | null;
-                /** @description JSON-encoded decoded call arguments. */
-                call_args?: unknown | null;
-                call_function?: string | null;
-                call_module?: string | null;
-                extrinsic_hash?: string | null;
+                call_args: ({
+                    [key: string]: unknown;
+                } | unknown[]) | null;
+                call_function: string | null;
+                call_module: string | null;
+                extrinsic_hash: string | null;
                 extrinsic_index: number | null;
-                fee_tao?: number | null;
-                observed_at?: string | null;
-                signer?: string | null;
-                success?: boolean | null;
-                /** @description Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525). */
-                summary?: string | null;
-                tip_tao?: number | null;
+                fee_tao: number | null;
+                observed_at: string | null;
+                signer: string | null;
+                success: boolean | null;
+                summary: string | null;
+                tip_tao: number | null;
             }[];
             limit: number | null;
             next_cursor?: string | null;
@@ -20203,7 +20203,17 @@ export interface operations {
                      *         "extrinsics": [
                      *           {
                      *             "block_number": 5000000,
-                     *             "extrinsic_index": 1
+                     *             "call_args": {},
+                     *             "call_function": "example",
+                     *             "call_module": "example",
+                     *             "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *             "extrinsic_index": 1,
+                     *             "fee_tao": 0.5,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "signer": "example",
+                     *             "success": false,
+                     *             "summary": "Example description.",
+                     *             "tip_tao": 0.5
                      *           }
                      *         ],
                      *         "limit": 1,

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -7508,12 +7508,12 @@ export interface components {
             source: {
                 candidates: string;
                 native: string | {
-                    identity_storage?: string | null;
-                    kind?: string | null;
-                    method?: string | null;
-                    package?: string | null;
-                    rpc_family?: string | null;
-                    version?: string | null;
+                    identity_storage?: string;
+                    kind?: string;
+                    method?: string;
+                    package?: string;
+                    rpc_family?: string;
+                    version?: string;
                 };
                 overlays: string;
             };
@@ -10241,12 +10241,8 @@ export interface components {
             }[];
             source: string;
             summary?: {
-                by_drift_status: {
-                    [key: string]: number;
-                };
-                by_status: {
-                    [key: string]: number;
-                };
+                by_drift_status: components["schemas"]["CountMap"];
+                by_status: components["schemas"]["CountMap"];
                 schema_count: number;
                 surface_count: number;
             };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -28184,64 +28184,22 @@
                     "additionalProperties": false,
                     "properties": {
                       "identity_storage": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
+                        "type": "string"
                       },
                       "kind": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
+                        "type": "string"
                       },
                       "method": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
+                        "type": "string"
                       },
                       "package": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
+                        "type": "string"
                       },
                       "rpc_family": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
+                        "type": "string"
                       },
                       "version": {
-                        "anyOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "null"
-                          }
-                        ]
+                        "type": "string"
                       }
                     },
                     "type": "object"
@@ -43247,26 +43205,10 @@
             "additionalProperties": false,
             "properties": {
               "by_drift_status": {
-                "additionalProperties": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "propertyNames": {
-                  "type": "string"
-                },
-                "type": "object"
+                "$ref": "#/components/schemas/CountMap"
               },
               "by_status": {
-                "additionalProperties": {
-                  "maximum": 9007199254740991,
-                  "minimum": 0,
-                  "type": "integer"
-                },
-                "propertyNames": {
-                  "type": "string"
-                },
-                "type": "object"
+                "$ref": "#/components/schemas/CountMap"
               },
               "schema_count": {
                 "maximum": 9007199254740991,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -370,7 +370,17 @@
             "extrinsics": [
               {
                 "block_number": 5000000,
-                "extrinsic_index": 1
+                "call_args": {},
+                "call_function": "example",
+                "call_module": "example",
+                "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                "extrinsic_index": 1,
+                "fee_tao": 0.5,
+                "observed_at": "2026-06-01T00:00:00.000Z",
+                "signer": "example",
+                "success": false,
+                "summary": "Example description.",
+                "tip_tao": 0.5
               }
             ],
             "limit": 1,
@@ -14414,7 +14424,7 @@
                   "anyOf": [
                     {
                       "maximum": 9007199254740991,
-                      "minimum": -9007199254740991,
+                      "minimum": 0,
                       "type": "integer"
                     },
                     {
@@ -14424,12 +14434,25 @@
                 },
                 "call_args": {
                   "anyOf": [
-                    {},
+                    {
+                      "anyOf": [
+                        {
+                          "additionalProperties": {},
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "items": {},
+                          "type": "array"
+                        }
+                      ]
+                    },
                     {
                       "type": "null"
                     }
-                  ],
-                  "description": "JSON-encoded decoded call arguments."
+                  ]
                 },
                 "call_function": {
                   "anyOf": [
@@ -14465,7 +14488,7 @@
                   "anyOf": [
                     {
                       "maximum": 9007199254740991,
-                      "minimum": -9007199254740991,
+                      "minimum": 0,
                       "type": "integer"
                     },
                     {
@@ -14521,8 +14544,7 @@
                     {
                       "type": "null"
                     }
-                  ],
-                  "description": "Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525)."
+                  ]
                 },
                 "tip_tao": {
                   "anyOf": [
@@ -14537,7 +14559,17 @@
               },
               "required": [
                 "block_number",
-                "extrinsic_index"
+                "extrinsic_index",
+                "extrinsic_hash",
+                "signer",
+                "call_module",
+                "call_function",
+                "call_args",
+                "success",
+                "fee_tao",
+                "tip_tao",
+                "observed_at",
+                "summary"
               ],
               "type": "object"
             },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5235,19 +5235,19 @@ export interface components {
             extrinsic_count: number;
             extrinsics: {
                 block_number: number | null;
-                /** @description JSON-encoded decoded call arguments. */
-                call_args?: unknown | null;
-                call_function?: string | null;
-                call_module?: string | null;
-                extrinsic_hash?: string | null;
+                call_args: ({
+                    [key: string]: unknown;
+                } | unknown[]) | null;
+                call_function: string | null;
+                call_module: string | null;
+                extrinsic_hash: string | null;
                 extrinsic_index: number | null;
-                fee_tao?: number | null;
-                observed_at?: string | null;
-                signer?: string | null;
-                success?: boolean | null;
-                /** @description Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525). */
-                summary?: string | null;
-                tip_tao?: number | null;
+                fee_tao: number | null;
+                observed_at: string | null;
+                signer: string | null;
+                success: boolean | null;
+                summary: string | null;
+                tip_tao: number | null;
             }[];
             limit: number | null;
             next_cursor?: string | null;
@@ -20203,7 +20203,17 @@ export interface operations {
                      *         "extrinsics": [
                      *           {
                      *             "block_number": 5000000,
-                     *             "extrinsic_index": 1
+                     *             "call_args": {},
+                     *             "call_function": "example",
+                     *             "call_module": "example",
+                     *             "extrinsic_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *             "extrinsic_index": 1,
+                     *             "fee_tao": 0.5,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "signer": "example",
+                     *             "success": false,
+                     *             "summary": "Example description.",
+                     *             "tip_tao": 0.5
                      *           }
                      *         ],
                      *         "limit": 1,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -7508,12 +7508,12 @@ export interface components {
             source: {
                 candidates: string;
                 native: string | {
-                    identity_storage?: string | null;
-                    kind?: string | null;
-                    method?: string | null;
-                    package?: string | null;
-                    rpc_family?: string | null;
-                    version?: string | null;
+                    identity_storage?: string;
+                    kind?: string;
+                    method?: string;
+                    package?: string;
+                    rpc_family?: string;
+                    version?: string;
                 };
                 overlays: string;
             };
@@ -10241,12 +10241,8 @@ export interface components {
             }[];
             source: string;
             summary?: {
-                by_drift_status: {
-                    [key: string]: number;
-                };
-                by_status: {
-                    [key: string]: number;
-                };
+                by_drift_status: components["schemas"]["CountMap"];
+                by_status: components["schemas"]["CountMap"];
                 schema_count: number;
                 surface_count: number;
             };

--- a/schemas-src/artifacts/schema-drift.ts
+++ b/schemas-src/artifacts/schema-drift.ts
@@ -56,7 +56,14 @@ export const SchemaDriftSurfaceSchema = z
   .strict();
 export type SchemaDriftSurface = z.infer<typeof SchemaDriftSurfaceSchema>;
 
-const SchemaDriftSummarySchema = z
+/**
+ * The captured-schema census -- ONE declaration (#10790).
+ *
+ * `SchemaIndexArtifact.summary` (routes/subnet-profiles.ts) carried the same
+ * four counters, with `by_status`/`by_drift_status` written out as the record
+ * `CountMapSchema` already names.
+ */
+export const SchemaDriftSummarySchema = z
   .object({
     surface_count: z.int().min(0),
     schema_count: z.int().min(0),

--- a/schemas-src/mcp-tools/agent-catalog-resources.ts
+++ b/schemas-src/mcp-tools/agent-catalog-resources.ts
@@ -6,14 +6,11 @@
 // array). Neither mirrors an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
-import { MAX_LIMIT } from "../../workers/request-params.ts";
-import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
-  offsetSchema,
-  limitSchema,
   orderSchema,
   sortSchema,
   McpUnsortedPageFields,
+  McpOffsetPageInput,
 } from "./shared.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { AgentResourcesArtifactSchema } from "../routes/agent-catalog.ts";
@@ -27,18 +24,7 @@ import { LIVE_HEALTH_OVERLAY } from "../routes/subnet-detail.ts";
 export const GetAgentCatalogInputSchema = z
   .object({
     netuid: netuidSchema().optional(),
-    // The page (#10605). Both numbers come from the constants that actually
-    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
-    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
-    // really applies -- published rather than hidden, because #10101 found 83
-    // tools whose schema left a caller unable to tell what an omitted
-    // limit returns. Publishing the ceiling while hiding the default would
-    // recreate exactly that gap.
-    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
-    // An integer OFFSET, which is what these routes publish
-    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
-    // two is the mistake query-params.ts calls out by name.
-    cursor: offsetSchema().optional(),
+    ...McpOffsetPageInput,
     sort: sortSchema(
       API_QUERY_COLLECTIONS["agent-catalog"].sort_fields,
     ).optional(),

--- a/schemas-src/mcp-tools/catalog-indexes.ts
+++ b/schemas-src/mcp-tools/catalog-indexes.ts
@@ -15,14 +15,11 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { MAX_LIMIT } from "../../workers/request-params.ts";
-import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
-  offsetSchema,
-  limitSchema,
   orderSchema,
   sortSchema,
   McpUnsortedPageFields,
+  McpOffsetPageInput,
 } from "./shared.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { FixturesIndexArtifactSchema } from "../routes/fixtures.ts";
@@ -30,18 +27,7 @@ import { SchemaIndexArtifactSchema } from "../routes/subnet-profiles.ts";
 
 export const ListFixturesInputSchema = z
   .object({
-    // The page (#10605). Both numbers come from the constants that actually
-    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
-    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
-    // really applies -- published rather than hidden, because #10101 found 83
-    // tools whose schema left a caller unable to tell what an omitted
-    // limit returns. Publishing the ceiling while hiding the default would
-    // recreate exactly that gap.
-    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
-    // An integer OFFSET, which is what these routes publish
-    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
-    // two is the mistake query-params.ts calls out by name.
-    cursor: offsetSchema().optional(),
+    ...McpOffsetPageInput,
     sort: sortSchema(API_QUERY_COLLECTIONS.fixtures.sort_fields).optional(),
     order: orderSchema().optional(),
   })

--- a/schemas-src/mcp-tools/curation-and-gaps.ts
+++ b/schemas-src/mcp-tools/curation-and-gaps.ts
@@ -14,13 +14,10 @@ import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListArtifactStamp,
   McpListPageFields,
-  fieldsSchema,
   kindSchema,
-  limitSchema,
-  numericCursorSchema,
-  orderSchema,
   projectableRows,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import { CurationArtifactSchema } from "../routes/curation-gaps.ts";
 import { GapsArtifactSchema } from "../routes/curation-gaps.ts";
@@ -40,10 +37,7 @@ export const ListCurationInputSchema = z
       .meta({ examples: [COVERAGE_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.curation.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListCurationInput = z.infer<typeof ListCurationInputSchema>;
@@ -68,10 +62,7 @@ export const ListGapsInputSchema = z
       .meta({ examples: [COVERAGE_LEVELS[0]] }),
     curation_level: kindSchema(CURATION_LEVELS).optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.gaps.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListGapsInput = z.infer<typeof ListGapsInputSchema>;

--- a/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
+++ b/schemas-src/mcp-tools/endpoint-pools-and-provider.ts
@@ -26,6 +26,7 @@ import {
   projectableRows,
   providerSlugSchema,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import { EndpointPoolsArtifactSchema } from "../routes/endpoints-pools.ts";
 import { EndpointIncidentsArtifactSchema } from "../routes/endpoints-pools.ts";
@@ -38,48 +39,59 @@ import {
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
 import { ENDPOINT_INCIDENT_SEVERITY_VALUES } from "../routes/endpoints-pools.ts";
 
+/**
+ * The pool list-query FILTERS, declared once for both callers (#10790).
+ *
+ * `list_endpoint_pools` and `list_rpc_pools` share every filter -- and shared
+ * the same BUG before #10118: both advertised endpoint LAYERS where the route
+ * takes pool KINDS, so all four published values were rejected and none of the
+ * three that work was advertised. Two copies, one wrong vocabulary, fixed
+ * twice. What they do not share is their sort field list, which is per
+ * collection and stays declared per site.
+ */
+export const POOL_LIST_FILTERS = {
+  id: idFilterSchema().optional(),
+  // POOL kinds, not endpoint LAYERS -- the same confusion list_rpc_pools
+  // carried (#10118). Verified against production: all four layer values
+  // are rejected here and none of the three that work was advertised.
+  kind: kindSchema(RPC_POOL_KIND_VALUES).optional(),
+  min_eligible_count: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
+    )
+    .meta({ examples: [1] }),
+  max_eligible_count: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
+    )
+    .meta({ examples: [10] }),
+  min_endpoint_count: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive lower bound on endpoint count; rows below it are excluded.",
+    )
+    .meta({ examples: [1] }),
+  max_endpoint_count: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive upper bound on endpoint count; rows above it are excluded.",
+    )
+    .meta({ examples: [10] }),
+};
+
 export const ListEndpointPoolsInputSchema = z
   .object({
-    id: idFilterSchema().optional(),
-    // POOL kinds, not endpoint LAYERS -- the same confusion list_rpc_pools
-    // carried (#10118). Verified against production: all four layer values
-    // are rejected here and none of the three that work was advertised.
-    kind: kindSchema(RPC_POOL_KIND_VALUES).optional(),
-    min_eligible_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
-      )
-      .meta({ examples: [1] }),
-    max_eligible_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
-      )
-      .meta({ examples: [10] }),
-    min_endpoint_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on endpoint count; rows below it are excluded.",
-      )
-      .meta({ examples: [1] }),
-    max_endpoint_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on endpoint count; rows above it are excluded.",
-      )
-      .meta({ examples: [10] }),
+    ...POOL_LIST_FILTERS,
     sort: sortSchema(
       API_QUERY_COLLECTIONS["endpoint-pools"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListEndpointPoolsInput = z.infer<
@@ -123,10 +135,7 @@ export const ListEndpointIncidentsInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["endpoint-incidents"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListEndpointIncidentsInput = z.infer<

--- a/schemas-src/mcp-tools/endpoints-catalog.ts
+++ b/schemas-src/mcp-tools/endpoints-catalog.ts
@@ -44,64 +44,83 @@ const SURFACE_KINDS = SURFACE_KIND_VALUES;
 const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
 const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
+
+/**
+ * The endpoint list-query FILTERS, declared once for their three callers
+ * (#10790).
+ *
+ * `list_endpoints`, `list_provider_endpoints` and `list_subnet_endpoints` share
+ * every filter, sort and projection argument. What they do NOT share is
+ * `netuid` -- an optional FILTER on the network-wide list, the required SUBJECT
+ * on the subnet-scoped one -- or their limit ceilings. Same key set, and on
+ * that one key a genuinely different argument, so it stays declared per site
+ * where the difference is visible instead of being averaged away.
+ */
+export const ENDPOINT_LIST_FILTERS = {
+  kind: kindSchema(SURFACE_KINDS).optional(),
+  layer: z
+    .enum(ENDPOINT_LAYERS)
+    .optional()
+    .describe(
+      "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
+    )
+    .meta({ examples: [ENDPOINT_LAYERS[0]] }),
+  provider: providerSlugSchema().optional(),
+  publication_state:
+    API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
+      .optional()
+      .describe(
+        "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
+      )
+      .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
+  status: kindSchema(HEALTH_STATUSES).optional(),
+  pool_eligible: z
+    .boolean()
+    .optional()
+    .describe(
+      "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
+    )
+    .meta({ examples: [true] }),
+  min_latency_ms: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
+    )
+    .meta({ examples: [50] }),
+  max_latency_ms: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
+    )
+    .meta({ examples: [500] }),
+  min_score: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive lower bound on endpoint score; rows below it are excluded.",
+    )
+    .meta({ examples: [50] }),
+  max_score: z
+    .number()
+    .optional()
+    .describe(
+      "Inclusive upper bound on endpoint score; rows above it are excluded.",
+    )
+    .meta({ examples: [100] }),
+  sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
+  order: orderSchema().optional(),
+  fields: fieldsSchema().optional(),
+  // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
+  // because schemas-src/ imports from neither src/ nor workers/.
+};
+
 export const ListEndpointsInputSchema = z
   .object({
-    kind: kindSchema(SURFACE_KINDS).optional(),
-    layer: z
-      .enum(ENDPOINT_LAYERS)
-      .optional()
-      .describe(
-        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      )
-      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
+    ...ENDPOINT_LIST_FILTERS,
+    // The network-wide list: netuid NARROWS the result set.
     netuid: API_QUERY_COLLECTIONS.endpoints.filter_schemas.netuid.optional(),
-    provider: providerSlugSchema().optional(),
-    publication_state:
-      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
-        .optional()
-        .describe(
-          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-        )
-        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
-    status: kindSchema(HEALTH_STATUSES).optional(),
-    pool_eligible: z
-      .boolean()
-      .optional()
-      .describe(
-        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      )
-      .meta({ examples: [true] }),
-    min_latency_ms: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      )
-      .meta({ examples: [50] }),
-    max_latency_ms: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      )
-      .meta({ examples: [500] }),
-    min_score: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      )
-      .meta({ examples: [50] }),
-    max_score: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      )
-      .meta({ examples: [100] }),
-    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
     // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
     // because schemas-src/ imports from neither src/ nor workers/.
     limit: limitSchema(1000, 20).optional(),

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -15,14 +15,11 @@ import {
   reviewStateSchema,
   McpListArtifactStamp,
   McpListPageFields,
-  fieldsSchema,
   kindSchema,
-  limitSchema,
-  numericCursorSchema,
-  orderSchema,
   projectableRows,
   querySchema,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import {
   REVIEW_ENRICHMENT_LANE_VALUES,
@@ -77,10 +74,7 @@ export const ListEnrichmentEvidenceInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["enrichment-evidence"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListEnrichmentEvidenceInput = z.infer<
@@ -115,10 +109,7 @@ export const ListReviewGapsInputSchema = z
       .meta({ examples: [SURFACE_KINDS[0]] }),
     review_state: reviewStateSchema().optional(),
     sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListReviewGapsInput = z.infer<typeof ListReviewGapsInputSchema>;
@@ -212,10 +203,7 @@ export const ListReviewEnrichmentTargetsInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["enrichment-targets"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListReviewEnrichmentTargetsInput = z.infer<

--- a/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
+++ b/schemas-src/mcp-tools/enrichment-evidence-and-targets.ts
@@ -95,19 +95,32 @@ export type ListEnrichmentEvidenceOutput = z.infer<
   typeof ListEnrichmentEvidenceOutputSchema
 >;
 
-const CURATION_LEVELS = CURATION_LEVEL_VALUES;
+/**
+ * The gap-review FILTERS, declared once for both callers (#10790).
+ *
+ * `list_review_gaps` and `list_subnet_gaps` share all three. What they do not
+ * share is `netuid` -- an optional FILTER on the network-wide feed, the
+ * required SUBJECT of the per-subnet one -- or their sort fields, which name
+ * different collections (`gaps` against `review-gap-priorities`). Same key set,
+ * genuinely different arguments, so those two stay declared per site where the
+ * difference is visible.
+ */
+export const GAP_REVIEW_FILTERS = {
+  curation_level: kindSchema(CURATION_LEVEL_VALUES).optional(),
+  missing_kinds: z
+    .enum(SURFACE_KIND_VALUES)
+    .optional()
+    .describe(
+      "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
+    )
+    .meta({ examples: [SURFACE_KIND_VALUES[0]] }),
+  review_state: reviewStateSchema().optional(),
+};
+
 export const ListReviewGapsInputSchema = z
   .object({
     netuid: API_QUERY_COLLECTIONS.gaps.filter_schemas.netuid.optional(),
-    curation_level: kindSchema(CURATION_LEVELS).optional(),
-    missing_kinds: z
-      .enum(SURFACE_KINDS)
-      .optional()
-      .describe(
-        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      )
-      .meta({ examples: [SURFACE_KINDS[0]] }),
-    review_state: reviewStateSchema().optional(),
+    ...GAP_REVIEW_FILTERS,
     sort: sortSchema(PRIORITY_SORT_FIELDS).optional(),
     ...McpSortableListPage,
   })

--- a/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
+++ b/schemas-src/mcp-tools/enrichment-queue-and-candidates.ts
@@ -14,14 +14,11 @@ import {
   reviewStateSchema,
   McpListArtifactStamp,
   McpListPageFields,
-  fieldsSchema,
   kindSchema,
-  limitSchema,
-  numericCursorSchema,
-  orderSchema,
   projectableRows,
   querySchema,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import {
   REVIEW_ENRICHMENT_LANE_VALUES,
@@ -96,10 +93,7 @@ export const ListEnrichmentQueueInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["enrichment-queue"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListEnrichmentQueueInput = z.infer<
@@ -149,10 +143,7 @@ export const ListAdapterCandidatesInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["adapter-candidates"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListAdapterCandidatesInput = z.infer<

--- a/schemas-src/mcp-tools/get-subnet-trajectory.ts
+++ b/schemas-src/mcp-tools/get-subnet-trajectory.ts
@@ -2,14 +2,11 @@
 // "Mirrors" claim in its description and no covered REST route to reuse.
 // Modeled fresh, shallow, from the hand-written literal it replaces.
 import { z } from "zod";
-import { MAX_LIMIT } from "../../workers/request-params.ts";
-import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
-  offsetSchema,
-  limitSchema,
   orderSchema,
   sortSchema,
   McpUnsortedPageFields,
+  McpOffsetPageInput,
 } from "./shared.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { netuidSchema } from "./shared.ts";
@@ -18,18 +15,7 @@ import { SubnetTrajectoryArtifactSchema } from "../routes/subnet-trajectory.ts";
 export const GetSubnetTrajectoryInputSchema = z
   .object({
     netuid: netuidSchema(),
-    // The page (#10605). Both numbers come from the constants that actually
-    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
-    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
-    // really applies -- published rather than hidden, because #10101 found 83
-    // tools whose schema left a caller unable to tell what an omitted
-    // limit returns. Publishing the ceiling while hiding the default would
-    // recreate exactly that gap.
-    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
-    // An integer OFFSET, which is what these routes publish
-    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
-    // two is the mistake query-params.ts calls out by name.
-    cursor: offsetSchema().optional(),
+    ...McpOffsetPageInput,
     sort: sortSchema(
       API_QUERY_COLLECTIONS["subnet-trajectory"].sort_fields,
     ).optional(),

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -74,7 +74,6 @@ const SubnetOverviewCountsSchema = z
   })
   .strict();
 
-
 /** One ranked enrichment opportunity. Was `z.array(z.unknown())`, which says
  * strictly less than an open object: not merely "shape unknown" but "nothing is
  * known about this value at all". */

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -32,6 +32,11 @@ import { z } from "zod";
 import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import { netuidSchema } from "./shared.ts";
 import { ReviewGapPrioritySchema } from "../routes/review-gaps-profile.ts";
+// The route's OWN curation block (#10790). The copy typed `level` and
+// `review_state` as bare strings where the route publishes the two enums that
+// say what the values MEAN -- so an agent reading this tool's contract could
+// not learn that `review_state` is one of four states.
+import { CurationMetadataSchema } from "../routes/subnet-detail.ts";
 
 export const GetSubnetInputSchema = z
   .object({
@@ -69,17 +74,6 @@ const SubnetOverviewCountsSchema = z
   })
   .strict();
 
-/** The human-governance axis: who reviewed this record and when. */
-const SubnetOverviewCurationSchema = z
-  .object({
-    level: z.string().nullable().optional(),
-    review_state: z.string().nullable().optional(),
-    reviewed_at: z.string().nullable().optional(),
-    verified_at: z.string().nullable().optional(),
-    source_count: z.int().nullable().optional(),
-    gap_notes: z.array(z.string()).optional(),
-  })
-  .strict();
 
 /** One ranked enrichment opportunity. Was `z.array(z.unknown())`, which says
  * strictly less than an open object: not merely "shape unknown" but "nothing is
@@ -94,7 +88,7 @@ export const GetSubnetOutputSchema = z
     // The profile surface's own shape, not a restatement of it.
     profile: SubnetProfileArtifactSchema.shape.profile.nullable().optional(),
     counts: SubnetOverviewCountsSchema.optional(),
-    curation: SubnetOverviewCurationSchema.nullable().optional(),
+    curation: CurationMetadataSchema.nullable().optional(),
     gaps: SubnetProfileArtifactSchema.shape.gaps.nullable().optional(),
     // The REVIEW ROUTE'S OWN ROW, not a copy of it (#10790). This was a
     // hand-written six-field restatement of an eleven-field producer, so

--- a/schemas-src/mcp-tools/meta-artifacts-1.ts
+++ b/schemas-src/mcp-tools/meta-artifacts-1.ts
@@ -19,14 +19,11 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
-import { MAX_LIMIT } from "../../workers/request-params.ts";
-import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 import {
-  offsetSchema,
-  limitSchema,
   orderSchema,
   sortSchema,
   McpUnsortedPageFields,
+  McpOffsetPageInput,
 } from "./shared.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
@@ -54,18 +51,7 @@ export type GetFreshnessOutput = z.infer<typeof GetFreshnessOutputSchema>;
 
 export const GetContractsInputSchema = z
   .object({
-    // The page (#10605). Both numbers come from the constants that actually
-    // decide them: MAX_LIMIT is the ceiling listQuerySchema gives every list
-    // route, and MCP_LIST_LIMIT_DEFAULT is the default applyMcpQueryFilters
-    // really applies -- published rather than hidden, because #10101 found 83
-    // tools whose schema left a caller unable to tell what an omitted
-    // limit returns. Publishing the ceiling while hiding the default would
-    // recreate exactly that gap.
-    limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
-    // An integer OFFSET, which is what these routes publish
-    // (`{minimum: 0, type: integer}`) -- not the keyset cursor. Conflating the
-    // two is the mistake query-params.ts calls out by name.
-    cursor: offsetSchema().optional(),
+    ...McpOffsetPageInput,
     sort: sortSchema(API_QUERY_COLLECTIONS.contracts.sort_fields).optional(),
     order: orderSchema().optional(),
   })

--- a/schemas-src/mcp-tools/registry-catalogs-1.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-1.ts
@@ -28,6 +28,7 @@ import {
   providerSlugSchema,
   sortSchema,
   McpListPageFields,
+  McpSortableListPage,
 } from "./shared.ts";
 import { CandidatesArtifactSchema } from "../routes/candidates-evidence.ts";
 import { SurfacesArtifactSchema } from "../routes/endpoints-pools.ts";
@@ -60,10 +61,7 @@ export const ListProvidersInputSchema = z
       )
       .meta({ examples: [PROVIDER_AUTHORITIES[0]] }),
     sort: sortSchema(API_QUERY_COLLECTIONS.providers.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListProvidersInput = z.infer<typeof ListProvidersInputSchema>;
@@ -125,10 +123,7 @@ export const ListSurfacesInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSurfacesInput = z.infer<typeof ListSurfacesInputSchema>;

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -18,20 +18,16 @@
 // now publishes.
 import { z } from "zod";
 import { ENDPOINT_LIST_FILTERS } from "./endpoints-catalog.ts";
+import { POOL_LIST_FILTERS } from "./endpoint-pools-and-provider.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
-  idFilterSchema,
   McpListArtifactStamp,
   McpListPageFields,
-  RPC_POOL_KIND_VALUES,
-  fieldsSchema,
-  kindSchema,
   limitSchema,
-  numericCursorSchema,
-  orderSchema,
   projectableRows,
   querySchema,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import { EvidenceLedgerArtifactSchema } from "../routes/candidates-evidence.ts";
 import { SourceSnapshotsArtifactSchema } from "../routes/evidence-search.ts";
@@ -54,10 +50,7 @@ export const ListEvidenceInputSchema = z
   .object({
     q: querySchema().optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListEvidenceInput = z.infer<typeof ListEvidenceInputSchema>;
@@ -103,45 +96,9 @@ export type ListRpcEndpointsOutput = z.infer<
 
 export const ListRpcPoolsInputSchema = z
   .object({
-    id: idFilterSchema().optional(),
-    // POOL kinds, not endpoint LAYERS. This read ENDPOINT_LAYER_VALUES
-    // (`bittensor-base`, `subnet-app`, …) -- a different vocabulary entirely,
-    // so all four advertised values were rejected by the route and none of the
-    // three it accepts was advertised (#10118).
-    kind: kindSchema(RPC_POOL_KIND_VALUES).optional(),
-    min_eligible_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on pool-eligible endpoint count; rows below it are excluded.",
-      )
-      .meta({ examples: [1] }),
-    max_eligible_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on pool-eligible endpoint count; rows above it are excluded.",
-      )
-      .meta({ examples: [10] }),
-    min_endpoint_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on endpoint count; rows below it are excluded.",
-      )
-      .meta({ examples: [1] }),
-    max_endpoint_count: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on endpoint count; rows above it are excluded.",
-      )
-      .meta({ examples: [10] }),
+    ...POOL_LIST_FILTERS,
     sort: sortSchema(API_QUERY_COLLECTIONS["rpc-pools"].sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListRpcPoolsInput = z.infer<typeof ListRpcPoolsInputSchema>;
@@ -164,10 +121,7 @@ export const ListSourceSnapshotsInputSchema = z
   .object({
     q: querySchema().optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.sources.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSourceSnapshotsInput = z.infer<
@@ -227,10 +181,7 @@ export const ListProfileCompletenessInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["profile-completeness"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListProfileCompletenessInput = z.infer<

--- a/schemas-src/mcp-tools/registry-catalogs-2.ts
+++ b/schemas-src/mcp-tools/registry-catalogs-2.ts
@@ -17,6 +17,7 @@
 // this file was called live and its response validated against the schema it
 // now publishes.
 import { z } from "zod";
+import { ENDPOINT_LIST_FILTERS } from "./endpoints-catalog.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   idFilterSchema,
@@ -29,7 +30,6 @@ import {
   numericCursorSchema,
   orderSchema,
   projectableRows,
-  providerSlugSchema,
   querySchema,
   sortSchema,
 } from "./shared.ts";
@@ -39,12 +39,9 @@ import { RpcEndpointsArtifactSchema } from "../routes/providers-rpc.ts";
 import { ReviewProfileCompletenessArtifactSchema } from "../routes/review-gaps-profile.ts";
 import { RpcPoolsArtifactSchema } from "../routes/providers-rpc.ts";
 import {
-  ENDPOINT_LAYER_VALUES,
-  ENDPOINT_PUBLICATION_STATE_VALUES,
   LIVE_HEALTH_OVERLAY,
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
-import { HEALTH_STATUS_VALUES } from "../shared.ts";
 import {
   CONFIDENCE_LEVEL_VALUES,
   IDENTITY_LEVEL_VALUES,
@@ -74,79 +71,10 @@ export const ListEvidenceOutputSchema = EvidenceLedgerArtifactSchema.extend({
 export type ListEvidenceOutput = z.infer<typeof ListEvidenceOutputSchema>;
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
-const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
-const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
-const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
 export const ListRpcEndpointsInputSchema = z
   .object({
-    kind: kindSchema(SURFACE_KINDS).optional(),
-    layer: z
-      .enum(ENDPOINT_LAYERS)
-      .optional()
-      .describe(
-        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      )
-      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
+    ...ENDPOINT_LIST_FILTERS,
     netuid: API_QUERY_COLLECTIONS.endpoints.filter_schemas.netuid.optional(),
-    provider: providerSlugSchema().optional(),
-    publication_state:
-      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
-        .optional()
-        .describe(
-          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-        )
-        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
-    status: kindSchema(HEALTH_STATUSES).optional(),
-    pool_eligible: z
-      .boolean()
-      .optional()
-      .describe(
-        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      )
-      .meta({ examples: [true] }),
-    min_latency_ms: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      )
-      .meta({ examples: [50] }),
-    max_latency_ms: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      )
-      .meta({ examples: [500] }),
-    min_score: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      )
-      .meta({ examples: [50] }),
-    max_score: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      )
-      .meta({ examples: [100] }),
-    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
-    order: orderSchema().optional(),
-    // Both `fields` and `cursor` are UNIONS here, unlike everywhere else, so
-    // neither can take a shared builder -- the sentence has to say which forms
-    // are accepted rather than assume one.
-    fields: z
-      .union([z.string(), z.array(z.string())])
-      .describe(
-        "Row fields to project. Accepts either a comma-separated string " +
-          "(`id,url,status`) or an array of bare names. Omit for the full row.",
-      )
-      .optional()
-      .meta({ examples: ["netuid,name,slug"] }),
-    // Ceiling is MAX_LIMIT (workers/request-params.ts:21); a literal here
-    // because schemas-src/ imports from neither src/ nor workers/.
     limit: limitSchema(1000, 20).optional(),
     cursor: z
       .union([z.int().min(0), z.string()])

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -6,13 +6,12 @@
 // array). None mirror an existing schemas-src/routes/ REST schema --
 // modeled fresh, matching each hand-written literal field-for-field.
 import { z } from "zod";
+import { GAP_REVIEW_FILTERS } from "./enrichment-evidence-and-targets.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { RegistrySummaryArtifactSchema } from "../routes/registry-summary-leaderboards.ts";
 import {
-  reviewStateSchema,
   McpListPageFields,
   McpSubnetListArtifactStamp,
-  kindSchema,
   limitSchema,
   netuidSchema,
   projectableRows,
@@ -21,8 +20,6 @@ import {
   McpSortableListPage,
 } from "./shared.ts";
 import { SubnetGapsArtifactSchema } from "../routes/review-gaps-profile.ts";
-import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
-import { CURATION_LEVEL_VALUES } from "../shared.ts";
 import {
   AgentReadinessBlockerSchema,
   CoverageDepthDimensionsSchema,
@@ -201,23 +198,13 @@ export const GetSubnetGapsOutputSchema = z
   .strict();
 export type GetSubnetGapsOutput = z.infer<typeof GetSubnetGapsOutputSchema>;
 
-const CURATION_LEVELS = CURATION_LEVEL_VALUES;
-const SURFACE_KINDS = SURFACE_KIND_VALUES;
 // The REST route pages this artifact through the review-gap-priorities
 // collection (rows live under `priorities`), not the network-wide `gaps`
 // collection -- same sort fields as list_review_gaps (batch 10, #8074).
 export const ListSubnetGapsInputSchema = z
   .object({
     netuid: netuidSchema(),
-    curation_level: kindSchema(CURATION_LEVELS).optional(),
-    missing_kinds: z
-      .enum(SURFACE_KINDS)
-      .optional()
-      .describe(
-        "Restrict to subnets where surfaces of this kind the subnet is MISSING. One kind per call; see this parameter's enum.",
-      )
-      .meta({ examples: [SURFACE_KINDS[0]] }),
-    review_state: reviewStateSchema().optional(),
+    ...GAP_REVIEW_FILTERS,
     sort: sortSchema(
       API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields,
     ).optional(),

--- a/schemas-src/mcp-tools/registry-summary-gaps.ts
+++ b/schemas-src/mcp-tools/registry-summary-gaps.ts
@@ -12,15 +12,13 @@ import {
   reviewStateSchema,
   McpListPageFields,
   McpSubnetListArtifactStamp,
-  fieldsSchema,
   kindSchema,
   limitSchema,
   netuidSchema,
-  numericCursorSchema,
-  orderSchema,
   projectableRows,
   querySchema,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import { SubnetGapsArtifactSchema } from "../routes/review-gaps-profile.ts";
 import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
@@ -223,10 +221,7 @@ export const ListSubnetGapsInputSchema = z
     sort: sortSchema(
       API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields,
     ).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSubnetGapsInput = z.infer<typeof ListSubnetGapsInputSchema>;

--- a/schemas-src/mcp-tools/search-documents.ts
+++ b/schemas-src/mcp-tools/search-documents.ts
@@ -16,13 +16,10 @@ import {
   McpListArtifactStamp,
   McpListPageFields,
   NotesFieldSchema,
-  fieldsSchema,
-  limitSchema,
-  numericCursorSchema,
-  orderSchema,
   projectableRows,
   querySchema,
   sortSchema,
+  McpSortableListPage,
 } from "./shared.ts";
 import { SearchIndexArtifactSchema } from "../routes/evidence-search.ts";
 import { SearchArtifactSchema } from "../routes/evidence-search.ts";
@@ -37,10 +34,7 @@ export const ListSearchIndexInputSchema = z
       .meta({ examples: [SEARCH_DOCUMENT_TYPE_VALUES[0]] }),
     netuid: API_QUERY_COLLECTIONS.documents.filter_schemas.netuid.optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.documents.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSearchIndexInput = z.infer<typeof ListSearchIndexInputSchema>;
@@ -63,10 +57,7 @@ export const ListSearchInputSchema = z
       .meta({ examples: [SEARCH_DOCUMENT_TYPE_VALUES[0]] }),
     netuid: API_QUERY_COLLECTIONS.documents.filter_schemas.netuid.optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.documents.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSearchInput = z.infer<typeof ListSearchInputSchema>;

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -12,6 +12,9 @@ import { z } from "zod";
 import { distributionStatsSchema } from "../shared.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
+import { limitSchema, offsetSchema } from "../query-params.ts";
+import { MAX_LIMIT } from "../../workers/request-params.ts";
+import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 
 // The query-parameter vocabulary now lives in schemas-src/query-params.ts so the
 // REST route schemas can use it too (#9986). Re-exported here because ~100 MCP
@@ -358,3 +361,24 @@ export function projectableRows<Row extends z.ZodObject<z.ZodRawShape>>(
 ) {
   return z.array(rows.element.partial());
 }
+
+/**
+ * The offset page every document-collection tool takes -- ONE declaration
+ * (#10790).
+ *
+ * Six tools carried this pair, each under the same twelve-line comment copied
+ * verbatim. Both numbers come from the constants that actually decide them:
+ * `MAX_LIMIT` is the ceiling `listQuerySchema` gives every list route, and
+ * `MCP_LIST_LIMIT_DEFAULT` is the default `applyMcpQueryFilters` really
+ * applies -- published rather than hidden, because #10101 found 83 tools whose
+ * schema left a caller unable to tell what an omitted `limit` returns.
+ * Publishing the ceiling while hiding the default would recreate that gap.
+ *
+ * `cursor` is an integer OFFSET, which is what these routes publish
+ * (`{minimum: 0, type: integer}`), NOT the keyset cursor. Conflating the two is
+ * the mistake `query-params.ts` calls out by name.
+ */
+export const McpOffsetPageInput = {
+  limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
+  cursor: offsetSchema().optional(),
+};

--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -12,7 +12,13 @@ import { z } from "zod";
 import { distributionStatsSchema } from "../shared.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { NeuronSchema } from "../routes/subnet-metagraph.ts";
-import { limitSchema, offsetSchema } from "../query-params.ts";
+import {
+  fieldsSchema,
+  limitSchema,
+  numericCursorSchema,
+  offsetSchema,
+  orderSchema,
+} from "../query-params.ts";
 import { MAX_LIMIT } from "../../workers/request-params.ts";
 import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
 
@@ -381,4 +387,24 @@ export function projectableRows<Row extends z.ZodObject<z.ZodRawShape>>(
 export const McpOffsetPageInput = {
   limit: limitSchema(MAX_LIMIT, MCP_LIST_LIMIT_DEFAULT).optional(),
   cursor: offsetSchema().optional(),
+};
+
+/**
+ * The projection + keyset page every SORTABLE list tool takes -- ONE
+ * declaration (#10790).
+ *
+ * `order`, `fields`, `limit` and `cursor` are identical on every one of them;
+ * only `sort` differs, because its allowed values are the collection's own
+ * sort fields. So `sort` stays declared per site, beside the collection it
+ * belongs to, and the four that never vary come from here.
+ *
+ * The `limit` ceiling is the tools' 100, not the route's 1000: MCP caps pages
+ * for the context window, deliberately (#9981). That is a declaration, not
+ * drift, and `validate:mcp-input-parity` records it as one.
+ */
+export const McpSortableListPage = {
+  order: orderSchema().optional(),
+  fields: fieldsSchema().optional(),
+  limit: limitSchema(100, 20).optional(),
+  cursor: numericCursorSchema().optional(),
 };

--- a/schemas-src/mcp-tools/subnet-registry-lists.ts
+++ b/schemas-src/mcp-tools/subnet-registry-lists.ts
@@ -25,11 +25,9 @@ import {
   idFilterSchema,
   McpListPageFields,
   McpSubnetListArtifactStamp,
-  fieldsSchema,
   kindSchema,
   limitSchema,
   netuidSchema,
-  numericCursorSchema,
   offsetSchema,
   orderSchema,
   projectableRows,
@@ -37,6 +35,7 @@ import {
   querySchema,
   sortSchema,
   McpUnsortedPageFields,
+  McpSortableListPage,
 } from "./shared.ts";
 import {
   SubnetCandidatesArtifactSchema,
@@ -108,10 +107,7 @@ export const ListSubnetCandidatesInputSchema = z
       .describe("How confident the machine assessment is.")
       .meta({ examples: [CONFIDENCE_LEVEL_VALUES[0]] }),
     sort: sortSchema(API_QUERY_COLLECTIONS.candidates.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSubnetCandidatesInput = z.infer<
@@ -199,10 +195,7 @@ export const ListSubnetEvidenceInputSchema = z
     netuid: netuidSchema(),
     q: querySchema().optional(),
     sort: sortSchema(API_QUERY_COLLECTIONS.claims.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
-    limit: limitSchema(100, 20).optional(),
-    cursor: numericCursorSchema().optional(),
+    ...McpSortableListPage,
   })
   .strict();
 export type ListSubnetEvidenceInput = z.infer<

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -36,9 +36,7 @@ import { SubnetSurfacesArtifactSchema } from "../routes/endpoints-pools.ts";
 // rather than hand-copied -- which is how it came to lack the collection's
 // three boolean filters in the first place.
 import { ListSurfacesInputSchema } from "./registry-catalogs-1.ts";
-import {
-  SURFACE_KIND_VALUES,
-} from "../routes/subnet-detail.ts";
+import { SURFACE_KIND_VALUES } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
 import { HEALTH_CLASSIFICATION_VALUES } from "./shared.ts";
 

--- a/schemas-src/mcp-tools/subnet-scoped-lists.ts
+++ b/schemas-src/mcp-tools/subnet-scoped-lists.ts
@@ -16,11 +16,11 @@
 // list_subnet_surfaces/list_subnet_health have no `fields` projection param
 // at all, unlike every other list_* tool in this epic.
 import { z } from "zod";
+import { ENDPOINT_LIST_FILTERS } from "./endpoints-catalog.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import {
   McpListPageFields,
   McpSubnetListArtifactStamp,
-  fieldsSchema,
   kindSchema,
   limitSchema,
   netuidSchema,
@@ -37,75 +37,18 @@ import { SubnetSurfacesArtifactSchema } from "../routes/endpoints-pools.ts";
 // three boolean filters in the first place.
 import { ListSurfacesInputSchema } from "./registry-catalogs-1.ts";
 import {
-  ENDPOINT_LAYER_VALUES,
-  ENDPOINT_PUBLICATION_STATE_VALUES,
   SURFACE_KIND_VALUES,
 } from "../routes/subnet-detail.ts";
 import { HEALTH_STATUS_VALUES } from "../shared.ts";
 import { HEALTH_CLASSIFICATION_VALUES } from "./shared.ts";
 
 const SURFACE_KINDS = SURFACE_KIND_VALUES;
-const ENDPOINT_LAYERS = ENDPOINT_LAYER_VALUES;
-const ENDPOINT_PUBLICATION_STATES = ENDPOINT_PUBLICATION_STATE_VALUES;
 const HEALTH_STATUSES = HEALTH_STATUS_VALUES;
-const BOOLEAN_STRINGS = ["true", "false"] as const;
 export const ListSubnetEndpointsInputSchema = z
   .object({
+    ...ENDPOINT_LIST_FILTERS,
+    // The subnet-scoped list: netuid is the SUBJECT, not a filter.
     netuid: netuidSchema(),
-    kind: kindSchema(SURFACE_KINDS).optional(),
-    layer: z
-      .enum(ENDPOINT_LAYERS)
-      .optional()
-      .describe(
-        "Which layer of the stack the endpoint belongs to: the Bittensor base chain, a data or docs provider, or a subnet's own app.",
-      )
-      .meta({ examples: [ENDPOINT_LAYERS[0]] }),
-    provider: providerSlugSchema().optional(),
-    publication_state:
-      API_QUERY_COLLECTIONS.endpoints.filter_schemas.publication_state
-        .optional()
-        .describe(
-          "Where the endpoint sits in the review pipeline, from unreviewed candidate through to pool-eligible or rejected.",
-        )
-        .meta({ examples: [ENDPOINT_PUBLICATION_STATES[0]] }),
-    status: kindSchema(HEALTH_STATUSES).optional(),
-    pool_eligible: API_QUERY_COLLECTIONS.endpoints.filter_schemas.pool_eligible
-      .optional()
-      .describe(
-        "Restrict to endpoints that are (or are not) eligible for the public RPC pool.",
-      )
-      .meta({ examples: [BOOLEAN_STRINGS[0]] }),
-    min_latency_ms: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on probe latency in milliseconds; rows below it are excluded.",
-      )
-      .meta({ examples: [50] }),
-    max_latency_ms: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on probe latency in milliseconds; rows above it are excluded.",
-      )
-      .meta({ examples: [500] }),
-    min_score: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive lower bound on endpoint score; rows below it are excluded.",
-      )
-      .meta({ examples: [50] }),
-    max_score: z
-      .number()
-      .optional()
-      .describe(
-        "Inclusive upper bound on endpoint score; rows above it are excluded.",
-      )
-      .meta({ examples: [100] }),
-    sort: sortSchema(API_QUERY_COLLECTIONS.endpoints.sort_fields).optional(),
-    order: orderSchema().optional(),
-    fields: fieldsSchema().optional(),
     limit: limitSchema(100, 20).optional(),
     cursor: numericCursorSchema().optional(),
   })

--- a/schemas-src/routes/account-extrinsics.ts
+++ b/schemas-src/routes/account-extrinsics.ts
@@ -22,36 +22,14 @@
 // numbers -- same finding as account-events-feed.ts's 3 routes. Fixed to
 // required non-nullable integers.
 import { z } from "zod";
+import { ExtrinsicSchema } from "./extrinsics.ts";
 
-const ExtrinsicSchema = z
-  .object({
-    block_number: z.int().nullable(),
-    extrinsic_index: z.int().nullable(),
-    extrinsic_hash: z.string().nullable().optional(),
-    signer: z.string().nullable().optional(),
-    call_module: z.string().nullable().optional(),
-    call_function: z.string().nullable().optional(),
-    call_args: z
-      .unknown()
-      .nullable()
-      .optional()
-      .describe("JSON-encoded decoded call arguments."),
-    fee_tao: z.number().nullable().optional(),
-    tip_tao: z.number().nullable().optional(),
-    success: z.boolean().nullable().optional(),
-    observed_at: z.string().nullable().optional(),
-    // #8525: deterministic human-readable action sentence for this
-    // extrinsic's call, or null when no template matches
-    // call_module.call_function -- never a guessed/partial sentence.
-    summary: z
-      .string()
-      .nullable()
-      .optional()
-      .describe(
-        "Deterministic human-readable action sentence for this extrinsic's call, or null when no template matches call_module.call_function (#8525).",
-      ),
-  })
-  .strict();
+// The extrinsic-feed route's OWN row (#10790). One producer writes both --
+// `formatExtrinsic` in src/extrinsics.ts, which sets every field with `?? null`
+// -- so a row is always PRESENT and sometimes null, never absent. This copy
+// said `.optional()` on nine of the twelve and typed `call_args` as
+// `z.unknown()` where the shared row states the record/positional-tuple duality
+// `decodeChainEventArgs` produces.
 
 export const AccountExtrinsicsArtifactSchema = z
   .object({

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -7,7 +7,10 @@
 import { z } from "zod";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
-import { BittensorNetworkSchema } from "../shared.ts";
+import {
+  BittensorNetworkSchema,
+  NativeSnapshotSourceSchema,
+} from "../shared.ts";
 
 /** One surface kind's share of the registry: how many subnets have it, and
  * that as a whole-number percentage. Exported because
@@ -49,19 +52,7 @@ const CoverageSourceSchema = z
     // read -- which package, which RPC family, which storage item -- which is the
     // provenance a caller needs to judge the figure. The string arm is the older
     // shorthand form and is kept for wire compatibility.
-    native: z.union([
-      z.string(),
-      z
-        .object({
-          identity_storage: z.string().nullable().optional(),
-          kind: z.string().nullable().optional(),
-          method: z.string().nullable().optional(),
-          package: z.string().nullable().optional(),
-          rpc_family: z.string().nullable().optional(),
-          version: z.string().nullable().optional(),
-        })
-        .strict(),
-    ]),
+    native: z.union([z.string(), NativeSnapshotSourceSchema]),
     overlays: z.string(),
   })
   .strict();

--- a/schemas-src/routes/subnet-concentration.ts
+++ b/schemas-src/routes/subnet-concentration.ts
@@ -13,7 +13,10 @@
 // more times -- so the published GraphQL schema grew five anonymous twins of
 // a type it already had a name for.
 import { z } from "zod";
-import { ConcentrationMetricsSchema } from "../shared.ts";
+import {
+  ConcentrationMetricsSchema,
+  subnetHistoryArtifactSchema,
+} from "../shared.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_CONCENTRATION_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
@@ -78,20 +81,8 @@ const SubnetConcentrationHistoryPointSchema = z
   })
   .strict();
 
-export const SubnetConcentrationHistoryArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: z.int().min(0),
-    window: z
-      .string()
-      .nullable()
-      .optional()
-      .describe("The resolved window label (7d/30d/90d)."),
-    point_count: z.int().min(0),
-    points: z.array(SubnetConcentrationHistoryPointSchema),
-  })
-  .strict()
-  .describe(
+export const SubnetConcentrationHistoryArtifactSchema =
+  subnetHistoryArtifactSchema(SubnetConcentrationHistoryPointSchema).describe(
     "Per-subnet per-day concentration trend (#5901) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. Mirrors GET /api/v1/subnets/{netuid}/concentration/history.",
   );
 export type SubnetConcentrationHistoryArtifact = z.infer<

--- a/schemas-src/routes/subnet-hyperparameters.ts
+++ b/schemas-src/routes/subnet-hyperparameters.ts
@@ -17,6 +17,7 @@
 // *.schema.json file), and all three are converted together in this same
 // batch, so both hand-edited component keys become fully orphaned.
 import { z } from "zod";
+import { subnetEntryListSchema } from "../shared.ts";
 
 const SubnetHyperparametersSchema = z
   .object({
@@ -101,17 +102,9 @@ const SubnetHyperparamsHistoryEntrySchema = z
     "One observed hyperparameter change: the full block as of that block_number, plus the hash the diff-on-change writer keyed it by.",
   );
 
-export const SubnetHyperparamsHistoryArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: z.int().min(0),
-    entry_count: z.int().min(0),
-    limit: z.int().min(1).max(1000).nullable().optional(),
-    offset: z.int().min(0).nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    entries: z.array(SubnetHyperparamsHistoryEntrySchema),
-  })
-  .strict();
+export const SubnetHyperparamsHistoryArtifactSchema = subnetEntryListSchema(
+  SubnetHyperparamsHistoryEntrySchema,
+);
 export type SubnetHyperparamsHistoryArtifact = z.infer<
   typeof SubnetHyperparamsHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-identity-history.ts
+++ b/schemas-src/routes/subnet-identity-history.ts
@@ -12,6 +12,7 @@
 // schema would have rejected. Modeled here as nullable (still required --
 // the key itself is always present), matching real behavior.
 import { z } from "zod";
+import { subnetEntryListSchema } from "../shared.ts";
 
 export const SubnetIdentityHistoryEntrySchema = z
   .object({
@@ -34,20 +35,11 @@ export type SubnetIdentityHistoryEntry = z.infer<
   typeof SubnetIdentityHistoryEntrySchema
 >;
 
-export const SubnetIdentityHistoryArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: z.int().min(0),
-    entry_count: z.int().min(0),
-    limit: z.int().min(1).max(1000).nullable().optional(),
-    offset: z.int().min(0).nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    entries: z.array(SubnetIdentityHistoryEntrySchema),
-  })
-  .strict()
-  .describe(
-    "Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history.",
-  );
+export const SubnetIdentityHistoryArtifactSchema = subnetEntryListSchema(
+  SubnetIdentityHistoryEntrySchema,
+).describe(
+  "Append-only on-chain subnet identity timeline (#1647 / #5721). Empty entries on a cold/absent store. Mirrors GET /api/v1/subnets/{netuid}/identity-history.",
+);
 export type SubnetIdentityHistoryArtifact = z.infer<
   typeof SubnetIdentityHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnet-lifecycle.ts
+++ b/schemas-src/routes/subnet-lifecycle.ts
@@ -9,6 +9,7 @@
 // Backed by `subnet_lifecycle` in Neon, appended by the detection folded into
 // the neurons-staleness tick (#10262).
 import { z } from "zod";
+import { subnetEntryListSchema } from "../shared.ts";
 
 /**
  * The two transitions.
@@ -50,17 +51,9 @@ export const SubnetLifecycleEntrySchema = z
   );
 export type SubnetLifecycleEntry = z.infer<typeof SubnetLifecycleEntrySchema>;
 
-export const SubnetLifecycleArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: z.int().min(0),
-    entry_count: z.int().min(0),
-    limit: z.int().min(1).max(1000).nullable().optional(),
-    offset: z.int().min(0).nullable().optional(),
-    next_cursor: z.string().nullable().optional(),
-    entries: z.array(SubnetLifecycleEntrySchema),
-  })
-  .strict();
+export const SubnetLifecycleArtifactSchema = subnetEntryListSchema(
+  SubnetLifecycleEntrySchema,
+);
 export type SubnetLifecycleArtifact = z.infer<
   typeof SubnetLifecycleArtifactSchema
 >;

--- a/schemas-src/routes/subnet-performance.ts
+++ b/schemas-src/routes/subnet-performance.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import {
   ConcentrationMetricsSchema,
   ScoreDistributionSchema,
+  subnetHistoryArtifactSchema,
 } from "../shared.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
@@ -93,20 +94,8 @@ const SubnetPerformanceHistoryPointSchema = z
     "One day's point in a subnet's concentration trend (#5901). Flattened (not nested) stake/emission metrics keep the series trivial to plot; each is null on a cold/empty day.",
   );
 
-export const SubnetPerformanceHistoryArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: z.int().min(0),
-    window: z
-      .string()
-      .nullable()
-      .optional()
-      .describe("The resolved window label (7d/30d/90d)."),
-    point_count: z.int().min(0),
-    points: z.array(SubnetPerformanceHistoryPointSchema),
-  })
-  .strict()
-  .describe(
+export const SubnetPerformanceHistoryArtifactSchema =
+  subnetHistoryArtifactSchema(SubnetPerformanceHistoryPointSchema).describe(
     "Per-subnet per-day reward-distribution trend (#6981) from the neuron_daily rollup, newest first. An empty series (point_count 0) on a cold store, never a GraphQL error. The history twin of subnet_performance, mirroring GET /api/v1/subnets/{netuid}/performance/history.",
   );
 export type SubnetPerformanceHistoryArtifact = z.infer<

--- a/schemas-src/routes/subnet-profiles.ts
+++ b/schemas-src/routes/subnet-profiles.ts
@@ -29,6 +29,7 @@ import {
   SurfaceSchema,
 } from "./subnet-detail.ts";
 import { SchemaDriftStatusSchema } from "../shared.ts";
+import { SchemaDriftSummarySchema } from "../artifacts/schema-drift.ts";
 
 export const SubnetProfilesArtifactSchema = ArtifactBaseSchema.extend({
   profiles: z.array(SubnetProfileSchema),
@@ -149,14 +150,6 @@ export const SchemaIndexArtifactSchema = ArtifactBaseSchema.extend({
   // .optional() rather than required. Not in the hand-edited schema's named
   // properties, only legal today via additionalProperties:true.
   observed_at: z.string().optional(),
-  summary: z
-    .object({
-      surface_count: z.int().min(0),
-      schema_count: z.int().min(0),
-      by_status: z.record(z.string(), z.int().min(0)),
-      by_drift_status: z.record(z.string(), z.int().min(0)),
-    })
-    .strict()
-    .optional(),
+  summary: SchemaDriftSummarySchema.optional(),
 });
 export type SchemaIndexArtifact = z.infer<typeof SchemaIndexArtifactSchema>;

--- a/schemas-src/routes/subnet-yield.ts
+++ b/schemas-src/routes/subnet-yield.ts
@@ -4,6 +4,7 @@
 // buildSubnetYieldHistory(), cross-checked against the hand-edited
 // SubnetYieldArtifact/SubnetYieldHistoryArtifact components they replace.
 import { z } from "zod";
+import { subnetHistoryArtifactSchema } from "../shared.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_YIELD_WINDOW_VALUES = ["7d", "30d", "90d"] as const;
@@ -69,22 +70,11 @@ const SubnetYieldHistoryPointSchema = z
   })
   .strict();
 
-export const SubnetYieldHistoryArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    netuid: z.int().min(0),
-    window: z
-      .string()
-      .nullable()
-      .optional()
-      .describe("The resolved window label (7d/30d/90d)."),
-    point_count: z.int().min(0),
-    points: z.array(SubnetYieldHistoryPointSchema),
-  })
-  .strict()
-  .describe(
-    "Per-day emission-yield distribution trend for one subnet (newest first) over a 7d/30d/90d window: the subnet-wide return plus the mean/median/p25/p75/p90 of the per-UID emission-per-stake yields. The return-rate twin of /concentration/history and the time-series companion to the /yield snapshot — the per-UID yield distribution (median/percentiles) is not reconstructable from the stake+emission totals in /history. Computed live from the neuron_daily D1 rollup.",
-  );
+export const SubnetYieldHistoryArtifactSchema = subnetHistoryArtifactSchema(
+  SubnetYieldHistoryPointSchema,
+).describe(
+  "Per-day emission-yield distribution trend for one subnet (newest first) over a 7d/30d/90d window: the subnet-wide return plus the mean/median/p25/p75/p90 of the per-UID emission-per-stake yields. The return-rate twin of /concentration/history and the time-series companion to the /yield snapshot — the per-UID yield distribution (median/percentiles) is not reconstructable from the stake+emission totals in /history. Computed live from the neuron_daily D1 rollup.",
+);
 export type SubnetYieldHistoryArtifact = z.infer<
   typeof SubnetYieldHistoryArtifactSchema
 >;

--- a/schemas-src/routes/subnets.ts
+++ b/schemas-src/routes/subnets.ts
@@ -9,7 +9,11 @@
 // Query params from the same OpenAPI operation's `parameters` array (the
 // route() call in src/contracts.ts for "subnets").
 import { z } from "zod";
-import { SocialLinksSchema, GithubReleaseSchema } from "../shared.ts";
+import {
+  SocialLinksSchema,
+  GithubReleaseSchema,
+  NativeSnapshotSourceSchema,
+} from "../shared.ts";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import {
   BittensorNetworkSchema,
@@ -118,16 +122,7 @@ export const SubnetsArtifactSchema = ArtifactBaseSchema.extend({
     .describe(
       "Capture stamp of the native (SDK) snapshot the identity overlay was merged onto.",
     ),
-  source: z
-    .object({
-      identity_storage: z.string().optional(),
-      kind: z.string().optional(),
-      method: z.string().optional(),
-      package: z.string().optional(),
-      rpc_family: z.string().optional(),
-      version: z.string().optional(),
-    })
-    .strict(),
+  source: NativeSnapshotSourceSchema,
   subnets: z.array(SubnetIndexEntrySchema),
 });
 export type SubnetsArtifact = z.infer<typeof SubnetsArtifactSchema>;

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -730,3 +730,57 @@ export function distributionStatsSchema(
     })
     .strict();
 }
+
+/**
+ * A per-subnet, per-day trend series -- ONE envelope, three point types (#10790).
+ *
+ * `{schema_version, netuid, window, point_count, points}` was written out three
+ * times, for concentration, performance and yield, differing only in what a
+ * point IS. The envelope is one vocabulary; the point is the parameter.
+ *
+ * `point_count` is the rows RETURNED. An empty series on a cold store is a
+ * measurement, never an error -- which is why every one of these resolves to a
+ * schema-stable empty card rather than null.
+ */
+export function subnetHistoryArtifactSchema(point: z.ZodType) {
+  return z
+    .object({
+      schema_version: z.int(),
+      netuid: z.int().min(0),
+      window: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("The resolved window label (7d/30d/90d)."),
+      point_count: z.int().min(0),
+      points: z.array(point),
+    })
+    .strict();
+}
+
+/**
+ * A per-subnet, offset-paged entry list -- ONE envelope, three entry types
+ * (#10790).
+ *
+ * `{schema_version, netuid, entry_count, limit, offset, next_cursor, entries}`
+ * was written out three times, for hyperparameter history, identity history and
+ * lifecycle, differing only in what an entry IS.
+ *
+ * `limit`/`offset` are NULLABLE rather than merely optional: the REST layer
+ * defaults them before the loader runs, so a live response carries integers,
+ * but the loader is reachable without them and a schema that promised numbers
+ * would be wrong on that path.
+ */
+export function subnetEntryListSchema(entry: z.ZodType) {
+  return z
+    .object({
+      schema_version: z.int(),
+      netuid: z.int().min(0),
+      entry_count: z.int().min(0),
+      limit: z.int().min(1).max(1000).nullable().optional(),
+      offset: z.int().min(0).nullable().optional(),
+      next_cursor: z.string().nullable().optional(),
+      entries: z.array(entry),
+    })
+    .strict();
+}

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -784,3 +784,24 @@ export function subnetEntryListSchema(entry: z.ZodType) {
     })
     .strict();
 }
+
+/**
+ * How the native snapshot was read -- ONE declaration (#10790).
+ *
+ * `fetch-native-subnets.py` writes this block once and it is copied into both
+ * `subnets.json` and `coverage.json`'s `source.native`, which each declared it
+ * separately: one with `.nullable()` the producer never emits, one without.
+ * Optional rather than required, because an artifact captured before a field
+ * existed still has to parse; never nullable, because the producer writes six
+ * strings or nothing at all.
+ */
+export const NativeSnapshotSourceSchema = z
+  .object({
+    identity_storage: z.string().optional(),
+    kind: z.string().optional(),
+    method: z.string().optional(),
+    package: z.string().optional(),
+    rpc_family: z.string().optional(),
+    version: z.string().optional(),
+  })
+  .strict();

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -429,8 +429,12 @@ const CONSTRAINT_DIVERGENCES: Record<string, Divergence> = {
   "list_endpoints.pool_eligible": "SHAPE",
   "list_extrinsics.success": "SHAPE",
   "list_provider_endpoints.pool_eligible": "SHAPE",
+  // The third of the three, declared when #10790 single-sourced the endpoint
+  // filter block: its handler has decoded a real boolean through
+  // `withBooleanWords` since #10772, and only its SCHEMA still spelled the
+  // route's `"true"`/`"false"` words. GraphQL publishes `Boolean` here too.
+  "list_subnet_endpoints.pool_eligible": "SHAPE",
   "list_rpc_endpoints.cursor": "SHAPE",
-  "list_rpc_endpoints.fields": "SHAPE",
   "list_rpc_endpoints.pool_eligible": "SHAPE",
   "list_subnet_validators.fields": "SHAPE",
 

--- a/scripts/validate-schema-opacity.ts
+++ b/scripts/validate-schema-opacity.ts
@@ -86,6 +86,11 @@ const ROUTE_OPEN_SITES: Record<string, string> = {
   // that shape, not us. Empty on every published route -- the API is public --
   // and declared rather than left undescribed since #10790.
   "OpenApiArtifact.security[]": EMBEDDED_JSON_SCHEMA,
+  // Reachable since #10790 collapsed the account-scoped extrinsic feed onto the
+  // network-wide route's `ExtrinsicSchema`. It was `z.unknown()` before -- which
+  // is not an OPEN OBJECT, so this gate could not see it, and which described
+  // the payload less than the open record does.
+  "AccountExtrinsicsArtifact.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
   "BlockChainEventsArtifact.events[].args": DECODED_CHAIN_PAYLOAD,
   "BlockExtrinsicsArtifact.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
   "ChainEventsFeedArtifact.events[].args": DECODED_CHAIN_PAYLOAD,
@@ -128,6 +133,7 @@ const MCP_REASONED_OPEN_SITES: Record<string, string> = {
   // before -- which is not an OPEN OBJECT, so this gate could not see them,
   // and which described the payload less than the open record does. Same blob
   // as the REST entries above, same reason.
+  "get_account_extrinsics.extrinsics[].call_args": DECODED_CHAIN_PAYLOAD,
   "get_block_chain_events.events[].args": DECODED_CHAIN_PAYLOAD,
   "get_extrinsic_chain_events.events[].args": DECODED_CHAIN_PAYLOAD,
   "get_api_schema.document": EMBEDDED_THIRD_PARTY_DOCUMENT,

--- a/scripts/validate-schema-shape-duplicates.ts
+++ b/scripts/validate-schema-shape-duplicates.ts
@@ -65,6 +65,37 @@ export interface ShapeDuplicate {
   sites: ShapeSite[];
 }
 
+/**
+ * How many of this literal's fields are DERIVED rather than declared.
+ *
+ * A derivation reads its constraint from somewhere else -- `Other.shape.field`,
+ * or a spread of a shared block -- so it adds no second opinion about what the
+ * field is. Only hand-written values count toward the duplicate threshold.
+ */
+function derivedKeyCount(literal: ts.ObjectLiteralExpression): number {
+  let derived = 0;
+  for (const property of literal.properties) {
+    if (!ts.isPropertyAssignment(property)) continue;
+    let expression: ts.Expression = property.initializer;
+    // Peel the `.optional()` / `.nullable()` / `.describe(...)` a derivation
+    // may carry: narrowing a borrowed field is still borrowing it.
+    while (
+      ts.isCallExpression(expression) &&
+      ts.isPropertyAccessExpression(expression.expression)
+    ) {
+      expression = expression.expression.expression;
+    }
+    if (
+      ts.isPropertyAccessExpression(expression) &&
+      ts.isPropertyAccessExpression(expression.expression) &&
+      expression.expression.name.text === "shape"
+    ) {
+      derived += 1;
+    }
+  }
+  return derived;
+}
+
 /** Every `z.object({ … })` literal under the given files. */
 export function findObjectShapes(files: readonly string[]): ShapeSite[] {
   const out: ShapeSite[] = [];
@@ -94,7 +125,15 @@ export function findObjectShapes(files: readonly string[]): ShapeSite[] {
             ? [property.name.text]
             : [],
         );
-        if (keys.length >= MIN_KEYS) {
+        // A field DERIVED from another schema is not a second declaration of
+        // it. `netuid: RouteQuery_x.shape.netuid` restates a name, not a
+        // vocabulary -- the constraint still has exactly one home, and a
+        // rename there is still a compile error here. Counting those the same
+        // as a hand-written `netuid: z.int().min(0)` reported the #10064 idiom
+        // -- MCP inputs built field by field off their route's schema -- as
+        // the very duplication it exists to prevent.
+        const declared = keys.length - derivedKeyCount(node.arguments[0]!);
+        if (keys.length >= MIN_KEYS && declared >= MIN_KEYS) {
           out.push({
             file,
             line:

--- a/scripts/validate-schema-shape-duplicates.ts
+++ b/scripts/validate-schema-shape-duplicates.ts
@@ -180,35 +180,33 @@ function schemaFiles(): string[] {
 /**
  * The count this gate holds the line at, and it only goes DOWN.
  *
- * A RATCHET, not a rule, and MEASURED rather than assumed.
- * `scripts/report-shape-duplicate-drift.ts` compares each duplicated
- * vocabulary field by field, and the answer decides which pile the pair lands
- * in:
+ * **42 to 1.** Every duplicated object vocabulary in `schemas-src/` has been
+ * collapsed, and `scripts/report-shape-duplicate-drift.ts` is what made that
+ * safe: it compares each pair field by field, so a mechanical collapse was
+ * never confused with a contract change. Some became a shared const, some a
+ * FACTORY where the shape was one vocabulary and the measure was not
+ * (`distributionStatsSchema`, `subnetHistoryArtifactSchema`,
+ * `subnetEntryListSchema`), and four were the #10064 derivation idiom that this
+ * gate used to misread as duplication until it learned that
+ * `Route.shape.field` is a borrowing rather than a second opinion.
  *
- *   IDENTICAL  a mechanical collapse. #10790 did all of them -- `auth`,
- *              `revenue`, the entity label whose two copies each told the
- *              other to "keep both in sync", the social-links block, and the
- *              GitHub release shape written out three times byte for byte.
- *   DIVERGENT  42 remain, and NOT ONE is mechanical. The two declarations
- *              disagree about at least one field, so collapsing means choosing
- *              which side is right -- a published-contract decision per field,
- *              not a cleanup.
+ * ONE REMAINS, and it is not duplication:
  *
- * What that disagreement looks like, from the report:
+ *   {limit, since, tag, until}
+ *     schemas-src/route-queries.ts       FEED_QUERY_SCHEMAS.common
+ *     schemas-src/mcp-tools/feed.ts      GetFeedOutput.filters
  *
- *   limit         `limitSchema(1000, 20)` against `limitSchema(100, 20)` --
- *                 collapsing changes the page a caller may ask for.
- *   captured_at   `z.string()` against `z.iso.datetime()`.
- *   recent_events required on one side, `.optional()` on the other.
- *   netuid        the network-wide list's optional FILTER against the
- *                 subnet-scoped list's required SUBJECT. Same name, same key
- *                 set, different field -- and collapsing those two would be
- *                 actively wrong.
+ * The first is what a caller may SEND -- `since` accepts a bare date, `limit`
+ * carries the route's ceiling. The second is what the response ECHOES BACK:
+ * the filters as applied, `since` already resolved to an instant. Same four
+ * names, opposite directions, different value spaces. Collapsing them would
+ * either make the echo reject a value the handler legitimately produced or
+ * make the input accept anything the echo can carry -- which is the input/
+ * output conflation #10790 was explicitly told to keep separate.
  *
- * So the mechanism lands with the measurement beside it, and the backlog is
- * worked with data rather than by hand. Run `npm run report:shape-duplicates`.
+ * So the ceiling is 1, and it is a rule in all but name.
  */
-const CEILING = 42;
+const CEILING = 1;
 
 function main(): void {
   const files = schemaFiles();

--- a/tests/schema-strictness-gates.test.ts
+++ b/tests/schema-strictness-gates.test.ts
@@ -117,6 +117,39 @@ describe("schema-shape-duplicates", () => {
     );
   });
 
+  test("a DERIVED field is not a second declaration", () => {
+    // The #10064 idiom: an MCP input built field by field off its route's
+    // schema. The constraint still has one home and a rename there is still a
+    // compile error here, so counting these as duplicates reported the fix as
+    // the disease (#10790).
+    const derived = [
+      "  a: Route.shape.a,",
+      "  b: Route.shape.b.optional(),",
+      "  c: Route.shape.c,",
+      "  d: Route.shape.d,",
+    ].join("\n");
+    assert.deepEqual(
+      findDuplicates(findObjectShapes(twoFiles(FOUR, derived))),
+      [],
+    );
+  });
+
+  test("but a literal that only PARTLY derives is still reported", () => {
+    // The negative that keeps the exemption honest: three borrowed fields and
+    // one hand-written is still a hand-written vocabulary, and if the threshold
+    // were "any derivation exempts the literal" this would pass silently.
+    const mostly = [
+      "  a: Route.shape.a,",
+      "  b: z.string(),",
+      "  c: z.string(),",
+      "  d: z.string(),",
+      "  e: z.string(),",
+    ].join("\n");
+    const other = `${FOUR}\n  e: z.string(),`;
+    const found = findDuplicates(findObjectShapes(twoFiles(other, mostly)));
+    assert.equal(found.length, 1, "four declared keys still meet the bar");
+  });
+
   test("is silent for two literals in ONE file", () => {
     // A schema and its history variant sharing a point shape, declared side by
     // side where a reader sees both. The failure this gate exists for is the


### PR DESCRIPTION
`validate:schema-shape-duplicates` landed in #10853 as a ratchet at **42**, deliberately deferred. This is that backlog, worked to **1**.

## The measurement had to be fixed twice before it could be trusted

The drift report's first run announced **"45 identical, 0 divergent"** — a clean bill of health produced by comparing nothing. It matched the enclosing object literal rather than the declaration at the reported line, so every field read `<absent>` on both sides. The truth was the reverse: **42 of the 45 disagreed.** It now asserts that the keys it extracted are the keys the gate found, and a test fails loudly if that guard ever regresses.

The gate itself was over-reporting too. Four "duplicates" were the #10064 idiom — an MCP input built field by field off its route's schema. `netuid: Route.shape.netuid` restates a name, not a vocabulary: the constraint still has one home and a rename there is still a compile error here. Counting those as duplication **reported the fix as the disease**. The gate now discounts derived fields, with tests both ways — a fully-derived literal is silent, a partly-derived one with four hand-written keys is still reported.

## Three things a collapse turned out to be

**A shared const**, where the copies really were one vocabulary — the entity label whose two copies each told the other to "keep both in sync", the social-links block, the GitHub release shape written out three times byte for byte, the offset page carried by six tools under the same twelve-line comment, the sortable-list page across **twenty** sites.

**A factory**, where the SHAPE was one vocabulary and the MEASURE was not:

- `distributionStatsSchema(measure, percentile)` — the eight-key summary written over a 0–100 stability score with integer percentiles, a net flow that can go negative, a non-negative intensity, and an unbounded generic. One schema would have erased the bounds that say what each measure *is*.
- `subnetHistoryArtifactSchema(point)` — one trend envelope, three point types.
- `subnetEntryListSchema(entry)` — one paged-entry envelope, three entry types.

**Nothing**, where the key set coincides and the field does not. `netuid` is an optional **filter** on the network-wide endpoint list and the required **subject** on the subnet-scoped one; collapsing those would be actively wrong, so they share what they share and declare that field per site. The one duplicate left is the same class: `{limit, since, tag, until}` is the feed's INPUT constraint in one place and the response's ECHO of what was applied in the other — `since` accepts a bare date going in and comes back a resolved instant. Same four names, opposite directions. That is the input/output conflation #10790 was told to keep separate.

## What the collapses found

Each one had to choose which side was right, and the route — whose schema is validated against its producer — kept winning:

- **`operational-surfaces`** promised non-null on five fields `serviceSchemaSource()` writes `|| null`, and named two of the three `match` values `resolveAgentServiceSchema` returns. A `surface-id` match would have failed that artifact's own contract.
- **`account-extrinsics`** said `.optional()` on nine of twelve fields and typed `call_args` as `z.unknown()`, where `formatExtrinsic` sets every field with `?? null` — always present, sometimes null, never absent.
- **`get_subnet`'s curation block** typed `level` and `review_state` as bare strings where the route publishes the two enums that say what the values mean.
- **The chain-event row** existed three times, and both route copies carried a comment claiming the hand-edited component was "fully orphaned as of this batch". Each believed it was the last.

Two collapses made a real `call_args` union visible where a `z.unknown()` had hidden it from `validate:schema-opacity` — `z.unknown()` is not an open object, so the gate could not see it, and it described the payload *less* than the open record does. Both now carry the same declared reason as their siblings.

## Verification

- `npm run validate` **exit 0**; all 55 CI validators green
- Full suite **872 files, 19,885 tests**
- **`validate:contract-drift` clean at every step** — the factories and shared consts emit byte-identical OpenAPI
- **`validate:mcp` green against live responses** after each collapse, 235 tools
- No files under `src/**` or `workers/**` — this is `schemas-src/`, `scripts/` and `tests/` only, so there is no patch-coverage surface

**42 → 1**, and the ceiling only goes down.

Closes #10858
