### PR TITLE
refactor(lib): split nullableTao into the two functions it always was

### DIFF
--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -1,4 +1,4 @@
-import { RAO_PER_TAO_NUMBER } from "./lib/rao.ts";
+import { RAO_PER_TAO_NUMBER, nonNegativeCellOrNull } from "./lib/rao.ts";
 // Nominator-side (coldkey) position reconstruction (#5233): "what does this
 // coldkey actually hold, across every hotkey/subnet it delegates to" — the
 // coldkey-scoped counterpart to buildAccountPortfolio's hotkey-scoped view
@@ -54,12 +54,6 @@ export const NOMINATOR_POSITION_INSERT_COLUMNS = [
 // Blank Postgres cells coerce via Number("") -> 0; skip those rather than
 // joining a phantom zero-stake hotkey (mirrors buildGlobalValidators/
 // numberOrZero's sibling null-safety elsewhere in this codebase).
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
-}
 
 function nonNegativeInt(value: unknown): number | null {
   if (value == null) return null;
@@ -402,7 +396,7 @@ export function stakeByHotkeyNetuid(
   for (const row of Array.isArray(neuronRows) ? neuronRows : []) {
     const hotkey = typeof row?.hotkey === "string" ? row.hotkey : null;
     const netuid = nonNegativeInt(row?.netuid);
-    const stake = nullableTao(row?.stake_tao);
+    const stake = nonNegativeCellOrNull(row?.stake_tao);
     if (!hotkey || netuid == null || stake == null) continue;
     map.set(`${hotkey}|${netuid}`, stake);
   }

--- a/src/account-stake-flow.ts
+++ b/src/account-stake-flow.ts
@@ -1,4 +1,8 @@
-import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
+import {
+  RAO_PER_TAO_NUMBER,
+  finiteCellOrNull,
+  numberOrZero,
+} from "./lib/rao.ts";
 // Per-account stake flow: how one account's capital moved in (StakeAdded) vs out
 // (StakeRemoved) over a recent window, broken down per subnet and rolled up into a
 // staking-behavior scorecard. Pure shaping (buildAccountStakeFlow); the Worker /
@@ -55,12 +59,6 @@ function roundConcentration(value: number): number {
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank cells
 // coerce via Number("") → 0; skip those rows rather than counting phantom zero-TAO
 // stake events (mirrors buildCounterparties #3059).
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
 
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null
 // explicitly so a null netuid is skipped rather than coerced to subnet 0 (Number(null) === 0).
@@ -154,7 +152,7 @@ export function buildAccountStakeFlow(
     if (netuid == null) continue;
     const kind = row?.event_kind;
     if (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND) continue;
-    const tao = nullableTao(row?.total_tao);
+    const tao = finiteCellOrNull(row?.total_tao);
     if (tao == null) continue;
     const bucket = perSubnet.get(netuid) ?? {
       staked: 0,

--- a/src/chain-stake-flow.ts
+++ b/src/chain-stake-flow.ts
@@ -9,7 +9,11 @@
 
 import { median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
-import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
+import {
+  RAO_PER_TAO_NUMBER,
+  finiteCellOrNull,
+  numberOrZero,
+} from "./lib/rao.ts";
 
 // The two account_events kinds that move stake: StakeAdded is capital entering a subnet,
 // StakeRemoved is capital leaving. Both carry a positive amount_tao, so net = staked - unstaked.
@@ -35,12 +39,6 @@ function roundTao(value: number): number {
 }
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric.
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
 
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null AND a
 // blank/whitespace-only string explicitly so neither is silently coerced to subnet 0
@@ -183,7 +181,7 @@ export function buildChainStakeFlow(
     // the pure builder aligned with the "active stake-flow subnets" contract.
     const kind = row?.event_kind;
     if (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND) continue;
-    const tao = nullableTao(row?.total_tao);
+    const tao = finiteCellOrNull(row?.total_tao);
     if (tao == null) continue;
     const bucket = perNetuid.get(netuid) ?? {
       staked: 0,

--- a/src/chain-yield.ts
+++ b/src/chain-yield.ts
@@ -9,7 +9,12 @@
 // envelope. Null-safe: an empty snapshot yields a schema-stable zeroed card.
 
 import { median, percentile } from "./lib/stats.ts";
-import { raoBigToTao, round9, toRaoBig } from "./lib/rao.ts";
+import {
+  nonNegativeCellOrNull,
+  raoBigToTao,
+  round9,
+  toRaoBig,
+} from "./lib/rao.ts";
 
 // The neurons-tier columns the network yield handler reads. `netuid` lets the
 // artifact report how many subnets the snapshot spans (mirrors
@@ -24,12 +29,6 @@ const YIELD_PERCENTILES = [10, 25, 75, 90];
 // A finite TAO cell, or null when absent/blank/non-numeric. Blank cells coerce via
 // Number("") → 0; skip those rows rather than fabricating zero-stake neurons or
 // zero-yield readings (mirrors subnet-yield.ts / metagraph-neurons.ts).
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
-}
 
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
 // for why, and for the overflow guard that lived in only one of the nine copies
@@ -185,11 +184,11 @@ export function buildChainYield(
     // before `netuids`/`neuronCount` too, so subnet_count and neuron_count
     // describe exactly the population the totals were computed over.
     if (netuid === 0) continue;
-    const stake = nullableTao(row?.stake_tao);
+    const stake = nonNegativeCellOrNull(row?.stake_tao);
     if (stake == null) continue;
     if (netuid != null) netuids.add(netuid);
     neuronCount += 1;
-    const emission = nullableTao(row?.emission_tao);
+    const emission = nonNegativeCellOrNull(row?.emission_tao);
     // Match the neuron formatter's SQLite 0/1 convention: only an integer 1 is a
     // validator, so a numeric-string "0" cannot slip through as truthy.
     const isValidator = Number(row?.validator_permit) === 1;

--- a/src/lib/rao.ts
+++ b/src/lib/rao.ts
@@ -187,3 +187,40 @@ export function taoCellOrNull(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? round9(n) : null;
 }
+
+/**
+ * A store cell as a finite number, or null when the cell says nothing.
+ *
+ * NOT `taoCellOrNull`: this does NOT round. Seven modules declared it as
+ * `nullableTao`, and collapsing them onto the rounding one would have
+ * introduced rao-rounding where there was none on seven surfaces (#10948).
+ * Blank-string handling is shared with `taoCellOrNull` for the same reason it
+ * exists there -- `Number("")` is 0, and a blank cell is not a zero.
+ *
+ * The name says `Cell` because the input is a raw store value: several callers
+ * hand a Postgres/D1 column straight in, where a BIGINT often arrives as a
+ * string.
+ */
+export function finiteCellOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * `finiteCellOrNull`, and a negative reads as null too.
+ *
+ * THE OTHER HALF OF ONE NAME. Of the seven `nullableTao` copies, four accepted
+ * a negative and three rejected it -- same name, same file shape, opposite
+ * answer for `-1`. Which is right depends on the column: a stake or a balance
+ * cannot be negative, so a negative there is a junk cell; a net flow or a delta
+ * can be, and nulling it would erase a real measurement.
+ *
+ * Two exports rather than a flag, so a call site says which of those it means
+ * and a reader does not have to resolve a boolean to find out.
+ */
+export function nonNegativeCellOrNull(value: unknown): number | null {
+  const n = finiteCellOrNull(value);
+  return n != null && n >= 0 ? n : null;
+}

--- a/src/stake-flow.ts
+++ b/src/stake-flow.ts
@@ -1,4 +1,8 @@
-import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
+import {
+  RAO_PER_TAO_NUMBER,
+  finiteCellOrNull,
+  numberOrZero,
+} from "./lib/rao.ts";
 // Net stake flow (capital in vs out) for one subnet over a recent window: how much
 // TAO entered (StakeAdded) vs left (StakeRemoved), summed from the first-party
 // account_events stream. Pure shaping (buildStakeFlow); the Worker / data-api
@@ -47,12 +51,6 @@ function roundTao(value: number): number {
 }
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric.
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
 
 // Shape a subnet's StakeAdded/StakeRemoved aggregate into a stake-flow scorecard.
 // `rows` is the GROUP BY event_kind result: at most one row per kind carrying
@@ -72,7 +70,7 @@ export function buildStakeFlow(
   // not just the single-row-per-kind shape GROUP BY event_kind guarantees.
   for (const row of list) {
     const kind = row?.event_kind;
-    const tao = nullableTao(row?.total_tao);
+    const tao = finiteCellOrNull(row?.total_tao);
     if (tao == null) continue;
     if (kind === STAKE_ADDED_KIND) {
       stakedTao += tao;

--- a/src/subnet-yield.ts
+++ b/src/subnet-yield.ts
@@ -8,7 +8,12 @@
 // Null-safe: a cold/empty subnet yields a zeroed, empty-neuron card (never throws).
 
 import { median, percentile } from "./lib/stats.ts";
-import { raoBigToTao, round9OrZero, toRaoBig } from "./lib/rao.ts";
+import {
+  nonNegativeCellOrNull,
+  raoBigToTao,
+  round9OrZero,
+  toRaoBig,
+} from "./lib/rao.ts";
 
 type Row = Record<string, unknown>;
 type SqlRunner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -23,12 +28,6 @@ function roundedMedian(ascending: number[]): number | null {
 // A finite TAO cell, or null when absent/blank/non-numeric. Blank cells coerce via
 // Number("") → 0; skip those rows rather than fabricating zero-stake neurons or
 // zero-yield readings (mirrors nullableNumber in metagraph-neurons.ts).
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
-}
 
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
 // for why, and for the overflow guard that lived in only one of the nine copies
@@ -118,9 +117,9 @@ export function buildSubnetYield(
         blockNumber = Number.isFinite(block) ? block : null;
       }
     }
-    const stake = nullableTao(row?.stake_tao);
+    const stake = nonNegativeCellOrNull(row?.stake_tao);
     if (stake == null) continue;
-    const emission = nullableTao(row?.emission_tao);
+    const emission = nonNegativeCellOrNull(row?.emission_tao);
     // Match the sibling neuron formatter's SQLite 0/1 convention: only an integer 1
     // is a validator, so a numeric-string "0" cannot slip through as truthy.
     const isValidator = Number(row?.validator_permit) === 1;
@@ -269,10 +268,10 @@ function yieldHistoryPoint(date: string, dayRows: Row[]): Row {
   let neuronCount = 0;
   const definedYields: number[] = [];
   for (const row of dayRows) {
-    const stake = nullableTao(row?.stake_tao);
+    const stake = nonNegativeCellOrNull(row?.stake_tao);
     if (stake == null) continue;
     neuronCount += 1;
-    const emission = nullableTao(row?.emission_tao);
+    const emission = nonNegativeCellOrNull(row?.emission_tao);
     if (emission != null) {
       yieldStakeRao += toRaoBig(stake);
       yieldEmissionRao += toRaoBig(emission);

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -1,5 +1,5 @@
 import { clampRowLimit } from "../workers/request-params.ts";
-import { RAO_PER_TAO_NUMBER } from "./lib/rao.ts";
+import { RAO_PER_TAO_NUMBER, finiteCellOrNull } from "./lib/rao.ts";
 // Nominator list for one validator hotkey (#4334/7.2): who has staked to this
 // validator (across every subnet it operates in), derived from the same
 // StakeAdded/StakeRemoved account_events flow src/account-stake-flow.ts
@@ -36,12 +36,6 @@ function roundTao(value: number): number {
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank D1
 // cells coerce via Number("") -> 0; skip those rather than counting a
 // phantom zero-TAO stake event (mirrors buildAccountStakeFlow/#3059).
-function nullableTao(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
 
 function coerceEpochMs(value: unknown): number | null {
   if (value == null) return null;
@@ -233,8 +227,8 @@ export function buildValidatorNominators(
       last_observed_ms: null,
     };
     if (kind == null) {
-      const staked = nullableTao(row?.staked_tao);
-      const unstaked = nullableTao(row?.unstaked_tao);
+      const staked = finiteCellOrNull(row?.staked_tao);
+      const unstaked = finiteCellOrNull(row?.unstaked_tao);
       if (staked == null && unstaked == null) continue;
       bucket.staked_tao += staked ?? 0;
       bucket.unstaked_tao += unstaked ?? 0;
@@ -242,7 +236,7 @@ export function buildValidatorNominators(
       if (kind !== STAKE_ADDED_KIND && kind !== STAKE_REMOVED_KIND) {
         continue;
       }
-      const tao = nullableTao(row?.total_tao);
+      const tao = finiteCellOrNull(row?.total_tao);
       if (tao == null) continue;
       if (kind === STAKE_ADDED_KIND) bucket.staked_tao += tao;
       else bucket.unstaked_tao += tao;

--- a/tests/rao.test.ts
+++ b/tests/rao.test.ts
@@ -17,6 +17,8 @@ import {
   raoBigToTao,
   round9,
   round9OrNull,
+  finiteCellOrNull,
+  nonNegativeCellOrNull,
   round9OrZero,
   taoCellOrNull,
   toRaoBig,
@@ -211,6 +213,41 @@ describe("round9 / round9OrZero / round9OrNull", () => {
       assert.equal(
         taoCellOrNull(v),
         round9OrNull(v),
+        `diverged on ${String(v)}`,
+      );
+    }
+  });
+
+  test("finiteCellOrNull does NOT round, and taoCellOrNull does", () => {
+    // The trap in batch 3: seven modules' `nullableTao` looked like
+    // taoCellOrNull and returns the RAW coerced number. Collapsing them onto
+    // the rounding one would have introduced rao-rounding on seven surfaces
+    // that never had it.
+    const finer = 1.2345678901234;
+    assert.equal(finiteCellOrNull(finer), finer);
+    assert.equal(taoCellOrNull(finer), 1.23456789);
+  });
+
+  test("the two cell variants differ only on a negative", () => {
+    // ONE NAME, TWO CONTRACTS: of seven `nullableTao` copies, four accepted a
+    // negative and three rejected it. Which is right depends on the column --
+    // a stake cannot be negative, a net flow can.
+    assert.equal(finiteCellOrNull(-1), -1);
+    assert.equal(nonNegativeCellOrNull(-1), null);
+    for (const v of [
+      null,
+      undefined,
+      "",
+      "  ",
+      "nope",
+      Number.NaN,
+      0,
+      2.5,
+      "3.5",
+    ]) {
+      assert.equal(
+        finiteCellOrNull(v),
+        nonNegativeCellOrNull(v),
         `diverged on ${String(v)}`,
       );
     }


### PR DESCRIPTION
Batch 2 (#10964) found this family and deliberately left it alone, because it *looked* like `taoCellOrNull` and is not. Two things were true of it, and collapsing on the resemblance would have destroyed both.

## It does not round

`nullableTao` returns the **raw coerced number**. Folding it into `taoCellOrNull` would have introduced rao-rounding on seven surfaces that never had it.

## And it is two contracts under one name

| behaviour on `-1` | modules |
| --- | --- |
| accepts the negative | `account-stake-flow`, `chain-stake-flow`, `stake-flow`, `validator-nominators` |
| rejects it (→ `null`) | `account-nominator-positions`, `chain-yield`, `subnet-yield` |

Same name, same file shape, opposite answer. Which is right depends on the column: a **stake or balance cannot be negative**, so a negative there is a junk cell; a **net flow or delta can be**, and nulling it would erase a real measurement.

So each module keeps the contract it had, under a name that says which — `finiteCellOrNull` and `nonNegativeCellOrNull`. Two exports rather than a boolean flag, so a call site *states* which it means instead of a reader having to resolve an argument to find out.

## How this was partitioned

By reading all seven bodies first, not by pattern.

That check is the through-line of this issue: skipped in #10963, where the existing suites caught the resulting behaviour change; applied in #10964, where it stopped a wrong collapse before it happened; applied again here.

## Verification

176 tests green across the seven migrated suites, **no assertion changes** — plus two new cases pinning that `finiteCellOrNull` does not round and that the two variants differ **only** on a negative.

`grep -rl "function nullableTao" src/*.ts` → **0**

Refs #10948
