### PR TITLE
fix(ui): one chain-stream socket per topic set, not one per call site

### DIFF
--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { ChainStreamSource, ChainStreamSessionDeps, SseStatus } from "./use-chain-stream";
 import {
@@ -10,6 +10,8 @@ import {
   CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES,
   CHAIN_STREAM_DOWNGRADE_RETRY_MS,
   createChainStreamSession,
+  acquireSharedChainStream,
+  activeSharedChainStreamCount,
   createDebouncedHandler,
   parseChainStreamPayload,
 } from "./use-chain-stream";
@@ -366,5 +368,184 @@ describe("createChainStreamSession", () => {
 
     sources[0]!.emitError();
     expect(statuses).toEqual(["connecting", "open", "error"]);
+  });
+});
+
+/**
+ * `expect(a).toEqual(b)` with a message, so a pooling failure says WHICH
+ * invariant broke rather than printing two object dumps.
+ */
+function expectEq(actual: unknown, expected: unknown, message?: string): void {
+  expect(actual, message).toEqual(expected);
+}
+
+// ── One socket per topic set, not one per call site (#10606) ───────────────
+//
+// THE BUG. `useChainStream` opened its own EventSource per CALL SITE, and
+// there are six: two in home-watched-module, plus registry-ticker (in the
+// header, so on every page), chain-events-feed, live-block-rail and the subnet
+// detail route. Three ask for `account_events` and two for `blocks` --
+// identical URLs, separate sockets.
+//
+// The server caps ONE IP at 20 concurrent SSE connections, so a handful of
+// tabs reaches it unaided. /api/v1/chain/stream ran at ~95% 5xx for days, and
+// once cap attribution shipped every refusal came back
+// `chain_firehose_cap_sse_per_ip` -- not the global cap, and not
+// `:unattributed`. The app was refusing itself.
+describe("acquireSharedChainStream", () => {
+  function fakeSource() {
+    const listeners = new Map<string, (ev: Event) => void>();
+    return {
+      closed: 0,
+      listeners,
+      addEventListener(type: string, listener: (ev: Event) => void) {
+        listeners.set(type, listener);
+      },
+      close() {
+        this.closed += 1;
+      },
+      onmessage: null as ((ev: MessageEvent) => void) | null,
+      emit(payload: unknown) {
+        listeners.get("chain")?.({
+          data: JSON.stringify(payload),
+        } as unknown as Event);
+      },
+      open() {
+        listeners.get("open")?.(new Event("open"));
+      },
+    };
+  }
+
+  function subscriber(overrides: Partial<Record<string, unknown>> = {}) {
+    const seen: unknown[] = [];
+    const statuses: string[] = [];
+    let activity = 0;
+    return {
+      seen,
+      statuses,
+      get activity() {
+        return activity;
+      },
+      sub: {
+        getMatches: () => undefined,
+        setStatus: (s: string) => statuses.push(s),
+        markActivity: () => {
+          activity += 1;
+        },
+        deliver: (p: unknown) => seen.push(p),
+        cancel: () => {},
+        ...overrides,
+      } as never,
+    };
+  }
+
+  afterEach(() => {
+    expectEq(activeSharedChainStreamCount(), 0, "a shared connection outlived its last subscriber");
+  });
+
+  it("two consumers of the same topics share ONE socket", () => {
+    let opened = 0;
+    const src = fakeSource();
+    const open = () => {
+      opened += 1;
+      return src as never;
+    };
+    const a = subscriber();
+    const b = subscriber();
+    const releaseA = acquireSharedChainStream("account_events|400", open, a.sub);
+    const releaseB = acquireSharedChainStream("account_events|400", open, b.sub);
+    expectEq(opened, 1, "the second consumer opened a second socket");
+    releaseA();
+    releaseB();
+  });
+
+  it("different topics still get their own socket", () => {
+    // Sharing must be keyed, not global: a consumer of `blocks` must not be
+    // silently subscribed to `account_events`.
+    let opened = 0;
+    const open = () => {
+      opened += 1;
+      return fakeSource() as never;
+    };
+    const a = subscriber();
+    const b = subscriber();
+    const releaseA = acquireSharedChainStream("account_events|400", open, a.sub);
+    const releaseB = acquireSharedChainStream("blocks|400", open, b.sub);
+    expectEq(opened, 2);
+    releaseA();
+    releaseB();
+  });
+
+  it("the socket survives one consumer leaving and closes with the last", () => {
+    const src = fakeSource();
+    const a = subscriber();
+    const b = subscriber();
+    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
+    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    releaseA();
+    expectEq(src.closed, 0, "unmounting one consumer closed the shared socket");
+    releaseB();
+    expectEq(src.closed, 1, "the last consumer left and the socket stayed open");
+  });
+
+  it("every subscriber receives each frame", () => {
+    const src = fakeSource();
+    const a = subscriber();
+    const b = subscriber();
+    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
+    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    src.emit({ block: 1 });
+    expectEq(a.seen, [{ block: 1 }]);
+    expectEq(b.seen, [{ block: 1 }]);
+    releaseA();
+    releaseB();
+  });
+
+  it("each subscriber applies its OWN matches", () => {
+    // Pooling the socket must not pool the filtering, or a consumer starts
+    // seeing frames it explicitly excluded.
+    const src = fakeSource();
+    const a = subscriber({
+      getMatches: () => (p: unknown) => (p as { block: number }).block > 5,
+    });
+    const b = subscriber();
+    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
+    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    src.emit({ block: 1 });
+    src.emit({ block: 9 });
+    expectEq(a.seen, [{ block: 9 }], "a's own filter was not applied");
+    expectEq(b.seen, [{ block: 1 }, { block: 9 }]);
+    // markActivity follows the subscriber's own filter, not the socket's.
+    expectEq(a.activity, 1);
+    expectEq(b.activity, 2);
+    releaseA();
+    releaseB();
+  });
+
+  it("a late subscriber is told the connection is already open", () => {
+    // Without the replay it would sit at whatever it initialised to while
+    // attached to a live socket, and the LIVE chip would lie by omission.
+    const src = fakeSource();
+    const a = subscriber();
+    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
+    src.open();
+    const b = subscriber();
+    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    expectEq(b.statuses.at(-1), "open");
+    releaseA();
+    releaseB();
+  });
+
+  it("a released subscriber stops receiving frames", () => {
+    const src = fakeSource();
+    const a = subscriber();
+    const b = subscriber();
+    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
+    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    releaseA();
+    src.emit({ block: 2 });
+    expectEq(a.seen, [], "an unmounted consumer still received a frame");
+    expectEq(b.seen, [{ block: 2 }]);
+    releaseB();
   });
 });

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -161,6 +161,18 @@ export interface ChainStreamSessionDeps {
   setStatus: (s: SseStatus) => void;
   /** Called on every accepted frame (feeds `lastEventAt`). */
   markActivity: () => void;
+  /**
+   * Deliver each accepted frame SYNCHRONOUSLY and uncoalesced, instead of
+   * through `debounceMs` + `getOnEvent`.
+   *
+   * For the shared pool (`acquireSharedChainStream`), where one socket has
+   * many subscribers and each does its own debouncing. Coalescing at the
+   * socket would be wrong for all of them: `pending = payload` OVERWRITES, so
+   * a burst inside one debounce window would silently drop every frame but
+   * the last -- correct when a single consumer asked for exactly that, data
+   * loss when it is imposed on consumers that did not.
+   */
+  deliverRaw?: (payload: unknown) => void;
 }
 
 /**
@@ -233,6 +245,10 @@ export function createChainStreamSession(deps: ChainStreamSessionDeps): {
       const match = deps.getMatches();
       if (match && !match(payload)) return;
       deps.markActivity();
+      if (deps.deliverRaw) {
+        deps.deliverRaw(payload);
+        return;
+      }
       pending = payload;
       flush();
     };
@@ -273,6 +289,133 @@ export function createChainStreamSession(deps: ChainStreamSessionDeps): {
   };
 
   return { connect, dispose };
+}
+
+/**
+ * ONE CONNECTION PER TOPIC SET PER TAB, shared by every consumer of it.
+ *
+ * ## THE BUG THIS FIXES
+ *
+ * `useChainStream` opened its own `EventSource` per CALL SITE, and there are
+ * six: two in home-watched-module, plus registry-ticker (which lives in the
+ * header, so it is on every page), chain-events-feed, live-block-rail and the
+ * subnet detail route. Three of them ask for `account_events` and two for
+ * `blocks` -- identical URLs, separate sockets.
+ *
+ * The server caps ONE IP at CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP = 20
+ * concurrent SSE connections, so a handful of open tabs reaches the cap on its
+ * own. Measured 2026-08-12: /api/v1/chain/stream ran at ~95% 5xx for days, and
+ * once the cap attribution shipped every refusal came back
+ * `chain_firehose_cap_sse_per_ip` -- NOT `:unattributed` and NOT the global
+ * cap. The app was refusing itself, and the browser's own reconnect made it
+ * look like sustained load.
+ *
+ * ## WHY SHARING IS SAFE HERE
+ *
+ * The connection is shared; the PROCESSING is not. The shared session applies
+ * no `matches` and no debounce -- each subscriber still runs its own filter,
+ * its own debounce and its own `markActivity`, so a consumer sees exactly the
+ * frames and the coalescing it would have seen on a private socket. Only the
+ * socket is pooled.
+ *
+ * Keyed on the topic list AND the debounce, because debounce is a property of
+ * the delivery a caller asked for; two callers wanting different coalescing
+ * still share nothing they should not. In practice every current call site
+ * takes the default, so the six collapse to three.
+ */
+interface ChainStreamSubscriber {
+  getMatches: () => ((payload: unknown) => boolean) | undefined;
+  setStatus: (s: SseStatus) => void;
+  markActivity: () => void;
+  /** This subscriber's OWN debounced hand-off to its `onEvent`. */
+  deliver: (payload: unknown) => void;
+  /** Cancels a pending `deliver`, so a frame cannot land after release. */
+  cancel: () => void;
+}
+
+interface SharedChainStream {
+  session: { connect: () => void; dispose: () => void };
+  subscribers: Set<ChainStreamSubscriber>;
+  /** Last status the socket reported, replayed to a late subscriber so it
+   * does not sit at "connecting" for a connection that is already open. */
+  status: SseStatus;
+  offNetwork: () => void;
+  offApiBase: () => void;
+}
+
+const SHARED_CHAIN_STREAMS = new Map<string, SharedChainStream>();
+
+/** Exported for tests: no connection may outlive its last subscriber. */
+export function activeSharedChainStreamCount(): number {
+  return SHARED_CHAIN_STREAMS.size;
+}
+
+/**
+ * Join (or open) the shared connection for `topicList`. Returns the release
+ * function; the socket closes when the last subscriber releases it.
+ */
+export function acquireSharedChainStream(
+  key: string,
+  /**
+   * Opens the socket. INJECTED, like `createChainStreamSession`'s own
+   * `openSource` and for the same reason: this suite runs in plain node with
+   * no `EventSource`, and a pool that could only be exercised in a browser is
+   * a pool whose ref-counting nobody checks.
+   */
+  openSource: () => ChainStreamSource,
+  subscriber: ChainStreamSubscriber,
+): () => void {
+  let shared = SHARED_CHAIN_STREAMS.get(key);
+  if (!shared) {
+    const subscribers = new Set<ChainStreamSubscriber>();
+    const entry = {
+      subscribers,
+      status: "connecting" as SseStatus,
+    } as SharedChainStream;
+    const session = createChainStreamSession({
+      openSource,
+      // Every subscriber filters for itself below, so the socket accepts
+      // everything the server already topic-filtered.
+      getMatches: () => undefined,
+      // Unused: `deliverRaw` below takes the frame path instead, so nothing
+      // coalesces at the socket.
+      debounceMs: 0,
+      getOnEvent: () => undefined,
+      deliverRaw: (payload: unknown) => {
+        for (const sub of subscribers) {
+          const match = sub.getMatches();
+          if (match && !match(payload)) continue;
+          sub.markActivity();
+          sub.deliver(payload);
+        }
+      },
+      setStatus: (s) => {
+        entry.status = s;
+        for (const sub of subscribers) sub.setStatus(s);
+      },
+      markActivity: () => {},
+    });
+    entry.session = session;
+    entry.offNetwork = onNetworkChange(session.connect);
+    entry.offApiBase = onApiBaseChange(session.connect);
+    SHARED_CHAIN_STREAMS.set(key, entry);
+    shared = entry;
+    session.connect();
+  }
+  shared.subscribers.add(subscriber);
+  // Replay the socket's current status, so a consumer joining an already-open
+  // connection shows LIVE immediately rather than waiting for the next event.
+  subscriber.setStatus(shared.status);
+  return () => {
+    const entry = SHARED_CHAIN_STREAMS.get(key);
+    if (!entry) return;
+    entry.subscribers.delete(subscriber);
+    if (entry.subscribers.size > 0) return;
+    entry.offNetwork();
+    entry.offApiBase();
+    entry.session.dispose();
+    SHARED_CHAIN_STREAMS.delete(key);
+  };
 }
 
 export interface UseChainStreamOptions {
@@ -376,22 +519,38 @@ export function useChainStream(options: UseChainStreamOptions = {}): {
       ? topicsKey.split(",").filter(Boolean)
       : (["chain_events"] as string[]);
 
-    const session = createChainStreamSession({
-      openSource: () => new EventSource(buildChainStreamUrl(topicList)),
-      getOnEvent: () => onEventRef.current,
-      getMatches: () => matchesRef.current,
-      debounceMs,
-      setStatus,
-      markActivity: () => setLastEventAt(new Date().toISOString()),
-    });
+    // This subscriber's OWN debounce, so pooling the socket does not pool the
+    // coalescing: a consumer sees exactly the delivery it asked for.
+    let pending: unknown = null;
+    const flush = createDebouncedHandler(() => {
+      if (pending === null) return;
+      const payload = pending;
+      pending = null;
+      onEventRef.current?.(payload);
+    }, debounceMs);
 
-    session.connect();
-    const offNetwork = onNetworkChange(session.connect);
-    const offApiBase = onApiBaseChange(session.connect);
+    const release = acquireSharedChainStream(
+      `${topicsKey || "chain_events"}|${debounceMs}`,
+      () => new EventSource(buildChainStreamUrl(topicList)),
+      {
+        getMatches: () => matchesRef.current,
+        setStatus,
+        markActivity: () => setLastEventAt(new Date().toISOString()),
+        deliver: (payload) => {
+          pending = payload;
+          flush();
+        },
+        cancel: flush.cancel,
+      },
+    );
+
     return () => {
-      offNetwork();
-      offApiBase();
-      session.dispose();
+      // Cancel BEFORE releasing: a frame already scheduled by this
+      // subscriber's debounce would otherwise fire into an unmounted
+      // consumer, which is the same stale-delivery hazard #8179 fixed for
+      // the reconnect path.
+      flush.cancel();
+      release();
       if (typeof document !== "undefined" && document.hidden) {
         wasHiddenRef.current = true;
       }


### PR DESCRIPTION
`/api/v1/chain/stream` has run at ~95% 5xx for days. #10945's cap attribution deployed this afternoon and answered it:

```
error_code                      status  events
chain_firehose_cap_sse_per_ip   5xx     86      (16:24–16:39)
(null)                          5xx     788     (before the deploy)
```

**Not the global cap, and not `:unattributed`** — which also disproves the hypothesis I put in #10945 that `cf-connecting-ip` might not survive the hop into the Durable Object. It does. This is one client exceeding its own per-IP quota, and the client is us.

## The fan-out

`useChainStream` opened its own `EventSource` per **call site**, and there are six:

| call site | topics |
| --- | --- |
| `home-watched-module` ×2 | `account_events` |
| `-subnets-netuid-page` | `account_events` |
| `registry-ticker` (in the header — every page) | `blocks` |
| `blocks/live-block-rail` | `blocks` |
| `chain-events-feed` | `chain_events` |

Identical URLs, separate sockets. The server caps one IP at **20** concurrent SSE connections, so a handful of open tabs reaches it unaided — and the browser's own reconnect makes a self-inflicted refusal look like sustained load.

## The connection is pooled; the processing is not

Each subscriber keeps its own `matches`, its own debounce and its own `markActivity`, so a consumer sees exactly the frames and the coalescing it would have seen on a private socket. Only the socket is shared, keyed on topics **and** debounce.

### A real bug in the first cut of this

`createChainStreamSession` debounces by **overwriting** `pending`, so a burst inside one window keeps only the last frame. That is correct when a single consumer asked for exactly that, and **data loss** when imposed on subscribers that did not. The pool would have silently dropped frames for everyone.

`deliverRaw` now delivers each accepted frame synchronously and uncoalesced. The debounced path is untouched for every existing caller.

## Verification

Ref-counted: the socket survives one consumer unmounting and closes with the last, with an `afterEach` that fails if any connection outlives its subscribers.

Proven by removing the reuse lookup and watching exactly the sharing tests fail:

```
FAIL  two consumers of the same topics share ONE socket
FAIL  every subscriber receives each frame
FAIL  each subscriber applies its OWN matches
```

511 UI tests green. **Hooks-only — no visual change**, so this follows the normal gate.

## What this does not claim

Sharing takes a fully-loaded tab from ~4 sockets to 3, not to 1. Collapsing further would mean one socket per tab subscribing to the *union* of topics, which requires client-side topic classification so a `blocks` consumer does not start receiving `account_events` frames — a larger change I have not made here. Whether 20 is the right cap for real multi-tab usage is now measurable rather than guessable.

Refs #10606
