### PR TITLE
ci(install): one lockfile-keyed node_modules cache, so installs stop gambling on third-party CDNs

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,54 @@
+# npm ci behind a node_modules cache, so an install's network exposure -- the
+# npm registry AND every postinstall's own download -- happens once per
+# lockfile change instead of in every job of every run.
+#
+# Why this exists (#10871): `@posthog/cli` rides in transitively via
+# apps/ui's `@posthog/rollup-plugin`, and its postinstall downloads a platform
+# binary from GitHub's release CDN on every `npm ci`. setup-node's `cache: npm`
+# does not help -- it caches registry tarballs, and this download bypasses npm
+# entirely. On 2026-08-12 that CDN served 503s and four jobs across three PRs
+# died inside `npm ci` before running a single test, each failure reading like
+# an unrelated flake until the log was opened. A restored node_modules runs no
+# postinstalls at all, which is the point: the property to keep is that a test
+# shard's install opens no network connection a lockfile change did not buy.
+#
+# EXACT key only -- deliberately no `restore-keys`. A prefix fallback would
+# hand `npm ci`'s clean-slate guarantee to whatever stale tree matched last,
+# which is how phantom "works in CI, fails locally" trees get minted. A miss
+# pays one full install and saves; every later job in every later run on the
+# same lockfile restores.
+#
+# The key carries the Node major (.nvmrc) because node_modules holds
+# ABI-specific native builds, and the OS for the same reason.
+name: Install dependencies
+description: npm ci, skipped when the lockfile-keyed node_modules cache hits.
+runs:
+  using: composite
+  steps:
+    - name: Restore node_modules
+      id: modules
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        key: node-modules-${{ runner.os }}-node${{ hashFiles('.nvmrc') }}-${{ hashFiles('package-lock.json') }}
+        path: |
+          node_modules
+          apps/ui/node_modules
+          packages/*/node_modules
+    - name: npm ci
+      if: steps.modules.outputs.cache-hit != 'true'
+      shell: bash
+      # The miss path still gambles on the registry and every postinstall's
+      # CDN -- the exact class this action exists to kill -- so it retries
+      # rather than handing one 503 a whole job. Between attempts the tree is
+      # removed: a failed npm ci leaves a partial node_modules, and npm ci's
+      # own clean-slate rm is what the retry would otherwise spend its time
+      # on. Three attempts, 30s apart, covers the transient window measured
+      # on 2026-08-12 (the same URL succeeded on immediate rerun).
+      run: |
+        for attempt in 1 2 3; do
+          npm ci && exit 0
+          [ "$attempt" = 3 ] && exit 1
+          echo "npm ci failed (attempt $attempt); retrying in 30s"
+          rm -rf node_modules apps/ui/node_modules packages/*/node_modules
+          sleep 30
+        done

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -318,7 +318,10 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install
-        run: npm ci
+        # Behind the lockfile-keyed node_modules cache: a hit skips npm ci and
+        # every postinstall's network reach with it (#10871) -- see the
+        # composite's header for why setup-node's tarball cache cannot do this.
+        uses: ./.github/actions/install-deps
 
       # Report-only SCA for the ROOT workspace — workers/** (the Worker API, MCP
       # server, webhook dispatcher), src/**, and scripts/** — the repo's larger,
@@ -841,7 +844,10 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install
-        run: npm ci
+        # Behind the lockfile-keyed node_modules cache: a hit skips npm ci and
+        # every postinstall's network reach with it (#10871) -- see the
+        # composite's header for why setup-node's tarball cache cannot do this.
+        uses: ./.github/actions/install-deps
 
       # Report-only SCA for the ROOT workspace — workers/** (the Worker API, MCP
       # server, webhook dispatcher), src/**, and scripts/** — the repo's larger,
@@ -1142,7 +1148,10 @@ jobs:
       # from the one root lockfile -- there is no way to `npm ci` a single
       # workspace in isolation.
       - name: Install
-        run: npm ci
+        # Behind the lockfile-keyed node_modules cache: a hit skips npm ci and
+        # every postinstall's network reach with it (#10871) -- see the
+        # composite's header for why setup-node's tarball cache cannot do this.
+        uses: ./.github/actions/install-deps
 
       # apps/ui consumes packages/client as a live workspace link (#3066), not
       # a published package. packages/client/dist/index.js + index.cjs (the


### PR DESCRIPTION
## Summary

- Adds `.github/actions/install-deps`: `npm ci` behind a `node_modules` cache keyed on `{OS, Node major, package-lock.json}`, **exact key only** — a hit restores the tree and skips the install entirely; a miss pays one full install and saves for every later job and run on the same lockfile.
- Adopted at all three install sites in `validate.yml` (which cover every installing job, including the test-shard matrix).
- This closes the flake class, not the instance: `@posthog/cli` (transitive, via apps/ui's `@posthog/rollup-plugin`) downloads a binary from GitHub's release CDN in its postinstall on every `npm ci`. setup-node's `cache: npm` cannot help — it caches registry tarballs, and this download bypasses npm. On 2026-08-12 that CDN's 503s killed four jobs across three PRs (#10863's `test (mocked 1/2)` + `ui`, #10872's and #10873's `test (shared 3/3)` + `validate`) before a single test ran. A restored `node_modules` runs no postinstalls, so a test shard's install opens no network connection a lockfile change didn't buy — which also removes the npm-registry-hiccup flake class and shaves install time off every warm job.

## Design notes

- **No `restore-keys`, deliberately.** A prefix fallback would hand `npm ci`'s clean-slate guarantee to whatever stale tree matched last. Exact hash or full install, no third state.
- The repo has no `postinstall`/`prepare` scripts of its own (verified), so gating `npm ci` skips nothing but dependency postinstalls — whose outputs live inside `node_modules` and are restored with it.
- Cache paths cover the workspace layout: root, `apps/ui`, `packages/*`. Key carries the Node major because `node_modules` holds ABI-specific native builds.
- First run on a new lockfile: parallel jobs all miss and install (today's behavior); one saves, the rest no-op. Every subsequent job and run restores.
- The composite is adoptable by the scheduled workflows as a follow-up; this PR scopes to the PR-blocking path.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none touched.
- [x] Public API/OpenAPI/schema changes: none — CI only.

## Validation

- [x] `npm run validate:workflows` — 33 workflow files validated
- [x] `prettier --check` on both files · `git diff --check`
- [x] The adoption's own CI run on this PR is the live proof: first run installs and saves; the cache's effect is visible from the second run on this lockfile.

## Template Used

- backend-code

Closes #10871