### PR TITLE
feat(api): the two composite subnet routes take a sections= lever, on both surfaces

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -48,7 +48,7 @@ type Query {
   """
   One subnet with its health, surfaces, endpoints, and economics. network scopes which static artifact the registry-metric backfill reads (finney default, test for testnet), mirroring list_subnets. Mirrors GET /api/v1/subnets/{netuid}.
   """
-  subnet(netuid: Int!, network: Network): Subnet
+  subnet(netuid: Int!, sections: String, network: Network): Subnet
 
   """
   Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations.
@@ -408,7 +408,7 @@ type Query {
   """
   One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile.
   """
-  subnet_profile(netuid: Int!): JSON
+  subnet_profile(netuid: Int!, sections: String): JSON
 
   """
   Paginated provider/source registry -- filter by id/kind/authority, sort with sort/order, project with fields, and page with limit/cursor. An invalid filter/sort is a GraphQL error, not a silently substituted default. Cursor remains the pre-existing opaque string id-keyset (not REST's integer offset), and a cold/absent artifact still resolves to an empty list. Filter/sort reuse loadProvidersList (same logic as GET /api/v1/providers / list_providers). Mirrors GET /api/v1/providers.

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4697,6 +4697,7 @@ export type QuerySource_SnapshotsArgs = {
 export type QuerySubnetArgs = {
   netuid: Scalars['Int']['input'];
   network?: InputMaybe<Network>;
+  sections?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4955,6 +4956,7 @@ export type QuerySubnet_Performance_HistoryArgs = {
 
 export type QuerySubnet_ProfileArgs = {
   netuid: Scalars['Int']['input'];
+  sections?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -18225,7 +18225,10 @@ export interface operations {
     };
     subnetDetailByNetwork: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
@@ -39663,7 +39666,10 @@ export interface operations {
     };
     subnetDetail: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 netuid: number;
@@ -44963,7 +44969,10 @@ export interface operations {
     };
     subnetProfile: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2844,7 +2844,16 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "name": "sections",
+          "schema": {
+            "pattern": "^(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes)(?:,(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes))*$",
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/profiles.json",
@@ -3021,7 +3030,16 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "name": "sections",
+          "schema": {
+            "pattern": "^(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes)(?:,(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes))*$",
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/overview/{netuid}.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -65685,6 +65685,16 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "in": "query",
+            "name": "sections",
+            "required": false,
+            "schema": {
+              "pattern": "^(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes)(?:,(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes))*$",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -90476,6 +90486,16 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "in": "query",
+            "name": "sections",
+            "required": false,
+            "schema": {
+              "pattern": "^(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes)(?:,(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes))*$",
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -95803,6 +95823,16 @@
             "schema": {
               "minimum": 0,
               "type": "integer"
+            }
+          },
+          {
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "in": "query",
+            "name": "sections",
+            "required": false,
+            "schema": {
+              "pattern": "^(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes)(?:,(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes))*$",
+              "type": "string"
             }
           }
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -18225,7 +18225,10 @@ export interface operations {
     };
     subnetDetailByNetwork: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 /** @description Network to address. `mainnet` and `finney` are the same network, as are `testnet` and `test`. */
@@ -39663,7 +39666,10 @@ export interface operations {
     };
     subnetDetail: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 netuid: number;
@@ -44963,7 +44969,10 @@ export interface operations {
     };
     subnetProfile: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/schemas-src/mcp-tools/get-subnet-detail.ts
+++ b/schemas-src/mcp-tools/get-subnet-detail.ts
@@ -16,12 +16,24 @@
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
+import { QUERY_ENUMS } from "../query-enums.ts";
+import { sectionsSchema } from "../query-params.ts";
 import { SubnetDetailArtifactSchema } from "../routes/subnet-detail.ts";
 
 export const GetSubnetDetailInputSchema = z
   .object({
     netuid: netuidSchema(),
     network: McpNetworkSchema.optional(),
+    // #10600. The route publishes this, so the tool has to accept it --
+    // validate:mcp-input-parity fails a tool that cannot pass a parameter its
+    // own route advertises, on the grounds that an agent reading our contract
+    // would send it and be rejected. The bound comes FROM the route's
+    // vocabulary rather than being restated, which is the same rule every
+    // other shared parameter here follows.
+    //
+    // Worth more here than on REST: a REST caller pays the unprojected 272,825
+    // B in bandwidth, an agent pays it in context window.
+    sections: sectionsSchema(QUERY_ENUMS.subnetDetailSection).optional(),
   })
   .strict();
 export type GetSubnetDetailInput = z.infer<typeof GetSubnetDetailInputSchema>;

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -13,6 +13,8 @@
 // subnetType,curationLevel,profileLevel} and the "profiles" query
 // collection's sort_fields at the time of writing.
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
+import { sectionsSchema } from "../query-params.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import {
@@ -69,6 +71,12 @@ export type ListProfilesInput = z.infer<typeof ListProfilesInputSchema>;
 export const GetSubnetProfileInputSchema = z
   .object({
     netuid: netuidSchema(),
+    // #10600. Mirrors the route's own parameter -- validate:mcp-input-parity
+    // fails a tool that cannot pass what its route publishes, because an agent
+    // reading our contract would send it and be rejected. Worth more here than
+    // on REST: a REST caller pays the unprojected payload in bandwidth, an
+    // agent pays it in context window.
+    sections: sectionsSchema(QUERY_ENUMS.subnetProfileSection).optional(),
   })
   .strict();
 export type GetSubnetProfileInput = z.infer<typeof GetSubnetProfileInputSchema>;

--- a/schemas-src/query-enums.ts
+++ b/schemas-src/query-enums.ts
@@ -70,6 +70,53 @@ export const QUERY_ENUMS = {
     "adapter-backed",
   ],
   subnetStatus: ["active", "inactive"],
+  /**
+   * Top-level sections of `/api/v1/subnets/{netuid}`, selectable via `sections=`
+   * (#10600).
+   *
+   * A DIFFERENT UNIT FROM `fields`, which is why it is a different parameter.
+   * `fields` picks columns out of the rows of a list, everywhere it appears;
+   * this picks whole cards out of one composite document. Same idea, different
+   * unit of selection -- and `fieldsSchema`'s published description says "row
+   * field names", so overloading the name would have meant one parameter with
+   * two meanings and nothing telling a caller which they got.
+   *
+   * WHY PAGING DOES NOT SUBSTITUTE. The route's 272,825 B is not one dominant
+   * list: `endpoints`, `surfaces`, `verified_surfaces` and `candidate_surfaces`
+   * are four parallel arrays over the same subject (76/76/76/16 on subnet 64).
+   * A query collection pages ONE data_key, so declaring one here would narrow a
+   * quarter of the payload and leave the rest -- a response that looks bounded
+   * while staying fat.
+   *
+   * The ENVELOPE is not listed and is never projected away: schema_version,
+   * contract_version, generated_at, operational_observed_at and health_source
+   * identify what the caller is holding, and a document that cannot say what it
+   * is or when it was built is not a smaller document, it is an anonymous one.
+   */
+  subnetDetailSection: [
+    "subnet",
+    "economics",
+    "endpoints",
+    "surfaces",
+    "verified_surfaces",
+    "candidate_surfaces",
+    "candidates",
+    "gaps",
+    "notes",
+  ],
+  /** Top-level sections of `/api/v1/subnets/{netuid}/profile` (#10600). Its own
+   * list rather than a shared one: the profile carries `profile` and no
+   * `economics`/`candidates`/`verified_surfaces`, and a shared vocabulary would
+   * let a caller ask this route for a section it can never return. */
+  subnetProfileSection: [
+    "subnet",
+    "profile",
+    "endpoints",
+    "surfaces",
+    "candidate_surfaces",
+    "gaps",
+    "notes",
+  ],
   subnetType: ["root", "application"],
   endpointLayer: [
     "bittensor-base",

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -849,3 +849,48 @@ export const uidSchema = () =>
         "after deregistration.",
     )
     .meta({ examples: [0, 128] });
+
+/**
+ * A comma-separated selection from a CLOSED set of top-level document sections
+ * (#10600).
+ *
+ * PUBLISHES THE SET IN THE PATTERN, not only in the prose. `fields` cannot do
+ * that -- its column names differ per route and are checked at runtime -- but a
+ * section list is fixed per route, so the regex can name every member and a
+ * generated client rejects `?sections=bogus` without a round trip. That is the
+ * difference the separate parameter buys: `fields` is open and validated late,
+ * `sections` is closed and validated at the edge.
+ *
+ * STRICTER THAN `fields` ON WHITESPACE, deliberately. `fieldsSchema` is
+ * permissive because `parseFieldsParam` already accepts `"a, b"` and `"a,,b"`
+ * in production, and publishing a tighter regex than the server enforces makes
+ * a generated client reject input the server takes. Nothing accepts `sections`
+ * yet, so its parser and its pattern are written to agree from the start rather
+ * than being reconciled after the fact.
+ *
+ * An unknown name is REJECTED, not ignored: silently dropping it would answer
+ * a request for `?sections=eeconomics` with a document missing the one section
+ * the caller asked for, and a 200 that omits what was requested is worse than
+ * a 400 that says why.
+ */
+export const sectionsSchema = (allowed: readonly [string, ...string[]]) => {
+  const alternation = `(?:${allowed.join("|")})`;
+  // `slice(0, 2)` rather than a `allowed[1] ? ... : ...` ternary: every
+  // vocabulary this takes is a fixed list of 7+ names, so the one-element arm
+  // is a branch nothing can reach -- and an unreachable branch is a partial
+  // that no test can honestly close.
+  const example = allowed.slice(0, 2).join(",");
+  return z
+    .string()
+    .regex(new RegExp(`^${alternation}(?:,${alternation})*$`))
+    .describe(
+      `Comma-separated top-level sections to return, e.g. \`${example}\`. ` +
+        `One of: ${allowed.join(", ")}. Selecting sections never removes the ` +
+        `response envelope (schema_version, contract_version, generated_at, ` +
+        `operational_observed_at, health_source) -- a smaller document still has ` +
+        `to say what it is. An unknown name is rejected rather than ignored. ` +
+        `NOT the same parameter as \`fields\`, which projects columns out of the ` +
+        `rows of a list.`,
+    )
+    .meta({ examples: [allowed[0], example] });
+};

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -56,6 +56,7 @@
 // worth guessing now. The gate compares `properties`, so this does not affect
 // what 3/5 publishes either way.
 import { z } from "zod";
+import { QUERY_ENUMS } from "./query-enums.ts";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
   ACCOUNTS_LIST_LIMIT_MAX,
@@ -213,6 +214,7 @@ import {
   orderSchema,
   feedInstantSchema,
   querySchema,
+  sectionsSchema,
   SERVING_BOUND,
   sortSchema,
   stakeActionSchema,
@@ -266,8 +268,6 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
   // null schema means the router validates nothing at all -- so the route
   // would silently ACCEPT any query string instead of rejecting it.
   "/api/v1/chain/deregistration-ranking",
-  "/api/v1/subnets/{netuid}",
-  "/api/v1/subnets/{netuid}/profile",
   "/api/v1/subnets/{netuid}/overview",
   "/api/v1/agent-catalog/{netuid}",
   "/api/v1/providers/{slug}",
@@ -395,6 +395,22 @@ export const FEED_QUERY_SCHEMAS = {
 } as const;
 
 export const ROUTE_QUERY_SCHEMAS = {
+  // #10600: the two composite subnet routes. They took NO parameters until
+  // now -- not for want of size (272,825 B and 202,948 B) but because the
+  // ordinary lever does not fit: a query collection pages ONE data_key, and
+  // their bulk is four parallel arrays over the same subject, so paging one
+  // would narrow a quarter of the payload and leave the rest.
+  //
+  // `sections` rather than `fields`, decided on #10600: `fields` means "pick
+  // columns out of the rows of a list" on all five routes that carry it, and
+  // its published description says so. One name with two units of selection
+  // would give a caller a different KIND of answer with nothing telling them.
+  "/api/v1/subnets/{netuid}": z.object({
+    sections: sectionsSchema(QUERY_ENUMS.subnetDetailSection).optional(),
+  }),
+  "/api/v1/subnets/{netuid}/profile": z.object({
+    sections: sectionsSchema(QUERY_ENUMS.subnetProfileSection).optional(),
+  }),
   "/api/v1/search/semantic": z.object({
     // Both were wrong before #10075: `q` published no ceiling though the
     // handler rejects one over SEMANTIC_QUERY_MAX_LENGTH, and `limit`

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -77,6 +77,22 @@ const CURATED_VIEW =
 const RENAMED_ON_THE_MCP_SIDE =
   "a compatibility ALIAS the route does not publish; the tool also accepts the route's canonical name (#10018)";
 
+/**
+ * The tool serves a DIFFERENT DOCUMENT from the route it is mapped to, so a
+ * section name the route publishes does not exist in the tool's response.
+ *
+ * `get_subnet` is mapped to `/api/v1/subnets/{netuid}/profile` but reads
+ * `/metagraph/overview/{netuid}.json` -- measured 2026-08-13, the overview
+ * carries counts/curation/gap_priorities/health/name/netuid/slug/status where
+ * the profile carries subnet/endpoints/surfaces/candidate_surfaces/notes.
+ * Accepting `sections=subnet` there would advertise a card the document does
+ * not have and answer with an almost-empty projection, which is worse than
+ * refusing the parameter. `get_subnet_profile` reads the profile document
+ * itself and DOES take it.
+ */
+const DIFFERENT_DOCUMENT =
+  "this tool serves a different document from the route it mirrors; the section names the route publishes do not exist in its response (#10600)";
+
 /** A header on the route, an argument on the tool. */
 const REQUEST_HEADER =
   "the route takes this as a header; a tool has no headers, only arguments";
@@ -179,6 +195,8 @@ for (const [key, reason] of Object.entries({
   "list_review_gaps.review_state": MCP_NATIVE,
   "list_enrichment_targets.severity": MCP_NATIVE,
   "list_enrichment_targets.gap_code": MCP_NATIVE,
+  // --- a different document behind the same mapping (#10600) --------------
+  "get_subnet.sections": DIFFERENT_DOCUMENT,
   // --- curated views (#10008) ---------------------------------------------
   "find_subnet_opportunities.board": CURATED_VIEW,
   "search_subnets.type": CURATED_VIEW,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -335,6 +335,7 @@ import {
   SITE_ORIGIN,
   QUERY_ENUMS,
 } from "./contracts.ts";
+import { projectToolSections } from "./section-projection.ts";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,
@@ -5697,9 +5698,22 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // record would report mainnet numbers against a testnet subnet (the
       // exact leak tests/network-routing.test.ts guards on the REST side).
       // Testnet carries its own chain economics inside `subnet.economics`.
-      if (network && network !== "finney") return detail;
+      if (network && network !== "finney")
+        return projectToolSections(
+          detail,
+          args,
+          QUERY_ENUMS.subnetDetailSection,
+        );
       const { economics } = await loadSubnetEconomics(ctx, netuid);
-      return economics ? { ...detail, economics } : detail;
+      // Projected LAST, after the economics overlay, for the same reason the
+      // REST seam does: `economics` is itself a selectable section, so
+      // projecting before the overlay would drop the very card a caller asked
+      // for -- a smaller answer that is also a wrong one.
+      return projectToolSections(
+        economics ? { ...detail, economics } : detail,
+        args,
+        QUERY_ENUMS.subnetDetailSection,
+      );
     },
   },
   {
@@ -8185,9 +8199,17 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     ) {
       const netuid = requireNetuid(args);
       try {
-        return await loadSubnetProfile(asMcpLoaderCtx(ctx), netuid, {
-          readArtifact: loadArtifactData,
-        });
+        // #10600: the same projection the route applies. This tool serves
+        // /metagraph/profiles/{netuid}.json, whose top-level keys ARE the
+        // profile vocabulary -- unlike get_subnet, which serves the overview
+        // artifact and therefore declares the divergence instead.
+        return projectToolSections(
+          await loadSubnetProfile(asMcpLoaderCtx(ctx), netuid, {
+            readArtifact: loadArtifactData,
+          }),
+          args,
+          QUERY_ENUMS.subnetProfileSection,
+        );
       } catch (rawErr) {
         const tagged = taggedLoaderError(rawErr, "profilesMcp");
         if (tagged) throw toolError(tagged.code, tagged.message);

--- a/src/section-projection.ts
+++ b/src/section-projection.ts
@@ -1,0 +1,130 @@
+// `?sections=` on a composite document (#10600).
+//
+// Two routes -- `/api/v1/subnets/{netuid}` (272,825 B) and its `/profile`
+// (202,948 B) -- had no lever at all. The ordinary one does not fit: a query
+// collection pages ONE `data_key`, and their bulk is four parallel arrays over
+// the same subject (`endpoints`, `surfaces`, `verified_surfaces`,
+// `candidate_surfaces` -- 76/76/76/16 on subnet 64), so paging one would narrow
+// a quarter of the payload and leave the rest fat.
+//
+// WHY NOT `fields`. It exists on 5 routes and everywhere it means the same
+// thing: pick columns out of the rows of a list. This picks whole cards out of
+// one document. `fieldsSchema`'s published description says "row field names",
+// so extending the name meant either weakening that description for every route
+// that carries it, or publishing one name with two meanings and no error when a
+// caller applied the wrong one. #9884's partial-object rule was written for the
+// row-projection meaning too. A second name is the honest cost of a second unit
+// of selection.
+//
+// THE ENVELOPE IS NOT A SECTION. schema_version/contract_version/generated_at/
+// operational_observed_at/health_source survive every projection: they say what
+// the caller is holding and when it was built, and a document that cannot say
+// that is not smaller, it is anonymous. A caller asking for `economics` wants a
+// smaller answer, not an unattributable one.
+
+/** Envelope keys every projection keeps, whatever was asked for. */
+export const ALWAYS_KEPT_SECTIONS: readonly string[] = [
+  "schema_version",
+  "contract_version",
+  "generated_at",
+  "operational_observed_at",
+  "health_source",
+];
+
+export interface SectionProjection {
+  /** The requested section names, in the order given, deduplicated. */
+  sections: string[];
+  /** Names the route cannot serve. Non-empty means the caller gets a 400. */
+  unknown: string[];
+}
+
+/**
+ * Parse a raw `sections=` value against a route's vocabulary.
+ *
+ * Rejects rather than ignores an unknown name: dropping it would answer
+ * `?sections=eeconomics` with a document missing the one section that was asked
+ * for, and a 200 omitting the request is worse than a 400 explaining it.
+ *
+ * Whitespace is NOT tolerated, matching `sectionsSchema`'s published regex. The
+ * looser `fields` parser exists because production already accepted `"a, b"`
+ * before the pattern was written; nothing accepts `sections` yet, so the parser
+ * and the pattern agree from the start instead of being reconciled later.
+ */
+export function parseSectionsParam(
+  raw: string | null | undefined,
+  allowed: readonly string[],
+): SectionProjection | null {
+  if (raw == null || raw === "") return null;
+  const seen = new Set<string>();
+  const sections: string[] = [];
+  const unknown: string[] = [];
+  for (const part of raw.split(",")) {
+    if (seen.has(part)) continue;
+    seen.add(part);
+    // An empty segment (`a,,b`) is not a section name, so it lands in `unknown`
+    // and is reported as such rather than being silently skipped -- the caller
+    // wrote something they believed selected a section.
+    if (allowed.includes(part)) sections.push(part);
+    else unknown.push(part);
+  }
+  return { sections, unknown };
+}
+
+/**
+ * Keep the requested sections plus the envelope; drop the rest.
+ *
+ * Key ORDER follows the document, not the request: a caller writing
+ * `?sections=notes,subnet` gets the same byte layout as `?sections=subnet,notes`,
+ * so a response cannot differ by how the question was phrased. A requested
+ * section the document does not carry is simply absent -- the schema already
+ * marks these optional, and inventing a null would claim the section exists and
+ * is empty.
+ */
+export function projectSections(
+  data: Record<string, unknown>,
+  sections: readonly string[],
+): Record<string, unknown> {
+  const keep = new Set([...ALWAYS_KEPT_SECTIONS, ...sections]);
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (keep.has(key)) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * The same projection for an MCP tool, which receives typed JSON rather than a
+ * query string (#10600).
+ *
+ * The tools do NOT reach the REST serving seam -- each composes its own
+ * response from `loadArtifactData` plus its overlays -- so the projection has
+ * to happen in the handler. Sharing this function is what keeps the two
+ * surfaces from disagreeing about what `sections=economics` returns.
+ *
+ * An unknown name cannot arrive: the tool's input schema carries the same
+ * closed pattern the route publishes, and the dispatch validates against it.
+ * A non-string (an agent sending `sections: ["a","b"]`) is treated as absent
+ * rather than coerced -- on a typed surface an array is the type error it
+ * looks like, and guessing would serve a projection the caller did not ask for.
+ */
+export function projectToolSections<T>(
+  data: T,
+  args: unknown,
+  allowed: readonly string[],
+): T {
+  const raw = (args as Record<string, unknown> | null | undefined)?.sections;
+  if (typeof raw !== "string") return data;
+  const requested = parseSectionsParam(raw, allowed);
+  if (
+    !requested ||
+    requested.unknown.length > 0 ||
+    !data ||
+    typeof data !== "object"
+  ) {
+    return data;
+  }
+  return projectSections(
+    data as Record<string, unknown>,
+    requested.sections,
+  ) as T;
+}

--- a/tests/subnet-sections.test.ts
+++ b/tests/subnet-sections.test.ts
@@ -1,0 +1,356 @@
+// `?sections=` on the two composite subnet documents (#10600).
+//
+// #9981 gave four document-shaped routes a lever by declaring a query
+// collection (tests/document-route-paging.test.ts pins those). These two could
+// not take it: their bulk is four parallel arrays over the same subject
+// (`endpoints`, `surfaces`, `verified_surfaces`, `candidate_surfaces` --
+// 76/76/76/16 on subnet 64), and a collection pages ONE `data_key`, so
+// declaring one would have narrowed a quarter of 272,825 B and left the rest.
+//
+// What this pins is the part a reader cannot check by looking: that selecting
+// sections never costs the caller the envelope, that an unknown name is
+// refused rather than quietly dropped, and that the two routes have DIFFERENT
+// vocabularies -- the profile carries no `economics`, so accepting that name
+// there would promise a section it can never return.
+import assert from "node:assert/strict";
+import { describe, expect, it, test } from "vitest";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+import {
+  ALWAYS_KEPT_SECTIONS,
+  parseSectionsParam,
+  projectSections,
+  projectToolSections,
+} from "../src/section-projection.ts";
+
+const DETAIL = QUERY_ENUMS.subnetDetailSection;
+const PROFILE = QUERY_ENUMS.subnetProfileSection;
+
+/** A document shaped like the served artifact: envelope + sections. */
+const document = (): Record<string, unknown> => ({
+  schema_version: 1,
+  contract_version: "2026-08-13",
+  generated_at: "2026-08-13T00:00:00.000Z",
+  operational_observed_at: "2026-08-13T00:00:00.000Z",
+  health_source: "probe",
+  subnet: { netuid: 64, name: "Chutes" },
+  economics: { alpha_price_tao: 0.02 },
+  endpoints: [{ id: "e1" }],
+  surfaces: [{ id: "s1" }, { id: "s2" }],
+  verified_surfaces: [{ id: "s1" }],
+  candidate_surfaces: [{ id: "c1" }],
+  candidates: [{ id: "c1" }],
+  gaps: { missing: [] },
+  notes: "hand-written",
+});
+
+describe("parseSectionsParam", () => {
+  test("absent and empty are both 'no projection', not 'project nothing'", () => {
+    // The distinction matters: returning `{sections: []}` for an absent
+    // parameter would project every section away and serve a bare envelope to
+    // every caller who did not ask for one.
+    assert.equal(parseSectionsParam(null, DETAIL), null);
+    assert.equal(parseSectionsParam(undefined, DETAIL), null);
+    assert.equal(parseSectionsParam("", DETAIL), null);
+  });
+
+  test("known names are kept in the order given, deduplicated", () => {
+    const parsed = parseSectionsParam("economics,subnet,economics", DETAIL);
+    assert.deepEqual(parsed?.sections, ["economics", "subnet"]);
+    assert.deepEqual(parsed?.unknown, []);
+  });
+
+  test("an unknown name is reported, not dropped", () => {
+    // Dropping it would answer `?sections=eeconomics` with a document missing
+    // the one section the caller asked for -- a 200 that omits the request.
+    const parsed = parseSectionsParam("economics,eeconomics", DETAIL);
+    assert.deepEqual(parsed?.sections, ["economics"]);
+    assert.deepEqual(parsed?.unknown, ["eeconomics"]);
+  });
+
+  test("an empty segment is unknown, not skipped", () => {
+    // `a,,b` means the caller wrote something they believed named a section.
+    const parsed = parseSectionsParam("subnet,,notes", DETAIL);
+    assert.deepEqual(parsed?.unknown, [""]);
+  });
+
+  test("the two routes do not share a vocabulary", () => {
+    // `economics` is a real section of the detail route and does not exist on
+    // the profile. Accepting it there would promise a section that can never
+    // arrive, which is worse than refusing it.
+    // Widened deliberately: QUERY_ENUMS is `as const`, so asking whether the
+    // PROFILE list contains "economics" is a type error rather than a false --
+    // which is the type system making exactly this issue's point, that the two
+    // vocabularies are different sets and not one shared one.
+    assert.ok((DETAIL as readonly string[]).includes("economics"));
+    assert.ok(!(PROFILE as readonly string[]).includes("economics"));
+    assert.deepEqual(parseSectionsParam("economics", PROFILE)?.unknown, [
+      "economics",
+    ]);
+    assert.ok(PROFILE.includes("profile"));
+    assert.deepEqual(parseSectionsParam("profile", DETAIL)?.unknown, [
+      "profile",
+    ]);
+  });
+});
+
+describe("projectSections", () => {
+  test("keeps the requested section and drops the rest", () => {
+    const out = projectSections(document(), ["economics"]);
+    assert.deepEqual(
+      Object.keys(out).filter((k) => !ALWAYS_KEPT_SECTIONS.includes(k)),
+      ["economics"],
+    );
+    assert.deepEqual(out.economics, { alpha_price_tao: 0.02 });
+  });
+
+  test("the envelope survives every projection", () => {
+    // A smaller document still has to say what it is and when it was built.
+    // Without this, `?sections=notes` would return an anonymous blob.
+    for (const sections of [[], ["notes"], ["subnet", "gaps"]]) {
+      const out = projectSections(document(), sections);
+      for (const key of ALWAYS_KEPT_SECTIONS) {
+        assert.ok(
+          key in out,
+          `${key} must survive ?sections=${sections.join(",")}`,
+        );
+      }
+    }
+  });
+
+  test("key order follows the document, not the request", () => {
+    // Two callers asking for the same sections in different orders must get
+    // byte-identical responses, or a cache keyed on the body diverges for no
+    // reason a caller can see.
+    const a = JSON.stringify(projectSections(document(), ["notes", "subnet"]));
+    const b = JSON.stringify(projectSections(document(), ["subnet", "notes"]));
+    assert.equal(a, b);
+  });
+
+  test("a requested section the document lacks is absent, not null", () => {
+    // Inventing a null would claim the section exists and is empty. The schema
+    // already marks these optional.
+    const sparse = { schema_version: 1, subnet: { netuid: 1 } };
+    const out = projectSections(sparse, ["economics", "subnet"]);
+    assert.ok(!("economics" in out));
+    assert.deepEqual(out.subnet, { netuid: 1 });
+  });
+
+  test("projecting the four surface arrays away is where the bytes go", () => {
+    // The measurement behind the issue: these four are the payload. Asking for
+    // `subnet` alone has to actually shed them, not merely reorder.
+    const full = document();
+    const out = projectSections(full, ["subnet"]);
+    for (const heavy of [
+      "endpoints",
+      "surfaces",
+      "verified_surfaces",
+      "candidate_surfaces",
+    ]) {
+      assert.ok(heavy in full, `fixture must carry ${heavy}`);
+      assert.ok(!(heavy in out), `${heavy} must be projected away`);
+    }
+    assert.ok(JSON.stringify(out).length < JSON.stringify(full).length);
+  });
+});
+
+// ── End to end, through the router ─────────────────────────────────────────
+//
+// The unit tests above prove the projection; these prove the WIRING, which is
+// the half a reader cannot check. A route can declare `sections` in its schema,
+// publish it in openapi.json, and still never apply it -- the parameter would
+// validate, the response would be full-size, and every gate would stay green.
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "../scripts/lib.ts";
+import { handleRequest } from "../workers/api.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+const ORIGIN = "https://api.metagraph.sh";
+
+async function getRoute(pathname: string) {
+  const res = await handleRequest(
+    new Request(`${ORIGIN}${pathname}`),
+    createLocalArtifactEnv() as unknown as Parameters<typeof handleRequest>[1],
+    {} as Parameters<typeof handleRequest>[2],
+  );
+  let body: Row | null;
+  try {
+    body = JSON.parse(await res.clone().text()) as Row;
+  } catch {
+    // A non-JSON body is a real answer here (a 5xx page, say), and the caller
+    // asserts on `res.status` in that case rather than on a parse that threw.
+    body = null;
+  }
+  return { res, body };
+}
+
+describe("GET /api/v1/subnets/{netuid}?sections=", () => {
+  test("without the parameter the whole document is served", async () => {
+    // The control. If this ever returns a projected document, the default
+    // changed and every existing caller silently lost sections.
+    const { res, body } = await getRoute("/api/v1/subnets/1");
+    assert.equal(res.status, 200);
+    const data = (body?.data ?? {}) as Row;
+    assert.ok("surfaces" in data, "surfaces present by default");
+    assert.ok("endpoints" in data, "endpoints present by default");
+  });
+
+  test("a selected section is served and the rest are gone", async () => {
+    const { res, body } = await getRoute("/api/v1/subnets/1?sections=subnet");
+    assert.equal(res.status, 200);
+    const data = (body?.data ?? {}) as Row;
+    assert.ok("subnet" in data, "the requested section is present");
+    for (const shed of [
+      "surfaces",
+      "endpoints",
+      "verified_surfaces",
+      "candidate_surfaces",
+    ]) {
+      assert.ok(!(shed in data), `${shed} must be projected away`);
+    }
+  });
+
+  test("the envelope survives the projection", async () => {
+    const { body } = await getRoute("/api/v1/subnets/1?sections=notes");
+    const data = (body?.data ?? {}) as Row;
+    assert.equal(
+      data.schema_version,
+      1,
+      "a projected document still says what it is",
+    );
+    assert.ok(data.generated_at, "and when it was built");
+  });
+
+  test("two sections are both served", async () => {
+    const { body } = await getRoute("/api/v1/subnets/1?sections=subnet,gaps");
+    const data = (body?.data ?? {}) as Row;
+    assert.ok("subnet" in data);
+    assert.ok("gaps" in data);
+    assert.ok(!("surfaces" in data));
+  });
+
+  test("an unknown section is a 400 that names the vocabulary", async () => {
+    // The refusal is the ROUTER's, not the handler's: `routeText` reads a value
+    // already parsed against the published pattern, so an unknown section never
+    // reaches the projection. That is why no handler-side message exists to
+    // unit-test -- this drives the real request instead.
+    const { res, body } = await getRoute("/api/v1/subnets/1?sections=bogus");
+    assert.equal(res.status, 400);
+    const error = (body?.error ?? {}) as Row;
+    assert.equal(error.code, "invalid_query");
+    assert.match(String(error.message), /sections/);
+  });
+
+  test("the profile route refuses `economics`, which it cannot serve", async () => {
+    // Its own vocabulary, not a shared one: accepting a name this document
+    // never carries would promise a section that can never arrive.
+    const { res } = await getRoute(
+      "/api/v1/subnets/1/profile?sections=economics",
+    );
+    assert.equal(res.status, 400);
+    const ok = await getRoute("/api/v1/subnets/1/profile?sections=subnet");
+    assert.equal(ok.res.status, 200);
+    assert.ok("subnet" in ((ok.body?.data ?? {}) as Row));
+  });
+});
+
+describe("the lever is published, not just implemented", () => {
+  // Asserted against the EMITTED contract, the same way
+  // document-route-paging.test.ts pins #9981's four: a caller discovers the
+  // lever from openapi.json or not at all, and a route quietly returning to
+  // NO_QUERY_PARAMETERS would restore the 272 KB default with the handler code
+  // still sitting there unreachable.
+  const openapi = JSON.parse(
+    readFileSync(path.join(repoRoot, "public/metagraph/openapi.json"), "utf8"),
+  ) as {
+    paths: Record<
+      string,
+      { get?: { parameters?: Array<{ name?: string; $ref?: string }> } }
+    >;
+  };
+
+  const published = (route: string): Array<Record<string, unknown>> =>
+    (openapi.paths[route]?.get?.parameters ?? []) as Array<
+      Record<string, unknown>
+    >;
+
+  it.each([
+    ["/api/v1/subnets/{netuid}", QUERY_ENUMS.subnetDetailSection],
+    ["/api/v1/subnets/{netuid}/profile", QUERY_ENUMS.subnetProfileSection],
+  ])("%s publishes sections with its own closed set", (route, vocabulary) => {
+    const parameter = published(route).find((p) => p.name === "sections");
+    expect(parameter, `${route} must publish sections`).toBeTruthy();
+    // The pattern carries the vocabulary, so a generated client rejects an
+    // unknown section without a round trip. That is what the separate
+    // parameter buys over `fields`, whose column names cannot be enumerated.
+    const pattern = String(
+      (parameter?.schema as Record<string, unknown> | undefined)?.pattern ?? "",
+    );
+    for (const section of vocabulary) {
+      expect(pattern, `${route} pattern must name ${section}`).toContain(
+        section,
+      );
+    }
+  });
+
+  it("does not publish sections on a route that cannot project", () => {
+    // Positive control for the assertions above: `sections` is not simply
+    // everywhere. /api/v1/subnets is a list, and its lever is paging.
+    expect(
+      published("/api/v1/subnets").find((p) => p.name === "sections"),
+    ).toBeUndefined();
+  });
+});
+
+describe("projectToolSections (the MCP side)", () => {
+  // The tools do NOT reach the REST serving seam -- each composes its own
+  // response -- so the projection is applied in the handler and shares this
+  // function, which is what stops the two surfaces disagreeing about what
+  // `sections=economics` returns.
+  test("projects when the tool was given a section list", () => {
+    const out = projectToolSections(
+      document(),
+      { netuid: 64, sections: "economics" },
+      DETAIL,
+    );
+    assert.ok("economics" in out);
+    assert.ok(!("surfaces" in out));
+  });
+
+  test("absent sections leaves the document whole", () => {
+    const out = projectToolSections(document(), { netuid: 64 }, DETAIL);
+    assert.deepEqual(Object.keys(out).sort(), Object.keys(document()).sort());
+  });
+
+  test("a non-string is treated as absent, not coerced", () => {
+    // An agent sending `sections: ["a","b"]` has made the type error it looks
+    // like on a typed surface. Guessing would serve a projection nobody asked
+    // for; the tool's own input schema is what rejects it.
+    const out = projectToolSections(
+      document(),
+      { sections: ["economics"] },
+      DETAIL,
+    );
+    assert.ok("surfaces" in out, "an array is not a section list");
+  });
+
+  test("an unknown name projects nothing rather than a partial guess", () => {
+    // Unreachable through the dispatch (the input schema carries the same
+    // closed pattern), so this pins the fallback rather than the contract: a
+    // half-understood request must not be answered as if it were understood.
+    const out = projectToolSections(
+      document(),
+      { sections: "economics,bogus" },
+      DETAIL,
+    );
+    assert.ok("surfaces" in out);
+  });
+
+  test("a null document survives", () => {
+    assert.equal(
+      projectToolSections(null, { sections: "economics" }, DETAIL),
+      null,
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -177,6 +177,24 @@ import {
   paginationLinkHeader,
   queryCollectionConfig,
 } from "./list-query.ts";
+import {
+  parseSectionsParam,
+  projectSections,
+} from "../src/section-projection.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+
+/**
+ * Route id -> the sections that route serves (#10600).
+ *
+ * Keyed on the matched route id rather than the path so the lookup cannot drift
+ * from the router, and derived from QUERY_ENUMS rather than restated -- the same
+ * vocabulary the published schema validates against, so the edge and the handler
+ * cannot disagree about what `sections=economics` means.
+ */
+const SECTION_VOCABULARIES: Record<string, readonly string[] | undefined> = {
+  "subnet-detail": QUERY_ENUMS.subnetDetailSection,
+  "subnet-profile": QUERY_ENUMS.subnetProfileSection,
+};
 import { csvRequested, csvResponse } from "./csv.ts";
 import {
   apiHeaders,
@@ -8924,6 +8942,31 @@ async function handleApiRequest(
     });
   }
 
+  // `?sections=` on the two composite subnet documents (#10600). AFTER every
+  // overlay above and BEFORE the envelope below: the live economics overlay,
+  // the USD twins and the alias overlay all write INTO `subnet`/`economics`, so
+  // projecting earlier would return a section the overlays had not reached yet
+  // -- a smaller answer that is also a staler one.
+  //
+  // `routeText`, not `url.searchParams.get` (#10060): the value has already
+  // been parsed against this route's published schema, so an unknown section
+  // never arrives here -- the router answered it 400 before dispatch, quoting
+  // the vocabulary out of the pattern. Reading the raw string would re-read a
+  // value the contract had already checked, and would make this the second
+  // place that decides what a section name is.
+  const sectionVocabulary = SECTION_VOCABULARIES[matched.id];
+  if (sectionVocabulary && baseData && typeof baseData === "object") {
+    const requested = parseSectionsParam(
+      routeText(url, "sections"),
+      sectionVocabulary,
+    );
+    if (requested) {
+      baseData = projectSections(
+        baseData as Record<string, unknown>,
+        requested.sections,
+      ) as typeof baseData;
+    }
+  }
   const transformed = applyQueryFilters(
     baseData,
     url,


### PR DESCRIPTION
## Summary

`/api/v1/subnets/{netuid}` (272,825 B) and `/api/v1/subnets/{netuid}/profile` (202,948 B)
were the two routes #9981 named that could not take the ordinary lever, and they took no
query parameters at all. They do now: `?sections=subnet,economics` returns those cards and
not the four surface arrays.

## Why not `fields`, which already exists

Settled on #10600 before writing any code, because it is a contract decision rather than an
implementation detail. The evidence:

- `fieldsSchema()` in `schemas-src/query-params.ts` is **one shared declaration**, and its
  published description names the unit: *"Comma-separated **row field names** to project."*
  Extending the name to mean document sections forces either weakening that sentence for
  every route that carries it, or publishing one parameter name with two descriptions and
  nothing telling a caller which they got.
- There is no existing `include=`/`sections=` anywhere, so neither is being overloaded.
- #9884's partial-object rule was written for the row-projection meaning; extending `fields`
  would extend that rule to a shape it was not written for.

`sections` over `include=`: these are named cards of one composite document, not related
resources, so `include=`'s JSON:API connotation would mislead.

## Two things the issue's premise got wrong

**"Both routes compose their response from named sections already"** — they do not. These are
**built artifacts** served from R2, so the projection had to go at the serving seam in
`workers/api.ts`, and specifically **after** the live economics overlay, the USD twins and
the alias overlay, all of which write into `subnet`/`economics`. Projecting earlier would
return a section the overlays had not reached: a smaller answer that is also a staler one.

**`sections` is validated by the router, not the handler.** My first version read
`url.searchParams.get("sections")` and returned its own 400 — which
`tests/parsed-query-reads.test.ts` (#10060) correctly failed, because the router has already
parsed the value against the route's published schema. It now reads `routeText(url,
"sections")`, and the handler-side message is deleted rather than left as a second place that
decides what a section name is. The refusal a caller sees is the router's, and it quotes the
whole vocabulary out of the published pattern.

## Design

- **The vocabulary lives in `QUERY_ENUMS`**, the existing owner both surfaces read, so the
  edge and the handler cannot disagree about what `sections=economics` means.
- **Two vocabularies, not one.** The profile carries `profile` and no
  `economics`/`candidates`/`verified_surfaces`; a shared list would let a caller ask it for a
  section it can never return.
- **The pattern publishes the closed set**, so a generated client rejects `?sections=bogus`
  without a round trip. That is what the separate parameter buys — `fields`' column names
  differ per route and cannot be enumerated.
- **The envelope is never projected away.** `schema_version`, `contract_version`,
  `generated_at`, `operational_observed_at` and `health_source` survive every request: a
  smaller document still has to say what it is and when it was built.
- **Key order follows the document, not the request**, so `?sections=notes,subnet` and
  `?sections=subnet,notes` are byte-identical.

## Both surfaces, because a gate requires it

`validate:mcp-input-parity` fails a tool that cannot pass a parameter its route publishes —
*"an agent reading our own contract would send these and be rejected."* I had run
`validate:mcp` locally but not this one, so CI caught it. MCP parity is therefore part of
this PR rather than the follow-up I first filed (#10958, now closed by it).

Implementing it surfaced that the three tools are **not** interchangeable:

| Tool | Serves | Outcome |
| --- | --- | --- |
| `get_subnet_detail` | `/metagraph/subnets/{n}.json` — matches the detail vocabulary | takes `sections`, projects |
| `get_subnet_profile` | `/metagraph/profiles/{n}.json` — matches the profile vocabulary | takes `sections`, projects |
| `get_subnet` | **`/metagraph/overview/{n}.json`** — a different document | declares the divergence |

`get_subnet` is mapped to the profile route but reads the overview artifact, whose keys are
`counts`/`curation`/`gap_priorities`/`health`/`name`/`netuid`/`slug`/`status` — none of
`subnet`/`endpoints`/`surfaces`/`candidate_surfaces`/`notes`. Accepting the route's sections
there would advertise cards the document does not have and answer with an almost-empty
projection, so it is a declared divergence carrying that measurement.

Both handlers project **after** their overlays, for the same reason the REST seam does:
`economics` is itself a selectable section.

## One thing a reviewer should see, because I checked it and did not fix it here

`SubnetDetailArtifact` marks `subnet`, `surfaces`, `gaps` and `candidate_surfaces`
**required**, so `?sections=economics` returns a document missing four required properties.

That is not new with this PR — it is exactly what the sibling lever already does, verified
live rather than assumed:

```
GET /api/v1/subnets/1/metagraph?fields=uid  ->  200, 256 rows, row keys ["uid"]
SubnetMetagraphArtifact.neurons.items required: uid, hotkey, coldkey, active, validator_permit
```

So `sections` follows the established behaviour of `fields` rather than inventing a second
answer for one parameter. Filed as #10960, because the honest fix is one contract decision
covering both (loosen `required`, publish a projected variant, or document that `required`
describes the unprojected response) and it should not be settled by whichever lever shipped
last. The MCP surface already answers it one way (#9884), and REST does not follow — that
divergence is part of the same question.

## Verification

- 24 tests: the projection, the wiring end-to-end through `handleRequest`, and the published
  contract. Proven load-bearing — disabling the projection fails exactly the 2 tests that
  assert sections are shed, and all 19 pass restored.
- Patch coverage by lcov ∩ diff: **0 uncovered lines, 0 untaken branches**;
  `src/section-projection.ts` is LF 16/16, BRF 10/10.
- `npx tsc --noEmit` 0 · `lint` · `format:check` · `build` · `validate:contract-drift` ·
  `validate:api` · `validate:mcp` · `validate:openapi` · `validate:unreferenced-exports` ·
  `validate:retired-store-vocabulary` — all pass
- Full `npx vitest run` — green

Closes #10600
Closes #10958
