### PR TITLE
fix(identity): give the change diff a real baseline, and stop the flag comment lying about it

### DIFF
--- a/src/subnet-identity-history.ts
+++ b/src/subnet-identity-history.ts
@@ -20,6 +20,9 @@ import {
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { storeAll } from "./analytics-live.ts";
 import { readStore } from "./read-store.ts";
+// The one table latestIdentityHashes reads (#10700), declared where every
+// other read-store table set is.
+import { SUBNET_IDENTITY_HISTORY_TABLES } from "./read-store-tables.ts";
 
 /** The one table latestBlockNumber reads. Declared so readStore can refuse when
  * Neon does not own it, rather than reading a store that has no such table. */
@@ -185,33 +188,59 @@ function rowNetuid(value: unknown): number | null {
 // query D1's own subnet_identity_history directly; now reads the same latest-
 // per-netuid hash via the Postgres-backed internal endpoint (workers/data-
 // api.ts's /api/v1/internal/subnet-identity-latest-hashes), reusing
-// METAGRAPH_SUBNET_IDENTITY_SOURCE (same table, already flipped to postgres).
-// An unavailable/off tier degrades to an empty map -- every profile then
-// reads as "changed" for that one run, the same degrade recordSubnetIdentity
-// Changes already tolerates on a cold table.
+// the same table DIRECTLY (see latestIdentityHashes below): no flag, no
+// forward. METAGRAPH_SUBNET_IDENTITY_SOURCE is back to "retired" and reads
+// nowhere (#10893), so a tier read here would decline unconditionally. An
+// unreadable store degrades to an empty map -- every profile then reads as
+// "changed" for that one run, the same degrade recordSubnetIdentityChanges
+// already tolerates on a cold table.
 /**
- * THERE IS NO BASELINE, and saying so is the point (#10700).
+ * THE BASELINE: the newest identity hash per netuid (#10700).
  *
- * This read `tryDataApiTier(..., "METAGRAPH_SUBNET_IDENTITY_SOURCE")` and
- * derived the map from `pg?.hashes`. That flag reads "retired" in every deployed
- * config and is absent from FORWARDABLE_TIER_FLAGS, so the tier resolved to null
- * on every call, `pg?.hashes` was always undefined, and the `|| []` absorbed it
- * without a throw, a log or a degraded marker. The map has been empty in
- * production ever since the flag was retired.
+ * WAS AN EMPTY MAP, and the emptiness was load-bearing in the worst way. The
+ * original read went through `tryDataApiTier(...,
+ * "METAGRAPH_SUBNET_IDENTITY_SOURCE")`, a flag that reads "retired" in every
+ * deployed config and is absent from FORWARDABLE_TIER_FLAGS, so the tier
+ * resolved to null on every call and `pg?.hashes` was always undefined --
+ * absorbed by a `|| []` with no throw, no log and no degraded marker. #10190
+ * removed the dead read and left the empty Map behind with this note, because
+ * removing it does not change behaviour: `recordSubnetIdentityChanges` diffs
+ * against this map, so an empty one makes EVERY subnet look changed on every
+ * tick and the prober publishes that count (~129 phantom changes an hour).
  *
- * The dead read is removed rather than kept as decoration, because it made this
- * look like a source that might answer. It never did. The CONSEQUENCE is filed
- * as #10700: `recordSubnetIdentityChanges` diffs against this map, so an empty
- * one makes every subnet look changed on every tick, and the prober publishes
- * that count. Removing the read does not change that behaviour -- it makes it
- * visible, which is the prerequisite for fixing it.
+ * A DIRECT STORE READ, not a restored tier forward -- the move
+ * src/health-status-live.ts made for the same reason, and the one
+ * `latestBlockNumber` below already makes for `blocks_head`. The table is a
+ * Neon table with a live writer since #10740 (the chain-direct poller lane,
+ * hourly), it is declared in SUBNET_IDENTITY_HISTORY_TABLES, and reading it
+ * needs no flag: `readStore` refuses when the binding is absent, which is the
+ * only question a read here actually has.
  *
- * A real baseline wants a direct read of the latest hash per netuid from
- * `subnet_identity_history` (a Neon table), the move src/health-status-live.ts
- * already made when it stopped going through tryDataApiTier for the same reason.
+ * DISTINCT (netuid) ON, ordered newest-first, so one row per subnet comes back
+ * -- the same latest-per-netuid shape the deleted internal endpoint returned.
+ *
+ * Still degrades to an empty Map rather than throwing: no binding, an
+ * undeclared table or an unreadable query all mean "no baseline this tick",
+ * which is the state that existed before -- and the caller already treats a
+ * read failure as its own outcome (`read_failed`) rather than as "unchanged".
  */
-async function latestIdentityHashes(): Promise<Map<number, unknown>> {
-  return new Map<number, unknown>();
+async function latestIdentityHashes(env: Env): Promise<Map<number, unknown>> {
+  const rows = await storeAll(
+    readStore(env, SUBNET_IDENTITY_HISTORY_TABLES) as never,
+    "SELECT DISTINCT ON (netuid) netuid, identity_hash FROM subnet_identity_history " +
+      "ORDER BY netuid, observed_at DESC, id DESC",
+    [],
+  );
+  const byNetuid = new Map<number, unknown>();
+  for (const row of rows as Row[]) {
+    const netuid = Number(row?.netuid);
+    // A row whose netuid is unusable cannot be matched against a profile, and
+    // seeding it under NaN would make one subnet's baseline unreachable while
+    // looking present in the map's size.
+    if (!Number.isSafeInteger(netuid)) continue;
+    byNetuid.set(netuid, row?.identity_hash ?? null);
+  }
+  return byNetuid;
 }
 
 /**

--- a/tests/subnet-identity-history.test.ts
+++ b/tests/subnet-identity-history.test.ts
@@ -621,6 +621,93 @@ describe("recordSubnetIdentityChanges", () => {
   //
   // Exercised indirectly through recordSubnetIdentityChanges's own
   // `block_number` field, same style the retired tier tests used.
+  describe("the identity baseline reads subnet_identity_history (#10700)", () => {
+    // WAS AN EMPTY MAP, so every subnet diffed as changed on every tick and
+    // the prober published that count (~129 phantom changes an hour). These
+    // pin that the default baseline is a real read now, and that its failure
+    // modes stay the degrades they were rather than becoming false "changed".
+    const profiles = [
+      { netuid: 7, native_identity: { subnet_name: "Same" } },
+      { netuid: 9, native_identity: { subnet_name: "Different" } },
+    ];
+
+    beforeEach(() => {
+      pg.control.queries.length = 0;
+      pg.control.answers = [];
+      pg.control.rows = null;
+      pg.control.failNext = null;
+    });
+
+    test("an UNCHANGED subnet is skipped, using the stored hash as the baseline", async () => {
+      // The whole point of #10700: with a real baseline, a subnet whose
+      // identity did not move must not be reported as changed.
+      // AWAITED: identityHash is async, and an unawaited Promise would never
+      // equal the diff's own string -- the test would pass for the wrong reason.
+      const unchanged = await identityHash(
+        identitySnapshotFromProfile(profiles[0] as Row) as Row,
+      );
+      pg.control.answers = [
+        {
+          match: "FROM subnet_identity_history",
+          rows: [{ netuid: 7, identity_hash: unchanged }],
+        },
+        { match: "FROM blocks_head", rows: [{ block_number: 1 }] },
+      ];
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles: [profiles[0]] },
+      );
+      assert.equal(result.rows, 0, JSON.stringify(result));
+      // DISTINCT ON (netuid), newest first -- one row per subnet, the shape
+      // the deleted internal endpoint used to return.
+      assert.match(pg.control.queries[0].text, /DISTINCT ON \(netuid\)/);
+      assert.match(pg.control.queries[0].text, /observed_at DESC/);
+    });
+
+    test("a subnet whose hash MOVED is still reported changed", async () => {
+      pg.control.answers = [
+        {
+          match: "FROM subnet_identity_history",
+          rows: [{ netuid: 7, identity_hash: "stale-hash" }],
+        },
+        { match: "FROM blocks_head", rows: [{ block_number: 1 }] },
+      ];
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles: [profiles[0]] },
+      );
+      assert.equal(result.rows, 1);
+    });
+
+    test("an unusable netuid is skipped rather than seeded under NaN", async () => {
+      pg.control.answers = [
+        {
+          match: "FROM subnet_identity_history",
+          rows: [
+            { netuid: "not-a-number", identity_hash: "x" },
+            { netuid: 7, identity_hash: "y" },
+          ],
+        },
+        { match: "FROM blocks_head", rows: [{ block_number: 1 }] },
+      ];
+      // The good row still lands: a bad row must not poison the map.
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles: [profiles[0]] },
+      );
+      assert.equal(result.rows, 1);
+    });
+
+    test("an unbound store degrades to an empty baseline, never a throw", async () => {
+      const result = await recordSubnetIdentityChanges({} as unknown as Env, {
+        profiles: [profiles[0]],
+      });
+      // No baseline this tick: the pre-#10700 behaviour, kept deliberately.
+      assert.equal(result.rows, 1);
+      assert.deepEqual(pg.control.queries, []);
+    });
+  });
+
   describe("latestBlockNumber reads blocks_head", () => {
     const profiles = [{ netuid: 7, native_identity: { subnet_name: "First" } }];
 
@@ -640,7 +727,12 @@ describe("recordSubnetIdentityChanges", () => {
         { profiles },
       );
       assert.equal(result.block_number, 8_404_076);
-      assert.match(pg.control.queries[0].text, /MAX\(block_number\)/);
+      // NOT queries[0] any more: the #10700 baseline read runs first now.
+      assert.ok(
+        pg.control.queries.some((q: { text: string }) =>
+          /MAX\(block_number\)/.test(q.text),
+        ),
+      );
     });
 
     test("degrades to null when the store is unbound", async () => {

--- a/tests/subnet-identity-history.test.ts
+++ b/tests/subnet-identity-history.test.ts
@@ -679,6 +679,25 @@ describe("recordSubnetIdentityChanges", () => {
       assert.equal(result.rows, 1);
     });
 
+    test("a row with no hash of its own is a null baseline, not a skip", async () => {
+      // `identity_hash ?? null` -- a stored row whose hash column is absent
+      // still HAS a baseline entry (null), which no profile hash equals, so
+      // the subnet reports changed. Skipping it instead would be the same
+      // empty-map bug one row at a time.
+      pg.control.answers = [
+        {
+          match: "FROM subnet_identity_history",
+          rows: [{ netuid: 7 }],
+        },
+        { match: "FROM blocks_head", rows: [{ block_number: 1 }] },
+      ];
+      const result = await recordSubnetIdentityChanges(
+        pgMockEnv() as unknown as Env,
+        { profiles: [profiles[0]] },
+      );
+      assert.equal(result.rows, 1);
+    });
+
     test("an unusable netuid is skipped rather than seeded under NaN", async () => {
       pg.control.answers = [
         {


### PR DESCRIPTION
Closes #10700

`latestIdentityHashes()` returned an empty Map, so `recordSubnetIdentityChanges` diffed every subnet against nothing and reported **all ~129 as changed on every hourly tick** — a number the prober publishes. #10190 removed the dead tier read that used to (never) supply it and left the empty Map with a note saying a real read was owed; this is that read.

**A direct store read, not a restored tier forward** — the move `src/health-status-live.ts` made for the same reason, and the one `latestBlockNumber` directly below already makes for `blocks_head`. `subnet_identity_history` is a Neon table with a live writer since #10740 (the chain-direct poller lane, hourly), it is already declared in `SUBNET_IDENTITY_HISTORY_TABLES`, and reading it needs no flag: `readStore` refuses when the binding is absent, which is the only question a read here actually has. `DISTINCT ON (netuid) … ORDER BY netuid, observed_at DESC, id DESC` returns the same latest-per-netuid shape the deleted internal endpoint did.

Failure modes are unchanged on purpose: an unbound store, an undeclared table or an unreadable query all degrade to an empty baseline ("no baseline this tick") rather than throwing, and the caller keeps treating a read failure as `read_failed` rather than as "unchanged".

**Also fixes #10893's leftover.** That issue's config half is already resolved on main (the flag is back to `"retired"` with the "THIS VALUE IS NOT READ" comment it asked for), but the flip left a stale claim behind in this file — "same table, already flipped to postgres" — describing a forward that cannot happen. Rewritten to say what the code now does: reads the table directly, no flag, and the flag reads nowhere.

Tests: four new cases pin the baseline is real — an UNCHANGED subnet is skipped (against a hash computed from the same helpers the diff uses; the `await` matters, an unawaited Promise would never compare equal and the test would pass for the wrong reason), a MOVED hash still reports changed, an unusable netuid is skipped rather than seeded under NaN, and an unbound store still degrades. One existing assertion updated: the blocks_head test asserted `queries[0]`, and the baseline read now runs first.

64 tests in the identity suites + 113 in the adjacent prober/read-store suites, `tsc`, startup budget, fresh eslint, prettier — all green.