### PR TITLE
refactor(lib): one implementation per numeric behaviour, and a name for each

### DIFF
--- a/src/account-balance.ts
+++ b/src/account-balance.ts
@@ -11,6 +11,7 @@
 // (wrangler dev) with output identical to node:crypto's blake2b512.
 import { blake2b } from "@noble/hashes/blake2.js";
 import type { FieldSources } from "./field-provenance.ts";
+import { RAO_PER_TAO } from "./lib/rao.ts";
 import {
   type ChainNetworkId,
   networkKvKey,
@@ -60,8 +61,6 @@ const ACCOUNT_INFO_U128_MIN_LENGTH = ACCOUNT_INFO_HEADER_BYTES + 2 * U128_BYTES;
 // header + free/reserved/frozen/flags (u128 each) — a full u128 AccountData.
 const ACCOUNT_INFO_U128_FULL_LENGTH =
   ACCOUNT_INFO_HEADER_BYTES + 4 * U128_BYTES; // 80
-const RAO_PER_TAO = 1_000_000_000n;
-
 function decodeBase58(value: string): Uint8Array | null {
   const bytes = [0];
   for (const char of value) {

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -1,3 +1,4 @@
+import { RAO_PER_TAO_NUMBER } from "./lib/rao.ts";
 // Nominator-side (coldkey) position reconstruction (#5233): "what does this
 // coldkey actually hold, across every hotkey/subnet it delegates to" — the
 // coldkey-scoped counterpart to buildAccountPortfolio's hotkey-scoped view
@@ -76,10 +77,9 @@ function nullableFraction(value: unknown): number | null {
 
 // 1 TAO = 1e9 rao; round tao outputs to that precision (matches the sibling
 // account-tier modules' own round9/roundTao helpers).
-const RAO_PER_TAO = 1e9;
 function roundTao(value: number | null): number | null {
   if (value == null || !Number.isFinite(value)) return null;
-  return Math.round(value * RAO_PER_TAO) / RAO_PER_TAO;
+  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 function round6(value: number | null): number | null {

--- a/src/account-portfolio.ts
+++ b/src/account-portfolio.ts
@@ -9,23 +9,12 @@
 
 import { computeConcentration } from "./concentration.ts";
 import { loadStoreAlphaPricesByNetuid } from "./metagraph-neurons.ts";
+import { numberOrZero, round9 } from "./lib/rao.ts";
 
 // The neurons-tier columns the portfolio reads for one hotkey.
 export const ACCOUNT_PORTFOLIO_READ_COLUMNS =
   "netuid, uid, stake_tao, emission_tao, rank, trust, incentive, " +
   "dividends, validator_permit, active, captured_at";
-
-// 1 TAO = 1e9 rao; round tao + yield outputs to that precision.
-const SCALE = 1e9;
-function round9(value: number): number {
-  return Math.round(value * SCALE) / SCALE;
-}
-
-// Coerce a D1 numeric cell (number, numeric string, or null) to a finite number.
-function toNumber(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
 
 // A nullable 0..1 score cell -> rounded number, or null when absent/non-finite.
 function nullableScore(value: unknown): number | null {
@@ -135,8 +124,8 @@ export function buildAccountPortfolio(
     if (captured && (capturedAt == null || captured.ms > capturedAt.ms)) {
       capturedAt = captured;
     }
-    const stake = toNumber(row?.stake_tao);
-    const emission = toNumber(row?.emission_tao);
+    const stake = numberOrZero(row?.stake_tao);
+    const emission = numberOrZero(row?.emission_tao);
     const isValidator = Number(row?.validator_permit) === 1;
     if (isValidator) validatorCount += 1;
     const rowPrice = priceByNetuid.get(netuid);

--- a/src/account-position-history.ts
+++ b/src/account-position-history.ts
@@ -1,3 +1,4 @@
+import { numberOrZero, round9 } from "./lib/rao.ts";
 // Per-account daily position HISTORY (block-explorer Tier-1, epic #4329/6.1).
 //
 // The refresh-metagraph cron lands the LATEST per-UID snapshot in Postgres's
@@ -51,19 +52,6 @@
 // netuid every row shares) — only `uid` and `coldkey` can legitimately vary
 // day-to-day for one (account, netuid) pair (a hotkey re-registering at a new
 // UID slot, or a coldkey key-rotation), so those travel with each point.
-
-// 1 TAO = 1e9 rao; round tao + yield outputs to that precision (matches
-// account-portfolio.ts's round9 — each module owns its own copy, this
-// codebase's established convention for these small numeric coercions).
-const SCALE = 1e9;
-function round9(value: number): number {
-  return Math.round(value * SCALE) / SCALE;
-}
-
-function toNumber(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
 
 function nullableScore(value: unknown): number | null {
   if (value == null) return null;
@@ -120,8 +108,8 @@ export function formatAccountPosition(
   row: Record<string, unknown> | null | undefined,
 ): AccountPositionEntry | null {
   if (!row || typeof row !== "object") return null;
-  const stake = toNumber(row.stake_tao);
-  const emission = toNumber(row.emission_tao);
+  const stake = numberOrZero(row.stake_tao);
+  const emission = numberOrZero(row.emission_tao);
   const isValidator = Number(row.validator_permit) === 1;
   return {
     uid: toInt(row.uid),

--- a/src/account-stake-flow.ts
+++ b/src/account-stake-flow.ts
@@ -1,3 +1,4 @@
+import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
 // Per-account stake flow: how one account's capital moved in (StakeAdded) vs out
 // (StakeRemoved) over a recent window, broken down per subnet and rolled up into a
 // staking-behavior scorecard. Pure shaping (buildAccountStakeFlow); the Worker /
@@ -35,11 +36,10 @@ const DIRECTIONAL_RATIO = 0.2;
 
 // 1 TAO = 1e9 rao. Round every TAO output to rao precision to shed IEEE-754 noise
 // below the rao floor (the same rounding the per-subnet stake-flow scorecard applies).
-const RAO_PER_TAO = 1e9;
 function roundTao(value: number): number {
   /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
   if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO) / RAO_PER_TAO;
+  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect
@@ -50,12 +50,6 @@ function roundTao(value: number): number {
 function roundConcentration(value: number): number {
   const rounded = Math.round(value * 10000) / 10000;
   return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
-
-// Coerce a SUM()/COUNT() cell (number, numeric string, or null) to a finite number.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank cells
@@ -170,7 +164,7 @@ export function buildAccountStakeFlow(
     };
     // Counts are integer (the schema requires it); truncate defensively so a non-D1
     // caller passing a float cannot emit a fractional event count.
-    const count = Math.max(0, Math.trunc(toNumber(row?.event_count)));
+    const count = Math.max(0, Math.trunc(numberOrZero(row?.event_count)));
     if (kind === STAKE_ADDED_KIND) {
       bucket.staked += tao;
       bucket.stakeEvents += count;

--- a/src/accounts-list.ts
+++ b/src/accounts-list.ts
@@ -29,7 +29,12 @@
 
 import { loadStoreAlphaPricesByNetuid } from "./metagraph-neurons.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
-import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
+import {
+  RAO_PER_TAO_NUMBER,
+  nonNegativeOrZero,
+  raoBigToTao,
+  toRaoBig,
+} from "./lib/rao.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -38,8 +43,6 @@ import {
   ACCOUNTS_LIST_LIMIT_MAX,
 } from "./route-limits.ts";
 export { ACCOUNTS_LIST_LIMIT_DEFAULT, ACCOUNTS_LIST_LIMIT_MAX };
-const RAO_PER_TAO = 1e9;
-
 export const ACCOUNTS_LIST_SORTS = [
   "total_stake",
   "total_emission",
@@ -67,11 +70,6 @@ function toIso(ms: number | null): string | null {
   return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
-function numberOrZero(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-}
-
 function nonNegativeInt(value: unknown): number | null {
   if (value == null) return null;
   if (typeof value === "string" && value.trim() === "") return null;
@@ -80,7 +78,10 @@ function nonNegativeInt(value: unknown): number | null {
 }
 
 function roundTao(value: unknown): number {
-  return Math.round(numberOrZero(value) * RAO_PER_TAO) / RAO_PER_TAO;
+  return (
+    Math.round(nonNegativeOrZero(value) * RAO_PER_TAO_NUMBER) /
+    RAO_PER_TAO_NUMBER
+  );
 }
 
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
@@ -89,7 +90,7 @@ function roundTao(value: unknown): number {
 
 function round(value: number | null, dp = 6): number | null {
   /* v8 ignore next -- defensive: this module's one caller (applyStakeDominance)
-     only ever divides a numberOrZero() result by an already-Number.isFinite-
+     only ever divides a nonNegativeOrZero() result by an already-Number.isFinite-
      and->0-checked denominator, so this branch is provably unreachable today. */
   if (value == null || !Number.isFinite(value)) return null;
   const factor = 10 ** dp;
@@ -196,7 +197,7 @@ function applyStakeDominance(
   return accounts.map((entry) => ({
     ...entry,
     stake_dominance: round(
-      numberOrZero(entry.total_stake_tao) / networkStakeTotal,
+      nonNegativeOrZero(entry.total_stake_tao) / networkStakeTotal,
     ),
   }));
 }
@@ -267,8 +268,8 @@ export function buildAccountsList(
     const uid = nonNegativeInt(row?.uid);
     if (!hotkey || netuid == null || uid == null) continue;
 
-    const stake = numberOrZero(row?.stake_tao);
-    const emission = numberOrZero(row?.emission_tao);
+    const stake = nonNegativeOrZero(row?.stake_tao);
+    const emission = nonNegativeOrZero(row?.emission_tao);
     const isValidator = Number(row?.validator_permit) === 1;
     const capturedAt =
       row?.captured_at == null ? null : Number(row.captured_at);

--- a/src/alpha-volume.ts
+++ b/src/alpha-volume.ts
@@ -1,3 +1,4 @@
+import { numberOrZero } from "./lib/rao.ts";
 // Rolling 24h buy/sell alpha volume for one subnet (#4339/8.1), plus a
 // buy/sell sentiment indicator derived from it (#4339/8.2 — net/gross alpha
 // lean, no new capture or query): how much subnet alpha was bought
@@ -20,13 +21,6 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 // amount_tao, so one query yields both units without a second read.
 export const STAKE_ADDED_KIND = "StakeAdded";
 export const STAKE_REMOVED_KIND = "StakeRemoved";
-
-// Coerce a SUM()/COUNT() cell (number, numeric string, or null) to a finite
-// number, defaulting to 0.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
 
 // A finite amount aggregate cell, or null when absent/blank/non-numeric.
 function nullableAmount(value: unknown): number | null {
@@ -179,7 +173,7 @@ export function buildAlphaVolume(
     const kind = row?.event_kind;
     const alpha = nullableAmount(row?.alpha_volume) ?? 0;
     const tao = nullableAmount(row?.tao_volume) ?? 0;
-    const count = toNumber(row?.event_count);
+    const count = numberOrZero(row?.event_count);
     if (kind === STAKE_ADDED_KIND) {
       buyAlpha += alpha;
       buyTao += tao;

--- a/src/chain-stake-flow.ts
+++ b/src/chain-stake-flow.ts
@@ -9,6 +9,7 @@
 
 import { median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
+import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
 
 // The two account_events kinds that move stake: StakeAdded is capital entering a subnet,
 // StakeRemoved is capital leaving. Both carry a positive amount_tao, so net = staked - unstaked.
@@ -27,18 +28,10 @@ export const DEFAULT_CHAIN_STAKE_FLOW_WINDOW = "7d";
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise below the
 // rao floor; round every TAO output to rao precision (the same rounding the sibling scorecards
 // apply). A non-finite sum can only arise from a malformed direct call — coerce it to 0.
-const RAO_PER_TAO = 1e9;
 function roundTao(value: number): number {
   /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
   if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO) / RAO_PER_TAO;
-}
-
-// Coerce a SUM()/COUNT() cell (number, numeric string, or null) to a finite number,
-// defaulting to 0.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
+  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric.
@@ -200,10 +193,10 @@ export function buildChainStakeFlow(
     };
     if (kind === STAKE_ADDED_KIND) {
       bucket.staked += tao;
-      bucket.stakeEvents += toNumber(row?.event_count);
+      bucket.stakeEvents += numberOrZero(row?.event_count);
     } else {
       bucket.unstaked += tao;
-      bucket.unstakeEvents += toNumber(row?.event_count);
+      bucket.unstakeEvents += numberOrZero(row?.event_count);
     }
     perNetuid.set(netuid, bucket);
     const observed = coerceEpochMs(row?.last_observed);

--- a/src/chain-transfer-pairs.ts
+++ b/src/chain-transfer-pairs.ts
@@ -1,3 +1,4 @@
+import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
 // Network-wide native-TAO transfer-pair analytics: over a recent window, which
 // sender -> receiver corridors dominate Balances.Transfer flow. This is the pair
 // companion to /chain/transfers (top individual senders/receivers) and
@@ -9,16 +10,8 @@ export const DEFAULT_CHAIN_TRANSFER_PAIR_WINDOW = "7d";
 export const CHAIN_TRANSFER_PAIR_LIMIT_DEFAULT = 25;
 export const CHAIN_TRANSFER_PAIR_LIMIT_MAX = 100;
 export const CHAIN_TRANSFER_PAIR_SORTS = ["volume", "count"];
-
-const RAO_PER_TAO = 1e9;
-
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
-}
-
 function toCount(value: unknown): number {
-  return Math.max(0, Math.trunc(toNumber(value)));
+  return Math.max(0, Math.trunc(numberOrZero(value)));
 }
 
 function toBlockNumber(value: unknown): number | null {
@@ -30,8 +23,8 @@ function toBlockNumber(value: unknown): number | null {
 }
 
 function roundTao(value: unknown): number {
-  const n = toNumber(value);
-  return Math.round(n * RAO_PER_TAO) / RAO_PER_TAO;
+  const n = numberOrZero(value);
+  return Math.round(n * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 function toNonNegativeTao(value: unknown): number {

--- a/src/chain-transfers.ts
+++ b/src/chain-transfers.ts
@@ -1,3 +1,4 @@
+import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
 // Network-wide native-TAO transfer analytics: over a recent window, how much TAO moved
 // via Balances.Transfer across the whole chain, who moved the most out (top senders) and
 // in (top receivers), and how concentrated that flow is among the top accounts. Pure
@@ -18,21 +19,14 @@ export const CHAIN_TRANSFER_LIMIT_MAX = 100;
 
 // 1 TAO = 1e9 rao; round every TAO output to that precision to shed IEEE-754 noise from
 // summing many REAL amount_tao values (the same rounding the chain/fees market applies).
-const RAO_PER_TAO = 1e9;
 function roundTao(value: unknown): number {
-  const n = toNumber(value);
-  return Math.round(n * RAO_PER_TAO) / RAO_PER_TAO;
-}
-
-// Coerce a SUM()/COUNT() cell (number, numeric string, or null) to a finite number.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
+  const n = numberOrZero(value);
+  return Math.round(n * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 // A whole non-negative count (D1 COUNT is integer; truncate defensively for direct callers).
 function toCount(value: unknown): number {
-  return Math.max(0, Math.trunc(toNumber(value)));
+  return Math.max(0, Math.trunc(numberOrZero(value)));
 }
 
 // Round a 0..1 concentration ratio to a stable precision WITHOUT letting a

--- a/src/chain-yield.ts
+++ b/src/chain-yield.ts
@@ -9,7 +9,7 @@
 // envelope. Null-safe: an empty snapshot yields a schema-stable zeroed card.
 
 import { median, percentile } from "./lib/stats.ts";
-import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
+import { raoBigToTao, round9, toRaoBig } from "./lib/rao.ts";
 
 // The neurons-tier columns the network yield handler reads. `netuid` lets the
 // artifact report how many subnets the snapshot spans (mirrors
@@ -20,13 +20,6 @@ export const CHAIN_YIELD_READ_COLUMNS =
 
 // The return-rate spread reported alongside the conventional median.
 const YIELD_PERCENTILES = [10, 25, 75, 90];
-
-// 1 TAO = 1e9 rao; round tao + yield outputs to that precision to shed IEEE-754
-// noise below the rao floor while keeping small emission/stake ratios meaningful.
-const SCALE = 1e9;
-function round9(value: unknown): number {
-  return Math.round(Number(value) * SCALE) / SCALE;
-}
 
 // A finite TAO cell, or null when absent/blank/non-numeric. Blank cells coerce via
 // Number("") → 0; skip those rows rather than fabricating zero-stake neurons or

--- a/src/emission-decomposition.ts
+++ b/src/emission-decomposition.ts
@@ -30,10 +30,9 @@ import {
 } from "./emission-pipeline.ts";
 import { blockEmissionForIssuance } from "./block-emission.ts";
 import type { FieldSources } from "./field-provenance.ts";
+import { RAO_PER_TAO } from "./lib/rao.ts";
 
 /** Rao per TAO. */
-const RAO_PER_TAO = 1_000_000_000n;
-
 /**
  * TAO (as a JSON number or an exact decimal string) to exact rao.
  *

--- a/src/emission-split.ts
+++ b/src/emission-split.ts
@@ -42,7 +42,7 @@
 // tier owns the SQL for every neuron_daily-derived series); this module never
 // touches a store, so the same rows always produce the same payload.
 
-import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
+import { raoBigToTao, round9, toRaoBig } from "./lib/rao.ts";
 import { BLOCKS_PER_DAY, OWNER_CUT } from "./revenue-coverage.ts";
 import {
   DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
@@ -66,13 +66,6 @@ type Row = Record<string, unknown>;
  * point covers a whole day. Mirrors YIELD_HISTORY_ROW_CAP, whose read is the
  * same shape over the same table. */
 export const EMISSION_SPLIT_HISTORY_ROW_CAP = 50_000;
-
-// Round every alpha/TAO/ratio output to the rao floor (1e-9) to shed IEEE-754
-// noise below the precision the chain itself carries.
-const SCALE = 1e9;
-function round9(value: number): number {
-  return Math.round(value * SCALE) / SCALE;
-}
 
 // A finite, non-negative numeric cell, or null when absent/blank/non-numeric.
 // Blank cells coerce via Number("") -> 0, and a fabricated zero is a

--- a/src/lib/rao.ts
+++ b/src/lib/rao.ts
@@ -63,3 +63,106 @@ export function toRaoBig(taoValue: unknown): bigint {
 export function raoBigToTao(rao: bigint): number {
   return Number(rao / RAO_PER_TAO) + Number(rao % RAO_PER_TAO) / 1e9;
 }
+
+/**
+ * 1 TAO in rao, as a NUMBER.
+ *
+ * The same constant as `RAO_PER_TAO` above in a different type, because both
+ * are genuinely needed: bigint for exact accumulation, number for the 9-decimal
+ * rounding below and for the many `value / 1e9` conversions that never enter
+ * rao space at all. Fourteen modules declared one or the other privately and
+ * `src/movers.ts` declared BOTH, four lines apart.
+ */
+export const RAO_PER_TAO_NUMBER = 1e9;
+
+/**
+ * Round to 9 decimal places -- rao precision, the finest TAO can express.
+ *
+ * ## THREE FUNCTIONS, NOT ONE, AND THAT IS THE POINT
+ *
+ * Six modules declared `round9`, described in their own comments as matching
+ * each other ("Matches src/chain-yield.ts / src/subnet-yield.ts's own round9
+ * exactly"). They did not match. On the same non-finite input they returned
+ * three different answers:
+ *
+ *   - `NaN` / `Infinity`  chain-yield        (bare `Number()`, unguarded)
+ *   - `0`                 subnet-yield       (via a local `toNumber()`)
+ *   - `null`              metagraph-neurons  (explicit non-finite check)
+ *
+ * That is not hypothetical. Both yield modules compute `round9(emission /
+ * stake)`, so a subnet with zero stake produces `Infinity` on one surface and
+ * `0` on the other, from the same arithmetic.
+ *
+ * Collapsing them onto whichever is most common would hand some call site the
+ * other's behaviour silently, which is the failure this refactor exists to
+ * remove rather than repeat. So each behaviour keeps a name that says what it
+ * does, and each caller keeps the one it had. Choosing BETWEEN them is a
+ * separate decision about what a zero-stake subnet should report, and it wants
+ * its own change and its own issue.
+ */
+export function round9(value: number): number {
+  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
+}
+
+/**
+ * `round9`, but a non-finite input reads as 0 rather than propagating.
+ *
+ * Replaces subnet-yield's `round9(toNumber(value))`. Note that 0 is a CLAIM --
+ * "this yield is zero" -- where the input was actually unusable; preserved
+ * because changing it is a product decision, not a refactor.
+ */
+export function round9OrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? round9(n) : 0;
+}
+
+/**
+ * `round9`, but a non-finite or absent input reads as null.
+ *
+ * Replaces metagraph-neurons' variant. The honest one of the three: it says
+ * "not computable" instead of asserting a number nobody measured.
+ */
+export function round9OrNull(value: unknown): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? round9(n) : null;
+}
+
+/**
+ * A value as a finite number, or 0.
+ *
+ * Nine modules declared this privately and all nine were behaviourally
+ * identical -- the only difference between them was whether the local was
+ * called `n` or `parsed`, which is what a "deliberate byte-for-byte copy"
+ * convention produces when it is actually followed. (`round9` above is what it
+ * produces when it is not.)
+ *
+ * ZERO IS A CLAIM, and callers should know they are making it: this reports an
+ * unusable input as the number zero, which is right for an accumulator and
+ * wrong for anything a reader will interpret as a measurement. `round9OrNull`
+ * exists for the other case.
+ */
+export function numberOrZero(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * A value as a finite NON-NEGATIVE number, or 0.
+ *
+ * A different function from `numberOrZero`, and it was hiding under the same
+ * name: `accounts-list` and `metagraph-neurons` each declared a private
+ * `numberOrZero` that also clamped negatives, while nine other modules
+ * declared a `toNumber` that did not. Collapsing them onto one name turned a
+ * negative stake cell into a real negative on two surfaces that had been
+ * treating it as zero, and both modules' existing suites failed -- which is
+ * how this is a separate export rather than a footnote.
+ *
+ * Use where the quantity CANNOT be negative in the domain (a stake, a balance,
+ * a count) and a negative therefore means the cell is junk. Where a negative is
+ * meaningful (a net flow, a delta), `numberOrZero` is the one that says so.
+ */
+export function nonNegativeOrZero(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -20,7 +20,13 @@ import {
   type FieldProjectionResult,
 } from "./field-projection.ts";
 import type { Neurons } from "../generated/db/types.ts";
-import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
+import {
+  RAO_PER_TAO_NUMBER,
+  nonNegativeOrZero,
+  raoBigToTao,
+  round9OrNull,
+  toRaoBig,
+} from "./lib/rao.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -281,8 +287,6 @@ export const GLOBAL_VALIDATOR_SORTS = [
 ];
 export const DEFAULT_GLOBAL_VALIDATOR_SORT = "subnet_count";
 const GLOBAL_VALIDATOR_SUBNET_LIMIT = 10;
-const RAO_PER_TAO = 1e9;
-
 // Bittensor's network-wide block time is a long-stable EXTERNAL protocol
 // parameter (~12s) that this repo does not measure per-request -- distinct
 // from any live-computed block-time distribution elsewhere in this repo
@@ -312,11 +316,6 @@ function toIso(ms: unknown): string | null {
   return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
-function numberOrZero(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
-}
-
 function nullableNumber(value: unknown): number | null {
   if (value == null) return null;
   // Blank cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
@@ -337,7 +336,10 @@ function nonNegativeInt(value: unknown): number | null {
 }
 
 function roundTao(value: unknown): number {
-  return Math.round(numberOrZero(value) * RAO_PER_TAO) / RAO_PER_TAO;
+  return (
+    Math.round(nonNegativeOrZero(value) * RAO_PER_TAO_NUMBER) /
+    RAO_PER_TAO_NUMBER
+  );
 }
 
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
@@ -348,16 +350,6 @@ function round(value: unknown, dp = 6): number | null {
   if (value == null || !Number.isFinite(value as number)) return null;
   const factor = 10 ** dp;
   return Math.round((value as number) * factor) / factor;
-}
-
-// 1 TAO = 1e9 rao; round yield-shaped outputs to that precision to shed
-// IEEE-754 noise below the rao floor while keeping small ratios meaningful.
-// Matches src/chain-yield.ts / src/subnet-yield.ts's own round9 exactly
-// (apy_estimate is a sibling yield-shaped field, not a trust/take value, so
-// it uses this precision convention rather than round()'s 6dp default).
-function round9(value: unknown): number | null {
-  if (value == null || !Number.isFinite(value as number)) return null;
-  return Math.round(Number(value) * RAO_PER_TAO) / RAO_PER_TAO;
 }
 
 /**
@@ -395,7 +387,7 @@ interface ImmunityWindow {
 // guards preserve the previous null-on-missing contract: Number(null) is
 // 0 (not NaN), so nonNegativeInt(null) / nullableNumber(null) / roundTao(null)
 // would otherwise serialize as 0 instead of null. roundTao itself falls
-// back to numberOrZero(0) for null/non-finite, so the wrapping guards here
+// back to nonNegativeOrZero(0) for null/non-finite, so the wrapping guards here
 // are what keep "missing cell" cells flowing through as null. Mirrors the
 // proven toBlockNumber / toTaoOrNull null-guards in account-events.ts
 // (#2487).
@@ -661,7 +653,7 @@ function priceForNetuid(
 // the numerator and denominator -- never defaulted to an assumed tempo,
 // mirroring this codebase's null-never-fabricated convention (see
 // nominator_count above). stake/emission are already-coerced
-// numberOrZero() results, matching every other call site in this file.
+// nonNegativeOrZero() results, matching every other call site in this file.
 //
 // Each eligible row's emission_tao (a single most-recently-captured
 // per-epoch reading, see NEURON_COLUMNS) is annualized using that row's own
@@ -698,7 +690,7 @@ function finalizeApy(acc: ApyAccumulator): Row {
   const apy =
     raoBigToTao(acc.apyNumeratorRao) / raoBigToTao(acc.apyDenominatorRao);
   return {
-    apy_estimate: round9(apy),
+    apy_estimate: round9OrNull(apy),
     apy_estimate_eligible_subnet_count: acc.apyEligibleCount,
   };
 }
@@ -736,7 +728,7 @@ function realizedReturn(
   if (baselineStakeTao == null) return null;
   const baselineRao = toRaoBig(baselineStakeTao);
   if (baselineRao <= 0n) return null;
-  return round9(
+  return round9OrNull(
     raoBigToTao(currentStakeRao - baselineRao) / raoBigToTao(baselineRao),
   );
 }
@@ -877,7 +869,7 @@ function applyStakeDominance(validators: Row[]): Row[] {
   return validators.map((entry) => ({
     ...entry,
     stake_dominance: round(
-      numberOrZero(entry.total_stake_tao) / networkStakeTotal,
+      nonNegativeOrZero(entry.total_stake_tao) / networkStakeTotal,
     ),
   }));
 }
@@ -959,8 +951,8 @@ export function buildGlobalValidators(
     const uid = nonNegativeInt(row?.uid);
     if (!hotkey || netuid == null || uid == null) continue;
 
-    const stake = numberOrZero(row?.stake_tao);
-    const emission = numberOrZero(row?.emission_tao);
+    const stake = nonNegativeOrZero(row?.stake_tao);
+    const emission = nonNegativeOrZero(row?.emission_tao);
     const trust = nullableNumber(row?.validator_trust);
     const capturedAt = nullableNumber(row?.captured_at);
     const blockNumber = nonNegativeInt(row?.block_number);
@@ -1341,8 +1333,8 @@ export function buildValidatorDetail(
       const rowTake = nullableNumber(row?.take);
       if (rowTake != null) take = rowTake;
     }
-    const stake = numberOrZero(row?.stake_tao);
-    const emission = numberOrZero(row?.emission_tao);
+    const stake = nonNegativeOrZero(row?.stake_tao);
+    const emission = nonNegativeOrZero(row?.emission_tao);
     // TAO-priced accumulation (#9051), mirroring buildGlobalValidators: each
     // membership converts through its own subnet's alpha price; an
     // unpriceable one lands in the residuals. Root prices at exactly 1, so

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -2,7 +2,12 @@
 // published `maximum` and this route's enforcement cannot drift (#9127).
 import { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX } from "./route-limits.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
-import { toRaoBig } from "./lib/rao.ts";
+import {
+  RAO_PER_TAO,
+  RAO_PER_TAO_NUMBER,
+  numberOrZero,
+  toRaoBig,
+} from "./lib/rao.ts";
 export { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX };
 // Cross-subnet momentum ("movers"): rank every subnet by how much its stake, emission,
 // and validator set changed between a window's start and end neuron_daily snapshots.
@@ -31,12 +36,11 @@ export const DEFAULT_MOVERS_SORT = "stake";
 
 // 1 TAO = 1e9 rao. Round every TAO output to rao precision; IEEE-754 noise below the rao
 // floor is artifact (mirrors the rounding the turnover/history scorecards apply).
-const RAO_PER_TAO = 1e9;
 function roundTao(value: unknown): number {
-  return Math.round(toNumber(value) * RAO_PER_TAO) / RAO_PER_TAO;
+  return (
+    Math.round(numberOrZero(value) * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER
+  );
 }
-
-const RAO_PER_TAO_BIG = 1_000_000_000n;
 
 // Exact rao-integer BigInt for one subnet's TAO value, for summation across every subnet
 // (#5290, mirrors toRaoBig/raoBigToTao in chain-yield.ts and stake_sum_rao in
@@ -48,7 +52,7 @@ const RAO_PER_TAO_BIG = 1_000_000_000n;
 // relative error from Number(bigint) is immaterial there, unlike the lossless string totals
 // raoToTaoString produces, which must stay exact.
 function raoToTaoNumber(rao: bigint): number {
-  return Number(rao) / RAO_PER_TAO;
+  return Number(rao) / RAO_PER_TAO_NUMBER;
 }
 
 // Lossless fixed 9-decimal (rao-precision) TAO string -- a JSON number (double) is only
@@ -61,16 +65,9 @@ function raoToTaoNumber(rao: bigint): number {
 function raoToTaoString(rao: bigint): string {
   const negative = rao < 0n;
   const abs = negative ? -rao : rao;
-  const whole = abs / RAO_PER_TAO_BIG;
-  const frac = abs % RAO_PER_TAO_BIG;
+  const whole = abs / RAO_PER_TAO;
+  const frac = abs % RAO_PER_TAO;
   return `${negative ? "-" : ""}${whole}.${frac.toString().padStart(9, "0")}`;
-}
-
-// Coerce a SUM()/COUNT() cell (number, numeric string, or null) to a finite number,
-// defaulting to 0.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 // A finite aggregate cell, or null when absent/blank/non-numeric. Blank cells coerce

--- a/src/neuron-history.ts
+++ b/src/neuron-history.ts
@@ -21,6 +21,7 @@ type Row = Record<string, unknown>;
 export { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_DAYS } from "./route-limits.ts";
 import { HISTORY_WINDOW_DAYS, DEFAULT_HISTORY_WINDOW } from "./route-limits.ts";
 import type { NeuronDaily } from "../generated/db/types.ts";
+import { RAO_PER_TAO } from "./lib/rao.ts";
 // Bounds any single time-series response (1y = 365 daily points < this cap).
 export const MAX_HISTORY_POINTS = 400;
 
@@ -292,9 +293,6 @@ function toFiniteOrNull(v: unknown): number | null {
 function roundTao(v: number): number {
   return Math.round(v * 1e6) / 1e6;
 }
-
-const RAO_PER_TAO = 1_000_000_000n;
-
 // Exact rao-precision decimal string, never a JS number (#2924): a network-
 // wide daily total_stake_tao sum is already well past 2^53-1's exact-double
 // ceiling (~9,007,199 TAO at rao precision) -- confirmed live 2026-07-14 at

--- a/src/stake-flow.ts
+++ b/src/stake-flow.ts
@@ -1,3 +1,4 @@
+import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
 // Net stake flow (capital in vs out) for one subnet over a recent window: how much
 // TAO entered (StakeAdded) vs left (StakeRemoved), summed from the first-party
 // account_events stream. Pure shaping (buildStakeFlow); the Worker / data-api
@@ -39,18 +40,10 @@ export const DEFAULT_STAKE_FLOW_DIRECTION = "all";
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise
 // below the rao floor; round every TAO output to rao precision, the smallest real
 // unit (the same rounding the turnover/account-summary scorecards apply).
-const RAO_PER_TAO = 1e9;
 function roundTao(value: number): number {
   /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
   if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO) / RAO_PER_TAO;
-}
-
-// Coerce a SUM()/COUNT() cell (number, numeric string, or null) to a finite
-// number, defaulting to 0.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
+  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric.
@@ -83,10 +76,10 @@ export function buildStakeFlow(
     if (tao == null) continue;
     if (kind === STAKE_ADDED_KIND) {
       stakedTao += tao;
-      stakeEvents += toNumber(row?.event_count);
+      stakeEvents += numberOrZero(row?.event_count);
     } else if (kind === STAKE_REMOVED_KIND) {
       unstakedTao += tao;
-      unstakeEvents += toNumber(row?.event_count);
+      unstakeEvents += numberOrZero(row?.event_count);
     }
   }
   return {

--- a/src/subnet-ohlc.ts
+++ b/src/subnet-ohlc.ts
@@ -80,11 +80,17 @@ export const MAX_OHLC_WINDOW_DAYS = 365;
 // an unrelated ranking, not a chronological series).
 export const MAX_CANDLES = 2000;
 
-// 1 TAO/alpha = 1e9 rao. Copied verbatim from alpha-volume.ts's/
-// chain-alpha-volume.ts's own roundUnit -- every rao-precision rounding
-// helper in this codebase is a deliberate byte-for-byte copy, not a shared
-// import, so each module stays independently reviewable (see those modules'
-// own header comments for the same note).
+// 1 TAO/alpha = 1e9 rao.
+//
+// The comment that used to sit here said "every rao-precision rounding helper
+// in this codebase is a deliberate byte-for-byte copy, not a shared import, so
+// each module stays independently reviewable". That convention is what let six
+// `round9` copies drift into three different answers for a non-finite input
+// (#10948), and it is no longer true: `src/lib/rao.ts` owns the family. This
+// one is still local because `roundUnit` is named for a UNIT (alpha or TAO,
+// whichever the row is denominated in) rather than for rao, and collapsing it
+// on the strength of a matching body is the mistake this note is about --
+// see #10948 for the remaining named variants.
 const RAO_PER_UNIT = 1e9;
 function roundUnit(value: number): number {
   /* v8 ignore next -- defensive: callers only pass finite accumulator sums */

--- a/src/subnet-yield.ts
+++ b/src/subnet-yield.ts
@@ -8,30 +8,16 @@
 // Null-safe: a cold/empty subnet yields a zeroed, empty-neuron card (never throws).
 
 import { median, percentile } from "./lib/stats.ts";
-import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
+import { raoBigToTao, round9OrZero, toRaoBig } from "./lib/rao.ts";
 
 type Row = Record<string, unknown>;
 type SqlRunner = (sql: string, params: unknown[]) => Promise<Row[]>;
-
-// 1 TAO = 1e9 rao; round every tao + ratio output to that precision to shed IEEE-754
-// noise below the rao floor while keeping small yields (emission/stake) meaningful.
-const SCALE = 1e9;
-function round9(value: unknown): number {
-  const n = toNumber(value);
-  return Math.round(n * SCALE) / SCALE;
-}
 
 // The shared median() returns its raw, unrounded value -- round it to rao precision
 // here, preserving null (an empty yield set) rather than coercing it to 0.
 function roundedMedian(ascending: number[]): number | null {
   const m = median(ascending);
-  return m == null ? null : round9(m);
-}
-
-// Coerce a D1 numeric cell (number, numeric string, or null) to a finite number.
-function toNumber(value: unknown): number {
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : 0;
+  return m == null ? null : round9OrZero(m);
 }
 
 // A finite TAO cell, or null when absent/blank/non-numeric. Blank cells coerce via
@@ -83,7 +69,7 @@ function computeYieldValue(
 ): number | null {
   if (!(stake != null && stake > 0)) return null;
   if (emission == null) return null;
-  return round9(emission / stake);
+  return round9OrZero(emission / stake);
 }
 
 interface YieldNeuron {
@@ -149,8 +135,8 @@ export function buildSubnetYield(
       uid,
       hotkey: row?.hotkey ?? null,
       role: isValidator ? "validator" : "miner",
-      stake_tao: round9(stake),
-      emission_tao: emission != null ? round9(emission) : null,
+      stake_tao: round9OrZero(stake),
+      emission_tao: emission != null ? round9OrZero(emission) : null,
       yield: computeYieldValue(emission, stake),
     });
   }
@@ -169,7 +155,7 @@ export function buildSubnetYield(
   const medianYield = roundedMedian(definedYields);
   const meanYield =
     definedYields.length > 0
-      ? round9(
+      ? round9OrZero(
           definedYields.reduce((sum, y) => sum + y, 0) / definedYields.length,
         )
       : null;
@@ -201,11 +187,12 @@ export function buildSubnetYield(
     neuron_count: neurons.length,
     validator_count: validatorCount,
     miner_count: neurons.length - validatorCount,
-    total_stake_alpha: round9(totalStake),
-    total_emission_alpha: round9(totalEmission),
+    total_stake_alpha: round9OrZero(totalStake),
+    total_emission_alpha: round9OrZero(totalEmission),
     // Subnet-wide return over UIDs with known stake + emission only — blank-emission
     // rows stay in the neuron list but must not dilute the aggregate as if emission were 0.
-    subnet_yield: yieldStake > 0 ? round9(yieldEmission / yieldStake) : null,
+    subnet_yield:
+      yieldStake > 0 ? round9OrZero(yieldEmission / yieldStake) : null,
     mean_yield: meanYield,
     median_yield: medianYield,
     p25_yield: percentile(definedYields, 25),
@@ -299,7 +286,7 @@ function yieldHistoryPoint(date: string, dayRows: Row[]): Row {
   const yieldEmission = raoBigToTao(yieldEmissionRao);
   const meanYield =
     definedYields.length > 0
-      ? round9(
+      ? round9OrZero(
           definedYields.reduce((sum, y) => sum + y, 0) / definedYields.length,
         )
       : null;
@@ -308,7 +295,8 @@ function yieldHistoryPoint(date: string, dayRows: Row[]): Row {
     neuron_count: neuronCount,
     validator_count: validatorCount,
     yield_count: definedYields.length,
-    subnet_yield: yieldStake > 0 ? round9(yieldEmission / yieldStake) : null,
+    subnet_yield:
+      yieldStake > 0 ? round9OrZero(yieldEmission / yieldStake) : null,
     mean_yield: meanYield,
     median_yield: roundedMedian(definedYields),
     p25_yield: percentile(definedYields, 25),

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -1,4 +1,5 @@
 import { clampRowLimit } from "../workers/request-params.ts";
+import { RAO_PER_TAO_NUMBER } from "./lib/rao.ts";
 // Nominator list for one validator hotkey (#4334/7.2): who has staked to this
 // validator (across every subnet it operates in), derived from the same
 // StakeAdded/StakeRemoved account_events flow src/account-stake-flow.ts
@@ -26,12 +27,10 @@ export const NOMINATOR_SORTS = ["net_staked", "gross_staked", "last_activity"];
 export const DEFAULT_NOMINATOR_SORT = "net_staked";
 export const NOMINATOR_LIMIT_DEFAULT = 20;
 export const NOMINATOR_LIMIT_MAX = 100;
-
-const RAO_PER_TAO = 1e9;
 function roundTao(value: number): number {
   /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
   if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO) / RAO_PER_TAO;
+  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
 }
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank D1

--- a/tests/rao.test.ts
+++ b/tests/rao.test.ts
@@ -9,7 +9,17 @@
 // the drift cannot come back.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { RAO_PER_TAO, raoBigToTao, toRaoBig } from "../src/lib/rao.ts";
+import {
+  RAO_PER_TAO,
+  RAO_PER_TAO_NUMBER,
+  nonNegativeOrZero,
+  numberOrZero,
+  raoBigToTao,
+  round9,
+  round9OrNull,
+  round9OrZero,
+  toRaoBig,
+} from "../src/lib/rao.ts";
 
 describe("toRaoBig", () => {
   test("converts TAO to exact rao", () => {
@@ -102,4 +112,89 @@ describe("raoBigToTao", () => {
 test("RAO_PER_TAO is 1e9 as a BigInt", () => {
   assert.equal(RAO_PER_TAO, 1_000_000_000n);
   assert.equal(typeof RAO_PER_TAO, "bigint");
+});
+
+// ── The rounding family (#10948) ────────────────────────────────────────────
+//
+// Six modules declared `round9`, and their own comments said they matched:
+// metagraph-neurons' read "Matches src/chain-yield.ts / src/subnet-yield.ts's
+// own round9 exactly". It did not match either of them, and they did not match
+// each other. On the same non-finite input the three returned three different
+// answers.
+//
+// These pin that the three behaviours are still three, because collapsing them
+// onto whichever was most common is the failure this refactor exists to remove
+// rather than repeat.
+describe("round9 / round9OrZero / round9OrNull", () => {
+  test("all three agree on an ordinary value", () => {
+    assert.equal(round9(1.2345678901), 1.23456789);
+    assert.equal(round9OrZero(1.2345678901), 1.23456789);
+    assert.equal(round9OrNull(1.2345678901), 1.23456789);
+  });
+
+  test("and disagree on a non-finite one, deliberately", () => {
+    // THE DIVERGENCE, stated. Not hypothetical: both yield modules compute
+    // `round9(emission / stake)`, so a subnet with zero stake produces
+    // Infinity on one surface and 0 on the other, from the same arithmetic.
+    assert.equal(Number.isNaN(round9(Number.NaN)), true);
+    assert.equal(round9(Number.POSITIVE_INFINITY), Number.POSITIVE_INFINITY);
+    assert.equal(round9OrZero(Number.NaN), 0);
+    assert.equal(round9OrZero(Number.POSITIVE_INFINITY), 0);
+    assert.equal(round9OrNull(Number.NaN), null);
+    assert.equal(round9OrNull(Number.POSITIVE_INFINITY), null);
+  });
+
+  test("the zero-stake case each yield surface actually hits", () => {
+    // 1 TAO of emission over 0 stake. This is the input that made the two
+    // "identical" implementations answer differently in production.
+    const emission = 1;
+    const stake = 0;
+    assert.equal(round9(emission / stake), Number.POSITIVE_INFINITY);
+    assert.equal(round9OrZero(emission / stake), 0);
+    assert.equal(round9OrNull(emission / stake), null);
+  });
+
+  test("null and undefined are absent, not zero, for the nullable one", () => {
+    assert.equal(round9OrNull(null), null);
+    assert.equal(round9OrNull(undefined), null);
+  });
+
+  test("a non-numeric string is not a number on either coercing variant", () => {
+    assert.equal(round9OrZero("nope"), 0);
+    assert.equal(round9OrNull("nope"), null);
+    // ...but a numeric string is, which is why these take `unknown`: several
+    // callers hand a raw store cell straight in.
+    assert.equal(round9OrZero("1.5"), 1.5);
+    assert.equal(round9OrNull("1.5"), 1.5);
+  });
+
+  test("negatives round toward the same rao grid", () => {
+    assert.equal(round9(-1.2345678904), -1.23456789);
+    assert.equal(round9OrZero(-1.2345678904), -1.23456789);
+    assert.equal(round9OrNull(-1.2345678904), -1.23456789);
+  });
+
+  test("numberOrZero and nonNegativeOrZero are different functions", () => {
+    // They were hiding under ONE name. Nine modules' `toNumber` passed a
+    // negative through; `accounts-list` and `metagraph-neurons` declared a
+    // `numberOrZero` that clamped it. Collapsing them onto one export turned a
+    // negative stake cell into a real negative on two surfaces that had been
+    // reading it as zero, and both suites failed -- which is the only reason
+    // this is two exports instead of a footnote.
+    assert.equal(numberOrZero(-5), -5, "a negative net flow is a real value");
+    assert.equal(nonNegativeOrZero(-5), 0, "a negative stake cell is junk");
+    // They agree everywhere else, which is what made the divergence invisible.
+    for (const v of [0, 1.5, "2.25", null, undefined, "nope", Number.NaN]) {
+      assert.equal(
+        numberOrZero(v),
+        nonNegativeOrZero(v),
+        `disagreed on ${String(v)}`,
+      );
+    }
+  });
+
+  test("the two constants are the same quantity in two types", () => {
+    // src/movers.ts declared BOTH privately, four lines apart.
+    assert.equal(BigInt(RAO_PER_TAO_NUMBER), RAO_PER_TAO);
+  });
 });


### PR DESCRIPTION
#10947 collapsed the `toRaoBig` pair after finding nine "deliberate byte-for-byte copies" were four different implementations. This does the rest of the family it measured — and the same convention had produced the same result again.

## `RAO_PER_TAO` — 14 declarations, two types

`src/movers.ts` declared **both**, four lines apart, while already importing the shared bigint. Now one bigint and one number export.

## `round9` — six copies, three answers

Their own comments said they matched. `metagraph-neurons`' read *"Matches src/chain-yield.ts / src/subnet-yield.ts's own round9 exactly"*. It matched neither, and those two did not match each other:

| input | chain-yield | subnet-yield | metagraph-neurons |
| --- | --- | --- | --- |
| non-finite | `NaN` / `Infinity` | `0` | `null` |

**Not hypothetical.** Both yield modules compute `round9(emission / stake)`, so a subnet with **zero stake** reports `Infinity` on one surface and `0` on the other, from the same arithmetic.

Collapsing them onto whichever was most common would hand a call site the other's behaviour silently — the failure being removed, not repeated. So each behaviour keeps a name that says what it does (`round9`, `round9OrZero`, `round9OrNull`) and every caller keeps the one it had. Choosing *between* them is a product decision about what a zero-stake subnet should report, and wants its own issue.

## `toNumber` — nine copies, all identical

Differing only in whether the local was called `n` or `parsed` — which is what the convention looks like when it *is* followed.

## A fourth variant the tests caught

I collapsed `accounts-list`' and `metagraph-neurons`' `numberOrZero` into the shared one **without comparing the bodies first**. Both also clamp negatives, and both suites failed immediately: a negative stake cell had been reading as zero on those two surfaces and started passing through as a real negative.

`nonNegativeOrZero` is a separate export for that reason, documented as the domain distinction it is — a negative stake is junk, a negative net flow is a measurement. That is precisely the "don't unify two functions that mean different things" the issue warns about, and I walked into it; the existing suites are what stopped it.

## Verification

- **608 tests green across 21 touched suites, with no assertion changes.**
- `grep -rc "^const RAO_PER_TAO" src/*.ts` → **0**
- `grep -rl "^function round9\|^function toNumber" src/*.ts` → **0** (the one hit is `toNumbers`, a Row transformer matched by prefix)

## The false comment is gone

`subnet-ohlc.ts` claimed *"every rao-precision rounding helper in this codebase is a deliberate byte-for-byte copy, not a shared import"*. That is now false and it is the sentence that licensed the drift, so it says what is actually true — including why its own `roundUnit` stays local: it is named for a **unit** (alpha or TAO, whichever the row carries) rather than for rao, and collapsing it on a matching body is the mistake the note is about.

## Not done here

**~20 more rao-precision helpers under other names** (`roundUnit`, `roundTao`, bare inline) that a name-based grep misses entirely — I found them by sweeping bodies rather than names. They are the next batch, per the issue's own instruction to migrate in batches rather than touch 51 files at once.

Refs #10948
