### PR TITLE
refactor(lib): the rao-precision helpers hiding under other names

### DIFF
--- a/src/account-events.ts
+++ b/src/account-events.ts
@@ -10,6 +10,7 @@ import {
 } from "../workers/request-params.ts";
 import { resolvePriceAtTx, type PriceBasis } from "./price-at-tx.ts";
 import { loadAccountHistoryColdTier } from "./account-history-cold-tier.ts";
+import { taoCellOrNull } from "./lib/rao.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
 // published `maximum` and this route's enforcement cannot drift (#9127).
@@ -199,16 +200,9 @@ function toBlockNumber(value: unknown): number | null {
 // in src/chain-analytics.ts (which rounds the SAME signer-total-fee value for
 // /chain/signers + /chain/fees); kept null-preserving here because the activity
 // aggregate is null on a cold store, not 0.
-function toTaoOrNull(value: unknown): number | null {
-  if (value == null) return null;
-  // Blank cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
-}
 
 function toTaoOrZero(value: unknown): number {
-  return toTaoOrNull(value) ?? 0;
+  return taoCellOrNull(value) ?? 0;
 }
 
 function toCount(value: unknown): number {
@@ -260,8 +254,8 @@ export function formatAccountEvent(
     // so a numeric string never leaks the string form into the JSON payload,
     // and SUM float noise is rounded to rao precision. Mirrors the coercion
     // applied in formatRegistration (#2487) and the sibling formatters.
-    amount_tao: toTaoOrNull(row.amount_tao),
-    alpha_amount: toTaoOrNull(row.alpha_amount),
+    amount_tao: taoCellOrNull(row.amount_tao),
+    alpha_amount: taoCellOrNull(row.alpha_amount),
     observed_at: toIso(row.observed_at),
     extrinsic_index: toBlockNumber(row.extrinsic_index),
     // #8369: derived from the two legs already on this row -- no join, no
@@ -303,7 +297,7 @@ export function formatRegistration(
   return {
     netuid: toBlockNumber(row.netuid),
     uid: toBlockNumber(row.uid),
-    stake_tao: toTaoOrNull(row.stake_tao),
+    stake_tao: taoCellOrNull(row.stake_tao),
     validator_permit: toBooleanFlag(row.validator_permit),
     active: toBooleanFlag(row.active),
   };
@@ -354,7 +348,7 @@ export function formatAccountActivity(
     tx_count: txCount,
     last_tx_block: toBlockNumber(a.last_tx_block),
     last_tx_at: toIso(a.last_tx_at),
-    total_fee_tao: toTaoOrNull(a.total_fee_tao),
+    total_fee_tao: taoCellOrNull(a.total_fee_tao),
     modules_called: (modules || [])
       .filter((m) => m && m.call_module)
       .map((m) => ({
@@ -936,7 +930,7 @@ export function buildAccountTransfers(
       event_index: toBlockNumber(r.event_index),
       from: (r.hotkey as string | null | undefined) ?? null,
       to: (r.coldkey as string | null | undefined) ?? null,
-      amount_tao: toTaoOrNull(r.amount_tao),
+      amount_tao: taoCellOrNull(r.amount_tao),
       direction:
         fixedDirection ??
         (r.hotkey === ss58 ? "sent" : r.coldkey === ss58 ? "received" : null),

--- a/src/chain-analytics.ts
+++ b/src/chain-analytics.ts
@@ -1,3 +1,4 @@
+import { nonNegativeOrZero, round9 } from "./lib/rao.ts";
 // Chain analytics builders (#1987, epic #1986): pure row→API shapers for the
 // network-activity aggregates served live from the first-party chain store tiers
 // (blocks / extrinsics / account_events). Kept pure + exported so the Worker does
@@ -22,10 +23,13 @@ function round4(value: number): number {
 // Coerce a D1 fee/tip cell (TAO float, numeric string, or null) to a finite
 // non-negative number rounded to 9 dp (rao precision), so SUM float noise and
 // NULL fees never leak into the payload.
+/**
+ * Composed rather than re-implemented (#10948): `nonNegativeOrZero` is the
+ * `!Number.isFinite(n) || n < 0 -> 0` half and `round9` is the rest, so this
+ * is exactly what it was and there is one fewer body to drift.
+ */
 function toTao(value: unknown): number {
-  const n = Number(value);
-  if (!Number.isFinite(n) || n < 0) return 0;
-  return Math.round(n * 1e9) / 1e9;
+  return round9(nonNegativeOrZero(value));
 }
 
 function toNullableTao(value: unknown): number | null {

--- a/src/chain-holders.ts
+++ b/src/chain-holders.ts
@@ -41,6 +41,7 @@ import {
   CHAIN_HOLDERS_LIMIT_MAX,
 } from "./route-limits.ts";
 import { median } from "./lib/stats.ts";
+import { round9 } from "./lib/rao.ts";
 
 export { CHAIN_HOLDERS_LIMIT_DEFAULT, CHAIN_HOLDERS_LIMIT_MAX };
 
@@ -182,7 +183,7 @@ export function buildChainHolders(
       const entry: Row = {
         netuid,
         holder_count: nonNegativeOrNull(r?.holder_count),
-        total_alpha: total === null ? null : round(total),
+        total_alpha: total === null ? null : round9(total),
         top_holder: typeof r?.top_holder === "string" ? r.top_holder : null,
       };
       for (const n of CHAIN_HOLDERS_RANKS) {
@@ -256,7 +257,7 @@ function networkRollup(subnets: Row[]): Row {
       .length,
     // median() is null-typed for the empty case, which the length guard already
     // excludes -- narrowed rather than asserted so an empty array can never
-    // reach round() and become NaN.
+    // reach round9() and become NaN.
     median_top1_share: medianOrNull(top1),
   };
 }
@@ -273,13 +274,13 @@ function emptyNetwork(): Row {
 /** The median of an ASCENDING array, rounded, or null when there is none. */
 function medianOrNull(ascending: number[]): number | null {
   const value = median(ascending);
-  return value === null ? null : round(value);
+  return value === null ? null : round9(value);
 }
 
 /** A share, or null. A zero denominator yields null, never 0 or Infinity. */
 function share(part: number | null, whole: number | null): number | null {
   if (part === null || whole === null || whole <= 0) return null;
-  return round(part / whole);
+  return round9(part / whole);
 }
 
 function nonNegativeOrNull(value: unknown): number | null {
@@ -314,8 +315,4 @@ function toIsoOrNull(value: number | null): string | null {
   if (value === null || !Number.isFinite(value) || value <= 0) return null;
   const date = new Date(value);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-}
-
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
 }

--- a/src/extrinsics.ts
+++ b/src/extrinsics.ts
@@ -17,6 +17,7 @@ import { decodeEthereumEvmCallArgs } from "./indexer-rs-ethereum-decode.ts";
 import { parseJsonPreservingBigInts } from "./big-int-safe-json.ts";
 import { decodeBTreeSetFields } from "./postgres-collection-normalize.ts";
 import { summarizeCall } from "@jsonbored/chain-summaries";
+import { taoCellOrNull } from "./lib/rao.ts";
 
 type SqlRunner = (
   sql: string,
@@ -69,13 +70,6 @@ function toChainPosition(value: unknown): number | null {
 // would leak the string form into the ["number","null"] contract field and
 // serve unrounded float noise. Mirrors toTaoOrNull in account-events.ts
 // (#2662) and the coercion in formatRegistration (#2487).
-function toTaoOrNull(value: unknown): number | null {
-  if (value == null) return null;
-  // Blank cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? Math.round(n * 1e9) / 1e9 : null;
-}
 
 // ---- Extrinsic API builders ------------------------------------------------
 // The columns the extrinsic handlers SELECT for an extrinsic row.
@@ -190,8 +184,8 @@ export function formatExtrinsic(
     // fee_tao / tip_tao (D1 REAL columns) — coerce through toTaoOrNull so a
     // numeric string never leaks the string form into the ["number","null"]
     // payload, matching formatAccountEvent (#2662) and the sibling formatters.
-    fee_tao: toTaoOrNull(row.fee_tao),
-    tip_tao: toTaoOrNull(row.tip_tao),
+    fee_tao: taoCellOrNull(row.fee_tao),
+    tip_tao: taoCellOrNull(row.tip_tao),
     observed_at: toIso(row.observed_at),
     // #8525: computed from the SAME fully-decoded call_args just built above
     // (post decodePostgresCallArgs/normalizePostgresValue/decodeEthereumEvmCallArgs/

--- a/src/lib/rao.ts
+++ b/src/lib/rao.ts
@@ -166,3 +166,24 @@ export function nonNegativeOrZero(value: unknown): number {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 }
+
+/**
+ * A store cell as rao-rounded TAO, or null when the cell says nothing.
+ *
+ * The difference from `round9OrNull`, and why it is a separate function rather
+ * than an option: `Number("")` is 0, so a BLANK cell would round to a
+ * confident zero. `account-events` and `extrinsics` both carried an identical
+ * private copy that rejects blank and whitespace-only strings first, and their
+ * comment says why -- "Blank cells coerce via Number('') -> 0; trim rejects
+ * '' / whitespace-only".
+ *
+ * Folding that rule into `round9OrNull` would silently change what a blank
+ * cell means on every existing caller of it, which is the move #10948 exists
+ * to stop.
+ */
+export function taoCellOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? round9(n) : null;
+}

--- a/src/neuron-history.ts
+++ b/src/neuron-history.ts
@@ -21,7 +21,7 @@ type Row = Record<string, unknown>;
 export { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_DAYS } from "./route-limits.ts";
 import { HISTORY_WINDOW_DAYS, DEFAULT_HISTORY_WINDOW } from "./route-limits.ts";
 import type { NeuronDaily } from "../generated/db/types.ts";
-import { RAO_PER_TAO } from "./lib/rao.ts";
+import { RAO_PER_TAO, round9 } from "./lib/rao.ts";
 // Bounds any single time-series response (1y = 365 daily points < this cap).
 export const MAX_HISTORY_POINTS = 400;
 
@@ -262,7 +262,7 @@ export function buildEconomicsTrends(
       : null,
     alpha_price_tao_weighted:
       acc.weighted_price_den > 0
-        ? roundPrice(acc.weighted_price_num / acc.weighted_price_den)
+        ? round9(acc.weighted_price_num / acc.weighted_price_den)
         : null,
     alpha_price_tao_median: median(acc.prices),
     validator_count: acc.validator_seen ? acc.validator_sum : null,
@@ -316,9 +316,7 @@ function roundTaoOrNull(v: unknown): number | null {
   const n = toFiniteOrNull(v);
   return n == null ? null : roundTao(n);
 }
-function roundPrice(v: number): number {
-  return Math.round(v * 1e9) / 1e9;
-}
+
 function roundShare(v: number): number {
   return Math.round(v * 1e6) / 1e6;
 }
@@ -329,7 +327,7 @@ function median(values: number[]): number | null {
   const mid = Math.floor(sorted.length / 2);
   const raw =
     sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
-  return roundPrice(raw);
+  return round9(raw);
 }
 
 // Per-subnet metric-over-time: the daily count + a couple of cheap aggregates per

--- a/src/owner-cut-disposition.ts
+++ b/src/owner-cut-disposition.ts
@@ -1,3 +1,4 @@
+import { round9 } from "./lib/rao.ts";
 // #10485: what happened to the owner cut after it accrued.
 //
 // #10484 answers how much was credited. This answers where it went, and it is
@@ -88,10 +89,6 @@ function finite(value: unknown): number | null {
     : null;
 }
 
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
-}
-
 function emptyBuckets(): Record<DispositionBucket, number | null> {
   return {
     "held-as-stake": null,
@@ -139,8 +136,8 @@ export function classifyOwnerCutDisposition(
     return {
       netuid: input.netuid,
       window_days,
-      accrued_alpha: round(accrued),
-      buckets: { ...buckets, unresolved: round(accrued) },
+      accrued_alpha: round9(accrued),
+      buckets: { ...buckets, unresolved: round9(accrued) },
       residual_alpha: 0,
       reconciles: false,
       notes,
@@ -152,9 +149,9 @@ export function classifyOwnerCutDisposition(
   const burned = finite(input.burned_alpha) ?? 0;
   const held = finite(input.held_alpha);
 
-  buckets.unstaked = round(unstaked);
-  buckets["transferred-out"] = round(transferred);
-  buckets.burned = round(burned);
+  buckets.unstaked = round9(unstaked);
+  buckets["transferred-out"] = round9(transferred);
+  buckets.burned = round9(burned);
 
   if (held === null) {
     notes.push(
@@ -166,7 +163,7 @@ export function classifyOwnerCutDisposition(
     // be self-bonded validator capital, and `holders: 1` proves owner control
     // rather than origin (#10481). So the held figure is capped at what
     // actually accrued; the excess belongs to a different question.
-    buckets["held-as-stake"] = round(Math.min(held, accrued));
+    buckets["held-as-stake"] = round9(Math.min(held, accrued));
     if (held > accrued + DISPOSITION_TOLERANCE_ALPHA) {
       notes.push(
         "standing stake exceeds the window's accrual; the excess is not " +
@@ -183,7 +180,7 @@ export function classifyOwnerCutDisposition(
   // flows that include capital this accrual never contained. Reported, never
   // clamped: a clamp would hide the contradiction.
   if (residual > DISPOSITION_TOLERANCE_ALPHA) {
-    buckets.unresolved = round(residual);
+    buckets.unresolved = round9(residual);
     notes.push(
       "the accounted buckets do not cover the accrual; the remainder is " +
         "unresolved rather than assigned",
@@ -202,9 +199,9 @@ export function classifyOwnerCutDisposition(
   return {
     netuid: input.netuid,
     window_days,
-    accrued_alpha: round(accrued),
+    accrued_alpha: round9(accrued),
     buckets,
-    residual_alpha: round(residual),
+    residual_alpha: round9(residual),
     reconciles: Math.abs(residual) <= DISPOSITION_TOLERANCE_ALPHA,
     notes,
   };

--- a/src/revenue-chain-inflow.ts
+++ b/src/revenue-chain-inflow.ts
@@ -23,6 +23,7 @@
 //      own alpha is circular, not external, and adding it to a USD total would
 //      quietly count a subnet paying itself.
 import { protocolSubnetNetuid } from "./subnet-accounts.ts";
+import { round9 } from "./lib/rao.ts";
 
 export interface ChainTransfer {
   to: string;
@@ -141,7 +142,7 @@ export function aggregateChainInflow(input: InflowInput): InflowResult {
 
   return {
     netuid,
-    tao: Math.round(tao * 1e9) / 1e9,
+    tao: round9(tao),
     // A total nobody could price is null, not zero. Partial pricing still
     // reports what it could price, and the caller can see the gap from
     // transfer_count.
@@ -150,7 +151,7 @@ export function aggregateChainInflow(input: InflowInput): InflowResult {
     excluded: [...excluded.entries()].map(([reason, v]) => ({
       reason,
       count: v.count,
-      tao: Math.round(v.tao * 1e9) / 1e9,
+      tao: round9(v.tao),
     })),
     rejected_collectors: rejected,
   };

--- a/src/subnet-burn-history.ts
+++ b/src/subnet-burn-history.ts
@@ -13,6 +13,7 @@
 
 import { loadChainBurn } from "./chain-burn.ts";
 import type { ChainNetworkId } from "./chain-network.ts";
+import { round9 } from "./lib/rao.ts";
 
 type Row = Record<string, unknown>;
 
@@ -214,7 +215,7 @@ export function buildSubnetBurnHistory(
   const changeTao =
     newest === null || oldest === null || points.length < 2
       ? null
-      : round(newest - oldest);
+      : round9(newest - oldest);
   return {
     schema_version: 1,
     netuid,
@@ -230,7 +231,7 @@ export function buildSubnetBurnHistory(
     change_pct:
       changeTao === null || oldest === null || oldest === 0
         ? null
-        : round(changeTao / oldest),
+        : round9(changeTao / oldest),
     points,
   };
 }
@@ -278,8 +279,4 @@ function toIsoOrNull(value: unknown): string | null {
   if (!Number.isFinite(n) || n <= 0) return null;
   const date = new Date(n);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-}
-
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
 }

--- a/src/subnet-holders.ts
+++ b/src/subnet-holders.ts
@@ -1,3 +1,4 @@
+import { round9 } from "./lib/rao.ts";
 // GET /api/v1/subnets/{netuid}/holders (#9557): who owns one subnet's alpha.
 //
 // WHAT NOTHING ELSE ANSWERS. Four routes look like they should and each answers
@@ -268,7 +269,7 @@ export function buildSubnetHolders(
   return {
     ...base,
     holder_count: read.aggregate?.holderCount ?? null,
-    total_alpha: totalAlpha === null ? null : round(totalAlpha),
+    total_alpha: totalAlpha === null ? null : round9(totalAlpha),
     concentration: concentrationBlock(read.aggregate ?? null, totalAlpha),
     captured_at: toIsoOrNull(read.capturedAt),
     positions_captured_at: toIsoOrNull(
@@ -309,7 +310,7 @@ function concentrationBlock(
  */
 function share(part: number | null, whole: number | null): number | null {
   if (part === null || whole === null || whole <= 0) return null;
-  return round(part / whole);
+  return round9(part / whole);
 }
 
 /** Finite and >= 0, else null. A holding cannot be negative: a negative here is
@@ -329,8 +330,4 @@ function toIsoOrNull(value: number | null): string | null {
   if (value === null || !Number.isFinite(value) || value <= 0) return null;
   const date = new Date(value);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-}
-
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
 }

--- a/src/tao-usd-series.ts
+++ b/src/tao-usd-series.ts
@@ -1,3 +1,4 @@
+import { round9 } from "./lib/rao.ts";
 // GET /api/v1/network/tao-usd (#9609): what one TAO is worth in USD, how that
 // figure was derived, and how it has moved.
 //
@@ -215,7 +216,7 @@ export function buildTaoUsdSeries(
   const changeUsd =
     newest === null || oldest === null || priced.length < 2
       ? null
-      : round(newest - oldest);
+      : round9(newest - oldest);
 
   const newestRow = Array.isArray(rows) && rows.length ? rows[0] : null;
   return {
@@ -255,7 +256,7 @@ export function buildTaoUsdSeries(
     change_pct:
       changeUsd === null || oldest === null || oldest === 0
         ? null
-        : round(changeUsd / oldest),
+        : round9(changeUsd / oldest),
     // OMITTED, not emptied, when the caller opts out (#9720). An empty array
     // would be indistinguishable from a window that priced nothing, and the
     // counts above already say how many points exist -- so absence is the only
@@ -327,10 +328,6 @@ function toIsoOrNull(value: unknown): string | null {
   if (!Number.isFinite(n) || n <= 0) return null;
   const date = new Date(n);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-}
-
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
 }
 
 /**

--- a/src/validator-nominator-positions.ts
+++ b/src/validator-nominator-positions.ts
@@ -1,3 +1,4 @@
+import { round9 } from "./lib/rao.ts";
 // The POSITIONS basis for /validators/{hotkey}/nominators (#9617).
 //
 // The default basis is FLOW: src/validator-nominators.ts derives the nominator
@@ -157,7 +158,7 @@ export function buildNominatorPositions(
     }
     if (coldkey === null || netuid === null || alpha === null) continue;
     const list = byColdkey.get(coldkey) ?? [];
-    list.push({ netuid, alpha: round(alpha) });
+    list.push({ netuid, alpha: round9(alpha) });
     byColdkey.set(coldkey, list);
   }
 
@@ -221,8 +222,4 @@ function toIsoOrNull(value: number | null): string | null {
   if (value === null || !Number.isFinite(value) || value <= 0) return null;
   const date = new Date(value);
   return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-}
-
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
 }

--- a/src/wallet-activity.ts
+++ b/src/wallet-activity.ts
@@ -1,3 +1,4 @@
+import { round9 } from "./lib/rao.ts";
 // #10486: what moves through a DECLARED wallet, per window.
 //
 // Aggregation only. Attribution comes from registry/entities/ (#10483) and is
@@ -57,10 +58,6 @@ export interface WalletActivity {
 
 function finite(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function round(value: number): number {
-  return Math.round(value * 1e9) / 1e9;
 }
 
 function legKey(denomination: string, netuid: number | null): string {
@@ -130,9 +127,9 @@ export function aggregateWalletActivity(
       net: 0,
       events: 0,
     };
-    if (row.direction === "in") leg.in = round(leg.in + amount);
-    else leg.out = round(leg.out + amount);
-    leg.net = round(leg.in - leg.out);
+    if (row.direction === "in") leg.in = round9(leg.in + amount);
+    else leg.out = round9(leg.out + amount);
+    leg.net = round9(leg.in - leg.out);
     leg.events += 1;
     legs.set(key, leg);
 

--- a/tests/rao.test.ts
+++ b/tests/rao.test.ts
@@ -18,6 +18,7 @@ import {
   round9,
   round9OrNull,
   round9OrZero,
+  taoCellOrNull,
   toRaoBig,
 } from "../src/lib/rao.ts";
 
@@ -189,6 +190,28 @@ describe("round9 / round9OrZero / round9OrNull", () => {
         numberOrZero(v),
         nonNegativeOrZero(v),
         `disagreed on ${String(v)}`,
+      );
+    }
+  });
+
+  test("taoCellOrNull rejects a blank cell that round9OrNull would zero", () => {
+    // THE REASON IT IS A SEPARATE FUNCTION. `Number("")` is 0, so a blank
+    // store cell rounds to a confident zero — a measurement nobody made.
+    // account-events and extrinsics both carried an identical private copy
+    // guarding this; folding the rule into round9OrNull would have changed
+    // what a blank cell means for every existing caller of that one.
+    assert.equal(round9OrNull(""), 0);
+    assert.equal(taoCellOrNull(""), null);
+    assert.equal(taoCellOrNull("   "), null);
+    assert.equal(taoCellOrNull("\t"), null);
+  });
+
+  test("taoCellOrNull otherwise agrees with round9OrNull", () => {
+    for (const v of [null, undefined, "nope", Number.NaN, 1.5, "2.25", 0, -3]) {
+      assert.equal(
+        taoCellOrNull(v),
+        round9OrNull(v),
+        `diverged on ${String(v)}`,
       );
     }
   });


### PR DESCRIPTION
The first batch (#10963) collapsed what a **name**-based grep could see. This is what a **body**-based sweep found afterwards — the same function under `round`, `roundPrice`, `toTao`, `toTaoOrNull`, and two bare inline copies.

## What collapsed

| shape | modules |
| --- | --- |
| `function round(value: number): number` — byte-identical to `round9` | chain-holders, owner-cut-disposition, subnet-burn-history, subnet-holders, tao-usd-series, validator-nominator-positions, wallet-activity |
| `roundPrice` | neuron-history |
| bare inline `Math.round(x * 1e9) / 1e9` | revenue-chain-inflow (×2) |

`chain-analytics`' `toTao` is **composed** rather than re-implemented — `round9(nonNegativeOrZero(value))` is exactly what its body was, so this is one fewer thing to drift rather than one more export.

## `taoCellOrNull` is new, and separate on purpose

`Number("")` is `0`, so a **blank** store cell rounds to a confident zero — a measurement nobody made. `account-events` and `extrinsics` both carried an identical private copy guarding exactly that, comment and all.

Folding the rule into `round9OrNull` would have changed what a blank cell means for **every existing caller** of that one. Pinned by a test that asserts the two disagree on `""` and agree everywhere else.

## Two near-misses, both caught by checking rather than by tests

**A loose regex matched the wrong function.** My first pass grabbed `toBlockNumber` and `toChainPosition` instead of `toTaoOrNull` — it would have renamed a block-height helper into a TAO one. Caught on the typecheck, reverted, redone against the exact function rather than a pattern.

**The `nullableTao` family looked like `taoCellOrNull` and is not.** Seven modules declare it. It does **not round** — it returns the raw coerced number — and it is itself *two* variants: four accept a negative, three reject it. Collapsing them onto `taoCellOrNull` would have introduced rounding where there was none, on seven surfaces.

That is the same "same name, different contract" trap that produced the `numberOrZero` failure in #10963, and this time I checked the bodies before touching anything. Left for batch 3 with the divergence recorded rather than swept in on an assumption.

## Verification

439 tests green across the 13 touched suites, **no assertion changes**.

Refs #10948
