### PR TITLE
refactor(store): the read handles speak our verbs -- the last D1 emulation is gone

### DIFF
--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -5,8 +5,10 @@
 import { z } from "zod";
 import { McpUnsortedPageFields, netuidSchema } from "./shared.ts";
 import { ListSubnetHealthInputSchema } from "./subnet-scoped-lists.ts";
+import { HealthSubnetSummarySchema } from "../routes/health.ts";
+import { LIVE_HEALTH_OVERLAY } from "../routes/subnet-detail.ts";
 import {
-  HealthSubnetArtifactSchema,
+  HealthSubnetSurfaceSchema,
   ReliabilityScoreSchema,
 } from "../routes/health-surfaces.ts";
 
@@ -25,21 +27,35 @@ export const GetSubnetHealthInputSchema = ListSubnetHealthInputSchema.omit({
   .strict();
 export type GetSubnetHealthInput = z.infer<typeof GetSubnetHealthInputSchema>;
 
-// THE ROUTE'S OWN ARTIFACT SCHEMA (#10904, completed), not a copy of any of
-// it. #10905 shared the surface ROW and left the top level restated -- and the
-// restatement was already wrong: overlaySubnetHealth() emits contract_version/
-// generated_at/slug/name at the top level (undefined-valued when the static
-// half is absent, but present, which .strict() counts), so every warm-tier
-// call still drifted on exactly the four keys the route artifact declares and
-// this copy lacked. The whole shape now derives from HealthSubnetArtifactSchema;
-// what remains here is only what the TOOL adds to the route's contract.
-export const GetSubnetHealthOutputSchema = HealthSubnetArtifactSchema.extend({
-  // The route's OWN reliability shape (#10790) -- `computeReliability().subnet`,
-  // served here since the score landed and declared nowhere. Nullable is the
-  // honest answer for a subnet with no samples: no probe data, no score, never
-  // a zero that reads as "measured, and bad".
-  reliability: ReliabilityScoreSchema.nullable().optional(),
-  // This tool pages its `surfaces`; the route serves them whole.
-  ...McpUnsortedPageFields,
-});
+// THE ROUTE'S OWN ROW SCHEMA (#10904), not a copy. This tool serves the
+// same overlaySubnetHealth()/fallback-tier rows GET /subnets/{netuid}/health
+// serves, and its previous hand-copied row schema sat five fields behind
+// the route's -- so the outbound tripwire refused every netuid-0 call the
+// moment the fallback tier answered. A second declaration is how the copy
+// comes to omit the field that matters (#10790's own words); this tool
+// advertises no `fields`, so the rows are never projected and the route's
+// exact shape is the right one.
+const GetSubnetHealthSurfaceSchema = HealthSubnetSurfaceSchema;
+
+export const GetSubnetHealthOutputSchema = z
+  .object({
+    netuid: netuidSchema(),
+    // Typed from the route's own HealthSubnetSummarySchema (#9797). This tool
+    // advertises no `fields`, so it is not partial. Verified against
+    // production 2026-08-07.
+    summary: HealthSubnetSummarySchema,
+    ...LIVE_HEALTH_OVERLAY,
+    surfaces: z.array(GetSubnetHealthSurfaceSchema),
+    // The route's OWN reliability shape (#10790) -- `computeReliability().subnet`,
+    // served here since the score landed and declared nowhere. Bounded score and
+    // an A-F grade enum, which a second declaration here had loosened to
+    // `z.number()`/`z.string()` before this collapse. Nullable is the honest
+    // answer for a subnet with no samples: no probe data, no score, never a zero
+    // that reads as "measured, and bad".
+    reliability: ReliabilityScoreSchema.nullable().optional(),
+    schema_version: z.int().optional(),
+    // This tool pages its `surfaces`, and said so nowhere.
+    ...McpUnsortedPageFields,
+  })
+  .strict();
 export type GetSubnetHealthOutput = z.infer<typeof GetSubnetHealthOutputSchema>;

--- a/src/account-balances-completeness.ts
+++ b/src/account-balances-completeness.ts
@@ -29,9 +29,7 @@
 // Neither is a producer bug. Both are why the reader needs its own answer.
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    first(): Promise<unknown>;
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface AccountBalancesCompleteness {
@@ -69,17 +67,15 @@ const NONE: AccountBalancesCompleteness = {
 export async function latestCompleteAccountBalancesPass(
   db: StatementClientLike | null | undefined,
 ): Promise<AccountBalancesCompleteness> {
-  if (!db?.prepare) return { ...NONE, reason: "unavailable" };
+  if (!db?.first) return { ...NONE, reason: "unavailable" };
   try {
-    const row = (await db
-      .prepare(
-        `SELECT captured_at, expected_rows, received_rows
-           FROM account_balances_passes
-          WHERE completed_at IS NOT NULL
-          ORDER BY completed_at DESC
-          LIMIT 1`,
-      )
-      .first()) as {
+    const row = (await db.first(
+      `SELECT captured_at, expected_rows, received_rows
+         FROM account_balances_passes
+        WHERE completed_at IS NOT NULL
+        ORDER BY completed_at DESC
+        LIMIT 1`,
+    )) as {
       captured_at?: unknown;
       expected_rows?: unknown;
       received_rows?: unknown;

--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -273,9 +273,7 @@ function countOrZero(value: unknown): number {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): { first(): Promise<unknown> };
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface AccountBalancesStalenessDeps {
@@ -304,7 +302,7 @@ export async function runAccountBalancesStalenessWatchdog(
   // stalled while the lane was fine.
   const db = readStore(env, ["account_balances"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS) ||
@@ -317,10 +315,9 @@ export async function runAccountBalancesStalenessWatchdog(
     ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS;
 
   try {
-    const row = (await db
-      .prepare(ACCOUNT_BALANCES_COVERAGE_SQL)
-      .bind(passWindowMs)
-      .first()) as {
+    const row = (await db.first(ACCOUNT_BALANCES_COVERAGE_SQL, [
+      passWindowMs,
+    ])) as {
       latest: number | null;
       covered: number | null;
       total: number | null;

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -526,14 +526,10 @@ export async function loadAccountPrometheusColdTier(
   };
 }
 
-/** The D1 surface this module needs from `neurons` -- structural, so tests
+/** The store surface this module needs from `neurons` -- structural, so tests
  * can hand a plain object (same pattern as src/blocks-cold-tier.ts). */
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 /** The hotkey's registered (netuid, uid) slots from D1 `neurons` -- the same
@@ -547,15 +543,14 @@ async function neuronSlots(
 ): Promise<{ netuid: number; uid: number }[] | null> {
   const db = readStore(env, ["neurons"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   let results: unknown[];
   try {
-    const res = await db
-      .prepare("SELECT netuid, uid FROM neurons WHERE hotkey = ?")
-      .bind(addr)
-      .all?.();
-    if (!Array.isArray(res?.results)) return null;
-    results = res.results;
+    if (!db.query) return null;
+    results = await db.query(
+      "SELECT netuid, uid FROM neurons WHERE hotkey = ?",
+      [addr],
+    );
   } catch {
     return null;
   }

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -546,7 +546,6 @@ async function neuronSlots(
   if (!db?.query) return null;
   let results: unknown[];
   try {
-    if (!db.query) return null;
     results = await db.query(
       "SELECT netuid, uid FROM neurons WHERE hotkey = ?",
       [addr],

--- a/src/account-summary-card.ts
+++ b/src/account-summary-card.ts
@@ -43,6 +43,7 @@ import {
 import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
 import { isR2SqlConfigured } from "./r2-sql.ts";
 import { readStore } from "./read-store.ts";
+import type { Neurons } from "../generated/db/types.ts";
 
 /** The D1 surface this module needs -- structural, so tests can hand it a
  * plain object (the same pattern as src/blocks-cold-tier.ts). */
@@ -58,6 +59,14 @@ interface StatementClientLike {
  * rows through the same formatRegistration, and cannot come to disagree about
  * where one hotkey is registered.
  */
+/** Exactly the columns ACCOUNT_REGISTRATIONS_SQL selects, from the generated
+ * table type -- so a renamed or retyped column is a compile error here rather
+ * than a silently-missing field in the card. */
+export type AccountRegistrationRow = Pick<
+  Neurons,
+  "netuid" | "uid" | "stake_tao" | "validator_permit" | "active"
+>;
+
 export const ACCOUNT_REGISTRATIONS_SQL =
   "SELECT netuid, uid, stake_tao, validator_permit, active FROM neurons " +
   "WHERE hotkey = ? ORDER BY netuid";
@@ -73,12 +82,12 @@ export const ACCOUNT_REGISTRATIONS_SQL =
 export async function loadAccountRegistrationsFromStore(
   env: Env | null | undefined,
   ss58: string,
-): Promise<Record<string, unknown>[] | null> {
+): Promise<AccountRegistrationRow[] | null> {
   const db = readStore(env, ["neurons"]) as unknown as
     StatementClientLike | undefined;
   if (!db?.query) return [];
   try {
-    return await db.query<Record<string, unknown>>(ACCOUNT_REGISTRATIONS_SQL, [
+    return await db.query<AccountRegistrationRow>(ACCOUNT_REGISTRATIONS_SQL, [
       ss58,
     ]);
   } catch {

--- a/src/account-summary-card.ts
+++ b/src/account-summary-card.ts
@@ -47,11 +47,7 @@ import { readStore } from "./read-store.ts";
 /** The D1 surface this module needs -- structural, so tests can hand it a
  * plain object (the same pattern as src/blocks-cold-tier.ts). */
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 /**
@@ -80,11 +76,11 @@ export async function loadAccountRegistrationsFromStore(
 ): Promise<Record<string, unknown>[] | null> {
   const db = readStore(env, ["neurons"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return [];
+  if (!db?.query) return [];
   try {
-    const res = await db.prepare(ACCOUNT_REGISTRATIONS_SQL).bind(ss58).all?.();
-    const rows = res?.results;
-    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+    return await db.query<Record<string, unknown>>(ACCOUNT_REGISTRATIONS_SQL, [
+      ss58,
+    ]);
   } catch {
     return null;
   }

--- a/src/alpha-usd-history.ts
+++ b/src/alpha-usd-history.ts
@@ -73,11 +73,7 @@ type Row = Record<string, unknown>;
 
 /** The minimal store surface used here, matching src/tao-usd-series.ts. */
 export interface TaoUsdBucketDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 /**
@@ -148,14 +144,9 @@ export async function loadTaoUsdBuckets(
   db: TaoUsdBucketDb | null | undefined,
   { sinceMs, bucketMs }: { sinceMs: number; bucketMs: number },
 ): Promise<Row[] | null> {
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   try {
-    const res = await (
-      db.prepare(taoUsdBucketSql(bucketMs)).bind(sinceMs) as {
-        all?(): Promise<{ results?: unknown[] } | null>;
-      }
-    ).all?.();
-    return (res?.results ?? []) as Row[];
+    return await db.query<Row>(taoUsdBucketSql(bucketMs), [sinceMs]);
   } catch {
     return null;
   }
@@ -450,27 +441,22 @@ export async function loadTaoUsdAtInstants(
 ): Promise<Map<number, TaoUsdReading> | null> {
   const wanted = [...new Set(instants.filter((n) => Number.isFinite(n)))];
   if (wanted.length === 0) return new Map();
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   try {
-    const res = await (
-      db
-        .prepare(
-          `SELECT e.t AS instant, r.usd_per_tao, r.observed_at,` +
-            ` r.block_number, r.price_basis` +
-            ` FROM unnest(?::bigint[]) AS e(t)` +
-            ` LEFT JOIN LATERAL (` +
-            `SELECT usd_per_tao, observed_at, block_number, price_basis` +
-            ` FROM ${TAO_USD_TABLE}` +
-            ` WHERE observed_at <= e.t AND usd_per_tao IS NOT NULL` +
-            ` ORDER BY observed_at DESC LIMIT 1` +
-            `) r ON TRUE`,
-        )
-        .bind(wanted) as {
-        all?(): Promise<{ results?: unknown[] } | null>;
-      }
-    ).all?.();
+    const rows = await db.query<Row>(
+      `SELECT e.t AS instant, r.usd_per_tao, r.observed_at,` +
+        ` r.block_number, r.price_basis` +
+        ` FROM unnest(?::bigint[]) AS e(t)` +
+        ` LEFT JOIN LATERAL (` +
+        `SELECT usd_per_tao, observed_at, block_number, price_basis` +
+        ` FROM ${TAO_USD_TABLE}` +
+        ` WHERE observed_at <= e.t AND usd_per_tao IS NOT NULL` +
+        ` ORDER BY observed_at DESC LIMIT 1` +
+        `) r ON TRUE`,
+      [wanted],
+    );
     const map = new Map<number, TaoUsdReading>();
-    for (const row of (res?.results ?? []) as Row[]) {
+    for (const row of rows) {
       const instant = int(row?.instant);
       // A row with no reading is the pre-index case: left out, not stored as
       // a null, so a caller cannot mistake "no rate existed" for "rate null".

--- a/src/analytics-live.ts
+++ b/src/analytics-live.ts
@@ -53,15 +53,13 @@ const COMPARE_NETUIDS_PATTERN = /^\d{1,5}(,\d{1,5}){0,127}$/;
 // it misses (or its flag is off), the D1 read replaces what used to be a
 // guaranteed-empty payload.
 //
-// The read slice of the D1 API these loaders use — structural (mirroring
-// ObservationsDb, the write slice in observations-d1.ts) so tests can hand
-// in node:sqlite-backed fakes and the real binding both.
+// The read slice these loaders use -- the owned query() verb (#10909),
+// structural so tests can hand in plain fakes and the real store both.
 export interface ObservationsReadDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all(): Promise<{ results?: unknown[] } | unknown>;
-    };
-  };
+  query<Row = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ): Promise<Row[]>;
 }
 
 // A failed D1 read degrades to zero rows, and the payload built from those
@@ -89,18 +87,11 @@ export async function storeAll(
   sql: string,
   params: unknown[],
 ): Promise<Record<string, unknown>[]> {
-  if (!db?.prepare) return [];
+  if (!db?.query) return [];
   try {
-    const outcome = await db
-      .prepare(sql)
-      .bind(...params)
-      .all();
-    // D1 wraps rows in { results }; a node:sqlite-backed test fake returns
-    // the array directly. Accept both, and anything else is zero rows.
-    const rows = Array.isArray(outcome)
-      ? outcome
-      : (outcome as { results?: unknown[] })?.results;
-    return (Array.isArray(rows) ? rows : []) as Record<string, unknown>[];
+    // The dual-envelope acceptance (D1's { results } vs a bare array) retired
+    // with the emulators (#10909): query() answers rows, full stop.
+    return await db.query(sql, params);
   } catch (error) {
     storeReadFailureGeneration += 1;
     console.error("[analytics-store]", String((error as Error)?.message));

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -45,6 +45,7 @@ import {
   type BlockFeedQuery,
 } from "./r2-sql-blocks.ts";
 import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
+import type { BlocksHead } from "../generated/db/types.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { readStore } from "./read-store.ts";
@@ -107,6 +108,19 @@ const STORE_SELECT =
   // between a block being seen and being decoded -- the window that used to
   // publish null and render "Events 0".
   "COALESCE(c.chain_event_count, b.event_count) AS event_count";
+/** What STORE_SELECT returns: blocks_head's own columns, plus the two joined
+ * from chain_detail_blocks. Named rather than left untyped so a column rename
+ * on either side of the join is a compile error (#10261). */
+type BlockSeamRow = Pick<
+  BlocksHead,
+  | "block_number"
+  | "block_hash"
+  | "parent_hash"
+  | "extrinsic_count"
+  | "observed_at"
+  | "author"
+> & { spec_version: number | null; event_count: number | null };
+
 const STORE_FROM =
   "blocks_head b LEFT JOIN chain_detail_blocks c " +
   "ON c.block_number = b.block_number";
@@ -422,7 +436,7 @@ export async function loadBlockColdTier(
         asNumber !== null ? "b.block_number = ?" : "lower(b.block_hash) = ?";
       const value = asNumber !== null ? asNumber : asHash!;
       const rows = db.query
-        ? await db.query<Record<string, unknown>>(
+        ? await db.query<BlockSeamRow>(
             `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${predicate} LIMIT 1`,
             [value],
           )

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -45,7 +45,7 @@ import {
   type BlockFeedQuery,
 } from "./r2-sql-blocks.ts";
 import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
-import type { BlocksHead } from "../generated/db/types.ts";
+import type { BlocksHead, ChainDetailBlocks } from "../generated/db/types.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { readStore } from "./read-store.ts";
@@ -108,18 +108,29 @@ const STORE_SELECT =
   // between a block being seen and being decoded -- the window that used to
   // publish null and render "Events 0".
   "COALESCE(c.chain_event_count, b.event_count) AS event_count";
-/** What STORE_SELECT returns: blocks_head's own columns, plus the two joined
- * from chain_detail_blocks. Named rather than left untyped so a column rename
- * on either side of the join is a compile error (#10261). */
-type BlockSeamRow = Pick<
-  BlocksHead,
-  | "block_number"
-  | "block_hash"
-  | "parent_hash"
-  | "extrinsic_count"
-  | "observed_at"
-  | "author"
-> & { spec_version: number | null; event_count: number | null };
+/**
+ * What STORE_SELECT returns: a JOIN projection, not either table.
+ *
+ * Every field takes its type by INDEXED ACCESS from the generated table it
+ * actually comes from, so a renamed or retyped column on either side of the
+ * join is a compile error here (#10261). Written as its own interface rather
+ * than `Pick<BlocksHead, ...> & { ... }` deliberately: an alias-and-widen of a
+ * generated type is what validate:type-duplicates exists to refuse, and it is
+ * right to -- a field a PRODUCER adds belongs in the schema. This adds none:
+ * it is the shape of a query over two tables, which is a third thing.
+ */
+interface BlockSeamRow {
+  block_number: BlocksHead["block_number"];
+  block_hash: BlocksHead["block_hash"];
+  parent_hash: BlocksHead["parent_hash"];
+  extrinsic_count: BlocksHead["extrinsic_count"];
+  observed_at: BlocksHead["observed_at"];
+  author: BlocksHead["author"];
+  /** COALESCE(c.chain_event_count, b.event_count) -- either side answers. */
+  event_count:
+    ChainDetailBlocks["chain_event_count"] | BlocksHead["event_count"];
+  spec_version: ChainDetailBlocks["spec_version"];
+}
 
 const STORE_FROM =
   "blocks_head b LEFT JOIN chain_detail_blocks c " +

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -295,7 +295,6 @@ async function storeHeadRows(
   }
 
   try {
-    if (!db.query) return null;
     return (await db.query(
       `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${where.join(" AND ")}
        ORDER BY b.observed_at DESC, b.block_number DESC LIMIT ?`,
@@ -446,12 +445,10 @@ export async function loadBlockColdTier(
       const predicate =
         asNumber !== null ? "b.block_number = ?" : "lower(b.block_hash) = ?";
       const value = asNumber !== null ? asNumber : asHash!;
-      const rows = db.query
-        ? await db.query<BlockSeamRow>(
-            `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${predicate} LIMIT 1`,
-            [value],
-          )
-        : [];
+      const rows = await db.query<BlockSeamRow>(
+        `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${predicate} LIMIT 1`,
+        [value],
+      );
       const row = rows[0];
       if (row) return buildBlock(row as never, ref);
     } catch {

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -112,11 +112,7 @@ const STORE_FROM =
   "ON c.block_number = b.block_number";
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 /** The one binding this module still reads directly, independent of the full
@@ -244,7 +240,7 @@ async function storeHeadRows(
 ): Promise<Record<string, unknown>[] | null> {
   const db = readStore(env, BLOCKS_SEAM_TABLES) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare || want <= 0) return null;
+  if (!db?.query || want <= 0) return null;
 
   // Every predicate is qualified to `b`: block_number, observed_at and
   // extrinsic_count all exist on BOTH sides of the join, so an unqualified
@@ -274,15 +270,12 @@ async function storeHeadRows(
   }
 
   try {
-    const res = await db
-      .prepare(
-        `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${where.join(" AND ")}
-         ORDER BY b.observed_at DESC, b.block_number DESC LIMIT ?`,
-      )
-      .bind(...params, want)
-      .all?.();
-    const rows = res?.results;
-    return Array.isArray(rows) ? (rows as Record<string, unknown>[]) : [];
+    if (!db.query) return null;
+    return (await db.query(
+      `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${where.join(" AND ")}
+       ORDER BY b.observed_at DESC, b.block_number DESC LIMIT ?`,
+      [...params, want],
+    )) as Record<string, unknown>[];
   } catch {
     // A cold or unbound D1 must not fail the request: the lakehouse leg below
     // still has every block up to the seam.
@@ -423,18 +416,18 @@ export async function loadBlockColdTier(
   // a source switch, so the same 0 meant the right thing there.
   const aboveSeam =
     network === DEFAULT_CHAIN_NETWORK && asNumber !== null && asNumber > seam;
-  if (db?.prepare && (aboveSeam || asHash !== null)) {
+  if (db?.query && (aboveSeam || asHash !== null)) {
     try {
       const predicate =
         asNumber !== null ? "b.block_number = ?" : "lower(b.block_hash) = ?";
       const value = asNumber !== null ? asNumber : asHash!;
-      const res = await db
-        .prepare(
-          `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${predicate} LIMIT 1`,
-        )
-        .bind(value)
-        .all?.();
-      const row = (res?.results as Record<string, unknown>[] | undefined)?.[0];
+      const rows = db.query
+        ? await db.query<Record<string, unknown>>(
+            `SELECT ${STORE_SELECT} FROM ${STORE_FROM} WHERE ${predicate} LIMIT 1`,
+            [value],
+          )
+        : [];
+      const row = rows[0];
       if (row) return buildBlock(row as never, ref);
     } catch {
       // Fall through to the lakehouse rather than failing the request.

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -50,13 +50,8 @@ import { summarizeEvent } from "@jsonbored/chain-summaries";
 
 type Row = Record<string, unknown>;
 
-interface StatementLike {
-  bind(...values: unknown[]): StatementLike;
-  all?(): Promise<{ results?: unknown[] } | null>;
-  first?(): Promise<unknown>;
-}
 interface StatementClientLike {
-  prepare(sql: string): StatementLike;
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 /** The four tables every statement in this module reads (#10148). Handed to
  *  readStore as one set: a hot tier split across stores would answer a block
@@ -71,7 +66,7 @@ export const CHAIN_DETAIL_HOT_TIER_TABLES = [
 function db(env: unknown): StatementClientLike | null {
   const binding = readStore(env, CHAIN_DETAIL_HOT_TIER_TABLES) as unknown as
     StatementClientLike | undefined;
-  return binding?.prepare ? binding : null;
+  return binding?.query ? binding : null;
 }
 
 /** Rows for one bound query, or null when D1 is unbound or the query fails. A
@@ -85,12 +80,8 @@ async function query(
   const binding = db(env);
   if (!binding) return null;
   try {
-    const res = await binding
-      .prepare(sql)
-      .bind(...params)
-      .all?.();
-    const rows = res?.results;
-    return Array.isArray(rows) ? (rows as Row[]) : [];
+    if (!binding.query) return null;
+    return (await binding.query(sql, params)) as Row[];
   } catch {
     return null;
   }

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -78,9 +78,8 @@ async function query(
   params: unknown[],
 ): Promise<Row[] | null> {
   const binding = db(env);
-  if (!binding) return null;
+  if (!binding?.query) return null;
   try {
-    if (!binding.query) return null;
     return (await binding.query(sql, params)) as Row[];
   } catch {
     return null;

--- a/src/chain-detail-neon-write.ts
+++ b/src/chain-detail-neon-write.ts
@@ -88,9 +88,7 @@ export const CHAIN_DETAIL_CONFLICT_KEYS = {
   chain_detail_account_events: ["block_number", "event_index"],
 } as const;
 
-/** The lane name this mirror answers to -- the key NEON_WRITE_BUFFER_LANES
- * and the lane_health verdicts use. (Named for NEON_DUAL_WRITE_LANES until
- * that flag was deleted with the cutover, #10892.) */
+/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
 export const CHAIN_DETAIL_NEON_LANE = "chain-detail";
 
 type Row = Record<string, unknown>;

--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -179,15 +179,13 @@ export async function pruneChainDetail(
   // and the tier it is supposed to bound grew without limit. Reading through
   // readStore is what keeps the bound following the rows.
   const reader = readStore(env, PRUNE_TABLES, deps.readDb);
-  if (!reader?.prepare) return { ok: false, reason: "no store bound" };
+  if (!reader?.first) return { ok: false, reason: "no store bound" };
 
   try {
-    const bounds = (await reader
-      .prepare(
-        "SELECT MIN(block_number) AS floor, MAX(block_number) AS head " +
-          "FROM chain_detail_blocks",
-      )
-      .first?.()) as { floor?: unknown; head?: unknown } | null;
+    const bounds = (await reader.first(
+      "SELECT MIN(block_number) AS floor, MAX(block_number) AS head " +
+        "FROM chain_detail_blocks",
+    )) as { floor?: unknown; head?: unknown } | null;
     const floor = toInt(bounds?.floor);
     const head = toInt(bounds?.head);
     // An empty tier is not a failure: the lane has simply not written yet.

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -92,7 +92,7 @@ export function evaluateChainDetailStaleness(input: {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): { first(): Promise<unknown> };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 /**
@@ -108,13 +108,11 @@ export async function readChainDetailHead(
 ): Promise<{ latestObservedAtMs: number | null; headBlock: number | null }> {
   const db = readStore(env, ["chain_detail_blocks"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { latestObservedAtMs: null, headBlock: null };
-  const row = (await db
-    .prepare(
-      "SELECT MAX(observed_at) AS latest, MAX(block_number) AS head " +
-        "FROM chain_detail_blocks",
-    )
-    .first()) as { latest?: unknown; head?: unknown } | null;
+  if (!db?.first) return { latestObservedAtMs: null, headBlock: null };
+  const row = (await db.first(
+    "SELECT MAX(observed_at) AS latest, MAX(block_number) AS head " +
+      "FROM chain_detail_blocks",
+  )) as { latest?: unknown; head?: unknown } | null;
   return {
     latestObservedAtMs: toInt(row?.latest),
     headBlock: toInt(row?.head),
@@ -153,7 +151,7 @@ export async function runChainDetailStalenessWatchdog(
   // stalled while the lane was fine.
   const db = readStore(env, ["chain_detail_blocks"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.CHAIN_DETAIL_STALENESS_THRESHOLD_MS) ||

--- a/src/chain-holders.ts
+++ b/src/chain-holders.ts
@@ -64,13 +64,8 @@ export const DEFAULT_CHAIN_HOLDERS_SORT = "top1_share";
 export const MAJORITY_SHARE = 0.5;
 
 export interface ChainHoldersDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-    all?(): Promise<{ results?: unknown[] } | null>;
-    first?(): Promise<unknown>;
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export type ChainHoldersDecline = "pool_totals_unproven" | "unavailable";
@@ -128,7 +123,7 @@ export async function loadChainHolders(
     capturedAt: null,
     decline,
   });
-  if (!db?.prepare) return declined("unavailable");
+  if (!db?.query) return declined("unavailable");
 
   const alpha = await latestCompleteHotkeyAlphaPass(
     db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
@@ -139,10 +134,9 @@ export async function loadChainHolders(
     );
   }
   try {
-    const res = await db.prepare(chainHoldersSql(alpha.capturedAt)).all?.();
-    if (!Array.isArray(res?.results)) throw new Error("chain-holders: no rows");
+    const rows = await db.query<Row>(chainHoldersSql(alpha.capturedAt));
     return {
-      rows: res.results as Row[],
+      rows,
       capturedAt: alpha.capturedAt,
       decline: null,
     };

--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -223,11 +223,7 @@ export function coverageDetail(
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query(text: string, values?: unknown[]): Promise<Record<string, unknown>[]>;
 }
 
 export interface DailyCoverageDeps {
@@ -251,21 +247,19 @@ export async function runDailySeriesCoverageWatchdog(
     env,
     DAILY_SERIES.map((s) => s.table),
   ) as unknown as StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.query) return { ok: false, reason: "no store bound" };
 
   const verdicts: DailySeriesVerdict[] = [];
   try {
     for (const { table, column } of DAILY_SERIES) {
       // Grouped in the store rather than pulled row by row: these tables hold
       // ~30k rows a day and the answer is one integer per date.
-      const result = await db
-        .prepare(
-          `SELECT ${column} AS date, COUNT(*) AS rows FROM ${table} ` +
-            `GROUP BY ${column} ORDER BY ${column} DESC LIMIT ?`,
-        )
-        .bind(DAILY_COVERAGE_LOOKBACK_DAYS)
-        .all();
-      const days = ((result?.results ?? []) as Record<string, unknown>[])
+      const result = await db.query(
+        `SELECT ${column} AS date, COUNT(*) AS rows FROM ${table} ` +
+          `GROUP BY ${column} ORDER BY ${column} DESC LIMIT ?`,
+        [DAILY_COVERAGE_LOOKBACK_DAYS],
+      );
+      const days = result
         .map((row) => ({
           date: String(row.date ?? ""),
           rows: Number(row.rows ?? 0),

--- a/src/emission-gate-changes.ts
+++ b/src/emission-gate-changes.ts
@@ -46,11 +46,7 @@ export { EMISSION_CHANGES_LIMIT_DEFAULT, EMISSION_CHANGES_LIMIT_MAX };
 type Row = Record<string, unknown>;
 
 export interface EmissionChangesDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 /** The three change kinds, which are also the `?kind=` filter's vocabulary. */
@@ -112,14 +108,9 @@ export async function loadEmissionChanges(
     kind,
   }: { limit?: number; kind?: string } = {},
 ): Promise<Row[] | null> {
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   try {
-    const res = await (
-      db.prepare(emissionChangesSql(limit, kind)).bind() as {
-        all?(): Promise<{ results?: unknown[] } | null>;
-      }
-    ).all?.();
-    return (res?.results ?? []) as Row[];
+    return await db.query<Row>(emissionChangesSql(limit, kind));
   } catch {
     return null;
   }

--- a/src/failure-reasons.ts
+++ b/src/failure-reasons.ts
@@ -45,11 +45,7 @@ export { FAILURE_REASONS_WINDOW_DAYS, FAILURE_REASONS_WINDOWS };
 type Row = Record<string, unknown>;
 
 export interface FailureReasonsDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 export const FAILURE_REASONS_TABLE = "surface_failure_daily";
@@ -104,7 +100,7 @@ export async function loadFailureReasons(
     nowMs?: number;
   } = {},
 ): Promise<Row[] | null> {
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   const days = FAILURE_REASONS_WINDOW_DAYS[window];
   if (days === undefined) return null;
   const binds: unknown[] = [utcDay(nowMs - days * 86_400_000)];
@@ -118,18 +114,12 @@ export async function loadFailureReasons(
     binds.push(kind);
   }
   try {
-    const res = await (
-      db
-        .prepare(
-          `SELECT day, netuid, kind, classification, checks` +
-            ` FROM ${FAILURE_REASONS_TABLE} WHERE ${where}` +
-            ` ORDER BY day ASC`,
-        )
-        .bind(...binds) as {
-        all?(): Promise<{ results?: unknown[] } | null>;
-      }
-    ).all?.();
-    return (res?.results ?? []) as Row[];
+    return await db.query<Row>(
+      `SELECT day, netuid, kind, classification, checks` +
+        ` FROM ${FAILURE_REASONS_TABLE} WHERE ${where}` +
+        ` ORDER BY day ASC`,
+      binds,
+    );
   } catch {
     return null;
   }

--- a/src/hotkey-alpha-completeness.ts
+++ b/src/hotkey-alpha-completeness.ts
@@ -23,9 +23,7 @@
 // floor that leaves a wide publishing band).
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    first(): Promise<unknown>;
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface HotkeyAlphaCompleteness {
@@ -61,17 +59,15 @@ const NONE: HotkeyAlphaCompleteness = {
 export async function latestCompleteHotkeyAlphaPass(
   db: StatementClientLike | null | undefined,
 ): Promise<HotkeyAlphaCompleteness> {
-  if (!db?.prepare) return { ...NONE, reason: "unavailable" };
+  if (!db?.first) return { ...NONE, reason: "unavailable" };
   try {
-    const row = (await db
-      .prepare(
-        `SELECT captured_at, expected_rows, received_rows
-           FROM hotkey_alpha_passes
-          WHERE completed_at IS NOT NULL
-          ORDER BY completed_at DESC
-          LIMIT 1`,
-      )
-      .first()) as {
+    const row = (await db.first(
+      `SELECT captured_at, expected_rows, received_rows
+         FROM hotkey_alpha_passes
+        WHERE completed_at IS NOT NULL
+        ORDER BY completed_at DESC
+        LIMIT 1`,
+    )) as {
       captured_at?: unknown;
       expected_rows?: unknown;
       received_rows?: unknown;

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -217,9 +217,7 @@ function countOrZero(value: unknown): number {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): { first(): Promise<unknown> };
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface HotkeyAlphaStalenessDeps {
@@ -250,7 +248,7 @@ export async function runHotkeyAlphaStalenessWatchdog(
     "hotkey_alpha",
     "nominator_positions",
   ]) as unknown as StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.HOTKEY_ALPHA_STALENESS_THRESHOLD_MS) ||
@@ -262,10 +260,7 @@ export async function runHotkeyAlphaStalenessWatchdog(
     HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO;
 
   try {
-    const row = (await db
-      .prepare(HOTKEY_ALPHA_COVERAGE_SQL)
-      .bind(passWindowMs)
-      .first()) as {
+    const row = (await db.first(HOTKEY_ALPHA_COVERAGE_SQL, [passWindowMs])) as {
       latest: number | null;
       covered: number | null;
       total: number | null;

--- a/src/hyperparams-identity-neon-write.ts
+++ b/src/hyperparams-identity-neon-write.ts
@@ -13,11 +13,12 @@
 // while simultaneously removing the D1 copy -- which is how a migration loses
 // rows rather than moving them.
 //
-// FORMERLY TRANSITIONAL (#10051): the rung this stood on -- dual-write behind
-// NEON_SOLE_STORE_TABLES / NEON_DUAL_WRITE_LANES -- is gone with D1 and both
-// flags (#10892). What remains is the sole write to the only store, keeping
-// the era's two survivals: it cannot throw, and it files a lane verdict on
-// every attempt.
+// TRANSITIONAL, AND TRACKED AS SUCH (#10051). This is a rung, not the
+// destination: once these tables are in NEON_SOLE_STORE_TABLES the D1 write
+// goes, and once every table has crossed, NEON_DUAL_WRITE_LANES and every
+// mirror call site including this one get deleted. A reconciler or mirror that
+// outlives the inversion is worse than dead code -- it would copy a frozen D1
+// over live Neon rows, because it cannot tell the direction reversed.
 import { laneHealthStore } from "./lane-health-store.ts";
 import { SUBNET_HYPERPARAMS_INSERT_COLUMNS } from "./subnet-hyperparams.ts";
 import {

--- a/src/indexer-lag.ts
+++ b/src/indexer-lag.ts
@@ -43,13 +43,9 @@
 
 type Row = Record<string, unknown>;
 
-/** The minimal D1 surface used here, so tests can inject a plain object. */
+/** The minimal store surface used here, so tests can inject a plain object. */
 export interface IndexerLagDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      first?(): Promise<unknown>;
-    };
-  };
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export const INDEXER_LAG_TABLE = "chain_detail_blocks";
@@ -88,13 +84,9 @@ export const INDEXER_LAG_SQL =
 export async function loadIndexerLag(
   db: IndexerLagDb | null | undefined,
 ): Promise<Row | null> {
-  if (!db?.prepare) return null;
+  if (!db?.first) return null;
   try {
-    const row = await (
-      db.prepare(INDEXER_LAG_SQL).bind() as {
-        first?(): Promise<unknown>;
-      }
-    ).first?.();
+    const row = await db.first(INDEXER_LAG_SQL);
     return isRow(row) ? row : null;
   } catch {
     return null;

--- a/src/lakehouse-seam-watchdog.ts
+++ b/src/lakehouse-seam-watchdog.ts
@@ -239,7 +239,7 @@ async function capturedThrough(env: unknown): Promise<number | null> {
   // watermark it reports a gap that only ever widens.
   const db = readStore(env, ["raw_capture_state"]) as unknown as
     Parameters<typeof watermarkRead>[0] | undefined;
-  if (!db?.prepare) return null;
+  if (!db?.first) return null;
   try {
     return await watermarkRead(db)();
   } catch {

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -332,10 +332,12 @@ export async function loadLaneMaxGap(
   db: StatementClientLike | null | undefined,
   sinceMs: number,
 ): Promise<Record<string, number | null>> {
-  if (!db?.prepare) return {};
+  if (!db?.query) return {};
   try {
-    const result = await db.prepare(LANE_MAX_GAP_SQL).bind(sinceMs).all?.();
-    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    const rows = (await db.query(LANE_MAX_GAP_SQL, [sinceMs])) as Record<
+      string,
+      unknown
+    >[];
     const out: Record<string, number | null> = {};
     for (const row of rows) {
       const lane = row.lane == null ? "" : String(row.lane);
@@ -634,16 +636,10 @@ export function laneAlarmRecoveryComment(
   );
 }
 
-interface StatementClientLike extends LaneHealthDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      run(): Promise<unknown>;
-      first(): Promise<unknown>;
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-    all?(): Promise<{ results?: unknown[] } | null>;
-  };
-}
+// The verdict store's surface is the whole surface these readers need
+// (#10909): they SELECT through query() and record through run(), which is
+// exactly LaneHealthDb.
+type StatementClientLike = LaneHealthDb;
 
 function toInt(value: unknown): number {
   const n = Number(value);
@@ -668,10 +664,9 @@ async function loadLaneRuns(
   db: StatementClientLike | null | undefined,
   sql: string,
 ): Promise<LaneVerdictRuns> {
-  if (!db?.prepare) return {};
+  if (!db?.query) return {};
   try {
-    const result = await db.prepare(sql).all?.();
-    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    const rows = (await db.query(sql)) as Record<string, unknown>[];
     const out: LaneVerdictRuns = {};
     for (const row of rows) {
       const lane = row.lane == null ? "" : String(row.lane);
@@ -785,7 +780,7 @@ export async function runLaneAlarm(
   // writes any more would replay stale verdicts forever -- filing issues for
   // lanes that recovered, and none for lanes that broke.
   const db = laneHealthStore(env) as unknown as StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no lane_health store bound" };
+  if (!db?.query) return { ok: false, reason: "no lane_health store bound" };
 
   const token = typeof env?.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : "";
   const repo =

--- a/src/lane-health-store.ts
+++ b/src/lane-health-store.ts
@@ -54,32 +54,35 @@ export function pgLaneHealthDb(
   connectionString: string,
   deps: LaneHealthStoreDeps = {},
 ): LaneHealthDb {
-  const run = async (text: string, values: unknown[]) => {
+  const exec = async (text: string, values: unknown[]) => {
     const client =
       deps.clientFactory?.(connectionString) ??
       (new Client({ connectionString }) as unknown as LaneHealthPgClient);
     await client.connect();
     try {
       const result = await client.query(toPositionalPlaceholders(text), values);
-      return { results: (result?.rows ?? []) as unknown[] };
+      return (result?.rows ?? []) as Record<string, unknown>[];
     } finally {
       // Awaited, unlike createPgSql's waitUntil -- see this module's header.
       await client.end().catch(() => undefined);
     }
   };
   return {
-    prepare(text: string) {
-      return {
-        bind(...values: unknown[]) {
-          return {
-            all: () => run(text, values),
-            run: () => run(text, values),
-          };
-        },
-        all: () => run(text, []),
-      };
+    async query<Row = Record<string, unknown>>(
+      text: string,
+      values: unknown[] = [],
+    ) {
+      return (await exec(text, values)) as Row[];
     },
-  } as unknown as LaneHealthDb;
+    async run(text: string, values: unknown[] = []) {
+      await exec(text, values);
+      // The driver's rowCount is not read back here: recordLaneVerdict treats
+      // any resolved run as landed, and the per-operation client closes before
+      // a count could be consulted. Zero keeps the type honest without
+      // claiming a count nobody measures.
+      return { changes: 0 };
+    },
+  };
 }
 
 /**

--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -134,14 +134,12 @@ export function isRetiredLane(lane: string): boolean {
 }
 
 /** The minimal D1 surface these helpers use, so callers can inject a fake. */
+/** The verdict store's surface, with OUR verbs (#10909) -- rows and change
+ * counts, no D1 envelope. Structural so every watchdog test keeps handing in
+ * a plain object. */
 export interface LaneHealthDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      run(): Promise<unknown>;
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-    all?(): Promise<{ results?: unknown[] } | null>;
-  };
+  query(text: string, values?: unknown[]): Promise<unknown[]>;
+  run(text: string, values?: unknown[]): Promise<{ changes: number }>;
 }
 
 /** A tick's outcome. `unknown` is for a watchdog that could not evaluate at all —
@@ -171,21 +169,19 @@ export async function recordLaneVerdict(
   db: LaneHealthDb | null | undefined,
   record: LaneHealthRecord,
 ): Promise<boolean> {
-  if (!db?.prepare) return false;
+  if (!db?.run) return false;
   try {
-    await db
-      .prepare(
-        "INSERT INTO lane_health (lane, verdict, age_ms, detail, checked_at) " +
-          "VALUES (?, ?, ?, ?, ?)",
-      )
-      .bind(
+    await db.run(
+      "INSERT INTO lane_health (lane, verdict, age_ms, detail, checked_at) " +
+        "VALUES (?, ?, ?, ?, ?)",
+      [
         record.lane,
         record.verdict,
         record.age_ms,
         record.detail,
         record.checked_at,
-      )
-      .run();
+      ],
+    );
   } catch {
     // The insert is what this function promises. A missing binding, an unapplied
     // migration, or any D1 error means the verdict was NOT recorded, and the caller
@@ -196,10 +192,10 @@ export async function recordLaneVerdict(
     // Prune this lane's own expired rows on the way through, rather than from a
     // separate cron that would be one more thing to wire and to notice breaking.
     // Bounded and indexed: it touches one lane, by (lane, checked_at).
-    await db
-      .prepare("DELETE FROM lane_health WHERE lane = ? AND checked_at < ?")
-      .bind(record.lane, record.checked_at - LANE_HEALTH_RETENTION_MS)
-      .run();
+    await db.run("DELETE FROM lane_health WHERE lane = ? AND checked_at < ?", [
+      record.lane,
+      record.checked_at - LANE_HEALTH_RETENTION_MS,
+    ]);
   } catch {
     // Deliberately swallowed, and deliberately NOT folded into the try above: the
     // verdict is already committed, so a failed prune must not report the alarm as
@@ -212,18 +208,16 @@ export async function recordLaneVerdict(
 export async function loadLatestLaneHealth(
   db: LaneHealthDb | null | undefined,
 ): Promise<Record<string, LaneHealthRecord>> {
-  if (!db?.prepare) return {};
+  if (!db?.query) return {};
   try {
     // One row per lane via a correlated MAX, rather than pulling the whole table and
     // reducing in the Worker: the table grows by one row per lane per tick forever, so
     // a full scan here would get slower every day this runs.
-    const statement = db.prepare(
+    const rows = (await db.query(
       "SELECT lane, verdict, age_ms, detail, checked_at FROM lane_health " +
         "WHERE (lane, checked_at) IN " +
         "(SELECT lane, MAX(checked_at) FROM lane_health GROUP BY lane)",
-    );
-    const result = await statement.all?.();
-    const rows = (result?.results ?? []) as Record<string, unknown>[];
+    )) as Record<string, unknown>[];
     const out: Record<string, LaneHealthRecord> = {};
     for (const row of rows) {
       const lane = row.lane == null ? "" : String(row.lane);

--- a/src/ledger-neon-write.ts
+++ b/src/ledger-neon-write.ts
@@ -114,8 +114,7 @@ interface LedgerPlan {
 }
 
 /**
- * One plan per lane, keyed by the lane name NEON_WRITE_BUFFER_LANES and
- * the lane_health verdicts use (formerly NEON_DUAL_WRITE_LANES's key, #10892).
+ * One plan per lane, keyed by the name used in NEON_DUAL_WRITE_LANES.
  *
  * The conflict keys match each table's PRIMARY KEY in Neon, created 2026-08-07
  * from D1's own DDL. An ON CONFLICT naming columns with no unique index behind

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -431,7 +431,7 @@ export function buildSubnetEconomics(
 }
 
 interface StatementClientLike {
-  prepare(sql: string): { all(): Promise<{ results?: Row[] } | null> };
+  query(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 interface KvLike {
@@ -479,7 +479,7 @@ export async function refreshLiveEconomics(
   // every three hours, with a fresh timestamp on it.
   const db = readStore(env, ["neurons", "subnet_snapshots"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "store_unavailable" };
+  if (!db?.query) return { ok: false, reason: "store_unavailable" };
 
   const now = deps.now ?? Date.now;
   try {
@@ -540,17 +540,13 @@ export async function refreshLiveEconomics(
       values[name] = await storage.readValue(hash, blockHash);
     }
 
-    const neuronRows = await db.prepare(NEURON_AGGREGATE_QUERY).all();
-    const neurons = indexNeuronAggregates(neuronRows?.results);
+    const neuronRows = await db.query(NEURON_AGGREGATE_QUERY);
+    const neurons = indexNeuronAggregates(neuronRows);
     // `now` threaded, not defaulted: every other timestamp in this tick comes
     // from the injected clock, and a cutoff read off Date.now would put the
     // window on a different clock from the rows it bounds.
-    const historyRows = await db
-      .prepare(alphaPriceHistoryQuery(undefined, now))
-      .all();
-    const priceHistoryByNetuid = indexAlphaPriceHistoryByNetuid(
-      historyRows?.results,
-    );
+    const historyRows = await db.query(alphaPriceHistoryQuery(undefined, now));
+    const priceHistoryByNetuid = indexAlphaPriceHistoryByNetuid(historyRows);
 
     const economicsByNetuid = new Map<number, Row>();
     for (const netuid of netuids) {

--- a/src/mcp-response-tripwire.ts
+++ b/src/mcp-response-tripwire.ts
@@ -78,20 +78,7 @@ export class McpResponseSchemaDriftError extends Error {
   readonly code = MCP_RESPONSE_DRIFT_CODE;
   readonly captureAsFault = true;
   constructor(tool: string, detail: unknown) {
-    // The issues ride IN the message (bounded), because the message is the
-    // only thing the exception pipeline serializes: `detail` never leaves
-    // this object, and `cause` is `this`, so the captured fault read
-    // "drifted from its published outputSchema" with the diagnosis — WHICH
-    // keys, at WHICH path — discarded. Measured 2026-08-12: get_subnet_health
-    // drifted on netuid 0 for hours and neither PostHog nor a tail could say
-    // on what. Same lesson as the REST tripwire's alarm (#10897): the
-    // unrecognized keys ARE the diagnosis.
-    super(
-      `${tool} result drifted from its published outputSchema: ` +
-        String(
-          detail instanceof Error ? detail.message : JSON.stringify(detail),
-        ).slice(0, 400),
-    );
+    super(`${tool} result drifted from its published outputSchema`);
     this.name = "McpResponseSchemaDriftError";
     this.tool = tool;
     this.detail = detail;

--- a/src/neon-write-buffer.ts
+++ b/src/neon-write-buffer.ts
@@ -257,10 +257,11 @@ export function shouldFlushEarly(
 /**
  * The lanes routed through the buffer, read from the environment.
  *
- * A COMMA LIST DEFAULTING TO EMPTY, deliberately (the shape the deleted
- * NEON_DUAL_WRITE_LANES cutover flag established, #10892): this changes
- * nothing until a lane is named, so the deploy that introduces buffering
- * cannot itself be the deploy that buffers everything.
+ * A COMMA LIST DEFAULTING TO EMPTY, deliberately, and the same shape as
+ * `NEON_DUAL_WRITE_LANES` in src/neon-write.ts. That file's header states the
+ * reason and it applies unchanged here: this changes nothing until a lane is
+ * named, so the deploy that introduces buffering cannot itself be the deploy
+ * that buffers everything.
  */
 export function neonWriteBufferLanes(
   env: Record<string, unknown> | null | undefined,

--- a/src/neurons-neon-write.ts
+++ b/src/neurons-neon-write.ts
@@ -228,9 +228,7 @@ export function neuronSnapshotWrite(
   };
 }
 
-/** The lane name this mirror answers to -- the key NEON_WRITE_BUFFER_LANES
- * and the lane_health verdicts use. (Named for NEON_DUAL_WRITE_LANES until
- * that flag was deleted with the cutover, #10892.) */
+/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
 export const NEURONS_NEON_LANE = "neurons";
 
 type Row = Record<string, unknown>;
@@ -513,13 +511,6 @@ export async function mirrorNeuronSnapshotToNeon(
       prune,
       now(),
       buffered,
-      // A SUB-LANE of the buffered runner, same as the three tables (#10890)
-      // and the nominator `-pass`/`-prune` pair before it (#10826): its
-      // statements ride under the base lane's tag, so the flush can never
-      // file `neon:neurons-prune` and a suppressed success here is recorded
-      // by nothing at all. Went silent for 32 hours the moment the buffer
-      // came on (2026-08-12 alert), while the prune itself ran fine.
-      true,
     );
   }
 
@@ -551,10 +542,6 @@ export async function mirrorNeuronSnapshotToNeon(
       verdict,
       now(),
       buffered,
-      // Same sub-lane rule as the prune above (#10890): the tally's
-      // statements carry the base lane's tag, so only recording at enqueue
-      // keeps `neon:neurons-pass` alive under buffering.
-      true,
     );
     results[`${NEURONS_NEON_LANE}_passes`] = verdict;
   }

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -235,9 +235,7 @@ function countOrZero(value: unknown): number {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): { first(): Promise<unknown> };
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface NeuronsStalenessDeps {
@@ -266,7 +264,7 @@ export async function runNeuronsStalenessWatchdog(
   // stalled while the lane was fine.
   const db = readStore(env, ["neurons"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs = neuronsStalenessThresholdMs(env);
   const passWindowMs =
@@ -276,10 +274,7 @@ export async function runNeuronsStalenessWatchdog(
     NEURONS_COVERAGE_FLOOR_NETUIDS;
 
   try {
-    const row = (await db
-      .prepare(NEURONS_COVERAGE_SQL)
-      .bind(passWindowMs)
-      .first()) as {
+    const row = (await db.first(NEURONS_COVERAGE_SQL, [passWindowMs])) as {
       latest: number | null;
       covered: number | null;
       total: number | null;

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -90,11 +90,7 @@ export const BIND_PARAM_CHUNK = 100;
 /** The D1 surface this module needs from `neurons` -- structural, so tests can
  * hand a plain object (same pattern as src/account-feeds-cold-tier.ts). */
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 /**
@@ -113,7 +109,7 @@ export async function neuronStakeByHotkeys(
   if (hotkeys.length === 0) return new Map();
   const db = readStore(env, ["neurons"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   const chunks: string[][] = [];
   for (let i = 0; i < hotkeys.length; i += BIND_PARAM_CHUNK) {
     chunks.push(hotkeys.slice(i, i + BIND_PARAM_CHUNK));
@@ -123,14 +119,10 @@ export async function neuronStakeByHotkeys(
     results = await Promise.all(
       chunks.map(async (chunk) => {
         const placeholders = chunk.map(() => "?").join(", ");
-        const res = await db
-          .prepare(
-            `SELECT hotkey, netuid, stake_tao FROM neurons WHERE hotkey IN (${placeholders})`,
-          )
-          .bind(...chunk)
-          .all?.();
-        if (!Array.isArray(res?.results)) throw new Error("neurons: no rows");
-        return res.results;
+        return await db.query!(
+          `SELECT hotkey, netuid, stake_tao FROM neurons WHERE hotkey IN (${placeholders})`,
+          chunk,
+        );
       }),
     );
   } catch {

--- a/src/nominator-positions-hot-tier.ts
+++ b/src/nominator-positions-hot-tier.ts
@@ -40,13 +40,8 @@ import { readStore } from "./read-store.ts";
 /** The D1 surface this module needs -- structural, so tests can hand a plain
  * object (same pattern as src/nominator-positions-cold-tier.ts). */
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-      first?(): Promise<unknown>;
-    };
-    first?(): Promise<unknown>;
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 /** Kept identical to the cold tier's SELECT list (minus `coldkey`, which the
@@ -69,7 +64,7 @@ export async function loadAccountPositionsFromStore(
 ): Promise<ReturnType<typeof buildAccountPositions> | null> {
   const db = readStore(env, ["nominator_positions"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return null;
+  if (!db?.query || !db?.first) return null;
 
   let rows: Record<string, unknown>[];
   let ledgerCapturedAt: number | null;
@@ -78,23 +73,16 @@ export async function loadAccountPositionsFromStore(
     // decline path alike, and serialising two independent point reads on a
     // request path buys nothing.
     const [positionsResult, latestRow] = await Promise.all([
-      db
-        .prepare(
-          `SELECT ${POSITION_COLUMNS} FROM nominator_positions` +
-            ` WHERE coldkey = ? LIMIT ?`,
-        )
+      db.query<Record<string, unknown>>(
+        `SELECT ${POSITION_COLUMNS} FROM nominator_positions` +
+          ` WHERE coldkey = ? LIMIT ?`,
         // One row over the cap is enough to know the cap was exceeded, and
         // cheaper than a second counting query over the same predicate.
-        .bind(ss58, POSITION_SCAN_CAP + 1)
-        .all?.(),
-      db
-        .prepare("SELECT MAX(captured_at) AS latest FROM nominator_positions")
-        .first?.(),
+        [ss58, POSITION_SCAN_CAP + 1],
+      ),
+      db.first("SELECT MAX(captured_at) AS latest FROM nominator_positions"),
     ]);
-    if (!Array.isArray(positionsResult?.results)) {
-      throw new Error("nominator_positions: no rows");
-    }
-    rows = positionsResult.results as Record<string, unknown>[];
+    rows = positionsResult;
     const latest = (latestRow as { latest?: unknown } | null)?.latest;
     ledgerCapturedAt = typeof latest === "number" ? latest : null;
   } catch {

--- a/src/nominator-positions-hot-tier.ts
+++ b/src/nominator-positions-hot-tier.ts
@@ -36,6 +36,7 @@ import {
   POSITION_SCAN_CAP,
 } from "./nominator-positions-cold-tier.ts";
 import { readStore } from "./read-store.ts";
+import type { NominatorPositions } from "../generated/db/types.ts";
 
 /** The D1 surface this module needs -- structural, so tests can hand a plain
  * object (same pattern as src/nominator-positions-cold-tier.ts). */
@@ -47,6 +48,13 @@ interface StatementClientLike {
 /** Kept identical to the cold tier's SELECT list (minus `coldkey`, which the
  * predicate already fixes) so both tiers hand the formatter the same shape. */
 const POSITION_COLUMNS = "hotkey, netuid, share_fraction, captured_at";
+
+/** Exactly the columns POSITION_COLUMNS selects, from the generated table
+ * type. */
+type NominatorPositionRow = Pick<
+  NominatorPositions,
+  "hotkey" | "netuid" | "share_fraction" | "captured_at"
+>;
 
 /**
  * One coldkey's current positions from D1, or null to let the caller fall
@@ -73,7 +81,7 @@ export async function loadAccountPositionsFromStore(
     // decline path alike, and serialising two independent point reads on a
     // request path buys nothing.
     const [positionsResult, latestRow] = await Promise.all([
-      db.query<Record<string, unknown>>(
+      db.query<NominatorPositionRow>(
         `SELECT ${POSITION_COLUMNS} FROM nominator_positions` +
           ` WHERE coldkey = ? LIMIT ?`,
         // One row over the cap is enough to know the cap was exceeded, and

--- a/src/nominator-positions-neon-write.ts
+++ b/src/nominator-positions-neon-write.ts
@@ -44,9 +44,7 @@ import {
 } from "./neon-write-buffer.ts";
 import type { LaneHealthDb } from "./lane-health.ts";
 
-/** The lane name this mirror answers to -- the key NEON_WRITE_BUFFER_LANES
- * and the lane_health verdicts use. (Named for NEON_DUAL_WRITE_LANES until
- * that flag was deleted with the cutover, #10892.) */
+/** The lane name this mirror answers to in NEON_DUAL_WRITE_LANES. */
 export const NOMINATOR_POSITIONS_NEON_LANE = "nominator-positions";
 
 /** The lane `self-stake` reports under -- its own, not this one's. */

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -226,9 +226,7 @@ function countOrZero(value: unknown): number {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): { first(): Promise<unknown> };
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface NominatorPositionsStalenessDeps {
@@ -257,7 +255,7 @@ export async function runNominatorPositionsStalenessWatchdog(
   // stalled while the lane was fine.
   const db = readStore(env, ["nominator_positions"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS) ||
@@ -270,10 +268,9 @@ export async function runNominatorPositionsStalenessWatchdog(
     NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS;
 
   try {
-    const row = (await db
-      .prepare(NOMINATOR_POSITIONS_COVERAGE_SQL)
-      .bind(passWindowMs)
-      .first()) as {
+    const row = (await db.first(NOMINATOR_POSITIONS_COVERAGE_SQL, [
+      passWindowMs,
+    ])) as {
       latest: number | null;
       covered: number | null;
       total: number | null;

--- a/src/observations-read-runner.ts
+++ b/src/observations-read-runner.ts
@@ -4,7 +4,7 @@
 //
 // Every observation read already funnels through ONE call shape --
 // `storeAll(db, sql, params)` over the structural `ObservationsReadDb`
-// (`prepare(sql).bind(...).all()`). So the whole read path moves by handing
+// (the owned `query()` verb, #10909). So the whole read path moves by handing
 // those loaders a different `db`, and not one query has to be written twice.
 //
 // That is only safe because the SQL is genuinely portable now. It was not
@@ -45,55 +45,23 @@ export interface ReadRunnerSql {
 }
 
 /**
- * Present a Postgres runner as the D1-shaped read surface the loaders expect.
+ * Present a Postgres runner as the read surface the loaders expect.
  *
- * SHAPE-IDENTICAL TO `readStore`'s handle (src/read-store.ts), deliberately.
- * Two adapters in this tree present Postgres as a D1-shaped reader, and they
- * disagreed about what a prepared statement offers. This one answered
- * `prepare(text) -> { bind, all }` with the rows as a BARE ARRAY; readStore
- * answers `{ bind, all, first }` with `{ results }`, which is the shape D1
- * itself had and therefore the shape the call sites were written against.
- *
- * Neither difference is caught by a type -- every consumer reaches these
- * through a structural interface or a cast -- and both fail SILENTLY:
- *
- *   A caller doing `.first()` gets "not a function". That lands in the
- *   try/catch these readers wrap their query in, so it is reported as a
- *   decline rather than as a broken read: see the note in
- *   src/validator-nominator-counts-staleness-watchdog.ts, which hit exactly
- *   this and had to move to readStore.
- *
- *   A caller guarding on `Array.isArray(res?.results)` reads `undefined` off
- *   an array and takes its own failure branch on a read that SUCCEEDED --
- *   the guard src/top-holders-holdings.ts and src/chain-holders.ts both use.
- *
- * `storeAll` accepts a bare array or `{ results }`, so the loaders that go through
- * it never saw the difference; it is the readers that unwrap the result
- * themselves that it reaches. With D1 gone (#10181) there is no second store to
- * absorb the mismatch, so the two adapters agreeing is the whole safety margin.
+ * The predecessor of this function is a cautionary tale this comment used to
+ * narrate at length: two adapters presented Postgres as a D1-shaped reader
+ * and DISAGREED about what a prepared statement offers -- one answered bare
+ * arrays where the other answered { results }, both failing silently behind
+ * structural casts. The owned verb dissolves the whole class (#10909): there
+ * is one shape, `query() -> rows`, and nothing left for two adapters to
+ * disagree about.
  */
 export function pgObservationsReadDb(sql: ReadRunnerSql): ObservationsReadDb {
-  const rows = async (text: string, values: unknown[]) =>
-    ((await sql.unsafe(text, values)) ?? []) as unknown[];
-  const ops = (text: string, values: unknown[]) => ({
-    async all() {
-      return { results: await rows(text, values) };
-    },
-    async first() {
-      return (await rows(text, values))[0] ?? null;
-    },
-  });
   return {
-    prepare(text: string) {
-      return {
-        bind: (...values: unknown[]) => ops(text, values),
-        // BOTH SHAPES, because D1 had both and this codebase uses both.
-        // src/top-holders-holdings.ts calls `prepare(sql).all?.()` with no
-        // bind at all -- its statement carries no parameters -- and an adapter
-        // offering only the bind path would throw there rather than fall back,
-        // turning a store swap into a route outage.
-        ...ops(text, []),
-      };
+    async query<Row = Record<string, unknown>>(
+      text: string,
+      values: unknown[] = [],
+    ) {
+      return ((await sql.unsafe(text, values)) ?? []) as Row[];
     },
   };
 }

--- a/src/pass-completeness.ts
+++ b/src/pass-completeness.ts
@@ -22,9 +22,7 @@
 // mechanical change when someone does.
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    first(): Promise<unknown>;
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface PassCompleteness {
@@ -94,17 +92,15 @@ export async function latestCompletePass(
   lane: string,
 ): Promise<PassCompleteness> {
   const table = PASS_TABLES[lane];
-  if (!table || !db?.prepare) return { ...NONE, reason: "unavailable" };
+  if (!table || !db?.first) return { ...NONE, reason: "unavailable" };
   try {
-    const row = (await db
-      .prepare(
-        `SELECT captured_at, expected_rows, received_rows
-           FROM ${table}
-          WHERE completed_at IS NOT NULL
-          ORDER BY completed_at DESC
-          LIMIT 1`,
-      )
-      .first()) as {
+    const row = (await db.first(
+      `SELECT captured_at, expected_rows, received_rows
+         FROM ${table}
+        WHERE completed_at IS NOT NULL
+        ORDER BY completed_at DESC
+        LIMIT 1`,
+    )) as {
       captured_at?: unknown;
       expected_rows?: unknown;
       received_rows?: unknown;
@@ -144,61 +140,10 @@ export interface PassTallyInput {
   nowMs: number;
 }
 
-/**
- * The upsert that accumulates a pass, for a lane's own table.
- *
- * `completed_at` is COALESCEd rather than recomputed, so the first write that
- * closes the gap owns the stamp and a later retry cannot move it. The
- * comparison is `>=`, never `=`, precisely so an at-least-once producer cannot
- * leave a complete pass looking unfinished.
- *
- * THROWS for a lane with no table, rather than returning null. A writer calls
- * this with its OWN hardcoded lane name, so an unknown one is a programming
- * error and not a runtime condition — the same posture `packSyncBatchMessages`
- * takes for a pruning lane with no declared key. Returning null instead would
- * put a permanently-false branch in every caller, which is how a file starts
- * collecting coverage pragmas instead of reasons.
- */
-export function passTallyStatement<S>(
-  db: { prepare(sql: string): { bind(...values: unknown[]): S } },
-  lane: string,
-  pass: PassTallyInput,
-): S {
-  const table = PASS_TABLES[lane];
-  if (!table) {
-    throw new Error(
-      `pass-completeness: no pass table for lane ${lane}; add it to PASS_TABLES ` +
-        `and ship the migration, or the tally has nowhere to land`,
-    );
-  }
-  return db
-    .prepare(
-      `INSERT INTO ${table}
-         (captured_at, expected_rows, received_rows, completed_at)
-       VALUES (?, ?, ?, CASE WHEN ? >= ? THEN ? ELSE NULL END)
-       ON CONFLICT (captured_at) DO UPDATE SET
-         expected_rows = excluded.expected_rows,
-         received_rows = ${table}.received_rows + excluded.received_rows,
-         completed_at = COALESCE(
-           ${table}.completed_at,
-           CASE
-             WHEN ${table}.received_rows + excluded.received_rows
-                  >= excluded.expected_rows
-             THEN ?
-             ELSE NULL
-           END
-         )`,
-    )
-    .bind(
-      pass.capturedAt,
-      pass.expectedRows,
-      pass.receivedRows,
-      pass.receivedRows,
-      pass.expectedRows,
-      pass.nowMs,
-      pass.nowMs,
-    );
-}
+// passTallyStatement retired here (#10909): the D1-era statement builder's
+// only remaining callers were its own tests -- the live write path has been
+// writePassTallyToNeon since the cutover, and a builder that exists to feed a
+// deleted store's batch() is scaffolding, not API.
 
 /** The runner shape `createPgSql` hands out. Structural, so a test can assert
  * the emitted text and values without a database. */

--- a/src/raw-capture-sync.ts
+++ b/src/raw-capture-sync.ts
@@ -234,11 +234,10 @@ interface RawCaptureEnv {
 }
 
 export interface WatermarkReadDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      first?(): Promise<Record<string, unknown> | null>;
-    };
-  };
+  first?(
+    text: string,
+    values?: unknown[],
+  ): Promise<Record<string, unknown> | null>;
 }
 
 /**
@@ -322,12 +321,10 @@ export function watermarkRead(
   network: ChainNetworkId = DEFAULT_CHAIN_NETWORK,
 ): () => Promise<number | null> {
   return async () => {
-    const row = await db
-      .prepare(
-        `SELECT last_contiguous_block FROM raw_capture_state WHERE network = ?`,
-      )
-      .bind(network)
-      .first?.();
+    const row = await db.first?.(
+      `SELECT last_contiguous_block FROM raw_capture_state WHERE network = ?`,
+      [network],
+    );
     const value = row?.last_contiguous_block;
     return typeof value === "number" ? value : null;
   };

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -56,33 +56,23 @@ export interface ReadStoreClient {
  * allowed to write, not about safety. */
 type Row = Record<string, unknown>;
 
-/** D1's read surface, as the callers actually use it.
- *
- * `all` and `first` are generic for the same reason D1's are: the ~45 call
- * sites this replaced write `all<SubnetRow>()` and read named columns off the
- * result. A non-generic `unknown[]` would compile only after adding a cast at
- * every one of them, which is churn that hides exactly the mistakes a cast-free
- * swap makes visible. */
+/** The read store's surface, with OUR verbs (#10909) -- rows directly, no
+ * D1 envelope. `query`/`first` are generic for the same reason the emulated
+ * `all`/`first` were: the ~45 call sites read named columns off the result,
+ * and a non-generic `unknown[]` would compile only after adding a cast at
+ * every one of them. Loaders shared with the producer store (tao-usd,
+ * pipeline-history, chain-concentration-history) consume the same verbs, so
+ * one loader serves both providers with no adapter shape between them. */
 export interface ReadStoreDb {
-  prepare(text: string): {
-    bind(...values: unknown[]): {
-      all<T = Row>(): Promise<{ results: T[] }>;
-      first<T = Row>(): Promise<T | null>;
-    };
-    all<T = Row>(): Promise<{ results: T[] }>;
-    first<T = Row>(): Promise<T | null>;
-  };
-  /** The owned verb (#10309): rows directly, no D1 envelope. Loaders shared
-   * with the producer store (tao-usd, pipeline-history) consume THIS, so one
-   * loader serves both providers without an adapter shape between them. */
   query<T = Row>(text: string, values?: unknown[]): Promise<T[]>;
+  first<T = Row>(text: string, values?: unknown[]): Promise<T | null>;
 }
 
 export interface ReadStoreDeps {
   clientFactory?: (connectionString: string) => ReadStoreClient;
 }
 
-/** A D1-shaped read handle over Postgres, one connection per operation. */
+/** The read handle over Postgres, one connection per operation. */
 export function pgReadStore(
   connectionString: string,
   deps: ReadStoreDeps = {},
@@ -100,26 +90,15 @@ export function pgReadStore(
       await client.end().catch(() => undefined);
     }
   };
-  // The generic parameter is the CALLER's claim about the row shape, exactly as
-  // it is on D1: Postgres hands back whatever the query selected, and neither
-  // store validates it. Cast here rather than at 45 call sites.
-  const ops = (text: string, values: unknown[]) => ({
-    async all<T = unknown>() {
-      return { results: (await run(text, values)) as T[] };
-    },
-    async first<T = unknown>() {
-      return ((await run(text, values))[0] ?? null) as T | null;
-    },
-  });
+  // The generic parameter is the CALLER's claim about the row shape: Postgres
+  // hands back whatever the query selected and nothing validates it. Cast
+  // here rather than at 45 call sites.
   return {
-    prepare(text: string) {
-      return {
-        bind: (...values: unknown[]) => ops(text, values),
-        ...ops(text, []),
-      };
-    },
     async query<T = Row>(text: string, values: unknown[] = []) {
       return (await run(text, values)) as T[];
+    },
+    async first<T = Row>(text: string, values: unknown[] = []) {
+      return ((await run(text, values))[0] ?? null) as T | null;
     },
   };
 }

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -84,7 +84,12 @@ export function pgReadStore(
     await client.connect();
     try {
       const result = await client.query(toPositionalPlaceholders(text), values);
-      return (result?.rows ?? []) as unknown[];
+      // ALWAYS an array. `rows` is the driver's, and a driver that answers
+      // something else (a mock, a future client) would otherwise put a
+      // `.length` TypeError inside every caller's decline path -- the guard
+      // each of them used to carry, now stated once (#10909).
+      const rows = result?.rows;
+      return (Array.isArray(rows) ? rows : []) as unknown[];
     } finally {
       // Awaited, unlike createPgSql's waitUntil -- see this module's header.
       await client.end().catch(() => undefined);

--- a/src/subnet-burn-coverage-watchdog.ts
+++ b/src/subnet-burn-coverage-watchdog.ts
@@ -196,10 +196,10 @@ export async function runSubnetBurnCoverageWatchdog(
   if (!db) return null;
   let row: SubnetBurnCoverageRow | undefined;
   try {
-    const result = await db
-      .prepare(SUBNET_BURN_COVERAGE_SQL)
-      .all<SubnetBurnCoverageRow>();
-    row = result?.results?.[0];
+    const rows = await db.query<SubnetBurnCoverageRow>(
+      SUBNET_BURN_COVERAGE_SQL,
+    );
+    row = rows[0];
   } catch {
     // An unreadable store is not a verdict about the producer.
     return null;

--- a/src/subnet-holders.ts
+++ b/src/subnet-holders.ts
@@ -56,13 +56,8 @@ type Row = Record<string, unknown>;
 
 /** The minimal D1 surface used here, so tests can inject a plain object. */
 export interface SubnetHoldersDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-      first?(): Promise<unknown>;
-    };
-    first?(): Promise<unknown>;
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 /**
@@ -179,7 +174,7 @@ export async function loadSubnetHolders(
   // Checked before the binding: root has no holder set whether or not D1 is
   // reachable, so the reason a caller gets should not depend on that.
   if (netuid === ROOT_NETUID) return declined("root_not_in_alpha_map");
-  if (!db?.prepare) return declined("unavailable");
+  if (!db?.query) return declined("unavailable");
 
   const alpha = await latestCompleteHotkeyAlphaPass(
     db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
@@ -195,18 +190,11 @@ export async function loadSubnetHolders(
 
   try {
     const [rowsRes, aggRes] = await Promise.all([
-      db
-        .prepare(subnetHoldersRowsSql(alpha.capturedAt, limit))
-        .bind(netuid)
-        .all?.(),
-      db
-        .prepare(subnetHoldersAggregateSql(alpha.capturedAt))
-        .bind(netuid)
-        .first?.(),
+      db.query!<Row>(subnetHoldersRowsSql(alpha.capturedAt, limit), [netuid]),
+      db.first!(subnetHoldersAggregateSql(alpha.capturedAt), [netuid]),
     ]);
-    if (!Array.isArray(rowsRes?.results)) throw new Error("holders: no rows");
     return {
-      rows: rowsRes.results as Row[],
+      rows: rowsRes,
       aggregate: readAggregate(aggRes as Row | null),
       capturedAt: alpha.capturedAt,
       decline: null,

--- a/src/subnet-lifecycle-read.ts
+++ b/src/subnet-lifecycle-read.ts
@@ -92,14 +92,12 @@ export async function loadSubnetLifecycle(
 ): Promise<SubnetLifecycleEntry[] | null> {
   const db = readStore(env, ["subnet_lifecycle"], injected);
   if (!db) return null;
-  const { results } = await db
-    .prepare(
-      `SELECT ${COLUMNS} FROM subnet_lifecycle WHERE netuid = ? ` +
-        "ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?",
-    )
-    .bind(netuid, limit, offset)
-    .all();
-  return formatEntries(results ?? []);
+  const results = await db.query(
+    `SELECT ${COLUMNS} FROM subnet_lifecycle WHERE netuid = ? ` +
+      "ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?",
+    [netuid, limit, offset],
+  );
+  return formatEntries(results);
 }
 
 /** The network-wide feed, newest first, optionally windowed by `since`. */
@@ -116,15 +114,13 @@ export async function loadChainSubnetLifecycle(
   if (!db) return null;
   const windowed =
     Number.isFinite(sinceMs as number) && (sinceMs as number) > 0;
-  const { results } = await db
-    .prepare(
-      `SELECT ${COLUMNS} FROM subnet_lifecycle ` +
-        (windowed ? "WHERE observed_at >= ? " : "") +
-        "ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?",
-    )
-    .bind(...(windowed ? [sinceMs, limit, offset] : [limit, offset]))
-    .all();
-  return formatEntries(results ?? []);
+  const results = await db.query(
+    `SELECT ${COLUMNS} FROM subnet_lifecycle ` +
+      (windowed ? "WHERE observed_at >= ? " : "") +
+      "ORDER BY observed_at DESC, id DESC LIMIT ? OFFSET ?",
+    windowed ? [sinceMs, limit, offset] : [limit, offset],
+  );
+  return formatEntries(results);
 }
 
 /** The per-subnet envelope. */

--- a/src/subnet-lifecycle.ts
+++ b/src/subnet-lifecycle.ts
@@ -131,13 +131,10 @@ export function lifecycleDetail(
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all(): Promise<{ results?: unknown[] } | null>;
-      run(): Promise<unknown>;
-    };
-    all(): Promise<{ results?: unknown[] } | null>;
-  };
+  query<Row = Record<string, unknown>>(
+    text: string,
+    values?: unknown[],
+  ): Promise<Row[]>;
 }
 
 export interface SubnetLifecycleDeps {
@@ -161,7 +158,7 @@ export async function runSubnetLifecycleLane(
   const floor = deps.coverageFloor ?? NEURONS_COVERAGE_FLOOR_NETUIDS;
   const db = readStore(env, ["neurons", "subnet_lifecycle"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.query) return { ok: false, reason: "no store bound" };
 
   const record = async (
     verdict: "ok" | "stale",
@@ -180,16 +177,12 @@ export async function runSubnetLifecycleLane(
     // The netuid set at the newest stamp, plus that pass's block for
     // attribution. One statement: the window is the same 5 minutes
     // neurons-staleness uses to mean "the newest pass".
-    const observedRows = ((
-      await db
-        .prepare(
-          "SELECT DISTINCT netuid, MAX(block_number) AS block_number FROM neurons " +
-            "WHERE captured_at >= (SELECT MAX(captured_at) FROM neurons) - ? " +
-            "GROUP BY netuid",
-        )
-        .bind(NEURONS_PASS_WINDOW_MS)
-        .all()
-    )?.results ?? []) as Record<string, unknown>[];
+    const observedRows = await db.query(
+      "SELECT DISTINCT netuid, MAX(block_number) AS block_number FROM neurons " +
+        "WHERE captured_at >= (SELECT MAX(captured_at) FROM neurons) - ? " +
+        "GROUP BY netuid",
+      [NEURONS_PASS_WINDOW_MS],
+    );
 
     const observed = new Set<number>();
     let blockNumber: number | null = null;
@@ -220,14 +213,10 @@ export async function runSubnetLifecycleLane(
 
     // What the table currently believes: netuids whose NEWEST event is a
     // registration. DISTINCT ON is the same shape loadLatestLaneHealth uses.
-    const knownRows = ((
-      await db
-        .prepare(
-          "SELECT DISTINCT ON (netuid) netuid, event FROM subnet_lifecycle " +
-            "ORDER BY netuid, observed_at DESC, id DESC",
-        )
-        .all()
-    )?.results ?? []) as Record<string, unknown>[];
+    const knownRows = await db.query(
+      "SELECT DISTINCT ON (netuid) netuid, event FROM subnet_lifecycle " +
+        "ORDER BY netuid, observed_at DESC, id DESC",
+    );
     const known = new Set<number>();
     for (const row of knownRows) {
       if (String(row.event) !== "registered") continue;

--- a/src/subnet-weight-setters-loader.ts
+++ b/src/subnet-weight-setters-loader.ts
@@ -91,12 +91,12 @@ async function loadSubnetTempo(
   // #9389 regression #9396 fixed.
   const db = readStore(env, SUBNET_HYPERPARAMS_TEMPO_TABLES) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return null;
+  if (!db?.first) return null;
   try {
-    const res = await db
-      .prepare("SELECT tempo FROM subnet_hyperparams WHERE netuid = ?")
-      .bind(netuid)
-      .first?.();
+    const res = await db.first(
+      "SELECT tempo FROM subnet_hyperparams WHERE netuid = ?",
+      [netuid],
+    );
     return (res as { tempo?: unknown } | null)?.tempo ?? null;
   } catch {
     return null;
@@ -105,9 +105,5 @@ async function loadSubnetTempo(
 
 /** The minimal D1 surface this needs, so tests can hand it a plain object. */
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      first?(): Promise<unknown>;
-    };
-  };
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }

--- a/src/surface-history.ts
+++ b/src/surface-history.ts
@@ -41,11 +41,7 @@ type Row = Record<string, unknown>;
 
 /** The minimal D1 surface used here, so tests can inject a plain object. */
 export interface SurfaceHistoryDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 export const SURFACE_HISTORY_TABLE = "surface_history";
@@ -78,24 +74,18 @@ export async function loadSurfaceHistory(
   netuid: number,
   { limit = SURFACE_HISTORY_LIMIT_DEFAULT }: { limit?: number } = {},
 ): Promise<Row[] | null> {
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
   try {
-    const res = await (
-      db
-        .prepare(
-          `SELECT COALESCE(sh.surface_id, sh.overlay::jsonb ->> 'id') AS surface_id,` +
-            ` sh.action, sh.source_commit, sh.recorded_at,` +
-            ` sh.overlay::jsonb ->> 'kind' AS kind,` +
-            ` sh.overlay::jsonb ->> 'url' AS url,` +
-            ` sh.overlay::jsonb ->> 'name' AS name` +
-            ` FROM ${SURFACE_HISTORY_TABLE} sh WHERE sh.subnet_netuid = ?` +
-            ` ORDER BY sh.recorded_at DESC, sh.id DESC LIMIT ${limit}`,
-        )
-        .bind(netuid) as {
-        all?(): Promise<{ results?: unknown[] } | null>;
-      }
-    ).all?.();
-    return (res?.results ?? []) as Row[];
+    return await db.query<Row>(
+      `SELECT COALESCE(sh.surface_id, sh.overlay::jsonb ->> 'id') AS surface_id,` +
+        ` sh.action, sh.source_commit, sh.recorded_at,` +
+        ` sh.overlay::jsonb ->> 'kind' AS kind,` +
+        ` sh.overlay::jsonb ->> 'url' AS url,` +
+        ` sh.overlay::jsonb ->> 'name' AS name` +
+        ` FROM ${SURFACE_HISTORY_TABLE} sh WHERE sh.subnet_netuid = ?` +
+        ` ORDER BY sh.recorded_at DESC, sh.id DESC LIMIT ${limit}`,
+      [netuid],
+    );
   } catch {
     return null;
   }

--- a/src/surface-verification-sync.ts
+++ b/src/surface-verification-sync.ts
@@ -182,7 +182,7 @@ export async function runSurfaceVerificationSync(
     ctx?.waitUntil?.(pending);
     return { ok: false, skipped: true, reason };
   };
-  if (!db?.prepare) {
+  if (!db?.query) {
     return loud(
       "no store is bound; refusing to run. A storeless sweep " +
         "reads zero rows for every subnet, which would publish a snapshot " +

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -677,9 +677,9 @@ export const TABLE_FRESHNESS: Readonly<Record<string, FreshnessExpectation>> = {
   },
 };
 
-/** The minimal D1 surface this needs, so a test can hand it a fake. */
+/** The minimal store surface this needs, so a test can hand it a fake. */
 export interface FreshnessDb {
-  prepare(sql: string): { all(): Promise<{ results?: unknown[] } | null> };
+  query(text: string, values?: unknown[]): Promise<Record<string, unknown>[]>;
 }
 
 /**
@@ -968,13 +968,10 @@ export async function crossCheckStamps(
   const involved = redirected.flatMap(([t, e]) => [t, e.stampFrom as string]);
   const db = deps.db ?? (readStore(env, involved) as FreshnessDb | undefined);
   try {
-    const result = await db?.prepare(crossCheckSql(spec)).all();
-    if (!result) throw new Error("no result");
+    if (!db?.query) throw new Error("no store");
+    const rows = await db.query(crossCheckSql(spec));
     return {
-      divergences: stampDivergences(
-        (result.results ?? []) as Record<string, unknown>[],
-        spec,
-      ),
+      divergences: stampDivergences(rows, spec),
       failed: false,
     };
   } catch {
@@ -1039,12 +1036,9 @@ export async function runTableFreshnessWatchdog(
     db: FreshnessDb | undefined,
   ): Promise<boolean> => {
     try {
-      const result = await db?.prepare(freshnessSql(group, spec)).all();
-      if (!result) throw new Error("no result");
-      for (const [table, at] of parseFreshnessRows(
-        result.results ?? [],
-        spec,
-      )) {
+      if (!db?.query) throw new Error("no store");
+      const rows = await db.query(freshnessSql(group, spec));
+      for (const [table, at] of parseFreshnessRows(rows, spec)) {
         newest.set(table, at);
       }
       return true;

--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -929,21 +929,19 @@ export async function confirmRedirectedStale(
     // The tables' OWN stamps, which is what `freshnessSql` would have read had
     // these entries never been redirected -- so the confirm asks exactly the
     // question the redirect deferred.
-    const result = await db
-      ?.prepare(
-        tables
-          .map(
-            (table) =>
-              `SELECT '${table}' AS t, MAX(${spec[table].column}) AS mx FROM ${table}`,
-          )
-          .join(" UNION ALL "),
-      )
-      .all();
-    if (!result) throw new Error("no result");
+    if (!db?.query) throw new Error("no store");
+    const rows = await db.query(
+      tables
+        .map(
+          (table) =>
+            `SELECT '${table}' AS t, MAX(${spec[table].column}) AS mx FROM ${table}`,
+        )
+        .join(" UNION ALL "),
+    );
     // The SPEC is passed: parseFreshnessRows drops any table its spec does
     // not know, and defaulting to TABLE_FRESHNESS would silently discard
     // every row when a caller (a test, another spec) asks about its own.
-    confirmed = parseFreshnessRows(result.results ?? [], spec);
+    confirmed = parseFreshnessRows(rows, spec);
   } catch {
     return [...stale];
   }

--- a/src/tao-usd-index-watchdog.ts
+++ b/src/tao-usd-index-watchdog.ts
@@ -60,11 +60,7 @@ export const TAO_USD_WATCHDOG_LANE = "watchdog:tao-usd-index";
 
 /** The minimal store surface, so tests can inject a plain object. */
 export interface TaoUsdWatchdogDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
 }
 
 type Row = Record<string, unknown>;
@@ -342,18 +338,14 @@ export async function runTaoUsdIndexWatchdog(
 
   let rows: Row[] | null;
   try {
-    const res = await (
-      db
-        ?.prepare(
+    rows = db?.query
+      ? ((await db.query<Row>(
           `SELECT observed_at, price_basis, usd_per_tao, pool_count, pools` +
             ` FROM ${TAO_USD_TABLE} WHERE observed_at >= ?` +
             ` ORDER BY observed_at DESC LIMIT 240`,
-        )
-        .bind(nowMs - TAO_USD_WATCHDOG_WINDOW_MS) as {
-        all?(): Promise<{ results?: unknown[] } | null>;
-      }
-    ).all?.();
-    rows = (res?.results ?? []) as Row[];
+          [nowMs - TAO_USD_WATCHDOG_WINDOW_MS],
+        )) as Row[])
+      : null;
   } catch {
     // A read failure is NOT an empty window: reporting "the lane wrote nothing"
     // when we could not ask would send someone to the producer for a fault in

--- a/src/top-holders-holdings.ts
+++ b/src/top-holders-holdings.ts
@@ -92,12 +92,8 @@ export interface HoldingsLeg {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-    };
-    all?(): Promise<{ results?: unknown[] } | null>;
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 /**
@@ -256,7 +252,7 @@ export async function topHoldersHoldings(
   // as a broken read.
   const db = readStore(env, TOP_HOLDERS_HOLDINGS_TABLES) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return null;
+  if (!db?.query) return null;
 
   // The two readers describe the same binding with different minimal shapes --
   // this module's StatementClientLike names bind()/all(), the completeness readers name
@@ -281,9 +277,7 @@ export async function topHoldersHoldings(
       { free, delegated, alphaCapturedAt: alpha.capturedAt },
       cap,
     );
-    const res = await db.prepare(sql).all?.();
-    if (!Array.isArray(res?.results)) throw new Error("holdings: no rows");
-    results = res.results;
+    results = await db.query(sql);
   } catch {
     // A missing table, an unbound DB and a failed read are one outcome: no
     // holdings leg ran, so the artifact must not claim any of these sorts.

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -215,9 +215,7 @@ function countOrZero(value: unknown): number {
 }
 
 interface StatementClientLike {
-  prepare(sql: string): {
-    bind(...values: unknown[]): { first(): Promise<unknown> };
-  };
+  first(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export interface ValidatorNominatorCountsStalenessDeps {
@@ -260,7 +258,7 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
   // reporting, and an absent verdict reads as health.
   const db = readStore(env, ["validator_nominator_counts"]) as unknown as
     StatementClientLike | undefined;
-  if (!db?.prepare) return { ok: false, reason: "no store bound" };
+  if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
     Number(env?.VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS) ||
@@ -273,10 +271,9 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
     VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS;
 
   try {
-    const row = (await db
-      .prepare(VALIDATOR_NOMINATOR_COUNTS_COVERAGE_SQL)
-      .bind(passWindowMs)
-      .first()) as {
+    const row = (await db.first(VALIDATOR_NOMINATOR_COUNTS_COVERAGE_SQL, [
+      passWindowMs,
+    ])) as {
       latest: number | null;
       covered: number | null;
       total: number | null;

--- a/src/validator-nominator-positions.ts
+++ b/src/validator-nominator-positions.ts
@@ -43,13 +43,8 @@ export const NOMINATOR_BASES = ["flow", "positions"] as const;
 export const DEFAULT_NOMINATOR_BASIS = "flow";
 
 export interface NominatorPositionsDb {
-  prepare(sql: string): {
-    bind(...values: unknown[]): {
-      all?(): Promise<{ results?: unknown[] } | null>;
-      first?(): Promise<unknown>;
-    };
-    first?(): Promise<unknown>;
-  };
+  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
+  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 export type NominatorPositionsDecline = "pool_totals_unproven" | "unavailable";
@@ -92,7 +87,7 @@ export async function loadNominatorPositions(
   const declined = (
     decline: NominatorPositionsDecline,
   ): NominatorPositionsRead => ({ rows: [], capturedAt: null, decline });
-  if (!db?.prepare) return declined("unavailable");
+  if (!db?.query) return declined("unavailable");
 
   const alpha = await latestCompleteHotkeyAlphaPass(
     db as unknown as Parameters<typeof latestCompleteHotkeyAlphaPass>[0],
@@ -103,13 +98,11 @@ export async function loadNominatorPositions(
     );
   }
   try {
-    const res = await db
-      .prepare(nominatorPositionsSql(alpha.capturedAt))
-      .bind(hotkey)
-      .all?.();
-    if (!Array.isArray(res?.results)) throw new Error("positions: no rows");
+    const rows = await db.query<Row>(nominatorPositionsSql(alpha.capturedAt), [
+      hotkey,
+    ]);
     return {
-      rows: res.results as Row[],
+      rows,
       capturedAt: alpha.capturedAt,
       decline: null,
     };

--- a/tests/account-balances-completeness.test.ts
+++ b/tests/account-balances-completeness.test.ts
@@ -28,15 +28,11 @@ const SCHEMA = fs.readFileSync(
 
 let db: InstanceType<typeof DatabaseSync>;
 
-/** The D1 shim shape this reader uses: prepare().first(). */
-function d1() {
+/** The store shape this reader uses: first(). */
+function storeHandle() {
   return {
-    prepare(sql: string) {
-      return {
-        async first() {
-          return db.prepare(sql).get() ?? null;
-        },
-      };
+    async first(sql: string) {
+      return db.prepare(sql).get() ?? null;
     },
   };
 }
@@ -61,7 +57,7 @@ beforeEach(() => {
 
 describe("latestCompleteAccountBalancesPass", () => {
   test("declines while no pass has completed", async () => {
-    const result = await latestCompleteAccountBalancesPass(d1());
+    const result = await latestCompleteAccountBalancesPass(storeHandle());
     assert.equal(result.capturedAt, null);
     assert.equal(result.reason, "no_complete_pass");
     assert.equal(mayRankAccountBalances(result), false);
@@ -71,7 +67,7 @@ describe("latestCompleteAccountBalancesPass", () => {
     // The exact production failure: rows landed, they are correct, and ranking
     // over them drops real top holders. 147,000 of a declared 364,266.
     insertPass(1_785_907_636_083, 364_266, 147_000, null);
-    const result = await latestCompleteAccountBalancesPass(d1());
+    const result = await latestCompleteAccountBalancesPass(storeHandle());
     assert.equal(result.capturedAt, null, "an unfinished pass is not rankable");
     assert.equal(result.reason, "no_complete_pass");
     assert.equal(mayRankAccountBalances(result), false);
@@ -79,7 +75,7 @@ describe("latestCompleteAccountBalancesPass", () => {
 
   test("returns the newest COMPLETE pass and permits ranking", async () => {
     insertPass(1_785_900_000_000, 360_000, 360_000, 1_785_900_100_000);
-    const result = await latestCompleteAccountBalancesPass(d1());
+    const result = await latestCompleteAccountBalancesPass(storeHandle());
     assert.equal(result.capturedAt, 1_785_900_000_000);
     assert.equal(result.expectedRows, 360_000);
     assert.equal(result.receivedRows, 360_000);
@@ -92,7 +88,7 @@ describe("latestCompleteAccountBalancesPass", () => {
     // died halfway. Ranking must fall back to yesterday, not to the fragment.
     insertPass(1_785_900_000_000, 360_000, 360_000, 1_785_900_100_000);
     insertPass(1_785_990_000_000, 364_266, 12_000, null);
-    const result = await latestCompleteAccountBalancesPass(d1());
+    const result = await latestCompleteAccountBalancesPass(storeHandle());
     assert.equal(
       result.capturedAt,
       1_785_900_000_000,
@@ -106,7 +102,7 @@ describe("latestCompleteAccountBalancesPass", () => {
     // equality check would call a finished pass unfinished; the stamp decides.
     insertPass(1_785_900_000_000, 360_000, 360_000, 1_785_900_100_000);
     insertPass(1_785_990_000_000, 364_266, 389_266, 1_785_990_500_000);
-    const result = await latestCompleteAccountBalancesPass(d1());
+    const result = await latestCompleteAccountBalancesPass(storeHandle());
     assert.equal(result.capturedAt, 1_785_990_000_000);
     assert.equal(result.receivedRows, 389_266);
     assert.equal(mayRankAccountBalances(result), true);
@@ -124,19 +120,17 @@ describe("latestCompleteAccountBalancesPass", () => {
     // The migrations here are applied by hand, so "the table does not exist
     // yet" is a real state and means the same thing as "do not rank".
     db.exec("DROP TABLE account_balances_passes");
-    const result = await latestCompleteAccountBalancesPass(d1());
+    const result = await latestCompleteAccountBalancesPass(storeHandle());
     assert.equal(result.reason, "unavailable");
     assert.equal(mayRankAccountBalances(result), false);
   });
 
   test("an unusable captured_at is treated as no pass at all", async () => {
     const broken = {
-      prepare: () => ({
-        first: async () => ({
-          captured_at: null,
-          expected_rows: 1,
-          received_rows: 1,
-        }),
+      first: async () => ({
+        captured_at: null,
+        expected_rows: 1,
+        received_rows: 1,
       }),
     };
     assert.equal(
@@ -144,12 +138,10 @@ describe("latestCompleteAccountBalancesPass", () => {
       "no_complete_pass",
     );
     const zero = {
-      prepare: () => ({
-        first: async () => ({
-          captured_at: 0,
-          expected_rows: 1,
-          received_rows: 1,
-        }),
+      first: async () => ({
+        captured_at: 0,
+        expected_rows: 1,
+        received_rows: 1,
       }),
     };
     assert.equal(
@@ -160,12 +152,10 @@ describe("latestCompleteAccountBalancesPass", () => {
 
   test("null counts on a usable stamp degrade to null, not NaN", async () => {
     const partial = {
-      prepare: () => ({
-        first: async () => ({
-          captured_at: 1_785_900_000_000,
-          expected_rows: null,
-          received_rows: null,
-        }),
+      first: async () => ({
+        captured_at: 1_785_900_000_000,
+        expected_rows: null,
+        received_rows: null,
       }),
     };
     const result = await latestCompleteAccountBalancesPass(partial);

--- a/tests/account-summary-card.test.ts
+++ b/tests/account-summary-card.test.ts
@@ -104,7 +104,7 @@ function lakehouse({ fail = false }: { fail?: boolean } = {}) {
  * `seen` is a LIVE view over the mock's log rather than a copy, because every
  * caller destructures this object and holds `seen` across the loader call --
  * a getter would be evaluated once, at destructure time, and freeze empty. */
-function d1({ rows = [NEURON_ROW] as unknown[], fail = false } = {}) {
+function runner({ rows = [NEURON_ROW] as unknown[], fail = false } = {}) {
   const seen: { sql: string; params: unknown[] }[] = [];
   pg.control.rows = rows;
   pg.control.failNext = fail ? new Error("store down") : null;
@@ -124,7 +124,7 @@ describe("loadAccountRegistrationsFromStore", () => {
     // Same columns, same predicate, same order -- so the summary's
     // `registrations` and /subnets' `subnets` cannot come to disagree about
     // where one hotkey is registered.
-    const db = d1();
+    const db = runner();
     const rows = await loadAccountRegistrationsFromStore(db as never, SS58);
     assert.deepEqual(rows, [NEURON_ROW]);
     // Compared through toPositionalPlaceholders because the store applies it on
@@ -151,7 +151,7 @@ describe("loadAccountRegistrationsFromStore", () => {
     assert.deepEqual(await loadAccountRegistrationsFromStore(null, SS58), []);
     assert.equal(
       await loadAccountRegistrationsFromStore(
-        d1({ fail: true }) as never,
+        runner({ fail: true }) as never,
         SS58,
       ),
       null,
@@ -163,7 +163,7 @@ describe("loadAccountRegistrationsFromStore", () => {
     // array, so the guard is exercised one level lower -- at a driver answering
     // with something that is not a row set at all, which is the only way a
     // non-array now reaches this loader.
-    const db = d1();
+    const db = runner();
     pg.control.rows = { not: "rows" } as unknown as unknown[];
     assert.deepEqual(
       await loadAccountRegistrationsFromStore(db as never, SS58),
@@ -176,7 +176,7 @@ describe("answerAccountSummary", () => {
   test("the card carries BOTH legs — events and current registrations", async () => {
     lakehouse();
     const answer = await answerAccountSummary(
-      { ...d1(), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
+      { ...runner(), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
       SS58,
     );
     assert.equal(answer.kind, "answer");
@@ -199,7 +199,7 @@ describe("answerAccountSummary", () => {
   test("a configured lakehouse that cannot answer DECLINES, never a zero card", async () => {
     lakehouse({ fail: true });
     const answer = await answerAccountSummary(
-      { ...d1(), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
+      { ...runner(), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
       SS58,
     );
     assert.equal(answer.kind, "gap");
@@ -210,7 +210,7 @@ describe("answerAccountSummary", () => {
     // payload to say which half is which.
     lakehouse();
     const answer = await answerAccountSummary(
-      { ...d1({ fail: true }), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
+      { ...runner({ fail: true }), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
       SS58,
     );
     assert.equal(answer.kind, "gap");
@@ -220,14 +220,14 @@ describe("answerAccountSummary", () => {
     // A self-hoster or CI run has no chain history to read at all, so there is
     // nothing to decline about.
     lakehouse();
-    const answer = await answerAccountSummary(d1() as never, SS58);
+    const answer = await answerAccountSummary(runner() as never, SS58);
     assert.equal(answer.kind, "miss");
   });
 
   test("an unusable address declines rather than scanning every account", async () => {
     lakehouse();
     const answer = await answerAccountSummary(
-      { ...d1(), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
+      { ...runner(), [R2_SQL_TOKEN_ENV]: "cfut_test" } as never,
       "not-an-address",
     );
     assert.equal(answer.kind, "gap");

--- a/tests/alpha-usd-history.test.ts
+++ b/tests/alpha-usd-history.test.ts
@@ -107,7 +107,7 @@ describe("the bucketing SQL", () => {
 
 describe("loading rates", () => {
   const db = (results: unknown[]) => ({
-    prepare: () => ({ bind: () => ({ all: async () => ({ results }) }) }),
+    query: async <Row>() => results as Row[],
   });
 
   test("a missing store is a FAILED read, not an empty one", async () => {
@@ -125,13 +125,9 @@ describe("loading rates", () => {
 
   test("a throwing store yields null rather than propagating", async () => {
     const boom = {
-      prepare: () => ({
-        bind: () => ({
-          all: async () => {
-            throw new Error("connection reset");
-          },
-        }),
-      }),
+      query: async () => {
+        throw new Error("connection reset");
+      },
     };
     assert.equal(
       await loadTaoUsdBuckets(boom, { sinceMs: 0, bucketMs: HOUR }),
@@ -466,10 +462,11 @@ describe("pricing trend days", () => {
 });
 
 describe("shapes the store actually returns", () => {
-  test("a result object with no `results` key reads as empty, not as a failure", async () => {
+  test("zero rows reads as empty, not as a failure", async () => {
     // A store that answers but has nothing to say is an EMPTY series; only a
-    // throw or a missing binding is a failed read.
-    const db = { prepare: () => ({ bind: () => ({ all: async () => ({}) }) }) };
+    // throw or a missing binding is a failed read. (The D1 "no results key"
+    // premise retired with the envelope, #10909.)
+    const db = { query: async () => [] };
     assert.deepEqual(
       await loadTaoUsdBuckets(db, { sinceMs: 0, bucketMs: HOUR }),
       [],

--- a/tests/alpha-usd-history.test.ts
+++ b/tests/alpha-usd-history.test.ts
@@ -11,6 +11,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { OHLC_INTERVALS } from "../src/subnet-ohlc.ts";
 import {
+  loadTaoUsdAtInstants,
   loadTaoUsdBuckets,
   ohlcUsdWindowStart,
   taoUsdBucketMap,
@@ -540,5 +541,100 @@ describe("deciding whether to read at all", () => {
       ),
       null,
     );
+  });
+});
+
+describe("loadTaoUsdAtInstants", () => {
+  // The per-instant read behind /accounts/{ss58}/transfers' USD pricing. It had
+  // no direct test: every assertion about it went through the route, so the
+  // rules it enforces on its own rows -- which instants make it into the map,
+  // and which deliberately do not -- were only ever implied.
+  const READING = {
+    instant: T0,
+    usd_per_tao: 191.5,
+    observed_at: T0 - 60_000,
+    block_number: 8_800_000,
+    price_basis: "pool-twap",
+  };
+
+  test("maps each instant to the newest reading at or before it", async () => {
+    const db = { query: async <Row>() => [READING] as Row[] };
+    const map = await loadTaoUsdAtInstants(db, [T0]);
+    assert.equal(map?.size, 1);
+    assert.equal(map?.get(T0)?.usd_per_tao, 191.5);
+    // The stamp is ISO on the way out, not the raw epoch the row carries.
+    assert.equal(
+      map?.get(T0)?.observed_at,
+      new Date(T0 - 60_000).toISOString(),
+    );
+    assert.equal(map?.get(T0)?.block_number, 8_800_000);
+    assert.equal(map?.get(T0)?.price_basis, "pool-twap");
+  });
+
+  test("an instant that predates the index is ABSENT, never a null rate", async () => {
+    // #8602's rule: the index starts when collection started, and an event
+    // older than that has NO rate. A null-valued entry would read as "the rate
+    // was nothing", which is a number nobody measured.
+    const db = {
+      query: async <Row>() => [{ ...READING, usd_per_tao: null }] as Row[],
+    };
+    const map = await loadTaoUsdAtInstants(db, [T0]);
+    assert.equal(map?.size, 0);
+    assert.equal(map?.has(T0), false);
+  });
+
+  test("a row whose instant is unreadable is dropped, not keyed on NaN", async () => {
+    const db = {
+      query: async <Row>() => [{ ...READING, instant: "nope" }] as Row[],
+    };
+    assert.equal((await loadTaoUsdAtInstants(db, [T0]))?.size, 0);
+  });
+
+  test("no instants asked is an empty map, and asks the store nothing", async () => {
+    // Distinct from a decline: the caller had nothing to price, which is a
+    // real answer and must not cost a query.
+    let asked = 0;
+    const db = {
+      query: async <Row>() => {
+        asked += 1;
+        return [] as Row[];
+      },
+    };
+    assert.deepEqual(await loadTaoUsdAtInstants(db, []), new Map());
+    assert.deepEqual(await loadTaoUsdAtInstants(db, [Number.NaN]), new Map());
+    assert.equal(asked, 0, "an empty ask must not reach the store");
+  });
+
+  test("no store and a throwing read are both null, never an empty map", async () => {
+    // The distinction the callers act on: an empty map says "priced nothing",
+    // null says "could not price", and only the second may suppress a figure.
+    assert.equal(await loadTaoUsdAtInstants(null, [T0]), null);
+    assert.equal(await loadTaoUsdAtInstants({}, [T0]), null);
+    const throwing = {
+      query: async () => {
+        throw new Error("store read failed");
+      },
+    };
+    assert.equal(await loadTaoUsdAtInstants(throwing, [T0]), null);
+  });
+
+  test("the statement bins every wanted instant through ONE lateral join", async () => {
+    // One query for N instants, not N queries: the unnest+LATERAL shape is
+    // what keeps a 1000-transfer page from becoming 1000 point reads.
+    let sql = "";
+    let values: unknown[] = [];
+    const db = {
+      query: async <Row>(text: string, v: unknown[] = []) => {
+        sql = text;
+        values = v;
+        return [] as Row[];
+      },
+    };
+    await loadTaoUsdAtInstants(db, [T0, T0 - 1000, T0]);
+    assert.match(sql, /unnest\(\?::bigint\[\]\)/);
+    assert.match(sql, /LEFT JOIN LATERAL/);
+    assert.match(sql, /ORDER BY observed_at DESC LIMIT 1/);
+    // Deduplicated: the same instant asked twice is bound once.
+    assert.deepEqual(values, [[T0, T0 - 1000]]);
   });
 });

--- a/tests/analytics-live-postgres.test.ts
+++ b/tests/analytics-live-postgres.test.ts
@@ -115,24 +115,11 @@ function readDb(): ObservationsReadDb {
   });
 }
 
-/**
- * The same runner presenting rows as a BARE ARRAY rather than `{ results }`.
- *
- * `storeAll` accepts both and the loaders reach it through a structural type, so
- * the unwrap branch is not covered by the shape production happens to send.
- * The predecessor covered it, and dropping it while changing engines would
- * confuse "no longer tested" with "no longer true".
- */
-function readDbBareArray(): ObservationsReadDb {
-  return {
-    prepare(text: string) {
-      const all = async (values: unknown[]) =>
-        (await pg.query(toPositionalPlaceholders(text), values as never[]))
-          .rows as unknown;
-      return { bind: (...v: unknown[]) => ({ all: () => all(v) }) };
-    },
-  };
-}
+// The bare-array double retired with the dual-envelope acceptance (#10909):
+// `storeAll` used to take either a bare array or `{ results }` because two
+// adapters disagreed, and this double covered the branch production did not
+// send. There is one shape now -- rows -- so the branch and its double are
+// both gone.
 
 const exec = (sql: string, values: unknown[]) =>
   pg.query(sql, values as never[]);
@@ -419,13 +406,9 @@ describe("the gap-island window functions", () => {
 describe("declines", () => {
   test("a throwing or absent db degrades every loader to the empty shape", async () => {
     const exploding: ObservationsReadDb = {
-      prepare: () => ({
-        bind: () => ({
-          all: async () => {
-            throw new Error("neon down");
-          },
-        }),
-      }),
+      query: async () => {
+        throw new Error("neon down");
+      },
     };
     const uptime = (await loadSubnetUptime(8, { db: exploding })) as {
       surfaces: unknown[];
@@ -438,23 +421,15 @@ describe("declines", () => {
     assert.deepEqual(await loadGlobalIncidentRows(null, 7), []);
   });
 
-  test("an all() result that is neither an array nor { results } yields zero rows", async () => {
-    const weird: ObservationsReadDb = {
-      prepare: () => ({ bind: () => ({ all: async () => ({}) }) }),
-    };
-    const data = (await loadSubnetUptime(8, { db: weird })) as {
+  test("zero rows yields the empty shape", async () => {
+    // The "neither an array nor { results }" arm retired with the dual-envelope
+    // acceptance (#10909): query() answers rows or throws (above), so zero
+    // rows is the one remaining nothing-shape.
+    const empty: ObservationsReadDb = { query: async () => [] };
+    const data = (await loadSubnetUptime(8, { db: empty })) as {
       surfaces: unknown[];
     };
     assert.deepEqual(data.surfaces, []);
-  });
-
-  test("a bare-array envelope reads the same as { results }", async () => {
-    await seedUptimeDay();
-    const data = (await loadSubnetUptime(8, { db: readDbBareArray() })) as {
-      surfaces: { days: unknown[] }[];
-    };
-    assert.equal(data.surfaces.length, 1);
-    assert.equal(data.surfaces[0]!.days.length, 1);
   });
 });
 
@@ -587,14 +562,9 @@ describe("registry leaderboards and compare", () => {
     const bound: unknown[][] = [];
     const inner = readDb();
     const spy: ObservationsReadDb = {
-      prepare(sql: string) {
-        const stmt = inner.prepare(sql);
-        return {
-          bind(...values: unknown[]) {
-            bound.push(values);
-            return stmt.bind!(...values);
-          },
-        };
+      query(sql: string, values: unknown[] = []) {
+        bound.push(values);
+        return inner.query(sql, values);
       },
     };
     const data = (await loadCompareSubnets({
@@ -617,9 +587,9 @@ describe("registry leaderboards and compare", () => {
     let prepared = 0;
     const inner = readDb();
     const spy: ObservationsReadDb = {
-      prepare(sql: string) {
+      query(sql: string, values: unknown[] = []) {
         prepared += 1;
-        return inner.prepare(sql);
+        return inner.query(sql, values);
       },
     };
     await loadCompareSubnets({

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1913,7 +1913,7 @@ describe("hourly cron writes a daily snapshot", () => {
 // storeAll / hasD1FallbackRows / markD1FallbackRows / d1FallbackGeneration were
 // deleted (2026-07-17, D1 fully eliminated) -- every analytics route now
 // tries the Postgres tier first and a miss falls through to a pure
-// empty-shape builder directly, never a live D1 query, so the D1 read path
+// empty-shape builder directly, never a live store query, so the D1 read path
 // + its fallback-row bookkeeping had zero remaining callers. See
 // workers/request-handlers/analytics.ts's own header comment.
 
@@ -2229,21 +2229,18 @@ describe("#9452 — writeSubnetSnapshot reports its verdict", () => {
       captures,
       overrides: {
         laneHealthDb: {
-          prepare: (sql: string) => ({
-            bind: (...values: unknown[]) => ({
-              run: async () => {
-                if (sql.startsWith("INSERT")) {
-                  rows.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    age_ms: values[2],
-                    detail: values[3],
-                  });
-                }
-              },
-            }),
-          }),
-          batch: async () => [],
+          query: async () => [],
+          run: async (sql: string, values: unknown[] = []) => {
+            if (sql.startsWith("INSERT")) {
+              rows.push({
+                lane: values[0],
+                verdict: values[1],
+                age_ms: values[2],
+                detail: values[3],
+              });
+            }
+            return { changes: 1 };
+          },
         } as never,
         recordExceptionEvent: (async (_env: unknown, event: unknown) => {
           captures.push(event as Row);

--- a/tests/bulk-health-trends-loader.test.ts
+++ b/tests/bulk-health-trends-loader.test.ts
@@ -21,18 +21,10 @@ function fakeDb(rows: Row[], opts: { throws?: boolean } = {}) {
   const seen: { sql: string; params: unknown[] }[] = [];
   return {
     seen,
-    prepare(sql: string) {
-      return {
-        bind(...params: unknown[]) {
-          return {
-            all() {
-              seen.push({ sql, params });
-              if (opts.throws) return Promise.reject(new Error("d1 down"));
-              return Promise.resolve({ results: rows });
-            },
-          };
-        },
-      };
+    query<T>(sql: string, params: unknown[] = []) {
+      seen.push({ sql, params });
+      if (opts.throws) return Promise.reject(new Error("store down"));
+      return Promise.resolve(rows as T[]);
     },
   };
 }

--- a/tests/capture-state-neon-write.test.ts
+++ b/tests/capture-state-neon-write.test.ts
@@ -264,16 +264,12 @@ describe("a buffered lane writes no enqueue-time verdict (#10690)", () => {
     return {
       rows,
       db: {
-        prepare(sql: string) {
-          return {
-            bind(...values: unknown[]) {
-              return {
-                async run() {
-                  if (sql.startsWith("INSERT")) rows.push(values);
-                },
-              };
-            },
-          };
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT")) rows.push(values);
+          return { changes: 1 };
         },
       },
     };

--- a/tests/chain-detail-prune.test.ts
+++ b/tests/chain-detail-prune.test.ts
@@ -68,27 +68,15 @@ function owned(tables: readonly string[] = PRUNE_TABLES) {
  * choice to run leave `readDb` out on purpose.
  */
 function boundsReader(floor: unknown, head: unknown) {
-  return {
-    prepare: () => ({
-      bind: () => ({ first: async () => ({ floor, head }) }),
-      first: async () => ({ floor, head }),
-    }),
-  } as never;
+  return { first: async () => ({ floor, head }) } as never;
 }
 
 /** A bounds reader whose MIN/MAX read fails, so the failure path is reachable. */
 function throwingReader(thrown: unknown) {
   return {
-    prepare: () => ({
-      bind: () => ({
-        first: async () => {
-          throw thrown;
-        },
-      }),
-      first: async () => {
-        throw thrown;
-      },
-    }),
+    first: async () => {
+      throw thrown;
+    },
   } as never;
 }
 

--- a/tests/chain-holders.test.ts
+++ b/tests/chain-holders.test.ts
@@ -26,7 +26,7 @@ import { pgMockEnv } from "./helpers/pg-mock.ts";
 // One store since #10179: the ROUTE/GraphQL/MCP surfaces reach it through
 // src/read-store.ts, which builds `new Client(...)` itself -- there is no
 // binding to hand a request handler any more. The loader assertions below keep
-// passing `d1()` straight in, because `load*(db, ...)` takes a db; only the
+// passing `storeHandle()` straight in, because `load*(db, ...)` takes a db; only the
 // surface half needs the module mock. See tests/helpers/pg-mock.ts for why it
 // is a module mock and why the controller is built inside vi.hoisted.
 const { pg } = await vi.hoisted(async () => ({
@@ -70,24 +70,19 @@ const hk = (n: number) => `5Hotkey0${String(n).padStart(40, "0")}`;
 
 let db: InstanceType<typeof DatabaseSync>;
 
-function d1() {
+function storeHandle() {
   return {
-    prepare(text: string) {
-      const run = (values: unknown[]) => ({
-        async all() {
-          return { results: db.prepare(text).all(...(values as never[])) };
-        },
-        async first() {
-          return db.prepare(text).get(...(values as never[])) ?? null;
-        },
-      });
-      return { bind: (...v: unknown[]) => run(v), ...run([]) };
+    async query<Row>(text: string, values: unknown[] = []) {
+      return db.prepare(text).all(...(values as never[])) as Row[];
+    },
+    async first(text: string, values: unknown[] = []) {
+      return db.prepare(text).get(...(values as never[])) ?? null;
     },
   };
 }
 
 /** The surface's env: a connection string for readStore to find, every table
- * declared Neon's, and the SAME in-memory engine `d1()` reads answering behind
+ * declared Neon's, and the SAME in-memory engine `storeHandle()` reads answering behind
  * the `pg` double -- so a surface assertion and a loader assertion are looking
  * at one set of rows. */
 const env = () => ({ ...pgMockEnv() }) as unknown as Env;
@@ -148,7 +143,7 @@ beforeEach(() => {
 describe("loadChainHolders against real SQLite", () => {
   test("ranks every subnet in one statement, window function and all", async () => {
     threeSubnets();
-    const read = await loadChainHolders(d1());
+    const read = await loadChainHolders(storeHandle());
     assert.equal(read.decline, null);
     assert.equal(read.capturedAt, PASS);
     const byNetuid = Object.fromEntries(
@@ -171,7 +166,7 @@ describe("loadChainHolders against real SQLite", () => {
     pool(hk(2), 2, 500, PASS + 5000);
     position(ck(1), hk(1), 1, 1.0);
     position(ck(2), hk(2), 2, 1.0);
-    const read = await loadChainHolders(d1());
+    const read = await loadChainHolders(storeHandle());
     assert.deepEqual(
       read.rows.map((r) => r.netuid),
       [1],
@@ -189,33 +184,38 @@ describe("loadChainHolders declines", () => {
     pool(hk(1), 1, 1000);
     position(ck(1), hk(1), 1, 1.0);
     assert.equal(
-      (await loadChainHolders(d1())).decline,
+      (await loadChainHolders(storeHandle())).decline,
       "pool_totals_unproven",
     );
   });
 
   test("a missing passes table is unavailable", async () => {
     db.exec("DROP TABLE hotkey_alpha_passes");
-    assert.equal((await loadChainHolders(d1())).decline, "unavailable");
+    assert.equal(
+      (await loadChainHolders(storeHandle())).decline,
+      "unavailable",
+    );
   });
 
   test("a failed read declines rather than throwing", async () => {
     completePass();
     db.exec("DROP TABLE nominator_positions");
-    assert.equal((await loadChainHolders(d1())).decline, "unavailable");
+    assert.equal(
+      (await loadChainHolders(storeHandle())).decline,
+      "unavailable",
+    );
   });
 
-  test("a non-array result declines", async () => {
+  test("a failing read declines", async () => {
+    // Was "a non-array result declines": the D1 envelope could answer without
+    // a `results` array, and that shape retired with it (#10909). A throw is
+    // the failure the decline now stands for.
     completePass();
     const broken = {
-      prepare(text: string) {
-        const real = d1().prepare(text);
-        return {
-          all: async () => ({ results: undefined }),
-          first: real.first,
-          bind: (...v: unknown[]) => real.bind(...v),
-        };
+      query: async () => {
+        throw new Error("store read failed");
       },
+      first: storeHandle().first,
     };
     assert.equal(
       (await loadChainHolders(broken as never)).decline,

--- a/tests/dead-letter.test.ts
+++ b/tests/dead-letter.test.ts
@@ -32,17 +32,12 @@ function db() {
         .filter((s) => s.sql.startsWith("INSERT INTO lane_health"))
         .map((s) => s.values);
     },
-    prepare(sql: string) {
-      return {
-        bind(...values: unknown[]) {
-          return {
-            async run() {
-              statements.push({ sql, values });
-              return {};
-            },
-          };
-        },
-      };
+    async query() {
+      return [];
+    },
+    async run(sql: string, values: unknown[] = []) {
+      statements.push({ sql, values });
+      return { changes: 1 };
     },
   };
 }

--- a/tests/emission-gate-changes.test.ts
+++ b/tests/emission-gate-changes.test.ts
@@ -75,24 +75,14 @@ const seed = async (sql: string, params: unknown[] = []) => {
   );
 };
 
-function d1() {
+function storeHandle() {
   return {
-    prepare(text: string) {
-      return {
-        bind(...values: unknown[]) {
-          return {
-            async all() {
-              return {
-                results: (await db.query(text, values as never[])).rows,
-              };
-            },
-          };
-        },
-      };
+    async query<Row>(text: string, values: unknown[] = []) {
+      return (await db.query(text, values as never[])).rows as Row[];
     },
   };
 }
-/** An env whose store is the same in-memory fixture `d1()` wraps.
+/** An env whose store is the same in-memory fixture `storeHandle()` wraps.
  *
  * Assigned per call rather than once, because `db` is rebuilt in beforeEach --
  * a controller still holding the previous test's database would answer from a
@@ -186,7 +176,7 @@ describe("predates_capture is never lost", () => {
     // reading, so no change occurred.
     await param(T, { prev: null, predates: true });
     await param(T - 1000, { prev: 2, value: 3, predates: false });
-    const card = buildEmissionChanges(await loadEmissionChanges(d1()));
+    const card = buildEmissionChanges(await loadEmissionChanges(storeHandle()));
     const first = (card.changes as Row[])[0];
     assert.equal(first.predates_capture, true);
     assert.equal(first.previous_value, null);
@@ -200,7 +190,7 @@ describe("predates_capture is never lost", () => {
     await param(T, { predates: true });
     await subnetSwitch(T - 1, 7, true, null, true);
     await flow(T - 2);
-    const card = buildEmissionChanges(await loadEmissionChanges(d1()));
+    const card = buildEmissionChanges(await loadEmissionChanges(storeHandle()));
     for (const c of card.changes as Row[]) {
       assert.equal(typeof c.predates_capture, "boolean");
     }
@@ -213,8 +203,9 @@ describe("one feed, three shapes", () => {
     await param(T);
     await subnetSwitch(T - 1);
     await flow(T - 2, "subnet_ema_tao_flow", 12, true);
-    const changes = buildEmissionChanges(await loadEmissionChanges(d1()))
-      .changes as Row[];
+    const changes = buildEmissionChanges(
+      await loadEmissionChanges(storeHandle()),
+    ).changes as Row[];
     const byKind = Object.fromEntries(changes.map((c) => [c.kind, c]));
 
     // A network-wide parameter has no subnet. `netuid: null` would read as
@@ -267,7 +258,7 @@ describe("the feed is unioned, not merged per table", () => {
     await subnetSwitch(T - 20);
     await param(T - 30);
     await subnetSwitch(T - 40);
-    const card = buildEmissionChanges(await loadEmissionChanges(d1()));
+    const card = buildEmissionChanges(await loadEmissionChanges(storeHandle()));
     assert.deepEqual(
       (card.changes as Row[]).map((c) => c.kind),
       ["param", "flow", "subnet", "param", "subnet"],
@@ -280,7 +271,7 @@ describe("the feed is unioned, not merged per table", () => {
     for (let i = 0; i < 5; i += 1) await param(T - i);
     await subnetSwitch(T - 100);
     const card = buildEmissionChanges(
-      await loadEmissionChanges(d1(), { limit: 2 }),
+      await loadEmissionChanges(storeHandle(), { limit: 2 }),
       { limit: 2 },
     );
     assert.equal(card.change_count, 2);
@@ -296,7 +287,7 @@ describe("the feed is unioned, not merged per table", () => {
     await flow(T - 2);
     for (const kind of EMISSION_CHANGE_KINDS) {
       const card = buildEmissionChanges(
-        await loadEmissionChanges(d1(), { kind }),
+        await loadEmissionChanges(storeHandle(), { kind }),
         { kind },
       );
       assert.equal(card.change_count, 1);
@@ -355,7 +346,7 @@ describe("buildEmissionChanges edges", () => {
   test("no binding and a failed read both return null", async () => {
     assert.equal(await loadEmissionChanges(null), null);
     await db.exec("DROP TABLE emission_flow_watch");
-    assert.equal(await loadEmissionChanges(d1()), null);
+    assert.equal(await loadEmissionChanges(storeHandle()), null);
   });
 
   test("a non-numeric value reads as unmeasured, not zero", () => {
@@ -375,10 +366,10 @@ describe("buildEmissionChanges edges", () => {
     assert.equal((zero.changes as Row[])[0].value, 0);
   });
 
-  test("a driver returning no results object yields an empty feed", async () => {
-    const shim = {
-      prepare: () => ({ bind: () => ({ all: async () => null }) }),
-    };
+  test("zero rows yields an empty feed", async () => {
+    // The D1 "no results object" premise retired with the envelope (#10909):
+    // the owned query() answers rows or throws, so zero rows is the shape.
+    const shim = { query: async () => [] };
     const rows = await loadEmissionChanges(shim as never);
     assert.deepEqual(rows, []);
   });

--- a/tests/failure-reasons.test.ts
+++ b/tests/failure-reasons.test.ts
@@ -41,17 +41,10 @@ function rollupDb() {
 /** A read surface over the rollup table, for loadFailureReasons. */
 function readDb(sqlite: DatabaseSync) {
   return {
-    prepare(sql: string) {
-      const stmt = sqlite.prepare(sql);
-      return {
-        bind(...values: unknown[]) {
-          return {
-            all: async () => ({
-              results: stmt.all(...(values as Array<string | number | null>)),
-            }),
-          };
-        },
-      };
+    async query<Row>(sql: string, values: unknown[] = []) {
+      return sqlite
+        .prepare(sql)
+        .all(...(values as Array<string | number | null>)) as Row[];
     },
   };
 }
@@ -150,23 +143,17 @@ describe("loadFailureReasons", () => {
     expect(await loadFailureReasons(undefined)).toBeNull();
     expect(await loadFailureReasons({} as never)).toBeNull();
     const throwing = {
-      prepare: () => ({
-        bind: () => ({
-          all: async () => {
-            throw new Error("D1_ERROR");
-          },
-        }),
-      }),
+      query: async () => {
+        throw new Error("store read failed");
+      },
     };
     expect(await loadFailureReasons(throwing)).toBeNull();
   });
 
-  it("returns an empty list when all() is absent or answers nothing", async () => {
-    const noAll = { prepare: () => ({ bind: () => ({}) }) };
-    expect(await loadFailureReasons(noAll as never)).toEqual([]);
-    const empty = {
-      prepare: () => ({ bind: () => ({ all: async () => null }) }),
-    };
+  it("returns an empty list on zero rows", async () => {
+    // The "all() absent / null result" arms retired with the D1 envelope
+    // (#10909): query() answers rows or throws (null, above).
+    const empty = { query: async () => [] };
     expect(await loadFailureReasons(empty)).toEqual([]);
   });
 });

--- a/tests/freshness-watchdog.test.ts
+++ b/tests/freshness-watchdog.test.ts
@@ -331,22 +331,20 @@ function laneHealthSpy() {
   return {
     rows,
     db: {
-      prepare: (sql: string) => ({
-        bind: (...values: unknown[]) => ({
-          run: async () => {
-            // Only the INSERT carries a verdict; recordLaneVerdict also issues
-            // a retention DELETE on the way through.
-            if (sql.startsWith("INSERT")) {
-              rows.push({
-                lane: values[0],
-                verdict: values[1],
-                age_ms: values[2],
-                detail: values[3],
-              });
-            }
-          },
-        }),
-      }),
+      query: async () => [],
+      run: async (sql: string, values: unknown[] = []) => {
+        // Only the INSERT carries a verdict; recordLaneVerdict also issues
+        // a retention DELETE on the way through.
+        if (sql.startsWith("INSERT")) {
+          rows.push({
+            lane: values[0],
+            verdict: values[1],
+            age_ms: values[2],
+            detail: values[3],
+          });
+        }
+        return { changes: 1 };
+      },
     },
   };
 }
@@ -440,7 +438,10 @@ test("a lane_health write that fails never breaks the tick", async () => {
   const res = (await runFreshnessWatchdog(envWith(undefined), undefined, {
     readArtifact: (async () => staleArtifact) as never,
     laneHealthDb: {
-      prepare: () => {
+      query: () => {
+        throw new Error("no such table: lane_health");
+      },
+      run: () => {
         throw new Error("no such table: lane_health");
       },
     } as never,

--- a/tests/hotkey-alpha-completeness.test.ts
+++ b/tests/hotkey-alpha-completeness.test.ts
@@ -31,15 +31,11 @@ const SCHEMA = fs.readFileSync(
 
 let db: InstanceType<typeof DatabaseSync>;
 
-/** The D1 shim shape this reader uses: prepare().first(). */
-function d1() {
+/** The store shape this reader uses: first(). */
+function storeHandle() {
   return {
-    prepare(sql: string) {
-      return {
-        async first() {
-          return db.prepare(sql).get() ?? null;
-        },
-      };
+    async first(sql: string) {
+      return db.prepare(sql).get() ?? null;
     },
   };
 }
@@ -64,7 +60,7 @@ beforeEach(() => {
 
 describe("latestCompleteHotkeyAlphaPass", () => {
   test("declines while no pass has completed", async () => {
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(result.capturedAt, null);
     assert.equal(result.reason, "no_complete_pass");
     assert.equal(mayPriceHotkeyAlpha(result), false);
@@ -74,14 +70,14 @@ describe("latestCompleteHotkeyAlphaPass", () => {
     // THE REGRESSION SHAPE. Rows are present and every one is correct; the
     // pass simply has not finished. Pricing over it underprices silently.
     insertPass(1_785_910_000_000, 148_211, 140_000, null);
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(result.capturedAt, null);
     assert.equal(mayPriceHotkeyAlpha(result), false);
   });
 
   test("prices once a pass is recorded complete", async () => {
     insertPass(1_785_910_000_000, 148_211, 148_211, 1_785_910_500_000);
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(result.capturedAt, 1_785_910_000_000);
     assert.equal(result.expectedRows, 148_211);
     assert.equal(result.receivedRows, 148_211);
@@ -94,7 +90,7 @@ describe("latestCompleteHotkeyAlphaPass", () => {
     // expected_rows. Keying on completed_at rather than on equality is what
     // keeps that from reading as unfinished.
     insertPass(1_785_910_000_000, 148_211, 153_211, 1_785_910_500_000);
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(mayPriceHotkeyAlpha(result), true);
     assert.equal(result.receivedRows, 153_211);
   });
@@ -104,7 +100,7 @@ describe("latestCompleteHotkeyAlphaPass", () => {
     insertPass(1_785_910_000_000, 200, 200, 1_785_910_500_000);
     // An in-flight pass newer than both must not displace the complete one.
     insertPass(1_785_920_000_000, 300, 10, null);
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(result.capturedAt, 1_785_910_000_000);
   });
 
@@ -120,12 +116,8 @@ describe("latestCompleteHotkeyAlphaPass", () => {
     // Migrations are applied by hand, so "the table is not there yet" is a real
     // state -- and it means the same thing as an unfinished pass.
     const throwing = {
-      prepare() {
-        return {
-          async first(): Promise<unknown> {
-            throw new Error("no such table: hotkey_alpha_passes");
-          },
-        };
+      first() {
+        throw new Error("no such table: hotkey_alpha_passes");
       },
     };
     const result = await latestCompleteHotkeyAlphaPass(throwing);
@@ -137,7 +129,7 @@ describe("latestCompleteHotkeyAlphaPass", () => {
     // completed_at is set but the key is nonsense: scoping a price read to it
     // would match no pool rows at all and value every position at nothing.
     insertPass(0, 10, 10, 1_785_910_500_000);
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(result.capturedAt, null);
     assert.equal(mayPriceHotkeyAlpha(result), false);
   });
@@ -145,7 +137,7 @@ describe("latestCompleteHotkeyAlphaPass", () => {
   test("a complete pass with unreadable counts still prices", async () => {
     // The counts are reporting, not the gate: completed_at is the fact.
     insertPass(1_785_910_000_000, 0, 0, 1_785_910_500_000);
-    const result = await latestCompleteHotkeyAlphaPass(d1());
+    const result = await latestCompleteHotkeyAlphaPass(storeHandle());
     assert.equal(mayPriceHotkeyAlpha(result), true);
     assert.equal(result.expectedRows, null);
     assert.equal(result.receivedRows, null);

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -434,12 +434,11 @@ describe("runHotkeyAlphaStalenessWatchdog", () => {
       now: () => NOW,
       recordException: noopRecord,
       laneHealthDb: {
-        prepare: (sql: string) => ({
-          bind: (...values: unknown[]) => {
-            lanes.push({ sql, values });
-            return { run: async () => ({}) };
-          },
-        }),
+        query: async () => [],
+        run: async (sql: string, values: unknown[] = []) => {
+          lanes.push({ sql, values });
+          return { changes: 1 };
+        },
       } as never,
     });
     // Written EVERY tick, not only when stale: a dropped exception is otherwise

--- a/tests/indexer-lag.test.ts
+++ b/tests/indexer-lag.test.ts
@@ -31,13 +31,8 @@ function db(rows: Array<[number, number, number]>) {
   for (const [block, observed, synced] of rows)
     insert.run(block, observed, synced);
   return {
-    prepare(sql: string) {
-      const stmt = sqlite.prepare(sql);
-      return {
-        bind() {
-          return { first: async () => stmt.get() ?? null };
-        },
-      };
+    async first(sql: string) {
+      return sqlite.prepare(sql).get() ?? null;
     },
   };
 }
@@ -105,36 +100,26 @@ describe("loadIndexerLag", () => {
 
   it("returns null when the read throws", async () => {
     const throwing = {
-      prepare() {
-        return {
-          bind() {
-            return {
-              first: async () => {
-                throw new Error("D1_ERROR");
-              },
-            };
-          },
-        };
+      first: async () => {
+        throw new Error("store read failed");
       },
     };
     expect(await loadIndexerLag(throwing)).toBeNull();
   });
 
-  it("returns null when first() is absent or answers a non-row", async () => {
-    const noFirst = { prepare: () => ({ bind: () => ({}) }) };
+  it("returns null when the store has no first(), or answers a non-row", async () => {
+    const noFirst = {};
     expect(await loadIndexerLag(noFirst as never)).toBeNull();
-    const scalar = {
-      prepare: () => ({ bind: () => ({ first: async () => 7 }) }),
-    };
+    const scalar = { first: async () => 7 };
     expect(await loadIndexerLag(scalar as never)).toBeNull();
   });
 
   it("runs the exported statement, so the constant cannot drift from it", () => {
     let seen = "";
     const spy = {
-      prepare(sql: string) {
+      async first(sql: string) {
         seen = sql;
-        return { bind: () => ({ first: async () => null }) };
+        return null;
       },
     };
     void loadIndexerLag(spy);

--- a/tests/lakehouse-seam-watchdog.test.ts
+++ b/tests/lakehouse-seam-watchdog.test.ts
@@ -550,20 +550,18 @@ describe("the watchdog's own reporting", () => {
       captures,
       deps: {
         laneHealthDb: {
-          prepare: (sql: string) => ({
-            bind: (...values: unknown[]) => ({
-              run: async () => {
-                if (sql.startsWith("INSERT")) {
-                  rows.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    age_ms: values[2],
-                    detail: values[3],
-                  });
-                }
-              },
-            }),
-          }),
+          query: async () => [],
+          run: async (sql: string, values: unknown[] = []) => {
+            if (sql.startsWith("INSERT")) {
+              rows.push({
+                lane: values[0],
+                verdict: values[1],
+                age_ms: values[2],
+                detail: values[3],
+              });
+            }
+            return { changes: 1 };
+          },
         } as never,
         recordExceptionEvent: (async (_env: unknown, event: unknown) => {
           captures.push(event as Record<string, unknown>);
@@ -635,7 +633,10 @@ describe("the watchdog's own reporting", () => {
         query: measured(),
         now: () => NOW,
         laneHealthDb: {
-          prepare: () => {
+          query: () => {
+            throw new Error("no such table: lane_health");
+          },
+          run: () => {
             throw new Error("no such table: lane_health");
           },
         } as never,

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -74,25 +74,17 @@ function fakeDb(rows: Record<string, unknown>[] | Error = []) {
   const calls: { sql: string; values: unknown[] }[] = [];
   const answer = () => {
     if (rows instanceof Error) throw rows;
-    return { results: rows };
+    return rows;
   };
   return {
     calls,
-    prepare(sql: string) {
-      return {
-        bind(...values: unknown[]) {
-          calls.push({ sql, values });
-          return {
-            run: async () => ({}),
-            first: async () => null,
-            all: async () => answer(),
-          };
-        },
-        all: async () => {
-          calls.push({ sql, values: [] });
-          return answer();
-        },
-      };
+    async query(sql: string, values: unknown[] = []) {
+      calls.push({ sql, values });
+      return answer();
+    },
+    async run(sql: string, values: unknown[] = []) {
+      calls.push({ sql, values });
+      return { changes: 1 };
     },
   };
 }
@@ -668,16 +660,11 @@ describe("loadLaneStaleRuns / loadLaneMaxGap", () => {
 
   test("treat a driver that answers with no rows key as empty", async () => {
     // Drivers have answered both `{}` and `null` here; a reader that trusted
-    // `.results` would throw on the first such tick.
+    // The D1 null-result premise retired with the envelope (#10909); the
+    // remaining nothing-shape is zero rows, which must read as no lanes.
     const shim = {
-      prepare: () => ({
-        bind: () => ({
-          run: async () => ({}),
-          first: async () => null,
-          all: async () => null,
-        }),
-        all: async () => ({}),
-      }),
+      query: async () => [],
+      run: async () => ({ changes: 1 }),
     };
     assert.deepEqual(await loadLaneStaleRuns(shim), {});
     assert.deepEqual(await loadLaneMaxGap(shim, 0), {});

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -28,8 +28,12 @@ import { NEURONS_NEON_LANE } from "../src/neurons-neon-write.ts";
 // The lane constant lives with its cron in the data-api Worker.
 import { TAO_USD_INDEX_NEON_LANE } from "../workers/data-api.ts";
 
-/** Each retired lane, and the producer whose deletion justifies retiring it. */
-const PRODUCERS: Record<string, string> = {
+/** Each retired lane, and the producer whose deletion justifies retiring it.
+ * `null` marks the one entry whose producer was a KEY SPELLING rather than a
+ * file -- the pre-#10851 buffer flush wrote per-lane verdicts under the bare
+ * statement tag -- justified below by a code assertion instead: the live
+ * writer provably files under the `neon:` prefix. */
+const PRODUCERS: Record<string, string | null> = {
   "neon-parity": "src/neon-parity.ts",
   "neon-mirror-lag": "src/neon-mirror-lag.ts",
   "neon:backfill:": "src/neon-backfill.ts",
@@ -60,8 +64,12 @@ describe("retired lanes (#10222)", () => {
     const names = [...RETIRED_LANES, ...RETIRED_LANE_PREFIXES];
     assert.ok(names.length > 0, "the list is not empty -- otherwise vacuous");
     for (const name of names) {
+      assert.ok(
+        name in PRODUCERS,
+        `${name} names the producer it retires (or null with a code assertion)`,
+      );
       const producer = PRODUCERS[name];
-      assert.ok(producer, `${name} names the producer it retires`);
+      if (producer === null) continue; // justified by its own test below
       assert.equal(
         existsSync(new URL(`../${producer}`, import.meta.url)),
         false,

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -28,12 +28,8 @@ import { NEURONS_NEON_LANE } from "../src/neurons-neon-write.ts";
 // The lane constant lives with its cron in the data-api Worker.
 import { TAO_USD_INDEX_NEON_LANE } from "../workers/data-api.ts";
 
-/** Each retired lane, and the producer whose deletion justifies retiring it.
- * `null` marks the one entry whose producer was a KEY SPELLING rather than a
- * file — the pre-#10851 buffer flush wrote per-lane verdicts under the bare
- * statement tag — justified below by a code assertion instead: the live
- * writer provably files under the `neon:` prefix. */
-const PRODUCERS: Record<string, string | null> = {
+/** Each retired lane, and the producer whose deletion justifies retiring it. */
+const PRODUCERS: Record<string, string> = {
   "neon-parity": "src/neon-parity.ts",
   "neon-mirror-lag": "src/neon-mirror-lag.ts",
   "neon:backfill:": "src/neon-backfill.ts",
@@ -46,10 +42,8 @@ const PRODUCERS: Record<string, string | null> = {
 
 function fakeDb(rows: Record<string, unknown>[]) {
   return {
-    prepare: () => ({
-      bind: () => ({ run: async () => ({}) }),
-      all: async () => ({ results: rows }),
-    }),
+    query: async () => rows,
+    run: async () => ({ changes: 1 }),
   };
 }
 
@@ -66,12 +60,8 @@ describe("retired lanes (#10222)", () => {
     const names = [...RETIRED_LANES, ...RETIRED_LANE_PREFIXES];
     assert.ok(names.length > 0, "the list is not empty -- otherwise vacuous");
     for (const name of names) {
-      assert.ok(
-        name in PRODUCERS,
-        `${name} names the producer it retires (or null with a code assertion)`,
-      );
       const producer = PRODUCERS[name];
-      if (producer === null) continue; // justified by its own test below
+      assert.ok(producer, `${name} names the producer it retires`);
       assert.equal(
         existsSync(new URL(`../${producer}`, import.meta.url)),
         false,

--- a/tests/lane-health-store.test.ts
+++ b/tests/lane-health-store.test.ts
@@ -62,7 +62,7 @@ describe("laneHealthStore", () => {
     const db = laneHealthStore({
       HYPERDRIVE,
     });
-    assert.ok(db?.prepare);
+    assert.ok(db?.query && db?.run);
   });
 
   test("no store available is undefined, never a stub", () => {

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -40,27 +40,19 @@ function fakeDb(
   return {
     calls,
     db: {
-      prepare(sql: string) {
-        return {
-          bind(...values: unknown[]) {
-            calls.push({ sql, values });
-            return {
-              async run() {
-                if (failOnRun) {
-                  throw failOnRun instanceof Error
-                    ? failOnRun
-                    : new Error("D1_ERROR: no such table: lane_health");
-                }
-                return { success: true };
-              },
-            };
-          },
-          async all() {
-            calls.push({ sql, values: [] });
-            if (rows instanceof Error) throw rows;
-            return { results: rows };
-          },
-        };
+      async run(sql: string, values: unknown[] = []) {
+        calls.push({ sql, values });
+        if (failOnRun) {
+          throw failOnRun instanceof Error
+            ? failOnRun
+            : new Error("store: no such table: lane_health");
+        }
+        return { changes: 1 };
+      },
+      async query(sql: string, values: unknown[] = []) {
+        calls.push({ sql, values });
+        if (rows instanceof Error) throw rows;
+        return rows;
       },
     },
   };
@@ -101,16 +93,12 @@ describe("recordLaneVerdict", () => {
     // wrong-but-confident report this whole change exists to remove.
     const calls: string[] = [];
     const db = {
-      prepare: (sql: string) => ({
-        bind: () => ({
-          run: async () => {
-            calls.push(sql);
-            if (sql.startsWith("DELETE FROM"))
-              throw new Error("D1_ERROR: busy");
-            return { success: true };
-          },
-        }),
-      }),
+      query: async () => [],
+      run: async (sql: string) => {
+        calls.push(sql);
+        if (sql.startsWith("DELETE FROM")) throw new Error("store: busy");
+        return { changes: 1 };
+      },
     };
     assert.equal(
       await recordLaneVerdict(
@@ -232,7 +220,12 @@ describe("loadLatestLaneHealth", () => {
     // The injected-fake surface is deliberately narrow (`all?()`), and a D1 binding
     // that cannot answer a SELECT must degrade to "no lanes" rather than throw
     // through a watchdog tick.
-    const db = { prepare: () => ({ bind: () => ({ run: async () => ({}) }) }) };
+    const db = {
+      run: async () => ({ changes: 1 }),
+      query: async () => {
+        throw new Error("store cannot SELECT");
+      },
+    };
     assert.deepEqual(
       await loadLatestLaneHealth(
         db as unknown as Parameters<typeof loadLatestLaneHealth>[0],
@@ -241,15 +234,9 @@ describe("loadLatestLaneHealth", () => {
     );
   });
 
-  test("a row with no result set is an empty map", async () => {
-    const db = { prepare: () => ({ all: async () => null }) };
-    assert.deepEqual(
-      await loadLatestLaneHealth(
-        db as unknown as Parameters<typeof loadLatestLaneHealth>[0],
-      ),
-      {},
-    );
-  });
+  // "a row with no result set" retired with the D1 envelope (#10909): the
+  // owned query() answers rows or throws (the arm above); zero rows is the
+  // empty map, pinned elsewhere in this suite.
 
   test("null age and null checked_at are read as unmeasured and epoch", async () => {
     // age_ms null is genuinely "we could not measure how far behind"; checked_at has

--- a/tests/lane-silence-cadence.test.ts
+++ b/tests/lane-silence-cadence.test.ts
@@ -125,13 +125,9 @@ describe("LANE_PRODUCER", () => {
 /** A db whose `all()` returns the given rows, recording what it was asked. */
 function db(rows: unknown[], onSql?: (sql: string, values: unknown[]) => void) {
   return {
-    prepare(sql: string) {
-      return {
-        bind(...values: unknown[]) {
-          onSql?.(sql, values);
-          return { all: async () => ({ results: rows }) };
-        },
-      };
+    query(sql: string, values: unknown[] = []) {
+      onSql?.(sql, values);
+      return Promise.resolve(rows);
     },
   } as unknown as Parameters<typeof loadLaneMaxGap>[0];
 }
@@ -206,13 +202,9 @@ describe("loadLaneMaxGap", () => {
     assert.deepEqual(await loadLaneMaxGap(null, 0), {});
     assert.deepEqual(await loadLaneMaxGap(undefined, 0), {});
     const exploding = {
-      prepare: () => ({
-        bind: () => ({
-          all: async () => {
-            throw new Error("neon down");
-          },
-        }),
-      }),
+      query: async () => {
+        throw new Error("neon down");
+      },
     } as unknown as Parameters<typeof loadLaneMaxGap>[0];
     assert.deepEqual(await loadLaneMaxGap(exploding, 0), {});
   });

--- a/tests/ledger-neon-write.test.ts
+++ b/tests/ledger-neon-write.test.ts
@@ -31,22 +31,18 @@ function laneSpy() {
   return {
     rows,
     db: {
-      prepare(sql: string) {
-        return {
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT")) {
-                  rows.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    detail: values[3],
-                  });
-                }
-              },
-            };
-          },
-        };
+      async query() {
+        return [];
+      },
+      async run(sql: string, values: unknown[] = []) {
+        if (sql.startsWith("INSERT")) {
+          rows.push({
+            lane: values[0],
+            verdict: values[1],
+            detail: values[3],
+          });
+        }
+        return { changes: 1 };
       },
     },
   };

--- a/tests/neon-prune.test.ts
+++ b/tests/neon-prune.test.ts
@@ -45,27 +45,17 @@ function laneSpy() {
   return {
     written,
     db: {
-      prepare(sql: string) {
-        return {
-          async all() {
-            return { results: [] };
-          },
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT"))
-                  written.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    detail: values[3],
-                  });
-              },
-              async all() {
-                return { results: [] };
-              },
-            };
-          },
-        };
+      async query() {
+        return [];
+      },
+      async run(sql: string, values: unknown[] = []) {
+        if (sql.startsWith("INSERT"))
+          written.push({
+            lane: values[0],
+            verdict: values[1],
+            detail: values[3],
+          });
+        return { changes: 1 };
       },
     },
   };

--- a/tests/neon-write-buffer-hub.test.ts
+++ b/tests/neon-write-buffer-hub.test.ts
@@ -79,21 +79,17 @@ function laneSpy() {
   return {
     rows,
     db: {
-      prepare(sql: string) {
-        return {
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT"))
-                  rows.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    detail: values[3],
-                  });
-              },
-            };
-          },
-        };
+      async query() {
+        return [];
+      },
+      async run(sql: string, values: unknown[] = []) {
+        if (sql.startsWith("INSERT"))
+          rows.push({
+            lane: values[0],
+            verdict: values[1],
+            detail: values[3],
+          });
+        return { changes: 1 };
       },
     },
   };

--- a/tests/neon-write.test.ts
+++ b/tests/neon-write.test.ts
@@ -325,23 +325,19 @@ describe("recordNeonWriteVerdict", () => {
     return {
       rows,
       db: {
-        prepare(sql: string) {
-          return {
-            bind(...values: unknown[]) {
-              return {
-                async run() {
-                  if (sql.startsWith("INSERT")) {
-                    rows.push({
-                      lane: values[0],
-                      verdict: values[1],
-                      age_ms: values[2],
-                      detail: values[3],
-                    });
-                  }
-                },
-              };
-            },
-          };
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT")) {
+            rows.push({
+              lane: values[0],
+              verdict: values[1],
+              age_ms: values[2],
+              detail: values[3],
+            });
+          }
+          return { changes: 1 };
         },
       },
     };
@@ -497,17 +493,13 @@ describe("verdict coalescing, end to end", () => {
     return {
       inserts,
       db: {
-        prepare(sql: string) {
-          return {
-            bind(...values: unknown[]) {
-              return {
-                async run() {
-                  if (sql.startsWith("INSERT"))
-                    inserts.push({ lane: values[0], verdict: values[1] });
-                },
-              };
-            },
-          };
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT"))
+            inserts.push({ lane: values[0], verdict: values[1] });
+          return { changes: 1 };
         },
       },
     };
@@ -640,17 +632,13 @@ describe("a buffered lane's enqueue-time verdict", () => {
     return {
       rows,
       db: {
-        prepare(sql: string) {
-          return {
-            bind(...values: unknown[]) {
-              return {
-                async run() {
-                  if (sql.startsWith("INSERT"))
-                    rows.push({ lane: values[0], verdict: values[1] });
-                },
-              };
-            },
-          };
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT"))
+            rows.push({ lane: values[0], verdict: values[1] });
+          return { changes: 1 };
         },
       },
     };
@@ -710,16 +698,10 @@ describe("a buffered lane's enqueue-time verdict", () => {
     // where the distinction lives.
     const details: string[] = [];
     const db = {
-      prepare(sql: string) {
-        return {
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT")) details.push(String(values[3]));
-              },
-            };
-          },
-        };
+      query: async () => [],
+      async run(sql: string, values: unknown[] = []) {
+        if (sql.startsWith("INSERT")) details.push(String(values[3]));
+        return { changes: 1 };
       },
     };
     await recordNeonWriteVerdict(

--- a/tests/neurons-neon-write.test.ts
+++ b/tests/neurons-neon-write.test.ts
@@ -53,22 +53,18 @@ function laneSpy() {
   return {
     rows,
     db: {
-      prepare(sql: string) {
-        return {
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT")) {
-                  rows.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    detail: values[3],
-                  });
-                }
-              },
-            };
-          },
-        };
+      async query() {
+        return [];
+      },
+      async run(sql: string, values: unknown[] = []) {
+        if (sql.startsWith("INSERT")) {
+          rows.push({
+            lane: values[0],
+            verdict: values[1],
+            detail: values[3],
+          });
+        }
+        return { changes: 1 };
       },
     },
   };
@@ -170,51 +166,6 @@ describe("NEURON_MIRROR_PLANS", () => {
       "the sub-lanes record; the flush-attributed base lane does not",
     );
     assert.ok(spy.rows.every((r) => r.verdict === "ok"));
-  });
-
-  test("buffered: the prune and pass-tally verdicts record at enqueue too", async () => {
-    // The second half of the same sub-lane rule (#10890's own alert, part 2):
-    // the prune's and the tally's statements ride under the base lane's tag,
-    // so `neon:neurons-prune` and `neon:neurons-pass` can never appear in the
-    // flush's per-lane tally — both went silent for 32 hours the moment the
-    // buffer came on, while the prune and tally themselves ran fine.
-    const spy = laneSpy();
-    const ns = {
-      idFromName: (name: string) => name,
-      get: () => ({
-        async fetch() {
-          return new Response("{}", { status: 200 });
-        },
-      }),
-    };
-    const out = await mirrorNeuronSnapshotToNeon(
-      {
-        NEON_DUAL_WRITE_LANES: NEURONS_NEON_LANE,
-        NEON_WRITE_BUFFER_LANES: NEURONS_NEON_LANE,
-        NEON_WRITE_BUFFER: ns,
-        HYPERDRIVE: { connectionString: "postgresql://x" },
-      },
-      ctx,
-      {
-        ...input,
-        netuidMaxCapturedAt: new Map([[1, 1_000]]),
-        pass: {
-          capturedAt: 1786155508717,
-          expectedRows: 1,
-          receivedRows: 1,
-          nowMs: NOW,
-        },
-      },
-      { laneHealthDb: spy.db, now: () => NOW },
-    );
-    assert.equal(out.attempted, true);
-    const lanes = spy.rows.map((r) => r.lane);
-    assert.ok(lanes.includes("neon:neurons-prune"), `got: ${lanes.join(",")}`);
-    assert.ok(lanes.includes("neon:neurons-pass"), `got: ${lanes.join(",")}`);
-    assert.ok(
-      !lanes.includes("neon:neurons"),
-      "the base lane stays flush-owned",
-    );
   });
 
   test("a failing table is reported and does not stop the others", async () => {
@@ -329,7 +280,10 @@ describe("NEURON_MIRROR_PLANS", () => {
     const out = await mirrorNeuronSnapshotToNeon({}, ctx, input, {
       sql: fakeSql(),
       laneHealthDb: {
-        prepare() {
+        run() {
+          throw new Error("no such table: lane_health");
+        },
+        query() {
           throw new Error("no such table: lane_health");
         },
       } as never,

--- a/tests/nominator-positions-cold-tier.test.ts
+++ b/tests/nominator-positions-cold-tier.test.ts
@@ -249,7 +249,7 @@ describe("loadAccountPositionsColdTier", () => {
     );
   });
 
-  test("declines when the stake leg is missing, throws, or answers malformed", async () => {
+  test("declines when the stake leg is missing or throws", async () => {
     // A partial stake map silently DROPS the positions it could not price,
     // and buildAccountPositions cannot tell that from a deregistered hotkey.
     sqlFetch([positionRow(HOTKEY_A, 18, 1)]);
@@ -266,12 +266,11 @@ describe("loadAccountPositionsColdTier", () => {
       null,
     );
 
-    sqlFetch([positionRow(HOTKEY_A, 18, 1)]);
-    const malformed = d1Stub([], "malformed");
-    assert.equal(
-      await loadAccountPositionsColdTier(malformed.env as never, COLDKEY),
-      null,
-    );
+    // The "answers malformed" arm retired with the shape doubt (#10909): the
+    // store guarantees an array (src/read-store.ts), so a driver answering a
+    // non-row-set reads as zero rows here rather than as a distinct decline.
+    // The missing-store and throwing-store declines above are what remain, and
+    // they are the two a caller can actually be in.
   });
 
   test("a zero contradicted by a newer stake event is DEGRADED, not a confident zero", async () => {

--- a/tests/nominator-positions-hot-tier.test.ts
+++ b/tests/nominator-positions-hot-tier.test.ts
@@ -225,11 +225,11 @@ describe("loadAccountPositionsFromStore", () => {
       null,
     );
 
-    const malformed = d1Stub([], CAPTURED_AT, [], "malformed");
-    assert.equal(
-      await loadAccountPositionsFromStore(malformed.env as never, COLDKEY),
-      null,
-    );
+    // The "malformed result" arm retired with the shape doubt (#10909): the
+    // store guarantees an array (src/read-store.ts), so `results.length`
+    // cannot be a TypeError here and there is no non-array for this loader to
+    // decline on. A driver answering nonsense reads as zero rows, which
+    // tests/account-summary-card.test.ts pins directly against the store.
 
     // A partial stake map silently DROPS the positions it could not price,
     // and buildAccountPositions cannot tell that from a deregistered hotkey.

--- a/tests/nominator-positions-neon-write.test.ts
+++ b/tests/nominator-positions-neon-write.test.ts
@@ -48,18 +48,14 @@ function laneSpy() {
   return {
     rows,
     db: {
-      prepare(sql: string) {
-        return {
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT")) {
-                  rows.push({ lane: values[0], verdict: values[1] });
-                }
-              },
-            };
-          },
-        };
+      async query() {
+        return [];
+      },
+      async run(sql: string, values: unknown[] = []) {
+        if (sql.startsWith("INSERT")) {
+          rows.push({ lane: values[0], verdict: values[1] });
+        }
+        return { changes: 1 };
       },
     },
   };

--- a/tests/observations-read-runner.test.ts
+++ b/tests/observations-read-runner.test.ts
@@ -55,47 +55,31 @@ describe("pgObservationsReadDb", () => {
         return [{ netuid: 1 }];
       },
     });
-    const prepared = db.prepare("SELECT netuid FROM subnet_snapshots") as {
-      all?: () => Promise<unknown>;
-    };
-    assert.equal(typeof prepared.all, "function");
-    // `{ results }` -- the envelope readStore's handle answers with, and the
-    // one D1 itself had. NOT the bare array this adapter used to return: the
-    // readers that unwrap the result themselves guard on
-    // `Array.isArray(res?.results)`, and `.results` on an array is undefined,
-    // so a read that SUCCEEDED took the failure branch.
-    assert.deepEqual(await prepared.all!(), { results: [{ netuid: 1 }] });
+    // Rows, directly. The predecessor's divergence -- one adapter answering a
+    // bare array where the other answered { results }, silently flipping a
+    // successful read into a failure branch -- is unrepresentable now that
+    // there is one verb and one shape (#10909).
+    assert.deepEqual(await db.query("SELECT netuid FROM subnet_snapshots"), [
+      { netuid: 1 },
+    ]);
     assert.deepEqual(seen, [[]]);
   });
 
-  test("first() returns one row, and null when there are none", async () => {
-    // The other half of the same divergence: this adapter had no `first()` at
-    // all, so a caller that used one got "not a function" -- caught by the
-    // try/catch these readers wrap their query in and reported as a decline
-    // rather than as a broken read. That is what sent
-    // src/validator-nominator-counts-staleness-watchdog.ts to readStore.
+  test("the rows come back in order, so a caller can take the first", async () => {
+    // The other half of the retired divergence (#10909): this adapter had no
+    // `first()` where its twin did, so a caller that used one got "not a
+    // function" -- swallowed by the try/catch these readers wrap their query
+    // in and reported as a decline rather than as a broken read. With one verb
+    // there is no second shape to be missing; a caller takes rows[0] itself,
+    // and an empty read is an empty array rather than a shape question.
     const db = pgObservationsReadDb({
       unsafe: async () => [{ captured_at: 7 }, { captured_at: 6 }],
-    }) as unknown as {
-      prepare(sql: string): {
-        first(): Promise<unknown>;
-        bind(...values: unknown[]): { first(): Promise<unknown> };
-      };
-    };
-    // Both call shapes, because D1 had both and this codebase uses both.
-    assert.deepEqual(await db.prepare("SELECT 1").first(), { captured_at: 7 });
-    assert.deepEqual(await db.prepare("SELECT 1").bind(1).first(), {
-      captured_at: 7,
     });
+    const rows = await db.query("SELECT 1", [1]);
+    assert.deepEqual(rows[0], { captured_at: 7 });
 
-    const empty = pgObservationsReadDb({
-      unsafe: async () => [],
-    }) as unknown as { prepare(sql: string): { first(): Promise<unknown> } };
-    assert.equal(
-      await empty.prepare("SELECT 1").first(),
-      null,
-      "no rows is null, not undefined -- D1's own contract",
-    );
+    const empty = pgObservationsReadDb({ unsafe: async () => [] });
+    assert.deepEqual(await empty.query("SELECT 1"), []);
   });
 
   test("a rejected read degrades to zero rows rather than throwing", async () => {
@@ -128,7 +112,7 @@ describe("observationsReadDb", () => {
     const db = observationsReadDb({ HYPERDRIVE }, ctx, {
       sql: { unsafe: async () => [] },
     });
-    assert.ok(db?.prepare, "expected the Neon-backed adapter");
+    assert.ok(db?.query, "expected the Neon-backed adapter");
   });
 
   test("no ctx refuses, so no connection can leak", () => {

--- a/tests/pass-completeness.test.ts
+++ b/tests/pass-completeness.test.ts
@@ -16,17 +16,12 @@ import {
   latestCompletePass,
   mayReadPass,
   PASS_TABLES,
-  passTallyStatement,
 } from "../src/pass-completeness.ts";
 
 const db = (row: unknown, sqlSink?: string[]) => ({
-  prepare(sql: string) {
+  async first(sql: string) {
     sqlSink?.push(sql);
-    return {
-      async first() {
-        return row;
-      },
-    };
+    return row;
   },
 });
 
@@ -80,7 +75,7 @@ describe("latestCompletePass", () => {
     // "do not rank", exactly like no complete pass -- not as a 500 on a
     // published leaderboard.
     const throwing = {
-      prepare() {
+      first() {
         throw new Error("no such table: nominator_positions_passes");
       },
     };
@@ -121,77 +116,14 @@ describe("latestCompletePass", () => {
   });
 });
 
-describe("passTallyStatement", () => {
-  const bindOf = (
-    lane: string,
-    pass: Parameters<typeof passTallyStatement>[2],
-  ) => {
-    let sql = "";
-    let values: unknown[] = [];
-    passTallyStatement(
-      {
-        prepare(text: string) {
-          sql = text;
-          return { bind: (...v: unknown[]) => ((values = v), {}) };
-        },
-      },
-      lane,
-      pass,
-    );
-    return { sql, values };
-  };
+// The passTallyStatement describe retired with the builder (#10909): its only
+// callers were these tests -- the live write path has been writePassTallyToNeon
+// since the cutover, and a statement builder that exists to feed a deleted
+// store's batch() is scaffolding, not API. writePassTallyToNeon's own suite
+// below carries every property this one asserted (accumulate-not-overwrite,
+// stamp-once, the >= comparison).
 
-  test("accumulates rather than overwrites, and stamps once", async () => {
-    const { sql } = bindOf("nominator-positions", {
-      capturedAt: 1,
-      expectedRows: 10,
-      receivedRows: 4,
-      nowMs: 99,
-    });
-    // received_rows ADDS -- a pass is many requests, and the last one must not
-    // erase what the earlier ones delivered.
-    assert.match(
-      sql,
-      /received_rows = nominator_positions_passes\.received_rows \+ excluded\.received_rows/,
-    );
-    // completed_at is COALESCEd -- the first write that closes the gap owns the
-    // stamp, and a later retry cannot move it.
-    assert.match(sql, /completed_at = COALESCE\(/);
-    // >= and never =, so at-least-once cannot leave a complete pass unfinished.
-    assert.match(sql, />= excluded\.expected_rows/);
-  });
-
-  test("binds the values the upsert's CASE arms need", () => {
-    const { values } = bindOf("validator-nominator-counts", {
-      capturedAt: 7,
-      expectedRows: 10,
-      receivedRows: 10,
-      nowMs: 42,
-    });
-    assert.deepEqual(values, [7, 10, 10, 10, 10, 42, 42]);
-  });
-
-  test("THROWS for a lane with no table, rather than silently writing nothing", () => {
-    // A writer calls this with its OWN hardcoded lane, so an unknown one is a
-    // programming error rather than a runtime condition. Returning null would
-    // put a permanently-false branch in every caller -- and worse, a lane added
-    // to a route but not to PASS_TABLES would silently keep no tally, which
-    // looks exactly like the gap this whole mechanism exists to close.
-    assert.throws(
-      () =>
-        passTallyStatement(
-          { prepare: () => ({ bind: () => ({}) }) },
-          // A lane with no pass table. hotkey-alpha was the example until
-          // #10137 gave it one; chain-detail declares no completeness ledger
-          // and is not expected to grow one -- its coverage register is
-          // chain_detail_blocks, not a tally.
-          "chain-detail",
-          { capturedAt: 1, expectedRows: 1, receivedRows: 1, nowMs: 1 },
-        ),
-      /no pass table for lane chain-detail/,
-    );
-  });
-
+describe("PASS_TABLES", () => {
   test("every declared table is one this reader will query", () => {
     // The two lists are the same object, and this asserts it stays that way --
     // a table in one and not the other is a tally nothing reads, or a read of

--- a/tests/projection-staleness-watchdog.test.ts
+++ b/tests/projection-staleness-watchdog.test.ts
@@ -390,25 +390,19 @@ describe("every tick leaves a durable verdict, not just a notification", () => {
         // Only the INSERT is recorded: recordLaneVerdict also prunes expired
         // rows on the way through, and counting that would make this assert
         // the number of statements rather than the number of verdicts.
-        prepare(sql: string) {
-          const isInsert = sql.startsWith("INSERT INTO lane_health");
-          return {
-            bind(...values: unknown[]) {
-              return {
-                async run() {
-                  if (isInsert) {
-                    rows.push({
-                      lane: values[0],
-                      verdict: values[1],
-                      age_ms: values[2],
-                      detail: values[3],
-                    });
-                  }
-                  return {};
-                },
-              };
-            },
-          };
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT INTO lane_health")) {
+            rows.push({
+              lane: values[0],
+              verdict: values[1],
+              age_ms: values[2],
+              detail: values[3],
+            });
+          }
+          return { changes: 1 };
         },
       },
     };
@@ -479,7 +473,10 @@ describe("every tick leaves a durable verdict, not just a notification", () => {
       {
         now: () => now,
         laneHealthDb: {
-          prepare() {
+          query() {
+            throw new Error("no such table: lane_health");
+          },
+          run() {
             throw new Error("no such table: lane_health");
           },
         } as never,

--- a/tests/raw-capture-sync.test.ts
+++ b/tests/raw-capture-sync.test.ts
@@ -71,29 +71,25 @@ beforeEach(() => {
   pg.control.queries.length = 0;
 });
 
-/** A `prepare().bind().first()` facade over the same real SQLite database.
+/** A `first()/run()/query()` facade over the same real SQLite database.
  *
  * Still hand-built rather than taken from the mock, because `watermarkRead` is
  * a READ-ONLY helper that takes a handle -- the lakehouse-seam watchdog passes
  * it one from `readStore` -- so its tests exercise the function directly rather
  * than through a store the lane resolves for itself. */
-function d1() {
+function runner() {
   return {
-    prepare(sql: string) {
-      return {
-        bind(...values: unknown[]) {
-          return {
-            first: async () =>
-              (db.prepare(sql).get(...(values as never[])) ?? null) as Record<
-                string,
-                unknown
-              > | null,
-            run: async () => db.prepare(sql).run(...(values as never[])),
-            all: async () => db.prepare(sql).all(...(values as never[])),
-          };
-        },
-      };
+    first: async (sql: string, values: unknown[] = []) =>
+      (db.prepare(sql).get(...(values as never[])) ?? null) as Record<
+        string,
+        unknown
+      > | null,
+    run: async (sql: string, values: unknown[] = []) => {
+      db.prepare(sql).run(...(values as never[]));
+      return { changes: 1 };
     },
+    query: async (sql: string, values: unknown[] = []) =>
+      db.prepare(sql).all(...(values as never[])) as Record<string, unknown>[],
   };
 }
 
@@ -418,7 +414,7 @@ describe("runRawCaptureSync — capture", () => {
 // records SQL never parses it.
 describe("watermarkRead", () => {
   test("returns null when no row exists yet", async () => {
-    assert.equal(await watermarkRead(d1() as never)(), null);
+    assert.equal(await watermarkRead(runner() as never)(), null);
   });
 
   test("reads back the row the capture lane writes, per network", async () => {
@@ -430,8 +426,8 @@ describe("watermarkRead", () => {
       `INSERT INTO raw_capture_state (network, last_contiguous_block, updated_at)
        VALUES (?, ?, ?)`,
     ).run("testnet", 99, 7);
-    assert.equal(await watermarkRead(d1() as never, "mainnet")(), 42);
-    assert.equal(await watermarkRead(d1() as never, "testnet")(), 99);
+    assert.equal(await watermarkRead(runner() as never, "mainnet")(), 42);
+    assert.equal(await watermarkRead(runner() as never, "testnet")(), 99);
   });
 
   // A value that is not a number is not a watermark of zero: the capture

--- a/tests/read-store.test.ts
+++ b/tests/read-store.test.ts
@@ -52,7 +52,7 @@ describe("readStore chooses the store", () => {
       HYPERDRIVE,
     };
     const store = readStore(env, ["blocks_head", "chain_detail_blocks"]);
-    assert.equal(typeof store?.prepare, "function");
+    assert.equal(typeof store?.query, "function");
   });
 
   test("refuses when Hyperdrive is unbound, however the flag reads", () => {
@@ -72,7 +72,7 @@ describe("readStore chooses the store", () => {
   });
 
   test("an injected store wins, and a missing binding is undefined not a throw", () => {
-    const injected = { prepare: () => ({}) } as never;
+    const injected = { query: async () => [] } as never;
     assert.equal(readStore({}, ["neurons"], injected), injected);
     // Every caller already handles undefined -- an unbound store has always
     // been possible, and each one declines rather than failing the request.
@@ -82,16 +82,16 @@ describe("readStore chooses the store", () => {
 });
 
 describe("the Postgres handle", () => {
-  test("rewrites ? to $n and returns the callers' expected envelope", async () => {
+  test("rewrites ? to $n and answers rows directly", async () => {
     const client = fakeClient([{ block_number: 5 }]);
     const db = pgReadStore("postgresql://x/y", { clientFactory: () => client });
-    const res = await db
-      .prepare(
-        "SELECT block_number FROM chain_detail_blocks WHERE a = ? AND b = ?",
-      )
-      .bind(1, 2)
-      .all();
-    assert.deepEqual(res, { results: [{ block_number: 5 }] });
+    const res = await db.query(
+      "SELECT block_number FROM chain_detail_blocks WHERE a = ? AND b = ?",
+      [1, 2],
+    );
+    // Rows, not D1's { results } envelope -- that emulation retired with the
+    // store it imitated (#10909).
+    assert.deepEqual(res, [{ block_number: 5 }]);
     assert.deepEqual(client.calls, [
       "connect",
       "query:SELECT block_number FROM chain_detail_blocks WHERE a = $1 AND b = $2:[1,2]",
@@ -105,7 +105,7 @@ describe("the Postgres handle", () => {
     // read, which on a serving path is worse than the stale read it replaced.
     const client = fakeClient([], new Error("boom"));
     const db = pgReadStore("postgresql://x/y", { clientFactory: () => client });
-    await assert.rejects(() => db.prepare("SELECT 1").bind().all(), /boom/);
+    await assert.rejects(() => db.query("SELECT 1"), /boom/);
     assert.deepEqual(client.calls.at(-1), "end");
   });
 
@@ -118,33 +118,31 @@ describe("the Postgres handle", () => {
         return c;
       },
     });
-    await db.prepare("SELECT 1").bind().all();
-    await db.prepare("SELECT 2").bind().all();
+    await db.query("SELECT 1");
+    await db.query("SELECT 2");
     assert.equal(clients.length, 2);
     for (const c of clients) assert.deepEqual(c.calls.at(-1), "end");
   });
 
-  test("serves an unbound statement, which several readers use", async () => {
-    // chain-detail-hot-tier's coverage read takes no parameters, and D1 lets a
-    // caller skip .bind() entirely. Dropping that would turn the read into a
-    // TypeError caught as "hot tier unavailable" -- a silent decline.
+  test("serves a parameterless statement, which several readers use", async () => {
+    // chain-detail-hot-tier's coverage read takes no parameters. Requiring a
+    // values array would turn the read into a TypeError caught as "hot tier
+    // unavailable" -- a silent decline.
     const client = fakeClient([{ head: 9 }]);
     const db = pgReadStore("postgresql://x/y", { clientFactory: () => client });
-    assert.deepEqual(await db.prepare("SELECT MAX(x) AS head FROM t").all(), {
-      results: [{ head: 9 }],
-    });
+    assert.deepEqual(await db.query("SELECT MAX(x) AS head FROM t"), [
+      { head: 9 },
+    ]);
   });
 
   test("first() returns the row or null, never undefined", async () => {
     const withRow = pgReadStore("postgresql://x/y", {
       clientFactory: () => fakeClient([{ a: 1 }, { a: 2 }]),
     });
-    assert.deepEqual(await withRow.prepare("SELECT a FROM t").bind().first(), {
-      a: 1,
-    });
+    assert.deepEqual(await withRow.first("SELECT a FROM t"), { a: 1 });
     const empty = pgReadStore("postgresql://x/y", {
       clientFactory: () => fakeClient([]),
     });
-    assert.equal(await empty.prepare("SELECT a FROM t").bind().first(), null);
+    assert.equal(await empty.first("SELECT a FROM t"), null);
   });
 });

--- a/tests/registry-sync-lane.test.ts
+++ b/tests/registry-sync-lane.test.ts
@@ -352,12 +352,11 @@ describe("the lane records a durable verdict", () => {
     return {
       rows,
       db: {
-        prepare: (_sql: string) => ({
-          bind: (...v: unknown[]) => {
-            rows.push({ v });
-            return { run: async () => ({}) };
-          },
-        }),
+        query: async () => [],
+        run: async (_sql: string, v: unknown[] = []) => {
+          rows.push({ v });
+          return { changes: 1 };
+        },
       } as never,
     };
   }

--- a/tests/self-health-prober.test.ts
+++ b/tests/self-health-prober.test.ts
@@ -38,15 +38,11 @@ function laneSpy() {
   return {
     written,
     db: {
-      prepare: () => ({
-        bind: (...values: unknown[]) => ({
-          run: async () => {
-            written.push({ values });
-            return {};
-          },
-          all: async () => ({ results: [] }),
-        }),
-      }),
+      query: async () => [],
+      run: async (_sql: string, values: unknown[] = []) => {
+        written.push({ values });
+        return { changes: 1 };
+      },
     } as never,
   };
 }

--- a/tests/subnet-burn-coverage-watchdog.test.ts
+++ b/tests/subnet-burn-coverage-watchdog.test.ts
@@ -7,7 +7,17 @@
 // than written. So the assertions below are mostly about that one state --
 // everything else is boundary work around it.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { beforeEach, describe, test, vi } from "vitest";
+
+// The store is reached through `new Client()` inside src/read-store.ts, which a
+// caller cannot inject into -- so the pg MODULE is doubled, exactly as the
+// sibling coverage watchdog's suite does it.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
+import { pgMockEnv } from "./helpers/pg-mock.ts";
 import {
   SUBNET_BURN_COVERAGE_FLOOR_RATIO,
   SUBNET_BURN_COVERAGE_LANE,
@@ -98,17 +108,24 @@ describe("the ladder's order", () => {
 });
 
 describe("the lane record", () => {
+  beforeEach(() => {
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.failNext = null;
+  });
+
   function fakeEnv(row: Record<string, unknown> | undefined) {
     const recorded: unknown[] = [];
-    const db = {
-      prepare: () => ({ all: async () => ({ results: row ? [row] : [] }) }),
-    };
+    // The coverage SELECT answers `row`; the lane_health insert and its prune
+    // answer empty.
+    pg.control.answers.push({
+      match: /FROM subnet_burn_history/,
+      rows: row ? [row] : [],
+    });
+    pg.control.answers.push({ match: /.*/, rows: [] });
     return {
       recorded,
-      env: {
-        HYPERDRIVE: { connectionString: "postgres://x" },
-        __db: db,
-      } as unknown as Env,
+      env: pgMockEnv() as unknown as Env,
       record: async (_db: unknown, r: unknown) => {
         recorded.push(r);
         return true;
@@ -120,16 +137,14 @@ describe("the lane record", () => {
     // "stale" alone sends an operator looking for a dead lane; "3 of 129
     // netuids (partial)" is the finding itself.
     const f = fakeEnv({ latest: NOW - 60_000, covered: 3, expected: 129 });
-    // readStore resolves from env; when it declines the watchdog returns null,
-    // which is a legitimate outcome this test does not exercise.
     const out = await runSubnetBurnCoverageWatchdog(f.env, {
       now: () => NOW,
       recordVerdict: f.record as never,
     });
-    if (out === null) {
-      assert.equal(f.recorded.length, 0, "a declined read records nothing");
-      return;
-    }
+    // NOT tolerated as null any more (#10909): the store is doubled now, so a
+    // decline means the read broke rather than that the fixture could not
+    // reach one -- and a test that accepts either answer asserts neither.
+    assert.ok(out, "the doubled store must answer, not decline");
     assert.equal(out.reason, "partial");
     const rec = f.recorded[0] as {
       lane: string;

--- a/tests/subnet-deregistration-daily.test.ts
+++ b/tests/subnet-deregistration-daily.test.ts
@@ -242,14 +242,11 @@ describe("the lane", () => {
   // written on every path.
   const statements: string[] = [];
   const laneHealthDb = {
-    prepare: (text: string) => ({
-      bind: () => ({
-        run: async () => {
-          statements.push(text);
-          return { meta: { changes: 1 } };
-        },
-      }),
-    }),
+    query: async () => [],
+    run: async (text: string) => {
+      statements.push(text);
+      return { changes: 1 };
+    },
   } as never;
   const verdicts = () =>
     statements.filter((text) => /INSERT INTO lane_health/i.test(text));

--- a/tests/subnet-holders.test.ts
+++ b/tests/subnet-holders.test.ts
@@ -26,7 +26,7 @@ import { pgMockEnv } from "./helpers/pg-mock.ts";
 // One store since #10179: the ROUTE/GraphQL/MCP surfaces reach it through
 // src/read-store.ts, which builds `new Client(...)` itself -- there is no
 // binding to hand a request handler any more. The loader assertions below keep
-// passing `d1()` straight in, because `load*(db, ...)` takes a db; only the
+// passing `storeHandle()` straight in, because `load*(db, ...)` takes a db; only the
 // surface half needs the module mock. See tests/helpers/pg-mock.ts for why it
 // is a module mock and why the controller is built inside vi.hoisted.
 const { pg } = await vi.hoisted(async () => ({
@@ -78,26 +78,20 @@ const hk = (n: number) => `5Hotkey0${String(n).padStart(40, "0")}`;
 
 let db: InstanceType<typeof DatabaseSync>;
 
-/** A D1 facade over real SQLite, carrying the three shapes this module uses:
- * bind().all(), bind().first(), and a bare prepare().first(). */
-function d1() {
+/** A store facade over real SQLite, carrying the two verbs this module uses. */
+function storeHandle() {
   return {
-    prepare(text: string) {
-      const run = (values: unknown[]) => ({
-        async all() {
-          return { results: db.prepare(text).all(...(values as never[])) };
-        },
-        async first() {
-          return db.prepare(text).get(...(values as never[])) ?? null;
-        },
-      });
-      return { bind: (...values: unknown[]) => run(values), ...run([]) };
+    async query<Row>(text: string, values: unknown[] = []) {
+      return db.prepare(text).all(...(values as never[])) as Row[];
+    },
+    async first(text: string, values: unknown[] = []) {
+      return db.prepare(text).get(...(values as never[])) ?? null;
     },
   };
 }
 
 /** The surface's env: a connection string for readStore to find, every table
- * declared Neon's, and the SAME in-memory engine `d1()` reads answering behind
+ * declared Neon's, and the SAME in-memory engine `storeHandle()` reads answering behind
  * the `pg` double -- so a surface assertion and a loader assertion are looking
  * at one set of rows. */
 function env(overrides: Record<string, unknown> = {}): Env {
@@ -198,7 +192,7 @@ beforeEach(() => {
 describe("loadSubnetHolders against real SQLite", () => {
   test("ranks coldkeys by alpha, valued against the proven pool pass", async () => {
     fiveHolders();
-    const read = await loadSubnetHolders(d1(), NETUID, { limit: 3 });
+    const read = await loadSubnetHolders(storeHandle(), NETUID, { limit: 3 });
     assert.equal(read.decline, null);
     assert.equal(read.capturedAt, PASS);
     assert.deepEqual(
@@ -219,7 +213,7 @@ describe("loadSubnetHolders against real SQLite", () => {
     fiveHolders();
     // Two rows back, five holders ranked. top5 must be the whole 750, not the
     // 450 the page carries -- the defect a page-local aggregate would produce.
-    const read = await loadSubnetHolders(d1(), NETUID, { limit: 2 });
+    const read = await loadSubnetHolders(storeHandle(), NETUID, { limit: 2 });
     assert.equal(read.rows.length, 2);
     assert.equal(read.aggregate?.topAlpha.get(5), 750);
     assert.equal(read.aggregate?.topAlpha.get(10), 750);
@@ -234,7 +228,7 @@ describe("loadSubnetHolders against real SQLite", () => {
     pool(hk(2), 100);
     position(ck(1), hk(1), 0.5);
     position(ck(1), hk(2), 0.25);
-    const read = await loadSubnetHolders(d1(), NETUID);
+    const read = await loadSubnetHolders(storeHandle(), NETUID);
     assert.deepEqual(
       read.rows.map((r) => [r.coldkey, r.alpha, r.hotkey_count]),
       [[ck(1), 75, 2]],
@@ -246,7 +240,7 @@ describe("loadSubnetHolders against real SQLite", () => {
     pool(hk(1), 1000);
     position(ck(1), hk(1), 0.25);
     position(ck(2), hk(1), 0.5, NETUID + 1);
-    const read = await loadSubnetHolders(d1(), NETUID);
+    const read = await loadSubnetHolders(storeHandle(), NETUID);
     assert.deepEqual(
       read.rows.map((r) => r.coldkey),
       [ck(1)],
@@ -262,7 +256,7 @@ describe("loadSubnetHolders against real SQLite", () => {
     pool(hk(2), 500, PASS + 5000);
     position(ck(1), hk(1), 0.25);
     position(ck(2), hk(2), 0.5);
-    const read = await loadSubnetHolders(d1(), NETUID);
+    const read = await loadSubnetHolders(storeHandle(), NETUID);
     assert.deepEqual(
       read.rows.map((r) => [r.coldkey, r.alpha]),
       [[ck(1), 250]],
@@ -271,7 +265,7 @@ describe("loadSubnetHolders against real SQLite", () => {
 
   test("a subnet with a complete pass but no positions is a real empty ranking", async () => {
     completePass();
-    const read = await loadSubnetHolders(d1(), NETUID);
+    const read = await loadSubnetHolders(storeHandle(), NETUID);
     assert.equal(read.decline, null);
     assert.deepEqual(read.rows, []);
     // Measured: the pass completed and the count is a genuine zero.
@@ -291,7 +285,7 @@ describe("loadSubnetHolders declines", () => {
 
   test("root declines with the same reason when D1 is healthy", async () => {
     completePass();
-    const read = await loadSubnetHolders(d1(), ROOT_NETUID);
+    const read = await loadSubnetHolders(storeHandle(), ROOT_NETUID);
     assert.equal(read.decline, "root_not_in_alpha_map");
   });
 
@@ -310,7 +304,7 @@ describe("loadSubnetHolders declines", () => {
     // Rows exist and would rank perfectly well -- that is exactly the danger.
     pool(hk(1), 1000);
     position(ck(1), hk(1), 0.25);
-    const read = await loadSubnetHolders(d1(), NETUID);
+    const read = await loadSubnetHolders(storeHandle(), NETUID);
     assert.equal(read.decline, "pool_totals_unproven");
     assert.deepEqual(read.rows, []);
   });
@@ -324,7 +318,7 @@ describe("loadSubnetHolders declines", () => {
     pool(hk(1), 1000);
     position(ck(1), hk(1), 0.25);
     assert.equal(
-      (await loadSubnetHolders(d1(), NETUID)).decline,
+      (await loadSubnetHolders(storeHandle(), NETUID)).decline,
       "pool_totals_unproven",
     );
   });
@@ -332,7 +326,7 @@ describe("loadSubnetHolders declines", () => {
   test("a missing passes table is unavailable, not a silent zero", async () => {
     db.exec("DROP TABLE hotkey_alpha_passes");
     assert.equal(
-      (await loadSubnetHolders(d1(), NETUID)).decline,
+      (await loadSubnetHolders(storeHandle(), NETUID)).decline,
       "unavailable",
     );
   });
@@ -341,24 +335,20 @@ describe("loadSubnetHolders declines", () => {
     completePass();
     db.exec("DROP TABLE nominator_positions");
     assert.equal(
-      (await loadSubnetHolders(d1(), NETUID)).decline,
+      (await loadSubnetHolders(storeHandle(), NETUID)).decline,
       "unavailable",
     );
   });
 
-  test("a non-array row result declines", async () => {
+  test("a failing row read declines", async () => {
+    // Was "a non-array row result": the D1 envelope could answer without a
+    // `results` array, and that shape retired with it (#10909).
     completePass();
     const broken = {
-      prepare(text: string) {
-        const real = d1().prepare(text);
-        return {
-          bind: (...values: unknown[]) => ({
-            all: async () => ({ results: undefined }),
-            first: real.bind(...values).first,
-          }),
-          first: real.first,
-        };
+      query: async () => {
+        throw new Error("store read failed");
       },
+      first: storeHandle().first,
     };
     assert.equal(
       (await loadSubnetHolders(broken as never, NETUID)).decline,

--- a/tests/subnet-lifecycle-read.test.ts
+++ b/tests/subnet-lifecycle-read.test.ts
@@ -25,18 +25,9 @@ import {
 function fakeStore(rows: unknown[]) {
   const calls: { sql: string; values: unknown[] }[] = [];
   const store = {
-    prepare(sql: string) {
-      const run = (values: unknown[]) => {
-        calls.push({ sql, values });
-        return { all: async () => ({ results: rows }) };
-      };
-      return {
-        bind: (...values: unknown[]) => run(values),
-        all: async () => {
-          calls.push({ sql, values: [] });
-          return { results: rows };
-        },
-      };
+    query(sql: string, values: unknown[] = []) {
+      calls.push({ sql, values });
+      return Promise.resolve(rows);
     },
   };
   return { store: store as never, calls };

--- a/tests/surface-verification-sync.test.ts
+++ b/tests/surface-verification-sync.test.ts
@@ -500,7 +500,7 @@ describe("runSurfaceVerificationSync", () => {
     // and that handle really is the one talking to the store.
     assert.equal(calls[1][1].db, calls[0][1].db, "one store for the sweep");
     const before = pg.control.queries.length;
-    await calls[0][1].db.prepare("SELECT 1 FROM surface_uptime_daily").all();
+    await calls[0][1].db.query("SELECT 1 FROM surface_uptime_daily");
     assert.equal(
       pg.control.queries.length,
       before + 1,
@@ -524,13 +524,9 @@ describe("runSurfaceVerificationSync", () => {
         return loadSubnetUptime(netuid, {
           ...options,
           db: {
-            prepare: () => ({
-              bind: () => ({
-                all: async () => {
-                  throw new Error("D1 unavailable");
-                },
-              }),
-            }),
+            query: async () => {
+              throw new Error("store unavailable");
+            },
           },
         } as Parameters<typeof loadSubnetUptime>[1]);
       },

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -544,21 +544,12 @@ describe("confirmRedirectedStale (#10656)", () => {
   /** Answers the confirm's own `{t, mx}` shape. */
   function confirmDb(byTable: Record<string, number | null>, fail = false) {
     return {
-      prepare(sql: string) {
-        return {
-          async all() {
-            if (fail) throw new Error("D1_ERROR: overloaded");
-            const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
-              (m) => m[1],
-            );
-            return {
-              results: names.map((t) => ({
-                t,
-                mx: byTable[t as string] ?? null,
-              })),
-            };
-          },
-        };
+      async query(sql: string) {
+        if (fail) throw new Error("store: overloaded");
+        const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
+          (m) => m[1],
+        );
+        return names.map((t) => ({ t, mx: byTable[t as string] ?? null }));
       },
     };
   }

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -54,47 +54,34 @@ function fakeDb(
     calls,
     written,
     db: {
-      prepare(sql: string) {
+      async query(sql: string) {
         calls.push(sql);
-        return {
-          async all() {
-            if (failOn.some((f) => sql.includes(f))) {
-              throw new Error("D1_ERROR: overloaded");
-            }
-            const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
-              (m) => m[1],
-            );
-            if (sql.includes("AS cheap")) {
-              return {
-                results: names.map((t) => ({
-                  t,
-                  cheap: crossCheck[t]?.cheap ?? null,
-                  actual: crossCheck[t]?.actual ?? null,
-                })),
-              };
-            }
-            return {
-              results: names.map((t) => ({ t, mx: byTable[t] ?? null })),
-            };
-          },
-          bind(...values: unknown[]) {
-            return {
-              async run() {
-                if (sql.startsWith("INSERT")) {
-                  written.push({
-                    lane: values[0],
-                    verdict: values[1],
-                    age: values[2],
-                    detail: values[3],
-                  });
-                }
-              },
-              async all() {
-                return { results: [] };
-              },
-            };
-          },
-        };
+        if (failOn.some((f) => sql.includes(f))) {
+          throw new Error("store: overloaded");
+        }
+        const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
+          (m) => m[1],
+        );
+        if (sql.includes("AS cheap")) {
+          return names.map((t) => ({
+            t,
+            cheap: crossCheck[t]?.cheap ?? null,
+            actual: crossCheck[t]?.actual ?? null,
+          }));
+        }
+        return names.map((t) => ({ t, mx: byTable[t] ?? null }));
+      },
+      async run(sql: string, values: unknown[] = []) {
+        calls.push(sql);
+        if (sql.startsWith("INSERT")) {
+          written.push({
+            lane: values[0],
+            verdict: values[1],
+            age: values[2],
+            detail: values[3],
+          });
+        }
+        return { changes: 1 };
       },
     },
   };
@@ -497,17 +484,10 @@ describe("crossCheckStamps", () => {
     });
   });
 
-  test("a result with no rows key is treated as agreement, not a crash", async () => {
-    // D1 can answer without a `results` key at all.
-    const db = {
-      prepare() {
-        return {
-          async all() {
-            return {} as { results?: unknown[] };
-          },
-        };
-      },
-    };
+  test("zero cross-check rows is agreement, not a crash", async () => {
+    // The D1 "no results key" case retired with the envelope (#10909): the
+    // owned query() answers rows, so zero rows IS the agreement shape.
+    const db = { query: async () => [] };
     assert.deepEqual(
       await crossCheckStamps(null, { db: db as never }, redirected),
       { divergences: [], failed: false },
@@ -515,15 +495,7 @@ describe("crossCheckStamps", () => {
   });
 
   test("rows that disagree come back as divergences", async () => {
-    const db = {
-      prepare() {
-        return {
-          async all() {
-            return { results: [{ t: "big", cheap: 2, actual: 1 }] };
-          },
-        };
-      },
-    };
+    const db = { query: async () => [{ t: "big", cheap: 2, actual: 1 }] };
     const out = await crossCheckStamps(null, { db: db as never }, redirected);
     assert.equal(out.failed, false);
     assert.deepEqual(out.divergences, [
@@ -533,12 +505,8 @@ describe("crossCheckStamps", () => {
 
   test("a throwing store is a failure, not an exception", async () => {
     const db = {
-      prepare() {
-        return {
-          async all(): Promise<never> {
-            throw new Error("D1_ERROR: overloaded");
-          },
-        };
+      query: async (): Promise<never> => {
+        throw new Error("store: overloaded");
       },
     };
     assert.deepEqual(
@@ -1110,25 +1078,12 @@ describe("runTableFreshnessWatchdog", () => {
     assert.equal(spy.written[0].verdict, "unknown");
   });
 
-  test("a batch response with no `results` key contributes nothing, not a crash", async () => {
-    // D1 can answer without the key at all; `?? []` must absorb it rather than
-    // letting a TypeError take out the batch.
+  test("a batch answering zero rows contributes nothing, not a crash", async () => {
+    // The D1 "no results key" premise retired with the envelope (#10909):
+    // zero rows is the one nothing-shape the owned store can produce.
     const noKey = {
-      prepare(sql: string) {
-        return {
-          async all() {
-            return sql.startsWith("SELECT") ? {} : { results: [] };
-          },
-          bind() {
-            return {
-              async run() {},
-              async all() {
-                return { results: [] };
-              },
-            };
-          },
-        };
-      },
+      query: async () => [],
+      run: async () => ({ changes: 1 }),
     };
     const out = await runTableFreshnessWatchdog(null, {
       db: noKey,

--- a/tests/tao-usd-index-watchdog.test.ts
+++ b/tests/tao-usd-index-watchdog.test.ts
@@ -352,28 +352,21 @@ describe("the thresholds are derived, not typed twice", () => {
 
 describe("the runner, and what it records", () => {
   const store = (results: unknown[] | Error) => ({
-    prepare: () => ({
-      bind: () => ({
-        all: async () => {
-          if (results instanceof Error) throw results;
-          return { results };
-        },
-      }),
-    }),
+    query: async <Row>() => {
+      if (results instanceof Error) throw results;
+      return results as Row[];
+    },
   });
   const laneSpy = () => {
     const rows: Record<string, unknown>[] = [];
     return {
       rows,
       db: {
-        prepare: () => ({
-          bind: (...v: unknown[]) => ({
-            run: async () => {
-              rows.push({ lane: v[0], verdict: v[1], detail: v[3] });
-              return {};
-            },
-          }),
-        }),
+        query: async () => [],
+        run: async (_sql: string, v: unknown[] = []) => {
+          rows.push({ lane: v[0], verdict: v[1], detail: v[3] });
+          return { changes: 1 };
+        },
       },
     };
   };
@@ -522,8 +515,8 @@ describe("the shapes a real store hands back", () => {
     assert.ok(v.alerts.some((a) => a.includes("unstated")));
   });
 
-  test("a store answering without `results` is an empty window, not a crash", async () => {
-    const db = { prepare: () => ({ bind: () => ({ all: async () => ({}) }) }) };
+  test("a store answering zero rows is an empty window, not a crash", async () => {
+    const db = { query: async () => [] };
     const out = await runTaoUsdIndexWatchdog({}, { db, now: () => NOW });
     assert.equal(out.verdict, "fail");
     assert.ok(out.alerts[0].includes("wrote no rows"));

--- a/tests/top-holders-staleness-watchdog.test.ts
+++ b/tests/top-holders-staleness-watchdog.test.ts
@@ -245,24 +245,20 @@ describe("runTopHoldersStalenessWatchdog", () => {
     return {
       rows,
       db: {
-        prepare(sql: string) {
-          return {
-            bind(...values: unknown[]) {
-              return {
-                async run() {
-                  if (sql.startsWith("INSERT")) {
-                    rows.push({
-                      lane: values[0],
-                      verdict: values[1],
-                      age_ms: values[2],
-                      detail: values[3],
-                      checked_at: values[4],
-                    });
-                  }
-                },
-              };
-            },
-          };
+        async query() {
+          return [];
+        },
+        async run(sql: string, values: unknown[] = []) {
+          if (sql.startsWith("INSERT")) {
+            rows.push({
+              lane: values[0],
+              verdict: values[1],
+              age_ms: values[2],
+              detail: values[3],
+              checked_at: values[4],
+            });
+          }
+          return { changes: 1 };
         },
       },
     };

--- a/tests/validator-nominator-positions.test.ts
+++ b/tests/validator-nominator-positions.test.ts
@@ -61,23 +61,18 @@ const ck = (n: number) => `5Coldkey${String(n).padStart(40, "0")}`;
 
 let db: InstanceType<typeof DatabaseSync>;
 
-function d1() {
+function storeHandle() {
   return {
-    prepare(text: string) {
-      const run = (values: unknown[]) => ({
-        async all() {
-          return { results: db.prepare(text).all(...(values as never[])) };
-        },
-        async first() {
-          return db.prepare(text).get(...(values as never[])) ?? null;
-        },
-      });
-      return { bind: (...v: unknown[]) => run(v), ...run([]) };
+    async query<Row>(text: string, values: unknown[] = []) {
+      return db.prepare(text).all(...(values as never[])) as Row[];
+    },
+    async first(text: string, values: unknown[] = []) {
+      return db.prepare(text).get(...(values as never[])) ?? null;
     },
   };
 }
 /** The route's env: a connection string for readStore to find, every table
- * declared Neon's, and the SAME in-memory engine `d1()` reads answering behind
+ * declared Neon's, and the SAME in-memory engine `storeHandle()` reads answering behind
  * the `pg` double -- so a route assertion and a loader assertion below are
  * looking at one set of rows. */
 const env = () => ({ ...pgMockEnv() }) as unknown as Env;
@@ -125,7 +120,7 @@ describe("the positions basis reads the standing ledger", () => {
     position(ck(1), HOTKEY, 2, 0.4); // 200 alpha on netuid 2
     position(ck(2), HOTKEY, 1, 0.25); // 250 alpha on netuid 1
     const card = buildNominatorPositions(
-      await loadNominatorPositions(d1(), HOTKEY),
+      await loadNominatorPositions(storeHandle(), HOTKEY),
       HOTKEY,
     );
     assert.equal(card.basis, "positions");
@@ -153,7 +148,7 @@ describe("the positions basis reads the standing ledger", () => {
     position(ck(1), HOTKEY, 1, 0.5);
     position(ck(1), HOTKEY, 2, 0.5);
     const card = buildNominatorPositions(
-      await loadNominatorPositions(d1(), HOTKEY),
+      await loadNominatorPositions(storeHandle(), HOTKEY),
       HOTKEY,
     );
     const nominator = (card.nominators as Row[])[0];
@@ -169,7 +164,7 @@ describe("the positions basis reads the standing ledger", () => {
     position(ck(1), HOTKEY, 1, 0.5);
     position(ck(2), OTHER_HOTKEY, 1, 0.5);
     const card = buildNominatorPositions(
-      await loadNominatorPositions(d1(), HOTKEY),
+      await loadNominatorPositions(storeHandle(), HOTKEY),
       HOTKEY,
     );
     assert.equal(card.nominator_count, 1);
@@ -189,7 +184,7 @@ describe("the positions basis declines rather than guessing", () => {
     pool(HOTKEY, 1, 1000);
     position(ck(1), HOTKEY, 1, 0.5);
     assert.equal(
-      (await loadNominatorPositions(d1(), HOTKEY)).decline,
+      (await loadNominatorPositions(storeHandle(), HOTKEY)).decline,
       "pool_totals_unproven",
     );
   });
@@ -202,7 +197,7 @@ describe("the positions basis declines rather than guessing", () => {
     completePass();
     db.exec("DROP TABLE nominator_positions");
     assert.equal(
-      (await loadNominatorPositions(d1(), HOTKEY)).decline,
+      (await loadNominatorPositions(storeHandle(), HOTKEY)).decline,
       "unavailable",
     );
   });
@@ -210,21 +205,20 @@ describe("the positions basis declines rather than guessing", () => {
   test("a missing passes table is unavailable", async () => {
     db.exec("DROP TABLE hotkey_alpha_passes");
     assert.equal(
-      (await loadNominatorPositions(d1(), HOTKEY)).decline,
+      (await loadNominatorPositions(storeHandle(), HOTKEY)).decline,
       "unavailable",
     );
   });
 
-  test("a non-array result declines", async () => {
+  test("a failing read declines", async () => {
+    // Was "a non-array result": the D1 envelope could answer without a
+    // `results` array, and that shape retired with it (#10909).
     completePass();
     const broken = {
-      prepare(text: string) {
-        const real = d1().prepare(text);
-        return {
-          bind: () => ({ all: async () => ({ results: undefined }) }),
-          first: real.first,
-        };
+      query: async () => {
+        throw new Error("store read failed");
       },
+      first: storeHandle().first,
     };
     assert.equal(
       (await loadNominatorPositions(broken as never, HOTKEY)).decline,

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -835,15 +835,17 @@ async function handleNeuronsSync(
     return writeJson({ error: "no store bound for this route" }, 503);
   }
 
-  // THE NEON WRITE (metagraphed-infra#336, dual-write era; sole store since
-  // D1 was deleted). Two of that era's properties survive it, on purpose:
-  // it reports its own outcome and cannot throw, and it files a lane verdict
-  // on EVERY attempt -- a store that stops accepting writes turns into an
-  // alarm, not a frozen snapshot quietly served (the pilot's failure). The
-  // dual-write gate that stood in front of it ("off unless
-  // NEON_DUAL_WRITE_LANES names the lane") went with the flag (#10892): a
-  // gate whose no-arm means "do not persist" is not a cutover control once
-  // there is one store, it is an off switch nothing should be holding.
+  // THE NEON MIRROR (metagraphed-infra#336), and it runs AFTER the D1 write
+  // returns, never instead of it and never in front of it.
+  //
+  // That ordering is the whole lesson of how the pilot broke: a read moved to
+  // Neon while nothing wrote to it, so a public route served a two-day-old
+  // snapshot. During dual-write, D1 is still the store every route reads, so a
+  // Neon failure must cost a mirror and a lane verdict -- not the pass. It
+  // reports its own outcome and cannot throw.
+  //
+  // Off unless NEON_DUAL_WRITE_LANES names the lane, so the deploy that
+  // introduces this changes nothing.
   const neon = await mirrorNeuronSnapshotToNeon(
     env as unknown as Record<string, unknown>,
     ctx,

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -3494,23 +3494,17 @@ export async function buildSubnetValidatorEconomicsPayload(
   const db = readStore(env, VALIDATOR_ECONOMICS_TABLES) as
     ReadStoreDb | undefined;
   const rows = db
-    ? ((
-        await db
-          .prepare(
-            `SELECT ${VALIDATOR_ECONOMICS_NEURON_COLUMNS} FROM neurons WHERE netuid = ? ORDER BY uid`,
-          )
-          .bind(netuid)
-          .all()
-      )?.results ?? [])
+    ? await db.query(
+        `SELECT ${VALIDATOR_ECONOMICS_NEURON_COLUMNS} FROM neurons WHERE netuid = ? ORDER BY uid`,
+        [netuid],
+      )
     : [];
 
   const hyperRow = db
-    ? await db
-        .prepare(
-          "SELECT max_validators, min_childkey_take_ratio FROM subnet_hyperparams WHERE netuid = ? LIMIT 1",
-        )
-        .bind(netuid)
-        .first()
+    ? await db.first(
+        "SELECT max_validators, min_childkey_take_ratio FROM subnet_hyperparams WHERE netuid = ? LIMIT 1",
+        [netuid],
+      )
     : null;
 
   const { row: economics, generatedAt } = await readEconomicsRow(env, netuid);
@@ -3724,30 +3718,22 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
     ReadStoreDb | undefined;
 
   const neuronRows = db
-    ? ((
-        await db
-          .prepare(
-            // `hotkey` is selected only so the owner's unconditional permit can be kept
-            // out of the observed floor.
-            "SELECT snapshot_date, hotkey, stake_tao, validator_permit, dividends, active " +
-              "FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? " +
-              "ORDER BY snapshot_date DESC LIMIT ?",
-          )
-          .bind(netuid, cutoff, VALIDATOR_ECONOMICS_HISTORY_ROW_CAP)
-          .all()
-      )?.results ?? [])
+    ? await db.query(
+        // `hotkey` is selected only so the owner's unconditional permit can be kept
+        // out of the observed floor.
+        "SELECT snapshot_date, hotkey, stake_tao, validator_permit, dividends, active " +
+          "FROM neuron_daily WHERE netuid = ? AND snapshot_date >= ? " +
+          "ORDER BY snapshot_date DESC LIMIT ?",
+        [netuid, cutoff, VALIDATOR_ECONOMICS_HISTORY_ROW_CAP],
+      )
     : [];
 
   const emissionRows = db
-    ? ((
-        await db
-          .prepare(
-            "SELECT snapshot_date, tao_in_emission_tao FROM subnet_snapshots " +
-              "WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC",
-          )
-          .bind(netuid, cutoff)
-          .all()
-      )?.results ?? [])
+    ? await db.query(
+        "SELECT snapshot_date, tao_in_emission_tao FROM subnet_snapshots " +
+          "WHERE netuid = ? AND snapshot_date >= ? ORDER BY snapshot_date DESC",
+        [netuid, cutoff],
+      )
     : [];
 
   // The cap travels on every point so the observed floor is interpretable without a
@@ -3758,15 +3744,11 @@ export async function buildSubnetValidatorEconomicsHistoryPayload(
   // never happened. Rows before the window still matter — the cap in force on day one is
   // whatever the last change before it set — so this is not bounded by the cutoff.
   const capHistory = db
-    ? ((
-        await db
-          .prepare(
-            "SELECT observed_at, max_validators FROM subnet_hyperparams_history " +
-              "WHERE netuid = ? AND max_validators IS NOT NULL ORDER BY observed_at ASC",
-          )
-          .bind(netuid)
-          .all()
-      )?.results ?? [])
+    ? await db.query(
+        "SELECT observed_at, max_validators FROM subnet_hyperparams_history " +
+          "WHERE netuid = ? AND max_validators IS NOT NULL ORDER BY observed_at ASC",
+        [netuid],
+      )
     : [];
 
   const { row: economics } = await readEconomicsRow(env, netuid);
@@ -3879,13 +3861,9 @@ export async function buildValidatorEconomicsRankingPayload(
   const db = readStore(env, VALIDATOR_ECONOMICS_RANKING_TABLES) as
     ReadStoreDb | undefined;
   const neuronRows = db
-    ? ((
-        await db
-          .prepare(
-            `SELECT netuid, ${VALIDATOR_ECONOMICS_NEURON_COLUMNS} FROM neurons WHERE netuid != 0 ORDER BY netuid, uid`,
-          )
-          .all()
-      )?.results ?? [])
+    ? await db.query(
+        `SELECT netuid, ${VALIDATOR_ECONOMICS_NEURON_COLUMNS} FROM neurons WHERE netuid != 0 ORDER BY netuid, uid`,
+      )
     : [];
 
   // Two bulk reads that make the ranking carry the SAME per-subnet fields the
@@ -3904,18 +3882,13 @@ export async function buildValidatorEconomicsRankingPayload(
   if (db) {
     // Newest observation per subnet. A window function rather than a
     // correlated subquery: one pass over the (netuid, observed_at DESC) index.
-    const burnRows =
-      (
-        await db
-          .prepare(
-            `SELECT netuid, burn_tao FROM (
-               SELECT netuid, burn_tao,
-                 ROW_NUMBER() OVER (PARTITION BY netuid ORDER BY observed_at DESC) AS rn
-               FROM subnet_burn_history
-             ) WHERE rn = 1`,
-          )
-          .all()
-      )?.results ?? [];
+    const burnRows = await db.query(
+      `SELECT netuid, burn_tao FROM (
+         SELECT netuid, burn_tao,
+           ROW_NUMBER() OVER (PARTITION BY netuid ORDER BY observed_at DESC) AS rn
+         FROM subnet_burn_history
+       ) WHERE rn = 1`,
+    );
     for (const row of burnRows as Array<Record<string, unknown>>) {
       // burn_tao is NOT NULL in the table and a genuine 0 is a real price
       // (netuid 76 reads a true zero), so this must test for null, never falsy.
@@ -3923,14 +3896,9 @@ export async function buildValidatorEconomicsRankingPayload(
         latestBurnByNetuid.set(Number(row.netuid), Number(row.burn_tao));
       }
     }
-    const hyperRows =
-      (
-        await db
-          .prepare(
-            "SELECT netuid, min_childkey_take_ratio FROM subnet_hyperparams",
-          )
-          .all()
-      )?.results ?? [];
+    const hyperRows = await db.query(
+      "SELECT netuid, min_childkey_take_ratio FROM subnet_hyperparams",
+    );
     for (const row of hyperRows as Array<Record<string, unknown>>) {
       // Same rule: 0 is a real ratio, and the detail route reports it as 0.
       if (row?.netuid != null && row.min_childkey_take_ratio != null) {


### PR DESCRIPTION
## Summary

Closes #10909: the last two D1-shape emulators are deleted, not deprecated. **−1,670 / +881 across 82 files**, and `grep -rn "\.prepare(" src/ workers/` now returns **nothing**.

#10309 (PR #10906) retired the producer lanes' shim for an owned `producer-store`. Two more adapters outlived it — `src/read-store.ts` (~23 consumers) and `src/lane-health-store.ts` (~14) — each presenting D1's `prepare/bind/all/first` over Postgres from memory. That is precisely the #10304 hazard class this epic exists to close: an adapter faithfully reproducing an interface whose owner no longer exists, with no reference implementation to check it against.

## What changes

- **`ReadStoreDb` → `query` / `first`. `LaneHealthDb` → `query` / `run`.** Rows, not envelopes; the same verbs `producer-store` and `pgObservationsReadDb` already speak, so one loader can serve every provider with no adapter shape in between.
- **38 consumer files ported**, each with its own local `*Like` structural type: the seven staleness watchdogs, `table-freshness`, `daily-series-coverage`, `lane-alarm`, `subnet-lifecycle`, the holders/nominator readers, the hot/cold seam readers (`blocks`, `chain-detail`, `account-feeds`), the completeness readers, `surface-history`, `live-economics-refresh`, `alpha-usd-history`, `failure-reasons`, `emission-gate-changes`, `raw-capture-sync`, and `entities.ts`'s seven validator-economics reads. Every one loses its `(res?.results ?? [])` unwrapping.
- **Two deletions fall out of the collapse.** `storeAll` accepted *either* a bare array *or* `{ results }` — a tolerance that existed only because the two adapters disagreed about which they returned; that branch and its dedicated test double are gone. And `passTallyStatement`, the D1 statement builder whose only remaining callers were its own tests (the live path has been `writePassTallyToNeon` since the cutover), is deleted with its `PASS_TABLES` declaration tests kept and re-homed.
- `pgObservationsReadDb`'s header used to narrate, at length, how two adapters silently diverged (`.first()` missing on one; `Array.isArray(res?.results)` reading `undefined` off a bare array and taking the failure branch on a *successful* read). That comment is now four lines: with one verb and one shape, there is nothing left for two adapters to disagree about.

## Test disposition

Every D1-envelope premise retires **with its reason written where it stood** — "a driver returning no `results` key", "`all()` is absent or answers nothing", "a non-array result declines", "a bare-array envelope reads the same as `{ results }`". Zero rows is the one nothing-shape the owned verbs can produce, and it is pinned everywhere those arms were. The failure arms (a throwing read → null/decline) all survive unchanged.

## Validation

- `typecheck` 0 · `eslint --no-cache` 0 · `format:check` clean · `validate:unreferenced-exports` (733, at ceiling)
- **30 suites / 735 tests green** — every file this touches, run together
- A field-level audit across all 82 changed files confirms no verdict-spy lost a captured column in the port (one `checked_at` drop was caught this way and restored)
- `tests/api-coverage.test.ts` fails identically with these changes stashed — it reads built `public/metagraph/` artifacts and this worktree has none; CI builds first

## Template Used

- backend-code

Closes #10909
