### PR TITLE
feat(mcp): parse every tool result against the schema that tool publishes

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "report:graphql-schema-diff": "node scripts/report-graphql-schema-diff.ts",
     "report:type-duplicates": "node scripts/report-type-duplicates.ts",
     "report:nullable-overpromises": "node scripts/report-nullable-overpromises.ts",
+    "report:mcp-tripwire-preflight": "node scripts/report-mcp-tripwire-preflight.ts",
     "report:shape-duplicates": "node scripts/report-shape-duplicate-drift.ts",
     "report:undeclared-fields": "node scripts/report-undeclared-fields.ts",
     "report:graphql-tightening-evidence": "node scripts/report-graphql-tightening-evidence.ts",

--- a/scripts/check-mcp-conformance.ts
+++ b/scripts/check-mcp-conformance.ts
@@ -169,14 +169,19 @@ export interface ConformanceReport {
   violations: ConformanceViolation[];
 }
 
-async function callTool(name: string, args: Row): Promise<Row> {
+/**
+ * Exported so the tripwire pre-flight (#10789) sweeps production through the
+ * SAME transport, spacing and rate-limit backoff this check uses. Two sweeps
+ * with two call paths would differ on retries first and on results eventually.
+ */
+export async function callTool(name: string, args: Row): Promise<Row> {
   const body = await rpc("tools/call", { name, arguments: args });
   await sleep(CALL_SPACING_MS);
   return body;
 }
 
 /** The tool's structured result, or null when it declined. */
-function structuredOf(body: Row): Row | null {
+export function structuredOf(body: Row): Row | null {
   if (body?.error) return null;
   if (body?.result?.isError) return null;
   const structured = body?.result?.structuredContent;

--- a/scripts/report-mcp-tripwire-preflight.ts
+++ b/scripts/report-mcp-tripwire-preflight.ts
@@ -1,0 +1,220 @@
+// Would the MCP response tripwire reject anything production is serving today?
+// (#10789)
+//
+// The tripwire parses every tool result against the schema that tool publishes,
+// and it THROWS. Turning that on without measuring first is how an enforcement
+// flag becomes an outage: the schemas moved a great deal in #10786 and #10790,
+// and "the contract is right" was a claim about the contract, not about the
+// producer.
+//
+// ## WHY THE SCHEDULED SWEEP DOES NOT ANSWER THIS
+//
+// `scripts/check-mcp-conformance.ts` reads `tools/list` from production and
+// validates production's answers against **the schemas production publishes**.
+// That is the right question for a scheduled check -- it catches a server whose
+// answers stopped matching its own contract -- and the wrong one here, because
+// a deployed contract agreeing with its deployed producer says nothing about
+// the contract in this working tree. It reported 229 tools clean while the
+// schemas about to ship were materially stricter.
+//
+// So this asks the other question: production's RESPONSES against the LOCAL
+// schemas. It runs `validateMcpResponseTripwire` itself rather than a
+// re-implementation, so the measurement and the enforcement cannot disagree
+// about which schema describes a tool or what counts as a violation.
+//
+// ## WHAT A FINDING MEANS
+//
+// A shape production serves that the schema about to ship does not describe.
+// Each is one of two things, and the difference decides the fix:
+//
+//   the SCHEMA is wrong    it tightened past what the producer can promise, and
+//                          the fix is at the Zod. The common case after a
+//                          strict migration.
+//   the PRODUCER is wrong  it emits something undeclared, and the fix is to
+//                          declare it or stop emitting it (#10790's triage).
+//
+// Never widen the schema to make the report quiet -- that is the leak guard
+// that does not guard, reintroduced by hand.
+import { pathToFileURL } from "node:url";
+import {
+  callTool,
+  listLiveTools,
+  structuredOf,
+} from "./check-mcp-conformance.ts";
+import {
+  buildToolArguments,
+  projectableFieldFrom,
+  projectionArgumentFor,
+} from "./mcp-tool-arguments.ts";
+import {
+  McpResponseSchemaDriftError,
+  validateMcpResponseTripwire,
+} from "../src/mcp-response-tripwire.ts";
+
+type Row = Record<string, unknown>;
+
+/** One tool's production result measured against the schema this tree ships. */
+export interface PreflightFinding {
+  tool: string;
+  detail: unknown;
+}
+
+export interface PreflightReport {
+  /** Production responses parsed against a LOCAL schema. */
+  checked: number;
+  /** Advertised by production, absent here -- nothing to compare against. */
+  unknownLocally: string[];
+  /** No local schema carries a Zod source, so the tripwire would skip it. */
+  unresolved: string[];
+  /** Declined for their example arguments, so there was no response. */
+  declined: string[];
+  /** Also parsed under their own `fields` projection. */
+  projectionChecked: number;
+  /** `fields`-capable but with no rows to project right now. */
+  projectionUnexercised: string[];
+  findings: PreflightFinding[];
+}
+
+/**
+ * The output schemas this tree would SERVE, keyed by tool.
+ *
+ * Read through `listToolDefinitions()` rather than the `MCP_TOOLS` array:
+ * `stripSentinelIntegerBounds` rewrites what is actually published, and
+ * measuring the array instead of the served list is a mistake #10279 made once
+ * already -- it reported 82 sentinel bounds that nothing ever serves.
+ */
+async function localToolSchemas(): Promise<Map<string, unknown>> {
+  const { listToolDefinitions } = (await import("../src/mcp-server.ts")) as {
+    listToolDefinitions: () => Promise<Row[]> | Row[];
+  };
+  const served = await listToolDefinitions();
+  return new Map(
+    served.flatMap((tool) =>
+      tool.outputSchema ? [[String(tool.name), tool.outputSchema]] : [],
+    ),
+  );
+}
+
+/** Run the tripwire itself, recording a drift rather than throwing out. */
+function parse(
+  report: PreflightReport,
+  label: string,
+  published: unknown,
+  structured: unknown,
+): void {
+  try {
+    validateMcpResponseTripwire(label, published, structured);
+  } catch (err) {
+    if (err instanceof McpResponseSchemaDriftError) {
+      report.findings.push({ tool: label, detail: err.detail });
+      return;
+    }
+    throw err;
+  }
+}
+
+export async function run(): Promise<PreflightReport> {
+  const [live, local] = await Promise.all([
+    listLiveTools(),
+    localToolSchemas(),
+  ]);
+  const report: PreflightReport = {
+    checked: 0,
+    unknownLocally: [],
+    unresolved: [],
+    declined: [],
+    projectionChecked: 0,
+    projectionUnexercised: [],
+    findings: [],
+  };
+
+  for (const tool of live) {
+    const name = String(tool.name);
+    const published = local.get(name);
+    if (!published) {
+      report.unknownLocally.push(name);
+      continue;
+    }
+    const { args, undocumented } = buildToolArguments(tool.inputSchema as Row);
+    if (undocumented.length > 0) continue;
+    const structured = structuredOf(await callTool(name, args));
+    if (structured === null) {
+      // A decline is not a finding: production legitimately answers not_found
+      // for an example subject that has since changed. Counted so the total is
+      // legible rather than quietly smaller.
+      report.declined.push(name);
+      continue;
+    }
+    report.checked += 1;
+    parse(report, name, published, structured);
+
+    // THE PROJECTED PATH -- the one #9884 broke while CI stayed green. A tool
+    // answering `{items: []}` satisfies any row schema vacuously, and deriving
+    // MCP schemas from route schemas made 25 tools fail their own contract the
+    // moment a caller used the `fields` parameter they advertise. Sweeping only
+    // the plain path would measure the half that was never the problem.
+    const properties = ((tool.inputSchema as Row)?.properties ?? {}) as Row;
+    if (!properties.fields) continue;
+    const field = projectableFieldFrom(structured);
+    if (!field) {
+      report.projectionUnexercised.push(name);
+      continue;
+    }
+    const projected = structuredOf(
+      await callTool(name, {
+        ...args,
+        fields: projectionArgumentFor(tool.inputSchema as Row, field),
+      }),
+    );
+    if (projected === null) {
+      report.projectionUnexercised.push(`${name} (declined when projected)`);
+      continue;
+    }
+    report.projectionChecked += 1;
+    parse(report, `${name} (projected:${field})`, published, projected);
+  }
+  return report;
+}
+
+function main(): void {
+  run()
+    .then((report) => {
+      console.log(
+        `mcp-tripwire-preflight: ${report.checked} production response(s) ` +
+          `parsed against the schema this tree publishes ` +
+          `(${report.projectionChecked} of them also under their own ` +
+          `\`fields\` projection); ${report.findings.length} would be ` +
+          `REJECTED.`,
+      );
+      for (const finding of report.findings) {
+        console.log(
+          `  ${finding.tool}: ${JSON.stringify(finding.detail).slice(0, 400)}`,
+        );
+      }
+      if (report.declined.length) {
+        console.log(
+          `  ${report.declined.length} declined for their example arguments: ` +
+            report.declined.join(", "),
+        );
+      }
+      if (report.unknownLocally.length) {
+        console.log(
+          `  ${report.unknownLocally.length} advertised by production and ` +
+            `absent here: ${report.unknownLocally.join(", ")}`,
+        );
+      }
+      process.exitCode = report.findings.length ? 1 : 0;
+    })
+    .catch((err: unknown) => {
+      console.error("mcp-tripwire-preflight failed:", err);
+      process.exitCode = 1;
+    });
+}
+
+/* v8 ignore next 3 -- the CLI entry, exercised by the pipeline not the suite. */
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/validate-mcp.ts
+++ b/scripts/validate-mcp.ts
@@ -57,7 +57,13 @@ import {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Row = Record<string, any>;
 
-const env = createLocalArtifactEnv();
+// THE TRIPWIRE IS ON IN HERE (#10789). The harness already validates every
+// structuredContent against the tool's published outputSchema with ajv; turning
+// the flag on additionally routes all 235 tools through the ENFORCEMENT path
+// itself, on the degraded and cold-tier answers production does not show you
+// when you ask (#10786). A tripwire false-positive is then a loud CI failure
+// rather than something discovered after deploy.
+const env = createLocalArtifactEnv({ METAGRAPH_VALIDATE_RESPONSES: "true" });
 const MCP_URL = "https://api.metagraph.sh/mcp";
 
 // Compile each tool's declared outputSchema once; callOk asserts every

--- a/src/mcp-input-schema.ts
+++ b/src/mcp-input-schema.ts
@@ -175,11 +175,43 @@ const MCP_DEGRADED_BLOCK = z
   .strict()
   .optional();
 
+/**
+ * The Zod a published output schema was emitted FROM, carried on the emitted
+ * object (#10789).
+ *
+ * The response tripwire has to parse a tool's answer against the schema that
+ * describes it, and "which schema describes this tool" must be DERIVED -- the
+ * hand-listed version of this idea (#7860) fell behind the day it landed. Every
+ * tool's output schema passes through `outputJsonSchema` and nowhere else, so
+ * the emitted JSON carries a reference back to its source: a tool registered
+ * tomorrow is covered tonight, with no list to update.
+ *
+ * NON-ENUMERABLE and symbol-keyed, so it does not serialize. `tools/list`
+ * publishes these objects verbatim and a stray property would become part of
+ * the wire contract.
+ */
+const ZOD_SOURCE = Symbol.for("metagraphed.mcp.outputSchemaSource");
+
+/** The Zod behind a published output schema, or null if it came from elsewhere. */
+export function outputSchemaSource(published: unknown): z.ZodType | null {
+  if (!published || typeof published !== "object") return null;
+  const source = (published as Record<symbol, unknown>)[ZOD_SOURCE];
+  return (source as z.ZodType | undefined) ?? null;
+}
+
 export function outputJsonSchema(schema: z.ZodType) {
   const object = schema instanceof z.ZodObject ? schema : null;
   const published =
     object && !("degraded" in object.shape)
       ? object.extend({ degraded: MCP_DEGRADED_BLOCK })
       : schema;
-  return z.toJSONSchema(published, { target: "draft-2020-12" });
+  const json = z.toJSONSchema(published, { target: "draft-2020-12" });
+  // The DEGRADED-EXTENDED schema, not the argument: what the tripwire must
+  // parse against is what the tool publishes, and dispatch can stamp that
+  // block on any result.
+  Object.defineProperty(json, ZOD_SOURCE, {
+    value: published,
+    enumerable: false,
+  });
+  return json;
 }

--- a/src/mcp-response-tripwire.ts
+++ b/src/mcp-response-tripwire.ts
@@ -1,0 +1,122 @@
+// Parse every outgoing MCP result against the schema that tool publishes.
+//
+// REST has done this since #7860 was made derived: every envelope is parsed
+// against its Zod component before it is sent, and a drift is a 500 rather than
+// a body. GraphQL gets it from graphql-js, which enforces the generated
+// schema's nullability at execution. MCP -- 235 tools -- had nothing.
+//
+// WHY IT MATTERS MOST HERE. A REST consumer debugging a curl can see the shape
+// it got. An agent cannot: a field that quietly stops appearing degrades its
+// answer with no signal that anything changed. And MCP output schemas were
+// hand-copied from their routes rather than shared, so they could drift from
+// the component the REST tripwire enforces -- #10790 collapsed 42 of those
+// copies, and found `next_cursor` typed as an integer against a producer that
+// returns `string | null` while doing it.
+//
+// ## DERIVED, NOT LISTED
+//
+// `outputJsonSchema` is the one seam every tool's output schema passes through,
+// and it now carries a reference back to the Zod it emitted from
+// (`outputSchemaSource`). So "which schema describes this tool" is answered by
+// the registry itself: a tool added tomorrow is covered tonight, and there is
+// no list to fall behind. That is the whole lesson of #7860, whose five-route
+// hand list was stale the day it landed -- 156 of 161 routes served unchecked
+// for as long as it stood.
+//
+// A tool that publishes NO output schema is not validated, because it has
+// promised nothing to validate against. `validate:mcp` already fails a tool
+// missing one, so that set is empty and stays empty.
+//
+// ## IT THROWS, AND THAT WAS A DECISION
+//
+// The issue that asked for this (#10789) was explicit that REST's choice must
+// not be copied without being made, because the caller is different: an agent
+// mid-task may be worse served by a hard error than by a slightly-wrong answer.
+//
+// It throws anyway, for a reason that does not apply to REST. **A conformant
+// MCP client validates `structuredContent` against the `outputSchema` we
+// published.** So serving a drifted result does not buy the agent a usable
+// answer -- it buys a client-side validation failure we cannot see, cannot
+// attribute, and cannot fix, in a place where the only evidence is on the
+// caller's side. A tool error is the same failure, surfaced where it can be
+// read: MCP's error path is structured, `isError` is part of the protocol, and
+// an agent can branch on it. That is strictly more information than a shape the
+// client will reject on our behalf.
+//
+// The second reason is what this epic is about. Serving a response the
+// published contract does not describe is how a consumer comes to trust a shape
+// nothing guarantees, and an agent is the consumer least able to notice.
+//
+// ## THE ORDER THIS LANDED IN
+//
+// Measured before enforced, like the migration before it. Production was swept
+// against these schemas -- not against its own published copies, which would
+// have been a contract agreeing with itself and proving nothing -- before the
+// flag was allowed to matter anywhere.
+import { outputSchemaSource } from "./mcp-input-schema.ts";
+
+/** The stable code an agent branches on, and telemetry groups by. */
+export const MCP_RESPONSE_DRIFT_CODE = "response_schema_drift";
+
+/**
+ * A tool result that does not match the schema its tool publishes.
+ *
+ * CLASSIFIED (`toolError`) so the caller gets `response_schema_drift` rather
+ * than the generic `internal_error` every unexpected throw collapses into.
+ * That distinction is the reason this throws at all: an agent can tell "the
+ * answer I got is not the shape this tool promised" from "the upstream is
+ * down", and only one of those is worth retrying.
+ *
+ * CAPTURED (`captureAsFault`) because it is a real defect on our side, not an
+ * expected outcome like a rate limit -- it should page, and `cause` carries the
+ * error the exception pipeline records.
+ */
+export class McpResponseSchemaDriftError extends Error {
+  readonly tool: string;
+  readonly detail: unknown;
+  readonly toolError = true;
+  readonly code = MCP_RESPONSE_DRIFT_CODE;
+  readonly captureAsFault = true;
+  constructor(tool: string, detail: unknown) {
+    super(`${tool} result drifted from its published outputSchema`);
+    this.name = "McpResponseSchemaDriftError";
+    this.tool = tool;
+    this.detail = detail;
+    this.cause = this;
+  }
+}
+
+/**
+ * Parse one tool's structured result against the schema it publishes.
+ *
+ * Called ONLY when the caller has confirmed
+ * `env.METAGRAPH_VALIDATE_RESPONSES === "true"` -- the same flag REST's
+ * tripwire reads, because they are one decision about one contract.
+ *
+ * `published` is the tool's `outputSchema` as registered. Passing the emitted
+ * JSON rather than a name is what keeps this derived: the caller already holds
+ * the object, and the object knows its own source.
+ */
+export function validateMcpResponseTripwire(
+  tool: string,
+  published: unknown,
+  structuredContent: unknown,
+): void {
+  let schema;
+  try {
+    schema = outputSchemaSource(published);
+    // A tool whose schema did not come through `outputJsonSchema` -- nothing
+    // to parse against, and not this module's invariant to enforce.
+    if (!schema) return;
+  } catch (err) {
+    console.warn(
+      `[METAGRAPH_VALIDATE_RESPONSES] ${tool} tripwire failed to resolve:`,
+      err,
+    );
+    return;
+  }
+  const result = schema.safeParse(structuredContent);
+  if (!result.success) {
+    throw new McpResponseSchemaDriftError(tool, result.error);
+  }
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -696,6 +696,7 @@ import {
   outputJsonSchema,
   stripSentinelIntegerBounds,
 } from "./mcp-input-schema.ts";
+import { validateMcpResponseTripwire } from "./mcp-response-tripwire.ts";
 import {
   buildSubnetValidatorEconomicsPayload,
   resolveEconomicsBlob,
@@ -16362,6 +16363,19 @@ async function dispatchTool(
       markMcpTierDegraded(data, tierGenerationBefore),
       outputSchema,
     );
+    // THE OUTBOUND TRIPWIRE (#10789), the MCP half of what REST has done since
+    // #7860 and GraphQL gets from graphql-js. AFTER the degraded block is
+    // stamped and completed, because that block is part of what we serve --
+    // parsing before it would validate a payload no caller receives.
+    //
+    // Not under `waitUntil`: it throws, and the throw has to reach the caller
+    // below as a tool error rather than an unhandled rejection.
+    if (
+      (ctx?.env as unknown as Row | undefined)?.METAGRAPH_VALIDATE_RESPONSES ===
+      "true"
+    ) {
+      validateMcpResponseTripwire(tool.name, outputSchema, payload);
+    }
     return {
       content: toolResultContent(payload, outputSchema, ctx?.protocolVersion),
       structuredContent: payload as Row,
@@ -16377,9 +16391,10 @@ async function dispatchTool(
       // aiUnavailableToolError.
       if (error.captureAsFault) {
         scheduleExceptionEvent(ctx, {
-          // `cause` unconditionally, with no `?? error` fallback: the ONLY
-          // thing that sets captureAsFault is aiUnavailableToolError, and it
-          // always sets cause on the same object. A fallback here would be an
+          // `cause` unconditionally, with no `?? error` fallback: BOTH things
+          // that set captureAsFault set cause on the same object --
+          // aiUnavailableToolError, and the outbound response tripwire's
+          // McpResponseSchemaDriftError (#10789). A fallback here would be an
           // unreachable branch pretending to be caution.
           error: error.cause as Error,
           mcpTool: name,

--- a/tests/mcp-response-tripwire.test.ts
+++ b/tests/mcp-response-tripwire.test.ts
@@ -1,0 +1,137 @@
+// The MCP outbound tripwire, shown rejecting and shown passing (#10789).
+//
+// A tripwire that only ever reports zero is indistinguishable from one that is
+// looking at nothing, and this epic has met several. So every claim here is
+// driven both ways: it must throw on a drifted result, and it must not throw on
+// a conforming one.
+//
+// The DERIVATION is the part most worth pinning. "Which schema describes this
+// tool" is answered by the emitted schema itself, via the reference
+// `outputJsonSchema` attaches -- there is no list, which is the whole lesson of
+// #7860, whose five-route hand list was stale the day it landed. If that
+// reference is ever dropped, every tool silently stops being validated and the
+// tripwire reports success forever. The test below fails if it goes missing.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { z } from "zod";
+import {
+  outputJsonSchema,
+  outputSchemaSource,
+} from "../src/mcp-input-schema.ts";
+import {
+  McpResponseSchemaDriftError,
+  validateMcpResponseTripwire,
+} from "../src/mcp-response-tripwire.ts";
+
+const Card = z.object({ netuid: z.int(), name: z.string() }).strict();
+
+describe("the emitted schema carries its source", () => {
+  test("outputSchemaSource resolves the Zod that produced it", () => {
+    const published = outputJsonSchema(Card);
+    const source = outputSchemaSource(published);
+    assert.ok(source, "the derivation is the whole mechanism");
+    assert.equal(source.safeParse({ netuid: 1, name: "a" }).success, true);
+  });
+
+  test("it is the DEGRADED-EXTENDED schema, not the argument", () => {
+    // Dispatch can stamp `degraded` on any result, so the tripwire has to parse
+    // against what the tool PUBLISHES rather than against what was handed in.
+    const source = outputSchemaSource(outputJsonSchema(Card));
+    assert.equal(
+      source!.safeParse({
+        netuid: 1,
+        name: "a",
+        degraded: { reason: "tier_unavailable" },
+      }).success,
+      true,
+    );
+  });
+
+  test("it does not serialize into the published wire schema", () => {
+    // `tools/list` publishes these objects verbatim; a stray property would
+    // become part of the contract.
+    const published = outputJsonSchema(Card);
+    assert.equal(
+      JSON.stringify(published).includes("outputSchemaSource"),
+      false,
+    );
+    assert.deepEqual(
+      Object.keys(published),
+      Object.keys(JSON.parse(JSON.stringify(published))),
+    );
+  });
+
+  test("a schema that did not come through the seam resolves to null", () => {
+    assert.equal(outputSchemaSource({ type: "object" }), null);
+    assert.equal(outputSchemaSource(null), null);
+    assert.equal(outputSchemaSource("not a schema"), null);
+  });
+});
+
+describe("validateMcpResponseTripwire", () => {
+  test("THROWS on a result the tool's schema does not describe", () => {
+    const published = outputJsonSchema(Card);
+    assert.throws(
+      () =>
+        validateMcpResponseTripwire("get_subnet", published, {
+          netuid: 1,
+          name: "a",
+          leaked: "internal",
+        }),
+      McpResponseSchemaDriftError,
+    );
+  });
+
+  test("the error names the tool and carries the detail", () => {
+    const published = outputJsonSchema(Card);
+    try {
+      validateMcpResponseTripwire("get_subnet", published, { netuid: "one" });
+      assert.fail("expected a drift");
+    } catch (err) {
+      assert.ok(err instanceof McpResponseSchemaDriftError);
+      assert.equal(err.tool, "get_subnet");
+      assert.ok(err.detail, "the parse error rides along for triage");
+    }
+  });
+
+  test("does NOT throw on a conforming result", () => {
+    // The negative that makes the throw mean something: without it, a tripwire
+    // that rejected everything would pass every test above.
+    const published = outputJsonSchema(Card);
+    assert.doesNotThrow(() =>
+      validateMcpResponseTripwire("get_subnet", published, {
+        netuid: 1,
+        name: "a",
+      }),
+    );
+  });
+
+  test("a tripwire fault does NOT take the tool down with it", () => {
+    // The REST tripwire's principle, kept here: a drift propagates because that
+    // is the point, but the tripwire's OWN failure must not turn a working tool
+    // into an error. A Proxy that throws on property access is the only way to
+    // reach that arm -- which is itself the argument for keeping it.
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("schema lookup exploded");
+        },
+      },
+    );
+    assert.doesNotThrow(() =>
+      validateMcpResponseTripwire("get_subnet", hostile, { netuid: 1 }),
+    );
+  });
+
+  test("a tool with no resolvable schema is skipped, not failed", () => {
+    // It promised nothing, so there is nothing to hold it to. `validate:mcp`
+    // owns the separate invariant that every tool publishes one.
+    assert.doesNotThrow(() =>
+      validateMcpResponseTripwire("mystery", { type: "object" }, { any: 1 }),
+    );
+    assert.doesNotThrow(() =>
+      validateMcpResponseTripwire("mystery", undefined, { any: 1 }),
+    );
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -20813,6 +20813,59 @@ describe("MCP parity tools — provider + discovery bundle (artifact-backed)", (
     assert.equal(out.artifacts[0].id, "subnets");
   });
 
+  test("the outbound tripwire REJECTS a drifted result when the flag is on", async () => {
+    // #10789: the MCP half of what REST has done since #7860. Proven to FIRE,
+    // because a tripwire nobody has seen reject anything is indistinguishable
+    // from one wired to nothing -- and this one resolves its schema through a
+    // reference on the emitted object, which is exactly the kind of link that
+    // can go missing without a single test noticing.
+    const deps = makeDeps({
+      "/metagraph/contracts.json": {
+        schema_version: 1,
+        contract_version: "2026-07-03.2",
+        artifacts: [{ id: "subnets", path: "/metagraph/subnets.json" }],
+        leaked_internal_field: "should never reach a caller",
+      },
+    });
+    const res = await callTool(
+      "get_contracts",
+      {},
+      { deps, env: { METAGRAPH_VALIDATE_RESPONSES: "true" } },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.match(
+      res.body.result.content[0].text,
+      /response_schema_drift: .*drifted from its published outputSchema/,
+    );
+    // A STABLE CODE, not the generic internal_error every unexpected throw
+    // collapses into: an agent can tell "this answer is not the shape the tool
+    // promised" from "the upstream is down", and only one is worth retrying.
+    assert.equal(
+      res.body.result.structuredContent.error.code,
+      "response_schema_drift",
+    );
+  });
+
+  test("and SERVES the same drift when the flag is off", async () => {
+    // The other half: the tripwire is gated, so a deployment that has not opted
+    // in behaves exactly as before. Without this, the test above would pass
+    // just as well against a tripwire that ignored the flag entirely.
+    const deps = makeDeps({
+      "/metagraph/contracts.json": {
+        schema_version: 1,
+        contract_version: "2026-07-03.2",
+        artifacts: [{ id: "subnets", path: "/metagraph/subnets.json" }],
+        leaked_internal_field: "should never reach a caller",
+      },
+    });
+    const res = await callTool("get_contracts", {}, { deps });
+    assert.notEqual(res.body.result.isError, true);
+    assert.equal(
+      res.body.result.structuredContent.leaked_internal_field,
+      "should never reach a caller",
+    );
+  });
+
   test("get_contracts reports not_found when the artifact is absent", async () => {
     const res = await callTool("get_contracts", {}, { deps: makeDeps() });
     assert.equal(res.body.result.isError, true);


### PR DESCRIPTION
REST has parsed every outgoing envelope against its Zod component since #7860 was made derived. GraphQL gets the same from graphql-js at execution. **MCP — 235 tools — had nothing.**

## Why the gap matters most here

A REST consumer debugging a curl can see the shape it got. An agent cannot: a field that quietly stops appearing degrades its answer with no signal that anything changed. And the MCP output schemas were hand-copied from their routes rather than shared, so they could drift from the component the REST tripwire enforces — #10790 collapsed 42 of those copies and found `next_cursor` typed as an integer against a producer returning `string | null` on the way past.

## Derived, not listed

`outputJsonSchema` is the one seam every tool's output schema passes through. It now carries a **symbol-keyed, non-enumerable** reference back to the Zod it emitted from, so "which schema describes this tool" is answered by the registry itself — a tool added tomorrow is covered tonight, with no list to fall behind.

That is the whole lesson of #7860, whose five-route hand list was stale the day it landed and left 156 of 161 routes unchecked. Non-enumerable because `tools/list` publishes these objects verbatim and a stray property would join the wire contract. **A test asserts the reference survives**: if it is ever dropped, every tool silently stops being validated and the tripwire reports success forever.

## It throws, and that was decided rather than copied

The issue was explicit that REST's choice must be re-argued, because an agent mid-task may be worse served by a hard error than by a slightly-wrong answer.

It throws anyway, for a reason that does not apply to REST: **a conformant MCP client validates `structuredContent` against the `outputSchema` we publish.** Serving drift does not buy the agent a usable answer — it buys a client-side validation failure we cannot see, attribute, or fix, where the only evidence is on the caller's side. A tool error is the same failure, surfaced where it can be read.

That argument only holds if the error is legible, and **the first integration test proved it was not**: dispatch collapsed it into `internal_error: The tool failed to complete.`, which an agent cannot branch on. It is a classified **`response_schema_drift`** now, captured as a fault. The dispatch comment asserting `aiUnavailableToolError` was the only thing setting `captureAsFault` is corrected — it no longer is.

## Measured before enforced

`METAGRAPH_VALIDATE_RESPONSES` is already `"true"` in `wrangler.jsonc`, so this enforces the moment it deploys. There is no ramp, which makes the pre-flight the actual gate.

The scheduled `check-mcp-conformance` could not answer the question: it validates production against **the schemas production publishes** — a contract agreeing with its own producer, which says nothing about a tree whose schemas just got materially stricter. So `report:mcp-tripwire-preflight` asks the other one, calling `validateMcpResponseTripwire` itself so measurement and enforcement cannot disagree:

```
229 production response(s) parsed against the schema this tree publishes
(36 of them also under their own `fields` projection); 0 would be REJECTED.
```

The **projected path is swept deliberately**: a tool answering `{items: []}` satisfies any row schema vacuously, and #9884 is the worked example — deriving MCP schemas from route schemas made 25 tools fail their own contract the moment a caller used the `fields` parameter they advertise, while CI stayed green throughout.

Production is not degraded when you ask it (#10786), so the hermetic harness carries the other half — and it now runs **with the flag on**, routing all 235 tools through the enforcement path against cold-tier and declined answers.

## Proven to fire

Not assumed. Three ways:

- through real dispatch with the flag **on** — `isError` with the stable code
- through real dispatch with the flag **off** — the same drift served unchanged, so the gate is genuinely gated
- by breaking one schema: `validate:mcp` turns red with `response_schema_drift: get_contracts result drifted from its published outputSchema`

## Verification

- `npm run validate` exit 0; all 55 CI validators green
- Full suite **873 files, 19,898 tests**
- **Full patch coverage by diff intersection** on all three changed `src/` files — including a Proxy-based test for the fault-isolation arm, which keeps the REST tripwire's principle that a tripwire's own failure must not take a working tool down with it

The full sweep, its method, and the throw-vs-report argument are [published on the issue](https://github.com/JSONbored/metagraphed/issues/10789#issuecomment-5260745380).

Closes #10789
