### PR TITLE
fix(observability): file the buffered snapshot's sub-lane verdicts at enqueue

### DIFF
--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -438,7 +438,26 @@ export async function mirrorNeuronSnapshotToNeon(
       plan.guard,
     );
     results[name] = result;
-    await recordNeonWriteVerdict(laneDb, name, result, now(), buffered);
+    // The derived tables are SUB-LANES of the buffered runner (#10888): every
+    // statement here rides under the ONE lane tag the runner was built with,
+    // NEURONS_NEON_LANE, so the flush can only ever file `neon:neurons` --
+    // `neon:neuron_daily` and `neon:account_position_daily` never appear in
+    // its per-lane tally under any key. Suppressing their buffered successes
+    // on the flush's behalf therefore silenced them permanently the moment
+    // the buffer came on (#10758): 30 hours of "neon:neuron_daily is silent"
+    // alarms, measured 2026-08-12, while the table held that day's snapshot.
+    // oncePerPass is #10826's remedy for exactly this shape, and the cost
+    // argument holds at this cadence too: two extra verdict rows per 15-minute
+    // pass. The base lane stays flush-attributed -- its statements DO carry
+    // its name.
+    await recordNeonWriteVerdict(
+      laneDb,
+      name,
+      result,
+      now(),
+      buffered,
+      name !== NEURONS_NEON_LANE,
+    );
   }
 
   // THE DEREGISTRATION PRUNE (#10184). D1's writer ran this and the Neon mirror

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -188,6 +188,48 @@ describe("mirrorNeuronSnapshotToNeon", () => {
     assert.ok(spy.rows.every((r) => r.verdict === "ok"));
   });
 
+  test("buffered: the derived tables record at enqueue; the base lane waits for the flush", async () => {
+    // #10888. Every statement here rides under the ONE lane tag the runner
+    // was built with (NEURONS_NEON_LANE), so the flush's per-lane tally can
+    // only ever name `neon:neurons` -- the derived tables' suppressed
+    // successes could be recorded by nothing at all, and the moment the
+    // buffer came on (#10758) both lanes went silent while the tables held
+    // that day's snapshot. This is #10826's sub-lane shape exactly, so their
+    // verdicts must land at enqueue time; the base lane's suppression stays,
+    // because its statements DO carry its name and the flush's verdict for it
+    // is the honest one.
+    const spy = laneSpy();
+    const sent: unknown[] = [];
+    const ns = {
+      idFromName: (name: string) => name,
+      get: () => ({
+        async fetch(request: Request) {
+          sent.push(await request.json());
+          return new Response("{}", { status: 200 });
+        },
+      }),
+    };
+    const out = await mirrorNeuronSnapshotToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE,
+        NEON_WRITE_BUFFER_LANES: NEURONS_NEON_LANE,
+        NEON_WRITE_BUFFER: ns,
+        HYPERDRIVE: { connectionString: "postgresql://x" },
+      },
+      ctx,
+      input,
+      { laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.attempted, true);
+    assert.ok(sent.length >= 3, "statements must enqueue, not connect");
+    assert.deepEqual(
+      spy.rows.map((r) => r.lane),
+      ["neon:neuron_daily", "neon:account_position_daily"],
+      "the sub-lanes record; the flush-attributed base lane does not",
+    );
+    assert.ok(spy.rows.every((r) => r.verdict === "ok"));
+  });
+
   test("a failing table is reported and does not stop the others", async () => {
     // The mirror is best-effort per table. A missing `neuron_daily` must not
     // cost `account_position_daily` its refresh, and each gets its own verdict


### PR DESCRIPTION
Closes #10888

The neurons snapshot mirror writes three tables through ONE runner tagged `NEURONS_NEON_LANE`, so every buffered statement — including `neuron_daily`'s and `account_position_daily`'s — carries the lane tag `neurons`, and the flush's per-lane tally can only ever file `neon:neurons`. The per-table verdict calls passed `buffered` without `oncePerPass`, so their successes were suppressed on the stated assumption that the flush would file them later — an assumption that is false for the two derived tables. The moment the write buffer came on (#10758), both lanes went silent permanently: 30 hours of `neon:neuron_daily is silent` alarms, measured 2026-08-12, while `/chain/turnover` showed the table holding that day's snapshot.

This is exactly the sub-lane shape `oncePerPass` (#10826) was built for, and the fix is to use it: the two derived tables' verdicts now record at enqueue time (`name !== NEURONS_NEON_LANE`), while the base lane keeps its suppression — its statements DO carry its name, so the flush's verdict for it remains the honest one. Cost: two extra verdict rows per 15-minute pass.

The new test drives the REAL buffered path (buffer lane flag + fake DO namespace + bound Hyperdrive, no injected runner) and asserts both halves: the sub-lanes record `ok` at enqueue, and the base lane records nothing.

Verified: 166 tests across the four neon-write suites, `tsc` clean, prettier clean.