### PR TITLE
fix(telemetry): count REST callers, and stop one unflagged event minting a person per session

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -42,8 +42,69 @@ export const POSTHOG_HOST_ENV = "POSTHOG_HOST";
 
 const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
 
-/** Stable distinct_id for anonymous Worker-side product events. */
+/**
+ * Fallback distinct_id for a Worker-side product event with no resolved caller.
+ *
+ * ONE ID FOR EVERY CALLER, which is what it was for two surfaces and is now
+ * only a fallback. Measured 2026-08-12: 3,962 REST events across 142 routes in
+ * six hours, all on this string -- so `uniq(distinct_id)` answered 1 no matter
+ * how many clients were behind it, and every person-level REST question
+ * ("how many callers", "is this one client looping or a hundred") was
+ * unanswerable by construction. It surfaced while diagnosing #10606, where
+ * 1,044 /chain/stream refusals could not be attributed to one browser or a
+ * farm, and the geoip fallback (37.751/-97.822, MaxMind's US centroid) could
+ * not separate them either.
+ *
+ * The MCP surface has always resolved a real caller (`github:` / `mcp-session:`);
+ * REST never did. See resolveUsageDistinctId in workers/api.ts.
+ */
 export const USAGE_EVENT_DISTINCT_ID = "metagraphed-worker";
+
+/**
+ * The namespace an API-key-authenticated REST caller is counted under.
+ *
+ * A real, already-known identity -- the account the key belongs to -- so this
+ * is the one REST namespace that mints a person profile, the same way
+ * `github:` does on the MCP side.
+ */
+export const USAGE_ACCOUNT_NAMESPACE = "account:";
+
+/**
+ * The namespace an anonymous REST caller is counted under.
+ *
+ * A SALTED HASH OF THE CLIENT IP, never the IP. Unsalted would not be
+ * pseudonymous at all: the IPv4 space is 2^32, so a rainbow table over it is
+ * minutes of work and the "hash" would be a reversible encoding of an address.
+ * The salt lives in a Worker secret (USAGE_DISTINCT_ID_SALT_ENV) and never
+ * leaves the edge.
+ *
+ * Counts CALLERS, not people: everyone behind one NAT counts once, and one
+ * caller that changes address counts twice. That is the honest resolution of
+ * an IP and the reason this namespace is named for the address rather than
+ * for a user.
+ */
+export const USAGE_ANONYMOUS_NAMESPACE = "ip:";
+
+/**
+ * Worker secret holding the salt for the anonymous-caller hash.
+ *
+ * UNSET IS A SUPPORTED STATE, and it degrades to the pre-#10606 behaviour:
+ * every anonymous caller collapses back onto USAGE_EVENT_DISTINCT_ID. A
+ * missing secret must never be allowed to emit an UNSALTED hash, which is the
+ * one outcome worse than the status quo -- so the absence is checked, not
+ * defaulted.
+ */
+export const USAGE_DISTINCT_ID_SALT_ENV = "USAGE_DISTINCT_ID_SALT";
+
+/**
+ * How many hex characters of the salted digest ride in the distinct_id.
+ *
+ * 16 hex chars = 64 bits. At even a million distinct callers the birthday
+ * bound puts a single collision at ~3e-8, so two callers sharing an id is not
+ * a rate that can move a count -- and a shorter id keeps the property small on
+ * an event this project emits ~1.1M times a day.
+ */
+export const USAGE_ANONYMOUS_ID_HEX_LENGTH = 16;
 
 /** PostHog event name owned by this wrapper — do not emit it elsewhere. */
 export const USAGE_EVENT_NAME = "usage_event";
@@ -534,6 +595,34 @@ export function statusClassOf(status: unknown): string | undefined {
 }
 
 /**
+ * Stamp `$process_person_profile` for a usage event.
+ *
+ * ## THIS IS A COST GATE, NOT A LABEL
+ *
+ * A distinct_id and a person profile are separable, and conflating them is how
+ * this project already spent $650 once (the free-tier volume crisis). PostHog
+ * counts `uniq(distinct_id)` straight off the events table with no profile
+ * involved -- so giving anonymous callers real ids buys accurate caller counts
+ * for nothing, while ALSO minting a profile per id would bill for one person
+ * per address seen. The first is the point; the second is the bill.
+ *
+ * So: an account-namespaced caller is a person (a known account, few of them,
+ * and the profile is what makes retention and funnels work). Everything else
+ * -- an anonymous `ip:` caller and the `metagraphed-worker` fallback -- is
+ * explicitly NOT, and `false` is written rather than omitted so an event's
+ * person handling is readable off the event itself. Same discipline, and the
+ * same reasoning, as assignMcpPersonProcessing above.
+ */
+export function assignUsagePersonProcessing(
+  properties: Record<string, unknown>,
+  distinctId?: string,
+): void {
+  properties["$process_person_profile"] = (
+    distinctId ?? USAGE_EVENT_DISTINCT_ID
+  ).startsWith(USAGE_ACCOUNT_NAMESPACE);
+}
+
+/**
  * Record one product-usage event. Resolves without throwing; returns whether
  * an event was handed to PostHog. Callers that need Workers flush semantics
  * should schedule the returned promise via `ctx.waitUntil(...)`.
@@ -565,6 +654,10 @@ export async function recordUsageEvent(
     // outside usageEventProperties so that function stays a pure projection of
     // its UsageEvent argument (it is exported and asserted as one).
     assignDeployment(properties, env);
+    // After sampling for the same reason as assignDeployment, and before the
+    // capture because the flag has to ride the event that would create the
+    // profile -- a later correction cannot un-bill one.
+    assignUsagePersonProcessing(properties, deps.distinctId);
 
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -35,8 +35,11 @@ function recorder({ result = true as boolean | (() => unknown) } = {}) {
   return {
     events,
     exceptions,
-    recordUsageEvent(env: unknown, event: unknown) {
-      events.push({ env, event });
+    // `deps` captured since #10606: the caller's distinct_id rides there, not
+    // on the event, so a spy that dropped the third argument could not see who
+    // an event was attributed to.
+    recordUsageEvent(env: unknown, event: unknown, deps: unknown) {
+      events.push({ env, event, deps });
       return typeof result === "function" ? result() : result;
     },
     recordExceptionEvent(env: unknown, event: unknown) {
@@ -1024,5 +1027,170 @@ describe("withUsageTelemetry — auth_tier", () => {
     );
     assert.equal(spy.events[0].event.ok, false);
     assert.equal(spy.events[0].event.authTier, "free");
+  });
+});
+
+// ── distinct_id: who a REST usage event is attributed to (#10606) ───────────
+//
+// Every REST usage event carried the literal `metagraphed-worker`, so
+// `uniq(distinct_id)` answered 1 across 142 routes and ~99% of this project's
+// traffic. It surfaced while trying to establish whether 1,044 /chain/stream
+// 503s were one browser reconnect-looping or a farm — a question the data
+// could not answer, and still could not once geoip resolved both the refused
+// and the served requests to MaxMind's US centroid.
+describe("withUsageTelemetry — distinct_id", () => {
+  const SALTED_ENV = {
+    ...CONFIGURED_ENV,
+    USAGE_DISTINCT_ID_SALT: "test-salt-not-a-real-secret",
+  };
+
+  /**
+   * Run one request and return the distinct_id it was attributed to.
+   *
+   * AWAITS THE SCHEDULED WORK. The id is resolved inside `waitUntil` so the
+   * hash never lands in front of a response, which means the recorder has not
+   * necessarily been called by the time `withUsageTelemetry` resolves. The
+   * unsalted path happens to settle in one microtask; the salted one does a
+   * real SubtleCrypto digest and does not. A test that asserted immediately
+   * would pass on the branch that does nothing and fail on the branch under
+   * test.
+   */
+  async function attributedTo(
+    env: Row,
+    request: Request,
+    inHandler: () => void = () => {},
+  ) {
+    const spy = recorder();
+    const ctx = fakeCtx();
+    await withUsageTelemetry(
+      request,
+      env as unknown as Env,
+      ctx,
+      async () => {
+        inHandler();
+        return new Response("ok");
+      },
+      spy,
+    );
+    await Promise.all(ctx.scheduled);
+    return (spy.events[0]?.deps as { distinctId?: string } | undefined)
+      ?.distinctId;
+  }
+
+  function fromIp(ip: string) {
+    return req("/api/v1/subnets", { headers: { "cf-connecting-ip": ip } });
+  }
+
+  test("an anonymous caller is counted under a salted hash of its address", async () => {
+    const id = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    assert.match(
+      String(id),
+      /^ip:[0-9a-f]{16}$/,
+      "an anonymous caller must be counted under the ip: namespace",
+    );
+  });
+
+  test("the same address is the same caller across requests", async () => {
+    // The whole point: a count is only a count if the id is stable.
+    const first = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    const second = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    assert.equal(first, second);
+  });
+
+  test("two addresses are two callers", async () => {
+    // Guards the guard: a hash that ignored its input would satisfy the
+    // stability test above and still answer 1 to every question this exists
+    // to answer.
+    const first = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    const second = await attributedTo(SALTED_ENV, fromIp("198.51.100.9"));
+    assert.notEqual(first, second);
+  });
+
+  test("the address never appears in the id", async () => {
+    const ip = "203.0.113.7";
+    const id = String(await attributedTo(SALTED_ENV, fromIp(ip)));
+    assert.equal(
+      id.includes(ip),
+      false,
+      "the raw address must never reach the event store",
+    );
+  });
+
+  test("the salt is what makes the hash a pseudonym", async () => {
+    // IPv4 is 2^32, so an unsalted digest is a reversible encoding of the
+    // address rather than a pseudonym. If the salt stopped being mixed in,
+    // two deployments with different salts would agree on the id — and this
+    // is the only assertion that would notice.
+    const other = await attributedTo(
+      { ...CONFIGURED_ENV, USAGE_DISTINCT_ID_SALT: "a-different-salt" },
+      fromIp("203.0.113.7"),
+    );
+    const mine = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    assert.notEqual(mine, other);
+  });
+
+  test("no salt falls back to the shared id rather than hashing without one", async () => {
+    // The one outcome worse than the status quo is an UNSALTED hash, which
+    // would put a recoverable address in a third party's store. Absent salt
+    // is a supported state and degrades to what it did before.
+    const id = await attributedTo(CONFIGURED_ENV, fromIp("203.0.113.7"));
+    assert.equal(id, undefined);
+  });
+
+  test("an unresolved address is not minted into a confident id", async () => {
+    // resolveClientIp collapses a missing cf-connecting-ip to one fixed
+    // bucket — right for a rate limiter, wrong here: hashing it would give
+    // every unresolvable caller ONE specific-looking id, which reads as "one
+    // caller" exactly like the shared fallback except that it looks precise.
+    const id = await attributedTo(SALTED_ENV, req("/api/v1/subnets"));
+    assert.equal(id, undefined);
+  });
+
+  test("a key-authenticated caller is counted as its account", async () => {
+    const request = fromIp("203.0.113.7");
+    const id = await attributedTo(SALTED_ENV, request, () => {
+      markRequestAuthTier(request, "paid", "acct_123");
+    });
+    assert.equal(id, "account:acct_123");
+  });
+
+  test("a presented identity outranks an observed address", async () => {
+    // An account is what the caller PROVED; an address is what we noticed.
+    // The first is the better answer whenever both exist — and it is also the
+    // only one that becomes a person profile.
+    const request = fromIp("203.0.113.7");
+    const anonymous = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    const identified = await attributedTo(SALTED_ENV, request, () => {
+      markRequestAuthTier(request, "paid", "acct_123");
+    });
+    assert.notEqual(identified, anonymous);
+    assert.equal(identified, "account:acct_123");
+  });
+
+  test("a blank or non-string account is not recorded as one", async () => {
+    const request = fromIp("203.0.113.7");
+    const id = await attributedTo(SALTED_ENV, request, () => {
+      markRequestAuthTier(request, "anonymous", "");
+      markRequestAuthTier(request, "anonymous", undefined);
+      markRequestAuthTier(request, "anonymous", 7);
+    });
+    assert.match(
+      String(id),
+      /^ip:/,
+      "a gate that resolved no account must leave the caller anonymous, " +
+        "never attributed to an account it did not present",
+    );
+  });
+
+  test("one request's account is never read by another", async () => {
+    const keyed = fromIp("203.0.113.7");
+    const identified = await attributedTo(SALTED_ENV, keyed, () => {
+      markRequestAuthTier(keyed, "paid", "acct_123");
+    });
+    // A DIFFERENT Request object from the same address, so the WeakMap has no
+    // entry for it and the account must not leak across.
+    const next = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
+    assert.equal(identified, "account:acct_123");
+    assert.match(String(next), /^ip:/);
   });
 });

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -285,6 +285,12 @@ describe("recordUsageEvent — configured", () => {
         // as development with no release. The production shape is asserted in
         // the resolveDeployment block below.
         environment: "development",
+        // #10606: written on EVERY usage event, including this one with no
+        // resolved caller. Absent, PostHog defaults to processing a person
+        // profile — so the fallback id was quietly minting one, and an
+        // anonymous `ip:` caller would have minted one PER ADDRESS. Stated,
+        // not omitted, because the default is the expensive direction.
+        $process_person_profile: false,
       },
     });
   });
@@ -3798,5 +3804,87 @@ describe("the resource/prompt poster's optional fields", () => {
       { fetch: fakeFetch({ throws: true }) },
     );
     assert.equal(emitted, false);
+  });
+});
+
+// ── The distinct_id cost gate (#10606) ─────────────────────────────────────
+//
+// A distinct_id and a person profile are separable, and conflating them is how
+// this project already spent $650 once. `uniq(distinct_id)` is computed off the
+// events table with no profile involved — so giving anonymous REST callers real
+// ids buys accurate caller counts for free, while ALSO minting a profile per id
+// would bill one person per address ever seen.
+//
+// This block is the thing standing between those two outcomes.
+describe("recordUsageEvent — person processing", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" } as Row;
+
+  async function personProcessingFor(distinctId?: string) {
+    const calls: Row[] = [];
+    await recordUsageEvent(
+      CONFIGURED as unknown as Env,
+      { route: "subnets", ok: true, durationMs: 1 },
+      {
+        ...(distinctId ? { distinctId } : {}),
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      },
+    );
+    return {
+      distinctId: (calls[0].body as Row).distinct_id,
+      person: ((calls[0].body as Row).properties as Row)
+        .$process_person_profile,
+    };
+  }
+
+  test("an anonymous caller gets an id but never a person profile", async () => {
+    // THE WHOLE POINT. The id is what makes the caller countable; the profile
+    // is what would make it billable. One without the other.
+    const { distinctId, person } = await personProcessingFor(
+      "ip:0123456789abcdef",
+    );
+    assert.equal(distinctId, "ip:0123456789abcdef");
+    assert.equal(person, false);
+  });
+
+  test("the shared fallback is not a person either", async () => {
+    // It was one before this landed — absent the property, PostHog defaults to
+    // processing a profile, so `metagraphed-worker` has been a maintained
+    // person for as long as the constant has existed.
+    const { distinctId, person } = await personProcessingFor();
+    assert.equal(distinctId, USAGE_EVENT_DISTINCT_ID);
+    assert.equal(person, false);
+  });
+
+  test("an account-authenticated caller is a person", async () => {
+    // A known account, few of them, and the profile is what makes retention
+    // and per-customer questions answerable at all.
+    const { person } = await personProcessingFor("account:acct_123");
+    assert.equal(person, true);
+  });
+
+  test("the account namespace cannot be smuggled into from elsewhere", async () => {
+    // The prefix is load-bearing, exactly as mcp-session: is on the MCP side:
+    // an id that merely CONTAINS the namespace must not be billed as a person.
+    const { person } = await personProcessingFor("ip:account:acct_123");
+    assert.equal(person, false);
+  });
+
+  test("every namespace is decided, none fall through to the default", async () => {
+    // Set EQUALITY over the namespaces this project can emit, so a namespace
+    // added later cannot inherit PostHog's default (process a profile) simply
+    // by not being mentioned here — which is the direction that costs money.
+    const decided = new Map<string, boolean>();
+    for (const id of [
+      "ip:0123456789abcdef",
+      "account:acct_123",
+      USAGE_EVENT_DISTINCT_ID,
+    ]) {
+      decided.set(id, (await personProcessingFor(id)).person as boolean);
+    }
+    assert.deepEqual(
+      [...decided.values()],
+      [false, true, false],
+      "exactly one namespace may mint person profiles",
+    );
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -150,6 +150,9 @@ import {
   recordUsageEvent,
   parseUserAgentClient,
   statusClassOf,
+  USAGE_ACCOUNT_NAMESPACE,
+  USAGE_ANONYMOUS_ID_HEX_LENGTH,
+  USAGE_ANONYMOUS_NAMESPACE,
   type UsageEvent,
 } from "../src/usage-telemetry.ts";
 import {
@@ -669,6 +672,7 @@ import {
   MAX_WEBHOOK_BODY_BYTES,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
+  ANONYMOUS_CLIENT_KEY,
   resolveClientIp,
   RUNTIME_VERSIONS_PATH_PATTERN,
   SUBNET_BURN_HISTORY_PATH_PATTERN,
@@ -1543,13 +1547,99 @@ function maskUsageRouteParams(pathname: string) {
 const requestAuthTier = new WeakMap<Request, string>();
 
 /**
+ * The account a request authenticated as, for its usage-event distinct_id.
+ *
+ * A SECOND WeakMap rather than widening the one above to an object: the tier
+ * is set by every gate and the account only by a key-verified one, so a single
+ * entry would have to encode "tier known, account not" as a partial object at
+ * every call site. Two maps say that by which one has an entry, and both stay
+ * collectable with the request for the reasons the tier map already documents.
+ */
+const requestAccountId = new WeakMap<Request, string>();
+
+/**
  * Record the tier a request authenticated on, for its usage event.
  *
  * Called from the tiered-rate-limit gates, which are the only places that
  * verify a key. Exported for tests.
+ *
+ * `accountId` is optional so the pre-#10606 two-argument form still compiles
+ * and still means what it did -- a gate that resolves no account passes
+ * nothing, and the caller stays anonymous rather than being attributed to an
+ * account it never presented.
  */
-export function markRequestAuthTier(request: Request, tier: unknown): void {
+export function markRequestAuthTier(
+  request: Request,
+  tier: unknown,
+  accountId?: unknown,
+): void {
   if (typeof tier === "string" && tier) requestAuthTier.set(request, tier);
+  if (typeof accountId === "string" && accountId) {
+    requestAccountId.set(request, accountId);
+  }
+}
+
+/**
+ * Who to count this request under, for the usage event's distinct_id.
+ *
+ * ## WHY REST HAD NO ANSWER TO THIS
+ *
+ * Every REST usage event carried the same literal id, so `uniq(distinct_id)`
+ * was 1 across 142 routes and the surface with ~99% of this project's traffic
+ * could not say how many callers it had. See USAGE_EVENT_DISTINCT_ID's own
+ * header for the measurement and for how it surfaced.
+ *
+ * ## THE TWO NAMESPACES, AND WHY THEY ARE DIFFERENT KINDS OF THING
+ *
+ * An `account:` id is an identity the caller PRESENTED -- it authenticated
+ * with a key belonging to that account. An `ip:` id is an observation we made
+ * about the connection. Naming them apart keeps that distinction queryable,
+ * and it is what `assignUsagePersonProcessing` reads to decide which callers
+ * become person profiles (only the first: see its header for why that is a
+ * cost gate and not a label).
+ *
+ * ## THE HASH IS SALTED, AND UNSALTED IS NOT AN OPTION
+ *
+ * IPv4 is 2^32 addresses -- small enough that an unsalted digest is a
+ * reversible encoding of the address rather than a pseudonym, and it would put
+ * a recoverable client IP in a third party's event store. So a missing salt
+ * degrades to the old shared id instead of hashing without one: no salt, no
+ * anonymous identity, and the count stays as uninformative as it was rather
+ * than becoming informative and leaky.
+ *
+ * Resolved through `resolveClientIp` -- the same cf-connecting-ip-only path
+ * the rate limiters use, not a second IP-extraction scheme that could disagree
+ * with the thing enforcing the per-IP quotas this was written to diagnose.
+ */
+async function resolveUsageDistinctId(
+  request: Request,
+  env: Env,
+): Promise<string | undefined> {
+  const accountId = requestAccountId.get(request);
+  if (accountId) return `${USAGE_ACCOUNT_NAMESPACE}${accountId}`;
+  // Read off the declared field rather than by index, so the access is typed
+  // against Env. The name is documented once as USAGE_DISTINCT_ID_SALT_ENV in
+  // src/usage-telemetry.ts, for the ops side that has to set it.
+  const salt: string | undefined = env.USAGE_DISTINCT_ID_SALT;
+  if (!salt) return undefined;
+  const ip = resolveClientIp(request);
+  // `resolveClientIp` NEVER returns falsy -- absent `cf-connecting-ip` collapses
+  // to ANONYMOUS_CLIENT_KEY, one fixed bucket, which is the right failure mode
+  // for a rate limiter and the wrong one here. Hashing it would mint a single
+  // confident-looking `ip:` id shared by every caller we could not resolve, and
+  // a count built on that reads as "one caller" exactly the way the shared
+  // fallback already did -- except now it looks specific. So an unresolved
+  // address falls back to the shared id, which at least says so.
+  if (ip === ANONYMOUS_CLIENT_KEY) return undefined;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${salt}:${ip}`),
+  );
+  const hex = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, USAGE_ANONYMOUS_ID_HEX_LENGTH);
+  return `${USAGE_ANONYMOUS_NAMESPACE}${hex}`;
 }
 
 /**
@@ -1692,16 +1782,22 @@ export async function withUsageTelemetry(
     // request never actually made. Same omitted-not-defaulted contract every
     // other optional dimension here follows.
     const authTier = requestAuthTier.get(request);
-    scheduleUsageEvent(env, ctx, record, {
-      route,
-      ok,
-      durationMs: endedAt - startedAt,
-      method,
-      ...(statusClass ? { statusClass } : {}),
-      ...(client ? { client } : {}),
-      ...(errorCode ? { errorCode } : {}),
-      ...(authTier ? { authTier } : {}),
-    });
+    scheduleUsageEvent(
+      env,
+      ctx,
+      record,
+      {
+        route,
+        ok,
+        durationMs: endedAt - startedAt,
+        method,
+        ...(statusClass ? { statusClass } : {}),
+        ...(client ? { client } : {}),
+        ...(errorCode ? { errorCode } : {}),
+        ...(authTier ? { authTier } : {}),
+      },
+      () => resolveUsageDistinctId(request, env),
+    );
     // metagraphed#7768: PostHog distributed tracing (alpha), one root span
     // per request -- replaces @sentry/cloudflare's automatic withSentry() HTTP
     // instrumentation. Off by default (POSTHOG_TRACES_SAMPLE_RATE unset --
@@ -1782,9 +1878,26 @@ function scheduleUsageEvent(
   ctx: Ctx,
   record: typeof recordUsageEvent,
   event: UsageEvent,
+  /**
+   * Resolves the caller's distinct_id, INSIDE the scheduled work.
+   *
+   * A thunk rather than a resolved string because resolving it hashes, and
+   * `withUsageTelemetry` awaits its telemetry in a `finally` -- an await there
+   * happens before the function returns, so computing this eagerly would put a
+   * SubtleCrypto digest in front of every response on a Worker serving ~1.1M
+   * requests a day. Deferring it into the waitUntil keeps the request path
+   * exactly as long as it was.
+   */
+  resolveDistinctId?: () => Promise<string | undefined>,
 ) {
   try {
-    const pending = Promise.resolve(record(env, event)).catch(() => false);
+    const pending = Promise.resolve(
+      resolveDistinctId
+        ? resolveDistinctId().then((distinctId) =>
+            record(env, event, distinctId ? { distinctId } : {}),
+          )
+        : record(env, event),
+    ).catch(() => false);
     if (typeof ctx?.waitUntil === "function") {
       ctx.waitUntil(pending);
     }
@@ -3628,7 +3741,7 @@ export async function handleChainEventsFamily(
     env,
     DATA_TIERED_RATE_LIMIT,
   );
-  markRequestAuthTier(request, rateLimit.tier);
+  markRequestAuthTier(request, rateLimit.tier, rateLimit.accountId);
   // #8609: recorded for BOTH outcomes, BEFORE the rejection return, with the
   // flag derived from the gate's own verdict -- so a 429 lands in
   // rejected_count instead of request_count. Recording after the return would
@@ -7635,7 +7748,7 @@ async function chainDetailRateLimit(
     env,
     DATA_TIERED_RATE_LIMIT,
   );
-  markRequestAuthTier(request, rateLimit.tier);
+  markRequestAuthTier(request, rateLimit.tier, rateLimit.accountId);
   // Both outcomes, BEFORE the rejection return -- the ordering #8609 established
   // for chain-events, so a 429 lands in rejected_count rather than going
   // uncounted entirely.
@@ -9213,7 +9326,7 @@ async function webhookSubscriptionRateLimited(
     env,
     WEBHOOK_SUBSCRIPTION_TIERED_RATE_LIMIT,
   );
-  markRequestAuthTier(request, rateLimit.tier);
+  markRequestAuthTier(request, rateLimit.tier, rateLimit.accountId);
   // #8609: recorded before the rejection return so a throttled request is
   // counted as a rejection rather than not counted at all.
   if (rateLimit.accountId) {
@@ -9639,7 +9752,7 @@ async function handleSemanticSearchRequest(
     env,
     AI_TIERED_RATE_LIMIT,
   );
-  markRequestAuthTier(request, rateLimit.tier);
+  markRequestAuthTier(request, rateLimit.tier, rateLimit.accountId);
   if (!rateLimit.allowed) {
     return aiRateLimitedResponse(rateLimit);
   }
@@ -9691,7 +9804,7 @@ async function handleAskRequest(request: Request, env: Env, ctx?: Ctx) {
     env,
     AI_TIERED_RATE_LIMIT,
   );
-  markRequestAuthTier(request, rateLimit.tier);
+  markRequestAuthTier(request, rateLimit.tier, rateLimit.accountId);
   if (!rateLimit.allowed) {
     return aiRateLimitedResponse(rateLimit);
   }

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -180,6 +180,19 @@ interface Env {
   SUBNET_SNAPSHOT_SYNC_SECRET?: string;
   TELEGRAM_BOT_TOKEN?: string;
   UNKEY_ROOT_KEY?: string;
+  /**
+   * #10606: salt for the anonymous REST caller's usage-event distinct_id.
+   *
+   * An ops-managed `wrangler secret put` value that never lives in this repo,
+   * for the same reason the VAPID keys below do not: it is the only thing
+   * standing between a hashed client IP and a recoverable one (IPv4 is 2^32,
+   * so an unsalted digest is an encoding, not a pseudonym).
+   *
+   * Absent is a SUPPORTED state and degrades to the shared fallback id --
+   * see resolveUsageDistinctId in workers/api.ts for why a missing salt must
+   * never fall through to hashing without one.
+   */
+  USAGE_DISTINCT_ID_SALT?: string;
   // #8385 web-push (VAPID, RFC 8292). Ops-managed Worker secrets — the KEY
   // VALUES never live in this repo. All three are required together; the
   // webpush channel degrades to a recorded delivery failure when any is


### PR DESCRIPTION
Every REST `usage_event` carried the literal `metagraphed-worker`, so `uniq(distinct_id)` answered **1** across 142 routes and ~99% of this project's traffic. Measured 2026-08-12: 3,962 events, 142 routes, six hours, one id.

It surfaced diagnosing #10606 — 1,044 `/chain/stream` 503s that could not be attributed to one browser reconnect-looping or to a farm. Geoip could not separate them either: both the refused and the served requests resolve to `37.751/-97.822`, MaxMind's US centroid, which is what an IP that only resolves to a country gives you. The MCP surface has always resolved a real caller (`github:`, `mcp-session:`); REST never did.

## Two namespaces, because they are different kinds of fact

| namespace | what it is | person profile |
| --- | --- | --- |
| `account:<id>` | an identity the caller **presented** — a verified key, from the `accountId` every tiered gate already resolved and discarded | yes |
| `ip:<16 hex>` | an observation **we made** — a salted SHA-256 of the client address, never the address | no |

Unsalted was not an option. IPv4 is 2^32, so an unsalted digest is a reversible encoding of the address rather than a pseudonym, and it would put a recoverable client IP in a third party's store. A **missing salt therefore degrades to the old shared id** rather than hashing without one — absent is a supported state, and the one outcome worse than the status quo is an unsalted hash.

An unresolved address degrades the same way. `resolveClientIp` collapses a missing `cf-connecting-ip` to one fixed bucket — correct for a rate limiter, wrong here: hashing it would mint a single specific-looking id shared by every caller we could not resolve, which reads as "one caller" exactly like the shared fallback except that it *looks* precise.

## The cost gate, which turned out to be the live half

A distinct_id and a person profile are separable — `uniq(distinct_id)` is computed off the events table with no profile involved. So **ids are free and profiles are billed**, and `$process_person_profile` was absent on `usage_event`. Absent means PostHog processes one, so handing out real ids without stating the flag would have billed a person per address ever seen.

Stating it also fixes a leak **already running**. Every `$mcp_*` event sets the flag `false`, but the `usage_event` emitted for the *same* MCP request did not — 313 unflagged events per three hours on `mcp-session:` ids — and **one unflagged event is enough to mint the profile**:

```
mcp-session: person profiles created, per hour (flag deployed ~12:16)
  11:00  22      13:00  29
  12:00  47      14:00  27
                 15:00  31
```

Flat straight through the flag's own deploy. That is what this measures, and it stops at zero once `usage_event` carries the flag too.

**Volume is unchanged**: same captures, one boolean property added, no new events. Current run rate is ~15.4K `usage_event`/day (~0.46M/month) against the 1M free tier.

## Performance

The hash resolves **inside `waitUntil`**, not in the telemetry `finally`. An await there happens before the function returns, so computing it eagerly would put a SubtleCrypto digest in front of every response on a Worker serving ~1.1M requests/day.

## Left out deliberately

`$exception` also omits the flag (1 event in the sampled window). Same defect class, different judgment — a fault arguably *should* carry person context for debugging — so it is not swept into this PR.

Refs #10606
