### PR TITLE
types(schemas): extend the brand sweep and collapse the two nullable spellings

### DIFF
--- a/schemas-src/mcp-tools/validators.ts
+++ b/schemas-src/mcp-tools/validators.ts
@@ -240,7 +240,7 @@ export const GetValidatorNominatorsOutputSchema = z
     // Carried by both builders, on every path including the decline.
     schema_version: z.int(),
     hotkey: z.unknown(),
-    limit: z.union([z.int().min(0), z.null()]),
+    limit: z.int().min(0).nullable(),
     offset: z.int().min(0),
     nominator_count: z.int().min(0).nullable(),
     // The item shape follows the basis: TAO totals over a window, or standing

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -464,7 +464,15 @@ export const blockEventCursorSchema = () =>
         "`next_cursor` from the previous response. Both parts are " +
         "non-negative safe integers.",
     )
-    .meta({ examples: ["8783000.4"] });
+    .meta({ examples: ["8783000.4"] })
+    // Branded (#10866): a caller round-trips this and the opaque keyset token
+    // both as strings, and handing one feed's cursor to the other compiled.
+    .brand<"BlockEventCursor">();
+
+/** A parsed block-event cursor, nominally distinct from the opaque keyset. */
+export type BlockEventCursor = z.infer<
+  ReturnType<typeof blockEventCursorSchema>
+>;
 
 /**
  * An opaque pagination token, published with NO length or shape claim.
@@ -520,7 +528,13 @@ export const keysetCursorSchema = () =>
         "response verbatim. Its contents are not stable and must not be parsed " +
         "or constructed. Stable across inserts, unlike a row offset.",
     )
-    .meta({ examples: ["eyJiIjo4NzgzMDAwLCJpIjo0fQ"] });
+    .meta({ examples: ["eyJiIjo4NzgzMDAwLCJpIjo0fQ"] })
+    // Branded (#10866): this and the block-event cursor are both strings a
+    // caller round-trips, and handing one feed's token to the other compiled.
+    .brand<"KeysetCursor">();
+
+/** A parsed opaque keyset token, nominally distinct from the dotted cursor. */
+export type KeysetCursor = z.infer<ReturnType<typeof keysetCursorSchema>>;
 
 /**
  * The accepted `fields` syntax, which was documented NOWHERE a caller could see it:
@@ -783,7 +797,14 @@ export const surfaceIdSchema = () =>
       "The surface's stable id (`sn-64-chutes-subnet-api`), as returned by " +
         "the surface-listing tools. Stable across renames, unlike the name.",
     )
-    .meta({ examples: ["sn-64-chutes-subnet-api"] });
+    .meta({ examples: ["sn-64-chutes-subnet-api"] })
+    // Branded with the other identifier families (#10866): a surface id and a
+    // provider slug are both short hyphenated strings, and the registry keys
+    // both. Type-level only; the wire format does not move.
+    .brand<"SurfaceId">();
+
+/** A parsed surface id, nominally distinct from the slug families. */
+export type SurfaceId = z.infer<ReturnType<typeof surfaceIdSchema>>;
 
 /**
  * A hotkey or coldkey the caller must pick. Distinct from `ss58Schema()` only

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -239,7 +239,7 @@ export const CandidateSurfaceSchema = z
     subnet_name: z.string().nullable().optional(),
     superseded_by: z.string().nullable().optional(),
     url: z.url(),
-    verification: z.union([VerificationResultSchema, z.null()]).optional(),
+    verification: VerificationResultSchema.nullable().optional(),
   })
   .strict();
 export type CandidateSurface = z.infer<typeof CandidateSurfaceSchema>;
@@ -535,7 +535,7 @@ export const SubnetDetailSchema = z
     revenue_search: RevenueSearchSchema.optional(),
     wallet_search: WalletSearchSchema.optional(),
     participant_count: z.int().min(0).optional(),
-    partnership: z.union([PartnershipMetadataSchema, z.null()]).optional(),
+    partnership: PartnershipMetadataSchema.nullable().optional(),
     previously_known_as: z.array(z.string()).optional(),
     probed_surface_count: z.int().min(0).optional(),
     // Same open-shape carve-out as `links` above.

--- a/schemas-src/routes/subnets.ts
+++ b/schemas-src/routes/subnets.ts
@@ -83,7 +83,7 @@ export const SubnetIndexEntrySchema = z
     netuid: z.int().min(0),
     official_surface_count: z.int().min(0).optional(),
     participant_count: z.int().min(0).optional(),
-    partnership: z.union([PartnershipMetadataSchema, z.null()]).optional(),
+    partnership: PartnershipMetadataSchema.nullable().optional(),
     probed_surface_count: z.int().min(0).optional(),
     registered_at_block: z.int().min(0).optional(),
     registry_observed_count: z.int().min(0).optional(),

--- a/scripts/validate-unreferenced-exports.ts
+++ b/scripts/validate-unreferenced-exports.ts
@@ -74,7 +74,7 @@ import { repoRoot } from "./lib.ts";
  * being separate declarations. A deletion this time, and the RIGHT kind --
  * nothing lost, because the thing deleted was a copy.
  */
-export const MAX_UNREFERENCED_EXPORTS: number = 734;
+export const MAX_UNREFERENCED_EXPORTS: number = 733;
 
 /** knip's JSON shape, as much of it as this gate reads. */
 interface KnipIssue {

--- a/tests/branded-identifiers.test.ts
+++ b/tests/branded-identifiers.test.ts
@@ -13,12 +13,18 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   accountKeySchema,
+  blockEventCursorSchema,
+  keysetCursorSchema,
   providerSlugSchema,
   ss58Schema,
+  surfaceIdSchema,
+  type BlockEventCursor,
   type Coldkey,
   type Hotkey,
+  type KeysetCursor,
   type ProviderSlug,
   type Ss58Address,
+  type SurfaceId,
 } from "../schemas-src/query-params.ts";
 
 const ADDRESS = "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F";
@@ -61,6 +67,26 @@ describe("branded identifiers", () => {
     assert.deepEqual(
       [wrongRole, wrongRoleBack, unproved, slugAsAddress, bare],
       [ADDRESS, ADDRESS, ADDRESS, "opentensor", ADDRESS],
+    );
+  });
+  test("the id and cursor families refuse each other too (#10866 sweep)", () => {
+    const surface: SurfaceId = surfaceIdSchema().parse(
+      "sn-64-chutes-subnet-api",
+    );
+    const keyset: KeysetCursor =
+      keysetCursorSchema().parse("eyJiIjo4NzgzMDAwfQ");
+    const dotted: BlockEventCursor =
+      blockEventCursorSchema().parse("8783000.4");
+
+    // @ts-expect-error a surface id is not a provider slug
+    const idAsSlug: ProviderSlug = surface;
+    // @ts-expect-error one feed's cursor is not the other's -- both are strings
+    const wrongCursor: KeysetCursor = dotted;
+    // @ts-expect-error and the other direction
+    const wrongCursorBack: BlockEventCursor = keyset;
+    assert.deepEqual(
+      [idAsSlug, wrongCursor, wrongCursorBack],
+      ["sn-64-chutes-subnet-api", "8783000.4", "eyJiIjo4NzgzMDAwfQ"],
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-through on the "everywhere possible" bar #10866 set:

- **Three more brands**: `SurfaceId` (sits beside `ProviderSlug` as a short hyphenated registry key), and the two string cursors `KeysetCursor`/`BlockEventCursor` — one feed's token handed to the other compiled until now. `numericCursorSchema` stays unbranded **deliberately**: it's an int, already un-transposable with either string cursor — no branding for its own sake.
- **One nullability spelling**: the four `z.union([X, z.null()])` sites collapse into `.nullable()`, which the other 1,454 sites already use. Two spellings of one concept is exactly the class the schema epics exist to delete.
- Swept and *closed empty* while measuring: no `z.discriminatedUnion` candidates exist — the three surviving `z.union`s are string-or-object/any-JSON with no discriminator, legitimately spelled.

## Proof

- Clean `npm run build` → `public/` and `generated/` **byte-identical** (both changes are type-level/spelling-level only)
- `tsc` — 0 errors; new transpositions pinned as `@ts-expect-error` in both directions
- `validate:schemas` · `openapi` · `tool-route-divergence` · `mcp-input-parity` · `route-query-parity` — pass
- `tests/branded-identifiers.test.ts` — 3/3

## Template Used

- backend-code

Refs #10866