### PR TITLE
fix(revenue): let a declaration say WHERE its rows live

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -52,3 +52,16 @@ runs:
           rm -rf node_modules apps/ui/node_modules packages/*/node_modules
           sleep 30
         done
+    - name: Regenerate codegen the cache cannot carry
+      # The cache-hit path skips every postinstall ON PURPOSE -- the property
+      # is network exposure, and a restored node_modules opens no connection.
+      # But apps/ui's fumadocs-mdx postinstall GENERATES apps/ui/.source, a
+      # gitignored tree OUTSIDE node_modules that the cache neither stores nor
+      # restores, and apps/ui's typecheck imports it (`collections/*` maps to
+      # ./.source/* in its tsconfig). So a cache hit shipped a tree that
+      # type-checks nowhere, found the first time the path-filtered ui job ran
+      # after #10871 landed. Local codegen over repo content, no network --
+      # re-running it unconditionally (the miss path's own run is idempotent)
+      # keeps the cache's actual contract intact.
+      shell: bash
+      run: npm run postinstall --workspace=apps/ui --if-present

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9169,6 +9169,8 @@ export interface components {
                      * @enum {string}
                      */
                     role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
+                    /** @description The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows. */
+                    rows?: string;
                     /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
                     searched_at?: string;
                     /**
@@ -12419,6 +12421,8 @@ export interface components {
                  * @enum {string}
                  */
                 role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
+                /** @description The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows. */
+                rows?: string;
                 /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
                 searched_at?: string;
                 /**

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -37455,6 +37455,10 @@
                           ],
                           "type": "string"
                         },
+                        "rows": {
+                          "description": "The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows.",
+                          "type": "string"
+                        },
                         "searched_at": {
                           "description": "When absence was established. Required for provenance 'none': an undated absence is not evidence.",
                           "type": "string"
@@ -55987,6 +55991,10 @@
                   "miner-payout",
                   "not-revenue"
                 ],
+                "type": "string"
+              },
+              "rows": {
+                "description": "The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows.",
                 "type": "string"
               },
               "searched_at": {

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -8258,6 +8258,7 @@
         "grain": "cumulative",
         "provenance": "chain-verified",
         "role": "external-revenue",
+        "rows": "items",
         "shape": "flat-array",
         "source_url": "https://api.chutes.ai/openapi.json"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9169,6 +9169,8 @@ export interface components {
                      * @enum {string}
                      */
                     role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
+                    /** @description The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows. */
+                    rows?: string;
                     /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
                     searched_at?: string;
                     /**
@@ -12419,6 +12421,8 @@ export interface components {
                  * @enum {string}
                  */
                 role: "external-revenue" | "usage-proxy" | "miner-payout" | "not-revenue";
+                /** @description The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows. */
+                rows?: string;
                 /** @description When absence was established. Required for provenance 'none': an undated absence is not evidence. */
                 searched_at?: string;
                 /**

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -912,6 +912,7 @@
         "currency": "USD",
         "grain": "cumulative",
         "shape": "flat-array",
+        "rows": "items",
         "fields": {
           "date": "timestamp",
           "amount": "usd_amount"
@@ -919,7 +920,7 @@
         "circularity": "external",
         "source_url": "https://api.chutes.ai/openapi.json"
       },
-      "notes": "Public no-auth GET /payments on api.chutes.ai, returning a list of TAO payment transactions with taostats.io transaction/account links. Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints. Distinct from the already-tracked /payments/summary/tao aggregate totals.",
+      "notes": "Public no-auth GET /payments on api.chutes.ai, returning a paginated envelope ({total, page, limit, items}) of TAO payment transactions with taostats.io transaction/account links. Discovered via a full diff of the subnet's own OpenAPI schema for undiscovered public GET endpoints. Distinct from the already-tracked /payments/summary/tao aggregate totals.",
       "probe": {
         "enabled": true,
         "expect": "json",

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -613,6 +613,10 @@ export const SurfaceRevenueSchema = z
         "Map of role -> field name in the upstream payload, e.g. {date: 'date', amount: 'total_revenue'}.",
     }),
     grain: z.enum(["daily", "weekly", "monthly", "cumulative"]).optional(),
+    rows: z.string().optional().meta({
+      description:
+        "The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows.",
+    }),
     shape: z.enum(["flat-array", "keyed-map", "scalar"]).optional().meta({
       description:
         "How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.",

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -404,6 +404,10 @@
           "enum": ["flat-array", "keyed-map", "scalar"],
           "description": "How the payload is arranged, so an extractor does not have to guess. `flat-array`: a list of records, `fields.date`/`fields.amount` naming keys within one (SN64's daily_revenue_summary). `keyed-map`: nested {period: {subkey: amount}} where the period IS the key and there are no field names to point at (SN51's revenue-for-validators). `scalar`: one object carrying a single total, `fields.amount` naming it (SN64's payments/summary/tao)."
         },
+        "rows": {
+          "type": "string",
+          "description": "The envelope key holding the payload `shape` describes, for a source that wraps its rows — api.chutes.ai/payments returns {total, page, limit, items: [...]} and the flat array lives under `items`. Absent means the payload IS the rows, which is every other declaration."
+        },
         "fields": {
           "description": "Map of role -> field name in the upstream payload, e.g. {\"date\": \"date\", \"amount\": \"total_revenue\"}.",
           "type": "object",

--- a/src/revenue-observation.ts
+++ b/src/revenue-observation.ts
@@ -24,6 +24,15 @@ export interface RevenueDeclaration {
   currency?: string;
   fields?: Record<string, string>;
   excludes?: string[];
+  /**
+   * WHERE the rows live (#10855): the envelope key holding the payload the
+   * shape describes. `shape` says how rows are arranged; it could never say
+   * that they sit under `items` in a pagination envelope, so a surface whose
+   * rows genuinely are a flat array — api.chutes.ai/payments — failed
+   * "expected an array payload" deterministically, every hour, forever.
+   * Absent means the payload IS the rows, which is every other declaration.
+   */
+  rows?: string;
 }
 
 export interface RevenueObservation {
@@ -102,6 +111,21 @@ export function extractRevenue(
   }
   if (!currency) return fail("no currency declared");
   const fields = declaration.fields ?? {};
+
+  // Unwrap the declared envelope BEFORE any shape dispatch, so `rows` means
+  // the same thing for every shape. Both failure modes name the key: "the
+  // envelope was not an object" and "the key was not there" are different
+  // upstream changes, and the dead-letter summary is where the distinction
+  // is read.
+  if (declaration.rows !== undefined) {
+    if (!isRecord(payload)) {
+      return fail(`rows "${declaration.rows}": payload is not an object`);
+    }
+    if (!(declaration.rows in payload)) {
+      return fail(`rows "${declaration.rows}": key missing from payload`);
+    }
+    payload = payload[declaration.rows];
+  }
 
   if (shape === "flat-array") {
     if (!Array.isArray(payload)) return fail("expected an array payload");

--- a/tests/revenue-observation.test.ts
+++ b/tests/revenue-observation.test.ts
@@ -212,3 +212,67 @@ describe("the declaration itself", () => {
     assert.equal(obs[0].currency, "TAO");
   });
 });
+
+// #10855: `shape` says how rows are arranged; `rows` says WHERE they live.
+// Without it, api.chutes.ai/payments -- whose rows genuinely are a flat array,
+// under `items` in a pagination envelope -- failed "expected an array payload"
+// deterministically, every hour, forever.
+describe("rows: the envelope key (#10855)", () => {
+  // The real shape, observed 2026-08-12 in #10855.
+  const PAYMENTS = {
+    shape: "flat-array" as const,
+    currency: "USD",
+    rows: "items",
+    fields: { date: "timestamp", amount: "usd_amount" },
+  };
+  const ENVELOPE = {
+    total: 18943,
+    page: 0,
+    limit: 25,
+    items: [
+      { payment_id: "p-1", usd_amount: 12.5, timestamp: "2026-08-11T01:00Z" },
+      { payment_id: "p-2", usd_amount: 7.25, timestamp: "2026-08-11T02:00Z" },
+    ],
+  };
+
+  test("unwraps the declared key and extracts the rows inside", () => {
+    const obs = ok(extractRevenue(PAYMENTS, ENVELOPE));
+    assert.equal(obs.length, 2);
+    assert.deepEqual(obs[0], {
+      period: "2026-08-11T01:00Z",
+      amount: 12.5,
+      currency: "USD",
+    });
+  });
+
+  test("a missing key and a non-object envelope refuse, each naming the key", () => {
+    // Two different upstream changes, two different reasons -- the
+    // dead-letter summary is where the distinction is read.
+    assert.match(
+      reason(extractRevenue(PAYMENTS, { total: 0, page: 0 })),
+      /rows "items": key missing/,
+    );
+    assert.match(
+      reason(extractRevenue(PAYMENTS, [1, 2, 3])),
+      /rows "items": payload is not an object/,
+    );
+  });
+
+  test("what the key holds is still validated by the shape", () => {
+    // Unwrapping must not loosen anything: an envelope whose `items` is not
+    // an array fails exactly as a bare non-array payload always has.
+    assert.match(
+      reason(extractRevenue(PAYMENTS, { items: "nope" })),
+      /expected an array payload/,
+    );
+  });
+
+  test("rows applies uniformly, not only to flat-array", () => {
+    // One meaning across shapes: a keyed-map wrapped in an envelope unwraps
+    // the same way, so the field never needs a per-shape rule.
+    const obs = ok(
+      extractRevenue({ ...LIUM, rows: "months" }, { months: { "2026-07": 5 } }),
+    );
+    assert.deepEqual(obs, [{ period: "2026-07", amount: 5, currency: "USD" }]);
+  });
+});


### PR DESCRIPTION
Closes #10855

`shape` says how a revenue payload's rows are arranged; it could never say that they sit inside an envelope. `api.chutes.ai/payments` returns `{total, page, limit, items: [...]}` — the rows genuinely are a flat array of `{timestamp, usd_amount}`, just under `items` — so `sn-64-chutes-payments-list` failed `expected an array payload` deterministically on every hourly tick, and its retries are what has held `revenue-probes-dlq` at `stale` (31h and counting as of this PR).

The fix is the one #10855 designs: an optional `rows` key on the revenue declaration naming the envelope member holding the payload the shape describes.

- `extractRevenue` unwraps the declared key BEFORE shape dispatch, so `rows` means the same thing for every shape; both failure modes name the key ("payload is not an object" vs "key missing from payload") since those are different upstream changes and the dead-letter summary is where the distinction is read. What the key holds is still validated by the shape — an envelope whose `items` is not an array fails exactly as a bare non-array always has.
- `schemas/subnet-manifest.schema.json` + `SurfaceRevenueSchema` (schemas-src) declare the field; regenerated `openapi.json`/types committed.
- `registry/subnets/chutes.json` declares `"rows": "items"` on the failing surface.

Verified: the live payload shape from the issue extracts (unit tests reproduce it verbatim), 74 revenue tests pass, `tsc` clean, `validate:schemas` / `validate:contract-drift` / `validate:api` / `validate:openapi` / `validate:types` all pass, lint + format clean.

After deploy, the hourly probe extracts instead of dead-lettering, and the `revenue-probes-dlq` staleness alarm clears on the next drain.