### PR TITLE
fix(ui): one chain-stream socket per tab, with a grow-only topic union

### DIFF
--- a/apps/ui/src/hooks/use-chain-stream.test.ts
+++ b/apps/ui/src/hooks/use-chain-stream.test.ts
@@ -12,6 +12,7 @@ import {
   createChainStreamSession,
   acquireSharedChainStream,
   activeSharedChainStreamCount,
+  sharedChainStreamTopics,
   createDebouncedHandler,
   parseChainStreamPayload,
 } from "./use-chain-stream";
@@ -416,7 +417,7 @@ describe("acquireSharedChainStream", () => {
     };
   }
 
-  function subscriber(overrides: Partial<Record<string, unknown>> = {}) {
+  function subscriber(topics: string[], overrides: Partial<Record<string, unknown>> = {}) {
     const seen: unknown[] = [];
     const statuses: string[] = [];
     let activity = 0;
@@ -427,6 +428,7 @@ describe("acquireSharedChainStream", () => {
         return activity;
       },
       sub: {
+        topics: new Set(topics),
         getMatches: () => undefined,
         setStatus: (s: string) => statuses.push(s),
         markActivity: () => {
@@ -443,94 +445,136 @@ describe("acquireSharedChainStream", () => {
     expectEq(activeSharedChainStreamCount(), 0, "a shared connection outlived its last subscriber");
   });
 
-  it("two consumers of the same topics share ONE socket", () => {
+  it("consumers of DIFFERENT topics share one socket", () => {
+    // The #10952 pool keyed by topic set, so a tab holding `blocks`,
+    // `account_events` and `chain_events` held three sockets. Against a 20
+    // per-IP cap that still breaks at seven tabs, and it did: refusals fell
+    // ~75% and did not stop.
     let opened = 0;
     const src = fakeSource();
     const open = () => {
       opened += 1;
       return src as never;
     };
-    const a = subscriber();
-    const b = subscriber();
-    const releaseA = acquireSharedChainStream("account_events|400", open, a.sub);
-    const releaseB = acquireSharedChainStream("account_events|400", open, b.sub);
-    expectEq(opened, 1, "the second consumer opened a second socket");
-    releaseA();
-    releaseB();
-  });
-
-  it("different topics still get their own socket", () => {
-    // Sharing must be keyed, not global: a consumer of `blocks` must not be
-    // silently subscribed to `account_events`.
-    let opened = 0;
-    const open = () => {
-      opened += 1;
-      return fakeSource() as never;
-    };
-    const a = subscriber();
-    const b = subscriber();
-    const releaseA = acquireSharedChainStream("account_events|400", open, a.sub);
-    const releaseB = acquireSharedChainStream("blocks|400", open, b.sub);
+    const a = subscriber(["blocks"]);
+    const b = subscriber(["account_events"]);
+    const releaseA = acquireSharedChainStream(open, a.sub);
+    const releaseB = acquireSharedChainStream(open, b.sub);
+    expectEq(activeSharedChainStreamCount(), 1, "a tab must hold ONE socket");
+    expectEq(sharedChainStreamTopics(), ["account_events", "blocks"]);
+    // Two opens, because the union GREW: the second consumer needed a topic
+    // the live URL did not carry.
     expectEq(opened, 2);
     releaseA();
     releaseB();
   });
 
+  it("a topic already carried joins the live socket without reopening", () => {
+    // The common case, and the one that must not churn: two consumers of the
+    // same topic (registry-ticker and live-block-rail both want `blocks`).
+    let opened = 0;
+    const src = fakeSource();
+    const open = () => {
+      opened += 1;
+      return src as never;
+    };
+    const a = subscriber(["blocks"]);
+    const b = subscriber(["blocks"]);
+    const releaseA = acquireSharedChainStream(open, a.sub);
+    const releaseB = acquireSharedChainStream(open, b.sub);
+    expectEq(opened, 1, "an already-covered topic must not reopen the socket");
+    releaseA();
+    releaseB();
+  });
+
+  it("the union never shrinks when a consumer leaves", () => {
+    // Shrinking would reopen on every navigation — a reconnect storm against
+    // a cap on CONCURRENT connections, which is the failure being fixed.
+    let opened = 0;
+    const src = fakeSource();
+    const open = () => {
+      opened += 1;
+      return src as never;
+    };
+    const a = subscriber(["blocks"]);
+    const b = subscriber(["account_events"]);
+    const releaseA = acquireSharedChainStream(open, a.sub);
+    const releaseB = acquireSharedChainStream(open, b.sub);
+    const openedAfterBoth = opened;
+    releaseA();
+    expectEq(sharedChainStreamTopics(), ["account_events", "blocks"]);
+    expectEq(opened, openedAfterBoth, "unmounting a consumer reopened the socket");
+    releaseB();
+  });
+
   it("the socket survives one consumer leaving and closes with the last", () => {
     const src = fakeSource();
-    const a = subscriber();
-    const b = subscriber();
-    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
-    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    const a = subscriber(["blocks"]);
+    const b = subscriber(["blocks"]);
+    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
     releaseA();
     expectEq(src.closed, 0, "unmounting one consumer closed the shared socket");
     releaseB();
     expectEq(src.closed, 1, "the last consumer left and the socket stayed open");
   });
 
-  it("every subscriber receives each frame", () => {
+  it("each subscriber receives only ITS OWN topics", () => {
+    // THE NEW OBLIGATION. The URL carries the union, so the topic filter the
+    // server used to apply now has to happen here — same rule as
+    // chainFirehoseMatchesTopics: `topics.has(payload.table)`.
     const src = fakeSource();
-    const a = subscriber();
-    const b = subscriber();
-    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
-    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
-    src.emit({ block: 1 });
-    expectEq(a.seen, [{ block: 1 }]);
-    expectEq(b.seen, [{ block: 1 }]);
+    const a = subscriber(["blocks"]);
+    const b = subscriber(["account_events"]);
+    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    src.emit({ table: "blocks", block_number: 1 });
+    src.emit({ table: "account_events", id: 7 });
+    expectEq(a.seen, [{ table: "blocks", block_number: 1 }]);
+    expectEq(b.seen, [{ table: "account_events", id: 7 }]);
+    // markActivity follows the same filter, so a consumer's LIVE chip is not
+    // refreshed by another consumer's traffic.
+    expectEq(a.activity, 1);
+    expectEq(b.activity, 1);
     releaseA();
     releaseB();
   });
 
-  it("each subscriber applies its OWN matches", () => {
-    // Pooling the socket must not pool the filtering, or a consumer starts
-    // seeing frames it explicitly excluded.
+  it("a frame for no subscribed topic is dropped by everyone", () => {
     const src = fakeSource();
-    const a = subscriber({
-      getMatches: () => (p: unknown) => (p as { block: number }).block > 5,
+    const a = subscriber(["blocks"]);
+    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    src.emit({ table: "something_else", id: 1 });
+    expectEq(a.seen, []);
+    releaseA();
+  });
+
+  it("each subscriber still applies its OWN matches", () => {
+    const src = fakeSource();
+    const a = subscriber(["blocks"], {
+      getMatches: () => (p: unknown) => (p as { block_number: number }).block_number > 5,
     });
-    const b = subscriber();
-    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
-    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
-    src.emit({ block: 1 });
-    src.emit({ block: 9 });
-    expectEq(a.seen, [{ block: 9 }], "a's own filter was not applied");
-    expectEq(b.seen, [{ block: 1 }, { block: 9 }]);
-    // markActivity follows the subscriber's own filter, not the socket's.
-    expectEq(a.activity, 1);
-    expectEq(b.activity, 2);
+    const b = subscriber(["blocks"]);
+    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
+    src.emit({ table: "blocks", block_number: 1 });
+    src.emit({ table: "blocks", block_number: 9 });
+    expectEq(a.seen, [{ table: "blocks", block_number: 9 }]);
+    expectEq(b.seen, [
+      { table: "blocks", block_number: 1 },
+      { table: "blocks", block_number: 9 },
+    ]);
     releaseA();
     releaseB();
   });
 
   it("a late subscriber is told the connection is already open", () => {
-    // Without the replay it would sit at whatever it initialised to while
-    // attached to a live socket, and the LIVE chip would lie by omission.
     const src = fakeSource();
-    const a = subscriber();
-    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
+    const a = subscriber(["blocks"]);
+    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
     src.open();
-    const b = subscriber();
-    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    const b = subscriber(["blocks"]);
+    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
     expectEq(b.statuses.at(-1), "open");
     releaseA();
     releaseB();
@@ -538,14 +582,14 @@ describe("acquireSharedChainStream", () => {
 
   it("a released subscriber stops receiving frames", () => {
     const src = fakeSource();
-    const a = subscriber();
-    const b = subscriber();
-    const releaseA = acquireSharedChainStream("blocks|400", () => src as never, a.sub);
-    const releaseB = acquireSharedChainStream("blocks|400", () => src as never, b.sub);
+    const a = subscriber(["blocks"]);
+    const b = subscriber(["blocks"]);
+    const releaseA = acquireSharedChainStream(() => src as never, a.sub);
+    const releaseB = acquireSharedChainStream(() => src as never, b.sub);
     releaseA();
-    src.emit({ block: 2 });
+    src.emit({ table: "blocks", block_number: 2 });
     expectEq(a.seen, [], "an unmounted consumer still received a frame");
-    expectEq(b.seen, [{ block: 2 }]);
+    expectEq(b.seen, [{ table: "blocks", block_number: 2 }]);
     releaseB();
   });
 });

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -324,6 +324,16 @@ export function createChainStreamSession(deps: ChainStreamSessionDeps): {
  * takes the default, so the six collapse to three.
  */
 interface ChainStreamSubscriber {
+  /**
+   * The topics this consumer actually asked for.
+   *
+   * Needed because the socket now carries the UNION of every consumer's
+   * topics, so a `blocks` consumer receives `account_events` frames and has to
+   * drop them. The server's own filter is `topics.has(payload.table)`
+   * (`chainFirehoseMatchesTopics`); this is the same rule applied on the side
+   * that now knows more than the URL says.
+   */
+  topics: Set<string>;
   getMatches: () => ((payload: unknown) => boolean) | undefined;
   setStatus: (s: SseStatus) => void;
   markActivity: () => void;
@@ -336,6 +346,8 @@ interface ChainStreamSubscriber {
 interface SharedChainStream {
   session: { connect: () => void; dispose: () => void };
   subscribers: Set<ChainStreamSubscriber>;
+  /** The union of every subscriber's topics. GROW-ONLY -- see acquire. */
+  topics: Set<string>;
   /** Last status the socket reported, replayed to a late subscriber so it
    * does not sit at "connecting" for a connection that is already open. */
   status: SseStatus;
@@ -343,46 +355,86 @@ interface SharedChainStream {
   offApiBase: () => void;
 }
 
+/**
+ * ONE SOCKET PER TAB. Not one per call site, and not one per topic set.
+ *
+ * ## WHY THIS GOT A SECOND PASS
+ *
+ * #10952 pooled by topic set, which took a fully-loaded tab from six sockets
+ * to three and cut refusals about 75% (measured: ~50-80 per 15 minutes before,
+ * 14 after). It did not close the problem, and the arithmetic says why: the
+ * server caps ONE IP at CHAIN_FIREHOSE_MAX_CONNECTIONS_PER_IP = 20 concurrent
+ * SSE connections, so three sockets a tab still breaks at seven tabs. Every
+ * remaining refusal came back `chain_firehose_cap_sse_per_ip` -- the app
+ * refusing itself, just less often.
+ *
+ * One socket a tab makes the same cap mean twenty tabs.
+ *
+ * ## GROW-ONLY, WHICH IS THE WHOLE TRICK
+ *
+ * The socket's URL carries the union of its subscribers' topics, and that
+ * union NEVER SHRINKS. Shrinking on unmount would reopen the connection on
+ * every navigation -- a reconnect storm against a cap on concurrent
+ * connections, which is the failure this exists to avoid. Growing is bounded
+ * by the topic vocabulary (three values today), so a tab reopens at most
+ * twice in its life and then holds one stable connection.
+ *
+ * A superset subscription is always SAFE because the filter moved to the
+ * subscriber: receiving a frame you did not ask for costs one `Set.has` and a
+ * discard, while missing one you did ask for would be data loss.
+ */
 const SHARED_CHAIN_STREAMS = new Map<string, SharedChainStream>();
+
+/** The single pool entry. A constant, so the map holds at most one. */
+const SHARED_CHAIN_STREAM_KEY = "chain-stream";
 
 /** Exported for tests: no connection may outlive its last subscriber. */
 export function activeSharedChainStreamCount(): number {
   return SHARED_CHAIN_STREAMS.size;
 }
 
+/** Exported for tests: what the live socket is currently subscribed to. */
+export function sharedChainStreamTopics(): string[] {
+  return [...(SHARED_CHAIN_STREAMS.get(SHARED_CHAIN_STREAM_KEY)?.topics ?? [])].sort();
+}
+
 /**
- * Join (or open) the shared connection for `topicList`. Returns the release
+ * Join (or open) the tab's chain-stream connection. Returns the release
  * function; the socket closes when the last subscriber releases it.
  */
 export function acquireSharedChainStream(
-  key: string,
   /**
-   * Opens the socket. INJECTED, like `createChainStreamSession`'s own
-   * `openSource` and for the same reason: this suite runs in plain node with
-   * no `EventSource`, and a pool that could only be exercised in a browser is
-   * a pool whose ref-counting nobody checks.
+   * Opens the socket for a given topic union. INJECTED, like
+   * `createChainStreamSession`'s own `openSource` and for the same reason:
+   * this suite runs in plain node with no `EventSource`, and a pool that could
+   * only be exercised in a browser is a pool whose ref-counting nobody checks.
    */
-  openSource: () => ChainStreamSource,
+  openSource: (topics: string[]) => ChainStreamSource,
   subscriber: ChainStreamSubscriber,
 ): () => void {
+  const key = SHARED_CHAIN_STREAM_KEY;
   let shared = SHARED_CHAIN_STREAMS.get(key);
   if (!shared) {
     const subscribers = new Set<ChainStreamSubscriber>();
     const entry = {
       subscribers,
+      topics: new Set<string>(),
       status: "connecting" as SseStatus,
     } as SharedChainStream;
     const session = createChainStreamSession({
-      openSource,
-      // Every subscriber filters for itself below, so the socket accepts
-      // everything the server already topic-filtered.
+      openSource: () => openSource([...entry.topics].sort()),
+      // Every subscriber filters for itself below, both by topic and by its
+      // own `matches`.
       getMatches: () => undefined,
       // Unused: `deliverRaw` below takes the frame path instead, so nothing
       // coalesces at the socket.
       debounceMs: 0,
       getOnEvent: () => undefined,
       deliverRaw: (payload: unknown) => {
+        const table = (payload as { table?: unknown } | null)?.table;
         for (const sub of subscribers) {
+          // The topic filter the URL used to do for us.
+          if (!sub.topics.has(table as string)) continue;
           const match = sub.getMatches();
           if (match && !match(payload)) continue;
           sub.markActivity();
@@ -400,9 +452,19 @@ export function acquireSharedChainStream(
     entry.offApiBase = onApiBaseChange(session.connect);
     SHARED_CHAIN_STREAMS.set(key, entry);
     shared = entry;
-    session.connect();
   }
   shared.subscribers.add(subscriber);
+  // Grow the union, and reconnect ONLY if it actually grew. An existing
+  // subscriber's topics are already covered, so the common case (a second
+  // consumer of a topic already carried) joins a live socket untouched.
+  let grew = false;
+  for (const topic of subscriber.topics) {
+    if (!shared.topics.has(topic)) {
+      shared.topics.add(topic);
+      grew = true;
+    }
+  }
+  if (grew) shared.session.connect();
   // Replay the socket's current status, so a consumer joining an already-open
   // connection shows LIVE immediately rather than waiting for the next event.
   subscriber.setStatus(shared.status);
@@ -530,9 +592,12 @@ export function useChainStream(options: UseChainStreamOptions = {}): {
     }, debounceMs);
 
     const release = acquireSharedChainStream(
-      `${topicsKey || "chain_events"}|${debounceMs}`,
-      () => new EventSource(buildChainStreamUrl(topicList)),
+      // The socket's URL is the UNION of every consumer's topics, so it is
+      // built from what the pool asks for rather than from this consumer's
+      // own list.
+      (unionTopics) => new EventSource(buildChainStreamUrl(unionTopics)),
       {
+        topics: new Set(topicList),
         getMatches: () => matchesRef.current,
         setStatus,
         markActivity: () => setLastEventAt(new Date().toISOString()),


### PR DESCRIPTION
#10952 pooled by topic set, and **it was not enough**. Measured before and after it deployed:

| | refusals / 15 min |
| --- | --- |
| before (15:30–17:45) | 16, 63, 83, 37, 77, 69, 37, 78, 29 |
| after (18:15, 18:30) | **14, 14** |

About a 75% drop — and every remaining refusal still came back `chain_firehose_cap_sse_per_ip`. The arithmetic says why: **three sockets a tab against a 20-per-IP cap still breaks at seven tabs.** The app was still refusing itself, just less often.

One socket a tab makes the same cap mean twenty tabs.

## Grow-only, which is the whole trick

The URL carries the **union** of its subscribers' topics, and that union **never shrinks**. Shrinking on unmount would reopen the connection on every navigation — a reconnect storm against a cap on *concurrent* connections, which is exactly the failure this exists to avoid.

Growth is bounded by the topic vocabulary (three values), so a tab reopens at most twice and then holds one stable connection. A consumer whose topic is already carried joins the live socket untouched — the common case, since `registry-ticker` and `live-block-rail` both want `blocks`.

## The new obligation

The URL now says more than any one consumer asked for, so **the topic filter moves to the subscriber**: a `blocks` consumer drops `account_events` frames itself. Same rule the server applies (`chainFirehoseMatchesTopics` → `topics.has(payload.table)`), and `markActivity` follows it too, so one consumer's traffic cannot refresh another's LIVE chip.

A superset subscription is safe *precisely because* the filter moved: receiving a frame you did not ask for costs a `Set.has` and a discard, while missing one you did ask for would be data loss.

## Verified, not assumed

Deleting the topic filter fails the two tests that exist for it:

```
FAIL  each subscriber receives only ITS OWN topics
FAIL  a frame for no subscribed topic is dropped by everyone
```

Without that check a green run would be consistent with the pool delivering everything to everyone.

513 UI tests green. **Hooks-only — no visual change.**

## What to watch

Refusals should go to approximately zero once this deploys and tabs reload. If they don't, the remaining cause is not fan-out and the cap itself needs revisiting — but that is now a measurement rather than a guess.

Refs #10606
