### PR TITLE
fix(mcp): complete the PostHog $mcp_* wire contract and label every caller

### DIFF
--- a/scripts/check-mcp-conformance.ts
+++ b/scripts/check-mcp-conformance.ts
@@ -82,6 +82,12 @@ async function rpc(method: string, params: Row): Promise<Row> {
         headers: {
           "content-type": "application/json",
           accept: "application/json, text/event-stream",
+          // Name this runner in the server's client analytics. Without it the
+          // sweep arrives as Node's default UA and was the single largest
+          // "unidentified client" in the MCP dashboard -- every probe it
+          // makes, including the deliberate error-path ones, showed up as an
+          // anonymous agent failing rather than as our own nightly check.
+          "user-agent": "metagraphed-conformance/1",
         },
         body: JSON.stringify({
           jsonrpc: "2.0",

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -25,12 +25,19 @@ type Row = Record<string, unknown>;
  * Arguments every tool may carry that no route publishes.
  *
  * These are transport-level, not data-level: `context` is agent-intent
- * telemetry (#9642), `cursor` is the MCP pagination idiom where REST uses the
- * same name but does not always publish it, `network` is a path PREFIX on the
- * REST side (`/api/v1/testnet/...`) rather than a parameter, and `fields` is
- * the projection contract (#9884).
+ * telemetry (#9642) and `conversation_id` its conversation-stitching sibling
+ * (both stripped before any handler runs), `cursor` is the MCP pagination
+ * idiom where REST uses the same name but does not always publish it,
+ * `network` is a path PREFIX on the REST side (`/api/v1/testnet/...`) rather
+ * than a parameter, and `fields` is the projection contract (#9884).
  */
-const MCP_TRANSPORT_ARGS = new Set(["context", "cursor", "network", "fields"]);
+const MCP_TRANSPORT_ARGS = new Set([
+  "context",
+  "conversation_id",
+  "cursor",
+  "network",
+  "fields",
+]);
 
 /** Query parameters a tool has no use for. `format` selects CSV; a tool
  * returns structuredContent. */

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17458,6 +17458,12 @@ export function alertTriggerErrorCode(status: number): string {
   if (status === 404) return "not_found";
   if (status === 401) return "auth_required";
   if (status === 403) return "forbidden";
+  // The tier's 400s ("malformed trigger id", a non-object body) are the
+  // caller's request, refused -- the same reading bad_request already carries
+  // for the pre-dispatch gate. #10810 left this one out, so the nightly
+  // conformance probe's malformed id was the only caller fault still filed
+  // as `internal`.
+  if (status === 400) return "bad_request";
   // Somebody else's 5xx, from the caller's side -- the same reading
   // provider_error already carries for an adapter's upstream.
   if (status >= 500) return "provider_error";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -211,6 +211,7 @@ import {
   recordMcpToolsListEvent,
   recordUsageEvent,
   parseUserAgentClient,
+  MCP_PERSON_NAMESPACE,
 } from "./usage-telemetry.ts";
 import { maskRouteParams } from "./route-label.ts";
 import {
@@ -4093,15 +4094,16 @@ export function validateToolArguments(
       );
     }
   }
-  // #9642: the intent argument is analytics metadata, never tool input, so it
-  // is removed before any handler sees it -- the same contract @posthog/mcp's
-  // SDK documents ("It strips that argument before your handler runs"). Not
-  // merely a courtesy: several handlers forward their whole argument object
-  // into a query builder or an upstream call, where an unexpected key becomes
-  // a filter, a cache-key difference, or a 400 from someone else's API.
+  // #9642: the analytics arguments are metadata, never tool input, so they
+  // are removed before any handler sees them -- the same contract
+  // @posthog/mcp's SDK documents ("It strips that argument before your
+  // handler runs"). Not merely a courtesy: several handlers forward their
+  // whole argument object into a query builder or an upstream call, where an
+  // unexpected key becomes a filter, a cache-key difference, or a 400 from
+  // someone else's API.
   return applyPublishedDefaults(
     tool,
-    clampServingBounds(tool, splitMcpIntent(args).rest),
+    clampServingBounds(tool, splitMcpAnalyticsArguments(args).rest),
   );
 }
 
@@ -4260,31 +4262,48 @@ function clampServingBounds(tool: ToolArgumentSource, args: Row): Row {
 }
 
 /**
- * Separate the intent argument from the real tool arguments.
+ * Separate the analytics arguments — intent (`context`) and
+ * `conversation_id` — from the real tool arguments.
  *
- * ONE splitter for both readers -- the dispatch path (which must not hand it
- * to a handler) and the telemetry path (which must not duplicate it inside
- * `$mcp_parameters`, where it would be a second copy of free-form agent text
- * on an event that is never sampled). Two implementations of "which key is the
- * intent" is exactly the drift this avoids.
+ * ONE splitter for both readers -- the dispatch path (which must not hand
+ * them to a handler) and the telemetry path (which must not duplicate them
+ * inside `$mcp_parameters`, where each would be a second copy of
+ * caller-controlled text on an event that is never sampled). Two
+ * implementations of "which keys are analytics" is exactly the drift this
+ * avoids.
  *
  * Returns the ORIGINAL object when there is nothing to strip, so the
  * overwhelmingly common case allocates nothing.
  */
-export function splitMcpIntent(args: Row | null | undefined): {
+export function splitMcpAnalyticsArguments(args: Row | null | undefined): {
   intent?: string;
+  conversationId?: string;
   rest: Row;
 } {
   // The nullable is in the SIGNATURE now: the body has always handled a
   // missing argument object by returning it unchanged, and the dispatch
   // caller reached it through `params?.arguments as Row` -- a cast whose only
   // job was to hide that this is exactly the case being handled (#10782).
-  if (!args || typeof args !== "object" || !Object.hasOwn(args, MCP_INTENT_ARG))
+  if (
+    !args ||
+    typeof args !== "object" ||
+    (!Object.hasOwn(args, MCP_INTENT_ARG) &&
+      !Object.hasOwn(args, MCP_CONVERSATION_ARG))
+  ) {
     return { rest: args ?? {} };
-  const { [MCP_INTENT_ARG]: intent, ...rest } = args;
+  }
+  const {
+    [MCP_INTENT_ARG]: intent,
+    [MCP_CONVERSATION_ARG]: conversationId,
+    ...rest
+  } = args;
   return {
-    // A non-string, or a caller sending only whitespace, is not an intent.
+    // A non-string, or a caller sending only whitespace, is not an intent --
+    // and the same reading applies to a conversation id.
     ...(typeof intent === "string" && intent.trim() ? { intent } : {}),
+    ...(typeof conversationId === "string" && conversationId.trim()
+      ? { conversationId }
+      : {}),
     rest,
   };
 }
@@ -5294,11 +5313,12 @@ const MCP_INTENT_ARG = "context";
 const MCP_INTENT_ARG_SCHEMA = {
   type: "string",
   // CARRIED BY ALL 224 TOOLS, so every character here is paid 224 times
-  // (#9696). At 136 characters the description alone cost 30,464 bytes, 4.2%
-  // of tools/list. This says the same three things -- what to write, that it
-  // is optional, that it changes nothing -- in half the bytes.
+  // (#9696). Says what to write and that it changes nothing, in the fewest
+  // bytes. No "Optional:" prefix any more -- the advertised schema marks it
+  // required (withAdvertisedRequiredIntent), and a description contradicting
+  // the schema teaches the model to distrust both.
   description:
-    "Optional: the user's goal, briefly. Analytics only; does not affect the result.",
+    "The user's goal, briefly. Analytics only; does not affect the result.",
   // A worked example, because "describe the user's goal" is exactly the kind
   // of instruction a model satisfies with one vague word. It shows the shape
   // that is useful in the intent view: the user's actual objective, not a
@@ -5309,11 +5329,43 @@ const MCP_INTENT_ARG_SCHEMA = {
 } as const;
 
 /**
- * Add the intent argument to one tool's published schema.
+ * The argument an agent uses to stitch calls into one logical conversation,
+ * and the property PostHog reads it as ($mcp_conversation_id).
  *
- * OPTIONAL, WHERE THE SDK MAKES IT REQUIRED. That divergence is deliberate and
- * is the whole reason this is hand-rolled rather than delegated: every one of
- * these tools declares `additionalProperties: false` and is already serving
+ * `conversation_id` is @posthog/mcp's own name for it (enableConversationId),
+ * kept verbatim for the same reason `context` was. Verified against every
+ * published schema before choosing it: none declares `conversation_id`.
+ *
+ * Deliberately only HALF of the SDK's feature: the argument is accepted and
+ * recorded, but the SDK's other half — minting an id server-side and
+ * appending a "[SERVER]: Reuse conversation_id=…" text block to every tool
+ * response — is not implemented. That prompt-back rides the response's
+ * content array, which consumers surface to end users verbatim (the SDK's
+ * own docs call the leak out), and it taxes every response to benefit only
+ * the calls where the agent would not cooperate anyway. An agent that wants
+ * stitching sends the id; one that does not costs nothing.
+ */
+const MCP_CONVERSATION_ARG = "conversation_id";
+const MCP_CONVERSATION_ARG_SCHEMA = {
+  type: "string",
+  // Paid once per tool on every tools/list, same budget discipline as the
+  // intent description above (#9696): what to send, that it is optional,
+  // that it changes nothing.
+  description:
+    "Optional: stable id for this conversation, same value on every call. Analytics only; does not affect the result.",
+  // The examples gate (tests/mcp-input-schema.test.ts) is right to apply
+  // here too: the useful shape -- opaque, stable, reused -- is easier shown
+  // than described.
+  examples: ["chat-8f3d"],
+} as const;
+
+/**
+ * Add the analytics arguments — intent (`context`) and `conversation_id` —
+ * to one tool's published schema.
+ *
+ * OPTIONAL, WHERE THE SDK MAKES INTENT REQUIRED. That divergence is deliberate
+ * and is the whole reason this is hand-rolled rather than delegated: every one
+ * of these tools declares `additionalProperties: false` and is already serving
  * live traffic, so a required argument would make the next deploy reject every
  * call from every existing client, on every tool at once. Coverage is worth
  * less than not breaking the public surface.
@@ -5328,17 +5380,20 @@ const MCP_INTENT_ARG_SCHEMA = {
  * JsonSchemaLike, and a defensive branch nobody can exercise is one nobody can
  * trust. Tested directly rather than annotated away.
  */
-export function withIntentArgument(tool: McpToolDefinition): McpToolDefinition {
+export function withAnalyticsArguments(
+  tool: McpToolDefinition,
+): McpToolDefinition {
   const schema = tool.inputSchema;
-  const withIntent: JsonSchemaLike = {
+  const withAnalytics: JsonSchemaLike = {
     ...schema,
     type: schema?.type ?? "object",
     properties: {
       ...(schema?.properties ?? {}),
       [MCP_INTENT_ARG]: MCP_INTENT_ARG_SCHEMA,
+      [MCP_CONVERSATION_ARG]: MCP_CONVERSATION_ARG_SCHEMA,
     },
   };
-  return { ...tool, inputSchema: withIntent };
+  return { ...tool, inputSchema: withAnalytics };
 }
 
 // Applied ONCE, here, rather than in listToolDefinitions() -- and that is the
@@ -5366,7 +5421,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     // one signal that names a gap in the catalogue in the agent's own words,
     // which is why PostHog treats it as the most actionable event an MCP
     // server owner can collect. The reasoning rides on the standard `context`
-    // argument (withIntentArgument puts it on every tool) so it lands in
+    // argument (withAnalyticsArguments puts it on every tool) so it lands in
     // $mcp_intent, which is the field their missing-capability views read.
     //
     // Deliberately NOT annotated open-world: it reads nothing at all.
@@ -14643,8 +14698,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
   },
 ];
 
-export const MCP_TOOLS: McpToolDefinition[] =
-  MCP_TOOLS_BASE.map(withIntentArgument);
+export const MCP_TOOLS: McpToolDefinition[] = MCP_TOOLS_BASE.map(
+  withAnalyticsArguments,
+);
 
 const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
 
@@ -14969,6 +15025,33 @@ const TOOL_OUTPUT_SCHEMAS: Record<string, JsonSchemaLike> = {
   ),
 };
 
+/**
+ * Advertise the intent argument as REQUIRED, on the advertised schema only.
+ *
+ * This is @posthog/mcp's own design, adopted deliberately: their SDK marks
+ * `context` required in the published JSON Schema while never enforcing it at
+ * validation ("advertised as required … but isn't enforced"), because a
+ * schema-following agent then supplies intent on every call while a
+ * schema-blind caller loses nothing. Measured before this shipped: roughly
+ * half of tool calls carried no intent at all.
+ *
+ * The SAFE direction of the two-tool-objects divergence: dispatch validates
+ * against the raw TOOLS_BY_NAME entry, where `context` stays optional, so a
+ * call without it can never be rejected — the advertise-then-reject trap this
+ * mount avoided for the argument itself cannot re-open here. Only `context`
+ * is promoted; `conversation_id` stays visibly optional, matching the SDK.
+ *
+ * Exported for tests, like withAnalyticsArguments above.
+ */
+export function withAdvertisedRequiredIntent(
+  schema: JsonSchemaLike,
+): JsonSchemaLike {
+  if (!schema || typeof schema !== "object") return schema;
+  const required = Array.isArray(schema.required) ? schema.required : [];
+  if (required.includes(MCP_INTENT_ARG)) return schema;
+  return { ...schema, required: [...required, MCP_INTENT_ARG] };
+}
+
 export function listToolDefinitions() {
   return MCP_TOOLS.map((tool) => {
     // NORMALISED HERE, not at the spread below (#9654). The sentinel is a Zod
@@ -14993,7 +15076,9 @@ export function listToolDefinitions() {
       // drop Zod's implicit safe-integer bounds. They are not constraints
       // anyone chose, and while they were emitted a real `maximum` could not be told
       // apart from `z.int()`'s default — see src/mcp-input-schema.ts.
-      inputSchema: stripSentinelIntegerBounds(tool.inputSchema),
+      inputSchema: withAdvertisedRequiredIntent(
+        stripSentinelIntegerBounds(tool.inputSchema),
+      ),
       // outputSchema (optional) lets a client validate the structuredContent the
       // tool returns; included only when the tool declares one.
       //
@@ -15756,12 +15841,16 @@ async function callTool(params: Row | null, ctx: McpCtx) {
     ...(result.isError ? { errorCode } : {}),
   });
   // #9642: `context` is the argument an agent uses to say WHY it called, and
-  // PostHog records it as $mcp_intent. Split here rather than read in place so
-  // `parameters` below carries the real arguments only -- the intent travels
-  // as its own property, not as a second copy inside the parameter blob.
-  const { intent, rest: toolParameters } = splitMcpIntent(
-    rowOf(params?.arguments),
-  );
+  // PostHog records it as $mcp_intent; `conversation_id` is the one it uses
+  // to stitch calls together, recorded as $mcp_conversation_id. Split here
+  // rather than read in place so `parameters` below carries the real
+  // arguments only -- each travels as its own property, not as a second copy
+  // inside the parameter blob.
+  const {
+    intent,
+    conversationId,
+    rest: toolParameters,
+  } = splitMcpAnalyticsArguments(rowOf(params?.arguments));
   scheduleMcpToolCallEvent(ctx, {
     toolName: toolLabel,
     // $mcp_tool_description: the description the agent actually chose from,
@@ -15781,9 +15870,21 @@ async function callTool(params: Row | null, ctx: McpCtx) {
     sessionId: ctx?.sessionId,
     parameters: toolParameters,
     response: result?.structuredContent,
-    // Omitted entirely when the agent said nothing, so "did not explain" stays
-    // distinguishable from "explained with an empty string".
-    ...(intent ? { intent } : {}),
+    // The agent's own words when it gave any; otherwise the intentFallback
+    // pattern from @posthog/mcp's docs — deterministic, no LLM, no argument
+    // inspection — labelled "inferred" so the intent views can always
+    // separate agent speech from this mechanical floor. What the fallback
+    // buys: an intent-coverage read that means "who is not cooperating"
+    // rather than mixing that with "we did not record".
+    ...(intent
+      ? { intent }
+      : {
+          intent: `Invoking ${toolLabel}`,
+          intentSource: "inferred" as const,
+        }),
+    // Only a caller that actually sent one — there is nothing honest to infer
+    // for a conversation label.
+    ...(conversationId ? { conversationId } : {}),
     // #8963: the same structuredContent.error.code usage_event already
     // threads above, projected onto PostHog's $mcp_error_type by
     // classifyMcpErrorType inside the recorder. Omitted on success.
@@ -16596,6 +16697,10 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
         // event exists to make visible.
         scheduleMcpToolsListEvent(ctx, {
           toolCount: tools.length,
+          // The names themselves, per the wire contract: joined against
+          // $mcp_tool_call on $session_id they answer "advertised but never
+          // called", which the count alone cannot.
+          listedToolNames: tools.map((tool) => tool.name),
           sessionId: ctx?.sessionId,
           ...mcpAttributionFor(ctx),
         });
@@ -16804,7 +16909,10 @@ export function mcpDistinctId(
   sessionId: string | null | undefined,
 ): string | undefined {
   if (typeof githubLogin === "string" && githubLogin) {
-    return `github:${githubLogin}`;
+    // MCP_PERSON_NAMESPACE rather than a literal: recordMcp*'s
+    // $process_person_profile decision keys on this prefix, and sharing the
+    // constant is what keeps "who is a person" a single decision.
+    return `${MCP_PERSON_NAMESPACE}${githubLogin}`;
   }
   if (typeof sessionId === "string" && sessionId) {
     return `mcp-session:${sessionId}`;
@@ -17566,13 +17674,22 @@ export function scheduleMcpRefusalEvent(
         {
           isError: true,
           errorCode: reason,
+          // The refusal's own status, verbatim -- the one place in the tool
+          // family where an HTTP status genuinely exists to report. It is what
+          // separates a HEAD-probing scanner's 405 from a client's 400 without
+          // decoding the reason vocabulary.
+          errorStatus: response.status,
           // Unmeasurable rather than instant: the gate rejected before any
           // handler ran, so there is no duration to report. The recorder omits
           // a zero for exactly this reason.
           durationMs: 0,
-          clientName: parseUserAgentClient(
-            request.headers.get("user-agent") ?? undefined,
-          ),
+          // SPREAD, not assigned: parseUserAgentClient returns a
+          // {clientName, clientVersion} bag. Assigning the bag itself to
+          // clientName handed sanitizeLabel an object, which it drops -- so
+          // every refusal since #10810 shipped with no client at all, and the
+          // scanner-vs-real-client split this field exists for was
+          // unanswerable.
+          ...parseUserAgentClient(request.headers.get("user-agent")),
           clientNameSource: "user_agent",
           sessionId: request.headers.get("mcp-session-id"),
           // WHAT was refused (#10810). The usage_event above has carried the

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -252,6 +252,11 @@ const MAX_LABEL_CHARS = 256;
 // pasting an entire system prompt into it cannot ship that on every call.
 const MAX_MCP_INTENT_CHARS = 1024;
 
+// Ceiling on $mcp_listed_tool_names entries. The catalogue is ~240 tools and
+// grows by ones; 512 leaves headroom for years of additions while bounding
+// what a misplumbed caller could ship on an unsampled event.
+const MAX_MCP_LISTED_TOOL_NAMES = 512;
+
 /**
  * A trimmed string capped at `max`, or undefined when there is nothing to say.
  *
@@ -748,9 +753,56 @@ export function classifyMcpErrorType(code: unknown): McpErrorType {
 }
 
 /**
+ * The `$mcp_source` marker @posthog/mcp stamps on every event it emits.
+ * PostHog's own docs designate it the filter for separating MCP analytics
+ * from everything else in a mixed project, so this hand-rolled emitter must
+ * carry it too or a `$mcp_source`-scoped query silently excludes this server.
+ */
+export const MCP_ANALYTICS_SOURCE = "posthog_mcp_analytics";
+
+/**
+ * The distinct_id namespace that names a real person.
+ *
+ * Owned here rather than in mcp-server.ts because the person-processing
+ * decision below has to agree with mcpDistinctId's namespacing forever, and a
+ * shared constant is what makes disagreement impossible. `mcp-session:<id>`
+ * and the anonymous fallback are transport artifacts, not people.
+ */
+export const MCP_PERSON_NAMESPACE = "github:";
+
+/**
+ * Stamp `$process_person_profile` per the SDK's own contract: false for
+ * sessions with no resolved identity, so anonymous MCP traffic does not mint
+ * (and bill as) a person profile per event -- only a `github:`-verified
+ * caller is a person. Explicit `true` for those rather than omitted, so an
+ * event's person handling is always readable off the event itself.
+ */
+function assignMcpPersonProcessing(
+  properties: Record<string, unknown>,
+  deps: RecordUsageEventDeps,
+  authTier?: string,
+): void {
+  const isPerson = (deps.distinctId ?? USAGE_EVENT_DISTINCT_ID).startsWith(
+    MCP_PERSON_NAMESPACE,
+  );
+  properties["$process_person_profile"] = isPerson;
+  // Person properties ride the event itself ($set on capture) rather than a
+  // separate $identify — the SDK's identify() feature without its extra
+  // event per session, which matters on a project already paying for volume.
+  // Only for a real person: $set on an anonymous event is dead weight.
+  if (isPerson && typeof authTier === "string" && authTier) {
+    properties["$set"] = { mcp_auth_tier: authTier };
+  }
+}
+
+/**
  * Stamp client + server attribution onto an outgoing $mcp_* property bag
  * (#8963). Shared by every event in the family so a breakdown by client or by
  * deploy version behaves identically whichever event it starts from.
+ *
+ * Also stamps `$mcp_source`, because this is the one function every `$mcp_*`
+ * recorder already calls -- the family marker must not depend on which event
+ * a query starts from.
  */
 function assignMcpAttribution(
   properties: Record<string, unknown>,
@@ -761,6 +813,7 @@ function assignMcpAttribution(
     authTier?: string;
   } & McpServerIdentity,
 ): void {
+  properties["$mcp_source"] = MCP_ANALYTICS_SOURCE;
   // #8967: "anonymous", or the tier of the verified mg_ key. This is the one
   // dimension that makes the MCP access model measurable -- authentication
   // currently buys throughput only, and without this there is no way to ask
@@ -912,6 +965,17 @@ export interface McpToolCallEvent extends McpServerIdentity {
    */
   errorCode?: string;
   /**
+   * The HTTP status behind the failure, emitted as `$mcp_error_status` — the
+   * documented member of this event's property set that PostHog's own
+   * failure-breakdown tooling groups by alongside $mcp_error_type. Passed only
+   * where a status genuinely exists: today that is the refusal path, whose
+   * Response carries it directly. A handler-thrown toolError has no status of
+   * its own, and inventing one from the error code would put fabricated
+   * numbers in a property dashboards treat as ground truth. Only meaningful
+   * when isError is true.
+   */
+  errorStatus?: number;
+  /**
    * The agent's own statement of WHY it made this call, taken from the
    * `context` argument (#9642). Emitted as $mcp_intent, which is what
    * PostHog's MCP Analytics intent view and clustering read.
@@ -922,6 +986,24 @@ export interface McpToolCallEvent extends McpServerIdentity {
    * verbatim on every call.
    */
   intent?: string;
+  /**
+   * Where `intent` came from, per PostHog's own vocabulary:
+   * "context_parameter" is the agent's stated reason, "inferred" is the
+   * server's intentFallback filling a call that stated none. The label is the
+   * entire protection — it is what stops server-derived text from being read
+   * as agent speech in the intent views. Defaults to context_parameter, the
+   * only value this field carried before the fallback existed.
+   */
+  intentSource?: "context_parameter" | "inferred";
+  /**
+   * The agent-supplied `conversation_id` argument, emitted as
+   * `$mcp_conversation_id` — PostHog's opt-in property for stitching calls
+   * into one logical conversation across reconnects, which a stateless
+   * transport's rotating $session_id cannot do. Caller-controlled, so the
+   * recorder caps it like every other identifier; it is a grouping label,
+   * never a security boundary.
+   */
+  conversationId?: string;
   clientName?: string;
   clientVersion?: string;
   clientNameSource?: McpClientNameSource;
@@ -990,6 +1072,13 @@ export interface McpInitializeEvent extends McpServerIdentity {
 export interface McpToolsListEvent extends McpServerIdentity {
   /** How many tools the response advertised. */
   toolCount?: number;
+  /**
+   * The advertised tool names, emitted as `$mcp_listed_tool_names` — the
+   * documented member of this event's property set. What it buys over the
+   * count alone: joined against $mcp_tool_call via $session_id, it answers
+   * "which tools are advertised but never called", which the count cannot.
+   */
+  listedToolNames?: string[];
   clientName?: string;
   clientVersion?: string;
   clientNameSource?: McpClientNameSource;
@@ -1053,12 +1142,13 @@ export async function recordMcpToolCallEvent(
     // $mcp_intent_source is part of the wire contract rather than decoration:
     // PostHog distinguishes an intent the agent actually stated
     // ("context_parameter") from one a server inferred on its behalf
-    // ("inferred"). We only ever emit the former, and saying so explicitly is
-    // what stops a future inference fallback from being read as agent speech.
+    // ("inferred"). The label travels with the text always, so the fallback's
+    // mechanical strings can never be read as agent speech.
     const intent = trimToLength(event.intent, MAX_MCP_INTENT_CHARS);
     if (intent !== undefined) {
       properties["$mcp_intent"] = intent;
-      properties["$mcp_intent_source"] = "context_parameter";
+      properties["$mcp_intent_source"] =
+        event.intentSource === "inferred" ? "inferred" : "context_parameter";
     }
 
     // What a refusal arrived on (#10810). Only set by scheduleMcpRefusalEvent,
@@ -1079,12 +1169,35 @@ export async function recordMcpToolCallEvent(
       const errorCode = sanitizeLabel(event.errorCode);
       if (errorCode !== undefined) properties["$mcp_error_code"] = errorCode;
       properties["$mcp_error_type"] = classifyMcpErrorType(event.errorCode);
+      // Bounded to real HTTP statuses: this recorder's callers are trusted,
+      // but a number outside 100-599 could only be a plumbing mistake, and a
+      // dashboard grouping by status must never have to explain a 0 or a NaN.
+      if (
+        typeof event.errorStatus === "number" &&
+        Number.isInteger(event.errorStatus) &&
+        event.errorStatus >= 100 &&
+        event.errorStatus <= 599
+      ) {
+        properties["$mcp_error_status"] = event.errorStatus;
+      }
     }
 
     assignMcpAttribution(properties, event);
+    // The tool call is the one event whose volume makes the $set rider stick:
+    // an identified caller must call tools to matter, so their person profile
+    // picks the tier up here without a separate $identify per session.
+    assignMcpPersonProcessing(properties, deps, event.authTier);
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();
+    }
+
+    // The logical-conversation label, distinct from $session_id above:
+    // sanitizeLabel's identifier cap is the bound, because this is the one
+    // property here whose value the caller invents outright.
+    const conversationId = sanitizeLabel(event.conversationId);
+    if (conversationId !== undefined) {
+      properties["$mcp_conversation_id"] = conversationId;
     }
 
     const parameters = boundedMcpPayload(event.parameters);
@@ -1142,6 +1255,7 @@ export async function recordMcpInitializeEvent(
         event.clientNameSource ??
         (event.clientName ? "client_info" : undefined),
     });
+    assignMcpPersonProcessing(properties, deps);
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();
@@ -1193,7 +1307,21 @@ export async function recordMcpToolsListEvent(
       properties["$mcp_tools_count"] = Math.round(event.toolCount);
     }
 
+    // Names, not just the count: each entry passes the same label cap every
+    // identifier here gets, and non-strings are dropped rather than
+    // stringified — a malformed entry is a caller bug, not data. The array
+    // itself is capped so a pathological caller cannot balloon the payload
+    // past the catalogue's own size.
+    if (Array.isArray(event.listedToolNames)) {
+      const names = event.listedToolNames
+        .map((name) => sanitizeLabel(name))
+        .filter((name): name is string => name !== undefined)
+        .slice(0, MAX_MCP_LISTED_TOOL_NAMES);
+      if (names.length > 0) properties["$mcp_listed_tool_names"] = names;
+    }
+
     assignMcpAttribution(properties, event);
+    assignMcpPersonProcessing(properties, deps);
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();
@@ -1287,6 +1415,7 @@ async function postMcpResourceEvent(
     }
 
     assignMcpAttribution(properties, event);
+    assignMcpPersonProcessing(properties, deps);
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();
@@ -1403,6 +1532,7 @@ export async function recordMcpMissingCapabilityEvent(
     }
 
     assignMcpAttribution(properties, event);
+    assignMcpPersonProcessing(properties, deps);
 
     if (typeof event.sessionId === "string" && event.sessionId.trim()) {
       properties["$session_id"] = event.sessionId.trim();

--- a/tests/feed-netuid-schema.test.ts
+++ b/tests/feed-netuid-schema.test.ts
@@ -62,13 +62,18 @@ describe("get_feed published inputSchema netuid dependency (#8829)", () => {
       GET_FEED_MCP_TOOL.inputSchema as Record<string, unknown>,
     );
     // #9642 adds a universal `context` argument to EVERY tool for agent-intent
-    // capture, so the registered schema is the wrapper's output plus that one
-    // property. Subtracted rather than added to the expectation, so this still
+    // capture, and `conversation_id` rides the same injection, so the
+    // registered schema is the wrapper's output plus those two properties.
+    // Subtracted rather than added to the expectation, so this still
     // asserts the wrapper's full output exactly -- including the `anyOf` that
     // is the whole point of it -- instead of being relaxed into a partial
     // match that would no longer notice the wrapper being dropped.
     const actual = tool.inputSchema as Record<string, unknown>;
-    const { context: _context, ...properties } = actual.properties as Row;
+    const {
+      context: _context,
+      conversation_id: _conversationId,
+      ...properties
+    } = actual.properties as Row;
     assert.deepEqual({ ...actual, properties }, expected);
   });
 });

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -159,6 +159,15 @@ describe("pre-dispatch refusals reach the $mcp_* family", () => {
       assert.equal(events[0].toolName, undefined);
       assert.equal(events[0].sessionId, "sess-1");
       assert.equal(events[0].clientNameSource, "user_agent");
+      // The NAME, not just the source label. parseUserAgentClient returns a
+      // {clientName, clientVersion} bag, and assigning the bag itself to
+      // clientName type-checked (the field is on a loose Row) while shipping
+      // every refusal clientless — the source label alone passed throughout.
+      assert.equal(events[0].clientName, "probe");
+      assert.equal(events[0].clientVersion, "1.0");
+      // The refusal's own status rides as $mcp_error_status: the one place in
+      // the family where an HTTP status genuinely exists.
+      assert.equal(events[0].errorStatus, status);
       // Both events go through waitUntil, never awaited in the MCP path.
       assert.equal(scheduled.length, 2);
     });

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -276,6 +276,9 @@ describe("the alert-triggers tier's status, classified (#10810)", () => {
       [401, "auth_required", "permission"],
       [403, "forbidden", "permission"],
       [404, "not_found", "missing_context"],
+      // The tier's own 400 -- "malformed trigger id", a non-object body -- is
+      // the caller's request, refused.
+      [400, "bad_request", "validation"],
       // Somebody else's 5xx, from the caller's side -- the reading
       // provider_error already carries for an adapter's upstream.
       [500, "provider_error", "api_5xx"],

--- a/tests/mcp-neuron-hotkey-lookup.test.ts
+++ b/tests/mcp-neuron-hotkey-lookup.test.ts
@@ -202,7 +202,9 @@ describe("get_neuron accepts a hotkey (#9872)", () => {
       { required: ["uid"] },
       { required: ["hotkey"] },
     ]);
-    assert.deepEqual(input.required, ["netuid"]);
+    // `context` rides every advertised required list (unenforced — see
+    // withAdvertisedRequiredIntent); the tool's own requirement is netuid.
+    assert.deepEqual(input.required, ["netuid", "context"]);
   });
 });
 

--- a/tests/mcp-schema-enforcement.test.ts
+++ b/tests/mcp-schema-enforcement.test.ts
@@ -223,6 +223,16 @@ describe("published MCP enums are enforced at runtime (#8942)", () => {
       if (!(await isRunnable(tool))) continue;
 
       for (const key of required) {
+        // `context` is the ONE advertised-required argument that is
+        // deliberately unenforced — @posthog/mcp's own intent design, adopted
+        // by withAdvertisedRequiredIntent: a schema-following agent supplies
+        // intent on every call, and a caller that omits it must never be
+        // rejected (it is analytics metadata, not tool input). The safe
+        // direction of the divergence this gate exists to catch: the server
+        // accepts MORE than it advertises, so no caller is ever harmed. Both
+        // halves are pinned in tests/mcp-usage-telemetry.test.ts ("context is
+        // advertised required" / "a call without context is still accepted").
+        if (key === "context") continue;
         checked++;
         const code = await errorCode(
           tool.name as string,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -25150,7 +25150,8 @@ describe("get_coverage_depth MCP tool (#6983)", () => {
     // way -- an argument appearing here by accident still fails.
     assert.deepEqual(
       Object.keys(tool.inputSchema.properties ?? {})
-        .filter((key) => key !== "context")
+        // The two universal analytics arguments every tool carries.
+        .filter((key) => key !== "context" && key !== "conversation_id")
         .sort(),
       [
         "agent_status",

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -12,8 +12,9 @@ import {
   mcpDistinctId,
   mcpRefusalReason,
   scheduleMcpRefusalEvent,
-  splitMcpIntent,
-  withIntentArgument,
+  splitMcpAnalyticsArguments,
+  withAdvertisedRequiredIntent,
+  withAnalyticsArguments,
 } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
 
@@ -1565,36 +1566,104 @@ describe("MCP agent intent capture (#9642)", () => {
     assert.deepEqual(missing, [], "these tools cannot carry agent intent");
   });
 
-  // THE COMPATIBILITY CONSTRAINT, pinned. PostHog's own SDK makes `context`
-  // required; doing that here would reject every call from every existing
-  // client on the next deploy, on all 224 tools at once. If someone ever
-  // "fixes" this to match the SDK, this test is what says why not.
-  test("context is optional on every tool -- never required", () => {
-    const required = tools()
-      .filter((t) =>
-        (((t.inputSchema as Row)?.required as string[]) ?? []).includes(
-          "context",
-        ),
+  // THE COMPATIBILITY CONSTRAINT, pinned — in its two-sided form. PostHog's
+  // own SDK advertises `context` as required while never enforcing it at
+  // validation, and that split is exactly what this server now does: a
+  // schema-following agent supplies intent on every call, and a caller that
+  // omits it is never rejected (dispatch validates the RAW tool entry, where
+  // context stays optional). What must never change is the ENFORCEMENT half
+  // — a validator that starts reading the advertised schema would reject
+  // every existing client on all ~230 tools at once.
+  test("context is advertised required on every tool", () => {
+    const missing = tools()
+      .filter(
+        (t) =>
+          !(((t.inputSchema as Row)?.required as string[]) ?? []).includes(
+            "context",
+          ),
       )
       .map((t) => t.name);
     assert.deepEqual(
-      required,
+      missing,
       [],
-      "a required context would break every existing client",
+      "these tools do not ask the agent for intent",
     );
+  });
+
+  test("...and a call without context is still accepted", async () => {
+    const payload = await callMcp(
+      {
+        ...toolCall(TOOL),
+        params: { name: TOOL, arguments: {} },
+      },
+      CONFIGURED_ENV,
+      { executionCtx: fakeExecutionCtx() },
+    );
+    assert.equal((payload.result as Row).isError, false);
+  });
+
+  test("a call without context gets the inferred fallback, labelled as such", async () => {
+    // The intentFallback half of PostHog's intent design: deterministic, no
+    // argument inspection, and NEVER presented as agent speech — the
+    // intentSource label is the entire protection.
+    const events: Row[] = [];
+    await callMcp(
+      {
+        ...toolCall(TOOL),
+        params: { name: TOOL, arguments: {} },
+      },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpToolCallEvent: (_env: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+      },
+    );
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.intent, `Invoking ${TOOL}`);
+    assert.equal(events[0]!.intentSource, "inferred");
+  });
+
+  test("an agent's own context wins over the fallback", async () => {
+    const events: Row[] = [];
+    await callMcp(
+      {
+        ...toolCall(TOOL),
+        params: { name: TOOL, arguments: { context: "the user's words" } },
+      },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpToolCallEvent: (_env: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+      },
+    );
+    assert.equal(events[0]!.intent, "the user's words");
+    assert.equal(events[0]!.intentSource, undefined);
   });
 
   test("the advertised schema describes what to write", () => {
     const schema = (tools()[0]!.inputSchema as Row).properties.context as Row;
     assert.equal(schema.type, "string");
     // Asserted on CONTENT, not wording (#9696). This description is carried by
-    // all 224 tools, so its length is paid 224 times and shortening it is a
-    // legitimate size change -- a gate pinned to one phrasing turns that into
-    // a failure. What must survive is that it tells the caller what to write,
-    // that it is optional, and that it changes nothing about the result.
+    // all ~230 tools, so its length is paid that many times and shortening it
+    // is a legitimate size change -- a gate pinned to one phrasing turns that
+    // into a failure. What must survive is that it tells the caller what to
+    // write and that it changes nothing about the result. It must NOT call
+    // itself optional any more: the advertised schema now marks it required,
+    // and a description contradicting the schema teaches the model to
+    // distrust both.
     const described = String(schema.description);
     assert.match(described, /goal/i, "says what to write");
-    assert.match(described, /optional/i, "says it is optional");
+    assert.doesNotMatch(
+      described,
+      /optional/i,
+      "must not contradict the advertised required",
+    );
     assert.match(
       described,
       /does not affect|analytics only/i,
@@ -1611,6 +1680,21 @@ describe("MCP agent intent capture (#9642)", () => {
       {
         ...toolCall(TOOL),
         params: { name: TOOL, arguments: { context: "why" } },
+      },
+      CONFIGURED_ENV,
+      { executionCtx: fakeExecutionCtx() },
+    );
+    assert.equal((payload.result as Row).isError, false);
+  });
+
+  test("a call carrying conversation_id is accepted, not rejected as an unknown key", async () => {
+    // Same both-sides guarantee as `context` above: injected upstream of the
+    // advertise AND validate paths, so publishing the argument and rejecting
+    // its use cannot diverge.
+    const payload = await callMcp(
+      {
+        ...toolCall(TOOL),
+        params: { name: TOOL, arguments: { conversation_id: "conv-1" } },
       },
       CONFIGURED_ENV,
       { executionCtx: fakeExecutionCtx() },
@@ -1647,7 +1731,10 @@ describe("MCP agent intent capture (#9642)", () => {
   });
 
   test("the handler never receives context", () => {
-    const { intent, rest } = splitMcpIntent({ netuid: 64, context: "why" });
+    const { intent, rest } = splitMcpAnalyticsArguments({
+      netuid: 64,
+      context: "why",
+    });
     assert.equal(intent, "why");
     assert.deepEqual(rest, { netuid: 64 });
     assert.equal("context" in rest, false);
@@ -1656,14 +1743,23 @@ describe("MCP agent intent capture (#9642)", () => {
   // "Did not explain" must stay distinguishable from "explained with nothing",
   // and a non-string is not an explanation.
   test("an empty, whitespace or non-string context yields no intent", () => {
-    assert.equal(splitMcpIntent({ context: "" }).intent, undefined);
-    assert.equal(splitMcpIntent({ context: "   " }).intent, undefined);
-    assert.equal(splitMcpIntent({ context: 42 }).intent, undefined);
-    assert.equal(splitMcpIntent({ context: null }).intent, undefined);
+    assert.equal(splitMcpAnalyticsArguments({ context: "" }).intent, undefined);
+    assert.equal(
+      splitMcpAnalyticsArguments({ context: "   " }).intent,
+      undefined,
+    );
+    assert.equal(splitMcpAnalyticsArguments({ context: 42 }).intent, undefined);
+    assert.equal(
+      splitMcpAnalyticsArguments({ context: null }).intent,
+      undefined,
+    );
     // Still stripped from the arguments even when it is not usable as intent.
-    assert.deepEqual(splitMcpIntent({ netuid: 1, context: 42 }).rest, {
-      netuid: 1,
-    });
+    assert.deepEqual(
+      splitMcpAnalyticsArguments({ netuid: 1, context: 42 }).rest,
+      {
+        netuid: 1,
+      },
+    );
   });
 
   // A schema that declares neither `type` nor `properties` is legal under
@@ -1671,7 +1767,7 @@ describe("MCP agent intent capture (#9642)", () => {
   // registered tool is shaped that way today. The fallbacks exist for that
   // tool; exercised here so they are known to work rather than assumed.
   test("a schema missing type/properties still gets a well-formed one", () => {
-    const injected = withIntentArgument({
+    const injected = withAnalyticsArguments({
       name: "hypothetical",
       title: "Hypothetical",
       description: "d",
@@ -1680,11 +1776,14 @@ describe("MCP agent intent capture (#9642)", () => {
     });
     const schema = injected.inputSchema as Row;
     assert.equal(schema.type, "object");
-    assert.deepEqual(Object.keys(schema.properties as Row), ["context"]);
+    assert.deepEqual(Object.keys(schema.properties as Row), [
+      "context",
+      "conversation_id",
+    ]);
   });
 
   test("an existing schema keeps its own type and every real property", () => {
-    const injected = withIntentArgument({
+    const injected = withAnalyticsArguments({
       name: "hypothetical",
       title: "Hypothetical",
       description: "d",
@@ -1702,16 +1801,134 @@ describe("MCP agent intent capture (#9642)", () => {
     assert.equal(schema.additionalProperties, false);
     assert.deepEqual(Object.keys(schema.properties as Row).sort(), [
       "context",
+      "conversation_id",
       "netuid",
     ]);
+  });
+
+  // The advertise-only required promotion, on its own: the guards exist for
+  // hand-written literals JsonSchemaLike still permits, so they are proven
+  // here rather than assumed unreachable.
+  test("withAdvertisedRequiredIntent appends, preserves, and passes through", () => {
+    // Appends to an existing required list without touching it.
+    assert.deepEqual(
+      withAdvertisedRequiredIntent({ type: "object", required: ["netuid"] })
+        .required,
+      ["netuid", "context"],
+    );
+    // A schema with no required list at all gets one.
+    assert.deepEqual(
+      withAdvertisedRequiredIntent({ type: "object" }).required,
+      ["context"],
+    );
+    // Already-required is returned unchanged — the same object, no copy.
+    const already = { type: "object", required: ["context"] };
+    assert.equal(withAdvertisedRequiredIntent(already), already);
+    // A non-object passes straight through, mirroring
+    // stripSentinelIntegerBounds' own contract for the hand-written case.
+    const notASchema = null as unknown as Parameters<
+      typeof withAdvertisedRequiredIntent
+    >[0];
+    assert.equal(withAdvertisedRequiredIntent(notASchema), notASchema);
   });
 
   // The common case is a call with no context at all, so it must not pay for
   // the feature.
   test("arguments without context are passed through untouched", () => {
     const args = { netuid: 64 };
-    const split = splitMcpIntent(args);
+    const split = splitMcpAnalyticsArguments(args);
     assert.equal(split.rest, args, "same object, no copy");
     assert.equal(split.intent, undefined);
+    assert.equal(split.conversationId, undefined);
+    // The nullable signature: a missing argument object is an empty rest,
+    // never a throw.
+    assert.deepEqual(splitMcpAnalyticsArguments(null).rest, {});
+    assert.deepEqual(splitMcpAnalyticsArguments(undefined).rest, {});
+  });
+
+  test("tools/list reports the advertised names alongside the count", async () => {
+    const events: Row[] = [];
+    await callMcp(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpToolsListEvent: (_env: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+      },
+    );
+    assert.equal(events.length, 1);
+    const names = events[0]!.listedToolNames as string[];
+    // The names ARE the advertised catalogue — same length as the count the
+    // event has always carried, so the two cannot tell different stories.
+    assert.equal(names.length, events[0]!.toolCount);
+    assert.ok(names.includes("get_subnet"));
+  });
+
+  // ── conversation_id: the stitching label, same lifecycle as the intent ──
+
+  test("the handler never receives conversation_id, and telemetry does", () => {
+    const { intent, conversationId, rest } = splitMcpAnalyticsArguments({
+      netuid: 64,
+      context: "why",
+      conversation_id: "conv-1",
+    });
+    assert.equal(intent, "why");
+    assert.equal(conversationId, "conv-1");
+    assert.deepEqual(rest, { netuid: 64 });
+  });
+
+  test("conversation_id alone is split too, without an intent", () => {
+    // The splitter's early return keys on EITHER argument being present;
+    // a caller sending only the id must not fall through it.
+    const split = splitMcpAnalyticsArguments({
+      netuid: 64,
+      conversation_id: "conv-1",
+    });
+    assert.equal(split.intent, undefined);
+    assert.equal(split.conversationId, "conv-1");
+    assert.deepEqual(split.rest, { netuid: 64 });
+  });
+
+  test("an empty, whitespace or non-string conversation_id yields none", () => {
+    for (const bad of ["", "   ", 42, null]) {
+      const split = splitMcpAnalyticsArguments({
+        netuid: 1,
+        conversation_id: bad,
+      });
+      assert.equal(split.conversationId, undefined, String(bad));
+      // Still stripped from the arguments even when unusable as a label.
+      assert.deepEqual(split.rest, { netuid: 1 });
+    }
+  });
+
+  test("a dispatched call carries conversationId end to end", async () => {
+    const events: Row[] = [];
+    await callMcp(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "get_subnet",
+          arguments: { netuid: 64, conversation_id: "conv-9" },
+        },
+      },
+      CONFIGURED_ENV,
+      {
+        executionCtx: fakeExecutionCtx(),
+        recordMcpToolCallEvent: (_env: unknown, event: Row) => {
+          events.push(event);
+          return true;
+        },
+      },
+    );
+    assert.equal(events.length, 1);
+    assert.equal(events[0]!.conversationId, "conv-9");
+    // Not duplicated inside the parameter blob, and never handed to the
+    // handler -- the same lifecycle context already has.
+    assert.deepEqual(events[0]!.parameters, { netuid: 64 });
   });
 });

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -42,6 +42,7 @@ import type {
   AiGenerationEvent,
   ExceptionEvent,
   McpToolCallEvent,
+  McpToolsListEvent,
   RecordUsageEventDeps,
   UsageEvent,
 } from "../src/usage-telemetry.ts";
@@ -402,6 +403,10 @@ describe("recordMcpToolCallEvent", () => {
       $mcp_is_error: false,
       $mcp_duration_ms: 12,
       $mcp_tool_name: "get_subnet",
+      // The family envelope: the SDK's source marker, and no person profile
+      // for a caller with no github: identity.
+      $mcp_source: "posthog_mcp_analytics",
+      $process_person_profile: false,
       $session_id: "sess-1",
       // #9446: the deployment dimension every capture now carries.
       // No CF_VERSION_METADATA binding in this env, so it reads as a
@@ -705,6 +710,10 @@ describe("recordMcpInitializeEvent", () => {
       // User-Agent guess a tool call has to fall back on.
       $mcp_client_name_source: "client_info",
       $mcp_client_version: "1.2.3",
+      // The family envelope: the SDK's source marker, and no person profile
+      // for a caller with no github: identity.
+      $mcp_source: "posthog_mcp_analytics",
+      $process_person_profile: false,
       $session_id: "sess-1",
       // #9446: the deployment dimension every capture now carries.
       // No CF_VERSION_METADATA binding in this env, so it reads as a
@@ -724,8 +733,11 @@ describe("recordMcpInitializeEvent", () => {
     // #9446: `environment` is the deployment dimension every capture now
     // carries; no CF_VERSION_METADATA binding here, so it reads as a
     // local/undeployed isolate. Everything the caller omitted is still
-    // absent, which is what this test is actually about.
+    // absent, which is what this test is actually about — the envelope pair
+    // is stamped by the recorder itself, never by the caller.
     assert.deepEqual(calls[0].body.properties, {
+      $mcp_source: "posthog_mcp_analytics",
+      $process_person_profile: false,
       environment: "development",
     });
   });
@@ -1949,6 +1961,10 @@ describe("recordMcpToolsListEvent", () => {
       $mcp_client_name_source: "user_agent",
       $mcp_server_name: "metagraphed",
       $mcp_server_version: "1.78.12",
+      // The family envelope: the SDK's source marker, and no person profile
+      // for a caller with no github: identity.
+      $mcp_source: "posthog_mcp_analytics",
+      $process_person_profile: false,
       $session_id: "sess-9",
       // #9446: the deployment dimension every capture now carries.
       // No CF_VERSION_METADATA binding in this env, so it reads as a
@@ -3069,6 +3085,325 @@ describe("every recorder stamps the deployment dimensions", () => {
       recorders.length,
       `recorders covered: ${recorders.length}, exported: ${exported.join(", ")}`,
     );
+  });
+});
+
+// ─── The $mcp_* family envelope: $mcp_source + person processing ────────────
+//
+// PostHog's own SDK stamps both on every event it emits, and its docs
+// designate $mcp_source as THE filter for MCP analytics in a mixed project —
+// an event without it is invisible to a $mcp_source-scoped query. Asserted
+// across every $mcp_* recorder for the same reason the deployment block
+// above loops: a recorder outside the envelope is a query gap, not a bug
+// anyone would notice locally.
+describe("every $mcp_* recorder carries the family envelope", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  const mcpRecorders: Array<
+    [string, (env: Env, deps: RecordUsageEventDeps) => Promise<unknown>]
+  > = [
+    [
+      "$mcp_tool_call",
+      (env, deps) =>
+        recordMcpToolCallEvent(
+          env,
+          { toolName: "get_subnet", isError: false, durationMs: 5 },
+          deps,
+        ),
+    ],
+    [
+      "$mcp_initialize",
+      (env, deps) => recordMcpInitializeEvent(env, { clientName: "c" }, deps),
+    ],
+    [
+      "$mcp_tools_list",
+      (env, deps) => recordMcpToolsListEvent(env, { toolCount: 3 }, deps),
+    ],
+    [
+      "$mcp_resources_list",
+      (env, deps) => recordMcpResourcesListEvent(env, {}, deps),
+    ],
+    [
+      "$mcp_resource_read",
+      (env, deps) =>
+        recordMcpResourceReadEvent(
+          env,
+          { resourceName: "metagraph://registry/summary" },
+          deps,
+        ),
+    ],
+    [
+      "$mcp_prompts_list",
+      (env, deps) => recordMcpPromptsListEvent(env, {}, deps),
+    ],
+    [
+      "$mcp_prompt_get",
+      (env, deps) =>
+        recordMcpPromptGetEvent(
+          env,
+          { resourceName: "integrate_with_subnet" },
+          deps,
+        ),
+    ],
+    [
+      "$mcp_missing_capability",
+      (env, deps) =>
+        recordMcpMissingCapabilityEvent(
+          env,
+          { intent: "needed per-validator slippage, no tool has it" },
+          deps,
+        ),
+    ],
+  ];
+
+  for (const [eventName, invoke] of mcpRecorders) {
+    test(`${eventName} carries $mcp_source and anonymous person processing`, async () => {
+      const calls: Row[] = [];
+      await invoke(mockEnv(CONFIGURED), {
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      });
+      assert.equal(calls.length, 1, "the recorder posted nothing");
+      const properties = (calls[0].body as Row).properties as Row;
+      assert.equal(properties.$mcp_source, "posthog_mcp_analytics");
+      // No distinctId override → the shared anonymous constant → no person.
+      assert.equal(properties.$process_person_profile, false);
+    });
+  }
+
+  test("a github:-verified caller keeps person processing on", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      mockEnv(CONFIGURED),
+      { toolName: "get_subnet", isError: false, durationMs: 5 },
+      {
+        distinctId: "github:someone",
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      },
+    );
+    assert.equal(calls[0].body.properties.$process_person_profile, true);
+  });
+
+  test("a session identity is a transport artifact, not a person", async () => {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      mockEnv(CONFIGURED),
+      { toolName: "get_subnet", isError: false, durationMs: 5 },
+      {
+        // The namespacing is the load-bearing part: a session id that
+        // CONTAINS "github:" must not smuggle itself into the person
+        // namespace, which is exactly why mcpDistinctId prefixes it.
+        distinctId: "mcp-session:github:someone",
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      },
+    );
+    assert.equal(calls[0].body.properties.$process_person_profile, false);
+  });
+
+  test("an identified caller's tier rides as a person property", async () => {
+    // The identify() feature without its extra event: $set on the capture
+    // itself, so the person profile learns the tier at zero added volume.
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      mockEnv(CONFIGURED),
+      {
+        toolName: "get_subnet",
+        isError: false,
+        durationMs: 5,
+        authTier: "community",
+      },
+      {
+        distinctId: "github:someone",
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      },
+    );
+    assert.deepEqual(calls[0].body.properties.$set, {
+      mcp_auth_tier: "community",
+    });
+  });
+
+  test("an anonymous caller's tier sets no person property", async () => {
+    // $set on an event whose person processing is off is dead weight — the
+    // profile it would write to is deliberately never created.
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(
+      mockEnv(CONFIGURED),
+      {
+        toolName: "get_subnet",
+        isError: false,
+        durationMs: 5,
+        authTier: "anonymous",
+      },
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    assert.ok(!("$set" in calls[0].body.properties));
+  });
+});
+
+// ─── $mcp_error_status: the failure's HTTP status, where one exists ─────────
+describe("recordMcpToolCallEvent $mcp_error_status", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  async function capture(event: McpToolCallEvent) {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(mockEnv(CONFIGURED), event, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    return (calls[0].body as Row).properties as Row;
+  }
+
+  test("a failed call carries its HTTP status", async () => {
+    const properties = await capture({
+      isError: true,
+      durationMs: 0,
+      errorCode: "method_not_allowed",
+      errorStatus: 405,
+    });
+    assert.equal(properties.$mcp_error_status, 405);
+  });
+
+  test("a successful call never carries one, even if handed a status", async () => {
+    // Same rule as $mcp_error_type: an error dimension on a success would
+    // poison every breakdown that does not also filter on $mcp_is_error.
+    const properties = await capture({
+      isError: false,
+      durationMs: 5,
+      errorStatus: 405,
+    });
+    assert.ok(!("$mcp_error_status" in properties));
+  });
+
+  test("a value outside 100-599, or a non-integer, is dropped", async () => {
+    for (const status of [0, 99, 600, 404.5, Number.NaN]) {
+      const properties = await capture({
+        isError: true,
+        durationMs: 0,
+        errorCode: "bad_request",
+        errorStatus: status,
+      });
+      assert.ok(
+        !("$mcp_error_status" in properties),
+        `status ${status} should be dropped`,
+      );
+    }
+  });
+});
+
+// ─── $mcp_intent_source: agent speech vs the inferred floor ─────────────────
+describe("recordMcpToolCallEvent $mcp_intent_source", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  async function capture(event: McpToolCallEvent) {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(mockEnv(CONFIGURED), event, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    return (calls[0].body as Row).properties as Row;
+  }
+
+  test("an inferred intent is labelled inferred on the wire", async () => {
+    const properties = await capture({
+      toolName: "get_subnet",
+      isError: false,
+      durationMs: 5,
+      intent: "Invoking get_subnet",
+      intentSource: "inferred",
+    });
+    assert.equal(properties.$mcp_intent, "Invoking get_subnet");
+    assert.equal(properties.$mcp_intent_source, "inferred");
+  });
+
+  test("no source field still means agent speech — the pre-fallback default", async () => {
+    const properties = await capture({
+      toolName: "get_subnet",
+      isError: false,
+      durationMs: 5,
+      intent: "checking SN64 health for a user",
+    });
+    assert.equal(properties.$mcp_intent_source, "context_parameter");
+  });
+});
+
+// ─── $mcp_conversation_id: the agent's stitching label ──────────────────────
+describe("recordMcpToolCallEvent $mcp_conversation_id", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  async function capture(event: McpToolCallEvent) {
+    const calls: Row[] = [];
+    await recordMcpToolCallEvent(mockEnv(CONFIGURED), event, {
+      fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+    });
+    return (calls[0].body as Row).properties as Row;
+  }
+
+  test("a supplied conversation id is carried, trimmed", async () => {
+    const properties = await capture({
+      toolName: "get_subnet",
+      isError: false,
+      durationMs: 5,
+      conversationId: " conv-1 ",
+    });
+    assert.equal(properties.$mcp_conversation_id, "conv-1");
+  });
+
+  test("absent means absent — no key, not an empty string", async () => {
+    const properties = await capture({
+      toolName: "get_subnet",
+      isError: false,
+      durationMs: 5,
+    });
+    assert.ok(!("$mcp_conversation_id" in properties));
+  });
+});
+
+// ─── $mcp_listed_tool_names: the advertised catalogue, bounded ──────────────
+describe("recordMcpToolsListEvent $mcp_listed_tool_names", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" };
+
+  async function capture(event: Row) {
+    const calls: Row[] = [];
+    await recordMcpToolsListEvent(
+      mockEnv(CONFIGURED),
+      event as McpToolsListEvent,
+      { fetch: fakeFetch({ onCall: (call) => calls.push(call) }) },
+    );
+    return (calls[0].body as Row).properties as Row;
+  }
+
+  test("carries the advertised names", async () => {
+    const properties = await capture({
+      toolCount: 2,
+      listedToolNames: ["get_subnet", "list_subnets"],
+    });
+    assert.deepEqual(properties.$mcp_listed_tool_names, [
+      "get_subnet",
+      "list_subnets",
+    ]);
+  });
+
+  test("drops non-string entries rather than stringifying them", async () => {
+    const properties = await capture({
+      toolCount: 3,
+      listedToolNames: ["get_subnet", 42, null],
+    });
+    assert.deepEqual(properties.$mcp_listed_tool_names, ["get_subnet"]);
+  });
+
+  test("an empty or absent list sets no key at all", async () => {
+    assert.ok(
+      !(
+        "$mcp_listed_tool_names" in
+        (await capture({ toolCount: 0, listedToolNames: [] }))
+      ),
+    );
+    assert.ok(!("$mcp_listed_tool_names" in (await capture({ toolCount: 0 }))));
+  });
+
+  test("caps a pathological list instead of shipping it", async () => {
+    const properties = await capture({
+      toolCount: 1000,
+      listedToolNames: Array.from({ length: 1000 }, (_, i) => `tool_${i}`),
+    });
+    assert.equal((properties.$mcp_listed_tool_names as string[]).length, 512);
   });
 });
 


### PR DESCRIPTION
Closes #10884

Two commits, one surface: what the MCP server tells PostHog about itself.

**Commit 1 — the last miscategorised error code.** The alert-triggers tier's 400 ("malformed trigger id", a non-object body) fell through `alertTriggerErrorCode`'s catch-all to `internal`. It now maps to the vocabulary's existing `bad_request` (→ `validation`), so `$mcp_error_type = internal` on the current version reads a true zero unless something is actually broken server-side.

**Commit 2 — attribution and the wire contract.**

Bugs fixed:
- Refusals shipped clientless: `parseUserAgentClient`'s `{clientName, clientVersion}` bag was assigned to `clientName` itself and dropped by `sanitizeLabel`. Spread now, and the refusal loop test asserts the NAME, which is what would have caught it.
- The nightly conformance sweep now sends `user-agent: metagraphed-conformance/1` instead of arriving as the dashboard's largest unidentified client.

Contract completed (per the documented `$mcp_*` reference):
- `$mcp_source: "posthog_mcp_analytics"` on every event in the family
- `$process_person_profile`: false for anonymous/session traffic, true for `github:`-verified callers (namespace now shared via `MCP_PERSON_NAMESPACE` so the decision cannot drift), with the caller's tier riding `$set` on identified tool calls
- `$mcp_listed_tool_names` on `$mcp_tools_list`, capped and sanitized
- `$mcp_error_status` on refusals, where an HTTP status genuinely exists
- `conversation_id` accepted on every tool, stripped before handlers, emitted as `$mcp_conversation_id` — the SDK's mint-and-prompt-back half is deliberately not implemented (it appends a visible text block to every response)
- Intent, PostHog's own design: `context` advertised as required while validation stays lenient (a call without it is never rejected — pinned both ways), plus a deterministic inferred fallback labelled `$mcp_intent_source: "inferred"` so intent coverage separates "did not cooperate" from "did not record"

The schema-enforcement gate exempts exactly `context` from required-means-enforced, with the reasoning in place: the divergence is in the safe direction (the server accepts more than it advertises), and both halves are pinned in tests.

Verified: `tsc` clean; 406 tests across the ten MCP/telemetry suites; `validate:mcp`, `validate:mcp-route-map`, `validate:mcp-input-parity`, `validate:tool-route-divergence` all pass; lint + format clean; rebased onto f7d929196.