### PR TITLE
feat(schemas): census the producer-side fallbacks the contract does not state

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "report:type-duplicates": "node scripts/report-type-duplicates.ts",
     "report:nullable-overpromises": "node scripts/report-nullable-overpromises.ts",
     "report:mcp-tripwire-preflight": "node scripts/report-mcp-tripwire-preflight.ts",
+    "report:fallback-census": "node scripts/report-fallback-census.ts",
     "report:shape-duplicates": "node scripts/report-shape-duplicate-drift.ts",
     "report:undeclared-fields": "node scripts/report-undeclared-fields.ts",
     "validate:published-names": "node scripts/validate-published-names.ts",

--- a/scripts/report-fallback-census.ts
+++ b/scripts/report-fallback-census.ts
@@ -1,0 +1,91 @@
+// The census of producer-side fallbacks feeding contract fields (#10868).
+//
+// A `?? 0` / `?? null` / `|| []` at a construction site is a default the
+// contract does not state, applied where no reader can see it. It is the
+// mechanism behind the `?? null`-against-non-null class #10786 closed, and it
+// survives wherever a fallback still lives producer-side: the compiler now
+// proves the VALUE cannot violate the contract, but the DEFAULT itself stays
+// undocumented behaviour a client cannot learn from the schema.
+//
+// This is the MEASUREMENT half of that issue -- flipping schemas or deleting
+// coalesces blind is how the breakage becomes indistinguishable from the leak
+// being hunted. The walk is `findOverPromises`' own (every contract-field
+// write, through conditionals, fallback chains, `.map` callbacks and the card
+// builders), so the census and the nullability gate cannot disagree about
+// which writes exist.
+//
+// Reading the output:
+//
+//   `?? null` on a NULLABLE field    the degraded-arm marker -- legitimate,
+//                                    and the schema already says so
+//   `?? <value>` on any field        a default the schema does not state:
+//                                    either it belongs there (`.default()` /
+//                                    `.meta({default})`) or the input is
+//                                    typed non-optional now and the coalesce
+//                                    is dead
+//   `|| <literal>`                   the truthiness trap on top -- `0` and
+//                                    `""` take the fallback too, which is a
+//                                    bug class of its own when the field is
+//                                    numeric or a string
+import { pathToFileURL } from "node:url";
+import {
+  findOverPromises,
+  generatedQueryType,
+} from "./report-nullable-overpromises.ts";
+import { createRepoProgram } from "./report-type-duplicates.ts";
+
+function main(): void {
+  const report = findOverPromises(createRepoProgram(), generatedQueryType());
+  const { fallbacks } = report;
+
+  const nullOnNullable = fallbacks.filter(
+    (site) => site.fallback === "null" && site.fieldNullable,
+  );
+  const valued = fallbacks.filter((site) => site.fallback !== "null");
+  const truthy = fallbacks.filter((site) => site.operator === "||");
+
+  console.log(
+    `fallback-census: ${fallbacks.length} literal fallback(s) inside ` +
+      `${report.examined} contract-field write(s) across ${report.fields} ` +
+      `root field(s).`,
+  );
+  console.log(
+    `\n  ${nullOnNullable.length} × \`?? null\` on a NULLABLE field ` +
+      `(degraded-arm markers, the schema already agrees)` +
+      `\n  ${valued.length} × a VALUE default the schema does not state` +
+      `\n  ${truthy.length} × \`||\` (0/"" take the fallback too)`,
+  );
+
+  const byFallback = new Map<string, number>();
+  for (const site of valued) {
+    byFallback.set(site.fallback, (byFallback.get(site.fallback) ?? 0) + 1);
+  }
+  if (byFallback.size) {
+    console.log("\nVALUE DEFAULTS by fallback:");
+    for (const [text, n] of [...byFallback].sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${String(n).padStart(4)}  ${text}`);
+    }
+    console.log("\nVALUE-DEFAULT SITES:");
+    for (const site of valued) {
+      console.log(
+        `  ${site.file}:${site.line} ${site.path} ${site.operator} ${site.fallback}`,
+      );
+    }
+  }
+  if (truthy.length) {
+    console.log("\n`||` SITES (truthiness on top of the default):");
+    for (const site of truthy) {
+      console.log(
+        `  ${site.file}:${site.line} ${site.path} || ${site.fallback}`,
+      );
+    }
+  }
+}
+
+/* v8 ignore next 3 -- the CLI entry, exercised by the pipeline not the suite. */
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/report-nullable-overpromises.ts
+++ b/scripts/report-nullable-overpromises.ts
@@ -96,6 +96,30 @@ export interface Passthrough {
   line: number;
 }
 
+/**
+ * One producer-side fallback (`x ?? <literal>` / `x || <literal>`) feeding a
+ * contract field (#10868).
+ *
+ * Each is a default the contract does not state, applied where no reader can
+ * see it -- the mechanism behind the `?? null`-against-non-null class #10786
+ * closed. This walk already visits every such write; recording the fallback
+ * is the census that issue asked for, and the triage (a real default belongs
+ * in the schema as `.default()`, dead defensive noise gets deleted, a
+ * degraded-arm marker must agree with a `.nullable()`) happens against this
+ * list rather than against a grep.
+ */
+export interface FallbackSite {
+  /** `Owner.field` -- the contract field the fallback feeds. */
+  path: string;
+  file: string;
+  line: number;
+  operator: "??" | "||";
+  /** The fallback's source text, e.g. `null`, `0`, `[]`, `"24h"`. */
+  fallback: string;
+  /** Does the field's published type admit null? */
+  fieldNullable: boolean;
+}
+
 const ARTIFACT_PASSTHROUGH =
   "an artifact passthrough: the spread republishes a document a typed " +
   "builder produced against the SAME Zod component this GraphQL type was " +
@@ -158,6 +182,8 @@ export interface NullabilityReport {
   undecided: Undecided[];
   /** Declared passthrough spreads, counted against `DECLARED_PASSTHROUGHS`. */
   passthroughs: Passthrough[];
+  /** Producer-side literal fallbacks feeding contract fields (#10868). */
+  fallbacks: FallbackSite[];
   /** Declared passthrough owners the walk never saw a spread on -- stale. */
   stalePassthroughs: string[];
   /** Property writes compared against a declared field. */
@@ -287,9 +313,58 @@ export function findOverPromises(
   const findings: OverPromise[] = [];
   const undecided: Undecided[] = [];
   const passthroughs: Passthrough[] = [];
+  const fallbacks: FallbackSite[] = [];
   const decided = new Set<string>();
   let examined = 0;
   let fields = 0;
+
+  /**
+   * Record every `?? <literal>` / `|| <literal>` inside one contract-field
+   * write (#10868). Only literal-ish right operands count -- `a ?? b` defers
+   * to another value and states no default; `a ?? 0` states one the schema
+   * does not.
+   */
+  const collectFallbacks = (
+    expression: ts.Expression,
+    path: string,
+    file: string,
+    fieldNullable: boolean,
+  ) => {
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isBinaryExpression(node) &&
+        (node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken ||
+          node.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+      ) {
+        const right = unwrap(node.right);
+        const literalish =
+          right.kind === ts.SyntaxKind.NullKeyword ||
+          right.kind === ts.SyntaxKind.TrueKeyword ||
+          right.kind === ts.SyntaxKind.FalseKeyword ||
+          ts.isNumericLiteral(right) ||
+          ts.isStringLiteralLike(right) ||
+          ts.isArrayLiteralExpression(right) ||
+          ts.isObjectLiteralExpression(right) ||
+          (ts.isPrefixUnaryExpression(right) &&
+            ts.isNumericLiteral(right.operand));
+        if (literalish) {
+          fallbacks.push({
+            path,
+            file,
+            line: lineOf(node),
+            operator:
+              node.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+                ? "??"
+                : "||",
+            fallback: right.getText().replace(/\s+/g, " ").slice(0, 40),
+            fieldNullable,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(expression);
+  };
 
   /** Guards mutual recursion between a card builder and its own helpers. */
   const seen = new Set<string>();
@@ -412,6 +487,12 @@ export function findOverPromises(
       const value = ts.isPropertyAssignment(member)
         ? member.initializer
         : member.name;
+      collectFallbacks(
+        value,
+        `${owner.name}.${name.text}`,
+        file,
+        !(field.type instanceof GraphQLNonNull),
+      );
       const actual = checker.getTypeAtLocation(value);
       examined += 1;
       if (isAny(actual)) {
@@ -469,6 +550,7 @@ export function findOverPromises(
     undecided,
     passthroughs,
     stalePassthroughs,
+    fallbacks,
     examined,
     fields,
     decided,

--- a/tests/nullable-overpromises.test.ts
+++ b/tests/nullable-overpromises.test.ts
@@ -305,6 +305,41 @@ describe("findOverPromises", () => {
     assert.deepEqual(report.stalePassthroughs, []);
   });
 
+  test("a literal fallback at a contract-field write is CENSUSED (#10868)", () => {
+    const report = findOverPromises(
+      programFor(`
+        const data: Record<string, unknown> = {};
+        const other: number | undefined = undefined;
+        const rootValue = {
+          card() {
+            return {
+              total: (data.total as number | undefined) ?? 0,
+              optional_total: (data.maybe as number | undefined) ?? other ?? null,
+              complete: (data.complete as boolean | undefined) || false,
+            };
+          },
+        };
+      `),
+      Query,
+    );
+    // `?? 0` and `|| false` state defaults the schema does not; `?? other`
+    // defers to another VALUE and states nothing, so only the trailing
+    // `?? null` of that chain is recorded.
+    assert.deepEqual(
+      report.fallbacks.map((site) => [
+        site.path,
+        site.operator,
+        site.fallback,
+        site.fieldNullable,
+      ]),
+      [
+        ["Card.total", "??", "0", false],
+        ["Card.optional_total", "??", "null", true],
+        ["Card.complete", "||", "false", false],
+      ],
+    );
+  });
+
   test("a declared passthrough with no matching spread is STALE (#10867)", () => {
     const report = findOverPromises(
       programFor(`


### PR DESCRIPTION
## Summary

- The measurement half of #10868, built before anything is flipped or deleted — the issue's own method. `findOverPromises`' walk now records every `?? <literal>` / `|| <literal>` inside the contract-field writes it already visits, so the census and the nullability gate cannot disagree about which writes exist, and `report:fallback-census` aggregates it.

## First run, the numbers the issue asked for

```
846 literal fallback(s) inside 1,034 contract-field write(s) across 174 root field(s)

  317 × `?? null` on a NULLABLE field  (degraded-arm markers — the schema already agrees)
  449 × a VALUE default the schema does not state
   44 × `||`                           (0 and "" take the fallback too)
```

The value defaults concentrate hard: 258 × `0`, 90 × `1`, 65 × `[]`, 12 × `"0.000000000"`, then a long tail of zeroed sub-objects — the zeroed-card shapes, one family per surface. The full per-site list (path, file:line, operator, fallback) is the report's output.

## What this deliberately does not do

No triage in this PR — rushed contract decisions ship wrong contracts. Each site's disposition (`.default()`/`.meta({default})` where the default belongs in the contract, deletion where the typed input made the coalesce dead, a `.nullable()` cross-check where it marks a degraded arm) happens against this list in follow-up passes per family, inside #10868.

## Validation

- [x] `npx vitest run tests/nullable-overpromises.test.ts` — 14/14, census behavior pinned (a literal fallback is recorded; `?? other` defers and is not)
- [x] `npm run validate:nullable-overpromises` — unchanged, 0/1,034, 10 declared, 0 undecided
- [x] `npm run typecheck` — 0 errors · `format:check` · `lint` · `git diff --check`

## Template Used

- backend-code

Refs #10868 (the census deliverable; the issue stays open for the triage passes)