### PR TITLE
docs(neon): the dual-write era's comments catch up with its deletion

### DIFF
--- a/src/chain-detail-neon-write.ts
+++ b/src/chain-detail-neon-write.ts
@@ -88,7 +88,9 @@ export const CHAIN_DETAIL_CONFLICT_KEYS = {
   chain_detail_account_events: ["block_number", "event_index"],
 } as const;
 
-/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
+/** The lane name this mirror answers to -- the key NEON_WRITE_BUFFER_LANES
+ * and the lane_health verdicts use. (Named for NEON_DUAL_WRITE_LANES until
+ * that flag was deleted with the cutover, #10892.) */
 export const CHAIN_DETAIL_NEON_LANE = "chain-detail";
 
 type Row = Record<string, unknown>;

--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -13,12 +13,11 @@
 // while simultaneously removing the D1 copy -- which is how a migration loses
 // rows rather than moving them.
 //
-// TRANSITIONAL, AND TRACKED AS SUCH (#10051). This is a rung, not the
-// destination: once these tables are in NEON_SOLE_STORE_TABLES the D1 write
-// goes, and once every table has crossed, NEON_DUAL_WRITE_LANES and every
-// mirror call site including this one get deleted. A reconciler or mirror that
-// outlives the inversion is worse than dead code -- it would copy a frozen D1
-// over live Neon rows, because it cannot tell the direction reversed.
+// FORMERLY TRANSITIONAL (#10051): the rung this stood on -- dual-write behind
+// NEON_SOLE_STORE_TABLES / NEON_DUAL_WRITE_LANES -- is gone with D1 and both
+// flags (#10892). What remains is the sole write to the only store, keeping
+// the era's two survivals: it cannot throw, and it files a lane verdict on
+// every attempt.
 import { laneHealthStore } from "./lane-health-store.ts";
 import { SUBNET_HYPERPARAMS_INSERT_COLUMNS } from "./subnet-hyperparams.ts";
 import {

--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -114,7 +114,8 @@ interface LedgerPlan {
 }
 
 /**
- * One plan per lane, keyed by the name used in NEON_DUAL_WRITE_LANES.
+ * One plan per lane, keyed by the lane name NEON_WRITE_BUFFER_LANES and
+ * the lane_health verdicts use (formerly NEON_DUAL_WRITE_LANES's key, #10892).
  *
  * The conflict keys match each table's PRIMARY KEY in Neon, created 2026-08-07
  * from D1's own DDL. An ON CONFLICT naming columns with no unique index behind

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -257,11 +257,10 @@ export function shouldFlushEarly(
 /**
  * The lanes routed through the buffer, read from the environment.
  *
- * A COMMA LIST DEFAULTING TO EMPTY, deliberately, and the same shape as
- * `NEON_DUAL_WRITE_LANES` in src/neon-write.ts. That file's header states the
- * reason and it applies unchanged here: this changes nothing until a lane is
- * named, so the deploy that introduces buffering cannot itself be the deploy
- * that buffers everything.
+ * A COMMA LIST DEFAULTING TO EMPTY, deliberately (the shape the deleted
+ * NEON_DUAL_WRITE_LANES cutover flag established, #10892): this changes
+ * nothing until a lane is named, so the deploy that introduces buffering
+ * cannot itself be the deploy that buffers everything.
  */
 export function neonWriteBufferLanes(
   env: Record<string, unknown> | null | undefined,

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -228,7 +228,9 @@ export function neuronSnapshotWrite(
   };
 }
 
-/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
+/** The lane name this mirror answers to -- the key NEON_WRITE_BUFFER_LANES
+ * and the lane_health verdicts use. (Named for NEON_DUAL_WRITE_LANES until
+ * that flag was deleted with the cutover, #10892.) */
 export const NEURONS_NEON_LANE = "neurons";
 
 type Row = Record<string, unknown>;

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -44,7 +44,9 @@ import {
 } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
-/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
+/** The lane name this mirror answers to -- the key NEON_WRITE_BUFFER_LANES
+ * and the lane_health verdicts use. (Named for NEON_DUAL_WRITE_LANES until
+ * that flag was deleted with the cutover, #10892.) */
 export const NOMINATOR_POSITIONS_NEON_LANE = "nominator-positions";
 
 /** The lane `self-stake` reports under -- its own, not this one's. */

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -835,17 +835,15 @@ async function handleNeuronsSync(
     return writeJson({ error: "no store bound for this route" }, 503);
   }
 
-  // THE NEON MIRROR (metagraphed-infra#336), and it runs AFTER the D1 write
-  // returns, never instead of it and never in front of it.
-  //
-  // That ordering is the whole lesson of how the pilot broke: a read moved to
-  // Neon while nothing wrote to it, so a public route served a two-day-old
-  // snapshot. During dual-write, D1 is still the store every route reads, so a
-  // Neon failure must cost a mirror and a lane verdict -- not the pass. It
-  // reports its own outcome and cannot throw.
-  //
-  // Off unless NEON_DUAL_WRITE_LANES names the lane, so the deploy that
-  // introduces this changes nothing.
+  // THE NEON WRITE (metagraphed-infra#336, dual-write era; sole store since
+  // D1 was deleted). Two of that era's properties survive it, on purpose:
+  // it reports its own outcome and cannot throw, and it files a lane verdict
+  // on EVERY attempt -- a store that stops accepting writes turns into an
+  // alarm, not a frozen snapshot quietly served (the pilot's failure). The
+  // dual-write gate that stood in front of it ("off unless
+  // NEON_DUAL_WRITE_LANES names the lane") went with the flag (#10892): a
+  // gate whose no-arm means "do not persist" is not a cutover control once
+  // there is one store, it is an off switch nothing should be holding.
   const neon = await mirrorNeuronSnapshotToNeon(
     env as unknown as Record<string, unknown>,
     ctx,


### PR DESCRIPTION
Closes #10892

The issue's mechanical work turned out to be already complete on main — #10886 deleted the last two cutover flags and #10889 deleted D1's vocabulary, together landing every deliverable except the prose:

- `NEON_DUAL_WRITE_LANES` is absent from all wrangler configs and from every live code path (`neonDualWriteEnabled` and its four gate sites: deleted; the mirrors run unconditionally, which is STRONGER than the inverted default requirement 1 asked for — with one store, "no flag" now means "always write" by construction, not by fallback).
- The no-flag-writes behavior is pinned: the mirror tests drive `mirrorNeuronSnapshotToNeon` with a bare `{}` env and assert all three tables write and verdict (the old "does nothing unless the lane is named" off-arm test was removed with the gate, with a tombstone saying so).
- `neonOwnsTable`: zero references — resolved by deletion rather than by decision, which is the stronger form of requirement 4.

What this PR does is the part that WAS still wrong: seven comments still describing the dual-write world as current — "off unless NEON_DUAL_WRITE_LANES names the lane" above a call that runs unconditionally, "During dual-write, D1 is still the store every route reads" above the sole write to the only store, a "TRANSITIONAL" header whose destination arrived, four lane-name doc comments keying on the deleted flag, and the buffer-lanes doc citing the deleted flag's header for its own rationale. Each rewritten to current truth, keeping the era's two deliberate survivals named (never throws; a verdict on every attempt) and pointing the lane names at their live registry (`NEON_WRITE_BUFFER_LANES` + the lane_health keys). The intentional tombstones in `src/neon-write.ts` ("lived here…") stay — those are obituaries, not stale claims.

Comments only; `tsc` clean, prettier clean.