### PR TITLE
cleanup(graphql): delete the providers resolver's dead fields branch

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -143,8 +143,11 @@ import { loadSurfacesList } from "./surfaces-mcp.ts";
 // collection), matching endpoint_pools / rpc_pools / provider_endpoints.
 import { loadRpcEndpointsList } from "./rpc-endpoints-mcp.ts";
 // #7888: GraphQL parity for GET /api/v1/providers list filters (id/kind/
-// authority/sort/order/fields + limit/cursor), reusing loadProvidersList that
-// MCP list_providers already calls -- not a reimplementation.
+// authority/sort/order + limit/cursor), reusing loadProvidersList that
+// MCP list_providers already calls -- not a reimplementation. The loader's
+// `fields` projection stays MCP-only: the tool declares it (#9701 narrowing),
+// GraphQL stopped publishing it when the selection set became the projection
+// (#10214), and the route never had it.
 import { loadProvidersList } from "./providers-mcp.ts";
 // #7167: GraphQL parity for the /api/v1/review/* contributor-review family,
 // reusing each list_* MCP loader unchanged (same artifact read, filter, sort,
@@ -4452,18 +4455,17 @@ const rootValue = {
     let rows: Row[] = [];
     try {
       // Omit GraphQL limit/cursor so the loader returns the full filtered set.
-      // When a fields projection is supplied, keep/force `id` so the opaque
-      // string keyset cursor still resolves.
-      const loadArgs: Row = { ...filters };
-      if (typeof loadArgs.fields === "string" && loadArgs.fields.trim()) {
-        const trimmed = loadArgs.fields.trim();
-        loadArgs.fields = /(^|,)\s*id\s*(,|$)/i.test(trimmed)
-          ? trimmed
-          : `id,${trimmed}`;
-      }
-      const data = await loadProvidersList(mcpCtx(context), loadArgs, {
-        readArtifact,
-      });
+      // An id-prefixing branch for a `fields` projection lived here until
+      // #10214 removed the argument (the selection set is the projection on a
+      // typed return); the spread into `Row` had kept the dead read compiling,
+      // which is exactly what #10864 was filed about.
+      const data = await loadProvidersList(
+        mcpCtx(context),
+        { ...filters },
+        {
+          readArtifact,
+        },
+      );
       rows = data.providers as Row[];
     } catch (rawErr) {
       const err = rowOf(rawErr);


### PR DESCRIPTION
## Summary

- Deletes the one piece of GraphQL-side `fields` plumbing #10863 orphaned: the providers resolver's id-prefix-for-keyset branch, which read a `fields` argument the schema no longer publishes.
- Measured before cutting (detail on the issue): the loaders' `fields` support **stays** — `list_providers`, `list_surfaces` and `list_endpoints` all publish `fields` in their served inputSchema as deliberate #9701 agent-narrowing, so only the resolver side was dead. The `endpoints`/`surfaces` resolvers carry no equivalent branch (audited).

## What Changed

The branch survived `tsc` because the typed args spread lands in a `Record<string, unknown>` before the read — compiler-invisible dead code, which is what the issue was filed about. The deletion carries a comment naming why the loader keeps its projection (MCP-only) and the import-site prose drops `fields` from the parity list it enumerates.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts were produced by repo scripts, not hand-edited (none touched).
- [x] R2-only/high-churn detail artifacts are not committed.
- [x] Public API/OpenAPI/schema changes: none — resolver-internal deletion only.

## Validation

- [x] `npm run typecheck` — 0 errors
- [x] `npx vitest run tests/graphql.test.ts` — 1107/1107
- [x] `npm run format:check` · `npm run lint`
- [x] `git diff --check`

## Template Used

- backend-code

Closes #10864