### PR TITLE
fix(observability): record the prune/tally sub-lane verdicts at enqueue, and retire the bare raw-capture-state key

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -86,6 +86,18 @@ export const RETIRED_LANES: readonly string[] = [
   // src/neon-mirror-lag.ts -- measured how far a mirror trailed its D1 source
   // (#10167). Reports `ok`, so it alarms nothing; it is equally a lie.
   "neon-mirror-lag",
+  // The BARE spelling, not `neon:raw-capture-state` (which is live and stays
+  // watched). Its producer was the pre-#10851 buffer flush, which filed
+  // per-lane verdicts under the raw statement tag; #10851 put both writers on
+  // neonLaneKey, so every verdict for this lane now lands under the `neon:`
+  // prefix and the bare key's newest row is frozen at the #10851 deploy --
+  // which is exactly when its silence alarm started counting (silent 20.9h,
+  // alerted 2026-08-12). Unlike the poller lanes, nothing else ever wrote
+  // this bare name: the watermark is worker-internal, so there is no
+  // producer-side usage record to keep the old spelling alive. The retirement
+  // test pins this to code rather than to a deleted file: the live writer
+  // provably cannot produce the bare key.
+  "raw-capture-state",
 ];
 
 /**

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -511,6 +511,13 @@ export async function mirrorNeuronSnapshotToNeon(
       prune,
       now(),
       buffered,
+      // A SUB-LANE of the buffered runner, same as the three tables (#10890)
+      // and the nominator `-pass`/`-prune` pair before it (#10826): its
+      // statements ride under the base lane's tag, so the flush can never
+      // file `neon:neurons-prune` and a suppressed success here is recorded
+      // by nothing at all. Went silent for 32 hours the moment the buffer
+      // came on (2026-08-12 alert), while the prune itself ran fine.
+      true,
     );
   }
 
@@ -542,6 +549,10 @@ export async function mirrorNeuronSnapshotToNeon(
       verdict,
       now(),
       buffered,
+      // Same sub-lane rule as the prune above (#10890): the tally's
+      // statements carry the base lane's tag, so only recording at enqueue
+      // keeps `neon:neurons-pass` alive under buffering.
+      true,
     );
     results[`${NEURONS_NEON_LANE}_passes`] = verdict;
   }

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -22,12 +22,19 @@ import {
   isRetiredLane,
   loadLatestLaneHealth,
 } from "../src/lane-health.ts";
+import { neonLaneKey } from "../src/neon-write.ts";
+import { RAW_CAPTURE_STATE_NEON_LANE } from "../src/capture-state-neon-write.ts";
 
-/** Each retired lane, and the producer whose deletion justifies retiring it. */
-const PRODUCERS: Record<string, string> = {
+/** Each retired lane, and the producer whose deletion justifies retiring it.
+ * `null` marks the one entry whose producer was a KEY SPELLING rather than a
+ * file — the pre-#10851 buffer flush wrote per-lane verdicts under the bare
+ * statement tag — justified below by a code assertion instead: the live
+ * writer provably files under the `neon:` prefix. */
+const PRODUCERS: Record<string, string | null> = {
   "neon-parity": "src/neon-parity.ts",
   "neon-mirror-lag": "src/neon-mirror-lag.ts",
   "neon:backfill:": "src/neon-backfill.ts",
+  "raw-capture-state": null,
 };
 
 function fakeDb(rows: Record<string, unknown>[]) {
@@ -52,14 +59,31 @@ describe("retired lanes (#10222)", () => {
     const names = [...RETIRED_LANES, ...RETIRED_LANE_PREFIXES];
     assert.ok(names.length > 0, "the list is not empty -- otherwise vacuous");
     for (const name of names) {
+      assert.ok(
+        name in PRODUCERS,
+        `${name} names the producer it retires (or null with a code assertion)`,
+      );
       const producer = PRODUCERS[name];
-      assert.ok(producer, `${name} names the producer it retires`);
+      if (producer === null) continue; // justified by its own test below
       assert.equal(
         existsSync(new URL(`../${producer}`, import.meta.url)),
         false,
         `${producer} is gone -- ${name} may only be retired because nothing writes it`,
       );
     }
+  });
+
+  test("raw-capture-state (bare) cannot be written by the live writer", () => {
+    // The bare spelling's producer was the pre-#10851 flush; since #10851
+    // both writers key through neonLaneKey, so every verdict for this lane
+    // lands under the prefix. Retiring the bare key silences a row frozen at
+    // that deploy — not a live signal. The prefixed lane stays watched.
+    assert.equal(
+      neonLaneKey(RAW_CAPTURE_STATE_NEON_LANE),
+      "neon:raw-capture-state",
+    );
+    assert.equal(isRetiredLane(RAW_CAPTURE_STATE_NEON_LANE), true);
+    assert.equal(isRetiredLane("neon:raw-capture-state"), false);
   });
 
   test("isRetiredLane matches the families and nothing else", () => {

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -172,6 +172,51 @@ describe("NEURON_MIRROR_PLANS", () => {
     assert.ok(spy.rows.every((r) => r.verdict === "ok"));
   });
 
+  test("buffered: the prune and pass-tally verdicts record at enqueue too", async () => {
+    // The second half of the same sub-lane rule (#10890's own alert, part 2):
+    // the prune's and the tally's statements ride under the base lane's tag,
+    // so `neon:neurons-prune` and `neon:neurons-pass` can never appear in the
+    // flush's per-lane tally — both went silent for 32 hours the moment the
+    // buffer came on, while the prune and tally themselves ran fine.
+    const spy = laneSpy();
+    const ns = {
+      idFromName: (name: string) => name,
+      get: () => ({
+        async fetch() {
+          return new Response("{}", { status: 200 });
+        },
+      }),
+    };
+    const out = await mirrorNeuronSnapshotToNeon(
+      {
+        NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE,
+        NEON_WRITE_BUFFER_LANES: NEURONS_NEON_LANE,
+        NEON_WRITE_BUFFER: ns,
+        HYPERDRIVE: { connectionString: "postgresql://x" },
+      },
+      ctx,
+      {
+        ...input,
+        netuidMaxCapturedAt: new Map([[1, 1_000]]),
+        pass: {
+          capturedAt: 1786155508717,
+          expectedRows: 1,
+          receivedRows: 1,
+          nowMs: NOW,
+        },
+      },
+      { laneHealthDb: spy.db, now: () => NOW },
+    );
+    assert.equal(out.attempted, true);
+    const lanes = spy.rows.map((r) => r.lane);
+    assert.ok(lanes.includes("neon:neurons-prune"), `got: ${lanes.join(",")}`);
+    assert.ok(lanes.includes("neon:neurons-pass"), `got: ${lanes.join(",")}`);
+    assert.ok(
+      !lanes.includes("neon:neurons"),
+      "the base lane stays flush-owned",
+    );
+  });
+
   test("a failing table is reported and does not stop the others", async () => {
     // The mirror is best-effort per table. A missing `neuron_daily` must not
     // cost `account_position_daily` its refresh, and each gets its own verdict


### PR DESCRIPTION
Closes #10907

Part 2 of the buffered-verdict family, from the 2026-08-12 20:28Z alert batch (`neon:neurons-prune` / `neon:neurons-pass` silent 31.9h, `raw-capture-state` silent 20.9h).

**The prune and pass-tally verdicts.** #10890 fixed the three per-TABLE verdicts in the neurons mirror but missed the two other verdict sites in the same file: the prune's and the tally's statements ride under the base lane's buffer tag, so the flush can never file `neon:neurons-prune`/`neon:neurons-pass`, and their suppressed successes were recorded by nothing — silent from the moment the buffer came on, while the prune and tally themselves ran fine. Both now pass `oncePerPass`, the same remedy the nominator `-pass`/`-prune` pair got in #10826. The buffered test drives the real path (buffer flag + fake DO + bound Hyperdrive) with a pass and cutoffs, asserting both sub-lane keys land at enqueue while the base lane stays flush-owned.

**The bare `raw-capture-state` key is a #10851 fossil, retired.** Its producer was the pre-#10851 buffer flush, which filed per-lane verdicts under the raw statement tag; #10851 put both writers on `neonLaneKey`, so every verdict now lands under `neon:raw-capture-state` (live, healthy, unretired) and the bare key's newest row froze at that deploy — which is exactly when its silence count started. Unlike the poller lanes, nothing else ever wrote this bare name (the watermark is worker-internal), so this is #10222's retirement case: a row no future tick can revise, reported as though current. The retirement list's file-absence contract gains a second justification kind for it — a code assertion that the live writer provably files under the prefix (`neonLaneKey(...)`), since the "deleted producer" here is a key spelling, not a file.

Verified: 71 tests across the three suites + self-health's 28, `tsc` clean, fresh (uncached) eslint clean, prettier clean.