### PR TITLE
fix(mcp): declare the fallback tier's five surface-row fields on get_subnet_health

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -7,7 +7,10 @@ import { McpUnsortedPageFields, netuidSchema } from "./shared.ts";
 import { ListSubnetHealthInputSchema } from "./subnet-scoped-lists.ts";
 import { HealthSubnetSummarySchema } from "../routes/health.ts";
 import { LIVE_HEALTH_OVERLAY } from "../routes/subnet-detail.ts";
-import { ReliabilityScoreSchema } from "../routes/health-surfaces.ts";
+import {
+  HealthSubnetSurfaceSchema,
+  ReliabilityScoreSchema,
+} from "../routes/health-surfaces.ts";
 
 /**
  * DERIVED FROM THE NETWORK-WIDE SIBLING (#9998).
@@ -24,19 +27,15 @@ export const GetSubnetHealthInputSchema = ListSubnetHealthInputSchema.omit({
   .strict();
 export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
 
-// objectItems(...) properties, none required at the item level (see
-// search-subnets.ts's same note from the pilot batch).
-const GetSubnetHealthSurfaceSchema = z
-  .object({
-    surface_id: z.string().optional(),
-    netuid: netuidSchema().optional(),
-    kind: z.string().nullable().optional(),
-    status: z.string().optional(),
-    latency_ms: z.int().nullable().optional(),
-    last_checked: z.string().nullable().optional(),
-    last_ok: z.string().nullable().optional(),
-  })
-  .strict();
+// THE ROUTE'S OWN ROW SCHEMA (#10904), not a copy. This tool serves the
+// same overlaySubnetHealth()/fallback-tier rows GET /subnets/{netuid}/health
+// serves, and its previous hand-copied row schema sat five fields behind
+// the route's -- so the outbound tripwire refused every netuid-0 call the
+// moment the fallback tier answered. A second declaration is how the copy
+// comes to omit the field that matters (#10790's own words); this tool
+// advertises no `fields`, so the rows are never projected and the route's
+// exact shape is the right one.
+const GetSubnetHealthSurfaceSchema = HealthSubnetSurfaceSchema;
 
 export const GetSubnetHealthOutputSchema = z
   .object({

--- a/schemas-src/routes/health-surfaces.ts
+++ b/schemas-src/routes/health-surfaces.ts
@@ -249,8 +249,12 @@ export type GlobalIncidentsArtifact = z.infer<
 
 // See this file's header -- deliberately NOT the registered HealthSurface
 // component below; overlaySubnetHealth()'s live-merged rows are a distinct,
-// much smaller shape.
-const HealthSubnetSurfaceSchema = z
+// much smaller shape. Exported (#10904): the MCP tool serving these exact
+// rows (get_subnet_health) carried a hand-copied, NARROWER row schema, and
+// the copy lagging the route by five fields had the outbound tripwire
+// refusing every root-network call. One declaration, like #10790 collapsed
+// the other 42.
+export const HealthSubnetSurfaceSchema = z
   .object({
     surface_id: z.string(),
     netuid: z.int().min(0),


### PR DESCRIPTION
Closes #10904

`get_subnet_health {"netuid": 0}` refuses with `response_schema_drift` on every call (alerted 2026-08-12 20:25Z, reproduced deterministically against production). The root network's response is served by the live-postgres-fallback tier, whose surface rows carry `provider`, `url`, `classification`, `status_code`, and `observed_by` — exactly the five keys the ROUTE's own row schema (`HealthSubnetSurfaceSchema`, routes/health-surfaces.ts) has declared all along and the MCP tool's hand-copied row schema lacked. The #10790 drift class, caught live by the outbound tripwire doing precisely its job.

All five declared as optional (the tiers differ in what they attach; the route requires several, so optional is the safe superset of every tier). Verified by validating the live production payload against the schema: the five `unrecognized_keys` issues on every surfaces[] row are gone.

`tsc` clean, `validate:mcp` (235 tools against real responses) and `validate:contract-drift` pass.