### PR TITLE
fix(telemetry): count a calling Worker as a caller, not as the shared fallback

### DIFF
--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -86,6 +86,21 @@ export const USAGE_ACCOUNT_NAMESPACE = "account:";
 export const USAGE_ANONYMOUS_NAMESPACE = "ip:";
 
 /**
+ * The namespace a calling Worker is counted under.
+ *
+ * A Worker-to-Worker subrequest carries no client address and is still a
+ * caller. `cf-worker` is set by Cloudflare rather than by the sender, so it is
+ * trustworthy and low-cardinality (one value per calling Worker) -- the same
+ * reason `resolveUsageClient` already trusts it for the `client` dimension.
+ *
+ * Never a person: it is a piece of software, and #9004 found one such caller
+ * (`zeronode.workers.dev`) accounting for 82% of `block-detail` -- so this
+ * namespace can be high-VOLUME while staying tiny in cardinality, which is
+ * exactly the shape that must not mint profiles.
+ */
+export const USAGE_WORKER_NAMESPACE = "worker:";
+
+/**
  * Worker secret holding the salt for the anonymous-caller hash.
  *
  * UNSET IS A SUPPORTED STATE, and it degrades to the pre-#10606 behaviour:
@@ -730,6 +745,17 @@ export function resolvePostHogHost(env: Env | null | undefined): string {
 
 function sanitizeLabel(value: unknown): string | undefined {
   return trimToLength(value, MAX_LABEL_CHARS);
+}
+
+/**
+ * Bound a caller-derived label before it becomes a distinct_id.
+ *
+ * Exported because `resolveUsageDistinctId` builds the `worker:` id in
+ * workers/api.ts, and an unbounded id is an unbounded property on an event
+ * this project emits ~1.1M times a day.
+ */
+export function sanitizeUsageLabel(value: unknown): string {
+  return sanitizeLabel(value) ?? "unknown";
 }
 
 // ─── $mcp_error_type projection (#8963) ────────────────────────────────────

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -753,9 +753,16 @@ function sanitizeLabel(value: unknown): string | undefined {
  * Exported because `resolveUsageDistinctId` builds the `worker:` id in
  * workers/api.ts, and an unbounded id is an unbounded property on an event
  * this project emits ~1.1M times a day.
+ *
+ * Returns undefined rather than a placeholder, and the caller guards on THAT
+ * rather than on the raw header. A placeholder would have been dead code here
+ * -- the Headers API normalises a whitespace-only value to the empty string,
+ * so a header that is truthy but sanitises to nothing cannot arrive over
+ * HTTP -- and it would have minted `worker:unknown` as though it were an
+ * identity if anything ever did reach it.
  */
-export function sanitizeUsageLabel(value: unknown): string {
-  return sanitizeLabel(value) ?? "unknown";
+export function sanitizeUsageLabel(value: unknown): string | undefined {
+  return sanitizeLabel(value);
 }
 
 // ─── $mcp_error_type projection (#8963) ────────────────────────────────────

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -1339,6 +1339,15 @@ describe("withUsageTelemetry — the calling Worker", () => {
     assert.equal(await idFor({}), undefined);
   });
 
+  test("a Worker name that sanitises away is not an identity", async () => {
+    // The Headers API normalises a whitespace-only value to the empty
+    // string, so this cannot become the bare namespace `worker:` -- a caller
+    // whose name is the empty string, which would read as an identity and is
+    // not one. Pinned because the guard is on the SANITISED value, and moving
+    // it back to the raw header would reintroduce exactly that.
+    assert.equal(await idFor({ "cf-worker": "   " }), undefined);
+  });
+
   test("a Worker is never a person", async () => {
     // It is software. High volume, tiny cardinality — exactly the shape that
     // must not mint profiles.

--- a/tests/request-usage-telemetry.test.ts
+++ b/tests/request-usage-telemetry.test.ts
@@ -1281,3 +1281,71 @@ describe("withUsageTelemetry — chain-firehose cap attribution", () => {
     assert.equal("errorCode" in (spy.events.at(-1)?.event ?? {}), false);
   });
 });
+
+// ── A calling Worker is a caller (#10606) ──────────────────────────────────
+//
+// A Worker-to-Worker subrequest carries no `cf-connecting-ip`, so it fell
+// through to the shared id — and #9004 found ONE such caller
+// (`zeronode.workers.dev`) was 82% of `block-detail`, the largest route in the
+// project. A caller that dominates the traffic and cannot be counted is the
+// exact gap this namespace closes.
+describe("withUsageTelemetry — the calling Worker", () => {
+  const SALTED_ENV = {
+    ...CONFIGURED_ENV,
+    USAGE_DISTINCT_ID_SALT: "test-salt-not-a-real-secret",
+  };
+
+  async function idFor(headers: Record<string, string>) {
+    const spy = recorder();
+    const ctx = fakeCtx();
+    await withUsageTelemetry(
+      req("/api/v1/subnets", { headers }),
+      SALTED_ENV as unknown as Env,
+      ctx,
+      async () => new Response("ok"),
+      spy,
+    );
+    await Promise.all(ctx.scheduled);
+    return (spy.events[0]?.deps as { distinctId?: string } | undefined)
+      ?.distinctId;
+  }
+
+  test("a subrequest with no address is counted as its Worker", async () => {
+    assert.equal(
+      await idFor({ "cf-worker": "zeronode.workers.dev" }),
+      "worker:zeronode.workers.dev",
+    );
+  });
+
+  test("an address outranks the calling Worker", async () => {
+    // A Worker proxying a browser forwards the end user's cf-connecting-ip,
+    // and the person behind the proxy is the more interesting caller — the
+    // same precedence resolveUsageClient already applies to `client`.
+    const id = await idFor({
+      "cf-worker": "proxy.workers.dev",
+      "cf-connecting-ip": "203.0.113.7",
+    });
+    assert.match(String(id), /^ip:[0-9a-f]{16}$/);
+  });
+
+  test("two Workers are two callers", async () => {
+    assert.notEqual(
+      await idFor({ "cf-worker": "a.workers.dev" }),
+      await idFor({ "cf-worker": "b.workers.dev" }),
+    );
+  });
+
+  test("neither an address nor a Worker still falls back", async () => {
+    assert.equal(await idFor({}), undefined);
+  });
+
+  test("a Worker is never a person", async () => {
+    // It is software. High volume, tiny cardinality — exactly the shape that
+    // must not mint profiles.
+    const { assignUsagePersonProcessing } =
+      await import("../src/usage-telemetry.ts");
+    const properties: Record<string, unknown> = {};
+    assignUsagePersonProcessing(properties, "worker:zeronode.workers.dev");
+    assert.equal(properties.$process_person_profile, false);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1668,9 +1668,13 @@ async function resolveUsageDistinctId(
   // Worker (`zeronode.workers.dev`) was 82% of `block-detail`, which was in
   // turn the largest route in the project -- a caller that dominated the
   // traffic and could not be counted.
-  const callingWorker = request.headers.get("cf-worker");
+  // Guarded on the SANITISED value, not the raw header: the id is what has to
+  // be non-empty, and checking the input instead would let a header that
+  // sanitises away become the bare namespace -- `worker:`, a caller whose name
+  // is the empty string, which reads as an identity and is not one.
+  const callingWorker = sanitizeUsageLabel(request.headers.get("cf-worker"));
   if (callingWorker) {
-    return `${USAGE_WORKER_NAMESPACE}${sanitizeUsageLabel(callingWorker)}`;
+    return `${USAGE_WORKER_NAMESPACE}${callingWorker}`;
   }
   return undefined;
 }

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -151,7 +151,9 @@ import {
   parseUserAgentClient,
   statusClassOf,
   anonymousUsageDistinctId,
+  sanitizeUsageLabel,
   USAGE_ACCOUNT_NAMESPACE,
+  USAGE_WORKER_NAMESPACE,
   type UsageEvent,
 } from "../src/usage-telemetry.ts";
 import {
@@ -1647,8 +1649,30 @@ async function resolveUsageDistinctId(
   // a count built on that reads as "one caller" exactly the way the shared
   // fallback already did -- except now it looks specific. So an unresolved
   // address falls back to the shared id, which at least says so.
-  if (ip === ANONYMOUS_CLIENT_KEY) return undefined;
-  return anonymousUsageDistinctId(salt, ip);
+  if (ip !== ANONYMOUS_CLIENT_KEY) {
+    return anonymousUsageDistinctId(salt, ip);
+  }
+  // #10606: a Worker-to-Worker subrequest has no client address and IS a
+  // caller. `cf-worker` is set by Cloudflare, not by the sender, so it is
+  // trustworthy and low-cardinality -- one value per calling Worker -- and
+  // `resolveUsageClient` above already trusts it for the `client` dimension
+  // for exactly that reason.
+  //
+  // RANKED BELOW THE ADDRESS, matching `resolveUsageClient`'s own precedence:
+  // a Worker proxying a browser forwards the end user's `cf-connecting-ip`,
+  // and the person behind the proxy is the more interesting caller than the
+  // proxy. Only when there is no address at all does the calling Worker
+  // become the best available answer.
+  //
+  // Worth having rather than collapsing to the shared id: #9004 found ONE
+  // Worker (`zeronode.workers.dev`) was 82% of `block-detail`, which was in
+  // turn the largest route in the project -- a caller that dominated the
+  // traffic and could not be counted.
+  const callingWorker = request.headers.get("cf-worker");
+  if (callingWorker) {
+    return `${USAGE_WORKER_NAMESPACE}${sanitizeUsageLabel(callingWorker)}`;
+  }
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
`USAGE_DISTINCT_ID_SALT` is now set in production, and the identifiers work — measured six minutes after rollout:

| namespace | distinct callers | events |
| --- | --- | --- |
| `ip:` | **9** | 53 |
| `mcp-session:` / other | 9 | 35 |
| shared fallback | 1 | 44 |

The shared fallback dropped from 266 events to 44. Those 44 are the gap this PR closes.

## Worker subrequests are callers

They carry no `cf-connecting-ip`, so they correctly decline an `ip:` id and fall through to the one bucket that answers "1 caller" no matter who is behind it. But they *are* callers, and one of them used to be most of the traffic: #9004 found `zeronode.workers.dev` was **82% of `block-detail`**, itself the largest route in the project — a caller that dominated the surface and could not be counted.

`cf-worker` is set by Cloudflare rather than by the sender, so it is trustworthy and low-cardinality (one value per calling Worker). That is the same reason `resolveUsageClient` already trusts it for the `client` dimension.

## Ranked below the address

Matching `resolveUsageClient`'s own precedence: a Worker proxying a browser forwards the end user's `cf-connecting-ip`, and the person behind the proxy is the more interesting caller than the proxy. The calling Worker is the best available answer only when there is no address at all.

Full precedence, both surfaces: `github:` → `account:` → `ip:` → `worker:` → `mcp-session:` → unattributed.

## Never a person

It is software, and high volume with tiny cardinality is exactly the shape that must not mint profiles. `assignUsagePersonProcessing` already answers `false` for it — asserted here so it stays that way.

461 tests green across the four telemetry suites.

Refs #10606
