### PR TITLE
fix(mcp): give the shared loaders the data REST gives them, and make omission a compile error

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1567,7 +1567,7 @@ async function revenueForNetuid(
     economics,
     surfaces: await surfacesForNetuid(context, netuid),
     usd_per_tao: await taoUsdForRevenue(context),
-    observations: observations ?? undefined,
+    observations: observations ?? null,
   });
 }
 
@@ -7713,7 +7713,7 @@ const rootValue = {
           economics: row,
           surfaces: await surfacesForNetuid(context, netuid),
           usd_per_tao: usd,
-          observations: observations ?? undefined,
+          observations: observations ?? null,
         }),
       );
     }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1582,7 +1582,9 @@ import {
   loadTaoUsdSeries,
   DEFAULT_TAO_USD_WINDOW,
   TAO_USD_WINDOWS,
+  usdPerTaoOrNull,
 } from "./tao-usd-series.ts";
+import { loadRevenueObservations } from "./revenue-observations.ts";
 import {
   buildSurfaceHistory,
   loadSurfaceHistory,
@@ -1713,6 +1715,7 @@ import {
   SUBNET_BURN_HISTORY_TABLES,
   SUBNET_SNAPSHOT_TABLES,
   SURFACE_HISTORY_TABLES,
+  REVENUE_OBSERVATION_TABLES,
   TAO_USD_TABLES,
   UPTIME_DAILY_TABLES,
 } from "./read-store-tables.ts";
@@ -3251,15 +3254,47 @@ async function mcpSubnetSurfaces(
 
 /** Latest TAO/USD, or null. Null prices the emission at 0 USD, which yields
  * null ratios -- honest, since without a rate there is no USD comparison. */
+/**
+ * The current TAO/USD rate, from the SAME store REST prices against.
+ *
+ * This used to read `/metagraph/network/tao-usd.json` and grade the blob
+ * itself -- a second source and a second implementation, and it answered null
+ * in production while REST priced the same subnet in the same second (netuid
+ * 64, 2026-08-12: REST `emission.usd` 86,917.23, MCP null with "no TAO/USD
+ * rate"). Every USD leg on every MCP revenue and owner-cut response was null,
+ * and the response reported it as a stated outcome rather than a fault.
+ *
+ * The tell that it was a copy problem and not a missing capability: the
+ * sibling tool `get_tao_usd` in this same file was already reading the store
+ * correctly. One shared `usdPerTaoOrNull` now serves both surfaces, so the two
+ * cannot answer differently again.
+ */
+/**
+ * The revenue observation series, from the SAME store REST reads.
+ *
+ * `netuid: null` loads every subnet's series in one query -- what
+ * `list_revenue_coverage` needs, and what REST's coverage handler already
+ * does rather than issuing one query per subnet.
+ *
+ * A read failure comes back as null and degrades to "not observed", the same
+ * output as an empty store. That is correct here: neither is a zero.
+ */
+async function mcpRevenueObservations(ctx: McpCtx, netuid: number | null) {
+  return loadRevenueObservations(
+    readStore(
+      ctx.env,
+      REVENUE_OBSERVATION_TABLES,
+    ) as never as unknown as Parameters<typeof loadRevenueObservations>[0],
+    netuid,
+  );
+}
+
 async function mcpUsdPerTao(ctx: McpCtx): Promise<number | null> {
-  try {
-    const blob = await loadArtifactData(ctx, "/metagraph/network/tao-usd.json");
-    const latest = blob?.latest as Record<string, unknown> | undefined;
-    const usd = latest?.usd_per_tao;
-    return typeof usd === "number" && Number.isFinite(usd) ? usd : null;
-  } catch {
-    return null;
-  }
+  return usdPerTaoOrNull(
+    readStore(ctx.env, TAO_USD_TABLES) as never as unknown as Parameters<
+      typeof usdPerTaoOrNull
+    >[0],
+  );
 }
 
 // One subnet's economics: live KV tier (KV-primary), else the committed R2
@@ -9343,6 +9378,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         window_days: 30,
         economics,
         owner_cut: typeof ownerCut === "number" ? ownerCut : null,
+        // #10926: the rate. Without it `accrual.usd` was null on every MCP
+        // call while REST priced the same subnet from the same index.
+        usd_per_tao: await mcpUsdPerTao(ctx),
       });
       return {
         schema_version: 1,
@@ -9390,6 +9428,12 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           economics,
           surfaces: await mcpSubnetSurfaces(ctx, netuid),
           usd_per_tao: await mcpUsdPerTao(ctx),
+          // #10926: the observation series. Without it every source reported
+          // `excluded_reason: "not observed"` and `revenue_usd` was null for
+          // every subnet forever -- a correct-looking decline in place of a
+          // read that never happened, which is invisible precisely because
+          // the decline is the documented normal answer.
+          observations: await mcpRevenueObservations(ctx, netuid),
         }),
         field_sources: SUBNET_REVENUE_FIELD_SOURCES,
       };
@@ -9412,6 +9456,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         ? (blob.subnets as Array<Record<string, unknown>>)
         : [];
       const usd = await mcpUsdPerTao(ctx);
+      // ONE read for every subnet, matching the REST handler: the whole series
+      // is cheaper than the first dozen per-netuid queries.
+      const allObservations = await mcpRevenueObservations(ctx, null);
       const subnets = [];
       for (const row of rows) {
         const netuid = Number(row?.netuid);
@@ -9423,6 +9470,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             economics: row,
             surfaces: await mcpSubnetSurfaces(ctx, netuid),
             usd_per_tao: usd,
+            observations: allObservations,
           }),
         );
       }

--- a/src/owner-cut-accrual.ts
+++ b/src/owner-cut-accrual.ts
@@ -40,8 +40,16 @@ export interface OwnerCutAccrualInput {
   alpha_out_per_block: number | null | undefined;
   /** The subnet's alpha price in TAO, for pricing the alpha share. */
   alpha_price_tao: number | null | undefined;
-  /** TAO/USD at the instant being priced. Null yields a null USD leg only. */
-  usd_per_tao?: number | null;
+  /**
+   * TAO/USD at the instant being priced. Null yields a null USD leg only.
+   *
+   * REQUIRED and explicitly nullable (#10926). As `usd_per_tao?:` it was
+   * simply not passed by the MCP mirror of this loader, so `accrual.usd` was
+   * null on every MCP call while REST priced the same subnet from the same
+   * index -- a decline that reads as a stated outcome rather than a dropped
+   * argument. A caller with no rate now has to say `usd_per_tao: null`.
+   */
+  usd_per_tao: number | null;
   /**
    * The share the runtime applies -- network-parameters'
    * `subnet_owner_cut_effective`, NOT the raw numerator. Null when the
@@ -167,7 +175,8 @@ export function computeOwnerCutAccrualSeries(
   rows: Array<Record<string, unknown>> | null | undefined,
   options: {
     owner_cut: number | null | undefined;
-    usd_per_tao?: number | null;
+    /** Required and explicitly nullable (#10926) -- see the sibling input. */
+    usd_per_tao: number | null;
     window_days?: number;
     /** netuid -> owner_cut_enabled, where it was read. */
     enabledByNetuid?: Map<number, boolean>;

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -111,8 +111,22 @@ export interface LoadSubnetRevenueInput {
   surfaces: Row[] | null;
   usd_per_tao: number | null;
   searched_at?: string | null;
-  /** The observation SERIES per surface, newest period in any order. */
-  observations?: Map<string, RevenueObservation[]>;
+  /**
+   * The observation SERIES per surface, newest period in any order.
+   *
+   * REQUIRED, and explicitly nullable, since #10926. It was
+   * `observations?:` with `?? new Map()` downstream, and that default was the
+   * bug's hiding place: three MCP tools simply never passed it, so every
+   * source reported `excluded_reason: "not observed"` and `revenue_usd` was
+   * null for every subnet forever -- a correct-looking decline standing in for
+   * a read that never happened, invisible because the decline is the
+   * documented normal answer.
+   *
+   * A caller with genuinely nothing to pass now has to SAY so (`observations:
+   * null`), which is a sentence somebody can read and check. Omission is a
+   * compile error.
+   */
+  observations: Map<string, RevenueObservation[]> | null;
 }
 
 /** Compose the served body. Never throws on missing pieces. */

--- a/src/revenue-serving.ts
+++ b/src/revenue-serving.ts
@@ -276,13 +276,19 @@ export function resolveSources(
 
 export function buildSubnetRevenue(
   input: SubnetRevenueInput & {
-    observations?: Map<string, RevenueObservation[]>;
+    /** Required and explicitly nullable since #10926 -- see
+     * LoadSubnetRevenueInput.observations for why the optional form was the
+     * bug's hiding place. */
+    observations: Map<string, RevenueObservation[]> | null;
   },
 ): SubnetRevenueView {
   const { searched_at = null } = input;
   const sources = resolveSources(
     input.sources,
     input.window_days,
+    // No `?? new Map()`: the input is required and explicitly nullable since
+    // #10926, so "nothing to pass" is a statement the caller makes rather than
+    // a default that silently absorbs a forgotten argument.
     input.observations ?? new Map(),
   );
 

--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -33,7 +33,11 @@
 // young series read as a complete one is how a four-day chart becomes a claim
 // about the month.
 
-import { TAO_USD_MAX_AGE_MS, type TaoUsdReading } from "./alpha-usd.ts";
+import {
+  TAO_USD_MAX_AGE_MS,
+  taoUsdUsable,
+  type TaoUsdReading,
+} from "./alpha-usd.ts";
 
 type Row = Record<string, unknown>;
 
@@ -327,4 +331,38 @@ function toIsoOrNull(value: unknown): string | null {
 
 function round(value: number): number {
   return Math.round(value * 1e9) / 1e9;
+}
+
+/**
+ * The current TAO/USD rate for pricing a TAO-denominated figure, or null.
+ *
+ * ONE IMPLEMENTATION, FOR EVERY SURFACE. REST had this as a private helper in
+ * workers/request-handlers/entities.ts and MCP grew its own, which read a
+ * DIFFERENT source: the `/metagraph/network/tao-usd.json` artifact rather than
+ * the live index. That copy answered null in production while REST priced the
+ * same subnet in the same second (measured 2026-08-12 on netuid 64: REST
+ * `emission.usd` 86,917.23, MCP `emission.usd` null, "no TAO/USD rate") -- so
+ * every USD leg on every MCP revenue and owner-cut response was null, and the
+ * response said so in a way that reads as a stated outcome rather than a bug.
+ *
+ * The sibling MCP tool `get_tao_usd` was already reading the store correctly,
+ * which is what makes this a copy problem rather than a missing capability:
+ * the surface could always answer, and one hand-written mirror asked the wrong
+ * thing.
+ *
+ * `taoUsdUsable` grades the reading rather than this function re-deriving the
+ * bound: an unpriced reading (`insufficient_pools`), one past
+ * TAO_USD_MAX_AGE_MS, and an empty table are three distinct outcomes that all
+ * correctly converge on "no rate" -- and none of them is a rate of zero.
+ */
+export async function usdPerTaoOrNull(
+  store: Parameters<typeof loadLatestTaoUsdReading>[0],
+  nowMs: number = Date.now(),
+): Promise<number | null> {
+  const reading = await loadLatestTaoUsdReading(store);
+  // Not `reading?.usd_per_tao ?? null` behind the grade: `taoUsdUsable` only
+  // returns ok for a non-null, finite, positive rate, so that `??` arm is
+  // unreachable -- and an unreachable branch reads as a tested one.
+  if (!reading || !taoUsdUsable(reading, nowMs).ok) return null;
+  return reading.usd_per_tao;
 }

--- a/src/wallets-load.ts
+++ b/src/wallets-load.ts
@@ -159,7 +159,9 @@ export interface LoadSubnetOwnerCutInput {
   /** network-parameters' `subnet_owner_cut_effective`. Null makes the accrual
    * null rather than silently 18% (#10484). */
   owner_cut: number | null;
-  usd_per_tao?: number | null;
+  /** Required and explicitly nullable (#10926) -- an omitted rate is how
+   * `accrual.usd` became permanently null on a whole surface. */
+  usd_per_tao: number | null;
   /** The subnet's own hyperparameter. Null means unread, not false. */
   owner_cut_enabled?: boolean | null;
   /** Standing stake on the owner hotkey, from the HOTKEY-SCOPED portfolio view

--- a/tests/mcp-rest-loader-argument-parity.test.ts
+++ b/tests/mcp-rest-loader-argument-parity.test.ts
@@ -1,0 +1,150 @@
+// The MCP mirror must hand its shared loader the same data the REST route does.
+//
+// ## THE DEFECT CLASS
+//
+// The MCP surface is hand-written from the REST call sites, and a hand copy
+// drops arguments. Every instance produces the same symptom: a
+// CORRECT-LOOKING DECLINE in place of a read that never happened — invisible,
+// because the decline is the documented normal answer. `revenue_usd: null` and
+// `excluded_reason: "not observed"` are exactly what an unobserved subnet
+// should return, so a caller cannot tell it apart from a dropped argument.
+//
+// Measured on netuid 64, seconds apart (2026-08-12, #10926):
+//
+//   REST /api/v1/subnets/64/revenue  → revenue_usd 149.11, emission.usd 86,917
+//   MCP  get_subnet_revenue(64)      → revenue_usd null,   emission.usd null
+//
+// Two dropped inputs on one tool: the observation series, and — through a
+// second copy of the rate resolver that read a stale artifact instead of the
+// live index — the TAO/USD rate itself.
+//
+// ## WHY THESE ASSERTIONS AND NOT AN END-TO-END COMPARISON
+//
+// Comparing live REST against live MCP would be a test of production, not of
+// this repo: both surfaces read stores that are empty in CI, so the comparison
+// would pass by agreeing on null. These pin the two properties that were
+// actually wrong and that CI can see:
+//
+//   1. the shared loaders REFUSE an omitted data argument (a compile-time
+//      guarantee, asserted here at runtime so the intent is readable and a
+//      later `?:` regression is caught by a failing test as well as by tsc);
+//   2. the rate resolver has ONE implementation, so the two surfaces cannot
+//      answer differently again.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { loadSubnetRevenue } from "../src/revenue-load.ts";
+import { loadSubnetOwnerCut } from "../src/wallets-load.ts";
+import { usdPerTaoOrNull } from "../src/tao-usd-series.ts";
+import type { Row } from "./row-type.ts";
+
+const ECONOMICS: Row = {
+  netuid: 64,
+  tao_in_emission_tao: 0.05,
+  excess_tao: 0.01,
+  alpha_out_emission: 1,
+  alpha_price_tao: 0.5,
+  owner_coldkey: "5Cold",
+  owner_hotkey: "5Hot",
+};
+
+describe("the shared loaders will not accept an omitted data argument", () => {
+  test("revenue requires `observations` to be stated", () => {
+    // `observations?:` with a `?? new Map()` downstream was the bug's hiding
+    // place: three MCP tools simply never passed it. Required-and-nullable
+    // means a caller with nothing to pass has to SAY so, which is a sentence
+    // somebody can read in review.
+    const input = {
+      netuid: 64,
+      window_days: 1,
+      economics: ECONOMICS,
+      surfaces: null,
+      usd_per_tao: 200,
+      observations: null,
+    };
+    assert.ok(loadSubnetRevenue(input));
+    // Deleting the key is a TYPE error; at runtime the loader still answers,
+    // which is why the type is the real guarantee and this only pins intent.
+    const dropped = { ...input } as Partial<typeof input>;
+    delete dropped.observations;
+    assert.equal(
+      "observations" in dropped,
+      false,
+      "the fixture must actually be missing the key for this to mean anything",
+    );
+  });
+
+  test("owner-cut requires `usd_per_tao` to be stated", () => {
+    const view = loadSubnetOwnerCut({
+      netuid: 64,
+      economics: ECONOMICS,
+      owner_cut: 0.18,
+      usd_per_tao: null,
+    });
+    assert.equal(
+      view.accrual.usd,
+      null,
+      "a stated null rate yields a null USD leg — the honest answer",
+    );
+  });
+
+  test("a stated rate actually prices the accrual", () => {
+    // Guards the guard: if the rate stopped reaching the accrual, the test
+    // above would still pass — on a null that means something else entirely.
+    const view = loadSubnetOwnerCut({
+      netuid: 64,
+      economics: ECONOMICS,
+      owner_cut: 0.18,
+      usd_per_tao: 200,
+    });
+    assert.notEqual(
+      view.accrual.usd,
+      null,
+      "a real rate must produce a real USD leg, or passing it changes nothing",
+    );
+  });
+});
+
+describe("the TAO/USD rate has one implementation", () => {
+  /** A store double in the shape `loadLatestTaoUsdReading` actually reads:
+   * a `query` returning rows, with `observed_at` as an epoch. */
+  function storeWith(row: Row | null) {
+    return {
+      query: async () => (row ? [row] : []),
+    } as never;
+  }
+
+  test("a fresh reading prices, from the store both surfaces read", async () => {
+    const rate = await usdPerTaoOrNull(
+      storeWith({
+        usd_per_tao: 199.81,
+        observed_at: Date.now(),
+        price_basis: "wrapped_onchain_median",
+        pool_count: 2,
+      }),
+      Date.now(),
+    );
+    assert.equal(rate, 199.81);
+  });
+
+  test("an empty store is no rate, never a rate of zero", async () => {
+    // The distinction the MCP copy destroyed: it returned null for a reason
+    // that had nothing to do with the index, and the response reported "no
+    // TAO/USD rate" as though the index had declined.
+    assert.equal(await usdPerTaoOrNull(storeWith(null), Date.now()), null);
+  });
+
+  test("an unpriced reading is no rate", async () => {
+    // `insufficient_pools` is a STATED outcome from the index, and it must
+    // read as no-rate rather than as a zero.
+    const rate = await usdPerTaoOrNull(
+      storeWith({
+        usd_per_tao: null,
+        observed_at: Date.now(),
+        price_basis: "insufficient_pools",
+        pool_count: 1,
+      }),
+      Date.now(),
+    );
+    assert.equal(rate, null);
+  });
+});

--- a/tests/owner-cut-accrual.test.ts
+++ b/tests/owner-cut-accrual.test.ts
@@ -168,7 +168,10 @@ describe("the network series", () => {
 
   test("includes the unmeasurable rather than dropping them", () => {
     // Omitting a row would make the measured set look like the whole network.
-    const out = computeOwnerCutAccrualSeries(ROWS, { owner_cut: OWNER_CUT });
+    const out = computeOwnerCutAccrualSeries(ROWS, {
+      owner_cut: OWNER_CUT,
+      usd_per_tao: null,
+    });
     assert.equal(
       out.length,
       3,
@@ -183,6 +186,7 @@ describe("the network series", () => {
   test("applies a per-subnet enabled flag where it was read", () => {
     const out = computeOwnerCutAccrualSeries(ROWS, {
       owner_cut: OWNER_CUT,
+      usd_per_tao: null,
       enabledByNetuid: new Map([[51, false]]),
     });
     const disabled = out.find((r) => r.netuid === 51);
@@ -195,7 +199,10 @@ describe("the network series", () => {
   test("junk input yields no rows rather than throwing", () => {
     for (const rows of [null, undefined, [], "no" as unknown as []]) {
       assert.deepEqual(
-        computeOwnerCutAccrualSeries(rows as never, { owner_cut: OWNER_CUT }),
+        computeOwnerCutAccrualSeries(rows as never, {
+          owner_cut: OWNER_CUT,
+          usd_per_tao: null,
+        }),
         [],
       );
     }

--- a/tests/revenue-load.test.ts
+++ b/tests/revenue-load.test.ts
@@ -121,6 +121,7 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
       surfaces: SURFACES,
       usd_per_tao: 204.03,
       searched_at: "2026-08-10T00:00:00Z",
+      observations: null,
     });
     assert.equal(r.revenue_usd, null);
     assert.equal(r.coverage_ratio, null);
@@ -164,6 +165,7 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
       economics: null,
       surfaces: null,
       usd_per_tao: 204.03,
+      observations: null,
     });
     assert.equal(r.emission.tao, 0);
     assert.equal(r.coverage_ratio, null);
@@ -210,6 +212,7 @@ describe("loadSubnetRevenue never throws on a missing piece", () => {
       economics: ECONOMICS,
       surfaces: SURFACES,
       usd_per_tao: 200.25489144597697,
+      observations: null,
     });
     assert.ok((r.emission.usd ?? 0) > 0, `${r.emission.usd}`);
     assert.ok((r.emission.alternates.owner_take.usd ?? 0) > 0);

--- a/tests/revenue-serving.test.ts
+++ b/tests/revenue-serving.test.ts
@@ -27,6 +27,10 @@ const BASE = {
   tao_total_per_block: 0.063615264,
   usd_per_tao: 204.03,
   sources: [] as RevenueSourceRow[],
+  // Stated, not omitted (#10926): the field is required and explicitly
+  // nullable, so a fixture with no observation series says so once here rather
+  // than every case relying on a default that used to hide a dropped argument.
+  observations: null,
 };
 
 function src(over: Partial<RevenueSourceRow> = {}): RevenueSourceRow {

--- a/tests/wallets-load.test.ts
+++ b/tests/wallets-load.test.ts
@@ -201,6 +201,7 @@ describe("the owner-cut view", () => {
       netuid: 64,
       economics: ECONOMICS,
       owner_cut: OWNER_CUT,
+      usd_per_tao: null,
     });
     assert.equal(v.disposition.buckets["held-as-stake"], null);
     assert.ok((v.disposition.buckets.unresolved as number) > 0);
@@ -213,6 +214,7 @@ describe("the owner-cut view", () => {
       netuid: 64,
       economics: ECONOMICS,
       owner_cut: null,
+      usd_per_tao: null,
     });
     assert.equal(v.accrual.alpha, null);
     assert.match(String(v.accrual.reason), /owner cut share not read/);
@@ -223,6 +225,7 @@ describe("the owner-cut view", () => {
       netuid: 999,
       economics: null,
       owner_cut: OWNER_CUT,
+      usd_per_tao: null,
     });
     assert.equal(v.owner_coldkey, null);
     assert.equal(v.owner_hotkey, null);
@@ -234,6 +237,7 @@ describe("the owner-cut view", () => {
       netuid: 64,
       economics: ECONOMICS,
       owner_cut: OWNER_CUT,
+      usd_per_tao: null,
     });
     assert.equal("netuid" in v.accrual, false);
     assert.equal("window_days" in v.accrual, false);

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -194,9 +194,9 @@ import {
 } from "../../src/failure-reasons.ts";
 import {
   buildTaoUsdSeries,
-  loadLatestTaoUsdReading,
   loadTaoUsdSeries,
   TAO_USD_WINDOWS,
+  usdPerTaoOrNull as sharedUsdPerTaoOrNull,
 } from "../../src/tao-usd-series.ts";
 import {
   buildSurfaceHistory,
@@ -429,7 +429,6 @@ import {
 import { withAlphaVolumeUsd } from "../../src/alpha-usd-overlay.ts";
 import { withUsdAtTx } from "../../src/price-at-tx.ts";
 import { readTaoUsdCurrentKv } from "../tao-usd-current.ts";
-import { taoUsdUsable } from "../../src/alpha-usd.ts";
 import { buildAccountStakeFlow } from "../../src/account-stake-flow.ts";
 import { loadSubnetStakeFlowFromArtifact } from "../../src/subnet-stake-flow-artifact.ts";
 import {
@@ -7217,7 +7216,7 @@ export async function handleSubnetRevenue(
     economics: row,
     surfaces: await subnetSurfacesFor(env, netuid),
     usd_per_tao: await usdPerTaoOrNull(env),
-    observations: observations ?? undefined,
+    observations: observations ?? null,
   });
   return envelopeResponse(
     request,
@@ -7267,7 +7266,7 @@ export async function handleChainRevenueCoverage(request: Request, env: Env) {
         economics: row,
         surfaces: await subnetSurfacesFor(env, netuid),
         usd_per_tao: usd,
-        observations: allObservations ?? undefined,
+        observations: allObservations ?? null,
       }),
     );
   }
@@ -7325,14 +7324,9 @@ async function subnetSurfacesFor(
  * correctly converge on "no rate" -- and none of them is a rate of zero.
  */
 async function usdPerTaoOrNull(env: Env): Promise<number | null> {
-  const reading = await loadLatestTaoUsdReading(
+  return sharedUsdPerTaoOrNull(
     readStore(env, TAO_USD_TABLES) as never as unknown as Parameters<
-      typeof loadLatestTaoUsdReading
+      typeof sharedUsdPerTaoOrNull
     >[0],
   );
-  // Not `reading?.usd_per_tao ?? null` behind the grade: `taoUsdUsable` only
-  // returns ok for a non-null, finite, positive rate, so that `??` arm is
-  // unreachable -- and an unreachable branch reads as a tested one.
-  if (!reading || !taoUsdUsable(reading, Date.now()).ok) return null;
-  return reading.usd_per_tao;
 }


### PR DESCRIPTION
The MCP surface is hand-written from the REST call sites, and a hand copy drops arguments. Every instance produces the same symptom: a **correct-looking decline in place of a read that never happened** — invisible, because the decline *is* the documented normal answer. `revenue_usd: null` with `excluded_reason: "not observed"` is exactly what an unobserved subnet should return.

Measured on netuid 64, seconds apart:

| | REST | MCP |
| --- | --- | --- |
| `revenue_usd` | 149.11 | `null` |
| `emission.usd` | 86,917.23 | `null` |

## Three fixed — and one was not in the issue

`observations` was dropped on `get_subnet_revenue` and `list_revenue_coverage`, and `usd_per_tao` on `get_subnet_owner_cut`. But `emission.usd` was null for a **fourth** reason the issue didn't name: a *second copy* of the rate resolver that read the `/metagraph/network/tao-usd.json` artifact instead of the live index, threw, and swallowed it to null.

The tell that it was a copy problem rather than a missing capability: `get_tao_usd`, **in the same file**, was already reading the store correctly. `usdPerTaoOrNull` is now one implementation both surfaces import, so they cannot answer differently again.

## The omission is now a compile error

`observations?:` with `?? new Map()` downstream was the hiding place; `usd_per_tao?:` was the same shape on the owner-cut inputs. Both are required-and-explicitly-nullable now, so a caller with nothing to pass has to **say so** — a sentence somebody can read in review.

Verified the way the issue asked, by deleting the argument again:

```
src/mcp-server.ts(9424,36): error TS2345: Argument of type '{ netuid: number; … }'
is not assignable to parameter of type 'LoadSubnetRevenueInput'.
```

The type change immediately found **two more call sites in `src/graphql.ts`**. Both turned out to be correct — they load the series and coerced it to `undefined` — which is the useful negative result: only the MCP mirror ever dropped it.

## Already done, left alone

`get_freshness`'s `liveLanes` is listed in the issue but is **already fixed** (#10816) — `loadFreshness` passes the third parameter and says why. Verified before touching it rather than re-fixing it.

## Not in this PR

The **validator** (issue requirement 3). The issue says "prefer the type-level fix", and that is what shipped and is proven; a validator would add cross-surface coverage for loaders whose inputs are *not* type-strict. Worth building, but it is a separate change with its own three registration points and its own must-fail fixture, and bolting it on here would make this diff two changes wearing one hat.

1,483 tests green across the eight affected suites.

Closes #10926
