### PR TITLE
docs(method): publish the attribution rules, and make the schema enforce them

### DIFF
--- a/apps/ui/content/docs/attribution-method.mdx
+++ b/apps/ui/content/docs/attribution-method.mdx
@@ -1,0 +1,82 @@
+---
+title: Attribution method
+description: The rules every owner-capture surface publishes under — what we will say about who controls a wallet, what we will not, and how to check us.
+---
+
+Some of what this API publishes is about **where a subnet's money goes**: how much emission the owner receives, whether an owner-run validator keeps what it earns, whether a treasury allocation matches what a subnet says it takes.
+
+Those are the most useful figures here and the easiest to get wrong in a way that harms someone. A wrong revenue number is an error. **"This team is quietly taking 60%" is not retractable once an agent has quoted it.**
+
+This page is the standard we hold ourselves to. It is published rather than internal so you can check us against it, and so a subnet operator who thinks we have it wrong knows exactly which rule to point at.
+
+## 1. A take rate does not tell you what an operator keeps
+
+What a validator operator actually retains is:
+
+```
+kept = take × dividends + (1 − take) × dividends × (operator_stake ÷ total_stake_on_hotkey)
+```
+
+A validator with an 18% take and no self-stake keeps **18%**. The same validator, fully self-staked, keeps **100%**. The take is published on chain and tells you almost nothing on its own — the self-stake fraction is the decisive term.
+
+So we do not report "the owner takes X%" from a take rate. Take-rate-only analysis is worse than none, because it looks rigorous.
+
+## 2. A large nominator is not evidence of anything
+
+Concentrated delegation behind an owner-run validator has at least four innocent explanations before "hidden team wallet":
+
+- a **custodial exchange** staking on behalf of many users
+- a **delegation service**
+- a single **unaffiliated whale**
+- a **DAO or treasury** with no relationship to the subnet
+
+Every one produces the identical on-chain shape. The default verdict for an unlabelled coldkey is `unresolved` — never `owner`.
+
+## 3. Affiliation needs linkable evidence, not correlation
+
+A coldkey moves above `unresolved` only on evidence you can check:
+
+| Evidence         | What it is                                                                                           |
+| ---------------- | ---------------------------------------------------------------------------------------------------- |
+| `funding-path`   | a transfer from the owner coldkey, cited to the extrinsic                                            |
+| `chain-identity` | an on-chain identity naming the team                                                                 |
+| `self-declared`  | the subnet's own docs, repo or site — pinned to a commit SHA, because a branch moves under the claim |
+| `key-rotation`   | a coldkey swap or hotkey rotation linking the two                                                    |
+| `known-entity`   | a labelled third party, which supports `third-party` rather than `affiliated`                        |
+
+Timing correlation, similar stake sizes and "registered in the same block" are **reviewer hints, not publishable evidence**. They are exactly the reasoning that turns a coincidence into an allegation.
+
+This is enforced in the schema, not by convention: a verdict above `unresolved` **cannot be serialised without an evidence entry**, and an evidence entry without a `source_url` or an `extrinsic_hash` is refused. `owner` is the one exemption, because it comes from `SubtensorModule.SubnetOwner` and the chain read is itself the citation.
+
+## 4. Disclosed is not dishonest
+
+A treasury allocation written into a subnet's own public repository is a **disclosed business model**, not a deception. Publishing it as a scandal would be a misrepresentation in the other direction.
+
+The signal worth serving is **divergence between what a subnet declares and what the chain shows** — and the honest headline for most subnets is _"declared take matches observed take."_ If a surface cannot produce that boring answer, it is not a measurement.
+
+## 5. Right of reply
+
+`operator-attested` is already a first-class provenance class here: displayed, and never summed into a headline. Subnet teams get the same deal on wallets. Declare your affiliated coldkeys and your treasury policy and we publish the declaration beside the measurement, showing where the two agree.
+
+A team that declares gets a cleaner card. A team that stays silent gets `unresolved` — **a neutral fact, not an allegation.**
+
+## 6. We publish the mechanism, never the motive
+
+| We do not say                              | We say                                                                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| "The owner secretly takes 60% of emission" | "60% of emission is attributed to UIDs held by the owner coldkey and one unresolved coldkey" |
+| "This subnet is a scam"                    | "98% of registered miner UIDs recorded zero emission over the last 31 days"                  |
+| "The team dumped tokens"                   | "44,186 TAO unstaked and 88,284 staked by the owner coldkey over 30 days; net accumulating"  |
+| "Hidden 10% tax on miners"                 | "A 10% treasury allocation is present in the subnet's published source at &lt;permalink&gt;" |
+
+Each pair is the same underlying number. The right-hand column is defensible, sourceable, and more useful to someone deciding where to put capital.
+
+## Two things these surfaces cannot see
+
+**Root delegation.** Root (netuid 0) stake is TAO-denominated with a `tao_weight` of 0.18, and root stakers earn dividends in alpha. It is a capture path that is **invisible on a subnet's own metagraph** — a subnet-scoped measurement cannot see it, and says so rather than implying its absence.
+
+**Per-subnet take.** `take` is stored globally per hotkey, not per subnet, so a validator operating on six subnets reports the same take on all six. A `null` take means no `Delegates` entry — **not 0%**. Childkey takes dilute it further, are read live, and have no history at all.
+
+## If you think we have this wrong
+
+Open an issue naming the rule and the row. A claim that cannot survive that conversation should not have been published, and we would rather correct it than defend it.

--- a/apps/ui/content/docs/economics.mdx
+++ b/apps/ui/content/docs/economics.mdx
@@ -64,4 +64,10 @@ data = requests.get(
 
 Both routes are cached 60s. `/economics` prefers a live KV snapshot (falling back to the last published R2 artifact, so it never 404s); `/economics/trends` is edge-cached and busts on the same publish stamp as the sibling history/trajectory routes.
 
+## Who receives it
+
+These routes say how much emission a subnet gets. They do not say who inside it received the money — that is the recipient split, and the surfaces built on it touch a question the chain does not answer on its own: whether a wallet belongs to the subnet's team.
+
+[Attribution method](/docs/attribution-method) is the standard those surfaces publish under — what we will say about wallet control, what we will not, and how to check us. Read it before quoting an owner-capture figure.
+
 <ApiSourceFooter paths={["/api/v1/economics", "/api/v1/economics/trends"]} />

--- a/schemas-src/attribution.ts
+++ b/schemas-src/attribution.ts
@@ -1,0 +1,132 @@
+// #10924: how a surface is allowed to talk about who controls a wallet.
+//
+// Every owner-capture surface in the #10923 epic reads the same on-chain facts
+// and then faces the same question: does this coldkey belong to the subnet's
+// team? The chain does not answer it. A large nominator behind an owner-run
+// validator has at least four innocent explanations before "hidden team
+// wallet" -- a custodial exchange staking for many users, a delegation service,
+// an unaffiliated whale, a DAO treasury -- and every one of them produces the
+// IDENTICAL on-chain shape.
+//
+// So the vocabulary here is not decoration. `unresolved` is the default and the
+// honest answer for most coldkeys, and a verdict above it is only expressible
+// with an `evidence` object attached. That pairing is the whole point: a
+// publishable claim is one a reader can follow to a page or an extrinsic.
+//
+// Getting this wrong is not a bug, it is a defamation exposure -- a wrong
+// revenue figure is an error, "this team is quietly taking 60%" is not
+// retractable once an agent has quoted it. See the published method statement
+// at apps/ui/content/docs/attribution-method.mdx, which states the six rules
+// this file enforces the shape of.
+import { z } from "zod";
+
+/**
+ * How confident we are that a coldkey belongs to a subnet's operator.
+ *
+ * ORDERED WEAKEST FIRST, and `unresolved` is index 0 deliberately: it is the
+ * default, not a failure state. A surface that cannot produce `unresolved` for
+ * most rows is not measuring, it is guessing.
+ *
+ * - `unresolved` -- nobody has established a relationship either way. NOT an
+ *   accusation, and never to be rendered as a negative.
+ * - `third-party` -- positively established as NOT the operator's: a known
+ *   exchange, a delegation service, a labelled institution.
+ * - `affiliated` -- linked to the operator by evidence, without being the
+ *   declared owner key itself (a funding path, a shared identity, a
+ *   self-declaration).
+ * - `owner` -- the subnet's declared `owner_coldkey` from chain storage. The
+ *   only verdict that needs no evidence object, because the chain IS the
+ *   evidence.
+ */
+export const ATTRIBUTION_VERDICT_VALUES = [
+  "unresolved",
+  "third-party",
+  "affiliated",
+  "owner",
+] as const;
+export const AttributionVerdictSchema = z.enum(ATTRIBUTION_VERDICT_VALUES);
+export type AttributionVerdict = (typeof ATTRIBUTION_VERDICT_VALUES)[number];
+
+/** The default. Stated as a constant so a surface cannot drift into a
+ * different one, and so the choice is greppable. */
+export const DEFAULT_ATTRIBUTION_VERDICT: AttributionVerdict = "unresolved";
+
+/**
+ * What kind of thing establishes a link.
+ *
+ * DELIBERATELY NARROW. Timing correlation, similar stake sizes and
+ * "registered in the same block" are absent because they are reviewer hints,
+ * not publishable evidence -- they are exactly the reasoning that turns a
+ * coincidence into an allegation.
+ *
+ * - `funding-path` -- a transfer from the owner coldkey, cited to the
+ *   extrinsic that carried it.
+ * - `chain-identity` -- an on-chain identity naming the team.
+ * - `self-declared` -- the subnet's own docs, repo or site says so. The
+ *   registry already stores these with a `source_url`.
+ * - `key-rotation` -- a coldkey swap or hotkey rotation linking the two.
+ * - `known-entity` -- a labelled third party (an exchange, a delegation
+ *   service). Supports `third-party`, not `affiliated`.
+ */
+export const ATTRIBUTION_EVIDENCE_KINDS = [
+  "funding-path",
+  "chain-identity",
+  "self-declared",
+  "key-rotation",
+  "known-entity",
+] as const;
+export const AttributionEvidenceKindSchema = z.enum(ATTRIBUTION_EVIDENCE_KINDS);
+
+/**
+ * One checkable reason for a verdict.
+ *
+ * `source_url` OR `extrinsic_hash` -- one of the two is required, because an
+ * evidence object a reader cannot follow is not evidence. Enforced by the
+ * refinement rather than by prose, so a surface cannot construct a claim
+ * without a citation.
+ */
+export const AttributionEvidenceSchema = z
+  .object({
+    kind: AttributionEvidenceKindSchema,
+    source_url: z.string().nullable().optional().meta({
+      description:
+        "A public page a reader can open — the subnet's own docs, repo or site. Pin a repo citation to a commit SHA; a branch moves under the claim.",
+    }),
+    extrinsic_hash: z.string().nullable().optional().meta({
+      description:
+        "The extrinsic that carried the funding path or key rotation, so the link can be re-derived from chain rather than trusted.",
+    }),
+    observed_at: z.string().meta({
+      description:
+        "When this was established. Evidence goes stale: a wallet relationship true last quarter may not be true today, and a citation without a date cannot be aged out.",
+    }),
+  })
+  .strict()
+  .refine(
+    (e) => Boolean(e.source_url) || Boolean(e.extrinsic_hash),
+    "evidence needs a source_url or an extrinsic_hash — a claim a reader cannot check is not publishable",
+  );
+
+/**
+ * A coldkey, its verdict, and why.
+ *
+ * THE REFINEMENT IS THE RULE. Anything above `unresolved` other than `owner`
+ * must carry evidence; `owner` is exempt because it comes from
+ * `SubtensorModule.SubnetOwner` and the chain read is itself the citation.
+ * Written as a schema constraint rather than a convention so a surface that
+ * forgets cannot serialise at all.
+ */
+export const AttributedColdkeySchema = z
+  .object({
+    coldkey: z.string(),
+    verdict: AttributionVerdictSchema.default(DEFAULT_ATTRIBUTION_VERDICT),
+    evidence: z.array(AttributionEvidenceSchema).default([]),
+  })
+  .strict()
+  .refine(
+    (row) =>
+      row.verdict === "unresolved" ||
+      row.verdict === "owner" ||
+      row.evidence.length > 0,
+    "a verdict above `unresolved` needs at least one evidence entry — see the attribution method statement",
+  );

--- a/tests/attribution.test.ts
+++ b/tests/attribution.test.ts
@@ -1,0 +1,147 @@
+// #10924: the attribution rules, enforced by the schema rather than by prose.
+//
+// The published statement (apps/ui/content/docs/attribution-method.mdx) says a
+// verdict above `unresolved` needs checkable evidence. A rule that lives only
+// in a docs page is a rule a surface can forget; these tests pin the refusals
+// so forgetting is a parse failure.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ATTRIBUTION_EVIDENCE_KINDS,
+  ATTRIBUTION_VERDICT_VALUES,
+  AttributedColdkeySchema,
+  AttributionEvidenceSchema,
+  DEFAULT_ATTRIBUTION_VERDICT,
+} from "../schemas-src/attribution.ts";
+
+const observed_at = "2026-08-12T00:00:00.000Z";
+const fundingPath = {
+  kind: "funding-path",
+  extrinsic_hash: "0xdead",
+  observed_at,
+};
+
+describe("unresolved is the default, not a failure state", () => {
+  test("a bare coldkey is unresolved", () => {
+    const parsed = AttributedColdkeySchema.parse({ coldkey: "5abc" });
+    assert.equal(parsed.verdict, "unresolved");
+    assert.deepEqual(parsed.evidence, []);
+  });
+
+  test("the default is the first value, so it reads as the weakest claim", () => {
+    assert.equal(ATTRIBUTION_VERDICT_VALUES[0], DEFAULT_ATTRIBUTION_VERDICT);
+    assert.equal(DEFAULT_ATTRIBUTION_VERDICT, "unresolved");
+  });
+
+  test("unresolved needs no evidence, because it claims nothing", () => {
+    assert.equal(
+      AttributedColdkeySchema.safeParse({
+        coldkey: "5a",
+        verdict: "unresolved",
+      }).success,
+      true,
+    );
+  });
+});
+
+describe("a claim above unresolved cannot be made without evidence", () => {
+  for (const verdict of ["affiliated", "third-party"] as const) {
+    test(`${verdict} with no evidence is REFUSED`, () => {
+      // The rule the whole page exists for: an inferred affiliation published
+      // as fact is a defamation exposure, not a bug.
+      const parsed = AttributedColdkeySchema.safeParse({
+        coldkey: "5a",
+        verdict,
+      });
+      assert.equal(parsed.success, false);
+    });
+
+    test(`${verdict} with a citable funding path is accepted`, () => {
+      assert.equal(
+        AttributedColdkeySchema.safeParse({
+          coldkey: "5a",
+          verdict,
+          evidence: [fundingPath],
+        }).success,
+        true,
+      );
+    });
+  }
+
+  test("owner is the ONE exemption -- the chain read is the citation", () => {
+    // `SubtensorModule.SubnetOwner` is itself the evidence, so requiring a
+    // second citation would make the only fully-measured verdict the hardest
+    // one to publish.
+    assert.equal(
+      AttributedColdkeySchema.safeParse({ coldkey: "5a", verdict: "owner" })
+        .success,
+      true,
+    );
+  });
+});
+
+describe("evidence a reader cannot follow is not evidence", () => {
+  test("neither a source_url nor an extrinsic_hash is REFUSED", () => {
+    assert.equal(
+      AttributionEvidenceSchema.safeParse({
+        kind: "self-declared",
+        observed_at,
+      }).success,
+      false,
+    );
+  });
+
+  test("either one alone is enough", () => {
+    for (const citation of [
+      { source_url: "https://github.com/x/y/blob/abc123/weights.py" },
+      { extrinsic_hash: "0xdead" },
+    ]) {
+      assert.equal(
+        AttributionEvidenceSchema.safeParse({
+          kind: "self-declared",
+          observed_at,
+          ...citation,
+        }).success,
+        true,
+      );
+    }
+  });
+
+  test("observed_at is required, so a citation can be aged out", () => {
+    // A wallet relationship true last quarter may not be true today.
+    assert.equal(
+      AttributionEvidenceSchema.safeParse({
+        kind: "funding-path",
+        extrinsic_hash: "0xdead",
+      }).success,
+      false,
+    );
+  });
+
+  test("the evidence kinds exclude correlation on purpose", () => {
+    // Timing, similar stake sizes and same-block registration are reviewer
+    // hints. Admitting them as evidence kinds is how a coincidence becomes an
+    // allegation, so they are absent by construction rather than by review.
+    for (const notEvidence of [
+      "timing",
+      "same-block",
+      "stake-size",
+      "cluster",
+    ]) {
+      assert.equal(
+        (ATTRIBUTION_EVIDENCE_KINDS as readonly string[]).includes(notEvidence),
+        false,
+        notEvidence,
+      );
+    }
+    assert.equal(ATTRIBUTION_EVIDENCE_KINDS.length, 5);
+  });
+
+  test("an unknown verdict is refused rather than passed through", () => {
+    assert.equal(
+      AttributedColdkeySchema.safeParse({ coldkey: "5a", verdict: "team" })
+        .success,
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Closes #10924

## Why this lands first

The owner-capture surfaces in #10923 all read the same on-chain facts and then hit the same question the chain does not answer: **does this coldkey belong to the subnet's team?**

A large nominator behind an owner-run validator has four innocent explanations before "hidden team wallet" — a custodial exchange staking for many users, a delegation service, an unaffiliated whale, a DAO treasury — and every one produces the **identical on-chain shape**.

A wrong revenue figure is an error. *"This team is quietly taking 60%"* is not retractable once an agent has quoted it. This gates #10929 and #10933 for that reason.

## The rules are structural, not conventional

A rule that lives only in a docs page is one a surface can forget. `schemas-src/attribution.ts` makes forgetting a parse failure — verified by `tests/attribution.test.ts`:

| Input | Result |
|---|---|
| bare coldkey | defaults to `unresolved` |
| `affiliated` / `third-party` with no evidence | **refused** |
| `affiliated` with a citable funding path | accepted |
| `owner` with no evidence | accepted — `SubtensorModule.SubnetOwner` *is* the citation |
| evidence with neither `source_url` nor `extrinsic_hash` | **refused** |
| evidence with no `observed_at` | **refused** — a citation that cannot be aged out |

The evidence kinds exclude timing, same-block registration and stake-size similarity **by construction**. Those are reviewer hints; admitting them as kinds is how a coincidence becomes an allegation. A test asserts they stay absent.

## The statement is published, not internal

`apps/ui/content/docs/attribution-method.mdx` carries the six rules so a subnet operator who thinks we have it wrong knows which rule to point at, and so the right-of-reply offer is on the record. It includes:

- the formula that makes take-rate-only analysis worthless — `kept = take × div + (1 − take) × div × (operator_stake ÷ total_stake)`, so a fully self-staked validator keeps **100%** at any take rate
- **disclosed is not dishonest**: a treasury cut in a public repo is a business model, and the publishable signal is divergence between declared and observed — if a surface cannot produce *"declared matches observed"*, it is not a measurement
- the do-not-say / do-say table, same number in both columns
- the two blind spots: root delegation is invisible on a subnet's own metagraph, and `take` is stored globally per hotkey where `null` means no `Delegates` entry rather than 0%

Linked from the economics docs, which is where a reader arrives before quoting one of these figures.

## Verification

13 tests, all validators green, tsc/eslint/prettier clean. **No ceiling moved** — the tests import the vocabulary, so `unreferenced-exports` holds at 731.