### PR TITLE
fix(observability): the stake-quote drift refusal files the fault too

### DIFF
--- a/tests/response-validation-tripwire.test.ts
+++ b/tests/response-validation-tripwire.test.ts
@@ -293,6 +293,69 @@ describe("workers/api.ts fails the request on drift", () => {
     });
   });
 
+  test("flag on: subnet-stake-quote's refusal FILES A FAULT too (#10901)", async () => {
+    // #10898 alarmed the dispatcher's refusal and left this inline site
+    // silent -- the exact invisibility #10897 closed, still live for one
+    // published route. Same drill as the dispatcher's fault test: force a
+    // drift, capture the recorder, and demand the event names the route with
+    // the drift detail in the message.
+    vi.resetModules();
+    const captured: Row[] = [];
+    vi.doMock("../src/response-validation-tripwire.ts", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/response-validation-tripwire.ts")
+      >("../src/response-validation-tripwire.ts");
+      return {
+        ...actual,
+        validateResponseTripwire: async (routeId: string) => {
+          throw new actual.ResponseSchemaDriftError(routeId, [
+            { code: "unrecognized_keys", keys: ["stray_quote_field"] },
+          ]);
+        },
+      };
+    });
+    vi.doMock("../src/usage-telemetry.ts", async () => {
+      const actual = await vi.importActual<
+        typeof import("../src/usage-telemetry.ts")
+      >("../src/usage-telemetry.ts");
+      return {
+        ...actual,
+        recordExceptionEvent: async (_env: unknown, event: Row) => {
+          captured.push(event);
+          return true;
+        },
+      };
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { handleRequest: freshHandle } = await import("../workers/api.ts");
+    try {
+      const env = createLocalArtifactEnv() as Row;
+      env.METAGRAPH_VALIDATE_RESPONSES = "true";
+      const waits: Promise<unknown>[] = [];
+      const res = await (freshHandle as unknown as typeof handleRequest)(
+        req("/api/v1/subnets/1/stake-quote?amount=1&direction=stake"),
+        env as unknown as Env,
+        { waitUntil: (p: Promise<unknown>) => waits.push(p) } as never,
+      );
+      assert.equal(res.status, 500);
+      await Promise.all(waits);
+      const fault = captured.find(
+        (e) => e.errorCode === "response_schema_drift",
+      );
+      assert.ok(fault, "the refusal must file a fault, not just a 500");
+      assert.equal(fault!.route, "subnet-stake-quote");
+      assert.match(
+        String((fault!.error as Error).message),
+        /stray_quote_field/,
+        "the drift detail must reach the alarm — it is the diagnosis",
+      );
+    } finally {
+      vi.doUnmock("../src/response-validation-tripwire.ts");
+      vi.doUnmock("../src/usage-telemetry.ts");
+      vi.resetModules();
+    }
+  });
+
   test("a NON-drift throw propagates -- it is not swallowed as a drift", async () => {
     // The tripwire swallows its own faults, so only a drift should ever escape
     // it. If something else does, that is a bug in the tripwire and the call

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -46,6 +46,7 @@ import {
 } from "../responses.ts";
 import { tryDataApiTier } from "../data-api-tier.ts";
 import { csvRequested, csvResponse } from "../csv.ts";
+import { recordExceptionEvent } from "../../src/usage-telemetry.ts";
 import {
   ResponseSchemaDriftError,
   validateResponseTripwire,
@@ -3300,10 +3301,10 @@ export async function handleSubnetStakeQuote(
   env: Env,
   netuid: number,
   url: URL,
-  // Kept in the signature for the caller, unused since the response tripwire
-  // stopped running under `waitUntil` -- it throws on drift now, and a throw
-  // from a background task ships the bad body anyway.
-  _ctx: { waitUntil?: (promise: Promise<unknown>) => void } = {},
+  // The tripwire itself is AWAITED (a throw from `waitUntil` ships the bad
+  // body anyway); ctx carries only the refusal's fault event (#10901), which
+  // must never block or fail the response.
+  ctx: { waitUntil?: (promise: Promise<unknown>) => void } = {},
 ) {
   const validationError = validateResponseFormat(url);
   if (validationError) return analyticsQueryError(validationError);
@@ -3353,6 +3354,28 @@ export async function handleSubnetStakeQuote(
           "[METAGRAPH_VALIDATE_RESPONSES] subnet-stake-quote refused:",
           err.detail,
         );
+        // The dispatcher's refusal files a fault (#10897); this inline site
+        // must too (#10901), or stake-quote is the one published route that
+        // can 500 on every request while error tracking shows zero rows.
+        // Same shape as workers/api.ts's scheduleExceptionEvent: fire and
+        // forget, parked on waitUntil, never surfacing into a path that is
+        // already failing. The drift detail rides in the message -- the
+        // unrecognized keys ARE the diagnosis.
+        try {
+          const pending = Promise.resolve(
+            recordExceptionEvent(env, {
+              error: new Error(
+                "response_schema_drift: subnet-stake-quote refused: " +
+                  String(JSON.stringify(err.detail)).slice(0, 400),
+              ),
+              route: "subnet-stake-quote",
+              errorCode: "response_schema_drift",
+            }),
+          ).catch(() => false);
+          ctx?.waitUntil?.(pending);
+        } catch {
+          // Telemetry must never surface into the request path.
+        }
         return errorResponse(
           "response_schema_drift",
           "The subnet-stake-quote response did not match its published schema and was not served.",


### PR DESCRIPTION
## Summary

Closes the alarm gap #10898 left: the **second** `response_schema_drift` refusal site — `handleSubnetStakeQuote`'s inline tripwire catch in `workers/request-handlers/entities.ts` — still 500'd with a `console.error` and **no exception event**. The route is matched and returned early in `workers/api.ts`, before the generic envelope path, so the dispatcher's alarm (#10898) never covers it. If stake-quote drifts, it is the one published route that can refuse every request while error tracking shows zero rows — the exact invisibility #10897 closed.

## What changes

- The catch files the same fault shape as the dispatcher's: `route: "subnet-stake-quote"`, `errorCode: "response_schema_drift"`, drift detail in the message (the unrecognized keys ARE the diagnosis), fire-and-forget on `ctx.waitUntil` so telemetry never surfaces into a path that is already failing. The handler's `ctx` parameter un-retires for exactly this — its "unused since the tripwire stopped running under waitUntil" comment is rewritten to the live split (tripwire awaited; only the fault rides waitUntil).
- **Test arm** mirroring the dispatcher's fault test against this route: forces a drift, captures the recorder, demands the event names `subnet-stake-quote` with the detail in the message. **Proven to fail without the fix** by neutralizing the recorder call — it fails with "the refusal must file a fault, not just a 500"; restored, 16/16 pass.

## Enumeration (requirement 3 of the issue)

`instanceof ResponseSchemaDriftError` has exactly three sites in the tree: the tripwire's own rethrow (`src/response-validation-tripwire.ts:123`), the dispatcher (`workers/api.ts:8912`, alarmed by #10898), and this one (`workers/request-handlers/entities.ts:3352`). Both refusal sites now alarm; the class is closed by enumeration, not by sampling.

## Validation

- `typecheck` 0 · `eslint --no-cache` 0 (touched files) · `prettier` clean
- `tests/response-validation-tripwire.test.ts`: 16/16, including the prove-it-can-fail cycle above

## Template Used

- backend-code

Closes #10901
