### PR TITLE
refactor(lib): the nullableNumber family, which was three contracts

### DIFF
--- a/src/counterparties.ts
+++ b/src/counterparties.ts
@@ -1,4 +1,4 @@
-import { raoBigToTao, toRaoBig } from "./lib/rao.ts"; /**
+import { raoBigToTao, taoCellOrNull, toRaoBig } from "./lib/rao.ts"; /**
  * Rows `buildCounterparties` returns when the caller names no limit.
  *
  * Named so the MCP tool can PUBLISH it (#10101). It was a bare `20` in the
@@ -28,25 +28,9 @@ export const COUNTERPARTIES_LIMIT_MAX = 100;
 export const COUNTERPARTIES_SCAN_CAP = 5000;
 export const COUNTERPARTY_RELATIONSHIP_SCAN_CAP = 5000;
 
-// Round a TAO sum to rao precision so accumulated float error never leaks a long
-// tail into the JSON.
-function round(value: number, dp = 9): number {
-  if (!Number.isFinite(value)) return 0;
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
-
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
 // for why, and for the overflow guard that lived in only one of the nine copies
 // this used to be.
-
-function nullableNumber(value: unknown): number | null {
-  if (value == null) return null;
-  // Blank cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(n) ? round(n) : null;
-}
 
 function nullableInteger(value: unknown): number | null {
   if (value == null) return null;
@@ -134,7 +118,7 @@ export function buildCounterparties(
     if (party == null) continue;
     // Align with buildCounterpartyRelationship: blank/null amount_tao cells must
     // be skipped, not coerced to 0 and counted as a phantom zero-TAO transfer.
-    const amount = nullableNumber(row?.amount_tao);
+    const amount = taoCellOrNull(row?.amount_tao);
     if (amount == null) continue;
     const sentRao = isSender && !isReceiver ? toRaoBig(amount) : 0n;
     const receivedRao = isReceiver && !isSender ? toRaoBig(amount) : 0n;
@@ -249,7 +233,7 @@ export function buildCounterpartyRelationship(
     const received = from === counterparty && to === ss58;
     if (!sent && !received) continue;
 
-    const amount = nullableNumber(row.amount_tao);
+    const amount = taoCellOrNull(row.amount_tao);
     if (amount == null) continue;
     if (sent) totalSentRao += toRaoBig(amount);
     if (received) totalReceivedRao += toRaoBig(amount);

--- a/src/emission-split.ts
+++ b/src/emission-split.ts
@@ -42,7 +42,12 @@
 // tier owns the SQL for every neuron_daily-derived series); this module never
 // touches a store, so the same rows always produce the same payload.
 
-import { raoBigToTao, round9, toRaoBig } from "./lib/rao.ts";
+import {
+  nonNegativeCellOrNull,
+  raoBigToTao,
+  round9,
+  toRaoBig,
+} from "./lib/rao.ts";
 import { BLOCKS_PER_DAY, OWNER_CUT } from "./revenue-coverage.ts";
 import {
   DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
@@ -70,12 +75,6 @@ export const EMISSION_SPLIT_HISTORY_ROW_CAP = 50_000;
 // A finite, non-negative numeric cell, or null when absent/blank/non-numeric.
 // Blank cells coerce via Number("") -> 0, and a fabricated zero is a
 // measurement this module must never invent.
-function nullableNumber(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n >= 0 ? n : null;
-}
 
 /**
  * Postgres and the SQLite double answer booleans differently (`true` vs `1`),
@@ -190,10 +189,10 @@ function emissionSplitPoint(
   for (const row of dayRows) {
     // Carried on every row of the day by the join; take the first non-null
     // rather than assuming row order.
-    alphaOutPerBlock ??= nullableNumber(row?.alpha_out_emission);
-    alphaPriceTao ??= nullableNumber(row?.alpha_price_tao);
+    alphaOutPerBlock ??= nonNegativeCellOrNull(row?.alpha_out_emission);
+    alphaPriceTao ??= nonNegativeCellOrNull(row?.alpha_price_tao);
 
-    const emission = nullableNumber(row?.emission_tao);
+    const emission = nonNegativeCellOrNull(row?.emission_tao);
     // A row with no emission cell is still a registered UID -- it counts toward
     // the population, and toward "earning zero", which is the fact #10931
     // reads off this. Skipping it would shrink the denominator and overstate

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -22,6 +22,7 @@ import {
 import type { Neurons } from "../generated/db/types.ts";
 import {
   RAO_PER_TAO_NUMBER,
+  finiteCellOrNull,
   nonNegativeOrZero,
   raoBigToTao,
   round9OrNull,
@@ -316,14 +317,6 @@ function toIso(ms: unknown): string | null {
   return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
-function nullableNumber(value: unknown): number | null {
-  if (value == null) return null;
-  // Blank cells coerce via Number("") → 0; trim rejects "" / whitespace-only.
-  if (typeof value === "string" && value.trim() === "") return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
 function nonNegativeInt(value: unknown): number | null {
   // Guard null first: Number(null) === 0, so a null column (block_number is a
   // nullable INTEGER) would masquerade as the real chain height / netuid / uid 0
@@ -385,7 +378,7 @@ interface ImmunityWindow {
 // string-typed uid/registered_at_block into real integers, and roundTao
 // rounds stake_tao / emission_tao to rao precision). The explicit null
 // guards preserve the previous null-on-missing contract: Number(null) is
-// 0 (not NaN), so nonNegativeInt(null) / nullableNumber(null) / roundTao(null)
+// 0 (not NaN), so nonNegativeInt(null) / finiteCellOrNull(null) / roundTao(null)
 // would otherwise serialize as 0 instead of null. roundTao itself falls
 // back to nonNegativeOrZero(0) for null/non-finite, so the wrapping guards here
 // are what keep "missing cell" cells flowing through as null. Mirrors the
@@ -462,18 +455,18 @@ export function formatNeuron(
     coldkey: row.coldkey ?? null,
     active: toBooleanFlag(row.active),
     validator_permit: toBooleanFlag(row.validator_permit),
-    rank: row.rank == null ? null : round(nullableNumber(row.rank)),
-    trust: row.trust == null ? null : round(nullableNumber(row.trust)),
+    rank: row.rank == null ? null : round(finiteCellOrNull(row.rank)),
+    trust: row.trust == null ? null : round(finiteCellOrNull(row.trust)),
     validator_trust:
       row.validator_trust == null
         ? null
-        : round(nullableNumber(row.validator_trust)),
+        : round(finiteCellOrNull(row.validator_trust)),
     consensus:
-      row.consensus == null ? null : round(nullableNumber(row.consensus)),
+      row.consensus == null ? null : round(finiteCellOrNull(row.consensus)),
     incentive:
-      row.incentive == null ? null : round(nullableNumber(row.incentive)),
+      row.incentive == null ? null : round(finiteCellOrNull(row.incentive)),
     dividends:
-      row.dividends == null ? null : round(nullableNumber(row.dividends)),
+      row.dividends == null ? null : round(finiteCellOrNull(row.dividends)),
     emission_tao: row.emission_tao == null ? null : roundTao(row.emission_tao),
     stake_tao: row.stake_tao == null ? null : roundTao(row.stake_tao),
     registered_at_block:
@@ -484,7 +477,7 @@ export function formatNeuron(
     axon: row.axon ?? null,
     // Global per-hotkey (SubtensorModule::Delegates), not per (netuid, uid) --
     // null means no Delegates entry at capture time (#2548).
-    take: row.take == null ? null : round(nullableNumber(row.take)),
+    take: row.take == null ? null : round(finiteCellOrNull(row.take)),
   };
   if (featuredHotkeys) {
     neuron.featured = Boolean(hotkey && featuredHotkeys.has(hotkey as string));
@@ -953,8 +946,8 @@ export function buildGlobalValidators(
 
     const stake = nonNegativeOrZero(row?.stake_tao);
     const emission = nonNegativeOrZero(row?.emission_tao);
-    const trust = nullableNumber(row?.validator_trust);
-    const capturedAt = nullableNumber(row?.captured_at);
+    const trust = finiteCellOrNull(row?.validator_trust);
+    const capturedAt = finiteCellOrNull(row?.captured_at);
     const blockNumber = nonNegativeInt(row?.block_number);
     let entry = validatorsByHotkey.get(hotkey);
     if (!entry) {
@@ -982,7 +975,7 @@ export function buildGlobalValidators(
     // Global per-hotkey, identical across every row for this hotkey -- take
     // the first non-null value seen rather than re-deriving/overwriting.
     if (entry.take == null) {
-      const take = nullableNumber(row?.take);
+      const take = finiteCellOrNull(row?.take);
       if (take != null) entry.take = take;
     }
     if (typeof row?.coldkey === "string" && row.coldkey.length > 0) {
@@ -1191,7 +1184,7 @@ export async function loadStoreAlphaPricesByNetuid(
     for (const row of rows) {
       const netuid = nonNegativeInt(row?.netuid);
       if (netuid == null) continue;
-      map.set(netuid, nullableNumber(row?.alpha_price_tao));
+      map.set(netuid, finiteCellOrNull(row?.alpha_price_tao));
     }
     return map;
   } catch {
@@ -1330,7 +1323,7 @@ export function buildValidatorDetail(
     }
     // Global per-hotkey, identical across every row here -- first non-null wins.
     if (take == null) {
-      const rowTake = nullableNumber(row?.take);
+      const rowTake = finiteCellOrNull(row?.take);
       if (rowTake != null) take = rowTake;
     }
     const stake = nonNegativeOrZero(row?.stake_tao);
@@ -1353,14 +1346,14 @@ export function buildValidatorDetail(
         tempoByNetuid,
       );
     }
-    const trust = nullableNumber(row?.validator_trust);
+    const trust = finiteCellOrNull(row?.validator_trust);
     if (trust != null) {
       validatorTrustTotal += trust;
       validatorTrustCount += 1;
       maxValidatorTrust =
         maxValidatorTrust == null ? trust : Math.max(maxValidatorTrust, trust);
     }
-    const capturedAt = nullableNumber(row?.captured_at);
+    const capturedAt = finiteCellOrNull(row?.captured_at);
     const blockNumber = nonNegativeInt(row?.block_number);
     if (
       capturedAt != null &&

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -5,6 +5,7 @@ import { clampRowLimit } from "../workers/request-params.ts";
 import {
   RAO_PER_TAO,
   RAO_PER_TAO_NUMBER,
+  finiteCellOrNull,
   numberOrZero,
   toRaoBig,
 } from "./lib/rao.ts";
@@ -72,12 +73,6 @@ function raoToTaoString(rao: bigint): string {
 
 // A finite aggregate cell, or null when absent/blank/non-numeric. Blank cells coerce
 // via Number("") → 0; trim rejects "" / whitespace-only (mirrors counterparties #3059).
-function nullableNumber(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
 
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null
 // explicitly so a null netuid is skipped rather than coerced to subnet 0
@@ -111,10 +106,10 @@ function indexByNetuid(rows: Row[]): Map<number, BoundaryEntry> {
   for (const row of Array.isArray(rows) ? rows : []) {
     const netuid = normalizedNetuid(row?.netuid);
     if (netuid == null) continue;
-    const neurons = nullableNumber(row?.neuron_count);
-    const validators = nullableNumber(row?.validator_count);
-    const stake = nullableNumber(row?.total_stake_tao);
-    const emission = nullableNumber(row?.total_emission_tao);
+    const neurons = finiteCellOrNull(row?.neuron_count);
+    const validators = finiteCellOrNull(row?.validator_count);
+    const stake = finiteCellOrNull(row?.total_stake_tao);
+    const emission = finiteCellOrNull(row?.total_emission_tao);
     if (
       neurons == null ||
       validators == null ||

--- a/src/subnet-hyperparams.ts
+++ b/src/subnet-hyperparams.ts
@@ -1,3 +1,4 @@
+import { finiteCellOrNull } from "./lib/rao.ts";
 // Subnet hyperparameters (#4303, epic #4301): one row per netuid, latest-only.
 // Field mapping documented in
 // apps/indexer-rs/src/bin/poller/jobs/subnet_hyperparams.rs and
@@ -60,13 +61,6 @@ function toIso(ms: unknown): string | null {
   return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
-function nullableNumber(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
 function nonNegativeInt(value: unknown): number | null {
   if (value == null) return null;
   if (typeof value === "string" && value.trim() === "") return null;
@@ -86,7 +80,7 @@ function round(value: number | null, dp: number): number | null {
 // too) — round again here as defense-in-depth against a future writer that
 // skips that rounding, not because this path expects dirty data.
 function ratio(value: unknown): number | null {
-  return round(nullableNumber(value), 9);
+  return round(finiteCellOrNull(value), 9);
 }
 
 // A flag column as a real boolean, in any store's spelling. The reasoning --
@@ -115,11 +109,11 @@ export function formatSubnetHyperparams(
     // rao/1e9-exact-split TAO values (rao_to_tao_exact) — round to rao
     // precision (9dp), not formatNeuron's 6dp roundTao, so no low-order rao
     // digits are lost re-serializing an already-exact value.
-    min_burn_tao: round(nullableNumber(row.min_burn_tao), 9),
-    max_burn_tao: round(nullableNumber(row.max_burn_tao), 9),
+    min_burn_tao: round(finiteCellOrNull(row.min_burn_tao), 9),
+    max_burn_tao: round(finiteCellOrNull(row.max_burn_tao), 9),
     burn_half_life: nonNegativeInt(row.burn_half_life),
     // Already float-decoded fixed-point on the SDK side — passed through.
-    burn_increase_mult: nullableNumber(row.burn_increase_mult),
+    burn_increase_mult: finiteCellOrNull(row.burn_increase_mult),
     // Raw on-chain integer, deliberately not scaled to a ratio (unconfirmed
     // scaling constant — see migrations/0036_subnet_hyperparams.sql).
     bonds_moving_avg_raw: nonNegativeInt(row.bonds_moving_avg_raw),
@@ -131,7 +125,7 @@ export function formatSubnetHyperparams(
     alpha_high_ratio: ratio(row.alpha_high_ratio),
     alpha_low_ratio: ratio(row.alpha_low_ratio),
     liquid_alpha_enabled: toBooleanFlag(row.liquid_alpha_enabled),
-    alpha_sigmoid_steepness: nullableNumber(row.alpha_sigmoid_steepness),
+    alpha_sigmoid_steepness: finiteCellOrNull(row.alpha_sigmoid_steepness),
     yuma_version: nonNegativeInt(row.yuma_version),
     subnet_is_active: toBooleanFlag(row.subnet_is_active),
     transfers_enabled: toBooleanFlag(row.transfers_enabled),


### PR DESCRIPTION
Five copies, **three** behaviours — the same shape this issue has produced at every step.

| behaviour | modules | now |
| --- | --- | --- |
| rounds to 9dp | `counterparties` | `taoCellOrNull` |
| rejects negatives | `emission-split` | `nonNegativeCellOrNull` |
| plain finite | `movers`, `metagraph-neurons`, `subnet-hyperparams` | `finiteCellOrNull` |

`counterparties`' was the one worth checking rather than pattern-matching: its `round(n)` sits behind an `isFinite` guard, so that local rounder's `!isFinite → 0` arm is **unreachable there** and the function is exactly `taoCellOrNull`. Its parameterised `round(value, dp = 9)` had no other caller once `nullableNumber` left, so it goes too.

The three plain ones differ only in whether the local was called `n` or `parsed`. Again.

## This closes the four families #10948 names

```
RAO_PER_TAO declarations   0
round9 / toNumber          0
nullableTao                0
nullableNumber             0
```

215 tests green across the five touched suites, **no assertion changes**.

## The pattern, across all four batches

Every family that looked like one function was two or three:

| family | copies | distinct contracts |
| --- | --- | --- |
| `round9` | 6 | 3 (`NaN`/`Infinity`, `0`, `null`) |
| `numberOrZero` vs `toNumber` | 11 | 2 (negatives clamped or not) |
| `nullableTao` | 7 | 2 (negatives rejected or not) |
| `nullableNumber` | 5 | 3 (rounds / rejects negatives / plain) |

Not one of them was safe to collapse on the name. Reading the bodies first is the whole method, and the one time I skipped it (#10963) the existing suites are what caught the behaviour change.

Refs #10948
