### PR TITLE
fix(chain-firehose): name which cap refused, without telling the caller

### DIFF
--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -11,7 +11,7 @@
 // equivalent) is out of reach here -- see that branch's own /* v8 ignore */
 // comment in the source and #4982's issue body.
 import assert from "node:assert/strict";
-import { test, vi } from "vitest";
+import { describe, test, vi } from "vitest";
 import {
   ALERTER_HUB_EVALUATE_TIMEOUT_MS,
   CHAIN_FIREHOSE_GRAPHQL_SUBSCRIPTION_HIGH_WATER_MARK,
@@ -49,7 +49,10 @@ import {
   formatChainFirehoseTopicNoticeFrame,
   unpublishedChainFirehoseTopics,
   chainFirehoseCapRefusal,
+  CHAIN_FIREHOSE_CAP_HEADER,
+  CHAIN_FIREHOSE_CAP_UNATTRIBUTED,
 } from "../workers/chain-firehose-hub.ts";
+import { ANONYMOUS_CLIENT_KEY } from "../workers/config.ts";
 import { MCP_CHAIN_STREAM_RESOURCE_URI } from "../workers/mcp-session-hub.ts";
 import { resetModuleState } from "../src/module-state-registry.ts";
 import { schema as chainEventsGraphqlSchema } from "../src/graphql.ts";
@@ -2539,6 +2542,91 @@ test("the observed count rides along, so a near-miss is visible too", () => {
     assert.ok(
       lines[0]!.includes("1000/1000"),
       "observed/limit, not just the fact of a refusal",
+    );
+  });
+});
+
+// ── Which cap refused, and who is allowed to know (#10606) ─────────────────
+//
+// /api/v1/chain/stream ran at 95% 5xx for days while nothing could say which
+// of two OPPOSITE conditions it was: a global cap (every subscriber refused —
+// an outage) or a per-IP cap (one client contained — the design working).
+// #10744 wrote the answer to the tail, and a tail is not a record: every
+// refusal was an unsampled usage_event carrying error_code: null.
+describe("chain-firehose cap attribution", () => {
+  test("each cap names itself on the internal header", async () => {
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    const opened = [];
+    for (let i = 0; i < CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP; i += 1) {
+      opened.push(await hub.fetch(subscribeRequest("203.0.113.7")));
+    }
+    const capped = await hub.fetch(subscribeRequest("203.0.113.7"));
+    assert.equal(capped.status, 503);
+    assert.equal(capped.headers.get(CHAIN_FIREHOSE_CAP_HEADER), "sse-per-ip");
+    await Promise.all(opened.map((res) => res.body!.cancel()));
+  });
+
+  test("an unattributable caller is named apart from a real per-IP cap", async () => {
+    // THE DISTINCTION THAT WAS MISSING. With no cf-connecting-ip,
+    // resolveClientIp collapses every caller into ONE fixed bucket — correct
+    // for a rate limiter, but it means the 21st unattributable connection is
+    // refused because of 20 that may have nothing to do with it. From outside
+    // that is indistinguishable from one client being contained, and the two
+    // call for opposite responses.
+    const hub = new ChainFirehoseHub(stubState(), mockEnv({}));
+    const opened = [];
+    for (let i = 0; i < CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP; i += 1) {
+      opened.push(await hub.fetch(subscribeRequest(null)));
+    }
+    const capped = await hub.fetch(subscribeRequest(null));
+    assert.equal(capped.status, 503);
+    assert.equal(
+      capped.headers.get(CHAIN_FIREHOSE_CAP_HEADER),
+      `sse-per-ip:${CHAIN_FIREHOSE_CAP_UNATTRIBUTED}`,
+    );
+    await Promise.all(opened.map((res) => res.body!.cancel()));
+  });
+
+  test("the global cap is never labelled unattributed", async () => {
+    // It is not counted per address at all, so the suffix would be a claim
+    // about a dimension that does not apply — and would make a global outage
+    // read as an addressing problem.
+    const refusal = chainFirehoseCapRefusal("sse-global", 1000, 1000);
+    assert.equal(refusal.headers.get(CHAIN_FIREHOSE_CAP_HEADER), "sse-global");
+  });
+
+  test("the body stays identical across every cap", async () => {
+    // #10744's decision, still standing: a distinct body would tell a scraper
+    // which limit it hit and therefore whether rotating addresses helps. The
+    // header is what carries the difference, and the edge deletes it.
+    const bodies = await Promise.all(
+      (
+        [
+          chainFirehoseCapRefusal("sse-global", 1000, 1000),
+          chainFirehoseCapRefusal("ws-global", 1000, 1000),
+          chainFirehoseCapRefusal("sse-per-ip", 20, 20, "203.0.113.7"),
+          chainFirehoseCapRefusal("ws-per-ip", 20, 20, ANONYMOUS_CLIENT_KEY),
+        ] as Response[]
+      ).map((res) => res.text()),
+    );
+    assert.equal(
+      new Set(bodies).size,
+      1,
+      "the caller must not be able to tell the caps apart",
+    );
+    assert.equal(bodies[0], "too many connections");
+  });
+
+  test("the address itself never rides the header", async () => {
+    const refusal = chainFirehoseCapRefusal(
+      "sse-per-ip",
+      20,
+      20,
+      "203.0.113.7",
+    );
+    assert.equal(
+      refusal.headers.get(CHAIN_FIREHOSE_CAP_HEADER)?.includes("203.0.113.7"),
+      false,
     );
   });
 });

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -4,6 +4,7 @@ import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import { POSTHOG_TRACES_SAMPLE_RATE_ENV } from "../src/tracing.ts";
 import worker, {
+  handleRequest,
   markRequestAuthTier,
   usageRouteLabel,
   withUsageTelemetry,
@@ -1192,5 +1193,91 @@ describe("withUsageTelemetry — distinct_id", () => {
     const next = await attributedTo(SALTED_ENV, fromIp("203.0.113.7"));
     assert.equal(identified, "account:acct_123");
     assert.match(String(next), /^ip:/);
+  });
+});
+
+// ── A refusal the response is not allowed to explain (#10606) ──────────────
+//
+// /api/v1/chain/stream ran at 95% 5xx for days while every refusal was an
+// unsampled usage_event carrying error_code: null — so the volume was paid
+// for and the diagnosis was not bought. The cap kind rides an internal header
+// the edge deletes: the Worker learns which limit refused, the caller does
+// not (#10744 keeps every cap's response identical so a scraper cannot learn
+// whether rotating addresses would help).
+describe("withUsageTelemetry — chain-firehose cap attribution", () => {
+  function hubEnv(capHeader: string | null) {
+    return {
+      ...CONFIGURED_ENV,
+      CHAIN_FIREHOSE_HUB: {
+        idFromName: () => "id",
+        get: () => ({
+          fetch: async () =>
+            new Response("too many connections", {
+              status: 503,
+              ...(capHeader
+                ? { headers: { "x-metagraph-cap": capHeader } }
+                : {}),
+            }),
+        }),
+      },
+    };
+  }
+
+  async function streamRefusal(capHeader: string | null) {
+    const spy = recorder();
+    const ctx = fakeCtx();
+    const env = hubEnv(capHeader) as unknown as Env;
+    // ONE Request object through both. The cap code is carried on a WeakMap
+    // keyed by request identity (the response is deliberately not allowed to
+    // carry it), so handing the wrapper a different-but-equal Request would
+    // look exactly like the code never being recorded.
+    const request = req("/api/v1/chain/stream");
+    const response = await withUsageTelemetry(
+      request,
+      env,
+      ctx,
+      () => handleRequest(request, env, ctx as unknown as WTCtx),
+      spy,
+    );
+    await Promise.all(ctx.scheduled);
+    return { response, spy };
+  }
+
+  test("the cap kind reaches telemetry as the error code", async () => {
+    const { spy } = await streamRefusal("sse-per-ip");
+    assert.equal(
+      spy.events.at(-1)?.event.errorCode,
+      "chain_firehose_cap_sse_per_ip",
+    );
+  });
+
+  test("an unattributable per-IP cap is a distinguishable code", async () => {
+    // The one that matters most: "one client contained" and "every caller we
+    // could not identify sharing a single 20-slot bucket" are opposite
+    // diagnoses and used to be the same event.
+    const { spy } = await streamRefusal("sse-per-ip:unattributed");
+    assert.equal(
+      spy.events.at(-1)?.event.errorCode,
+      "chain_firehose_cap_sse_per_ip_unattributed",
+    );
+  });
+
+  test("the caller never receives the header", async () => {
+    // Guards the half a scraper would exploit. If this stops holding, the
+    // response starts telling a client which limit it hit and therefore
+    // whether rotating addresses would help.
+    const { response } = await streamRefusal("sse-per-ip");
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get("x-metagraph-cap"), null);
+    assert.equal(await response.text(), "too many connections");
+  });
+
+  test("a response with no cap header is passed through untouched", async () => {
+    // The overwhelming majority of responses. Reconstructing every one of
+    // them to delete a header that is not there would put a copy in front of
+    // every streaming body on the route.
+    const { response, spy } = await streamRefusal(null);
+    assert.equal(response.status, 503);
+    assert.equal("errorCode" in (spy.events.at(-1)?.event ?? {}), false);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -518,6 +518,7 @@ import {
 } from "./request-handlers/analytics.ts";
 import { loadGlobalOperationalHealth } from "../src/global-operational-health.ts";
 import {
+  CHAIN_FIREHOSE_CAP_HEADER,
   CHAIN_FIREHOSE_INGEST_TOKEN_HEADER,
   ChainFirehoseHub,
 } from "./chain-firehose-hub.ts";
@@ -1557,6 +1558,23 @@ const requestAuthTier = new WeakMap<Request, string>();
 const requestAccountId = new WeakMap<Request, string>();
 
 /**
+ * An error code resolved somewhere the RESPONSE cannot carry it.
+ *
+ * `withUsageTelemetry` reads `error_code` off the response header, which works
+ * for every route that answers through `errorResponse`. It cannot work for a
+ * refusal whose whole design is that the response says nothing distinguishing
+ * -- the chain-firehose caps (#10606), where telling the caller which limit it
+ * hit tells a scraper whether to rotate addresses. Same WeakMap-on-the-Request
+ * shape as the tier above, and the same collectability argument.
+ */
+const requestErrorCode = new WeakMap<Request, string>();
+
+/** Record an error code the response is deliberately not allowed to carry. */
+export function markRequestErrorCode(request: Request, code: unknown): void {
+  if (typeof code === "string" && code) requestErrorCode.set(request, code);
+}
+
+/**
  * Record the tier a request authenticated on, for its usage event.
  *
  * Called from the tiered-rate-limit gates, which are the only places that
@@ -1727,7 +1745,13 @@ export async function withUsageTelemetry(
     // the successes (a route correctly rejecting a bad request is not a
     // failure), which makes "are callers sending us garbage" unanswerable.
     statusClass = statusClassOf(response.status);
-    errorCode = response.headers.get("x-metagraph-error-code") ?? undefined;
+    errorCode =
+      response.headers.get("x-metagraph-error-code") ??
+      // #10606: a refusal whose response is deliberately uniform records its
+      // code out of band. Second, never first -- a real header is the response
+      // this request actually served, and must win.
+      requestErrorCode.get(request) ??
+      undefined;
     // metagraphed#7734: GraphQL execution errors are a spec-mandated 200
     // with a populated `errors` array (src/graphql.ts) -- status alone
     // can't distinguish that from a real success, so this one code (set
@@ -5080,7 +5104,30 @@ async function handleChainFirehoseStream(request: Request, env: Env, url: URL) {
   );
   const forwardUrl = new URL("https://chain-firehose-hub.internal/subscribe");
   forwardUrl.search = url.search;
-  return stub.fetch(new Request(forwardUrl, request));
+  const response = await stub.fetch(new Request(forwardUrl, request));
+  // #10606: the DO names which cap refused, this records it, and the header is
+  // DELETED before the response continues. Both halves matter: the Worker
+  // needs the kind (a global cap and a per-IP cap are operationally opposite,
+  // and for days nothing but a live tail could tell them apart), and the
+  // caller must not have it (#10744 keeps every cap's response identical so a
+  // scraper cannot learn whether rotating addresses would help).
+  //
+  // The single forwarding point for BOTH transports, which is why it is here:
+  // withUsageTelemetry returns early on a WebSocket upgrade, so stripping
+  // there would leave the header on every refused WS handshake.
+  const cap = response.headers.get(CHAIN_FIREHOSE_CAP_HEADER);
+  if (!cap) return response;
+  markRequestErrorCode(
+    request,
+    `chain_firehose_cap_${cap.replace(/[:-]/g, "_")}`,
+  );
+  const headers = new Headers(response.headers);
+  headers.delete(CHAIN_FIREHOSE_CAP_HEADER);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
 }
 
 // POST /api/v1/internal/chain-firehose-ingest -- the write path the #4981

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -54,7 +54,7 @@ import {
   recordExceptionEvent,
   recordUsageEvent,
 } from "../src/usage-telemetry.ts";
-import { resolveClientIp } from "./config.ts";
+import { ANONYMOUS_CLIENT_KEY, resolveClientIp } from "./config.ts";
 import {
   CHAIN_FIREHOSE_PUBLISHED_TABLES,
   CHAIN_FIREHOSE_TABLES,
@@ -208,17 +208,63 @@ export const CHAIN_FIREHOSE_SSE_HIGH_WATER_MARK = 64;
 export type ChainFirehoseCapKind =
   "ws-global" | "ws-per-ip" | "sse-global" | "sse-per-ip";
 
+/**
+ * Header carrying the cap kind back to the Worker. STRIPPED AT THE EDGE.
+ *
+ * The tail was the only place the kind could be read (#10744), and a tail is
+ * not a record: /api/v1/chain/stream ran at 95% 5xx for days and no query
+ * could say which of two operationally OPPOSITE conditions it was -- a global
+ * cap (every subscriber refused: an outage) or a per-IP cap (one client
+ * contained: the design working). Every refusal was an unsampled
+ * `usage_event` with `error_code: null`, so the volume was paid for and the
+ * diagnosis was not bought.
+ *
+ * A HEADER THE EDGE REMOVES, rather than a distinct body or error code,
+ * because #10744's reason for one uniform response still holds: a scraper
+ * that learns WHICH limit it hit learns whether to rotate addresses. So
+ * `handleChainFirehoseStream` reads this, records it, and deletes it before
+ * the response continues -- the Worker learns, the caller does not.
+ */
+export const CHAIN_FIREHOSE_CAP_HEADER = "x-metagraph-cap";
+
+/**
+ * Whether the refusal could be attributed to a caller at all.
+ *
+ * A per-IP cap is only "one client contained" if the IP is a real client. When
+ * `cf-connecting-ip` is absent, `resolveClientIp` collapses to ONE fixed
+ * bucket by design -- correct for a rate limiter, but it means every
+ * unattributable caller shares a single 20-slot quota, and the 21st is refused
+ * because of the 20 before it that may be nothing to do with it. That reads
+ * identically to a real per-IP cap from outside, so the two are named apart
+ * here and the suffix is what tells them apart in a query.
+ */
+export const CHAIN_FIREHOSE_CAP_UNATTRIBUTED = "unattributed";
+
 /** The 503 every cap answers with, and the one line that tells them apart. */
 export function chainFirehoseCapRefusal(
   kind: ChainFirehoseCapKind,
   observed: number,
   limit: number,
+  /**
+   * The client key the cap was counted against, when the cap is per-IP. Only
+   * ever compared against the anonymous fallback -- the address itself never
+   * leaves this function, and never rides the header.
+   */
+  clientKey?: string,
 ): Response {
+  const unattributed =
+    clientKey !== undefined && clientKey === ANONYMOUS_CLIENT_KEY;
+  const label = unattributed
+    ? `${kind}:${CHAIN_FIREHOSE_CAP_UNATTRIBUTED}`
+    : kind;
   // Same labelled shape src/r2-sql.ts gives its suppressed queries, for the same
   // reason: the tail is where every occurrence can be read, and the response
   // deliberately will not carry it.
-  console.error("[chain-firehose] cap", kind, `${observed}/${limit}`);
-  return new Response("too many connections", { status: 503 });
+  console.error("[chain-firehose] cap", label, `${observed}/${limit}`);
+  return new Response("too many connections", {
+    status: 503,
+    headers: { [CHAIN_FIREHOSE_CAP_HEADER]: label },
+  });
 }
 
 export const CHAIN_FIREHOSE_MAX_SSE_CONNECTIONS = 1000;
@@ -1294,6 +1340,7 @@ export class ChainFirehoseHub implements DurableObject {
           "ws-per-ip",
           this.wsClientsByIp.get(clientIp) ?? 0,
           CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
+          clientIp,
         );
       }
       const requestedProtocols = (
@@ -1391,6 +1438,7 @@ export class ChainFirehoseHub implements DurableObject {
         "sse-per-ip",
         sseForIp,
         CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP,
+        clientIp,
       );
     }
 


### PR DESCRIPTION
`/api/v1/chain/stream` has run at **95% 5xx for days** — 1,044 refusals in 26 hours — and nothing could say which of two *operationally opposite* conditions it was:

- a **global** cap → every subscriber is refused. An outage.
- a **per-IP** cap → one client is contained. The design working.

Every refusal was an unsampled `usage_event` carrying `error_code: null`, so the volume was paid for and the diagnosis was not bought.

#10744 already worked this out and wrote the answer to the tail. **A tail is not a record** — it cannot be queried after the fact, which is the only time anyone looks. I hit this directly trying to diagnose #10606: PostHog could not separate the buckets, and geoip could not either (both the refused and the served requests resolve to MaxMind's US centroid).

## The kind rides a header the edge deletes

`handleChainFirehoseStream` records it and strips it, so the Worker learns and the caller does not. #10744's reason for one uniform response still holds: a distinct body or error code tells a scraper which limit it hit, and therefore whether rotating addresses would help.

Stripped at the **forwarding point**, not in `withUsageTelemetry` — that returns early on a WebSocket upgrade, so stripping there would leave the header on every refused WS handshake.

## A third state the two-way split could not express

A per-IP cap only means "one client contained" if the address identifies a client. `resolveClientIp` collapses a missing `cf-connecting-ip` into **one fixed bucket** — correct for a rate limiter, but it means every unattributable caller shares a single 20-slot quota, and the 21st is refused because of 20 that may have nothing to do with it.

From outside, that is indistinguishable from a real per-IP cap. The two call for opposite responses, so the refusal names them apart: `sse-per-ip` vs `sse-per-ip:unattributed`.

**This is a live hypothesis for the outage itself**, not just tidier telemetry. If `cf-connecting-ip` does not survive the hop into the Durable Object, every SSE client on the platform shares one 20-slot bucket — which fits every observation: 2xx and 5xx interleaved in the same hour, bursts during working hours, silence overnight, and a fresh connection succeeding whenever a slot frees. I am **not** claiming that is the cause; I am making it answerable with a query instead of a guess, which is the sequencing #10606 itself asks for.

## What is asserted, and why those two

The address never rides the header, and the body stays byte-identical across all four caps. Both are the parts a scraper would exploit if they stopped holding, so both are pinned rather than assumed.

238 tests green across the firehose and request-telemetry suites.

Refs #10606
