### PR TITLE
fix(observability): retire two more #10851 fossils, and declare self-stake's cadence instead of inferring it

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -98,6 +98,19 @@ export const RETIRED_LANES: readonly string[] = [
   // test pins this to code rather than to a deleted file: the live writer
   // provably cannot produce the bare key.
   "raw-capture-state",
+  // The SAME #10851 fossil, two more spellings (alerted 2026-08-12, "silent
+  // 21.9h" apiece). Both stopped receiving verdicts at 2026-08-11T23:35Z --
+  // the same instant as each other, which is the signature of a writer that
+  // changed its key rather than of two lanes independently dying -- while
+  // `neon:neurons` and `neon:tao-usd-index` were both `ok` on the same read
+  // ("11 statement(s) flushed", "10 statement(s) flushed", 22:01Z the next
+  // day). Since #10851 every verdict for these lanes lands under the
+  // prefixed key, and nothing else writes the bare ones: unlike
+  // `account-balances` and `validator-nominators`, whose bare names carry the
+  // POLLER's own scan outcome ("558009 scanned, 366107 written") and are
+  // therefore live, these two are written only from inside the Worker.
+  "neurons",
+  "tao-usd-index",
 ];
 
 /**

--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -96,6 +96,21 @@ export const PRODUCER_CADENCE_SECS = {
    * Revisit once it has run a full day (metagraphed-infra#454).
    */
   subnet_ownership: 300,
+  /**
+   * SELF_STAKE_POLL_SECS -- daily (`20 4 * * *`), one pass of ~64 minutes.
+   *
+   * ABSENT UNTIL NOW, which is the whole defect (alerted 2026-08-12: "lane
+   * self-stake is stale: 20.2h (producer cadence 3.1h)"). With no declared
+   * cadence the alarm fell back to the OBSERVED gap between lane_health
+   * writes -- and this lane writes several verdicts per pass, so the gaps it
+   * measured were intra-pass minutes rather than the day between passes. The
+   * inferred ~187m bound is roughly an eighth of the real interval, so a
+   * perfectly healthy daily lane read `stale` for most of every day.
+   *
+   * Exactly what the floor in this table exists for, and the same trap
+   * `account_identity` hit in #10329 from the other direction.
+   */
+  self_stake: 86_400,
 } as const;
 
 export type ProducerLane = keyof typeof PRODUCER_CADENCE_SECS;
@@ -135,6 +150,8 @@ export const LANE_PRODUCER: Readonly<Record<string, ProducerLane>> = {
   "neon:account-identity": "account_identity",
   "subnet-hyperparams": "subnet_hyperparams",
   "neon:subnet-hyperparams": "subnet_hyperparams",
+  "self-stake": "self_stake",
+  "neon:self-stake": "self_stake",
   "subnet-identity": "subnet_identity",
   "neon:subnet-identity": "subnet_identity",
   // No `neon:` sibling: this lane writes Postgres directly rather than through

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -24,6 +24,9 @@ import {
 } from "../src/lane-health.ts";
 import { neonLaneKey } from "../src/neon-write.ts";
 import { RAW_CAPTURE_STATE_NEON_LANE } from "../src/capture-state-neon-write.ts";
+import { NEURONS_NEON_LANE } from "../src/neurons-neon-write.ts";
+// The lane constant lives with its cron in the data-api Worker.
+import { TAO_USD_INDEX_NEON_LANE } from "../workers/data-api.ts";
 
 /** Each retired lane, and the producer whose deletion justifies retiring it.
  * `null` marks the one entry whose producer was a KEY SPELLING rather than a
@@ -35,6 +38,10 @@ const PRODUCERS: Record<string, string | null> = {
   "neon-mirror-lag": "src/neon-mirror-lag.ts",
   "neon:backfill:": "src/neon-backfill.ts",
   "raw-capture-state": null,
+  // Same #10851 key change, two more spellings -- justified by the code
+  // assertion below rather than by a deleted file.
+  neurons: null,
+  "tao-usd-index": null,
 };
 
 function fakeDb(rows: Record<string, unknown>[]) {
@@ -71,6 +78,34 @@ describe("retired lanes (#10222)", () => {
         `${producer} is gone -- ${name} may only be retired because nothing writes it`,
       );
     }
+  });
+
+  test("the bare #10851 spellings cannot be written by the live writer", () => {
+    // Every one of these lanes still runs -- what changed in #10851 is the KEY
+    // its verdicts land under. Retiring the bare spelling silences a row
+    // frozen at that deploy; the prefixed lane stays watched, and was `ok` on
+    // the same production read that showed these three stuck.
+    for (const lane of [
+      RAW_CAPTURE_STATE_NEON_LANE,
+      NEURONS_NEON_LANE,
+      TAO_USD_INDEX_NEON_LANE,
+    ]) {
+      assert.equal(isRetiredLane(lane), true, `${lane} (bare) is retired`);
+      assert.equal(
+        isRetiredLane(neonLaneKey(lane)),
+        false,
+        `${neonLaneKey(lane)} stays watched`,
+      );
+    }
+  });
+
+  test("the POLLER's own bare lanes are NOT retired", () => {
+    // The distinction this list turns on. `account-balances` and
+    // `validator-nominators` carry the poller's own scan outcome under their
+    // bare names ("558009 scanned, 366107 written"), so those spellings have a
+    // live writer and retiring them would be suppression, not cleanup.
+    assert.equal(isRetiredLane("account-balances"), false);
+    assert.equal(isRetiredLane("validator-nominators"), false);
   });
 
   test("raw-capture-state (bare) cannot be written by the live writer", () => {

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -155,7 +155,9 @@ describe("loadLatestLaneHealth", () => {
         checked_at: NOW,
       },
       {
-        lane: "neurons",
+        // `neon:neurons`, not the bare spelling: that one is retired (#10851
+        // froze it) and the serving read drops retired lanes by design.
+        lane: "neon:neurons",
         verdict: "ok",
         age_ms: 10,
         detail: null,
@@ -163,9 +165,12 @@ describe("loadLatestLaneHealth", () => {
       },
     ]);
     const latest = await loadLatestLaneHealth(db);
-    assert.deepEqual(Object.keys(latest).sort(), ["chain-detail", "neurons"]);
+    assert.deepEqual(Object.keys(latest).sort(), [
+      "chain-detail",
+      "neon:neurons",
+    ]);
     assert.equal(latest["chain-detail"].verdict, "stale");
-    assert.equal(latest.neurons.detail, null);
+    assert.equal(latest["neon:neurons"].detail, null);
     // The newest-per-lane reduction happens in SQL, not in the Worker: the table
     // grows by a row per lane per tick forever, so a full scan would get slower
     // every day this runs.

--- a/tests/producer-cadence.test.ts
+++ b/tests/producer-cadence.test.ts
@@ -11,6 +11,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  LANE_PRODUCER,
   PRODUCER_CADENCE_SECS,
   cadenceMs,
   missedTicksMs,
@@ -104,6 +105,30 @@ describe("the cadence table", () => {
         `${lane} cadence ${secs} is not a positive integer`,
       );
     }
+  });
+
+  test("every lane the alarm maps names a cadence in this table", () => {
+    // A lane mapped to a producer with no declared cadence falls back to the
+    // OBSERVED gap between its lane_health writes -- and a lane that writes
+    // several verdicts per pass measures intra-pass minutes rather than the
+    // interval between passes. That is how `self-stake` (daily) alarmed at
+    // "stale: 20.2h (producer cadence 3.1h)" on 2026-08-12: a bound roughly
+    // an eighth of the real one, so a healthy lane read stale most of the day.
+    for (const [lane, producer] of Object.entries(LANE_PRODUCER)) {
+      assert.ok(
+        producer in PRODUCER_CADENCE_SECS,
+        `${lane} maps to ${producer}, which has no declared cadence`,
+      );
+    }
+  });
+
+  test("self-stake is declared daily, not inferred", () => {
+    // The specific regression: both spellings must resolve, because the
+    // buffered writer files under the prefixed key and the poller under the
+    // bare one.
+    assert.equal(PRODUCER_CADENCE_SECS.self_stake, 86_400);
+    assert.equal(LANE_PRODUCER["self-stake"], "self_stake");
+    assert.equal(LANE_PRODUCER["neon:self-stake"], "self_stake");
   });
 
   test("hotkey-alpha runs four times less often than account-balances", () => {

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -5859,7 +5859,11 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         match: /FROM lane_health/i,
         rows: [
           {
-            lane: "neurons",
+            // `neon:neurons`, not the bare spelling: that one is RETIRED
+            // (#10851's key change froze it, see RETIRED_LANES), so the
+            // serving read drops it -- and the prefixed key is what
+            // production actually carries.
+            lane: "neon:neurons",
             verdict: "ok",
             age_ms: 30_000,
             detail: null,
@@ -5881,7 +5885,7 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     // Stale first: the row an operator acts on leads.
     assert.deepEqual(
       body.data.lanes.map((l: { lane: string }) => l.lane),
-      ["chain-detail", "neurons"],
+      ["chain-detail", "neon:neurons"],
     );
     assert.equal(body.data.stale_lane_count, 1);
   });


### PR DESCRIPTION
The three remaining lane alarms from the 2026-08-12 21:28Z batch, both causes verified against production's own `/api/v1/self-health` read rather than reasoned about.

**`neurons` and `tao-usd-index` (bare) are #10851 fossils** — the third and fourth of the family #10908 started. Both stopped receiving verdicts at **exactly 2026-08-11T23:35Z**, the same instant as each other, which is the signature of a writer that changed its key rather than of two lanes independently dying. On the same read that showed them stuck at `unknown`, their prefixed twins were healthy: `neon:neurons` ok "11 statement(s) flushed", `neon:tao-usd-index` ok "10 statement(s) flushed", both checked 22:01Z the next day. Since #10851 every verdict lands under the prefixed key, so the bare rows can never be revised — #10222's retirement case exactly.

**The distinction this list turns on, now pinned by its own test:** `account-balances` and `validator-nominators` carry the POLLER's own scan outcome under their bare names ("558009 scanned, 366107 written"), so those spellings have a live writer and retiring them would be suppression rather than cleanup. A new test asserts they stay watched, alongside one asserting all three retired spellings are retired *and* their `neon:` twins are not.

**`self-stake` was a watchdog bug, not a lane bug.** It alarmed "stale: 20.2h (producer cadence 3.1h)" — but the lane runs **daily**, so 20.2h is normal. The cause: `self_stake` was absent from `PRODUCER_CADENCE_SECS`, so the alarm fell back to the observed gap between `lane_health` writes — and this lane writes several verdicts per pass, so what it measured was intra-pass minutes, not the day between passes. The inferred ~187m bound is roughly an eighth of the real interval, so a healthy daily lane read stale for most of every day. Declared at 86,400s with both spellings mapped, which is exactly the floor this table exists to provide (the same trap `account_identity` hit from the other direction in #10329).

**A gate so the next lane cannot repeat it:** a new test asserts every lane in `LANE_PRODUCER` maps to a producer that has a declared cadence — the omission that caused this was silent precisely because nothing checked it.

110 tests across the four affected suites, `tsc`, prettier — all green.