### PR TITLE
fix(revenue): price the emission through the live TAO/USD index, and decline instead of publishing a zero rate

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -5952,7 +5952,11 @@ type RevenueEmission {
   """
   basis: String!
   tao: Float!
-  usd: Float!
+
+  """
+  The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — \`emission.tao\` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed.
+  """
+  usd: Float
   alternates: RevenueEmissionAlternates!
 }
 
@@ -5963,7 +5967,11 @@ type RevenueEmissionAlternates {
 
 type RevenueCoverageBasis {
   tao: Float!
-  usd: Float!
+
+  """
+  The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive \`tao\` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed.
+  """
+  usd: Float
 }
 
 type RevenueSource {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -5217,7 +5217,8 @@ export type RegistryLeaderboards = {
 export type RevenueCoverageBasis = {
   __typename?: 'RevenueCoverageBasis';
   tao: Scalars['Float']['output'];
-  usd: Scalars['Float']['output'];
+  /** The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+  usd?: Maybe<Scalars['Float']['output']>;
 };
 
 export type RevenueEmission = {
@@ -5226,7 +5227,8 @@ export type RevenueEmission = {
   /** SubnetTaoInEmission + SubnetExcessTao, the TAO the network directs into this subnet. Fully measured rather than reconstructed. The alternates are published beside it and never silently substituted. */
   basis: Scalars['String']['output'];
   tao: Scalars['Float']['output'];
-  usd: Scalars['Float']['output'];
+  /** The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed. */
+  usd?: Maybe<Scalars['Float']['output']>;
 };
 
 export type RevenueEmissionAlternates = {
@@ -11559,14 +11561,14 @@ export type RegistryLeaderboardsResolvers<ContextType = GqlContext, ParentType e
 
 export type RevenueCoverageBasisResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RevenueCoverageBasis'] = ResolversParentTypes['RevenueCoverageBasis']> = ResolversObject<{
   tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  usd?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type RevenueEmissionResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RevenueEmission'] = ResolversParentTypes['RevenueEmission']> = ResolversObject<{
   alternates?: Resolver<ResolversTypes['RevenueEmissionAlternates'], ParentType, ContextType>;
   basis?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   tao?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
-  usd?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type RevenueEmissionAlternatesResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['RevenueEmissionAlternates'] = ResolversParentTypes['RevenueEmissionAlternates']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6865,11 +6865,13 @@ export interface components {
                     alternates: {
                         alpha_out_priced: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         } | null;
                         owner_take: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         };
                     };
                     /**
@@ -6878,7 +6880,8 @@ export interface components {
                      */
                     basis: "tao_total";
                     tao: number;
-                    usd: number;
+                    /** @description The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed. */
+                    usd: number | null;
                 };
                 netuid: number;
                 /** @enum {string} */
@@ -11854,11 +11857,13 @@ export interface components {
                     alternates: {
                         alpha_out_priced: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         } | null;
                         owner_take: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         };
                     };
                     /**
@@ -11867,7 +11872,8 @@ export interface components {
                      */
                     basis: "tao_total";
                     tao: number;
-                    usd: number;
+                    /** @description The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed. */
+                    usd: number | null;
                 };
                 netuid: number;
                 /** @enum {string} */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -24431,7 +24431,15 @@
                                   "type": "number"
                                 },
                                 "usd": {
-                                  "type": "number"
+                                  "anyOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "description": "The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed."
                                 }
                               },
                               "required": [
@@ -24452,7 +24460,15 @@
                               "type": "number"
                             },
                             "usd": {
-                              "type": "number"
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed."
                             }
                           },
                           "required": [
@@ -24477,7 +24493,15 @@
                       "type": "number"
                     },
                     "usd": {
-                      "type": "number"
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed."
                     }
                   },
                   "required": [
@@ -52753,7 +52777,15 @@
                                 "type": "number"
                               },
                               "usd": {
-                                "type": "number"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ],
+                                "description": "The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed."
                               }
                             },
                             "required": [
@@ -52774,7 +52806,15 @@
                             "type": "number"
                           },
                           "usd": {
-                            "type": "number"
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed."
                           }
                         },
                         "required": [
@@ -52799,7 +52839,15 @@
                     "type": "number"
                   },
                   "usd": {
-                    "type": "number"
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed."
                   }
                 },
                 "required": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6865,11 +6865,13 @@ export interface components {
                     alternates: {
                         alpha_out_priced: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         } | null;
                         owner_take: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         };
                     };
                     /**
@@ -6878,7 +6880,8 @@ export interface components {
                      */
                     basis: "tao_total";
                     tao: number;
-                    usd: number;
+                    /** @description The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed. */
+                    usd: number | null;
                 };
                 netuid: number;
                 /** @enum {string} */
@@ -11854,11 +11857,13 @@ export interface components {
                     alternates: {
                         alpha_out_priced: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         } | null;
                         owner_take: {
                             tao: number;
-                            usd: number;
+                            /** @description The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed. */
+                            usd: number | null;
                         };
                     };
                     /**
@@ -11867,7 +11872,8 @@ export interface components {
                      */
                     basis: "tao_total";
                     tao: number;
-                    usd: number;
+                    /** @description The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed. */
+                    usd: number | null;
                 };
                 netuid: number;
                 /** @enum {string} */

--- a/schemas-src/routes/revenue-coverage.ts
+++ b/schemas-src/routes/revenue-coverage.ts
@@ -27,7 +27,13 @@ export const REVENUE_PROVENANCE_VALUES = [
 export const RevenueProvenanceSchema = z.enum(REVENUE_PROVENANCE_VALUES);
 
 export const CoverageBasisSchema = z
-  .object({ tao: z.number(), usd: z.number() })
+  .object({
+    tao: z.number(),
+    usd: z.number().nullable().meta({
+      description:
+        "The TAO leg priced through the TAO/USD index, or NULL when that moment is not priceable — an index below its two-pool quorum, a reading past its two-hour freshness bound, or no reading at all. NEVER 0: a zero here next to a positive `tao` claims the emission is worthless rather than unpriced, which is what this field published for all 129 subnets until the TAO/USD wiring was fixed.",
+    }),
+  })
   .strict();
 
 export const RevenueEmissionSchema = z
@@ -37,7 +43,10 @@ export const RevenueEmissionSchema = z
         "SubnetTaoInEmission + SubnetExcessTao, the TAO the network directs into this subnet. Fully measured rather than reconstructed. The alternates are published beside it and never silently substituted.",
     }),
     tao: z.number(),
-    usd: z.number(),
+    usd: z.number().nullable().meta({
+      description:
+        "The measured TAO denominator priced in USD, or NULL when the TAO/USD index could not price this moment. NEVER 0 — `emission.tao` carries a real figure, so a zero here reads as 'the network directs this much TAO into the subnet and it is worth nothing', which is what shipped for all 129 subnets until the TAO/USD wiring was fixed.",
+    }),
     alternates: z
       .object({
         alpha_out_priced: CoverageBasisSchema.nullable(),

--- a/src/revenue-coverage.ts
+++ b/src/revenue-coverage.ts
@@ -19,6 +19,14 @@
 // of 129 subnets have no readable revenue figure. Rendering them as "0% covered"
 // would be a false claim about every one of them, at scale, and it is the single
 // most likely way this feature does harm.
+//
+// THE RULE BINDS THE PRICE AS HARD AS IT BINDS THE REVENUE, and did not
+// revenue. `usd_per_tao` arrived here already coalesced to 0, so every USD leg
+// -- `emission.usd` and both `alternates` branches -- published a literal 0 for
+// all 129 subnets while `emission.tao` carried a real figure. Read straight,
+// that is "the network directs 441 TAO into this subnet and that is worth
+// nothing". The rate is now nullable end to end, and an unpriceable window
+// serialises null in every USD field or none of them.
 
 /** One day of blocks at 12s. Mirrors validator-economics.ts's own constant. */
 export const BLOCKS_PER_DAY = 7200;
@@ -34,7 +42,11 @@ export interface CoverageInput {
   alpha_out_per_block?: number;
   /** TAO-denominated alpha price, for the alternate denominator. */
   alpha_price_tao?: number;
-  usd_per_tao: number;
+  /** The rate to price the denominator through. NULL means the index could not
+   * price this moment -- ADR 0025's `insufficient_pools`, a stale index, or no
+   * reading at all. It is NOT a rate of zero, and every USD field downstream
+   * serialises null rather than 0 because of it. */
+  usd_per_tao: number | null;
   /** Days the window spans. */
   window_days: number;
   /** Summed external revenue over the window, from Tier A + B surfaces only.
@@ -44,7 +56,8 @@ export interface CoverageInput {
 
 export interface CoverageBasis {
   tao: number;
-  usd: number;
+  /** Null when there is no rate to price the TAO leg through. */
+  usd: number | null;
 }
 
 export interface CoverageResult {
@@ -53,7 +66,8 @@ export interface CoverageResult {
     /** The published denominator. */
     basis: "tao_total";
     tao: number;
-    usd: number;
+    /** Null when unpriceable. Never 0 -- see the header rule. */
+    usd: number | null;
     /** Computed and published, never silently substituted for the basis. */
     alternates: {
       alpha_out_priced: CoverageBasis | null;
@@ -93,12 +107,23 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
 
   for (const [name, value] of [
     ["tao_total_per_block", tao_total_per_block],
-    ["usd_per_tao", usd_per_tao],
     ["window_days", window_days],
   ] as const) {
     if (!Number.isFinite(value) || value < 0) {
       throw new Error(`${name} must be a finite, non-negative number`);
     }
+  }
+  // Null is a legitimate input -- "no rate" -- but a present rate still has to
+  // be a real one. A NaN or negative price would otherwise reach the payload as
+  // a NaN that serialises to null, which is the SAME output as "unpriceable"
+  // and must never be confusable with it.
+  if (
+    usd_per_tao !== null &&
+    (!Number.isFinite(usd_per_tao) || usd_per_tao < 0)
+  ) {
+    throw new Error(
+      "usd_per_tao must be null or a finite, non-negative number",
+    );
   }
   if (
     revenue_usd !== null &&
@@ -111,7 +136,11 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
 
   const blocks = BLOCKS_PER_DAY * window_days;
   const emissionTao = tao_total_per_block * blocks;
-  const emissionUsd = emissionTao * usd_per_tao;
+  /** Price a TAO leg, or decline. The ONE place the rate is applied, so an
+   * unpriceable window cannot be null in one field and 0 in the next. */
+  const priced = (tao: number): number | null =>
+    usd_per_tao === null ? null : roundTo(tao * usd_per_tao, 6);
+  const emissionUsd = priced(emissionTao);
 
   const alphaPriced =
     typeof alpha_out_per_block === "number" &&
@@ -120,10 +149,7 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
     Number.isFinite(alpha_price_tao)
       ? {
           tao: roundTo(alpha_out_per_block * blocks * alpha_price_tao),
-          usd: roundTo(
-            alpha_out_per_block * blocks * alpha_price_tao * usd_per_tao,
-            6,
-          ),
+          usd: priced(alpha_out_per_block * blocks * alpha_price_tao),
         }
       : null;
 
@@ -131,17 +157,20 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
   // off tao_total rather than alpha so it does not silently change basis.
   const ownerTake: CoverageBasis = {
     tao: roundTo(emissionTao * OWNER_CUT),
-    usd: roundTo(emissionTao * OWNER_CUT * usd_per_tao, 6),
+    usd: priced(emissionTao * OWNER_CUT),
   };
 
   // Null propagates. Zero emission also yields null rather than Infinity: a
   // subnet the gate is emitting nothing to has no ratio, and Infinity would
   // render as the worst possible subsidy rather than as "not applicable".
+  // An unpriceable window has no ratios either: both sides must be USD, and
+  // there is no rate to bring the denominator over.
   const haveRevenue = revenue_usd !== null;
+  const priceable = emissionUsd !== null && emissionUsd > 0;
   const coverage =
-    haveRevenue && emissionUsd > 0 ? roundTo(revenue_usd / emissionUsd) : null;
+    haveRevenue && priceable ? roundTo(revenue_usd / emissionUsd) : null;
   const subsidy =
-    haveRevenue && revenue_usd > 0 && emissionUsd > 0
+    haveRevenue && revenue_usd > 0 && priceable
       ? roundTo(emissionUsd / revenue_usd)
       : null;
 
@@ -165,9 +194,25 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
         : "revenue not observed, so both ratios are null",
     },
     {
+      // Tests the TAO leg, which is what the name and the detail have always
+      // said. It used to test `emissionUsd > 0`, so an unpriceable window
+      // reported a subnet with real emission as failing "emission_is_positive"
+      // -- a claim about the emission, sourced from the price.
       name: "emission_is_positive",
-      ok: emissionUsd > 0,
+      ok: emissionTao > 0,
       detail: `emission ${roundTo(emissionTao, 6)} TAO over ${window_days} day(s)`,
+    },
+    {
+      // The price-side twin of absent_revenue_is_null_not_zero, and the same
+      // rule: a rate we do not have is null, never 0. `emission.usd: 0` next to
+      // a positive `emission.tao` is a claim that the network emits nothing of
+      // value, published at network scale.
+      name: "unpriceable_emission_is_null_not_zero",
+      ok: usd_per_tao !== null || emissionUsd === null,
+      detail:
+        usd_per_tao === null
+          ? "no TAO/USD rate, so every USD leg is null"
+          : `priced through ${usd_per_tao} USD/TAO`,
     },
   ];
 
@@ -176,7 +221,7 @@ export function computeCoverage(input: CoverageInput): CoverageResult {
     emission: {
       basis: "tao_total",
       tao: roundTo(emissionTao, 6),
-      usd: roundTo(emissionUsd, 6),
+      usd: emissionUsd,
       alternates: { alpha_out_priced: alphaPriced, owner_take: ownerTake },
     },
     revenue_usd: revenue_usd === null ? null : roundTo(revenue_usd, 6),

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -129,10 +129,12 @@ export function loadSubnetRevenue(
     tao_total_per_block: taoTotalPerBlock(input.economics),
     alpha_out_per_block: num(input.economics?.alpha_out_emission),
     alpha_price_tao: num(input.economics?.alpha_price_tao),
-    // A missing price prices the emission at 0 USD, which computeCoverage then
-    // turns into null ratios -- the same output as unobserved revenue, and the
-    // honest one: without a rate there is no USD comparison to make.
-    usd_per_tao: input.usd_per_tao ?? 0,
+    // NOT `?? 0`. Coalescing here priced every subnet's emission at
+    // literally zero USD -- the ratios did come out null as intended, but
+    // `emission.usd` and both `alternates` branches published a hard 0 beside a
+    // real `emission.tao`. A missing rate travels as null the whole way down,
+    // and computeCoverage declines every USD leg together.
+    usd_per_tao: input.usd_per_tao,
     sources,
     observations: input.observations,
     searched_at: input.searched_at ?? null,

--- a/src/revenue-serving.ts
+++ b/src/revenue-serving.ts
@@ -69,7 +69,9 @@ export interface SubnetRevenueInput {
   tao_total_per_block: number;
   alpha_out_per_block?: number;
   alpha_price_tao?: number;
-  usd_per_tao: number;
+  /** Null when the index could not price this moment. Passed through to
+   * computeCoverage, which declines every USD leg rather than zeroing it. */
+  usd_per_tao: number | null;
   /** Every declared revenue surface for this subnet, readable or not. */
   sources: RevenueSourceRow[];
   /** When the subnet was searched and nothing found (#10543). */

--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -33,7 +33,7 @@
 // young series read as a complete one is how a four-day chart becomes a claim
 // about the month.
 
-import { TAO_USD_MAX_AGE_MS } from "./alpha-usd.ts";
+import { TAO_USD_MAX_AGE_MS, type TaoUsdReading } from "./alpha-usd.ts";
 
 type Row = Record<string, unknown>;
 
@@ -118,6 +118,46 @@ export async function loadTaoUsdSeries(
         ` ORDER BY observed_at DESC LIMIT ${TAO_USD_MAX_POINTS}`,
       [cutoff],
     );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The newest reading, in the shape `taoUsdUsable` grades.
+ *
+ * For callers that need the RATE and not the series -- revenue coverage and
+ * owner-cut price one scalar each and would otherwise pull 2000 rows to read
+ * the first. `LIMIT 1` on the same index the series query already uses.
+ *
+ * Returns the newest row WITHOUT skipping unpriced ones. A row carrying
+ * `price_basis: insufficient_pools` is the current state of the index, and
+ * stepping back to an older priced row would serve a rate past its freshness
+ * bound while looking healthy -- the failure ADR 0025 published the basis to
+ * make visible. `taoUsdUsable` tells `index_unpriced` from `index_stale`; this
+ * function's job is to report, not to choose.
+ *
+ * Null means the read failed or the table is empty, which is a third state
+ * again (`no_index_reading`) and equally not a price.
+ */
+export async function loadLatestTaoUsdReading(
+  db: TaoUsdSeriesDb | null | undefined,
+): Promise<TaoUsdReading | null> {
+  if (!db?.query) return null;
+  try {
+    const rows = await db.query<Row>(
+      `SELECT block_number, observed_at, usd_per_tao, price_basis` +
+        ` FROM ${TAO_USD_TABLE}` +
+        ` ORDER BY observed_at DESC LIMIT 1`,
+    );
+    const row = rows?.[0];
+    if (!row) return null;
+    return {
+      usd_per_tao: positiveOrNull(row.usd_per_tao),
+      observed_at: toIsoOrNull(row.observed_at),
+      block_number: intOrNull(row.block_number),
+      price_basis: typeof row.price_basis === "string" ? row.price_basis : null,
+    };
   } catch {
     return null;
   }

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24848,7 +24848,14 @@ describe("revenue coverage over GraphQL (#10476)", () => {
       [],
       "a non-array surfaces key declares nothing",
     );
-    assert.equal((r.emission as Row).usd, 0, "no usable rate prices it at 0");
+    // Was `0`. A rate we do not have is null, never a price of zero -- the
+    // GraphQL mirror has to decline in the same shape the route does, or a
+    // consumer reading the SDL type gets a different answer to the same fact.
+    assert.equal(
+      (r.emission as Row).usd,
+      null,
+      "no usable rate declines, never zeroes",
+    );
     assert.equal(r.coverage_ratio, null);
 
     const table = await gql(

--- a/tests/revenue-api-surface.test.ts
+++ b/tests/revenue-api-surface.test.ts
@@ -16,10 +16,72 @@
 // A test that only walks the happy path here would prove nothing: the happy
 // path is the rare one.
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, test, vi } from "vitest";
+
+// The price now comes from `tao_usd_index` through readStore, which builds its
+// own client -- there is no binding a route caller can inject. Mocking the
+// module is the seam; see tests/helpers/pg-mock.ts for why the controller has
+// to be built inside vi.hoisted.
+const { pg } = await vi.hoisted(async () => ({
+  pg: (await import("./helpers/pg-mock.ts")).createPgMock(),
+}));
+vi.mock("pg", () => pg.module);
+
 import { handleRequest } from "../workers/api.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
 import { jsonBody, mockEnv, type Row } from "./row-type.ts";
+import { pgMockEnv } from "./helpers/pg-mock.ts";
+import { TAO_USD_MAX_AGE_MS } from "../src/alpha-usd.ts";
+
+// The real DDL, so the CHECK pairing a null price with `insufficient_pools` is
+// enforced here too -- a fixture that could store a null price under
+// `wrapped_onchain_median` would be testing a state production cannot reach.
+const TAO_USD_SCHEMA = (() => {
+  const sql = fs.readFileSync(
+    path.join(
+      process.cwd(),
+      "tests/fixtures/sqlite-schema/0004_user_state.sql",
+    ),
+    "utf8",
+  );
+  const start = sql.indexOf("CREATE TABLE IF NOT EXISTS tao_usd_index");
+  const end = sql.indexOf(
+    "CREATE INDEX IF NOT EXISTS idx_tao_usd_index_observed",
+  );
+  return sql.slice(start, sql.indexOf(";", end) + 1);
+})();
+
+let taoUsdDb: InstanceType<typeof DatabaseSync>;
+
+beforeEach(() => {
+  taoUsdDb = new DatabaseSync(":memory:");
+  taoUsdDb.exec(TAO_USD_SCHEMA);
+  pg.control.db = taoUsdDb;
+  pg.control.queries.length = 0;
+});
+
+/** One reading in the index, `ageMs` old. A null price stores itself as the
+ * `insufficient_pools` decline the CHECK constraint requires. */
+function seedTaoUsd(usd: number | null, ageMs = 60_000) {
+  taoUsdDb
+    .prepare(
+      `INSERT INTO tao_usd_index
+         (block_number, observed_at, usd_per_tao, price_basis, eth_usd, pool_count, pools)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      25_692_599,
+      Date.now() - ageMs,
+      usd,
+      usd === null ? "insufficient_pools" : "wrapped_onchain_median",
+      1906.04,
+      usd === null ? 0 : 2,
+      "[]",
+    );
+}
 
 const ECONOMICS_PATH = "/metagraph/economics.json";
 const TAO_USD_PATH = "/metagraph/network/tao-usd.json";
@@ -95,10 +157,23 @@ function req(path: string) {
   return new Request(`https://api.metagraph.sh${path}`);
 }
 
+/** artifactEnv plus the Hyperdrive binding the price read resolves its store
+ * from, so a route test can exercise the priced path as well as the declining
+ * one. */
+function pricedEnv(artifacts: ArtifactMap, throwOn?: string) {
+  return {
+    ...(artifactEnv(artifacts, throwOn) as unknown as Record<string, unknown>),
+    ...pgMockEnv(),
+  } as never;
+}
+
 /** An MCP context whose artifact reads are the map given. */
 function mcpCtx(artifacts: ArtifactMap, throwOn?: string) {
   return {
-    env: mockEnv(),
+    env: {
+      ...(mockEnv() as unknown as Record<string, unknown>),
+      ...pgMockEnv(),
+    },
     readArtifact: async (_env: unknown, path: string) => {
       if (throwOn && path === throwOn)
         throw new Error("artifact read exploded");
@@ -181,56 +256,118 @@ describe("GET /api/v1/subnets/{netuid}/revenue", () => {
   });
 });
 
+// The price comes from `tao_usd_index`, NOT from
+// /metagraph/network/tao-usd.json -- that artifact is never published, so the
+// old read returned null on every request and every USD leg went with it.
+// These tests drive the real source, and assert null rather than the 0 they
+// used to pin.
 describe("the TAO/USD read is allowed to come back empty", () => {
-  test("a price artifact that is absent prices the emission at no USD", async () => {
+  test("no store bound declines every USD leg, and zeroes none", async () => {
     const res = await handleRequest(
       req("/api/v1/subnets/64/revenue"),
       artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
     );
     assert.equal(res.status, 200);
-    const revenue = (await jsonBody(res)).data as Row;
-    assert.equal(((revenue.revenue as Row).emission as Row).usd, 0);
+    const emission = (((await jsonBody(res)).data as Row).revenue as Row)
+      .emission as Row;
+    assert.ok((emission.tao as number) > 0, "the TAO leg is measured anyway");
+    assert.equal(emission.usd, null, "no rate declines, never zeroes");
+    const alternates = emission.alternates as Row;
+    assert.equal((alternates.owner_take as Row).usd, null);
+    assert.equal((alternates.alpha_out_priced as Row).usd, null);
   });
 
-  test("a non-numeric usd_per_tao is refused rather than coerced", async () => {
-    // A string here would multiply into NaN and publish it. Null is the only
-    // honest reading of a price that is not a number.
+  test("an unpriced newest reading declines rather than publishing a 0 rate", async () => {
+    // `price_basis: insufficient_pools` with a null price is ADR 0025's
+    // published decline. Multiplying by it would say TAO is worthless.
+    seedTaoUsd(null);
     const res = await handleRequest(
       req("/api/v1/subnets/64/revenue"),
-      artifactEnv({
-        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
-        [TAO_USD_PATH]: { latest: { usd_per_tao: "204.03" } },
-      }),
+      pricedEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
     );
     assert.equal(res.status, 200);
-    const revenue = (await jsonBody(res)).data as Row;
-    assert.equal(((revenue.revenue as Row).emission as Row).usd, 0);
+    const emission = (((await jsonBody(res)).data as Row).revenue as Row)
+      .emission as Row;
+    assert.equal(emission.usd, null);
   });
 
-  test("a price artifact with no latest block is likewise not a failure", async () => {
+  test("a reading past the freshness bound declines too", async () => {
+    seedTaoUsd(204.03, TAO_USD_MAX_AGE_MS + 60_000);
     const res = await handleRequest(
       req("/api/v1/subnets/64/revenue"),
-      artifactEnv({
-        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
-        [TAO_USD_PATH]: { schema_version: 1 },
-      }),
+      pricedEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
     );
-    assert.equal(res.status, 200);
+    const emission = (((await jsonBody(res)).data as Row).revenue as Row)
+      .emission as Row;
+    assert.equal(emission.usd, null, "a frozen rate must not keep serving");
   });
 
   test("a price read that THROWS is caught, not propagated to the caller", async () => {
     // The whole route must not 500 because the price lane is broken: the
     // revenue answer does not depend on it.
+    const env = pricedEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } });
+    pg.control.db = {
+      prepare() {
+        throw new Error("store exploded");
+      },
+    } as never;
+    const res = await handleRequest(req("/api/v1/subnets/64/revenue"), env);
+    assert.equal(res.status, 200);
+    const emission = (((await jsonBody(res)).data as Row).revenue as Row)
+      .emission as Row;
+    assert.equal(emission.usd, null);
+  });
+});
+
+// The requirement the whole fix exists for: a live price must reach the
+// payload as a real number. Nothing asserted this before -- the happy-path
+// test above checks the ratio and never looks at `emission.usd`, which is how
+// a hard 0 shipped to all 129 subnets unnoticed.
+describe("a live price reaches every USD leg", () => {
+  test("non-zero TAO emission with a live rate never serialises usd: 0", async () => {
+    seedTaoUsd(204.03);
     const res = await handleRequest(
       req("/api/v1/subnets/64/revenue"),
-      artifactEnv(
-        { [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } },
-        TAO_USD_PATH,
-      ),
+      pricedEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
     );
     assert.equal(res.status, 200);
-    const revenue = (await jsonBody(res)).data as Row;
-    assert.equal(((revenue.revenue as Row).emission as Row).usd, 0);
+    const emission = (((await jsonBody(res)).data as Row).revenue as Row)
+      .emission as Row;
+    const alternates = emission.alternates as Row;
+    for (const [name, usd] of [
+      ["emission.usd", emission.usd],
+      ["owner_take.usd", (alternates.owner_take as Row).usd],
+      ["alpha_out_priced.usd", (alternates.alpha_out_priced as Row).usd],
+    ] as const) {
+      assert.notEqual(
+        usd,
+        0,
+        `${name} serialised a zero against real emission`,
+      );
+      assert.equal(typeof usd, "number", `${name} must be priced`);
+      assert.ok((usd as number) > 0, `${name} must be positive`);
+    }
+    // 458.03 TAO/day x $204.03 -- the conversion, not merely "non-zero".
+    assert.ok(
+      Math.abs((emission.usd as number) - 93452) < 5,
+      `${emission.usd}`,
+    );
+  });
+
+  test("the cross-subnet sweep prices every row the same way", async () => {
+    seedTaoUsd(204.03);
+    const res = await handleRequest(
+      req("/api/v1/chain/revenue-coverage"),
+      pricedEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    );
+    assert.equal(res.status, 200);
+    const subnets = ((await jsonBody(res)).data as Row).subnets as Row[];
+    assert.ok(subnets.length > 0);
+    for (const row of subnets) {
+      const emission = row.emission as Row;
+      assert.notEqual(emission.usd, 0, `netuid ${row.netuid} zeroed`);
+      assert.ok((emission.usd as number) > 0);
+    }
   });
 });
 
@@ -346,23 +483,29 @@ describe("the get_subnet_revenue MCP tool", () => {
     assert.equal(((out.revenue as Row).emission as Row).tao, 0);
   });
 
-  test("a non-numeric TAO price is read as no price", async () => {
+  test("no readable price declines the USD legs rather than zeroing them", async () => {
     const out = (await tool("get_subnet_revenue").handler(
       { netuid: 64 },
-      mcpCtx({
-        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
-        [TAO_USD_PATH]: { latest: { usd_per_tao: null } },
-      }),
+      mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
     )) as Row;
-    assert.equal(((out.revenue as Row).emission as Row).usd, 0);
+    const emission = (out.revenue as Row).emission as Row;
+    assert.ok((emission.tao as number) > 0);
+    assert.equal(emission.usd, null);
+    assert.equal(((emission.alternates as Row).owner_take as Row).usd, null);
   });
 
-  test("a TAO price read that throws is caught", async () => {
+  test("a price read that throws is caught, not propagated", async () => {
+    const ctx = mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } });
+    pg.control.db = {
+      prepare() {
+        throw new Error("store exploded");
+      },
+    } as never;
     const out = (await tool("get_subnet_revenue").handler(
       { netuid: 64 },
-      mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }, TAO_USD_PATH),
+      ctx,
     )) as Row;
-    assert.equal(((out.revenue as Row).emission as Row).usd, 0);
+    assert.equal(((out.revenue as Row).emission as Row).usd, null);
   });
 });
 

--- a/tests/revenue-coverage.test.ts
+++ b/tests/revenue-coverage.test.ts
@@ -27,7 +27,7 @@ describe("the published SN64 numbers", () => {
     const r = computeCoverage(SN64);
     assert.equal(r.emission.basis, "tao_total");
     assert.ok(Math.abs(r.emission.tao - 458.03) < 0.01, `${r.emission.tao}`);
-    assert.ok(Math.abs(r.emission.usd - 93452) < 5, `${r.emission.usd}`);
+    assert.ok(Math.abs((r.emission.usd ?? 0) - 93452) < 5, `${r.emission.usd}`);
     assert.ok(Math.abs((r.subsidy_multiple ?? 0) - 8.0) < 0.05);
     assert.ok(Math.abs((r.coverage_ratio ?? 0) - 0.125) < 0.001);
     assert.equal(r.verification.verified, true);
@@ -143,6 +143,113 @@ describe("bad input throws instead of yielding NaN", () => {
       () => computeCoverage({ ...SN64, revenue_usd: -1 }),
       /revenue_usd/,
     );
+  });
+});
+
+// The price-side twin of "absent revenue is null, never zero". Every
+// USD field on this route published a literal 0 for all 129 subnets while
+// `emission.tao` carried a real figure, because `usd_per_tao` reached
+// computeCoverage already coalesced from null.
+describe("an unpriceable window is null, never zero", () => {
+  /** Every USD leg the payload publishes, so a fix that reaches `emission.usd`
+   * and forgets an `alternates` branch fails here rather than in production. */
+  const usdLegs = (r: ReturnType<typeof computeCoverage>) => [
+    ["emission.usd", r.emission.usd],
+    ["alternates.owner_take.usd", r.emission.alternates.owner_take.usd],
+    [
+      "alternates.alpha_out_priced.usd",
+      r.emission.alternates.alpha_out_priced?.usd,
+    ],
+  ];
+
+  test("a live price never serialises usd: 0 against non-zero emission", () => {
+    const r = computeCoverage({ ...SN64, usd_per_tao: 200.25489144597697 });
+    assert.ok(r.emission.tao > 0, "fixture must have real emission");
+    for (const [name, usd] of usdLegs(r)) {
+      assert.notEqual(
+        usd,
+        0,
+        `${name} serialised a zero against real emission`,
+      );
+      assert.equal(typeof usd, "number", `${name} should be priced`);
+      assert.ok((usd as number) > 0, `${name} should be positive`);
+    }
+    // The exact conversion, not just "non-zero": 458.03 TAO x $200.25.
+    assert.ok(
+      Math.abs((r.emission.usd as number) - 91723) < 5,
+      `${r.emission.usd}`,
+    );
+  });
+
+  test("no rate serialises every usd leg as null, and none as 0", () => {
+    const r = computeCoverage({ ...SN64, usd_per_tao: null });
+    assert.ok(r.emission.tao > 0, "the TAO leg is unaffected by the price");
+    for (const [name, usd] of usdLegs(r)) {
+      assert.equal(usd, null, `${name} must decline, not zero`);
+    }
+  });
+
+  test("an unpriceable window has no ratios either", () => {
+    const r = computeCoverage({ ...SN64, usd_per_tao: null });
+    // Revenue IS observed here -- the nulls come from the price alone, so this
+    // cannot pass by accidentally reproducing the absent-revenue path.
+    assert.equal(r.revenue_usd, 11668);
+    assert.equal(r.coverage_ratio, null);
+    assert.equal(r.subsidy_multiple, null);
+  });
+
+  test("the verification block states which side declined", () => {
+    const named = (r: ReturnType<typeof computeCoverage>, name: string) =>
+      r.verification.checks.find((c) => c.name === name);
+
+    const priced = computeCoverage(SN64);
+    assert.equal(
+      named(priced, "unpriceable_emission_is_null_not_zero")?.ok,
+      true,
+    );
+    assert.match(
+      named(priced, "unpriceable_emission_is_null_not_zero")?.detail ?? "",
+      /priced through/,
+    );
+
+    const unpriced = computeCoverage({ ...SN64, usd_per_tao: null });
+    assert.equal(
+      named(unpriced, "unpriceable_emission_is_null_not_zero")?.ok,
+      true,
+      "declining every leg together is the CORRECT outcome, not a failure",
+    );
+    assert.match(
+      named(unpriced, "unpriceable_emission_is_null_not_zero")?.detail ?? "",
+      /no TAO\/USD rate/,
+    );
+  });
+
+  test("emission_is_positive grades the TAO leg, not the price", () => {
+    const named = (r: ReturnType<typeof computeCoverage>) =>
+      r.verification.checks.find((c) => c.name === "emission_is_positive");
+    // Real emission, no rate: the check used to read `emissionUsd > 0` and so
+    // reported a subnet with 458 TAO of emission as having none.
+    assert.equal(
+      named(computeCoverage({ ...SN64, usd_per_tao: null }))?.ok,
+      true,
+    );
+    // And it still fails when the emission is genuinely absent.
+    assert.equal(
+      named(computeCoverage({ ...SN64, tao_total_per_block: 0 }))?.ok,
+      false,
+    );
+  });
+
+  test("null is the only accepted absence -- NaN still throws", () => {
+    // A NaN rate would multiply through to NaN, which serialises to null: the
+    // SAME payload as an honest decline, with no way to tell them apart.
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, -0.5]) {
+      assert.throws(
+        () => computeCoverage({ ...SN64, usd_per_tao: bad }),
+        /usd_per_tao/,
+      );
+    }
+    assert.doesNotThrow(() => computeCoverage({ ...SN64, usd_per_tao: null }));
   });
 });
 

--- a/tests/revenue-load.test.ts
+++ b/tests/revenue-load.test.ts
@@ -127,7 +127,7 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
     assert.equal(r.provenance, "probe-derived");
     // The emission side is fully real even with no revenue.
     assert.ok(Math.abs(r.emission.tao - 458.03) < 0.01);
-    assert.ok(r.emission.usd > 0);
+    assert.ok((r.emission.usd ?? 0) > 0);
   });
 
   test("with an observation it produces the published ratio", () => {
@@ -191,8 +191,28 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
         ],
       ]),
     });
-    assert.equal(r.emission.usd, 0);
+    // This asserted `0`, and that assertion is what kept the bug
+    // pinned -- the ratios were null as the test name says, but the USD legs
+    // beside them published a hard zero against a real TAO denominator.
+    assert.equal(r.emission.usd, null, "a missing rate declines, never zeroes");
+    assert.equal(r.emission.alternates.owner_take.usd, null);
+    assert.equal(r.emission.alternates.alpha_out_priced?.usd, null);
     assert.equal(r.coverage_ratio, null, "no rate means no USD comparison");
     assert.ok(r.emission.tao > 0, "the TAO denominator is still real");
+  });
+
+  // The `?? 0` that produced the zero above lived in loadSubnetRevenue, not in
+  // computeCoverage, so the unit test on the pure function could not see it.
+  test("a live rate reaches every USD leg through the loader", () => {
+    const r = loadSubnetRevenue({
+      netuid: 64,
+      window_days: 1,
+      economics: ECONOMICS,
+      surfaces: SURFACES,
+      usd_per_tao: 200.25489144597697,
+    });
+    assert.ok((r.emission.usd ?? 0) > 0, `${r.emission.usd}`);
+    assert.ok((r.emission.alternates.owner_take.usd ?? 0) > 0);
+    assert.ok((r.emission.alternates.alpha_out_priced?.usd ?? 0) > 0);
   });
 });

--- a/tests/tao-usd-current.test.ts
+++ b/tests/tao-usd-current.test.ts
@@ -63,7 +63,12 @@ describe("reading the current TAO/USD blob", () => {
       env,
       NOW + TAO_USD_CURRENT_KV_TTL_MS - 1,
     );
-    assert.deepEqual(a, { usd_per_tao: 204.125 });
+    assert.deepEqual(a, {
+      usd_per_tao: 204.125,
+      observed_at: null,
+      block_number: null,
+      price_basis: null,
+    });
     assert.deepEqual(b, a);
     assert.equal(state.reads, 1, "the second call must not hit KV");
   });
@@ -92,8 +97,8 @@ describe("reading the current TAO/USD blob", () => {
     resetModuleState();
     const a = envWith({ usd_per_tao: 1 });
     const b = envWith({ usd_per_tao: 2 });
-    assert.deepEqual(await readTaoUsdCurrentKv(a.env, NOW), { usd_per_tao: 1 });
-    assert.deepEqual(await readTaoUsdCurrentKv(b.env, NOW), { usd_per_tao: 2 });
+    assert.equal((await readTaoUsdCurrentKv(a.env, NOW))?.usd_per_tao, 1);
+    assert.equal((await readTaoUsdCurrentKv(b.env, NOW))?.usd_per_tao, 2);
     assert.equal(
       b.state.reads,
       1,
@@ -110,6 +115,110 @@ describe("reading the current TAO/USD blob", () => {
       TAO_USD_CURRENT_KV_TTL_MS < TAO_USD_MAX_AGE_MS,
       "the memo must never outlive the freshness bound",
     );
+  });
+
+  // The producer wrote `observed_at` as the raw epoch-ms integer from
+  // `tao_usd_index`, while `TaoUsdReading` declares a string. `taoUsdUsable`
+  // grades the stamp with `Date.parse`, which returns NaN for a stringified
+  // integer -- and an unparseable stamp is graded `index_stale` by design. So a
+  // cache rewritten every minute read as permanently stale, and /economics,
+  // /subnets/{netuid}/volume and /chain/alpha-volume declined every USD field.
+  describe("the observed_at stamp is normalised to ISO", () => {
+    test("an epoch-ms stamp is graded fresh, not stale", async () => {
+      resetModuleState();
+      const { env } = envWith({
+        usd_per_tao: 204.125,
+        observed_at: NOW - 1000,
+      });
+      const reading = await readTaoUsdCurrentKv(env, NOW);
+      assert.equal(reading?.observed_at, new Date(NOW - 1000).toISOString());
+      const { taoUsdUsable } = await import("../src/alpha-usd.ts");
+      assert.equal(
+        taoUsdUsable(reading, NOW).ok,
+        true,
+        "a one-second-old reading must not be graded stale",
+      );
+    });
+
+    test("an ISO stamp is passed through unchanged", async () => {
+      // Values written before the producer fix are numbers and values after it
+      // are strings; both are in KV at the same time across a deploy.
+      resetModuleState();
+      const iso = new Date(NOW - 1000).toISOString();
+      const { env } = envWith({ usd_per_tao: 204.125, observed_at: iso });
+      assert.equal((await readTaoUsdCurrentKv(env, NOW))?.observed_at, iso);
+    });
+
+    test("a genuinely stale stamp is still stale", async () => {
+      // Proving the fix cannot pass by making everything look fresh.
+      resetModuleState();
+      const { TAO_USD_MAX_AGE_MS, taoUsdUsable } =
+        await import("../src/alpha-usd.ts");
+      const { env } = envWith({
+        usd_per_tao: 204.125,
+        observed_at: NOW - TAO_USD_MAX_AGE_MS - 1000,
+      });
+      const graded = taoUsdUsable(await readTaoUsdCurrentKv(env, NOW), NOW);
+      assert.equal(graded.ok, false);
+      assert.equal(graded.ok === false && graded.reason, "index_stale");
+    });
+
+    test("an unusable stamp stays stale rather than defaulting to fresh", async () => {
+      resetModuleState();
+      const { taoUsdUsable } = await import("../src/alpha-usd.ts");
+      // 1e20 ms is past the Date range, so `new Date(v)` is Invalid Date --
+      // the one finite-positive number that still cannot become a stamp.
+      for (const bad of [0, -1, Number.NaN, {}, true, 1e20]) {
+        const { env } = envWith({ usd_per_tao: 204.125, observed_at: bad });
+        const reading = await readTaoUsdCurrentKv(env, NOW);
+        assert.equal(reading?.observed_at, null, `${JSON.stringify(bad)}`);
+        assert.equal(taoUsdUsable(reading, NOW).ok, false);
+        resetModuleState();
+      }
+    });
+
+    test("block_number is carried when it is a real height, else null", async () => {
+      resetModuleState();
+      const good = envWith({
+        usd_per_tao: 204.125,
+        observed_at: NOW - 1000,
+        block_number: 25_692_599,
+      });
+      assert.equal(
+        (await readTaoUsdCurrentKv(good.env, NOW))?.block_number,
+        25_692_599,
+      );
+      // A fractional or non-numeric height is not a height. It rides along as
+      // the audit trail for the rate, so a wrong one is worse than none.
+      for (const bad of [25_692_599.5, "25692599", null]) {
+        resetModuleState();
+        const { env } = envWith({
+          usd_per_tao: 204.125,
+          observed_at: NOW - 1000,
+          block_number: bad,
+        });
+        assert.equal(
+          (await readTaoUsdCurrentKv(env, NOW))?.block_number,
+          null,
+          `${JSON.stringify(bad)}`,
+        );
+      }
+    });
+
+    test("an unpriced blob is index_unpriced, never a zero rate", async () => {
+      resetModuleState();
+      const { taoUsdUsable } = await import("../src/alpha-usd.ts");
+      const { env } = envWith({
+        usd_per_tao: null,
+        observed_at: NOW - 1000,
+        price_basis: "insufficient_pools",
+      });
+      const reading = await readTaoUsdCurrentKv(env, NOW);
+      assert.equal(reading?.usd_per_tao, null);
+      assert.equal(reading?.price_basis, "insufficient_pools");
+      const graded = taoUsdUsable(reading, NOW);
+      assert.equal(graded.ok === false && graded.reason, "index_unpriced");
+    });
   });
 
   test("module-state reset clears it between test files", async () => {

--- a/tests/tao-usd-index-worker.test.ts
+++ b/tests/tao-usd-index-worker.test.ts
@@ -239,6 +239,57 @@ describe("writeTaoUsdIndexRow", () => {
 });
 
 describe("the ingestion tick", () => {
+  // The KV mirror had NO test, which is how it shipped `observed_at`
+  // as the raw epoch-ms integer while every reader grades that stamp with
+  // `Date.parse`. A once-a-minute cache read as permanently `index_stale`, and
+  // /economics, /subnets/{netuid}/volume and /chain/alpha-volume served no USD
+  // at all -- a dead cache that looked exactly like a healthy decline.
+  it("mirrors the reading into KV with an ISO stamp the readers can parse", async () => {
+    stubRpc([{ result: LIVE_HEADER }, LIVE_BATCH]);
+    const puts: Array<{ key: string; value: string }> = [];
+    const kvEnv = {
+      ...(env as unknown as Record<string, unknown>),
+      METAGRAPH_CONTROL: {
+        put: async (key: string, value: string) => {
+          puts.push({ key, value });
+        },
+      },
+    } as unknown as typeof env;
+
+    const result = await ingestTaoUsdIndex(kvEnv, ctx);
+    expect(result.ok).toBe(true);
+    expect(puts).toHaveLength(1);
+    expect(puts[0].key).toBe("tao-usd:current");
+    const blob = JSON.parse(puts[0].value) as Record<string, unknown>;
+
+    expect(typeof blob.observed_at).toBe("string");
+    // The property that actually matters: the stamp survives the round trip
+    // through the grader the serving side uses. `Date.parse` of a stringified
+    // integer is NaN, and an unparseable stamp is graded stale by design.
+    expect(Number.isFinite(Date.parse(String(blob.observed_at)))).toBe(true);
+    expect(blob.usd_per_tao).toBe(result.usd_per_tao);
+    expect(blob.block_number).toBe(result.block_number);
+    expect(blob.price_basis).toBe(result.price_basis);
+  });
+
+  it("a KV that refuses leaves the tick reporting its durable write", async () => {
+    // Best-effort by design: the series is already durable by this point, and
+    // a consumer with no cached reading declines rather than inventing a rate.
+    stubRpc([{ result: LIVE_HEADER }, LIVE_BATCH]);
+    const kvEnv = {
+      ...(env as unknown as Record<string, unknown>),
+      METAGRAPH_CONTROL: {
+        put: async () => {
+          throw new Error("KV unavailable");
+        },
+      },
+    } as unknown as typeof env;
+    await expect(ingestTaoUsdIndex(kvEnv, ctx)).resolves.toMatchObject({
+      ok: true,
+      written: true,
+    });
+  });
+
   it("is a recorded no-op with no endpoint configured", async () => {
     // Unset must not silently fall back to somebody's public node: which
     // endpoint we accept terms with is an ops decision.

--- a/tests/tao-usd-series.test.ts
+++ b/tests/tao-usd-series.test.ts
@@ -36,13 +36,14 @@ import {
   TAO_USD_MAX_POINTS,
   TAO_USD_WINDOWS,
   buildTaoUsdSeries,
+  loadLatestTaoUsdReading,
   loadTaoUsdSeries,
 } from "../src/tao-usd-series.ts";
 import { handleRequest } from "../workers/api.ts";
 import { handleGraphQLRequest } from "../src/graphql.ts";
 import { MCP_TOOLS } from "../src/mcp-server.ts";
 import type { Row } from "./row-type.ts";
-import { TAO_USD_MAX_AGE_MS } from "../src/alpha-usd.ts";
+import { TAO_USD_MAX_AGE_MS, taoUsdUsable } from "../src/alpha-usd.ts";
 
 // The real DDL, so the CHECK constraint that pairs a null price with
 // `insufficient_pools` is enforced in the fixtures too — a test that could
@@ -169,6 +170,82 @@ describe("loadTaoUsdSeries against real SQLite", () => {
         )
         .run(),
     );
+  });
+});
+
+// Revenue coverage and owner-cut need the RATE, not the series. They
+// used to read `/metagraph/network/tao-usd.json`, an artifact that is never
+// published, so the price was null on every request and every USD leg of
+// /revenue and /chain/revenue-coverage went with it.
+describe("loadLatestTaoUsdReading", () => {
+  test("returns the newest row, shaped for taoUsdUsable", async () => {
+    reading(60_000, 196.2, 99);
+    reading(0, 196.17, 100);
+    reading(3 * 60 * 60 * 1000, 190, 98);
+    const r = await loadLatestTaoUsdReading(storeHandle());
+    assert.equal(r?.usd_per_tao, 196.17);
+    assert.equal(r?.block_number, 100);
+    assert.equal(r?.price_basis, "wrapped_onchain_median");
+    // ISO, not the stored epoch-ms. `taoUsdUsable` grades the stamp with
+    // Date.parse, which returns NaN for a stringified integer and grades an
+    // unparseable stamp as stale -- so a fresh reading would read as hours old.
+    assert.equal(typeof r?.observed_at, "string");
+    assert.equal(r?.observed_at, new Date(NOW).toISOString());
+    assert.equal(taoUsdUsable(r, NOW).ok, true);
+  });
+
+  test("an unpriced newest row declines rather than falling back to an older price", async () => {
+    reading(60 * 60 * 1000, 196.2, 99);
+    reading(0, null, 100);
+    const r = await loadLatestTaoUsdReading(storeHandle());
+    // Stepping back to the older priced row would serve a rate the index has
+    // since withdrawn, while looking healthy.
+    assert.equal(r?.usd_per_tao, null);
+    assert.equal(r?.price_basis, "insufficient_pools");
+    const graded = taoUsdUsable(r, NOW);
+    assert.equal(graded.ok, false);
+    assert.equal(graded.ok === false && graded.reason, "index_unpriced");
+  });
+
+  test("a stale newest row is graded stale, not fresh", async () => {
+    reading(TAO_USD_MAX_AGE_MS + 60_000, 196.2, 99);
+    const graded = taoUsdUsable(
+      await loadLatestTaoUsdReading(storeHandle()),
+      NOW,
+    );
+    assert.equal(graded.ok, false);
+    assert.equal(graded.ok === false && graded.reason, "index_stale");
+  });
+
+  test("a non-string price_basis normalises to null, not to the raw value", async () => {
+    // The column is TEXT under a CHECK, so this is defensive -- but the shape
+    // is what `taoUsdUsable` grades, and a number leaking into `price_basis`
+    // would be published as the reason a price is missing.
+    const handle = {
+      async query<T>() {
+        return [
+          {
+            block_number: 100,
+            observed_at: NOW,
+            usd_per_tao: 196.17,
+            price_basis: 7,
+          },
+        ] as T[];
+      },
+    };
+    const r = await loadLatestTaoUsdReading(handle);
+    assert.equal(r?.price_basis, null);
+    assert.equal(r?.usd_per_tao, 196.17);
+  });
+
+  test("no binding, an empty table and a failed read are all null", async () => {
+    assert.equal(await loadLatestTaoUsdReading(null), null);
+    assert.equal(await loadLatestTaoUsdReading(storeHandle()), null);
+    db.exec("DROP TABLE tao_usd_index");
+    assert.equal(await loadLatestTaoUsdReading(storeHandle()), null);
+    // All three converge on `no_index_reading` -- never on a price of zero.
+    const graded = taoUsdUsable(null, NOW);
+    assert.equal(graded.ok === false && graded.reason, "no_index_reading");
   });
 });
 

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -762,7 +762,6 @@ import type { UsageObservation } from "../src/usage-rollup.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
 import { withAlphaUsdEconomics } from "../src/alpha-usd-overlay.ts";
 import { readTaoUsdCurrentKv } from "./tao-usd-current.ts";
-import type { TaoUsdReading } from "../src/alpha-usd.ts";
 import { runLakehouseSeamWatchdog } from "../src/lakehouse-seam-watchdog.ts";
 import { runSafeModeWatchdog } from "../src/safe-mode-watchdog.ts";
 import {
@@ -8635,7 +8634,7 @@ async function handleApiRequest(
     // this route otherwise touches no database -- see KV_TAO_USD_CURRENT.
     baseData = withAlphaUsdEconomics(
       baseData as Row,
-      (await readTaoUsdCurrentKv(env)) as TaoUsdReading | null,
+      await readTaoUsdCurrentKv(env),
       Date.now(),
     ) as typeof baseData;
   }

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8540,7 +8540,13 @@ async function writeTaoUsdCurrentKv(env: Env, row: TaoUsdIndexRow) {
       KV_TAO_USD_CURRENT,
       JSON.stringify({
         usd_per_tao: row.usd_per_tao,
-        observed_at: row.observed_at,
+        // ISO, NOT the raw epoch-ms this row carries. `TaoUsdReading`
+        // declares a string and `taoUsdUsable` grades it with `Date.parse`,
+        // which returns NaN for a stringified integer -- and an unparseable
+        // stamp is graded `index_stale` by design. Writing the number here made
+        // a once-a-minute cache read as permanently stale, so every USD field
+        // on /economics and the volume routes declined.
+        observed_at: new Date(row.observed_at).toISOString(),
         block_number: row.block_number,
         price_basis: row.price_basis,
       }),

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -26,7 +26,6 @@
 import { observationsReadDb } from "../../src/observations-read-runner.ts";
 import { withChainAlphaVolumeUsd } from "../../src/alpha-usd-overlay.ts";
 import { readTaoUsdCurrentKv } from "../tao-usd-current.ts";
-import type { TaoUsdReading } from "../../src/alpha-usd.ts";
 import { readStore } from "../../src/read-store.ts";
 import { HEALTH_CHECK_TABLES } from "../../src/read-store-tables.ts";
 import {
@@ -1839,7 +1838,7 @@ export async function handleChainAlphaVolume(
       // the window is fixed at 24h. See src/alpha-usd-overlay.ts.
       const priced = withChainAlphaVolumeUsd(
         data as unknown as Record<string, unknown>,
-        (await readTaoUsdCurrentKv(env)) as TaoUsdReading | null,
+        await readTaoUsdCurrentKv(env),
         Date.now(),
       ) as unknown as typeof data;
       // CSV exports the row-shaped per-subnet leaderboard; the network rollup +

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -194,6 +194,7 @@ import {
 } from "../../src/failure-reasons.ts";
 import {
   buildTaoUsdSeries,
+  loadLatestTaoUsdReading,
   loadTaoUsdSeries,
   TAO_USD_WINDOWS,
 } from "../../src/tao-usd-series.ts";
@@ -428,7 +429,7 @@ import {
 import { withAlphaVolumeUsd } from "../../src/alpha-usd-overlay.ts";
 import { withUsdAtTx } from "../../src/price-at-tx.ts";
 import { readTaoUsdCurrentKv } from "../tao-usd-current.ts";
-import type { TaoUsdReading } from "../../src/alpha-usd.ts";
+import { taoUsdUsable } from "../../src/alpha-usd.ts";
 import { buildAccountStakeFlow } from "../../src/account-stake-flow.ts";
 import { loadSubnetStakeFlowFromArtifact } from "../../src/subnet-stake-flow-artifact.ts";
 import {
@@ -4111,7 +4112,7 @@ export async function handleSubnetAlphaVolume(
       // per-trade instant survives to here. See src/alpha-usd-overlay.ts.
       data: withAlphaVolumeUsd(
         data as unknown as Record<string, unknown>,
-        (await readTaoUsdCurrentKv(env)) as TaoUsdReading | null,
+        await readTaoUsdCurrentKv(env),
         Date.now(),
       ),
       meta: await accountMeta(
@@ -7334,17 +7335,36 @@ async function subnetSurfacesFor(
     : null;
 }
 
-/** Latest TAO/USD, or null. Null prices the emission at 0 USD, which yields
- * null ratios -- honest, since without a rate there is no USD comparison. */
+/**
+ * Latest usable TAO/USD, or null when this moment is not priceable.
+ *
+ * READS THE INDEX, NOT AN ARTIFACT. This used to read
+ * `/metagraph/network/tao-usd.json`, which is not published -- the artifact
+ * 404s in R2 with `artifact_not_found`, so the price was null on EVERY request
+ * and every USD leg of /revenue, /chain/revenue-coverage and /owner-cut went
+ * with it. The identical #10566 shape: a decline standing in for a read that
+ * could never have succeeded, indistinguishable from a genuine "no rate"
+ * because null is the documented normal answer.
+ *
+ * `/api/v1/network/tao-usd` was healthy the whole time because it reads
+ * `tao_usd_index` directly -- 1,433 of 1,433 points priced, ~1/minute since
+ * 2026-08-02. Same store, same staleness rule as every other USD surface, so
+ * this cannot drift from what /network/tao-usd reports.
+ *
+ * `taoUsdUsable` grades the reading rather than this function re-deriving the
+ * bound: an unpriced reading (`insufficient_pools`), one past
+ * TAO_USD_MAX_AGE_MS, and an empty table are three distinct outcomes that all
+ * correctly converge on "no rate" -- and none of them is a rate of zero.
+ */
 async function usdPerTaoOrNull(env: Env): Promise<number | null> {
-  try {
-    const artifact = await readArtifact(env, "/metagraph/network/tao-usd.json");
-    if (!artifact.ok) return null;
-    const data = artifact.data as Record<string, unknown> | undefined;
-    const latest = data?.latest as Record<string, unknown> | undefined;
-    const usd = latest?.usd_per_tao;
-    return typeof usd === "number" && Number.isFinite(usd) ? usd : null;
-  } catch {
-    return null;
-  }
+  const reading = await loadLatestTaoUsdReading(
+    readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
+      typeof loadLatestTaoUsdReading
+    >[0],
+  );
+  // Not `reading?.usd_per_tao ?? null` behind the grade: `taoUsdUsable` only
+  // returns ok for a non-null, finite, positive rate, so that `??` arm is
+  // unreachable -- and an unreachable branch reads as a tested one.
+  if (!reading || !taoUsdUsable(reading, Date.now()).ok) return null;
+  return reading.usd_per_tao;
 }

--- a/workers/tao-usd-current.ts
+++ b/workers/tao-usd-current.ts
@@ -15,6 +15,7 @@
 import { readHealthKv } from "./storage.ts";
 import { KV_TAO_USD_CURRENT } from "../src/kv-keys.ts";
 import { registerModuleStateReset } from "../src/module-state-registry.ts";
+import type { TaoUsdReading } from "../src/alpha-usd.ts";
 
 type Row = Record<string, unknown>;
 
@@ -34,7 +35,37 @@ let memo: { env: unknown; value: unknown; expiresAt: number } = {
 };
 
 /**
+ * `observed_at` as an ISO string, whatever the stored value looks like.
+ *
+ * The producer wrote `observed_at` as the raw epoch-ms integer it holds
+ * in `tao_usd_index`, while `TaoUsdReading` declares a string and
+ * `taoUsdUsable` grades it with `Date.parse`. `Date.parse(1786564800000)`
+ * stringifies the number and fails to parse it -- NaN -- and an unparseable
+ * stamp is deliberately graded `index_stale` rather than fresh. So a cache
+ * rewritten EVERY MINUTE was read as hours old on every request, and
+ * /economics, /subnets/{netuid}/volume and /chain/alpha-volume served
+ * `tao_usd_unavailable: "index_stale"` permanently.
+ *
+ * Accepts both forms rather than only the fixed one: values written before the
+ * producer fix are still in KV, and a reader that only understood the new shape
+ * would keep declining until the next tick overwrote them.
+ */
+function observedAtIso(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null;
+}
+
+/**
  * The newest TAO/USD reading from KV, or null.
+ *
+ * Returns a NORMALISED `TaoUsdReading` rather than the raw blob. Every caller
+ * used to cast the bag with `as TaoUsdReading`, which is what let the
+ * epoch-ms/ISO mismatch above typecheck for as long as it did: an unchecked
+ * cast asserts a shape instead of establishing one.
  *
  * A NULL IS NOT MEMOISED. A cold or unbound store stays re-queried rather than
  * being cached as absent for a minute -- otherwise the first request after a
@@ -45,18 +76,30 @@ let memo: { env: unknown; value: unknown; expiresAt: number } = {
 export async function readTaoUsdCurrentKv(
   env: unknown,
   now: number = Date.now(),
-): Promise<Row | null> {
+): Promise<TaoUsdReading | null> {
   if (memo.env === env && now < memo.expiresAt) {
-    return memo.value as Row | null;
+    return memo.value as TaoUsdReading | null;
   }
   const value = await readHealthKv(
     env as Parameters<typeof readHealthKv>[0],
     KV_TAO_USD_CURRENT,
   );
-  if (value !== null) {
-    memo = { env, value, expiresAt: now + TAO_USD_CURRENT_KV_TTL_MS };
-  }
-  return value as Row | null;
+  if (value === null) return null;
+  const row = value as Row;
+  const reading: TaoUsdReading = {
+    usd_per_tao:
+      typeof row.usd_per_tao === "number" && Number.isFinite(row.usd_per_tao)
+        ? row.usd_per_tao
+        : null,
+    observed_at: observedAtIso(row.observed_at),
+    block_number:
+      typeof row.block_number === "number" && Number.isInteger(row.block_number)
+        ? row.block_number
+        : null,
+    price_basis: typeof row.price_basis === "string" ? row.price_basis : null,
+  };
+  memo = { env, value: reading, expiresAt: now + TAO_USD_CURRENT_KV_TTL_MS };
+  return reading;
 }
 
 registerModuleStateReset("workers/tao-usd-current.ts", () => {


### PR DESCRIPTION
## What was wrong

`GET /api/v1/chain/revenue-coverage` and `GET /api/v1/subnets/{netuid}/revenue` served `emission.usd: 0` for **all 129 subnets**, and a `0` inside both `alternates` branches, while `emission.tao` carried a real measured figure:

```
emission: { basis: "tao_total", tao: 441.496728, usd: 0,
            alternates: { alpha_out_priced: { tao: 618.584328, usd: 0 },
                          owner_take:       { tao:  79.467390, usd: 0 } } }
```

Read straight, that is *"the network directs 441 TAO into this subnet and it is worth nothing"* — published at network scale, on the one route whose stated reason for existing is that **absent is null and never zero**. `/api/v1/network/tao-usd` was healthy at the same moment: `usd_per_tao: 200.25`, `price_basis: wrapped_onchain_median`, `stale: false`, 1,433 of 1,433 points priced.

## Two independent defects, stacked

**1. The lookup could never succeed.** `usdPerTaoOrNull` read `/metagraph/network/tao-usd.json` — an artifact that is **never published**. It 404s in R2 (`artifact_not_found: latest/network/tao-usd.json`), so the rate was null on every request the route has ever served. `/api/v1/network/tao-usd` was fine the whole time because it reads `tao_usd_index` directly. This is the #10566 shape again: a correct-looking decline standing in for a read that could not have succeeded, invisible because null is the documented normal answer.

**2. A hardcoded default on top of it.** `loadSubnetRevenue` coalesced that null with `?? 0`. The ratios did come out null as intended — which is why this looked correct — but the USD legs beside them did not.

## The fix

The rate is `number | null` end to end and comes from the index the healthy route already uses, via a new `loadLatestTaoUsdReading` (`LIMIT 1` on the same ordering the series query uses). `taoUsdUsable` grades the reading rather than this code re-deriving the bound, so `insufficient_pools`, a reading past `TAO_USD_MAX_AGE_MS`, and an empty table stay three distinct outcomes that all converge on "no rate" — and none of them is a rate of zero.

A single `priced()` helper applies the multiplication, so an unpriceable window cannot be null in one field and `0` in the next. It declines the newest reading rather than stepping back to an older priced row: that would serve a rate the index has since withdrawn while looking healthy.

The contract now says so — `emission.usd` and both `alternates.*.usd` are `anyOf [number, null]` in OpenAPI and `Float` rather than `Float!` in the SDL.

## A third defect, same subsystem

Verifying which price source to trust turned up that `/economics` and the volume routes were serving `tao_usd_unavailable: "index_stale"` while the Neon index was 8 minutes fresh. The KV hot copy is not stale — it is rewritten every minute. Every reader misparses it: `writeTaoUsdCurrentKv` mirrors `observed_at` as the raw epoch-ms integer, `TaoUsdReading` declares a string, and `taoUsdUsable` grades it with `Date.parse` — which is `NaN` for a stringified integer, and an unparseable stamp is graded stale by design.

So USD has been dead on `/economics` (`alpha_price_usd`, `alpha_market_cap_usd`, `alpha_fdv_usd` for all 129 subnets), `/subnets/{netuid}/volume` and `/chain/alpha-volume`. The producer now writes ISO; the reader normalises both shapes, so values already in KV heal on the next read rather than on the next tick. `readTaoUsdCurrentKv` returns a typed `TaoUsdReading`, which removes the three `as TaoUsdReading` casts that let the mismatch typecheck in the first place.

## Also

`emission_is_positive` graded `emissionUsd > 0` while its name and its own detail string said TAO — so a subnet with 441 TAO of real emission and no rate reported its emission as absent. It grades the TAO leg now, and a new `unpriceable_emission_is_null_not_zero` check states which side declined.

## Tests

Added: a live rate never serialises `usd: 0` against non-zero emission (asserting the exact conversion, not just non-zero, so it cannot pass vacuously); an unpriceable rate serialises `null` on every USD leg; no ratios either; `NaN`/negative rates still throw so a bad rate cannot masquerade as an honest decline; the loader, route and cross-subnet sweep all exercised against a real SQLite fixture under the production DDL; and the KV cases including a genuinely stale stamp, proving the fix does not simply make everything look fresh. The KV mirror had **no test at all**, which is how it shipped.

**Six existing assertions across four suites pinned the zero** — including one named *"no TAO price yields null ratios rather than a bogus USD figure"* that then asserted the bogus figure. All updated.

Patch coverage measured by diff intersection: **98/98 lines, 44/44 branches**. One unreachable defensive branch was restructured away rather than left to read as tested.

## Out of scope

`observed_count` is untouched. The producer gap behind it — and the separate MCP bug where `get_subnet_revenue` / `list_revenue_coverage` never pass `observations` to the loader, so the MCP mirror reports "not observed" for every subnet while REST returns a figure — are both separate.
