### PR TITLE
types(schemas): brand the identifier vocabulary — a transposition no longer compiles

### DIFF
--- a/schemas-src/mcp-tools/get-adapter.ts
+++ b/schemas-src/mcp-tools/get-adapter.ts
@@ -28,7 +28,14 @@ export const GetAdapterInputSchema = z
       .describe(
         "The registry slug — lowercase, hyphenated (`gittensor`), not the display name. Slugs are stable across renames. Only subnets with a captured adapter snapshot have one; `list_subnets` is the way to find which.",
       )
-      .meta({ examples: ["gittensor"] }),
+      .meta({ examples: ["gittensor"] })
+      // Branded (#10866): this is a SUBNET slug, and `slug` is two
+      // vocabularies -- `provider(slug:)` takes a provider slug, this takes a
+      // subnet slug, and the confusion blinded a production probe once
+      // (#10769: `adapter(slug: "apex")` resolved null and the silence read
+      // as absence of evidence). The brand makes the transposition a compile
+      // error; the wire format does not move.
+      .brand<"SubnetSlug">(),
   })
   .strict();
 export type GetAdapterInput = z.infer<typeof GetAdapterInputSchema>;

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -163,7 +163,16 @@ export const ss58Schema = () =>
       "An SS58 account address (47-48 base58 characters). Coldkey or hotkey " +
         "depending on the tool — see the tool description for which this expects.",
     )
-    .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] });
+    .meta({ examples: ["5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F"] })
+    // Branded (#10866): every identifier the API takes was `string`, so
+    // transposing any two compiled. The brand is type-level only -- the wire
+    // format, the emitted JSON Schema and the published examples do not move
+    // -- but a parsed address now refuses to BE a slug, and vice versa, at
+    // compile time across all three surfaces at once.
+    .brand<"Ss58Address">();
+
+/** A parsed SS58 address — what `ss58Schema()` proves, as a nominal type. */
+export type Ss58Address = z.infer<ReturnType<typeof ss58Schema>>;
 
 /**
  * Sort direction. 31 of the 32 `order` parameters are this exact pair and mean
@@ -756,7 +765,15 @@ export const providerSlugSchema = () =>
       "Restrict to one provider, by SLUG (`opentensor-foundation`), not " +
         "display name. Unknown slugs yield an empty result, not an error.",
     )
-    .meta({ examples: ["opentensor-foundation"] });
+    .meta({ examples: ["opentensor-foundation"] })
+    // Branded (#10866): a provider slug and a subnet slug are both short
+    // lowercase strings, and handing one to the other's lookup compiled --
+    // the `adapter(slug:)`/`provider(slug:)` vocabulary confusion blinded a
+    // production probe exactly that way once (#10769).
+    .brand<"ProviderSlug">();
+
+/** A parsed provider slug, nominally distinct from a subnet slug. */
+export type ProviderSlug = z.infer<ReturnType<typeof providerSlugSchema>>;
 
 /** A surface id, the stable key a surface keeps across renames. */
 export const surfaceIdSchema = () =>
@@ -773,7 +790,7 @@ export const surfaceIdSchema = () =>
  * in that the tools using it name the ROLE in the parameter, so the sentence
  * says which one rather than deferring to the tool description.
  */
-export const accountKeySchema = (role: "hotkey" | "coldkey") =>
+export const accountKeySchema = <R extends "hotkey" | "coldkey">(role: R) =>
   z
     .string()
     .regex(SS58_PATTERN)
@@ -786,7 +803,19 @@ export const accountKeySchema = (role: "hotkey" | "coldkey") =>
     )
     .meta({
       examples: ["5CS3g6nVJM6ouns8n9buN9CzFf2C1YDHVcVGRcxoirKs2xbV"],
-    });
+    })
+    // Double-branded (#10866): a hotkey IS an address, so it stays assignable
+    // wherever the generic `Ss58Address` is asked for -- and refuses to be a
+    // COLDKEY, which is the transposition that used to compile. Both keys
+    // parse the same base58 pattern; the brand carries the ROLE the pattern
+    // cannot.
+    .brand<"Ss58Address">()
+    .brand<{ hotkey: "Hotkey"; coldkey: "Coldkey" }[R]>();
+
+/** A parsed hotkey — an `Ss58Address` that has proved its role. */
+export type Hotkey = z.infer<ReturnType<typeof accountKeySchema<"hotkey">>>;
+/** A parsed coldkey — an `Ss58Address` that has proved its role. */
+export type Coldkey = z.infer<ReturnType<typeof accountKeySchema<"coldkey">>>;
 
 /** A neuron's position within one subnet. */
 export const uidSchema = () =>

--- a/tests/branded-identifiers.test.ts
+++ b/tests/branded-identifiers.test.ts
@@ -1,0 +1,66 @@
+// The identifier brands, and proof the transpositions they exist to stop no
+// longer compile (#10866).
+//
+// The brand is TYPE-LEVEL only: this file asserts both halves of that
+// bargain. The runtime half runs under vitest -- a branded schema parses and
+// serializes exactly as the plain one did, so the wire format cannot have
+// moved. The compile-time half runs under `npm run typecheck`, which is where
+// `@ts-expect-error` bites: each one below marks a transposition that USED to
+// compile, and if a refactor ever un-brands a schema, tsc fails the build
+// with "unused @ts-expect-error" -- the prove-it-can-fail rule, standing
+// guard in both directions.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  accountKeySchema,
+  providerSlugSchema,
+  ss58Schema,
+  type Coldkey,
+  type Hotkey,
+  type ProviderSlug,
+  type Ss58Address,
+} from "../schemas-src/query-params.ts";
+
+const ADDRESS = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
+
+describe("branded identifiers", () => {
+  test("the brand does not move the wire format", () => {
+    // Same input, same output, same rejection -- the brand is invisible at
+    // runtime, which is the half of the contract the emitted JSON Schema
+    // relies on.
+    assert.equal(ss58Schema().parse(ADDRESS), ADDRESS);
+    assert.equal(accountKeySchema("hotkey").parse(ADDRESS), ADDRESS);
+    assert.equal(providerSlugSchema().parse("opentensor"), "opentensor");
+    assert.equal(ss58Schema().safeParse("not-an-address").success, false);
+  });
+
+  test("a role key is still the generic address; the transpositions are not", () => {
+    const hotkey: Hotkey = accountKeySchema("hotkey").parse(ADDRESS);
+    const coldkey: Coldkey = accountKeySchema("coldkey").parse(ADDRESS);
+    const slug: ProviderSlug = providerSlugSchema().parse("opentensor");
+
+    // A hotkey IS an SS58 address -- the widening direction stays open, so a
+    // function taking the generic address accepts either role.
+    const asAddress: Ss58Address = hotkey;
+    const coldAsAddress: Ss58Address = coldkey;
+    assert.equal(asAddress, ADDRESS);
+    assert.equal(coldAsAddress, ADDRESS);
+
+    // @ts-expect-error a COLDKEY is not a hotkey -- the transposition #10866 exists to stop
+    const wrongRole: Hotkey = coldkey;
+    // @ts-expect-error a hotkey is not a coldkey -- same transposition, other direction
+    const wrongRoleBack: Coldkey = hotkey;
+    // @ts-expect-error an address with no proved role is not a hotkey
+    const unproved: Hotkey = ss58Schema().parse(ADDRESS);
+    // @ts-expect-error a provider slug is not an address
+    const slugAsAddress: Ss58Address = slug;
+    // @ts-expect-error a bare string proved nothing
+    const bare: Ss58Address = ADDRESS;
+    // The runtime VALUES are all still plain strings -- only the compiler
+    // distinguishes them, which is the entire point.
+    assert.deepEqual(
+      [wrongRole, wrongRoleBack, unproved, slugAsAddress, bare],
+      [ADDRESS, ADDRESS, ADDRESS, "opentensor", ADDRESS],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Every identifier the API takes was `z.string()`, so passing a coldkey where a hotkey was expected **compiled** — and failed only at runtime, as a wrong answer when the transposed value resolved or a mystery `not_found` when it didn't. The adapter-slug/provider-slug pair blinded a production probe exactly this way once (#10769).
- Four families are now branded at the vocabulary layer: `ss58Schema` → `Ss58Address`; `accountKeySchema` double-brands per role (`Hotkey`/`Coldkey` stay assignable wherever the generic address is asked for, and refuse **each other**); `providerSlugSchema` → `ProviderSlug`; `get_adapter`'s slug → `SubnetSlug`.

## The two halves of the bargain, both proven

- **Type-level only**: a clean `npm run build` leaves `public/` and `generated/` **byte-identical** — the wire format, emitted JSON Schema, and published examples do not move.
- **The transpositions actually die**: `tests/branded-identifiers.test.ts` pins five of them as `@ts-expect-error` (coldkey→hotkey, hotkey→coldkey, unproved address→hotkey, slug→address, bare string→address), so they fail `typecheck` today and **un-branding a schema fails it in the other direction** ("unused @ts-expect-error") — the prove-it-can-fail rule standing guard both ways. The runtime half asserts parse/serialize/reject behavior is unchanged.
- **Zero fallout**: `tsc` reports 0 errors across the tree — no producer or handler was assigning raw strings into these positions (branded values widen to `string` freely; only the narrowing direction is guarded).

## Validation

- [x] `npm run typecheck` — 0 errors (and the five `@ts-expect-error` proofs bite)
- [x] `npx vitest run tests/branded-identifiers.test.ts` — 2/2
- [x] Clean `npm run build` → `git status` shows only the two schema sources + the new test
- [x] `validate:tool-route-divergence` · `mcp-input-parity` · `route-query-parity` · `query-vocabulary` · `schema-vocabularies` — all pass
- [x] `npm run format:check` · `npm run lint` · `git diff --check`

## Template Used

- backend-code

Closes #10866