### PR TITLE
feat(schemas): a spread must be typed or declared — the nullability walk's blind spot becomes a rule

### DIFF
--- a/scripts/report-nullable-overpromises.ts
+++ b/scripts/report-nullable-overpromises.ts
@@ -42,10 +42,11 @@
 //
 // A property whose expression the checker types as `any`, or whose target this
 // walk cannot resolve (a spread of an untyped bag, a field the generated schema
-// does not declare), is counted as UNDECIDED rather than clean. That number is
-// the honest edge of this measurement: those fields are unvalidated at the
-// serving boundary, which is a different defect with its own issue (#10789),
-// not a nullability finding to be quietly called zero here.
+// does not declare), is counted as UNDECIDED rather than clean -- and since
+// #10867 an undecided SPREAD fails the validator unless it carries a
+// `DECLARED_PASSTHROUGHS` entry naming where its guarantee actually lives.
+// The honest edge of the measurement stays visible either way; it is no
+// longer allowed to be a quiet number.
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -88,9 +89,77 @@ export interface Undecided {
   reason: "spread" | "undeclared-field" | "any-typed";
 }
 
+/** A declared artifact/builder passthrough the walk counts, not skips. */
+export interface Passthrough {
+  path: string;
+  file: string;
+  line: number;
+}
+
+const ARTIFACT_PASSTHROUGH =
+  "an artifact passthrough: the spread republishes a document a typed " +
+  "builder produced against the SAME Zod component this GraphQL type was " +
+  "generated from (one schema source, #10214), so the non-null guarantee is " +
+  "tsc's on the build side; graphql-js re-enforces it at execution, which " +
+  "also covers the residual this walk cannot -- a stored artifact predating " +
+  "a tightening.";
+
+/**
+ * Spreads this walk counts as DECIDED-ELSEWHERE, each with the evidence.
+ *
+ * The walker cannot type a spread of parsed JSON, and chasing it
+ * interprocedurally dead-ends at `readArtifact`'s `unknown` -- deciding the
+ * fields off the component there would judge the schema against itself
+ * (#10867). The guarantee these sites rely on is real and lives in two other
+ * compilations: the artifact BUILDER is tsc-checked against the same Zod
+ * component the GraphQL type derives from, and the executor enforces the
+ * published nullability on every request. An entry here declares exactly
+ * that, per owner type; `validate:nullable-overpromises` FAILS on a spread
+ * with no entry and on an entry with no spread, so the list can only
+ * describe what exists.
+ */
+export const DECLARED_PASSTHROUGHS: Readonly<Record<string, string>> = {
+  // subnetNode spreads the subnet row the subnets/detail artifacts carry.
+  Subnet: ARTIFACT_PASSTHROUGH,
+  // The shared list composer lifts envelope fields off the list artifact.
+  SubnetList: ARTIFACT_PASSTHROUGH,
+  // validatorNode spreads metagraph rows that deliberately carry more
+  // columns than the type exposes; the declared columns are the builder's.
+  Validator: ARTIFACT_PASSTHROUGH,
+  // providerNode spreads the ProvidersArtifact row.
+  Provider: ARTIFACT_PASSTHROUGH,
+  // Each window's delta object off the trajectory artifact's deltas record.
+  SubnetTrajectoryDelta: ARTIFACT_PASSTHROUGH,
+  // loadSurfacesList's envelope, with `surfaces` renamed to `items` beside
+  // the spread.
+  SurfaceList: ARTIFACT_PASSTHROUGH,
+  // loadChangelog's document, with the coverage_delta lift beside it.
+  Changelog: ARTIFACT_PASSTHROUGH,
+  // The evidence ledger document behind the incidents filter.
+  GlobalIncidents: ARTIFACT_PASSTHROUGH,
+  // buildGlobalHealth's rollup -- built IN THIS COMPILATION by
+  // src/global-operational-health.ts, so the guarantee is local tsc; the
+  // spread is still untypeable to the walker because `(result.global || {})`
+  // widens through the fallback arm.
+  GlobalHealth:
+    "a passthrough of buildGlobalHealth's rollup, typed in this compilation " +
+    "(src/global-operational-health.ts); the `|| {}` fallback arm widens the " +
+    "spread past what the walker can read, and the executor enforces the " +
+    "published nullability on every request either way.",
+  // The shared stake-quote calculator's quote, typed in this compilation.
+  SubnetStakeQuote:
+    "a passthrough of the shared stake-quote calculator's `quote`, typed in " +
+    "this compilation; `schema_version` is written beside the spread and the " +
+    "executor enforces the published nullability on every request.",
+};
+
 export interface NullabilityReport {
   findings: OverPromise[];
   undecided: Undecided[];
+  /** Declared passthrough spreads, counted against `DECLARED_PASSTHROUGHS`. */
+  passthroughs: Passthrough[];
+  /** Declared passthrough owners the walk never saw a spread on -- stale. */
+  stalePassthroughs: string[];
   /** Property writes compared against a declared field. */
   examined: number;
   /** Root fields reached from `rootValue`. */
@@ -207,10 +276,17 @@ function ownReturns(body: ts.Node): ts.Expression[] {
 export function findOverPromises(
   program: ts.Program,
   queryType: GraphQLObjectType,
+  // Injectable so a test can drive the ratchet with a MUTATED declaration --
+  // a gate only ever run against a passing tree proves it runs, not that it
+  // can fail (the same rule buildGeneratedSchema's declarations follow).
+  declaredPassthroughs: Readonly<
+    Record<string, string>
+  > = DECLARED_PASSTHROUGHS,
 ): NullabilityReport {
   const checker = program.getTypeChecker();
   const findings: OverPromise[] = [];
   const undecided: Undecided[] = [];
+  const passthroughs: Passthrough[] = [];
   const decided = new Set<string>();
   let examined = 0;
   let fields = 0;
@@ -300,12 +376,20 @@ export function findOverPromises(
     const file = relative(literal.getSourceFile());
     for (const member of literal.properties) {
       if (ts.isSpreadAssignment(member)) {
-        undecided.push({
-          path: owner.name,
-          file,
-          line: lineOf(member),
-          reason: "spread",
-        });
+        // A declared passthrough is COUNTED, not skipped -- the entry names
+        // where the guarantee lives (see DECLARED_PASSTHROUGHS). Anything
+        // else stays undecided, and the validator fails on it: type the
+        // source or declare it with evidence, no third state.
+        if (owner.name in declaredPassthroughs) {
+          passthroughs.push({ path: owner.name, file, line: lineOf(member) });
+        } else {
+          undecided.push({
+            path: owner.name,
+            file,
+            line: lineOf(member),
+            reason: "spread",
+          });
+        }
         continue;
       }
       const isShorthand = ts.isShorthandPropertyAssignment(member);
@@ -373,7 +457,22 @@ export function findOverPromises(
   // write is the arm that executes when the tier is sick, which is the whole
   // question. Findings win over the clean sites they share a name with.
   for (const finding of findings) decided.delete(finding.path);
-  return { findings, undecided, examined, fields, decided };
+  // An entry with no spread is stale: the passthrough it excused is gone, so
+  // the excuse must go with it -- the shrink-only rule every declared list
+  // here follows.
+  const matched = new Set(passthroughs.map((p) => p.path));
+  const stalePassthroughs = Object.keys(declaredPassthroughs).filter(
+    (name) => !matched.has(name),
+  );
+  return {
+    findings,
+    undecided,
+    passthroughs,
+    stalePassthroughs,
+    examined,
+    fields,
+    decided,
+  };
 }
 
 /** The tightened contract: the schema the Zod components build. */
@@ -394,7 +493,9 @@ function main(): void {
     `nullable-overpromises: ${report.fields} root field(s) walked, ` +
       `${report.examined} property write(s) compared against the field the ` +
       `components declare; ${report.findings.length} write null into a ` +
-      `NON-NULL field; ${report.undecided.length} could not be decided.`,
+      `NON-NULL field; ${report.undecided.length} could not be decided; ` +
+      `${report.passthroughs.length} declared passthrough(s) over ` +
+      `${Object.keys(DECLARED_PASSTHROUGHS).length} entr(ies).`,
   );
   if (report.findings.length) {
     console.log(
@@ -410,7 +511,7 @@ function main(): void {
   }
   if (byReason.size) {
     console.log(
-      `\nUNDECIDED (unvalidated at the boundary -- #10789's job, not counted clean): ` +
+      `\nUNDECIDED (not counted clean; a spread here must be typed or declared -- #10867): ` +
         [...byReason].map(([reason, n]) => `${reason} ${n}`).join(", "),
     );
   }

--- a/scripts/validate-nullable-overpromises.ts
+++ b/scripts/validate-nullable-overpromises.ts
@@ -18,13 +18,14 @@
 // TypeScript checker's view of what each resolver writes. Both sides are
 // derived; there is no list here to keep up to date.
 //
-// WHAT IT DOES NOT FAIL ON, deliberately: a property the walk cannot decide --
-// a spread of an untyped bag, or an expression the checker types as `any`.
-// Those are unvalidated at the serving boundary, which is a real defect with
-// its own issue (#10789) and a different fix. Counting them here would make
-// this gate fail for a reason it cannot tell you how to resolve. They are
-// REPORTED on every run so the blind spot stays visible rather than becoming
-// the quiet zero this gate exists to prevent.
+// UNDECIDED reached zero too (#10867), so it is also a rule now: a spread the
+// walk cannot type must carry a `DECLARED_PASSTHROUGHS` entry naming where
+// its guarantee actually lives (the artifact builder tsc-checks against the
+// same Zod component; the executor enforces the published nullability per
+// request) -- and an entry with no matching spread fails as stale, so the
+// list can only describe what exists. An `any`-typed write or a field the
+// schema does not build still reports without failing: each has a different
+// fix, and the count of both is zero on the tree this shipped against.
 
 import { pathToFileURL } from "node:url";
 import {
@@ -53,11 +54,35 @@ function main(): void {
     );
     process.exit(1);
   }
+  const undeclaredSpreads = report.undecided.filter(
+    (entry) => entry.reason === "spread",
+  );
+  if (undeclaredSpreads.length) {
+    console.error(
+      `nullable-overpromises: ${undeclaredSpreads.length} spread(s) the walk ` +
+        `cannot type and no DECLARED_PASSTHROUGHS entry covers. Type the ` +
+        `source, or declare the passthrough with the evidence for where its ` +
+        `non-null guarantee lives (#10867):\n` +
+        undeclaredSpreads
+          .map((entry) => `  ${entry.file}:${entry.line} ${entry.path}`)
+          .join("\n"),
+    );
+    process.exit(1);
+  }
+  if (report.stalePassthroughs.length) {
+    console.error(
+      `nullable-overpromises: ${report.stalePassthroughs.length} declared ` +
+        `passthrough(s) with no matching spread -- the excuse outlived what ` +
+        `it excused; delete the entr(ies): ` +
+        report.stalePassthroughs.join(", "),
+    );
+    process.exit(1);
+  }
   console.log(
     `nullable-overpromises: 0 over-promise(s) across ${report.examined} ` +
       `property write(s) in ${report.fields} root field(s), against the field ` +
-      `each one's component declares; ${report.undecided.length} property ` +
-      `write(s) undecided (unvalidated at the boundary, #10789).`,
+      `each one's component declares; ${report.passthroughs.length} declared ` +
+      `passthrough(s), ${report.undecided.length} undecided.`,
   );
 }
 

--- a/tests/nullable-overpromises.test.ts
+++ b/tests/nullable-overpromises.test.ts
@@ -275,6 +275,53 @@ describe("findOverPromises", () => {
     assert.deepEqual(report.findings, []);
     assert.equal(report.undecided.length, 1);
     assert.equal(report.undecided[0]!.reason, "spread");
+    // No declaration covers Card, so nothing counts as a passthrough -- and
+    // every real declared owner is stale against this one-field double, which
+    // is the shrink-only rule doing its job, not noise.
+    assert.deepEqual(report.passthroughs, []);
+  });
+
+  test("a spread on a DECLARED owner is a counted passthrough, not undecided (#10867)", () => {
+    const report = findOverPromises(
+      programFor(`
+        const data: Record<string, unknown> = {};
+        const rootValue = {
+          card() {
+            return { ...data, complete: true };
+          },
+        };
+      `),
+      Query,
+      { Card: "under test: the guarantee lives in this test's assertions" },
+    );
+    assert.deepEqual(report.findings, []);
+    assert.deepEqual(
+      report.undecided,
+      [],
+      "a declared spread must not stay undecided",
+    );
+    assert.equal(report.passthroughs.length, 1);
+    assert.equal(report.passthroughs[0]!.path, "Card");
+    assert.deepEqual(report.stalePassthroughs, []);
+  });
+
+  test("a declared passthrough with no matching spread is STALE (#10867)", () => {
+    const report = findOverPromises(
+      programFor(`
+        const rootValue = {
+          card() {
+            return { total: 1, optional_total: null, complete: true };
+          },
+        };
+      `),
+      Query,
+      { Card: "the spread this excused is gone" },
+    );
+    assert.deepEqual(
+      report.stalePassthroughs,
+      ["Card"],
+      "an excuse must not outlive what it excused",
+    );
   });
 
   test("a root field `rootValue` does not answer is simply not walked", () => {


### PR DESCRIPTION
## Summary

- The 10 spreads `report:nullable-overpromises` could not type were a quiet number in the gate's output, annotated with a pointer at an issue that has since closed. They are now a **declared category with a hard ratchet**: each carries a `DECLARED_PASSTHROUGHS` entry naming where its non-null guarantee actually lives, an untyped spread with **no** entry fails CI, and an entry with **no** matching spread fails as stale. Undecided reached zero and became a rule — the `validate-type-duplicates` idiom.

## Why declared, not typed — the design decision, with the dead ends named

The issue's first option was typing the spread sources. Traced to ground truth, that path has no honest implementation:

- The spreads republish loader output, and every artifact loader returns `Promise<unknown>` — a declaration-level annotation over parsed JSON is a cast in a costume, and casts are what this gate exists to forbid.
- Chasing the spread interprocedurally dead-ends at `readArtifact`'s `unknown`; resolving the loader's artifact to its component and deciding fields off the **component** would judge the schema against itself — not a producer check at all.
- The guarantee these sites rely on is real and lives in two other places: the artifact **builder** is `tsc`-checked against the same Zod component the GraphQL type derives from (one schema source, #10863), and **graphql-js enforces the published nullability at execution** — which also covers the one residual no static analysis can (a stored artifact predating a tightening).

Two of the ten (`GlobalHealth`, `SubnetStakeQuote`) spread in-repo **typed builders** — untypeable to the walker only through a `|| {}` widening arm — and their entries say that instead.

## What Changed

- `scripts/report-nullable-overpromises.ts`: `DECLARED_PASSTHROUGHS` (10 owners, per-entry evidence, injectable for the prove-it-can-fail tests), spreads on declared owners counted as `passthroughs`, stale detection, stale `#10789` prose replaced.
- `scripts/validate-nullable-overpromises.ts`: fails on an undeclared spread (with the type-it-or-declare-it instruction) and on a stale entry; summary line reports `10 declared passthrough(s), 0 undecided`.
- `tests/nullable-overpromises.test.ts`: both failure modes proven — a declared spread counts and does not stay undecided; a declaration whose spread is gone reports stale.

## Registry Safety

- [x] Links a tracked, currently-open issue (`Closes #<n>`) — required.
- [x] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
- [x] Generated artifacts: none touched. Public contract: unchanged.

## Validation

- [x] `npm run validate:nullable-overpromises` — 0 over-promises / 1,034 writes, 10 declared, 0 undecided
- [x] `npx vitest run tests/nullable-overpromises.test.ts` — 13/13
- [x] `npm run typecheck` — 0 errors · `npm run lint` · `npm run format:check` · `git diff --check`

## Template Used

- backend-code

Closes #10867