### PR TITLE
fix(mcp): derive get_subnet_health's output from the route artifact, and let the drift alarm carry its diagnosis

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -5,10 +5,8 @@
 import { z } from "zod";
 import { McpUnsortedPageFields, netuidSchema } from "./shared.ts";
 import { ListSubnetHealthInputSchema } from "./subnet-scoped-lists.ts";
-import { HealthSubnetSummarySchema } from "../routes/health.ts";
-import { LIVE_HEALTH_OVERLAY } from "../routes/subnet-detail.ts";
 import {
-  HealthSubnetSurfaceSchema,
+  HealthSubnetArtifactSchema,
   ReliabilityScoreSchema,
 } from "../routes/health-surfaces.ts";
 
@@ -27,35 +25,21 @@ export const GetSubnetHealthInputSchema = ListSubnetHealthInputSchema.omit({
   .strict();
 export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
 
-// THE ROUTE'S OWN ROW SCHEMA (#10904), not a copy. This tool serves the
-// same overlaySubnetHealth()/fallback-tier rows GET /subnets/{netuid}/health
-// serves, and its previous hand-copied row schema sat five fields behind
-// the route's -- so the outbound tripwire refused every netuid-0 call the
-// moment the fallback tier answered. A second declaration is how the copy
-// comes to omit the field that matters (#10790's own words); this tool
-// advertises no `fields`, so the rows are never projected and the route's
-// exact shape is the right one.
-const GetSubnetHealthSurfaceSchema = HealthSubnetSurfaceSchema;
-
-export const GetSubnetHealthOutputSchema = z
-  .object({
-    netuid: netuidSchema(),
-    // Typed from the route's own HealthSubnetSummarySchema (#9797). This tool
-    // advertises no `fields`, so it is not partial. Verified against
-    // production 2026-08-07.
-    summary: HealthSubnetSummarySchema,
-    ...LIVE_HEALTH_OVERLAY,
-    surfaces: z.array(GetSubnetHealthSurfaceSchema),
-    // The route's OWN reliability shape (#10790) -- `computeReliability().subnet`,
-    // served here since the score landed and declared nowhere. Bounded score and
-    // an A-F grade enum, which a second declaration here had loosened to
-    // `z.number()`/`z.string()` before this collapse. Nullable is the honest
-    // answer for a subnet with no samples: no probe data, no score, never a zero
-    // that reads as "measured, and bad".
-    reliability: ReliabilityScoreSchema.nullable().optional(),
-    schema_version: z.int().optional(),
-    // This tool pages its `surfaces`, and said so nowhere.
-    ...McpUnsortedPageFields,
-  })
-  .strict();
+// THE ROUTE'S OWN ARTIFACT SCHEMA (#10904, completed), not a copy of any of
+// it. #10905 shared the surface ROW and left the top level restated -- and the
+// restatement was already wrong: overlaySubnetHealth() emits contract_version/
+// generated_at/slug/name at the top level (undefined-valued when the static
+// half is absent, but present, which .strict() counts), so every warm-tier
+// call still drifted on exactly the four keys the route artifact declares and
+// this copy lacked. The whole shape now derives from HealthSubnetArtifactSchema;
+// what remains here is only what the TOOL adds to the route's contract.
+export const GetSubnetHealthOutputSchema = HealthSubnetArtifactSchema.extend({
+  // The route's OWN reliability shape (#10790) -- `computeReliability().subnet`,
+  // served here since the score landed and declared nowhere. Nullable is the
+  // honest answer for a subnet with no samples: no probe data, no score, never
+  // a zero that reads as "measured, and bad".
+  reliability: ReliabilityScoreSchema.nullable().optional(),
+  // This tool pages its `surfaces`; the route serves them whole.
+  ...McpUnsortedPageFields,
+});
 export type GetSubnetHealthOutput = z.infer<typeof GetSubnetHealthOutputSchema>;

--- a/src/mcp-response-tripwire.ts
+++ b/src/mcp-response-tripwire.ts
@@ -78,7 +78,20 @@ export class McpResponseSchemaDriftError extends Error {
   readonly code = MCP_RESPONSE_DRIFT_CODE;
   readonly captureAsFault = true;
   constructor(tool: string, detail: unknown) {
-    super(`${tool} result drifted from its published outputSchema`);
+    // The issues ride IN the message (bounded), because the message is the
+    // only thing the exception pipeline serializes: `detail` never leaves
+    // this object, and `cause` is `this`, so the captured fault read
+    // "drifted from its published outputSchema" with the diagnosis — WHICH
+    // keys, at WHICH path — discarded. Measured 2026-08-12: get_subnet_health
+    // drifted on netuid 0 for hours and neither PostHog nor a tail could say
+    // on what. Same lesson as the REST tripwire's alarm (#10897): the
+    // unrecognized keys ARE the diagnosis.
+    super(
+      `${tool} result drifted from its published outputSchema: ` +
+        String(
+          detail instanceof Error ? detail.message : JSON.stringify(detail),
+        ).slice(0, 400),
+    );
     this.name = "McpResponseSchemaDriftError";
     this.tool = tool;
     this.detail = detail;


### PR DESCRIPTION
Closes #10913

#10905 shared the surface ROW and the tool still refused every warm-tier call — because the top level was a second restatement with the same disease one level up. `overlaySubnetHealth()` emits `contract_version`/`generated_at`/`slug`/`name` at the top level (undefined-valued when the static half is absent, but PRESENT, which `.strict()` counts), all four declared by the route's `HealthSubnetArtifactSchema` and missing from the tool's copy.

The fix finishes the single-declaration move: `GetSubnetHealthOutputSchema` now DERIVES from `HealthSubnetArtifactSchema` (exported) via `.extend`, and the only things declared locally are what the TOOL adds to the route's contract — `reliability` and the paging fields. The hand-restated netuid/summary/overlay/surfaces/schema_version block is gone along with the row alias.

Second fix, same triage: `McpResponseSchemaDriftError`'s Zod issues lived in `.detail` (never serialized) and its `cause` is itself — so the captured fault said only "drifted from its published outputSchema" and neither PostHog nor a `wrangler tail` could name the keys. The bounded issue list now rides in the message, the same lesson the REST tripwire's alarm learned in #10897: the unrecognized keys ARE the diagnosis.

Verified with a local full-dispatch reproduction feeding production's own netuid-0 rows: drifted with exactly the four keys before, **NO DRIFT on both the warm tier and the cold branch** after. 1,709 tests across the three suites, `validate:mcp` (235 tools, real responses), `contract-drift`, startup budget, `tsc`, fresh eslint, prettier — all green.