### PR TITLE
test-infra: an unbuilt artifact tree names itself, on every caller

### DIFF
--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -640,8 +640,14 @@ export async function latestArtifactDate(
  * `public/metagraph/` is not empty in a fresh checkout -- openapi.json,
  * contracts.json and a few other publish-owned files are committed -- so the
  * root existing proves nothing. These per-entity directories are build output.
+ *
+ * ALL of them, not any (#10919). `some()` passed on a HALF-built tree, which
+ * degrades exactly like an unbuilt one at every reader whose own directory is
+ * the missing half -- and reports itself as a confident zero rather than as a
+ * missing build. The message names which are absent so the answer is one line
+ * rather than a bisect.
  */
-const BUILT_ARTIFACT_MARKERS = ["subnets", "health"];
+const BUILT_ARTIFACT_MARKERS = ["subnets", "health", "economics.json"];
 
 /**
  * Fail loudly when the artifact tree has not been built (#10174).
@@ -662,24 +668,64 @@ const BUILT_ARTIFACT_MARKERS = ["subnets", "health"];
  * Checks only for the absence of the whole tree: a single missing artifact
  * stays a `null`, because that is a real condition readers must handle.
  */
-export function assertArtifactsBuilt(): void {
-  const built = BUILT_ARTIFACT_MARKERS.some(
-    (marker) =>
-      existsSync(path.join(r2StagingRoot, marker)) ||
-      existsSync(path.join(publicMetagraphRoot, marker)),
+export function assertArtifactsBuilt(
+  // The roots are a parameter so the guard is testable in BOTH directions
+  // without a filesystem mock: a test can point it at an empty directory and
+  // watch it refuse, which is the half that cannot be observed from a repo
+  // whose tree is built (as CI's always is).
+  roots: readonly string[] = [publicMetagraphRoot, r2StagingRoot],
+): void {
+  const missing = BUILT_ARTIFACT_MARKERS.filter((marker) =>
+    roots.every((root) => !existsSync(path.join(root, marker))),
   );
-  if (built) return;
+  if (missing.length === 0) return;
   throw new Error(
-    "createLocalArtifactEnv(): the artifact tree is not built, so every read " +
-      "would return null and every reader would degrade to an empty card -- " +
-      "which is indistinguishable from a real empty result.\n" +
-      `Looked for ${BUILT_ARTIFACT_MARKERS.map((m) => `${m}/`).join(" or ")} ` +
-      `under ${publicMetagraphRoot} and ${r2StagingRoot}.\n` +
-      "Run `npm run build` first (CI does this before the suite).",
+    "createLocalArtifactEnv(): the artifact tree is not built, so reads " +
+      "return null and every reader degrades to an empty card -- which is " +
+      "indistinguishable from a real empty result.\n" +
+      `Missing: ${missing.join(", ")} (looked under ${roots.join(" and ")}).\n` +
+      "Run `npm run build` first (CI does this before the suite), or pass " +
+      "`{ requireBuiltArtifacts: false }` if an unbuilt tree is the subject.",
   );
 }
 
-export function createLocalArtifactEnv(overrides: Row = {}): Row {
+/**
+ * Options that are the FACTORY's, not the Worker env's.
+ *
+ * Kept as a second parameter rather than a magic key inside `overrides`,
+ * because everything in `overrides` is handed to the code under test as if it
+ * were a real binding, and a factory flag leaking into an Env is exactly the
+ * kind of thing that reads as a binding nobody declared.
+ */
+export interface LocalArtifactEnvOptions {
+  /**
+   * Assert a built artifact tree first (default true, #10919).
+   *
+   * INVERTED from #10174's opt-in. That version left the assert to the
+   * caller so `validate:committed-seed` -- whose SUBJECT is the committed,
+   * unbuilt tree -- would not fail on its own premise. But only 3 of ~90
+   * callers ever opted in, so every other artifact-dependent failure in a
+   * fresh worktree arrived as `true !== false` with no mention of the build.
+   * Default-on puts the loud message on every caller, including ones written
+   * later, and the one legitimate exception says so at its call site.
+   */
+  requireBuiltArtifacts?: boolean;
+  /**
+   * Where to look for the build markers (defaults to this repo's roots).
+   *
+   * Same parameterization `assertArtifactsBuilt` carries, and for the same
+   * reason: CI's tree is always built, so REFUSAL -- the direction this whole
+   * change is about -- cannot be observed from the repo's own roots. Not a
+   * test-only hook: a caller reading a staged tree elsewhere passes it too.
+   */
+  artifactRoots?: readonly string[];
+}
+
+export function createLocalArtifactEnv(
+  overrides: Row = {},
+  { requireBuiltArtifacts = true, artifactRoots }: LocalArtifactEnvOptions = {},
+): Row {
+  if (requireBuiltArtifacts) assertArtifactsBuilt(artifactRoots);
   return {
     ASSETS: {
       async fetch(request: Request) {

--- a/scripts/validate-committed-seed.ts
+++ b/scripts/validate-committed-seed.ts
@@ -138,7 +138,10 @@ async function main(): Promise<void> {
   const openapi = await readJson(
     path.join(repoRoot, "public/metagraph/openapi.json"),
   );
-  const env = createLocalArtifactEnv();
+  // The COMMITTED tree is this gate's subject: it reads what a cold start
+  // would serve before any build, so an unbuilt tree is the state under test
+  // rather than a mistake (#10919).
+  const env = createLocalArtifactEnv({}, { requireBuiltArtifacts: false });
   const { checked, errors } = await runCommittedSeedGate({ env, openapi });
 
   if (errors.length > 0) {

--- a/tests/lib-helpers.test.ts
+++ b/tests/lib-helpers.test.ts
@@ -47,6 +47,8 @@ import {
   dirtyTrackedPaths,
   isProductionPublishBuild,
   revertDeployOwnedArtifactsIfDirty,
+  assertArtifactsBuilt,
+  createLocalArtifactEnv,
 } from "../scripts/lib.ts";
 import { execFileSync } from "node:child_process";
 import type { Row } from "./row-type.ts";
@@ -2385,5 +2387,84 @@ describe("flattenSurfaces subnet_name (#9909)", () => {
   test("a netuid missing from the map falls back to the overlay", () => {
     const [row] = flattenSurfaces([overlay], {}, new Map<unknown, Row>());
     assert.equal(row.subnet_name, "Eirel");
+  });
+});
+
+describe("the built-tree guard (#10919)", () => {
+  // THE FAILURE THIS EXISTS TO STOP. With `public/metagraph/` unbuilt, every
+  // METAGRAPH_ARCHIVE.get() answers null, every reader degrades to a
+  // schema-stable empty card, and an assertion reads `openSlots.length > 0` as
+  // `true !== false` -- with nothing anywhere saying "run the build". #10174
+  // built the guard and left it opt-in; 3 of ~90 callers ever opted in, so the
+  // other 87 kept failing as mysteries. The default is ON now.
+  //
+  // Driven through an EMPTY ROOT rather than the repo's own tree, because CI
+  // builds before the suite: a test that read the real root would assert
+  // nothing there, which is exactly the direction that matters.
+  test("an unbuilt root is refused, naming what is missing and what to run", () => {
+    const empty = mkdtempSync(path.join(tmpdir(), "no-artifacts-"));
+    try {
+      assertArtifactsBuilt([empty]);
+      assert.fail("expected the unbuilt tree to be refused");
+    } catch (error) {
+      const message = String((error as Error).message);
+      assert.match(message, /artifact tree is not built/);
+      assert.match(message, /Missing: /, "it must name which are absent");
+      assert.match(message, /subnets/, "and list them");
+      assert.match(message, /npm run build/, "and say what to run");
+    }
+  });
+
+  test("a HALF-built tree is refused too, not accepted as built", () => {
+    // The `some()` this replaced accepted any one marker, so a tree with
+    // `subnets/` and no `health/` passed the guard and then degraded exactly
+    // like an unbuilt one -- at the readers whose own half was missing.
+    const half = mkdtempSync(path.join(tmpdir(), "half-artifacts-"));
+    mkdirSync(path.join(half, "subnets"));
+    try {
+      assertArtifactsBuilt([half]);
+      assert.fail("expected the half-built tree to be refused");
+    } catch (error) {
+      const message = String((error as Error).message);
+      assert.match(message, /health/, "the missing half must be named");
+      assert.doesNotMatch(
+        message,
+        /Missing: subnets/,
+        "and the present half must not be",
+      );
+    }
+  });
+
+  test("a complete tree passes", () => {
+    const built = mkdtempSync(path.join(tmpdir(), "built-artifacts-"));
+    mkdirSync(path.join(built, "subnets"));
+    mkdirSync(path.join(built, "health"));
+    writeFileSync(path.join(built, "economics.json"), "{}");
+    assertArtifactsBuilt([built]);
+  });
+
+  test("the factory asserts by DEFAULT -- that is the whole change", () => {
+    // The 87 callers that never opted in are what this reaches. Driven at an
+    // empty root rather than the repo's own, so it asserts the same thing in a
+    // built checkout and an unbuilt one -- a test whose verdict depends on
+    // whether somebody ran the build is the very failure being fixed here.
+    const empty = mkdtempSync(path.join(tmpdir(), "factory-default-"));
+    assert.throws(
+      () => createLocalArtifactEnv({}, { artifactRoots: [empty] }),
+      /artifact tree is not built/,
+    );
+  });
+
+  test("a caller whose SUBJECT is the unbuilt tree can opt out", () => {
+    // validate:committed-seed reads what a cold start would serve BEFORE any
+    // build. Refusing it would fail a gate on its own premise -- which is why
+    // #10174 made the guard opt-in in the first place, and why the escape
+    // hatch has to survive the inversion.
+    const empty = mkdtempSync(path.join(tmpdir(), "factory-optout-"));
+    const env = createLocalArtifactEnv(
+      {},
+      { requireBuiltArtifacts: false, artifactRoots: [empty] },
+    );
+    assert.ok(env.METAGRAPH_ARCHIVE, "the env is built, not refused");
   });
 });


### PR DESCRIPTION
## Summary

Closes #10919: an unbuilt artifact tree now names itself on **every** caller, instead of surfacing as a confident-zero assertion on 87 of them.

With `public/metagraph/` unbuilt, `METAGRAPH_ARCHIVE.get()` answers null, every reader degrades to a schema-stable empty card, and the failure reads `openSlots.length > 0` → `true !== false` — the exact confident-zero shape this repo keeps finding, with nothing anywhere saying "run the build".

#10174 built the guard for this and left it **opt-in**, for a good reason: `validate:committed-seed`'s subject *is* the committed, unbuilt tree, and a default-on assert would have failed a gate on its own premise. But three of ~90 callers ever opted in. The other 87 kept failing as mysteries — most recently four analytics-economics tests and one MCP end-to-end, which have cost a re-derivation per worktree this week.

## What changes

- **`createLocalArtifactEnv()` asserts by default.** The one legitimate exception passes `{ requireBuiltArtifacts: false }` and says why at its call site. New tests get the loud message for free rather than having to know the guard exists.
- **`some()` → all markers.** A half-built tree (say `subnets/` present, `health/` not) degrades exactly like an unbuilt one at the readers whose own half is missing, and used to pass the guard. `economics.json` joins the marker set, since the economics readers are where this last bit.
- **The message names which markers are absent**, so the answer is one line instead of a bisect.
- Options live in a second parameter, not inside `overrides` — everything in `overrides` is handed to the code under test as if it were a real binding, and a factory flag leaking into an Env is its own bug class.

## Proof it fires

Both the guard and the factory take their roots as a parameter, so every arm asserts the same thing in a built checkout and an unbuilt one — **a test whose verdict depends on whether somebody ran the build is the very failure this fixes**, and the first draft of one of these arms had exactly that bug (it passed on CI and failed locally) before being driven at a temp root instead.

Five arms in `tests/lib-helpers.test.ts`: unbuilt refuses and names what to run; half-built refuses and names **only** the missing half; a complete tree passes; the factory refuses **by default**; the opt-out still builds. **Verified the half-built arm fails against the old `some()`** by restoring it, watching the arm go red, and restoring the fix.

Patch coverage measured by diff intersection before pushing: **zero uncovered added statements, zero uncovered added branches** in `scripts/lib.ts` (the file is in vitest's `coverage.include`). One defensive `roots.length === 0` line was deleted rather than tested — a guard for a call nobody makes is debt, not safety.

Before / after, same command in an unbuilt worktree:

```
✗ committed economics yields open-slot subnets: true !== false
✗ createLocalArtifactEnv(): the artifact tree is not built ... Missing: subnets, health, economics.json ... Run `npm run build` first
```

## Validation

- `typecheck` 0 · `eslint --no-cache` 0 (touched files) · `format:check` clean
- `validate:committed-seed` passes — the opt-out caller still reads the pre-build tree it exists to check
- `tests/lib-helpers.test.ts` green, including the prove-it-can-fail cycle above

## Template Used

- backend-code

Closes #10919
