### PR TITLE
fix(ci): make the posthog CLI's CDN download unable to fail an install

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -34,7 +34,6 @@
     "@jsonbored/ui-kit": "*",
     "@polkadot/api": "^16.5.6",
     "@polkadot/extension-dapp": "^0.63.1",
-    "@posthog/rollup-plugin": "^1.4.7",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-router": "^1.170.23",
@@ -62,6 +61,9 @@
     "vite-tsconfig-paths": "^6.0.2",
     "workers-og": "^0.0.27",
     "zod": "^4.4.3"
+  },
+  "optionalDependencies": {
+    "@posthog/rollup-plugin": "^1.4.7"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.5",

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -8,7 +8,42 @@ import { defineConfig, type LovableViteTanstackOptions } from "@lovable.dev/vite
 import type { NitroPluginConfig } from "nitro/vite";
 import type { NormalizedOutputOptions, OutputBundle, Plugin, PluginContext } from "rollup";
 import mdx from "fumadocs-mdx/vite";
-import posthogRollupPlugin from "@posthog/rollup-plugin";
+// OPTIONAL AT INSTALL TIME (#10916), so this import must tolerate absence.
+// `@posthog/cli` -- which this plugin pulls in -- downloads a platform binary
+// from GitHub's release CDN in its postinstall, and that download fails
+// intermittently ("socket hang up"). While the plugin was a hard dependency
+// that failure took `npm ci` down with it, which on Cloudflare Workers Builds
+// means the build dies before running anything: five Worker projects, both
+// repos, red on a coin flip. It is an optionalDependency now, and npm's
+// contract for those is that the install proceeds without them -- so the
+// module may genuinely not be here.
+//
+// `createRequire` rather than a top-level `await import`: this config is
+// loaded synchronously by Vite, and the resolution failure has to be caught
+// rather than becoming an unhandled rejection.
+import { createRequire } from "node:module";
+
+const requireOptional = createRequire(import.meta.url);
+// Returns a Vite/Rollup plugin -- typed as the plugin array's own element
+// so `withTolerantSourcemapUpload` still type-checks its argument.
+type PosthogRollupPlugin = (
+  options: Record<string, unknown>,
+) => Plugin;
+let posthogRollupPlugin: PosthogRollupPlugin | null = null;
+try {
+  const loaded = requireOptional("@posthog/rollup-plugin") as
+    { default?: PosthogRollupPlugin } | PosthogRollupPlugin;
+  posthogRollupPlugin = (typeof loaded === "function" ? loaded : loaded.default) ?? null;
+} catch {
+  // The build proceeds WITHOUT sourcemap upload rather than failing. That is
+  // the same trade `withTolerantSourcemapUpload` below already makes for an
+  // upload that fails at runtime -- a shipped build with no symbolication
+  // beats a build that did not ship.
+  console.warn(
+    "[vite] @posthog/rollup-plugin is not installed; skipping PostHog " +
+      "sourcemap upload for this build (see #10916)",
+  );
+}
 
 // Cloudflare Workers Builds auto-injects this (no manual dashboard step) --
 // confirmed via Cloudflare's own docs (workers/ci-cd/builds/configuration/,
@@ -113,29 +148,35 @@ export default defineConfig({
     // PostHog error tracking (metagraphed#7759) source-map upload, wrapped
     // for the two build-safety gaps documented above this file's
     // `posthogSourcemapsEnabled` const.
-    withTolerantSourcemapUpload(
-      posthogRollupPlugin({
-        personalApiKey: posthogApiKey ?? "",
-        projectId: posthogProjectId,
-        sourcemaps: {
-          enabled: posthogSourcemapsEnabled,
-          // Stable name + per-deploy version, matching the Worker deploys'
-          // convention (scripts/deploy-worker-with-sourcemaps.sh passes
-          // metagraphed-<config> / <sha>). Passing the SHA as releaseName
-          // made every deploy its own one-off "project" in PostHog's release
-          // UI instead of versions of one app. commitSha is undefined
-          // locally/in PR CI, where sourcemaps.enabled is already false.
-          releaseName: "metagraphed-ui",
-          releaseVersion: commitSha,
-          // Same "don't publicly serve the app's own source maps" rationale
-          // as Sentry's filesToDeleteAfterUpload above -- this plugin's own
-          // equivalent option (config.ts's `deleteAfterUpload`, defaults
-          // true) already matches, set explicitly so the intent is documented
-          // here rather than relying on an unstated default.
-          deleteAfterUpload: true,
-        },
-      }),
-    ),
+    // Spread, so an absent plugin contributes NOTHING to the array rather
+    // than a null Vite would have to be asked to tolerate (#10916).
+    ...(posthogRollupPlugin
+      ? [
+          withTolerantSourcemapUpload(
+            posthogRollupPlugin({
+              personalApiKey: posthogApiKey ?? "",
+              projectId: posthogProjectId,
+              sourcemaps: {
+                enabled: posthogSourcemapsEnabled,
+                // Stable name + per-deploy version, matching the Worker deploys'
+                // convention (scripts/deploy-worker-with-sourcemaps.sh passes
+                // metagraphed-<config> / <sha>). Passing the SHA as releaseName
+                // made every deploy its own one-off "project" in PostHog's release
+                // UI instead of versions of one app. commitSha is undefined
+                // locally/in PR CI, where sourcemaps.enabled is already false.
+                releaseName: "metagraphed-ui",
+                releaseVersion: commitSha,
+                // Same "don't publicly serve the app's own source maps" rationale
+                // as Sentry's filesToDeleteAfterUpload above -- this plugin's own
+                // equivalent option (config.ts's `deleteAfterUpload`, defaults
+                // true) already matches, set explicitly so the intent is documented
+                // here rather than relying on an unstated default.
+                deleteAfterUpload: true,
+              },
+            }),
+          ),
+        ]
+      : []),
   ],
   // `vite: { ... }` is this preset's own documented passthrough for plain
   // Vite options beyond plugins (see the header comment above) --

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -26,9 +26,7 @@ import { createRequire } from "node:module";
 const requireOptional = createRequire(import.meta.url);
 // Returns a Vite/Rollup plugin -- typed as the plugin array's own element
 // so `withTolerantSourcemapUpload` still type-checks its argument.
-type PosthogRollupPlugin = (
-  options: Record<string, unknown>,
-) => Plugin;
+type PosthogRollupPlugin = (options: Record<string, unknown>) => Plugin;
 let posthogRollupPlugin: PosthogRollupPlugin | null = null;
 try {
   const loaded = requireOptional("@posthog/rollup-plugin") as

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
     },
     "apps/ui": {
       "name": "metagraphed-ui",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
@@ -69,7 +69,6 @@
         "@jsonbored/ui-kit": "*",
         "@polkadot/api": "^16.5.6",
         "@polkadot/extension-dapp": "^0.63.1",
-        "@posthog/rollup-plugin": "^1.4.7",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-router": "^1.170.23",
@@ -121,6 +120,9 @@
       },
       "engines": {
         "node": ">=22.23.1"
+      },
+      "optionalDependencies": {
+        "@posthog/rollup-plugin": "^1.4.7"
       }
     },
     "apps/ui/node_modules/@eslint/js": {
@@ -5331,6 +5333,7 @@
       "hasInstallScript": true,
       "hasShrinkwrap": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.1.2"
       },
@@ -5347,6 +5350,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5365,6 +5369,7 @@
       "resolved": "https://registry.npmjs.org/@posthog/plugin-utils/-/plugin-utils-1.1.2.tgz",
       "integrity": "sha512-CS/14cMmny9NN/LHAb4QZdW3TfxhbKzsfyVYMCjsRdE0IKMTrXMr0cPRZxwczsN6VnWvVoy2Dd5wcG6RrIjlYA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.6"
       }
@@ -5374,6 +5379,7 @@
       "resolved": "https://registry.npmjs.org/@posthog/rollup-plugin/-/rollup-plugin-1.4.7.tgz",
       "integrity": "sha512-bJgQLKZ5gkq79PBGTNqC8S6OAE8QtNIPYbvHnoboIh8qoZ0PS7RRpxuunoeOflxrHxpnM0Id9OxvrkGKJ2JE6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@posthog/cli": "~0.7.21",
         "@posthog/plugin-utils": "^1.1.2"

--- a/scripts/deploy-worker-with-sourcemaps.sh
+++ b/scripts/deploy-worker-with-sourcemaps.sh
@@ -86,6 +86,29 @@ if [[ -n "${POSTHOG_CLI_API_KEY:-}" && -n "${POSTHOG_CLI_PROJECT_ID:-}" ]]; then
   POSTHOG_ENABLED=true
 fi
 
+# ...AND THE CLI HAS TO BE INSTALLED (#10916). `@posthog/cli` is an optional
+# dependency now, reached through apps/ui's optional `@posthog/rollup-plugin`:
+# its postinstall downloads a platform binary from GitHub's release CDN, that
+# download fails intermittently ("socket hang up"), and while the package was
+# mandatory the failure took `npm ci` down with it. On Cloudflare Workers
+# Builds -- which auto-installs before running any configured command and
+# exposes no install command to retry -- that meant the build died before this
+# script ever ran. npm's contract for an optional dependency is that the
+# install proceeds without it, so the package may legitimately be absent here.
+#
+# SKIP, NEVER FAIL. A Worker deployed without symbolication is a small
+# observability loss; a Worker that did not deploy is an outage. The same
+# trade apps/ui's vite config makes for the same package. `--no-install` is
+# what makes this a check rather than a download attempt: without it, npx
+# would try to fetch the missing package from the network and hang the deploy
+# on the very CDN this is routing around.
+if [[ "$POSTHOG_ENABLED" == "true" ]] &&
+  ! npx --no-install @posthog/cli --version >/dev/null 2>&1; then
+  echo "warning: @posthog/cli is not installed (optional dependency, see" \
+    "#10916); deploying WITHOUT sourcemap injection or upload." >&2
+  POSTHOG_ENABLED=false
+fi
+
 if [[ "$POSTHOG_ENABLED" == "true" ]]; then
   # Phase 0: start from an empty $OUTDIR. `wrangler --outdir` writes into the
   # directory without clearing it, so anything left there from an earlier run


### PR DESCRIPTION
Closes #10916

`@posthog/cli`'s postinstall downloads a platform binary from GitHub's release CDN, that download fails intermittently (`Error fetching release: socket hang up`), and while the package was a **mandatory** dependency the failure took `npm ci` down with it. On Cloudflare Workers Builds that is fatal in a way it is not in Actions: Workers Builds auto-installs **before** running any configured command and — confirmed against the docs and the live dashboard — exposes **no install command**, only build / deploy / version / root directory. So there is nowhere to put the retry that fixed the Actions side in #10871, and the build dies before the build command runs. Five Worker projects across two repos, red on a coin flip.

**The fix is npm's own contract for this.** `@posthog/rollup-plugin` (apps/ui's only reason for having the CLI) moves from `devDependencies` to `optionalDependencies`. npm marks a package optional only when *every* path to it is optional, and this plugin is the CLI's sole requirer — so the relocked tree now carries `optional: true` on **both**, and an install that cannot fetch the binary proceeds instead of failing. Verified in the lockfile, not assumed.

Two consumers then have to tolerate absence, and both now do:

- **`apps/ui/vite.config.ts`** loads the plugin through `createRequire` in a try/catch (synchronous, because Vite loads this config synchronously and a rejected top-level import would be unhandled) and spreads it into `plugins` only when present. **Proven both ways:** `npm run build --workspace=apps/ui` exits 0 with the plugin installed *and* with `node_modules/@posthog/rollup-plugin` moved aside.
- **`scripts/deploy-worker-with-sourcemaps.sh`** checks `npx --no-install @posthog/cli --version` before enabling the sourcemap phases and warns + skips if it is missing. `--no-install` is what makes that a check rather than a download attempt — without it npx would reach for the very CDN this routes around. Verified against the real CLI (passes, 0.7.34) and with it absent (warns, sets `POSTHOG_ENABLED=false`, exits 0 under `set -euo pipefail`).

Both degradations trade the same way, deliberately: **a Worker deployed without symbolication is a small observability loss; a Worker that did not deploy is an outage.** It is the trade `withTolerantSourcemapUpload` already makes in that same vite config for an upload that fails at runtime.

**One approach ruled out, recorded so it is not retried:** `ignore-scripts=true` in `.npmrc` would kill the flake in one line, and would also break **esbuild** and **workerd**, which download their binaries in postinstall — i.e. wrangler itself. The install-script inventory is 8 packages; only `@posthog/cli` is both non-essential and network-dependent.

`tsc` clean (root and apps/ui), prettier clean, UI build green in both configurations.