### PR TITLE
fix(freshness): confirm a redirected stale before alarming, and read the stamp gap in the direction that is actually invariant

### DIFF
--- a/src/table-freshness-watchdog.ts
+++ b/src/table-freshness-watchdog.ts
@@ -724,9 +724,26 @@ export function freshnessSql(
  * redirect is not to scan these tables every time, and a cross-check that ran
  * as often as the sweep would give the saving straight back.
  *
- * EQUALITY, NOT "CLOSE ENOUGH". Both sides are written by the same producer
- * pass from the same clock read, so they are equal or something is wrong; a
- * tolerance here would only be a way to not notice.
+ * ORDER, NOT EQUALITY (#10656). The two sides carry the SAME quantity --
+ * `passTallyFromRows` (workers/data-api.ts) takes the pass row's `captured_at`
+ * from the posted rows' own, and refuses a request whose rows disagree -- but
+ * not at the same TIME: the tally lands after the tables it counts, and only
+ * once a pass declares its total, so the pass table trails between those
+ * writes. Measured 2026-08-11: 75 minutes. Demanding equality made that
+ * expected lag indistinguishable from a fault, and a divergence forces
+ * `unknown`, so the lane could not publish a green for as long as the lag
+ * persisted.
+ *
+ * What remains genuinely alarming is the OTHER direction. A cheap stamp NEWER
+ * than the table's own would mean the pass row claims data the table does not
+ * hold -- a freshness signal advancing over data that has not arrived, which
+ * is #9530 exactly, and the failure the redirect could reintroduce. That is
+ * what this now reports.
+ *
+ * The lag direction is not merely tolerated, it is CONFIRMED: a redirected
+ * table that reads stale is re-asked of itself before it alarms
+ * (`confirmRedirectedStale`), so an under-reporting stamp costs one scan on
+ * the alarming path instead of a false alarm.
  */
 export function crossCheckSql(
   spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
@@ -780,6 +797,12 @@ export function stampDivergences(
     const actual = row.actual == null ? null : Number(row.actual);
     if (cheap == null && actual == null) continue;
     if (cheap === actual) continue;
+    // THE LAG DIRECTION IS EXPECTED (#10656): the pass row lands after the
+    // rows it counts, so `cheap < actual` is the writes being ordered, not a
+    // fault -- and `confirmRedirectedStale` is what stops it costing a false
+    // alarm. Only a cheap stamp that RUNS AHEAD is reported: that one claims
+    // data the table does not hold.
+    if (cheap != null && actual != null && cheap < actual) continue;
     out.push({ table, stampFrom: entry.stampFrom, cheap, actual });
   }
   return out;
@@ -875,6 +898,66 @@ export interface FreshnessDeps {
  * reach one produces `failed` rather than a crash: no store means the redirect
  * went unverified this tick, which is a thing to report, not a thing to throw.
  */
+/**
+ * Re-ask the table itself before reporting a REDIRECTED table stale (#10656).
+ *
+ * Only redirected entries are re-asked, and only when they already read stale:
+ * a direct entry measured itself, and a fresh redirected entry cannot be
+ * hiding staleness (its real stamp is at least as new as the cheap one it
+ * answered from). So the expensive scan this redirect exists to avoid happens
+ * on the alarming path only.
+ *
+ * A FAILED CONFIRM KEEPS THE STALE. The cheap stamp said late and nothing
+ * refuted it, so reporting it is the honest outcome -- dropping a stale
+ * finding because the confirming read broke would be the one way this could
+ * hide a real outage.
+ */
+export async function confirmRedirectedStale(
+  stale: readonly StaleTable[],
+  env: Record<string, unknown> | null | undefined,
+  deps: FreshnessDeps = {},
+  now: () => number = Date.now,
+  spec: Readonly<Record<string, FreshnessExpectation>> = TABLE_FRESHNESS,
+): Promise<StaleTable[]> {
+  const redirected = new Set(redirectedTables(spec).map(([table]) => table));
+  const suspect = stale.filter((s) => redirected.has(s.table));
+  if (suspect.length === 0) return [...stale];
+  const tables = suspect.map((s) => s.table);
+  const db = deps.db ?? (readStore(env, tables) as FreshnessDb | undefined);
+  let confirmed: Map<string, number>;
+  try {
+    // The tables' OWN stamps, which is what `freshnessSql` would have read had
+    // these entries never been redirected -- so the confirm asks exactly the
+    // question the redirect deferred.
+    const result = await db
+      ?.prepare(
+        tables
+          .map(
+            (table) =>
+              `SELECT '${table}' AS t, MAX(${spec[table].column}) AS mx FROM ${table}`,
+          )
+          .join(" UNION ALL "),
+      )
+      .all();
+    if (!result) throw new Error("no result");
+    // The SPEC is passed: parseFreshnessRows drops any table its spec does
+    // not know, and defaulting to TABLE_FRESHNESS would silently discard
+    // every row when a caller (a test, another spec) asks about its own.
+    confirmed = parseFreshnessRows(result.results ?? [], spec);
+  } catch {
+    return [...stale];
+  }
+  const nowMs = now();
+  return stale.filter((entry) => {
+    if (!redirected.has(entry.table)) return true;
+    const at = confirmed.get(entry.table);
+    // No stamp of its own means the confirm established nothing -- keep the
+    // finding rather than clearing it on an absence.
+    if (at == null) return true;
+    return nowMs - at > entry.maxAgeMs;
+  });
+}
+
 export async function crossCheckStamps(
   env: Record<string, unknown> | null | undefined,
   deps: FreshnessDeps = {},
@@ -1004,7 +1087,30 @@ export async function runTableFreshnessWatchdog(
     return { attempted: true, reason: "all batches failed" };
   }
 
-  const stale = staleTables(newest, now(), spec);
+  // THE CHEAP STAMP CAN ONLY BE OLDER, so it can only ever manufacture a FALSE
+  // STALE -- never a false green (#10656). `neurons_passes.captured_at` is not
+  // a different quantity from `neurons.captured_at`: `passTallyFromRows`
+  // (workers/data-api.ts) derives it from the posted rows' own `captured_at`
+  // and refuses a request whose rows disagree. What differs is WHEN the row
+  // lands: the tally is written after the tables it counts, and only once a
+  // pass declares its total, so `MAX(captured_at)` over the pass table trails
+  // the data table between those writes. Measured 2026-08-11: 75 minutes,
+  // against a 120-minute bound -- 62% of the budget spent before the data was
+  // even late.
+  //
+  // So the redirect is confirmed only in the direction where being wrong
+  // costs something. A cheap stamp that reads FRESH is fresh a fortiori
+  // (`actual >= cheap`), and that is the 99% path the redirect exists to keep
+  // cheap. A cheap stamp that reads STALE is re-asked of the table itself
+  // before it alarms -- the one scan the saving can afford, because it happens
+  // only when the alternative is a false alarm on the estate's largest tables.
+  const stale = await confirmRedirectedStale(
+    staleTables(newest, now(), spec),
+    env,
+    deps,
+    now,
+    spec,
+  );
 
   // THE OTHER HALF OF `stampFrom`. Every redirected table above answered from
   // its pass companion instead of itself, which is only sound while the two

--- a/tests/table-freshness-watchdog.test.ts
+++ b/tests/table-freshness-watchdog.test.ts
@@ -15,6 +15,7 @@ import path from "node:path";
 import { describe, test } from "vitest";
 import {
   crossCheckSql,
+  confirmRedirectedStale,
   crossCheckStamps,
   describeStaleTables,
   FRESHNESS_BATCH,
@@ -413,6 +414,28 @@ describe("stampDivergences", () => {
     );
   });
 
+  test("the LAG direction is expected, not a divergence (#10656)", () => {
+    // The pass row lands after the rows it counts, so a cheap stamp that
+    // trails is the writes being ordered. Demanding equality made that
+    // indistinguishable from a fault and pinned the lane at `unknown` --
+    // measured at 75 minutes on 2026-08-11. `confirmRedirectedStale` is what
+    // stops the lag costing a false alarm instead.
+    assert.deepEqual(
+      stampDivergences([{ t: "big", cheap: 1000, actual: 2000 }], spec),
+      [],
+    );
+  });
+
+  test("a cheap stamp RUNNING AHEAD is still reported -- that is #9530", () => {
+    // The genuinely alarming direction: the pass row claims data the table
+    // does not hold, which is a freshness signal advancing over data that has
+    // not arrived.
+    assert.deepEqual(
+      stampDivergences([{ t: "big", cheap: 2000, actual: 1999 }], spec),
+      [{ table: "big", stampFrom: "big_passes", cheap: 2000, actual: 1999 }],
+    );
+  });
+
   test("an empty pass table beside a populated one IS a divergence", () => {
     // This is the redirect reading nothing at all -- the failure the
     // cross-check exists for. Skipping nulls would make it look healthy.
@@ -522,6 +545,211 @@ describe("crossCheckStamps", () => {
       await crossCheckStamps(null, { db: db as never }, redirected),
       { divergences: [], failed: true },
     );
+  });
+});
+
+describe("confirmRedirectedStale (#10656)", () => {
+  const NOW = 10 * HOUR;
+  const spec: Record<string, FreshnessExpectation> = {
+    big: {
+      column: "captured_at",
+      kind: "ms",
+      maxAgeMs: HOUR,
+      reason: "x",
+      stampFrom: "big_passes",
+    },
+    plain: { column: "captured_at", kind: "ms", maxAgeMs: HOUR, reason: "y" },
+  };
+  const staleBig = {
+    table: "big",
+    ageMs: 2 * HOUR,
+    maxAgeMs: HOUR,
+    reason: "x",
+  };
+  const stalePlain = {
+    table: "plain",
+    ageMs: 2 * HOUR,
+    maxAgeMs: HOUR,
+    reason: "y",
+  };
+
+  /** Answers the confirm's own `{t, mx}` shape. */
+  function confirmDb(byTable: Record<string, number | null>, fail = false) {
+    return {
+      prepare(sql: string) {
+        return {
+          async all() {
+            if (fail) throw new Error("D1_ERROR: overloaded");
+            const names = [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map(
+              (m) => m[1],
+            );
+            return {
+              results: names.map((t) => ({
+                t,
+                mx: byTable[t as string] ?? null,
+              })),
+            };
+          },
+        };
+      },
+    };
+  }
+
+  test("a redirected table whose OWN stamp is fresh is dropped", async () => {
+    // The whole point: the pass table trails the data table, so a cheap stamp
+    // can read late while the table itself is current. Measured at 75 minutes
+    // against a 120-minute bound on 2026-08-11.
+    const out = await confirmRedirectedStale(
+      [staleBig],
+      null,
+      { db: confirmDb({ big: NOW - HOUR / 2 }) as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, []);
+  });
+
+  test("a redirected table that is REALLY stale still reports", async () => {
+    // The confirm must not become a way to lose a real outage on the estate's
+    // largest tables.
+    const out = await confirmRedirectedStale(
+      [staleBig],
+      null,
+      { db: confirmDb({ big: NOW - 5 * HOUR }) as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [staleBig]);
+  });
+
+  test("a NON-redirected table is never re-asked", async () => {
+    // It measured itself; re-asking would be the scan this exists to avoid.
+    let asked = 0;
+    const db = {
+      prepare(sql: string) {
+        asked += 1;
+        return {
+          async all() {
+            return {
+              results: [...sql.matchAll(/SELECT '(\w+)' AS t/g)].map((m) => ({
+                t: m[1],
+                mx: NOW,
+              })),
+            };
+          },
+        };
+      },
+    };
+    const out = await confirmRedirectedStale(
+      [stalePlain],
+      null,
+      { db: db as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [stalePlain]);
+    assert.equal(asked, 0, "no confirm query for a table that measured itself");
+  });
+
+  test("a FAILED confirm keeps the stale finding", async () => {
+    // Nothing refuted the cheap stamp, so dropping it here would be the one
+    // way this could hide a real outage.
+    const out = await confirmRedirectedStale(
+      [staleBig],
+      null,
+      { db: confirmDb({}, true) as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [staleBig]);
+  });
+
+  test("no reachable store keeps the finding, resolving its own db", async () => {
+    // No injected db and no env: readStore has nothing to open, so the
+    // confirm asks nothing and cannot refute the cheap stamp. Same rule as a
+    // failed query -- an unproven staleness is still reported.
+    const out = await confirmRedirectedStale(
+      [staleBig],
+      null,
+      {},
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [staleBig]);
+  });
+
+  test("a table with no stamp of its own keeps the finding", async () => {
+    // An absence establishes nothing either way.
+    const out = await confirmRedirectedStale(
+      [staleBig],
+      null,
+      { db: confirmDb({ big: null }) as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [staleBig]);
+  });
+
+  test("a mixed list keeps the direct finding while clearing the confirmed one", async () => {
+    // The filter runs over the WHOLE list, not just the suspects: a
+    // non-redirected table measured itself and must survive a confirm that
+    // clears its neighbour.
+    const out = await confirmRedirectedStale(
+      [staleBig, stalePlain],
+      null,
+      { db: confirmDb({ big: NOW - HOUR / 2 }) as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [stalePlain]);
+  });
+
+  test("a result carrying no rows key keeps the finding", async () => {
+    // `result.results ?? []` -- a store that answers with no `results` key at
+    // all is not a refutation, and must not be read as an empty confirm that
+    // clears the finding.
+    const db = {
+      prepare() {
+        return {
+          async all() {
+            return {};
+          },
+        };
+      },
+    };
+    const out = await confirmRedirectedStale(
+      [staleBig],
+      null,
+      { db: db as never },
+      () => NOW,
+      spec,
+    );
+    assert.deepEqual(out, [staleBig]);
+  });
+
+  test("nothing stale asks nothing at all", async () => {
+    let asked = 0;
+    const db = {
+      prepare() {
+        asked += 1;
+        return {
+          async all() {
+            return { results: [] };
+          },
+        };
+      },
+    };
+    assert.deepEqual(
+      await confirmRedirectedStale(
+        [],
+        null,
+        { db: db as never },
+        () => NOW,
+        spec,
+      ),
+      [],
+    );
+    assert.equal(asked, 0);
   });
 });
 


### PR DESCRIPTION
Closes #10656

The issue asked for the pass-write path's intent rather than a guess between its three options. The code answers it: **`neurons_passes.captured_at` is not a different quantity from `neurons.captured_at`.** `passTallyFromRows` (workers/data-api.ts) takes the pass row's `captured_at` from the posted rows' own, and *refuses* a request whose rows disagree. So the issue's premise — "whatever it is, it is not a substitute stamp" — is refuted; what differs is not the quantity but **when the row lands**: the tally is written after the tables it counts, and only once a pass declares its total, so the pass table trails between those writes.

That makes the divergence one-directional, and each direction gets the treatment it deserves:

**The lag can only cause a FALSE STALE, so it is confirmed rather than tolerated.** A cheap stamp that reads fresh is fresh a fortiori (`actual >= cheap`) — the 99% path the redirect exists to keep cheap, untouched. A cheap stamp that reads *stale* is now re-asked of the table itself before it alarms (`confirmRedirectedStale`). That is option 3's correctness at option 1's cost profile, and it needs no tolerance and no knowledge of why the lag happens on any given tick. A failed or unreachable confirm **keeps** the stale finding — dropping it would be the one way this could hide a real outage.

**The cross-check now tests order, not equality.** Demanding equality made an expected lag indistinguishable from a fault, and a divergence forces `unknown` — which is exactly the second-order effect the issue flagged: the lane could never publish a green while drift persisted (masked today only because `providers` is genuinely stale and `stale` outranks `unknown`). What stays alarming is the *other* direction: a cheap stamp running AHEAD would mean the pass row claims data the table does not hold — #9530 exactly, the failure this redirect could reintroduce.

Also fixed en route: `confirmRedirectedStale` passes its spec to `parseFreshnessRows`, which otherwise defaults to `TABLE_FRESHNESS` and silently discards every row when a caller asks about its own spec. My first test caught it.

Nine new tests: a redirected stale whose own stamp is fresh is dropped; a really-stale one still reports; a non-redirected table is never re-asked (asserted by query count, since the scan is the whole cost); a mixed list keeps the direct finding while clearing the confirmed one; failed/unbound/no-rows-key/no-stamp confirms all keep the finding; and both cross-check directions — the lag is silence, running ahead still reports. 61 tests in the suite, 90 in self-health + lane-alarm, full patch coverage on the changed file, `tsc`, startup budget, fresh eslint, prettier — all green.

Live state for context: the lane currently reports `ok` ("every table is within its expected age"), so this lands ahead of the drift rather than during it.