### PR TITLE
refactor(lib): the last four roundUnit copies, and the one exception that stays

### DIFF
--- a/src/alpha-volume.ts
+++ b/src/alpha-volume.ts
@@ -1,4 +1,4 @@
-import { numberOrZero } from "./lib/rao.ts";
+import { numberOrZero, round9OrZero } from "./lib/rao.ts";
 // Rolling 24h buy/sell alpha volume for one subnet (#4339/8.1), plus a
 // buy/sell sentiment indicator derived from it (#4339/8.2 — net/gross alpha
 // lean, no new capture or query): how much subnet alpha was bought
@@ -28,16 +28,6 @@ function nullableAmount(value: unknown): number | null {
   if (typeof value === "string" && value.trim() === "") return null;
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
-}
-
-// 1 TAO/alpha = 1e9 rao. Summing many REAL amount cells accumulates IEEE-754
-// noise below the rao floor; round every output to rao precision, mirroring
-// stake-flow.ts's roundTao.
-const RAO_PER_UNIT = 1e9;
-function roundUnit(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_UNIT) / RAO_PER_UNIT;
 }
 
 // |net| / gross at or above this share reads as a directional lean rather than
@@ -186,22 +176,22 @@ export function buildAlphaVolume(
   }
   const netAlpha = buyAlpha - sellAlpha;
   const grossAlpha = buyAlpha + sellAlpha;
-  const totalVolumeTao = roundUnit(buyTao + sellTao);
+  const totalVolumeTao = round9OrZero(buyTao + sellTao);
   return {
     schema_version: 1,
     netuid,
     window: "24h",
-    buy_volume_alpha: roundUnit(buyAlpha),
-    sell_volume_alpha: roundUnit(sellAlpha),
-    total_volume_alpha: roundUnit(grossAlpha),
-    buy_volume_tao: roundUnit(buyTao),
-    sell_volume_tao: roundUnit(sellTao),
+    buy_volume_alpha: round9OrZero(buyAlpha),
+    sell_volume_alpha: round9OrZero(sellAlpha),
+    total_volume_alpha: round9OrZero(grossAlpha),
+    buy_volume_tao: round9OrZero(buyTao),
+    sell_volume_tao: round9OrZero(sellTao),
     total_volume_tao: totalVolumeTao,
     buy_count: buyCount,
     sell_count: sellCount,
     // Sentiment indicator (#4339/8.2), purely derived from the alpha totals
     // above — no new capture or query. See sentimentRatio/classifySentiment.
-    net_volume_alpha: roundUnit(netAlpha),
+    net_volume_alpha: round9OrZero(netAlpha),
     sentiment_ratio: sentimentRatio(netAlpha, grossAlpha),
     sentiment: classifySentiment(netAlpha, grossAlpha),
     // Vol/mcap ratio (#4339/8.3) — see volMcapRatio for the externally-loaded

--- a/src/chain-alpha-volume.ts
+++ b/src/chain-alpha-volume.ts
@@ -24,19 +24,10 @@ import {
 } from "./alpha-volume.ts";
 import { median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
+import { round9OrZero } from "./lib/rao.ts";
 
 export const CHAIN_ALPHA_VOLUME_LIMIT_DEFAULT = 20;
 export const CHAIN_ALPHA_VOLUME_LIMIT_MAX = 100;
-
-// 1 TAO/alpha = 1e9 rao. Summing many already-rounded per-subnet totals can still accumulate
-// IEEE-754 noise below the rao floor; round every network-rollup output to rao precision,
-// mirroring alpha-volume.ts's own roundUnit / chain-stake-flow.ts's roundTao.
-const RAO_PER_UNIT = 1e9;
-function roundUnit(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_UNIT) / RAO_PER_UNIT;
-}
 
 // A non-negative integer netuid, or null for a malformed/absent cell. Guard null AND a
 // blank/whitespace-only string explicitly so neither is silently coerced to subnet 0
@@ -84,10 +75,10 @@ function volumeDistribution(values: number[]): VolumeDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: roundUnit(sum / ascending.length),
+    mean: round9OrZero(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    median: roundUnit(median(ascending)!),
+    median: round9OrZero(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
@@ -208,15 +199,15 @@ export function buildChainAlphaVolume(
   const netAlpha = buyAlpha - sellAlpha;
   const grossAlpha = buyAlpha + sellAlpha;
   const network: ChainAlphaVolumeNetwork = {
-    buy_volume_alpha: roundUnit(buyAlpha),
-    sell_volume_alpha: roundUnit(sellAlpha),
-    total_volume_alpha: roundUnit(grossAlpha),
-    buy_volume_tao: roundUnit(buyTao),
-    sell_volume_tao: roundUnit(sellTao),
-    total_volume_tao: roundUnit(buyTao + sellTao),
+    buy_volume_alpha: round9OrZero(buyAlpha),
+    sell_volume_alpha: round9OrZero(sellAlpha),
+    total_volume_alpha: round9OrZero(grossAlpha),
+    buy_volume_tao: round9OrZero(buyTao),
+    sell_volume_tao: round9OrZero(sellTao),
+    total_volume_tao: round9OrZero(buyTao + sellTao),
     buy_count: buyCount,
     sell_count: sellCount,
-    net_volume_alpha: roundUnit(netAlpha),
+    net_volume_alpha: round9OrZero(netAlpha),
     // Network-wide sentiment reading (#4339/8.2 at the network scope), derived from the SAME
     // net/gross alpha totals above via alpha-volume.ts's own sentimentRatio/classifySentiment
     // rather than re-deriving the math a second time.

--- a/src/chain-analytics.ts
+++ b/src/chain-analytics.ts
@@ -32,10 +32,23 @@ function toTao(value: unknown): number {
   return round9(nonNegativeOrZero(value));
 }
 
+/**
+ * DELIBERATELY LOCAL, and the last one (#10948).
+ *
+ * It looks like `nonNegativeCellOrNull` composed with `round9`, and it is not:
+ * that pair treats a BLANK string as null, while this treats it as `Number("")
+ * === 0`, passes the `>= 0` check and returns a rounded 0. Composing would
+ * change what a blank cell means on this surface.
+ *
+ * Left as the one exception rather than adding a sixth shared variant for a
+ * single caller -- the point of the shared module is fewer contracts, not a
+ * function per call site. If a second module ever wants this exact behaviour,
+ * that is the moment it earns a name.
+ */
 function toNullableTao(value: unknown): number | null {
   const n = Number(value);
   if (!Number.isFinite(n) || n < 0) return null;
-  return Math.round(n * 1e9) / 1e9;
+  return round9(n);
 }
 
 // Coerce a block-height cell to a non-negative integer, or null when the value is

--- a/src/price-at-tx.ts
+++ b/src/price-at-tx.ts
@@ -1,3 +1,4 @@
+import { round9 } from "./lib/rao.ts";
 // Price-at-transaction for alpha-denominated stake events (#8369).
 //
 // The question a human actually asks about a stake event is "what was that
@@ -105,20 +106,6 @@ export function resolveUsdAtTx(
   };
 }
 
-// Rao-precision rounding, matching the roundUnit helpers in subnet-ohlc.ts /
-// chain-alpha-volume.ts (each module keeps its own copy by this codebase's
-// convention, so each stays independently reviewable).
-//
-// Unlike those, this one carries no `!Number.isFinite` guard: they round
-// accumulator sums from several call sites, whereas this has exactly one
-// caller which finiteness-checks the quotient immediately before calling —
-// so a guard here would be unreachable by construction rather than
-// defensive, and unreachable code is worse than no code.
-const RAO_PER_UNIT = 1e9;
-function roundUnit(value: number): number {
-  return Math.round(value * RAO_PER_UNIT) / RAO_PER_UNIT;
-}
-
 // The price denominator: zero/negative/non-finite must never reach the
 // division (Infinity/NaN/a nonsensical negative price). Same guard as
 // subnet-ohlc.ts's positiveFinite.
@@ -176,7 +163,7 @@ export function resolvePriceAtTx(
   const price = tao / alpha;
   if (!Number.isFinite(price)) return { price_at_tx: null, price_basis: null };
 
-  return { price_at_tx: roundUnit(price), price_basis: "trade_exact" };
+  return { price_at_tx: round9(price), price_basis: "trade_exact" };
 }
 
 /**

--- a/src/subnet-ohlc.ts
+++ b/src/subnet-ohlc.ts
@@ -38,6 +38,7 @@
 // which had explicitly excluded OHLC candlesticks) to cover this feature.
 
 import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "./alpha-volume.ts";
+import { round9OrZero } from "./lib/rao.ts";
 
 export { STAKE_ADDED_KIND, STAKE_REMOVED_KIND };
 
@@ -79,24 +80,6 @@ export const MAX_OHLC_WINDOW_DAYS = 365;
 // chain-alpha-volume's own cap (which keeps the biggest-volume subnets,
 // an unrelated ranking, not a chronological series).
 export const MAX_CANDLES = 2000;
-
-// 1 TAO/alpha = 1e9 rao.
-//
-// The comment that used to sit here said "every rao-precision rounding helper
-// in this codebase is a deliberate byte-for-byte copy, not a shared import, so
-// each module stays independently reviewable". That convention is what let six
-// `round9` copies drift into three different answers for a non-finite input
-// (#10948), and it is no longer true: `src/lib/rao.ts` owns the family. This
-// one is still local because `roundUnit` is named for a UNIT (alpha or TAO,
-// whichever the row is denominated in) rather than for rao, and collapsing it
-// on the strength of a matching body is the mistake this note is about --
-// see #10948 for the remaining named variants.
-const RAO_PER_UNIT = 1e9;
-function roundUnit(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite accumulator sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_UNIT) / RAO_PER_UNIT;
-}
 
 // A finite, strictly positive number, or null otherwise. Guards alpha_amount:
 // it's the price denominator, so zero/negative/non-finite must never reach a
@@ -189,12 +172,12 @@ export function buildSubnetOhlcFromBuckets(
     return {
       bucket_start: bucketStart,
       bucket_start_iso: new Date(bucketStart).toISOString(),
-      open: roundUnit(b.open),
-      high: roundUnit(b.high),
-      low: roundUnit(b.low),
-      close: roundUnit(b.close),
-      volume_alpha: roundUnit(b.volumeAlpha),
-      volume_tao: roundUnit(b.volumeTao),
+      open: round9OrZero(b.open),
+      high: round9OrZero(b.high),
+      low: round9OrZero(b.low),
+      close: round9OrZero(b.close),
+      volume_alpha: round9OrZero(b.volumeAlpha),
+      volume_tao: round9OrZero(b.volumeTao),
       event_count: b.eventCount,
     };
   });
@@ -222,8 +205,10 @@ export function buildSubnetOhlcFromBuckets(
 // Per bucket, in ascending trade order: open = first trade's price, close =
 // last trade's price, high/low = max/min trade price, volume_alpha/volume_tao
 // = summed alpha_amount/amount_tao, event_count = trade count. Every numeric
-// output is rounded to rao precision (roundUnit) to avoid IEEE-754 dust,
-// mirroring alpha-volume.ts/chain-alpha-volume.ts's own volume rounding.
+// output is rounded to rao precision (round9OrZero) to avoid IEEE-754 dust --
+// the SAME function alpha-volume.ts/chain-alpha-volume.ts use now, rather
+// than the three private `roundUnit` copies that used to mirror each other by
+// hand (#10948).
 //
 // Empty buckets (no trades in that time slot) are a genuine GAP -- they never
 // appear in the output array, never synthesized as a flat candle (standard


### PR DESCRIPTION
`roundUnit` is what a name-based sweep could never find: the same arithmetic as `round9`, named for a **unit**. Four copies, two behaviours.

| guard | modules | now |
| --- | --- | --- |
| `!isFinite → 0` | `alpha-volume`, `chain-alpha-volume`, `subnet-ohlc` | `round9OrZero` |
| none | `price-at-tx` | `round9` |

## I argued the opposite two batches ago, and was wrong

#10964 left `subnet-ohlc`'s copy alone, on the reasoning that it *"is named for a UNIT (alpha or TAO, whichever the row is denominated in) rather than for rao, so collapsing it on the strength of a matching body is the mistake this note is about"*.

That conflated two different things: what the **number** denominates, and what the **function** does. Rounding to nine decimal places is nine decimal places whatever the unit — the denomination never enters the arithmetic. The caution was right in general and wrong here, and the stale note goes with the function.

## The one exception, which stays and now says why

`chain-analytics`' `toNullableTao` looks like `nonNegativeCellOrNull` composed with `round9`, and is not: that pair reads a **blank string as null**, while this reads `Number("") === 0`, passes the `>= 0` check, and returns a rounded `0`. Composing would change what a blank cell means on that surface.

One caller does not earn a sixth shared variant — the point is fewer contracts, not a function per call site — so it is documented as the exception rather than bent into the shape. Its body now calls `round9` instead of re-inlining the arithmetic.

## The sweep is finally zero

```
grep -rn -E "Math\.round\([^)]*\* *(1e9|RAO_PER_UNIT)\) */ *(1e9|RAO_PER_UNIT)" src/*.ts   # 0
```

194 tests green across the five touched suites, **no assertion changes**.

Refs #10948
