### PR TITLE
fix(api): declare the serve-time stamps the .strict() flip refused, and make the refusal alarm

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5750,8 +5750,12 @@ export interface components {
             content_hash?: string;
             contract_version?: string;
             generated_at: string;
+            /** @description Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer. */
+            health_source?: string | null;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            /** @description When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp. */
+            operational_observed_at?: string | null;
             /** @description Real publish time from the KV latest pointer, distinct from `generated_at`. Null before the first publish, and on local/deterministic builds. */
             published_at?: string | null;
             /** @constant */
@@ -5792,11 +5796,15 @@ export interface components {
                 url: string;
             }[];
             generated_at: string;
+            /** @description Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer. */
+            health_source?: string | null;
             integration_readiness?: number;
             name?: string;
             netuid: number;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            /** @description When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp. */
+            operational_observed_at?: string | null;
             previously_known_as?: string[];
             readiness?: components["schemas"]["IntegrationReadiness"];
             /** @constant */
@@ -9933,6 +9941,8 @@ export interface components {
             generated_at: string;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            /** @description When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp. */
+            operational_observed_at?: string | null;
             /** @constant */
             schema_version: 1;
             /** @description Which producer answered: `artifact-build` for the committed catalog, the prober's label once the live overlay applies. */
@@ -10195,6 +10205,13 @@ export interface components {
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             observed_at?: string;
+            /** @description When the schema-snapshots cron promoted this index into the store. Absent on a build-baked baseline the cron has not promoted. */
+            promoted_at?: string;
+            /**
+             * @description Which producer promoted this index. Absent on a build-baked baseline.
+             * @constant
+             */
+            promoted_by?: "worker-cron";
             /** @constant */
             schema_version: 1;
             schemas: {
@@ -22594,7 +22611,9 @@ export interface operations {
                      *         "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health_source": "probe-derived",
                      *         "notes": "Example description.",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "published_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
@@ -22735,10 +22754,12 @@ export interface operations {
                      *           }
                      *         ],
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health_source": "probe-derived",
                      *         "integration_readiness": 1,
                      *         "name": "Example Subnet",
                      *         "netuid": 7,
                      *         "notes": "Example description.",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "previously_known_as": [
                      *           "example"
                      *         ],
@@ -37876,6 +37897,7 @@ export interface operations {
                      *         ],
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
                      *         "summary": {
@@ -38471,6 +38493,8 @@ export interface operations {
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "promoted_at": "2026-06-01T00:00:00.000Z",
+                     *         "promoted_by": "worker-cron",
                      *         "schema_version": 1,
                      *         "schemas": [
                      *           {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1430,7 +1430,9 @@
             "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "health_source": "probe-derived",
             "notes": "Example description.",
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
             "published_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "subnet_count": 1,
@@ -1501,10 +1503,12 @@
               }
             ],
             "generated_at": "2026-06-01T00:00:00.000Z",
+            "health_source": "probe-derived",
             "integration_readiness": 1,
             "name": "Example Subnet",
             "netuid": 7,
             "notes": "Example description.",
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
             "previously_known_as": [
               "example"
             ],
@@ -7930,6 +7934,7 @@
             ],
             "generated_at": "2026-06-01T00:00:00.000Z",
             "notes": "Example description.",
+            "operational_observed_at": "2026-06-01T00:00:00.000Z",
             "schema_version": 1,
             "source": "live-cron-prober",
             "summary": {
@@ -8224,6 +8229,8 @@
             "generated_at": "2026-06-01T00:00:00.000Z",
             "notes": "Example description.",
             "observed_at": "2026-06-01T00:00:00.000Z",
+            "promoted_at": "2026-06-01T00:00:00.000Z",
+            "promoted_by": "worker-cron",
             "schema_version": 1,
             "schemas": [
               {
@@ -17695,6 +17702,17 @@
           "generated_at": {
             "type": "string"
           },
+          "health_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer."
+          },
           "notes": {
             "anyOf": [
               {
@@ -17708,6 +17726,17 @@
               }
             ],
             "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp."
           },
           "published_at": {
             "anyOf": [
@@ -17915,6 +17944,17 @@
           "generated_at": {
             "type": "string"
           },
+          "health_source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer."
+          },
           "integration_readiness": {
             "maximum": 100,
             "minimum": 0,
@@ -17941,6 +17981,17 @@
               }
             ],
             "description": "Public-safe notes; may be a string or a string list depending on the adapter."
+          },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp."
           },
           "previously_known_as": {
             "items": {
@@ -41447,6 +41498,17 @@
             ],
             "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
+          "operational_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp."
+          },
           "schema_version": {
             "const": 1,
             "type": "number"
@@ -42837,6 +42899,15 @@
             "description": "Public-safe notes; may be a string or a string list depending on the adapter."
           },
           "observed_at": {
+            "type": "string"
+          },
+          "promoted_at": {
+            "description": "When the schema-snapshots cron promoted this index into the store. Absent on a build-baked baseline the cron has not promoted.",
+            "type": "string"
+          },
+          "promoted_by": {
+            "const": "worker-cron",
+            "description": "Which producer promoted this index. Absent on a build-baked baseline.",
             "type": "string"
           },
           "schema_version": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5750,8 +5750,12 @@ export interface components {
             content_hash?: string;
             contract_version?: string;
             generated_at: string;
+            /** @description Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer. */
+            health_source?: string | null;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            /** @description When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp. */
+            operational_observed_at?: string | null;
             /** @description Real publish time from the KV latest pointer, distinct from `generated_at`. Null before the first publish, and on local/deterministic builds. */
             published_at?: string | null;
             /** @constant */
@@ -5792,11 +5796,15 @@ export interface components {
                 url: string;
             }[];
             generated_at: string;
+            /** @description Which live tier answered for health on this response. Open-ended: the value comes from the health snapshot's own producer. */
+            health_source?: string | null;
             integration_readiness?: number;
             name?: string;
             netuid: number;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            /** @description When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp. */
+            operational_observed_at?: string | null;
             previously_known_as?: string[];
             readiness?: components["schemas"]["IntegrationReadiness"];
             /** @constant */
@@ -9933,6 +9941,8 @@ export interface components {
             generated_at: string;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
+            /** @description When the live health snapshot behind this response was taken. Null when the snapshot carries no run stamp. */
+            operational_observed_at?: string | null;
             /** @constant */
             schema_version: 1;
             /** @description Which producer answered: `artifact-build` for the committed catalog, the prober's label once the live overlay applies. */
@@ -10195,6 +10205,13 @@ export interface components {
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
             notes?: string | string[];
             observed_at?: string;
+            /** @description When the schema-snapshots cron promoted this index into the store. Absent on a build-baked baseline the cron has not promoted. */
+            promoted_at?: string;
+            /**
+             * @description Which producer promoted this index. Absent on a build-baked baseline.
+             * @constant
+             */
+            promoted_by?: "worker-cron";
             /** @constant */
             schema_version: 1;
             schemas: {
@@ -22594,7 +22611,9 @@ export interface operations {
                      *         "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health_source": "probe-derived",
                      *         "notes": "Example description.",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "published_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "subnet_count": 1,
@@ -22735,10 +22754,12 @@ export interface operations {
                      *           }
                      *         ],
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health_source": "probe-derived",
                      *         "integration_readiness": 1,
                      *         "name": "Example Subnet",
                      *         "netuid": 7,
                      *         "notes": "Example description.",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "previously_known_as": [
                      *           "example"
                      *         ],
@@ -37876,6 +37897,7 @@ export interface operations {
                      *         ],
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
                      *         "schema_version": 1,
                      *         "source": "live-cron-prober",
                      *         "summary": {
@@ -38471,6 +38493,8 @@ export interface operations {
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",
                      *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "promoted_at": "2026-06-01T00:00:00.000Z",
+                     *         "promoted_by": "worker-cron",
                      *         "schema_version": 1,
                      *         "schemas": [
                      *           {

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -36,7 +36,7 @@ import {
 } from "../envelope.ts";
 import { IntegrationReadinessSchema } from "./subnet-profile.ts";
 import { AgentReadinessBlockerSchema } from "./coverage.ts";
-import { AuthSchema } from "./subnet-detail.ts";
+import { AuthSchema, LIVE_HEALTH_OVERLAY } from "./subnet-detail.ts";
 
 export const AgentReadinessStatusSchema = z
   .object({
@@ -128,6 +128,11 @@ export const AgentCatalogArtifactSchema = ArtifactBaseSchema.extend({
   // (#10790) -- the omission the undeclared-field report found.
   content_hash: ContentHashSchema,
   published_at: PublishedAtSchema,
+  // The live overlay's provenance pair, stamped by overlayCatalogIndex on
+  // every response the 15-minute cron has data for. Undeclared, it was a
+  // passthrough; #10853's .strict() made it a hard refusal, and the route
+  // 500'd on every request for a day (#10897).
+  ...LIVE_HEALTH_OVERLAY,
   total_subnet_count: z.int().min(0).optional(),
   subnet_count: z.int().min(0),
   blocked_subnet_count: z.int().min(0).optional(),
@@ -258,6 +263,10 @@ const AgentCatalogExampleSchema = z
   .strict();
 
 export const AgentCatalogSubnetArtifactSchema = ArtifactBaseSchema.extend({
+  // overlayCatalogDetail stamps the same provenance pair the index gets --
+  // the LATENT twin of #10897's break: this route is parameterized, so the
+  // parameterless sweep that caught the index could never reach it.
+  ...LIVE_HEALTH_OVERLAY,
   netuid: z.int().min(0),
   slug: z.string().optional(),
   name: z.string().optional(),

--- a/schemas-src/routes/providers-rpc.ts
+++ b/schemas-src/routes/providers-rpc.ts
@@ -202,6 +202,13 @@ export const RpcEndpointsArtifactSchema = ArtifactBaseSchema.extend({
       by_status: z.record(z.string(), z.int().min(0)).optional(),
     })
     .strict(),
+  // mergeRpcEndpoints stamps the overlay's run stamp at the artifact level on
+  // every response the 15-minute cron has data for -- the same declaration the
+  // pools artifact below already carries, missed here (#10897: the route
+  // 500'd on every request for a day once #10853's .strict() went live).
+  // ONLY this half of the overlay, same reasoning as pools: `health_source`
+  // is per-ENDPOINT here and EndpointResourceSchema already declares it.
+  operational_observed_at: LIVE_HEALTH_OVERLAY.operational_observed_at,
   endpoints: z.array(RpcEndpointSchema),
 });
 export type RpcEndpointsArtifact = z.infer<typeof RpcEndpointsArtifactSchema>;

--- a/schemas-src/routes/subnet-profiles.ts
+++ b/schemas-src/routes/subnet-profiles.ts
@@ -151,5 +151,23 @@ export const SchemaIndexArtifactSchema = ArtifactBaseSchema.extend({
   // properties, only legal today via additionalProperties:true.
   observed_at: z.string().optional(),
   summary: SchemaDriftSummarySchema.optional(),
+  // The schema-snapshots cron's promotion provenance (SchemaIndexArtifact in
+  // src/schema-snapshots-sync.ts: "with only summary/schemas replaced ... and
+  // two provenance fields added"). The SERVED artifact carries them once the
+  // cron has promoted; the committed baseline never does, hence optional.
+  // Undeclared, they were a passthrough; #10853's .strict() 500'd the route
+  // on every request for a day (#10897).
+  promoted_at: z
+    .string()
+    .optional()
+    .describe(
+      "When the schema-snapshots cron promoted this index into the store. Absent on a build-baked baseline the cron has not promoted.",
+    ),
+  promoted_by: z
+    .literal("worker-cron")
+    .optional()
+    .describe(
+      "Which producer promoted this index. Absent on a build-baked baseline.",
+    ),
 });
 export type SchemaIndexArtifact = z.infer<typeof SchemaIndexArtifactSchema>;

--- a/tests/response-validation-tripwire.test.ts
+++ b/tests/response-validation-tripwire.test.ts
@@ -210,6 +210,72 @@ describe("workers/api.ts fails the request on drift", () => {
     assert.equal((body.error as Row).code, "response_schema_drift");
   });
 
+  test("flag on: the refusal FILES A FAULT naming the route (#10897)", async () => {
+    // Three published routes were down for 26 hours and error tracking showed
+    // nothing: the refusal was correct-by-design and silent, visible only as
+    // usage_event ok:false, and a latency sweep found it before any alarm. A
+    // published route refusing every request is a DOWN route — the 500 must
+    // carry an exception event naming it, with the drift detail in the
+    // message, because the unrecognized keys ARE the diagnosis.
+    vi.resetModules();
+    const captured: Row[] = [];
+    vi.doMock("../src/response-validation-tripwire.ts", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/response-validation-tripwire.ts")
+      >("../src/response-validation-tripwire.ts");
+      return {
+        ...actual,
+        validateResponseTripwire: async (routeId: string) => {
+          throw new actual.ResponseSchemaDriftError(routeId, [
+            { code: "unrecognized_keys", keys: ["stray_field"] },
+          ]);
+        },
+      };
+    });
+    vi.doMock("../src/usage-telemetry.ts", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/usage-telemetry.ts")
+      >("../src/usage-telemetry.ts");
+      return {
+        ...actual,
+        recordExceptionEvent: async (_env: unknown, event: Row) => {
+          captured.push(event);
+          return true;
+        },
+      };
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { handleRequest: freshHandle } = await import("../workers/api.ts");
+    try {
+      const env = createLocalArtifactEnv() as Row;
+      env.METAGRAPH_VALIDATE_RESPONSES = "true";
+      const waits: Promise<unknown>[] = [];
+      const res = await (freshHandle as unknown as typeof handleRequest)(
+        req("/api/v1/economics"),
+        env as unknown as Env,
+        { waitUntil: (p: Promise<unknown>) => waits.push(p) } as never,
+      );
+      assert.equal(res.status, 500);
+      await Promise.all(waits);
+      const fault = captured.find(
+        (e) => e.errorCode === "response_schema_drift",
+      );
+      assert.ok(fault, "the refusal must file a fault, not just a 500");
+      // The route rides in the event, so the fingerprint separates one
+      // drifted route's issue from another's instead of cross-throttling.
+      assert.equal(fault!.route, "economics");
+      assert.match(
+        String((fault!.error as Error).message),
+        /stray_field/,
+        "the drift detail must reach the alarm — it is the diagnosis",
+      );
+    } finally {
+      vi.doUnmock("../src/response-validation-tripwire.ts");
+      vi.doUnmock("../src/usage-telemetry.ts");
+      vi.resetModules();
+    }
+  });
+
   test("flag on: subnet-stake-quote refuses a drifting response too", async () => {
     // Its own call site -- the route is matched and returned early in
     // workers/api.ts, before the generic envelope path, so it needs its own.

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -314,6 +314,15 @@ import {
   AgentResourcesArtifactSchema,
   AgentReadinessStatusSchema,
 } from "../schemas-src/routes/agent-catalog.ts";
+// #10897: the serve-time overlay composers, driven directly below so the
+// fields they stamp onto `data` stay inside each artifact's contract — the
+// committed-artifact parses alone could never see a serve-time stamp, which
+// is exactly how three routes 500'd for a day under #10853's .strict().
+import {
+  mergeRpcEndpoints,
+  overlayCatalogDetail,
+  overlayCatalogIndex,
+} from "../src/health-serving.ts";
 import { generateOpenApiZodComponents } from "../scripts/generate-openapi-zod-components.ts";
 import {
   buildContractsArtifact,
@@ -3661,6 +3670,16 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
     });
     const parsed = RpcEndpointsArtifactSchema.parse(artifact);
     assert.ok(parsed);
+    // #10897: the 15-minute cron's overlay stamps operational_observed_at at
+    // the artifact level. Driven through the REAL composer so the stamped
+    // shape cannot drift out of the contract again.
+    const overlaid = mergeRpcEndpoints(artifact, {
+      last_run_at: GENERATED_AT_10,
+      endpoints: [{ id: "s1", status: "ok", classification: "live" }],
+    });
+    assert.ok(overlaid, "the overlay must apply");
+    const overlaidParsed = RpcEndpointsArtifactSchema.parse(overlaid);
+    assert.equal(overlaidParsed.operational_observed_at, GENERATED_AT_10);
   });
   test("rpc-endpoints: RpcEndpointsArtifactSchema.parse({}) fails (not a vacuous passthrough)", () => {
     const result = RpcEndpointsArtifactSchema.safeParse({});
@@ -3905,6 +3924,15 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
     const body = (await res.json()) as { data: unknown };
     const parsed = SchemaIndexArtifactSchema.parse(body.data);
     assert.ok(parsed);
+    // #10897: the schema-snapshots cron serves the KV-promoted index, which
+    // carries the promotion provenance pair the committed baseline never has.
+    // The exact served shape, parsed, so the pair stays inside the contract.
+    const promoted = SchemaIndexArtifactSchema.parse({
+      ...(body.data as Record<string, unknown>),
+      promoted_at: "2026-08-12T00:00:00.000Z",
+      promoted_by: "worker-cron",
+    });
+    assert.equal(promoted.promoted_by, "worker-cron");
   });
   test("schemas: SchemaIndexArtifactSchema.parse({}) fails (not a vacuous passthrough)", () => {
     const result = SchemaIndexArtifactSchema.safeParse({});
@@ -4003,6 +4031,20 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
     const parsed = AgentCatalogArtifactSchema.parse(data);
     assert.ok(parsed);
     assert.ok(agentReadiness31.blockers.length > 0);
+    // #10897: overlayCatalogIndex stamps the provenance pair at serve time —
+    // the pair whose absence from this schema 500'd the route for a day.
+    const overlaid = overlayCatalogIndex(data, {
+      subnets: [{ netuid: 7, status: "ok" }],
+      last_run_at: "2026-08-12T00:00:00.000Z",
+      health_source: "live-cron-prober",
+    });
+    assert.ok(overlaid, "the overlay must apply");
+    const overlaidParsed = AgentCatalogArtifactSchema.parse(overlaid);
+    assert.equal(overlaidParsed.health_source, "live-cron-prober");
+    assert.equal(
+      overlaidParsed.operational_observed_at,
+      "2026-08-12T00:00:00.000Z",
+    );
   });
   test("agent-catalog: AgentCatalogArtifactSchema.parse({}) fails (not a vacuous passthrough)", () => {
     const result = AgentCatalogArtifactSchema.safeParse({});
@@ -4077,6 +4119,21 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
     };
     const parsed = AgentCatalogSubnetArtifactSchema.parse(data);
     assert.ok(parsed);
+    // #10897's LATENT twin: overlayCatalogDetail stamps the same pair, and
+    // this route is parameterized, so no parameterless sweep can catch it —
+    // only this test can.
+    const overlaid = overlayCatalogDetail(
+      data,
+      {
+        surfaces: [],
+        last_run_at: "2026-08-12T00:00:00.000Z",
+        health_source: "live-cron-prober",
+      },
+      data.netuid,
+    );
+    assert.ok(overlaid, "the overlay must apply");
+    const overlaidParsed = AgentCatalogSubnetArtifactSchema.parse(overlaid);
+    assert.equal(overlaidParsed.health_source, "live-cron-prober");
   });
   test("agent-catalog-subnet: AgentCatalogSubnetArtifactSchema.parse({}) fails (not a vacuous passthrough)", () => {
     const result = AgentCatalogSubnetArtifactSchema.safeParse({});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -8923,17 +8923,14 @@ async function handleApiRequest(
         // rather than cross-throttling another's. The drift detail rides in
         // the message: the unrecognized keys ARE the diagnosis, and the
         // console.error above is unreachable without a tail.
-        const pending = Promise.resolve(
-          recordExceptionEvent(env, {
-            error: new Error(
-              `response_schema_drift: ${matched.id} refused: ` +
-                String(JSON.stringify(err.detail)).slice(0, 400),
-            ),
-            route: matched.id,
-            errorCode: "response_schema_drift",
-          }),
-        ).catch(() => false);
-        ctx?.waitUntil?.(pending);
+        scheduleExceptionEvent(env, ctx, recordExceptionEvent, {
+          error: new Error(
+            `response_schema_drift: ${matched.id} refused: ` +
+              String(JSON.stringify(err.detail)).slice(0, 400),
+          ),
+          route: matched.id,
+          errorCode: "response_schema_drift",
+        });
         return errorResponse(
           "response_schema_drift",
           `The ${matched.id} response did not match its published schema and was not served.`,

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -8914,6 +8914,26 @@ async function handleApiRequest(
           `[METAGRAPH_VALIDATE_RESPONSES] ${matched.id} refused:`,
           err.detail,
         );
+        // A published route refusing every request is a DOWN route, not a
+        // routine decline (#10897): three routes 500'd for 26 hours and error
+        // tracking showed nothing, because this branch filed no fault — the
+        // refusals were visible only as usage_event ok:false, and a latency
+        // sweep found them before any alarm did. The fingerprint keys on
+        // route+message, so each drifted route surfaces as its own issue
+        // rather than cross-throttling another's. The drift detail rides in
+        // the message: the unrecognized keys ARE the diagnosis, and the
+        // console.error above is unreachable without a tail.
+        const pending = Promise.resolve(
+          recordExceptionEvent(env, {
+            error: new Error(
+              `response_schema_drift: ${matched.id} refused: ` +
+                String(JSON.stringify(err.detail)).slice(0, 400),
+            ),
+            route: matched.id,
+            errorCode: "response_schema_drift",
+          }),
+        ).catch(() => false);
+        ctx?.waitUntil?.(pending);
         return errorResponse(
           "response_schema_drift",
           `The ${matched.id} response did not match its published schema and was not served.`,


### PR DESCRIPTION
Closes #10897

Three published routes have 500'd on every request since #10853's `.strict()` flip went live, because the fields they refuse on are stamped onto `data` at SERVE time — the committed-artifact parses that guard every schema could never see them. Verified against production's own drift details (captured via `wrangler tail` while tripping all three routes):

| route | undeclared serve-time fields | producer |
| --- | --- | --- |
| `/api/v1/agent-catalog` | `operational_observed_at`, `health_source` | `overlayCatalogIndex` (15-min cron overlay) |
| `/api/v1/rpc/endpoints` | `operational_observed_at` | `mergeRpcEndpoints` (artifact-level run stamp; per-endpoint `health_source` was already declared) |
| `/api/v1/schemas` | `promoted_at`, `promoted_by` | the schema-snapshots cron's promotion provenance — the SERVED KV artifact carries them, the committed baseline never does |

**Every field is a genuine, deliberate emission, so every call is DECLARE** — the catalog pair via the existing `LIVE_HEALTH_OVERLAY` spread, the rpc run-stamp mirroring exactly what the pools artifact already declares, and the promotion pair as optional with the baseline/promoted split documented. No schema returns to `.passthrough()`.

**The sweep (requirement 2)** walked every artifact-level key each overlay composer stamps (`health-serving.ts` + the `workers/api.ts` inline cases) against its schema: `subnet-health`, `subnet-overview`, `rpc-pools`, and `freshness` were already declared; the one LATENT break found is `agent-catalog-subnet` — `overlayCatalogDetail` stamps the same pair, and the route is parameterized, so the parameterless sweep that caught the index could never reach it. Declared here too.

**The alarm (requirement 3):** the drift refusal in `workers/api.ts` now files an exception event carrying the route id and the drift detail (the unrecognized keys ARE the diagnosis) — fingerprinted per route so two drifted routes alarm separately. Until now the refusal was visible only as `usage_event ok:false` and a `wrangler tail`.

**The tests are the durable half:** each artifact schema test now drives the REAL composer over its schema-valid base and parses the result, so a serve-time stamp can never drift out of the contract unseen again; the tripwire suite gains "the refusal FILES A FAULT naming the route". All fail without their fixes by construction.

Verified: 343 tests across the two suites, `tsc` clean, `validate:schemas` / `contract-drift` / `api` / `openapi` / `types` pass, regenerated artifacts committed, built fresh on current main.