### PR TITLE
refactor(mcp): the dispatch clamp reads the serving-bound marker, not a name

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -595,6 +595,7 @@ import {
 import {
   NEURON_FIELD_NAMES,
   NEURON_SORT_FIELD_NAMES,
+  SERVING_BOUND,
 } from "../schemas-src/mcp-tools/shared.ts";
 import {
   GetSubnetHistoryInputSchema,
@@ -4100,7 +4101,7 @@ export function validateToolArguments(
   // a filter, a cache-key difference, or a 400 from someone else's API.
   return applyPublishedDefaults(
     tool,
-    clampPublishedLimit(tool, splitMcpIntent(args).rest),
+    clampServingBounds(tool, splitMcpIntent(args).rest),
   );
 }
 
@@ -4207,7 +4208,8 @@ function applyPublishedDefaults(tool: ToolArgumentSource, args: Row): Row {
 }
 
 /**
- * Clamp `limit` to the ceiling the tool itself publishes (#10174).
+ * Clamp every SERVING bound to the ceiling the tool itself publishes
+ * (#10174, marker-driven since the #10780 aftermath).
  *
  * Over-ceiling `limit` used to do two different things depending on which
  * handler an agent happened to reach: 25 tools rejected it -- 15 through the
@@ -4222,26 +4224,39 @@ function applyPublishedDefaults(tool: ToolArgumentSource, args: Row): Row {
  * that miscounts a page size gets an answer instead of an error, and the
  * response already reports the limit actually applied.
  *
- * The ceiling is read from the tool's OWN inputSchema rather than a list kept
- * alongside it, so a tool cannot be added with a bound this does not honour.
- *
- * Deliberately `limit` only. A published `maximum` on an identifier is a
- * validity bound, not a page size: clamping `netuid: 99999` to 65535 would
- * answer a question the caller did not ask, where rejecting it is correct.
+ * WHICH bounds bend is no longer this function's opinion. `limitSchema` and
+ * `offsetSchema` declare it in the published schema itself --
+ * `x-serving-bound: true` (SERVING_BOUND), the keyword #10316 added exactly so
+ * "a policy we may clamp" and "the shape of the value" stop looking alike --
+ * and this reads the declaration off the tool's OWN inputSchema. `netuid:
+ * 99999` stays rejected because a validity bound never carries the marker:
+ * clamping it to 65535 would answer a question the caller did not ask. The
+ * GraphQL dispatch already clamps by the same marker (`isServingBound` in
+ * src/route-query.ts), so the two lenient surfaces now read one declaration
+ * instead of each keeping a private list of names.
  *
  * And deliberately only ABOVE the ceiling. `limit: 0`, a negative, and `1.5`
  * are malformed rather than over-ambitious, and each still reaches the handler
  * that rejects it -- `0` in particular means different things to the three
  * page-size rules (REST floors it to 1, MCP falls back to the tool's default,
  * the row builders honour it as zero), so rewriting it here would flatten a
- * distinction tests/pagination-bound-parity.test.ts exists to keep.
+ * distinction tests/pagination-bound-parity.test.ts exists to keep. (An
+ * over-ceiling `offset` reached its handler's clamp before this ran at
+ * dispatch; same final answer, one mechanism earlier.)
  */
-function clampPublishedLimit(tool: ToolArgumentSource, args: Row): Row {
-  const max = rowOf(tool.inputSchema?.properties?.limit)?.maximum;
-  const value = args?.limit;
-  if (typeof max !== "number" || typeof value !== "number") return args;
-  if (!Number.isInteger(value) || value <= max) return args;
-  return { ...args, limit: max };
+function clampServingBounds(tool: ToolArgumentSource, args: Row): Row {
+  const properties = rowOf(tool.inputSchema?.properties);
+  if (!properties || !args || typeof args !== "object") return args;
+  let clamped: Row | null = null;
+  for (const [name, value] of Object.entries(args)) {
+    const property = rowOf(properties[name]);
+    if (property?.[SERVING_BOUND] !== true) continue;
+    const max = property.maximum;
+    if (typeof max !== "number" || typeof value !== "number") continue;
+    if (!Number.isInteger(value) || value <= max) continue;
+    clamped = { ...(clamped ?? args), [name]: max };
+  }
+  return clamped ?? args;
 }
 
 /**

--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -171,6 +171,35 @@ describe("published MCP enums are enforced at runtime (#8942)", () => {
     }
   }, 60_000);
 
+  // The dispatch clamp is MARKER-driven now (`x-serving-bound`), not
+  // name-keyed to `limit` -- the same declaration the GraphQL dispatch reads.
+  // Both directions have to hold: a marked bound clamps at dispatch (an
+  // over-ceiling `offset` answers with the ceiling applied, one mechanism
+  // earlier than the handler clamp that always caught it), and an UNMARKED
+  // `maximum` -- `netuid`'s validity bound -- must never clamp, because
+  // subnet 65535 is not the subnet the caller asked about.
+  test("the dispatch clamp reads the serving-bound marker, both directions", async () => {
+    const clamped = await errorCode("list_blocks", {
+      limit: 2,
+      offset: 99_999_999,
+    });
+    assert.notEqual(
+      clamped,
+      "invalid_params",
+      "a marked serving bound must clamp at dispatch, not reject",
+    );
+    // The property is REJECTION, not a particular code (the enum test's own
+    // doctrine above): what must never happen is the unmarked bound clamping
+    // into a successful answer about subnet 65535.
+    const rejected = await errorCode("get_subnet", { netuid: 99_999 });
+    assert.notEqual(
+      rejected,
+      null,
+      "an unmarked validity bound must reject -- clamping answers a question " +
+        "the caller did not ask",
+    );
+  }, 60_000);
+
   // The third constraint class, and the last one without a gate. #8942's audit
   // covered enums (zero gaps) and numeric bounds (all 101 "gaps" were the
   // deliberate pagination clamping pinned above). `required` was never probed.


### PR DESCRIPTION
## Summary

The `.catch()` line of #10780's footnote, resolved the way the codebase already resolves leniency: **declared on the schema, applied per surface**. `clampPublishedLimit` hard-named `limit` while `limitSchema`/`offsetSchema` already publish `x-serving-bound: true` — the #10316 keyword that exists precisely so "a policy we may clamp" and "the shape of the value" stop looking alike — and the GraphQL dispatch has clamped by that marker all along (`isServingBound`, `src/route-query.ts`). Now MCP's dispatch reads the same declaration: one rule, two lenient surfaces, zero private name lists.

- **Verified against the served JSON first**: `list_blocks.limit` and `.offset` both carry the marker; `netuid` does not — so the validity-bound protection is by construction, not by name.
- **Behavior-exact**: `limit` clamps exactly as before; an over-ceiling `offset` was always clamped by its handler and now clamps one mechanism earlier — same final answer, and the pinned partition (`pagination-bound-parity`, `mcp-schema-enforcement`) agrees.
- Both directions pinned in a new test: a marked bound clamps at dispatch; an unmarked `maximum` must never clamp into a successful answer (rejection asserted per the file's own doctrine — the property, not a house-style code).
- Why not literal `.catch()`: the schema is *shared* — REST must keep rejecting the same value MCP clamps, so leniency cannot be a method on the one schema object; the marker + per-surface application *is* the declared form, and it is now the only form.

## Validation

- [x] `tests/mcp-schema-enforcement.test.ts` + `tests/pagination-bound-parity.test.ts` — 9/9
- [x] `npm run validate:mcp` · `typecheck` 0 · `format:check` · `git diff --check`

## Template Used

- backend-code

Refs #10780