### PR TITLE
fix(api): declare the per-row USD twins the economics overlay stamps

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -1090,6 +1090,19 @@ type SubnetHealth {
 }
 
 type SubnetEconomics {
+  """
+  What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).
+  """
+  alpha_market_cap_basis: String
+
+  """alpha_price_tao converted at the blob's tao_usd reading."""
+  alpha_price_usd: Float
+
+  """alpha_market_cap_tao converted at the blob's tao_usd reading."""
+  alpha_market_cap_usd: Float
+
+  """alpha_fdv_tao converted at the blob's tao_usd reading."""
+  alpha_fdv_usd: Float
   alpha_fdv_tao: Float
   alpha_in_emission: Float
   alpha_out_emission: Float
@@ -4486,6 +4499,20 @@ type OpportunityBoards {
 }
 
 type OpportunityEntry {
+  """
+  What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).
+  """
+  alpha_market_cap_basis: String
+
+  """alpha_price_tao converted at the blob's tao_usd reading."""
+  alpha_price_usd: Float
+
+  """alpha_market_cap_tao converted at the blob's tao_usd reading."""
+  alpha_market_cap_usd: Float
+
+  """alpha_fdv_tao converted at the blob's tao_usd reading."""
+  alpha_fdv_usd: Float
+
   """
   Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227).
   """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3232,12 +3232,20 @@ export type OpportunityBoards = {
 
 export type OpportunityEntry = {
   __typename?: 'OpportunityEntry';
+  /** alpha_fdv_tao converted at the blob's tao_usd reading. */
+  alpha_fdv_usd?: Maybe<Scalars['Float']['output']>;
+  /** What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381). */
+  alpha_market_cap_basis?: Maybe<Scalars['String']['output']>;
+  /** alpha_market_cap_tao converted at the blob's tao_usd reading. */
+  alpha_market_cap_usd?: Maybe<Scalars['Float']['output']>;
   /** Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
   alpha_price_change_1d?: Maybe<Scalars['Float']['output']>;
   /** Signed %-change in alpha_price_tao over ~7 days from subnet_snapshots (#7227). */
   alpha_price_change_7d?: Maybe<Scalars['Float']['output']>;
   /** The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
   alpha_price_tao?: Maybe<Scalars['Float']['output']>;
+  /** alpha_price_tao converted at the blob's tao_usd reading. */
+  alpha_price_usd?: Maybe<Scalars['Float']['output']>;
   emission_share?: Maybe<Scalars['Float']['output']>;
   max_uids?: Maybe<Scalars['Int']['output']>;
   max_validators?: Maybe<Scalars['Int']['output']>;
@@ -6139,9 +6147,15 @@ export type SubnetDeregistrations = {
 export type SubnetEconomics = {
   __typename?: 'SubnetEconomics';
   alpha_fdv_tao?: Maybe<Scalars['Float']['output']>;
+  /** alpha_fdv_tao converted at the blob's tao_usd reading. */
+  alpha_fdv_usd?: Maybe<Scalars['Float']['output']>;
   alpha_in_emission?: Maybe<Scalars['Float']['output']>;
   alpha_in_pool?: Maybe<Scalars['Float']['output']>;
+  /** What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381). */
+  alpha_market_cap_basis?: Maybe<Scalars['String']['output']>;
   alpha_market_cap_tao?: Maybe<Scalars['Float']['output']>;
+  /** alpha_market_cap_tao converted at the blob's tao_usd reading. */
+  alpha_market_cap_usd?: Maybe<Scalars['Float']['output']>;
   alpha_out_emission?: Maybe<Scalars['Float']['output']>;
   alpha_out_pool?: Maybe<Scalars['Float']['output']>;
   /** Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
@@ -6154,6 +6168,8 @@ export type SubnetEconomics = {
   alpha_price_change_7d?: Maybe<Scalars['Float']['output']>;
   /** The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
   alpha_price_tao?: Maybe<Scalars['Float']['output']>;
+  /** alpha_price_tao converted at the blob's tao_usd reading. */
+  alpha_price_usd?: Maybe<Scalars['Float']['output']>;
   block?: Maybe<Scalars['Int']['output']>;
   emission_enabled?: Maybe<Scalars['Boolean']['output']>;
   emission_share?: Maybe<Scalars['Float']['output']>;
@@ -11261,9 +11277,13 @@ export type OpportunityBoardsResolvers<ContextType = GqlContext, ParentType exte
 }>;
 
 export type OpportunityEntryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['OpportunityEntry'] = ResolversParentTypes['OpportunityEntry']> = ResolversObject<{
+  alpha_fdv_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_market_cap_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  alpha_market_cap_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_change_1d?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_change_7d?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_price_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   emission_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   max_uids?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   max_validators?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -12300,9 +12320,12 @@ export type SubnetDeregistrationsResolvers<ContextType = GqlContext, ParentType 
 
 export type SubnetEconomicsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEconomics'] = ResolversParentTypes['SubnetEconomics']> = ResolversObject<{
   alpha_fdv_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_fdv_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_in_emission?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_in_pool?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_market_cap_basis?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   alpha_market_cap_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_market_cap_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_out_emission?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_out_pool?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_change_1d?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
@@ -12310,6 +12333,7 @@ export type SubnetEconomicsResolvers<ContextType = GqlContext, ParentType extend
   alpha_price_change_1m?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_change_7d?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   alpha_price_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  alpha_price_usd?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   emission_enabled?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   emission_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10844,9 +10844,18 @@ export interface components {
         };
         SubnetEconomics: {
             alpha_fdv_tao: number | null;
+            /** @description alpha_fdv_tao converted at the blob's tao_usd reading. */
+            alpha_fdv_usd?: number;
             alpha_in_emission?: number | null;
             alpha_in_pool: number | null;
+            /**
+             * @description What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).
+             * @constant
+             */
+            alpha_market_cap_basis?: "total_stake_alpha";
             alpha_market_cap_tao: number | null;
+            /** @description alpha_market_cap_tao converted at the blob's tao_usd reading. */
+            alpha_market_cap_usd?: number;
             alpha_out_emission?: number | null;
             alpha_out_pool: number | null;
             /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
@@ -10859,6 +10868,8 @@ export interface components {
             alpha_price_change_7d?: number | null;
             /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
             alpha_price_tao: number | null;
+            /** @description alpha_price_tao converted at the blob's tao_usd reading. */
+            alpha_price_usd?: number;
             block?: number | null;
             emission_enabled?: boolean | null;
             emission_share: number | null;
@@ -18270,9 +18281,12 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_fdv_usd": 0.5,
                      *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
+                     *           "alpha_market_cap_basis": "total_stake_alpha",
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_market_cap_usd": 0.5,
                      *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
@@ -18280,6 +18294,7 @@ export interface operations {
                      *           "alpha_price_change_1m": 0.5,
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
+                     *           "alpha_price_usd": 0.5,
                      *           "block": 5000000,
                      *           "emission_enabled": false,
                      *           "emission_share": 0.5,
@@ -39702,9 +39717,12 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_fdv_usd": 0.5,
                      *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
+                     *           "alpha_market_cap_basis": "total_stake_alpha",
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_market_cap_usd": 0.5,
                      *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
@@ -39712,6 +39730,7 @@ export interface operations {
                      *           "alpha_price_change_1m": 0.5,
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
+                     *           "alpha_price_usd": 0.5,
                      *           "block": 5000000,
                      *           "emission_enabled": false,
                      *           "emission_share": 0.5,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9229,9 +9229,12 @@
             "contract_version": "2026-06-29.1",
             "economics": {
               "alpha_fdv_tao": 0.5,
+              "alpha_fdv_usd": 0.5,
               "alpha_in_emission": 0.5,
               "alpha_in_pool": 0.5,
+              "alpha_market_cap_basis": "total_stake_alpha",
               "alpha_market_cap_tao": 0.5,
+              "alpha_market_cap_usd": 0.5,
               "alpha_out_emission": 0.5,
               "alpha_out_pool": 0.5,
               "alpha_price_change_1d": 0.5,
@@ -9239,6 +9242,7 @@
               "alpha_price_change_1m": 0.5,
               "alpha_price_change_7d": 0.5,
               "alpha_price_tao": 0.5,
+              "alpha_price_usd": 0.5,
               "block": 5000000,
               "emission_enabled": false,
               "emission_share": 0.5,
@@ -46357,6 +46361,10 @@
               }
             ]
           },
+          "alpha_fdv_usd": {
+            "description": "alpha_fdv_tao converted at the blob's tao_usd reading.",
+            "type": "number"
+          },
           "alpha_in_emission": {
             "anyOf": [
               {
@@ -46377,6 +46385,11 @@
               }
             ]
           },
+          "alpha_market_cap_basis": {
+            "const": "total_stake_alpha",
+            "description": "What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).",
+            "type": "string"
+          },
           "alpha_market_cap_tao": {
             "anyOf": [
               {
@@ -46386,6 +46399,10 @@
                 "type": "null"
               }
             ]
+          },
+          "alpha_market_cap_usd": {
+            "description": "alpha_market_cap_tao converted at the blob's tao_usd reading.",
+            "type": "number"
           },
           "alpha_out_emission": {
             "anyOf": [
@@ -46461,6 +46478,10 @@
               }
             ],
             "description": "The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that."
+          },
+          "alpha_price_usd": {
+            "description": "alpha_price_tao converted at the blob's tao_usd reading.",
+            "type": "number"
           },
           "block": {
             "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10844,9 +10844,18 @@ export interface components {
         };
         SubnetEconomics: {
             alpha_fdv_tao: number | null;
+            /** @description alpha_fdv_tao converted at the blob's tao_usd reading. */
+            alpha_fdv_usd?: number;
             alpha_in_emission?: number | null;
             alpha_in_pool: number | null;
+            /**
+             * @description What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).
+             * @constant
+             */
+            alpha_market_cap_basis?: "total_stake_alpha";
             alpha_market_cap_tao: number | null;
+            /** @description alpha_market_cap_tao converted at the blob's tao_usd reading. */
+            alpha_market_cap_usd?: number;
             alpha_out_emission?: number | null;
             alpha_out_pool: number | null;
             /** @description Signed %-change in alpha_price_tao over ~1 day from subnet_snapshots (#7227). */
@@ -10859,6 +10868,8 @@ export interface components {
             alpha_price_change_7d?: number | null;
             /** @description The chain's MOVING price, not spot (#9408): on the live tier this is byte-identical to moving_price_pinned, the same word at the same instant. It is the right number for emission weighting, which is what the chain uses it for — but a lagging average is the wrong mark for valuing a position, and the gap widens exactly when the market moves. Use spot_price_tao for that. */
             alpha_price_tao: number | null;
+            /** @description alpha_price_tao converted at the blob's tao_usd reading. */
+            alpha_price_usd?: number;
             block?: number | null;
             emission_enabled?: boolean | null;
             emission_share: number | null;
@@ -18270,9 +18281,12 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_fdv_usd": 0.5,
                      *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
+                     *           "alpha_market_cap_basis": "total_stake_alpha",
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_market_cap_usd": 0.5,
                      *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
@@ -18280,6 +18294,7 @@ export interface operations {
                      *           "alpha_price_change_1m": 0.5,
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
+                     *           "alpha_price_usd": 0.5,
                      *           "block": 5000000,
                      *           "emission_enabled": false,
                      *           "emission_share": 0.5,
@@ -39702,9 +39717,12 @@ export interface operations {
                      *         "contract_version": "2026-06-29.1",
                      *         "economics": {
                      *           "alpha_fdv_tao": 0.5,
+                     *           "alpha_fdv_usd": 0.5,
                      *           "alpha_in_emission": 0.5,
                      *           "alpha_in_pool": 0.5,
+                     *           "alpha_market_cap_basis": "total_stake_alpha",
                      *           "alpha_market_cap_tao": 0.5,
+                     *           "alpha_market_cap_usd": 0.5,
                      *           "alpha_out_emission": 0.5,
                      *           "alpha_out_pool": 0.5,
                      *           "alpha_price_change_1d": 0.5,
@@ -39712,6 +39730,7 @@ export interface operations {
                      *           "alpha_price_change_1m": 0.5,
                      *           "alpha_price_change_7d": 0.5,
                      *           "alpha_price_tao": 0.5,
+                     *           "alpha_price_usd": 0.5,
                      *           "block": 5000000,
                      *           "emission_enabled": false,
                      *           "emission_share": 0.5,

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -299,8 +299,49 @@ export type PartnershipMetadata = z.infer<typeof PartnershipMetadataSchema>;
 // Per-subnet validator/economic metrics (src/contracts.ts's SubnetEconomics
 // component) — the /api/v1/economics list item AND the optional `economics`
 // field nested inside /api/v1/subnets/{netuid}'s SubnetDetailArtifact.
+/**
+ * The USD twins `withAlphaUsd` stamps on EACH economics row (#10381), as
+ * opposed to the blob-level reading in ALPHA_USD_OVERLAY below.
+ *
+ * DECLARED HERE BECAUSE THE ROW HALF WAS NOT. #10790 declared the blob half
+ * and the row half went with it undeclared, which was invisible while these
+ * schemas were `.passthrough()`. #10853's flip to `.strict()` turned that
+ * into a hard refusal, and `/api/v1/economics` began 500ing on every request
+ * with `response_schema_drift` naming these four keys (2026-08-12) -- the
+ * same shape as #10897's three routes, found the same way.
+ *
+ * ALL OPTIONAL, because emission is conditional by design: a `_usd` field is
+ * written only when the reading priced it (an explicit null would be
+ * indistinguishable from a genuine zero once it reached a chart), and the
+ * basis rides only on a row that has an `alpha_market_cap_tao` to describe.
+ * The blob's `tao_usd_unavailable` is what says why they are absent.
+ */
+export const ALPHA_USD_ROW_OVERLAY = {
+  alpha_market_cap_basis: z
+    .literal("total_stake_alpha")
+    .optional()
+    .describe(
+      "What alpha_market_cap_tao multiplies -- published rather than documented, because a market cap without its basis is not a number anyone can reconcile (#10381).",
+    ),
+  alpha_price_usd: z
+    .number()
+    .optional()
+    .describe("alpha_price_tao converted at the blob's tao_usd reading."),
+  alpha_market_cap_usd: z
+    .number()
+    .optional()
+    .describe("alpha_market_cap_tao converted at the blob's tao_usd reading."),
+  alpha_fdv_usd: z
+    .number()
+    .optional()
+    .describe("alpha_fdv_tao converted at the blob's tao_usd reading."),
+} as const;
+
 export const SubnetEconomicsSchema = z
   .object({
+    // The serve-time USD twins (#10381), declared with the schema they are
+    // stamped onto rather than restated here -- see ALPHA_USD_ROW_OVERLAY.
+    ...ALPHA_USD_ROW_OVERLAY,
     alpha_fdv_tao: z.number().nullable(),
     // --- v440 emission pipeline (#8743) ---------------------------------
     // Optional, not required: a refresh whose node could not serve

--- a/src/economics-field-sources.ts
+++ b/src/economics-field-sources.ts
@@ -177,6 +177,21 @@ export const ECONOMICS_FIELD_SOURCES = {
   // instant tao_in_pool_tao and alpha_in_pool were read at is the instant this is
   // true of, by construction.
   spot_price_tao: { kind: "reconstructed", storage: null },
+  // The serve-time USD twins (#10381), declared here because #9078's gate asks
+  // every PUBLISHED field for its provenance and these became published when
+  // the row schema learned them (ALPHA_USD_ROW_OVERLAY). `reconstructed`, and
+  // matching `ALPHA_USD_FIELD_SOURCE` in src/alpha-usd.ts, which
+  // withAlphaUsdEconomics stamps at serve time for the three `_usd` fields:
+  // no storage item holds a USD figure -- each is a TAO field multiplied by
+  // the blob's own tao_usd reading, which is why the reading rides at the
+  // blob level rather than per row.
+  alpha_price_usd: { kind: "reconstructed", storage: null },
+  alpha_market_cap_usd: { kind: "reconstructed", storage: null },
+  alpha_fdv_usd: { kind: "reconstructed", storage: null },
+  // Not a measurement at all: a constant naming WHAT alpha_market_cap_tao
+  // multiplies, so a consumer can reconcile the number. Reconstructed for the
+  // same reason `slug` is -- we mint it, no instant applies.
+  alpha_market_cap_basis: { kind: "reconstructed", storage: null },
   alpha_price_change_1h: { kind: "reconstructed", storage: null },
   alpha_price_change_1d: { kind: "reconstructed", storage: null },
   alpha_price_change_7d: { kind: "reconstructed", storage: null },
@@ -294,6 +309,21 @@ export const ECONOMICS_FIELD_SOURCES_LIVE_KV = {
   // instant tao_in_pool_tao and alpha_in_pool were read at is the instant this is
   // true of, by construction.
   spot_price_tao: { kind: "reconstructed", storage: null },
+  // The serve-time USD twins (#10381), declared here because #9078's gate asks
+  // every PUBLISHED field for its provenance and these became published when
+  // the row schema learned them (ALPHA_USD_ROW_OVERLAY). `reconstructed`, and
+  // matching `ALPHA_USD_FIELD_SOURCE` in src/alpha-usd.ts, which
+  // withAlphaUsdEconomics stamps at serve time for the three `_usd` fields:
+  // no storage item holds a USD figure -- each is a TAO field multiplied by
+  // the blob's own tao_usd reading, which is why the reading rides at the
+  // blob level rather than per row.
+  alpha_price_usd: { kind: "reconstructed", storage: null },
+  alpha_market_cap_usd: { kind: "reconstructed", storage: null },
+  alpha_fdv_usd: { kind: "reconstructed", storage: null },
+  // Not a measurement at all: a constant naming WHAT alpha_market_cap_tao
+  // multiplies, so a consumer can reconcile the number. Reconstructed for the
+  // same reason `slug` is -- we mint it, no instant applies.
+  alpha_market_cap_basis: { kind: "reconstructed", storage: null },
   alpha_price_change_1h: { kind: "reconstructed", storage: null },
   alpha_price_change_1d: { kind: "reconstructed", storage: null },
   alpha_price_change_7d: { kind: "reconstructed", storage: null },

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -4046,6 +4046,56 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
       "2026-08-12T00:00:00.000Z",
     );
   });
+  test("economics: the serve-time USD overlay stays inside the contract (#10381)", async () => {
+    // The ROW half of the overlay was undeclared while these schemas were
+    // .passthrough(); #10853's flip to .strict() turned that into
+    // /api/v1/economics 500ing on every request with response_schema_drift
+    // naming alpha_market_cap_basis / alpha_price_usd / alpha_market_cap_usd
+    // / alpha_fdv_usd. Driven through the REAL overlay over the REAL artifact
+    // -- a hand-built row would only re-specify the schema and would miss the
+    // required fields the committed data actually carries.
+    const { withAlphaUsdEconomics } = await import(
+      "../src/alpha-usd-overlay.ts"
+    );
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/economics"),
+      env as unknown as Env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const served = ((await res.json()) as { data: Record<string, unknown> }).data;
+    const overlaid = withAlphaUsdEconomics(
+      served,
+      {
+        usd_per_tao: 200,
+        block_number: 1,
+        // FRESH, deliberately: taoUsdUsable declines a stale reading, and a
+        // declined reading leaves the rows untouched -- which would make this
+        // test pass while proving nothing.
+        observed_at: new Date().toISOString(),
+        price_basis: "wrapped_onchain_median",
+        pools: 9,
+      } as never,
+      Date.now(),
+    ) as Record<string, unknown>;
+    // The overlay must actually have applied, or this passes vacuously --
+    // and it is CONDITIONAL: the basis rides only on a row carrying an
+    // alpha_market_cap_tao to describe (root does not), so assert on a row
+    // that qualifies rather than on index 0.
+    const rows = overlaid.subnets as Record<string, unknown>[];
+    const priced = rows.find((r) => r.alpha_market_cap_tao != null);
+    assert.ok(priced, "the fixture must carry at least one priced subnet");
+    assert.equal(priced!.alpha_market_cap_basis, "total_stake_alpha");
+    assert.equal(typeof priced!.alpha_price_usd, "number");
+    const parsed = EconomicsArtifactSchema.safeParse(overlaid);
+    assert.equal(
+      parsed.success,
+      true,
+      parsed.success ? "" : JSON.stringify(parsed.error.issues.slice(0, 4)),
+    );
+  });
+
   test("agent-catalog: AgentCatalogArtifactSchema.parse({}) fails (not a vacuous passthrough)", () => {
     const result = AgentCatalogArtifactSchema.safeParse({});
     assert.equal(result.success, false);

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -4054,9 +4054,8 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
     // / alpha_fdv_usd. Driven through the REAL overlay over the REAL artifact
     // -- a hand-built row would only re-specify the schema and would miss the
     // required fields the committed data actually carries.
-    const { withAlphaUsdEconomics } = await import(
-      "../src/alpha-usd-overlay.ts"
-    );
+    const { withAlphaUsdEconomics } =
+      await import("../src/alpha-usd-overlay.ts");
     const env = createLocalArtifactEnv();
     const res = await handleRequest(
       new Request("https://api.metagraph.sh/api/v1/economics"),
@@ -4064,7 +4063,8 @@ describe("batch 10 (#8064) route artifact schemas parse real builder output", ()
       {},
     );
     assert.equal(res.status, 200);
-    const served = ((await res.json()) as { data: Record<string, unknown> }).data;
+    const served = ((await res.json()) as { data: Record<string, unknown> })
+      .data;
     const overlaid = withAlphaUsdEconomics(
       served,
       {


### PR DESCRIPTION
`/api/v1/economics` is returning **HTTP 500 on every request** right now (`response_schema_drift`), and this restores it.

The alarm #10898 added is what caught it, within minutes and with the diagnosis attached: `unrecognized_keys: alpha_market_cap_basis, alpha_price_usd, alpha_market_cap_usd, alpha_fdv_usd`. Before that change the same outage would have been silent — visible only as `usage_event ok:false` until someone swept the routes.

Same class as #10897, one level down. #10790 declared the **blob**-level half of the #10381 USD overlay (`ALPHA_USD_OVERLAY`: `tao_usd` / `tao_usd_unavailable`) and the **row**-level half went with it undeclared. That was invisible while these schemas were `.passthrough()`; #10853's flip to `.strict()` made it a hard refusal, and the route began failing as soon as the TAO/USD index was fresh enough for `withAlphaUsd` to actually stamp the twins.

`ALPHA_USD_ROW_OVERLAY` now declares the four, spread into `SubnetEconomicsSchema` beside the `spot_price_tao` overlay that *was* declared (#9408) — one constant next to its blob-level sibling rather than four fields restated inline, so the pair cannot drift apart again. All four are optional because emission is conditional by design: a `_usd` field is written only when the reading priced it (an explicit null would be indistinguishable from a genuine zero once it reached a chart), and the basis rides only on a row carrying an `alpha_market_cap_tao` to describe.

**Verified against production data before writing the test:** the live `/metagraph/economics.json` artifact, run through the real `withAlphaUsdEconomics`, parses clean — `alpha_market_cap_basis=total_stake_alpha alpha_price_usd=17.194… alpha_market_cap_usd=67447404.80… alpha_fdv_usd=361075404.56`.

The regression test drives the **real overlay over the real served artifact** (a hand-built row only re-specifies the schema and misses the required fields the committed data carries — my first attempt did exactly that). Two guards against passing vacuously: it asserts the overlay actually applied before parsing, and it targets a row that *has* an `alpha_market_cap_tao` rather than index 0, since root has none. The reading is stamped fresh deliberately — `taoUsdUsable` declines a stale one, and a declined reading leaves rows untouched, which would have made the test prove nothing.

`tsc`, `validate:contract-drift`, `validate:openapi`, 329 tests, prettier — all green; regenerated contract artifacts committed.