### PR TITLE
fix(telemetry): count the caller, not the connection — and close the last two profile leaks

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -212,6 +212,8 @@ import {
   recordUsageEvent,
   parseUserAgentClient,
   MCP_PERSON_NAMESPACE,
+  USAGE_ACCOUNT_NAMESPACE,
+  anonymousUsageDistinctId,
 } from "./usage-telemetry.ts";
 import { maskRouteParams } from "./route-label.ts";
 import {
@@ -220,7 +222,7 @@ import {
   recordTraceSpan,
   shouldRecordTraceSpan,
 } from "./tracing.ts";
-import { resolveClientIp } from "../workers/config.ts";
+import { ANONYMOUS_CLIENT_KEY, resolveClientIp } from "../workers/config.ts";
 import {
   applyTieredRateLimit,
   spendDeferredDailyQuota,
@@ -16908,6 +16910,12 @@ function rpcError(id: unknown, code: number, message: string) {
 export function mcpDistinctId(
   githubLogin: unknown,
   sessionId: string | null | undefined,
+  /**
+   * A verified account (a key-authenticated caller) and the caller's already
+   * resolved `ip:` id. Both optional so the two-argument form still means what
+   * it did -- a caller with neither falls through to the session as before.
+   */
+  extra: { accountId?: unknown; anonymousId?: string } = {},
 ): string | undefined {
   if (typeof githubLogin === "string" && githubLogin) {
     // MCP_PERSON_NAMESPACE rather than a literal: recordMcp*'s
@@ -16915,13 +16923,39 @@ export function mcpDistinctId(
     // constant is what keeps "who is a person" a single decision.
     return `${MCP_PERSON_NAMESPACE}${githubLogin}`;
   }
+  // A verified key is an identity the caller PRESENTED, so it outranks
+  // anything we merely observed -- the same precedence REST applies.
+  if (typeof extra.accountId === "string" && extra.accountId) {
+    return `${USAGE_ACCOUNT_NAMESPACE}${extra.accountId}`;
+  }
+  // #10606: ABOVE the session, and that is the whole change.
+  //
+  // A session id is minted per CONNECTION, not per caller, so a client that
+  // reconnects is a new one every time -- and MCP clients reconnect
+  // constantly. Measured 2026-08-12: 462 distinct `mcp-session:` ids in a day
+  // against 4 authenticated users and 51 distinct client names, so "unique
+  // callers" read ~462 and the truth was nowhere near it. Every reconnect also
+  // minted a person profile, which is the cost half of the same fact.
+  //
+  // #7153 chose the session deliberately and said why: keying on an address
+  // "would mean fingerprinting, which is a real privacy tradeoff and is
+  // deliberately not made here". That tradeoff has since been made explicitly,
+  // for REST, and it is made the same way here -- a SALTED hash of the
+  // address, never the address, never the User-Agent. What it buys is the
+  // question #7153 was trying to answer actually being answerable: an address
+  // is stable across the reconnects a session id is destroyed by.
+  //
+  // The session is not lost. It still rides every event as `$session_id`, so
+  // per-run analysis is unchanged; it stops being the thing a CALLER count is
+  // computed from, which it was never able to be.
+  if (extra.anonymousId) return extra.anonymousId;
   if (typeof sessionId === "string" && sessionId) {
     return `mcp-session:${sessionId}`;
   }
   return undefined;
 }
 
-function buildContext(
+async function buildContext(
   request: Request,
   env: Env,
   deps: McpDeps,
@@ -16949,7 +16983,20 @@ function buildContext(
   // decision lives, not duplicated here.
   const githubLogin = deps.executionCtx?.props?.githubLogin;
   const sessionId = isValidMcpSessionId(rawSessionId) ? rawSessionId : null;
-  const distinctId = mcpDistinctId(githubLogin, sessionId);
+  // #10606: resolved the same way REST resolves it, through the same helper,
+  // so one client calling both surfaces is ONE caller rather than two. An
+  // unresolvable address (no cf-connecting-ip, which resolveClientIp collapses
+  // to a single fixed bucket) yields undefined rather than one shared
+  // confident-looking id, and the session below takes over.
+  const clientIp = resolveClientIp(request);
+  const anonymousId = await anonymousUsageDistinctId(
+    env.USAGE_DISTINCT_ID_SALT,
+    clientIp === ANONYMOUS_CLIENT_KEY ? undefined : clientIp,
+  );
+  const distinctId = mcpDistinctId(githubLogin, sessionId, {
+    accountId,
+    ...(anonymousId ? { anonymousId } : {}),
+  });
   const { clientName, clientVersion } = parseUserAgentClient(
     request.headers.get("user-agent"),
   );
@@ -17889,7 +17936,7 @@ async function dispatchMcpRequest(
   const versionError = validateMcpProtocolVersionHeader(request);
   if (versionError) return versionError;
 
-  const ctx = buildContext(request, env, deps, authTier, accountId);
+  const ctx = await buildContext(request, env, deps, authTier, accountId);
   // Generated here, not inside dispatchMessage: mintMcpSessionHeaderIfNeeded
   // below needs the SAME value the initialize event reported, or the header and
   // the telemetry would disagree about which session was created.

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -106,6 +106,35 @@ export const USAGE_DISTINCT_ID_SALT_ENV = "USAGE_DISTINCT_ID_SALT";
  */
 export const USAGE_ANONYMOUS_ID_HEX_LENGTH = 16;
 
+/**
+ * The `ip:` distinct_id for one client address.
+ *
+ * ONE IMPLEMENTATION for every surface. REST and MCP both need to answer "how
+ * many callers", and two hashes of the same address that disagreed would make
+ * the same client count as two -- which is the failure this whole namespace
+ * exists to remove. Callers resolve the address (through `resolveClientIp`, so
+ * the answer agrees with the rate limiters) and decide whether it is
+ * attributable; this only turns one into an id.
+ *
+ * Returns undefined for a missing salt or a blank address, so the single place
+ * that can emit an UNSALTED hash is nowhere.
+ */
+export async function anonymousUsageDistinctId(
+  salt: string | undefined,
+  clientIp: string | undefined,
+): Promise<string | undefined> {
+  if (!salt || !clientIp) return undefined;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${salt}:${clientIp}`),
+  );
+  const hex = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")
+    .slice(0, USAGE_ANONYMOUS_ID_HEX_LENGTH);
+  return `${USAGE_ANONYMOUS_NAMESPACE}${hex}`;
+}
+
 /** PostHog event name owned by this wrapper — do not emit it elsewhere. */
 export const USAGE_EVENT_NAME = "usage_event";
 
@@ -617,9 +646,18 @@ export function assignUsagePersonProcessing(
   properties: Record<string, unknown>,
   distinctId?: string,
 ): void {
-  properties["$process_person_profile"] = (
-    distinctId ?? USAGE_EVENT_DISTINCT_ID
-  ).startsWith(USAGE_ACCOUNT_NAMESPACE);
+  const id = distinctId ?? USAGE_EVENT_DISTINCT_ID;
+  // BOTH person namespaces, because one request produces events on both
+  // paths. An authenticated MCP call emits `$mcp_*` (which key on
+  // MCP_PERSON_NAMESPACE) AND a `usage_event` carrying the same `github:` id
+  // -- so checking only `account:` here would have this capture disagree with
+  // those about whether the very same caller is a person. Disagreement is not
+  // a labelling nit: PostHog creates the profile if ANY event on the id asks
+  // for one, so the two files must answer identically or the flag means
+  // nothing.
+  properties["$process_person_profile"] =
+    id.startsWith(USAGE_ACCOUNT_NAMESPACE) ||
+    id.startsWith(MCP_PERSON_NAMESPACE);
 }
 
 /**
@@ -2208,6 +2246,12 @@ export async function recordExceptionEvent(
     const queryShape = sanitizeLabel(event.queryShape);
     if (queryShape !== undefined) properties.query_shape = queryShape;
     assignDeployment(properties, env);
+    // #10606: a fault carries the SAME distinct_id as the request that
+    // produced it, so leaving the flag off here would have re-opened the leak
+    // the other captures close -- one unflagged event on an id is enough to
+    // mint the profile, which is exactly how usage_event kept minting one per
+    // MCP session while all six $mcp_* events said false.
+    assignUsagePersonProcessing(properties, deps.distinctId);
 
     const doFetch = deps.fetch ?? globalThis.fetch;
     const response = await doFetch(

--- a/tests/mcp-usage-telemetry.test.ts
+++ b/tests/mcp-usage-telemetry.test.ts
@@ -1932,3 +1932,89 @@ describe("MCP agent intent capture (#9642)", () => {
     assert.deepEqual(events[0]!.parameters, { netuid: 64 });
   });
 });
+
+// ── The caller, not the connection (#10606) ────────────────────────────────
+//
+// A session id is minted per CONNECTION, and MCP clients reconnect constantly.
+// Measured 2026-08-12: 462 distinct `mcp-session:` ids in one day against 4
+// authenticated users and 51 distinct client names — so "unique callers" read
+// ~462 and nothing about that number was true. Every reconnect also minted a
+// person profile, which is the same fact costing money.
+describe("mcpDistinctId — an address outranks a connection", () => {
+  test("a resolved address is preferred over the session", () => {
+    assert.equal(
+      mcpDistinctId(undefined, "s1", { anonymousId: "ip:0123456789abcdef" }),
+      "ip:0123456789abcdef",
+    );
+  });
+
+  test("the session is still the fallback when no address resolved", () => {
+    // Not a regression to the old behaviour — the honest answer when
+    // cf-connecting-ip is absent, which is exactly when an `ip:` id would be
+    // one shared bucket masquerading as a caller.
+    assert.equal(mcpDistinctId(undefined, "s1", {}), "mcp-session:s1");
+    assert.equal(
+      mcpDistinctId(undefined, "s1", { anonymousId: undefined }),
+      "mcp-session:s1",
+    );
+  });
+
+  test("a presented identity outranks an observed address", () => {
+    // Same precedence REST applies: what the caller PROVED beats what we
+    // noticed, and only the proved one becomes a person.
+    assert.equal(
+      mcpDistinctId("octocat", "s1", {
+        accountId: "acct_1",
+        anonymousId: "ip:0123456789abcdef",
+      }),
+      "github:octocat",
+    );
+    assert.equal(
+      mcpDistinctId(undefined, "s1", {
+        accountId: "acct_1",
+        anonymousId: "ip:0123456789abcdef",
+      }),
+      "account:acct_1",
+    );
+  });
+
+  test("a blank or non-string account is not an identity", () => {
+    assert.equal(
+      mcpDistinctId(undefined, "s1", { accountId: "" }),
+      "mcp-session:s1",
+    );
+    assert.equal(
+      mcpDistinctId(undefined, "s1", { accountId: 42 }),
+      "mcp-session:s1",
+    );
+    assert.equal(
+      mcpDistinctId(undefined, "s1", { accountId: null }),
+      "mcp-session:s1",
+    );
+  });
+
+  test("the two-argument form is unchanged", () => {
+    // Every pre-#10606 call site passes two arguments and must keep meaning
+    // what it did — the initialize path (mcpDistinctId(undefined, pendingId))
+    // among them.
+    assert.equal(mcpDistinctId("octocat", "s1"), "github:octocat");
+    assert.equal(mcpDistinctId(undefined, "s1"), "mcp-session:s1");
+    assert.equal(mcpDistinctId(undefined, null), undefined);
+  });
+
+  test("one address is one caller across many sessions", () => {
+    // THE POINT. Three reconnects, three session ids, one caller.
+    const ids = new Set(
+      ["s1", "s2", "s3"].map((session) =>
+        mcpDistinctId(undefined, session, {
+          anonymousId: "ip:0123456789abcdef",
+        }),
+      ),
+    );
+    assert.equal(
+      ids.size,
+      1,
+      "reconnects must not each count as a new caller — that is the defect",
+    );
+  });
+});

--- a/tests/usage-telemetry.test.ts
+++ b/tests/usage-telemetry.test.ts
@@ -30,6 +30,7 @@ import {
   recordMcpResourcesListEvent,
   recordMcpToolsListEvent,
   recordUsageEvent,
+  MCP_PERSON_NAMESPACE,
   resolvePostHogHost,
   resolveUsageSampleRate,
   POSTHOG_USAGE_SAMPLE_RATE_ENV,
@@ -3886,5 +3887,40 @@ describe("recordUsageEvent — person processing", () => {
       [false, true, false],
       "exactly one namespace may mint person profiles",
     );
+  });
+});
+
+// Both person namespaces, because ONE request emits on both paths (#10606).
+// An authenticated MCP call produces `$mcp_*` events keyed on
+// MCP_PERSON_NAMESPACE and a `usage_event` carrying that same `github:` id. If
+// the two files disagreed about whether that caller is a person, the flag
+// would mean nothing — PostHog creates the profile when ANY event on the id
+// asks for one.
+describe("recordUsageEvent — the two person namespaces agree", () => {
+  const CONFIGURED = { [POSTHOG_PROJECT_TOKEN_ENV]: "phc_token" } as Row;
+
+  async function personFor(distinctId: string) {
+    const calls: Row[] = [];
+    await recordUsageEvent(
+      CONFIGURED as unknown as Env,
+      { route: "subnets", ok: true, durationMs: 1 },
+      {
+        distinctId,
+        fetch: fakeFetch({ onCall: (call) => calls.push(call) }),
+      },
+    );
+    return ((calls[0].body as Row).properties as Row).$process_person_profile;
+  }
+
+  test("a github: caller is a person here too, not only on $mcp_*", async () => {
+    assert.equal(await personFor(`${MCP_PERSON_NAMESPACE}someone`), true);
+  });
+
+  test("a session id containing a person namespace is still not a person", async () => {
+    // The prefix is load-bearing in both directions: `mcp-session:github:x`
+    // must not smuggle itself into the person namespace, which is the reason
+    // mcpDistinctId prefixes at all.
+    assert.equal(await personFor("mcp-session:github:someone"), false);
+    assert.equal(await personFor("ip:account:acct_1"), false);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -150,9 +150,8 @@ import {
   recordUsageEvent,
   parseUserAgentClient,
   statusClassOf,
+  anonymousUsageDistinctId,
   USAGE_ACCOUNT_NAMESPACE,
-  USAGE_ANONYMOUS_ID_HEX_LENGTH,
-  USAGE_ANONYMOUS_NAMESPACE,
   type UsageEvent,
 } from "../src/usage-telemetry.ts";
 import {
@@ -1631,15 +1630,7 @@ async function resolveUsageDistinctId(
   // fallback already did -- except now it looks specific. So an unresolved
   // address falls back to the shared id, which at least says so.
   if (ip === ANONYMOUS_CLIENT_KEY) return undefined;
-  const digest = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(`${salt}:${ip}`),
-  );
-  const hex = [...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("")
-    .slice(0, USAGE_ANONYMOUS_ID_HEX_LENGTH);
-  return `${USAGE_ANONYMOUS_NAMESPACE}${hex}`;
+  return anonymousUsageDistinctId(salt, ip);
 }
 
 /**


### PR DESCRIPTION
#10942 fixed REST and left the same defect standing on two other surfaces. That is the pattern this repo keeps paying for, so all three land together.

## MCP counted connections, not callers

A session id is minted **per connection**, and MCP clients reconnect constantly. Measured 2026-08-12:

| | count |
| --- | --- |
| distinct `mcp-session:` ids | **462** |
| authenticated users (`github:`) | 4 |
| distinct client names | 51 |

So "unique callers" read ~462 and nothing about that number was true — and every reconnect also minted a person profile, which is the same fact costing money.

An address is stable across the reconnects a session id is destroyed by, so it now outranks the session — resolved through the **same helper REST uses**, so one client calling both surfaces is one caller rather than two.

#7153 chose the session deliberately and said why: keying on an address *"would mean fingerprinting, which is a real privacy tradeoff and is deliberately not made here."* That tradeoff has since been made explicitly, and it is made the same way here — a **salted** hash of the address, never the address, never the User-Agent. The session is not lost: it still rides every event as `$session_id`, so per-run analysis is unchanged. It stops being what a *caller* count is computed from, which it was never able to be.

`accountId` was already resolved in `buildContext` and already discarded, so a key-authenticated MCP caller now counts as its account, ranked above an observed address exactly as on REST.

**Precedence, both surfaces, one rule:** `github:` → `account:` → `ip:` → `mcp-session:` → unattributed. What the caller *proved* beats what we *observed*; only the proved ones become person profiles.

## `$exception` was the last unflagged path

A fault carries the same `distinct_id` as the request that produced it, so leaving the flag off would have re-opened the leak the other captures close. One unflagged event on an id is enough to mint the profile — which is precisely how `usage_event` kept minting one per MCP session while all six `$mcp_*` events said `false`.

## A bug this introduced, caught before it shipped

The usage-event person gate keyed only on `account:`. But **one request emits on both paths**: an authenticated MCP call produces `$mcp_*` events keyed on `github:` *and* a `usage_event` carrying that same id. Two files disagreeing about whether one caller is a person is not a labelling nit — PostHog creates the profile when *any* event on the id asks for one. Both namespaces, one answer, asserted in both directions (`mcp-session:github:x` and `ip:account:x` must still not be persons).

## Verification

380 tests green across the three telemetry suites, plus the full 1,372-test MCP server suite (`buildContext` became async). Volume unchanged — no new events.

Refs #10606
