### PR TITLE
docs(gates): record the .refine() measurement — the movable cross-argument set is empty

### DIFF
--- a/scripts/validate-graphql-hand-written-checks.ts
+++ b/scripts/validate-graphql-hand-written-checks.ts
@@ -21,8 +21,15 @@
 //   about the data, not about the argument, and no schema can express it.
 //
 //   CROSS-ARGUMENT rules -- `counterparty must differ from ss58` relates two
-//   values, which JSON Schema cannot state (#10219 tracks `.refine()` for the
-//   ones that could move into the schema).
+//   values, which JSON Schema cannot state. MEASURED for `.refine()`
+//   migration in the #10780 aftermath and the movable set is EMPTY: every
+//   known cross-argument rule relates a PATH parameter to a QUERY parameter,
+//   and the route query schema cannot see the path by construction -- while
+//   no query-to-query pair exists (an inverted from/to range answers empty,
+//   which is a valid answer, not a rejection). A schema-native home for the
+//   path+query rules arrives only with a canonical per-operation input that
+//   unifies both, the operations-registry evolution -- not a `.refine()`
+//   sprinkled where it cannot reach.
 //
 //   FIELDS WITH NO ROUTE -- the eight `QUERY_BINDINGS` entries with
 //   `route: null` compose several routes or none, so there is no single


### PR DESCRIPTION
## Summary

The last unresolved line of #10780's Zod-feature footnote, closed by measurement like its siblings (#10879 for `.transform()`, #10882 for `.catch()`):

- The flagship cross-argument rule — `counterparty must differ from ss58` — relates a **path** parameter to a **query** parameter. The route query schema cannot see the path by construction, so `.refine()` has nowhere to hold it.
- No query-to-query pair exists to migrate: an inverted `from`/`to` range answers empty, which is a valid answer, not a rejection.
- The schema-native home for path+query rules arrives only with a canonical per-operation input unifying both — the operations-registry evolution — and that dependency is now written where the gate describes the class, so nobody sprinkles a `.refine()` where it cannot reach.

With this, every feature in the footnote has a terminal state: **adopted** (`.brand()` ×7 families, marker-driven clamp, `z.preprocess` conversions), **settled with recorded reason** (`.default()` inputs, codec table as data, this), or **closed empty by sweep** (`discriminatedUnion`).

## Validation

- [x] `validate:graphql-hand-written-checks` — 246/246, comment-only · `format:check` · `git diff --check`

## Template Used

- backend-code

Refs #10780