### PR TITLE
refactor(schemas): a section list the document already declares

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -18297,7 +18297,7 @@ export interface operations {
     subnetDetailByNetwork: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -39738,7 +39738,7 @@ export interface operations {
     subnetDetail: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -45166,7 +45166,7 @@ export interface operations {
     subnetProfile: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2855,10 +2855,10 @@
       "query_filter_names": [],
       "query_parameters": [
         {
-          "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
           "name": "sections",
           "schema": {
-            "pattern": "^(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes)(?:,(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes))*$",
+            "pattern": "^(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces)(?:,(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces))*$",
             "type": "string"
           }
         }
@@ -3041,10 +3041,10 @@
       "query_filter_names": [],
       "query_parameters": [
         {
-          "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
           "name": "sections",
           "schema": {
-            "pattern": "^(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes)(?:,(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes))*$",
+            "pattern": "^(?:candidate_surfaces|endpoints|gaps|notes|profile|subnet|surfaces)(?:,(?:candidate_surfaces|endpoints|gaps|notes|profile|subnet|surfaces))*$",
             "type": "string"
           }
         }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -65997,12 +65997,12 @@
             }
           },
           {
-            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
             "in": "query",
             "name": "sections",
             "required": false,
             "schema": {
-              "pattern": "^(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes)(?:,(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes))*$",
+              "pattern": "^(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces)(?:,(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces))*$",
               "type": "string"
             }
           }
@@ -90798,12 +90798,12 @@
             }
           },
           {
-            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
             "in": "query",
             "name": "sections",
             "required": false,
             "schema": {
-              "pattern": "^(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes)(?:,(?:subnet|economics|endpoints|surfaces|verified_surfaces|candidate_surfaces|candidates|gaps|notes))*$",
+              "pattern": "^(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces)(?:,(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces))*$",
               "type": "string"
             }
           }
@@ -96283,12 +96283,12 @@
             }
           },
           {
-            "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
             "in": "query",
             "name": "sections",
             "required": false,
             "schema": {
-              "pattern": "^(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes)(?:,(?:subnet|profile|endpoints|surfaces|candidate_surfaces|gaps|notes))*$",
+              "pattern": "^(?:candidate_surfaces|endpoints|gaps|notes|profile|subnet|surfaces)(?:,(?:candidate_surfaces|endpoints|gaps|notes|profile|subnet|surfaces))*$",
               "type": "string"
             }
           }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -18297,7 +18297,7 @@ export interface operations {
     subnetDetailByNetwork: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -39738,7 +39738,7 @@ export interface operations {
     subnetDetail: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: subnet, economics, endpoints, surfaces, verified_surfaces, candidate_surfaces, candidates, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -45166,7 +45166,7 @@ export interface operations {
     subnetProfile: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: subnet, profile, endpoints, surfaces, candidate_surfaces, gaps, notes. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;

--- a/schemas-src/artifact-sections.ts
+++ b/schemas-src/artifact-sections.ts
@@ -1,0 +1,87 @@
+// The selectable sections of a composite document, DERIVED from its schema
+// (#10600 follow-up).
+//
+// WHY THIS IS NOT A QUERY_ENUMS ENTRY. The 19 other vocabularies there are
+// VALUE sets -- what a field may contain (`ok` | `degraded` | `failed`,
+// `active` | `inactive`). Literals are their only possible source, which is
+// exactly why that module is pure literals with zero imports.
+//
+// A section list is different in kind: it names the document's OWN top-level
+// keys, and the artifact schema already declares those. Writing them out again
+// created the only duplication in that file -- the first cut of `sections=`
+// hand-listed 9 names for the detail route and 7 for the profile, of which 6
+// were the same 6 names typed twice. Two lists that must agree with a third
+// thing (the schema) and with each other is three ways to drift.
+//
+// WHY NOT ONE SHARED LIST INSTEAD. Because the two documents genuinely differ:
+// the profile has no `economics`, `candidates` or `verified_surfaces`, and the
+// detail has no `profile`. A single global vocabulary would let a caller ask
+// `/profile?sections=economics` and get a 200 carrying nothing they asked for,
+// with no error to explain it. The per-route subset is a FACT ABOUT THE
+// DOCUMENT, not a policy choice -- so it should be read off the document rather
+// than decided by hand.
+//
+// Deriving gets the property that neither hand-written option can: a route
+// cannot advertise a section its document does not have, by construction. Add a
+// key to an artifact schema and it becomes selectable; remove one and it stops
+// being offered. No list to update, and nothing that can silently disagree.
+//
+// A DIFFERENT UNIT FROM `fields`, which is why it is a different parameter
+// (#10600). `fields` picks columns out of the rows of a list, everywhere it
+// appears; this picks whole cards out of one composite document. Same idea,
+// different unit of selection -- and `fieldsSchema`'s published description
+// says "row field names", so overloading the name would have meant one
+// parameter with two meanings and nothing telling a caller which they got.
+//
+// WHY PAGING DOES NOT SUBSTITUTE. The detail route's 272,825 B is not one
+// dominant list: `endpoints`, `surfaces`, `verified_surfaces` and
+// `candidate_surfaces` are four parallel arrays over the same subject
+// (76/76/76/16 on subnet 64). A query collection pages ONE data_key, so
+// declaring one would narrow a quarter of the payload and leave the rest -- a
+// response that looks bounded while staying fat.
+import type { z } from "zod";
+
+/**
+ * Keys that identify the document rather than carrying its content.
+ *
+ * Never selectable and never projected away: a caller asking for `economics`
+ * wants a smaller answer, not an anonymous one, and a document that cannot say
+ * what it is or when it was built is the latter. Excluded from every derived
+ * vocabulary for the same reason -- offering `?sections=schema_version` would
+ * imply the envelope is optional.
+ */
+export const ENVELOPE_SECTIONS: readonly string[] = [
+  "schema_version",
+  "contract_version",
+  "generated_at",
+  "operational_observed_at",
+  "health_source",
+];
+
+/**
+ * A document's selectable sections, sorted.
+ *
+ * SORTED, not in declaration order: the vocabulary is published verbatim in an
+ * OpenAPI `pattern` and description, and reordering keys inside an artifact
+ * schema is a cosmetic edit that should not rewrite a public contract. Sorting
+ * also keeps the two routes' patterns comparable by eye.
+ *
+ * Returns a non-empty tuple because `sectionsSchema` and `z.enum` both need
+ * one, and because a composite document with no content keys is a developer
+ * error rather than a route that serves an empty vocabulary -- it throws
+ * instead of publishing a parameter that can accept nothing.
+ */
+export function sectionsOf(schema: {
+  shape: Record<string, z.ZodType>;
+}): readonly [string, ...string[]] {
+  const sections = Object.keys(schema.shape)
+    .filter((key) => !ENVELOPE_SECTIONS.includes(key))
+    .sort();
+  if (sections.length === 0) {
+    throw new Error(
+      "sectionsOf: this schema declares only envelope keys, so `sections=` " +
+        "would publish a parameter with nothing to select",
+    );
+  }
+  return sections as unknown as readonly [string, ...string[]];
+}

--- a/schemas-src/mcp-tools/get-subnet-detail.ts
+++ b/schemas-src/mcp-tools/get-subnet-detail.ts
@@ -16,9 +16,11 @@
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
 import { McpNetworkSchema } from "../shared.ts";
-import { QUERY_ENUMS } from "../query-enums.ts";
 import { sectionsSchema } from "../query-params.ts";
-import { SubnetDetailArtifactSchema } from "../routes/subnet-detail.ts";
+import {
+  SubnetDetailArtifactSchema,
+  SUBNET_DETAIL_SECTIONS,
+} from "../routes/subnet-detail.ts";
 
 export const GetSubnetDetailInputSchema = z
   .object({
@@ -33,7 +35,10 @@ export const GetSubnetDetailInputSchema = z
     //
     // Worth more here than on REST: a REST caller pays the unprojected 272,825
     // B in bandwidth, an agent pays it in context window.
-    sections: sectionsSchema(QUERY_ENUMS.subnetDetailSection).optional(),
+    sections: sectionsSchema(SUBNET_DETAIL_SECTIONS, [
+      "subnet",
+      "economics",
+    ]).optional(),
   })
   .strict();
 export type GetSubnetDetailInput = z.infer<typeof GetSubnetDetailInputSchema>;

--- a/schemas-src/mcp-tools/profiles.ts
+++ b/schemas-src/mcp-tools/profiles.ts
@@ -13,10 +13,12 @@
 // subnetType,curationLevel,profileLevel} and the "profiles" query
 // collection's sort_fields at the time of writing.
 import { z } from "zod";
-import { QUERY_ENUMS } from "../query-enums.ts";
 import { sectionsSchema } from "../query-params.ts";
 import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
-import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
+import {
+  SubnetProfileArtifactSchema,
+  SUBNET_PROFILE_SECTIONS,
+} from "../routes/subnet-profiles.ts";
 import {
   reviewStateSchema,
   fieldsSchema,
@@ -76,7 +78,10 @@ export const GetSubnetProfileInputSchema = z
     // reading our contract would send it and be rejected. Worth more here than
     // on REST: a REST caller pays the unprojected payload in bandwidth, an
     // agent pays it in context window.
-    sections: sectionsSchema(QUERY_ENUMS.subnetProfileSection).optional(),
+    sections: sectionsSchema(SUBNET_PROFILE_SECTIONS, [
+      "subnet",
+      "profile",
+    ]).optional(),
   })
   .strict();
 export type GetSubnetProfileInput = z.infer<typeof GetSubnetProfileInputSchema>;

--- a/schemas-src/query-enums.ts
+++ b/schemas-src/query-enums.ts
@@ -70,53 +70,6 @@ export const QUERY_ENUMS = {
     "adapter-backed",
   ],
   subnetStatus: ["active", "inactive"],
-  /**
-   * Top-level sections of `/api/v1/subnets/{netuid}`, selectable via `sections=`
-   * (#10600).
-   *
-   * A DIFFERENT UNIT FROM `fields`, which is why it is a different parameter.
-   * `fields` picks columns out of the rows of a list, everywhere it appears;
-   * this picks whole cards out of one composite document. Same idea, different
-   * unit of selection -- and `fieldsSchema`'s published description says "row
-   * field names", so overloading the name would have meant one parameter with
-   * two meanings and nothing telling a caller which they got.
-   *
-   * WHY PAGING DOES NOT SUBSTITUTE. The route's 272,825 B is not one dominant
-   * list: `endpoints`, `surfaces`, `verified_surfaces` and `candidate_surfaces`
-   * are four parallel arrays over the same subject (76/76/76/16 on subnet 64).
-   * A query collection pages ONE data_key, so declaring one here would narrow a
-   * quarter of the payload and leave the rest -- a response that looks bounded
-   * while staying fat.
-   *
-   * The ENVELOPE is not listed and is never projected away: schema_version,
-   * contract_version, generated_at, operational_observed_at and health_source
-   * identify what the caller is holding, and a document that cannot say what it
-   * is or when it was built is not a smaller document, it is an anonymous one.
-   */
-  subnetDetailSection: [
-    "subnet",
-    "economics",
-    "endpoints",
-    "surfaces",
-    "verified_surfaces",
-    "candidate_surfaces",
-    "candidates",
-    "gaps",
-    "notes",
-  ],
-  /** Top-level sections of `/api/v1/subnets/{netuid}/profile` (#10600). Its own
-   * list rather than a shared one: the profile carries `profile` and no
-   * `economics`/`candidates`/`verified_surfaces`, and a shared vocabulary would
-   * let a caller ask this route for a section it can never return. */
-  subnetProfileSection: [
-    "subnet",
-    "profile",
-    "endpoints",
-    "surfaces",
-    "candidate_surfaces",
-    "gaps",
-    "notes",
-  ],
   subnetType: ["root", "application"],
   endpointLayer: [
     "bittensor-base",

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -22,6 +22,7 @@
 // import sites keep working unchanged.
 import { z } from "zod";
 import { DAY_PATTERN, MAX_OFFSET } from "../workers/request-params.ts";
+import { ENVELOPE_SECTIONS } from "./artifact-sections.ts";
 
 /**
  * A subnet id. Bounded because it genuinely is: `netuid` is a u16 on chain, and
@@ -873,24 +874,35 @@ export const uidSchema = () =>
  * the caller asked for, and a 200 that omits what was requested is worse than
  * a 400 that says why.
  */
-export const sectionsSchema = (allowed: readonly [string, ...string[]]) => {
+export const sectionsSchema = (
+  allowed: readonly [string, ...string[]],
+  example: readonly [string, ...string[]],
+) => {
+  // The vocabulary is derived from the document's schema, so it arrives in the
+  // schema's declaration order -- which puts inherited base keys like `notes`
+  // first and would make `?sections=notes` the published example. The example
+  // is therefore chosen for what it teaches, and checked against the derived
+  // vocabulary so it cannot outlive the sections it names: drop `economics`
+  // from the artifact and this throws at module load rather than shipping a
+  // documented example the route now rejects.
+  const unknown = example.filter((name) => !allowed.includes(name));
+  if (unknown.length > 0) {
+    throw new Error(
+      `sectionsSchema: example names ${unknown.join(", ")}, which the document ` +
+        `does not declare. Allowed: ${allowed.join(", ")}`,
+    );
+  }
   const alternation = `(?:${allowed.join("|")})`;
-  // `slice(0, 2)` rather than a `allowed[1] ? ... : ...` ternary: every
-  // vocabulary this takes is a fixed list of 7+ names, so the one-element arm
-  // is a branch nothing can reach -- and an unreachable branch is a partial
-  // that no test can honestly close.
-  const example = allowed.slice(0, 2).join(",");
   return z
     .string()
     .regex(new RegExp(`^${alternation}(?:,${alternation})*$`))
     .describe(
-      `Comma-separated top-level sections to return, e.g. \`${example}\`. ` +
+      `Comma-separated top-level sections to return, e.g. \`${example.join(",")}\`. ` +
         `One of: ${allowed.join(", ")}. Selecting sections never removes the ` +
-        `response envelope (schema_version, contract_version, generated_at, ` +
-        `operational_observed_at, health_source) -- a smaller document still has ` +
-        `to say what it is. An unknown name is rejected rather than ignored. ` +
-        `NOT the same parameter as \`fields\`, which projects columns out of the ` +
-        `rows of a list.`,
+        `response envelope (${ENVELOPE_SECTIONS.join(", ")}) -- a smaller ` +
+        `document still has to say what it is. An unknown name is rejected ` +
+        `rather than ignored. NOT the same parameter as \`fields\`, which ` +
+        `projects columns out of the rows of a list.`,
     )
-    .meta({ examples: [allowed[0], example] });
+    .meta({ examples: [example[0], example.join(",")] });
 };

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -56,7 +56,8 @@
 // worth guessing now. The gate compares `properties`, so this does not affect
 // what 3/5 publishes either way.
 import { z } from "zod";
-import { QUERY_ENUMS } from "./query-enums.ts";
+import { SUBNET_DETAIL_SECTIONS } from "./routes/subnet-detail.ts";
+import { SUBNET_PROFILE_SECTIONS } from "./routes/subnet-profiles.ts";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
   ACCOUNTS_LIST_LIMIT_MAX,
@@ -408,10 +409,16 @@ export const ROUTE_QUERY_SCHEMAS = {
   // its published description says so. One name with two units of selection
   // would give a caller a different KIND of answer with nothing telling them.
   "/api/v1/subnets/{netuid}": z.object({
-    sections: sectionsSchema(QUERY_ENUMS.subnetDetailSection).optional(),
+    sections: sectionsSchema(SUBNET_DETAIL_SECTIONS, [
+      "subnet",
+      "economics",
+    ]).optional(),
   }),
   "/api/v1/subnets/{netuid}/profile": z.object({
-    sections: sectionsSchema(QUERY_ENUMS.subnetProfileSection).optional(),
+    sections: sectionsSchema(SUBNET_PROFILE_SECTIONS, [
+      "subnet",
+      "profile",
+    ]).optional(),
   }),
   "/api/v1/search/semantic": z.object({
     // Both were wrong before #10075: `q` published no ceiling though the

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -23,6 +23,7 @@ import {
 } from "../shared.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { ArtifactBaseSchema } from "../envelope.ts";
+import { sectionsOf } from "../artifact-sections.ts";
 import {
   BittensorNetworkSchema,
   CoverageLevelSchema,
@@ -762,3 +763,9 @@ export const SubnetDetailArtifactSchema = ArtifactBaseSchema.extend({
   verified_surfaces: z.array(SurfaceSchema).optional(),
 });
 export type SubnetDetailArtifact = z.infer<typeof SubnetDetailArtifactSchema>;
+
+/**
+ * What `?sections=` accepts on the detail route -- read off the document above
+ * rather than restated, so the route cannot offer a card the artifact lacks.
+ */
+export const SUBNET_DETAIL_SECTIONS = sectionsOf(SubnetDetailArtifactSchema);

--- a/schemas-src/routes/subnet-profiles.ts
+++ b/schemas-src/routes/subnet-profiles.ts
@@ -19,6 +19,7 @@
 // neither declared in the hand-edited schema -- see SchemaIndexArtifactSchema.
 import { z } from "zod";
 import { ArtifactBaseSchema } from "../envelope.ts";
+import { sectionsOf } from "../artifact-sections.ts";
 import { SubnetProfileSchema } from "./subnet-profile.ts";
 import {
   CandidateSurfaceSchema,
@@ -60,6 +61,14 @@ export const SubnetProfileArtifactSchema = ArtifactBaseSchema.extend({
   gaps: GapsSchema,
 });
 export type SubnetProfileArtifact = z.infer<typeof SubnetProfileArtifactSchema>;
+
+/**
+ * What `?sections=` accepts on the profile route. Derived, and deliberately
+ * NOT shared with the detail route: this document has `profile` and no
+ * `economics`/`candidates`/`verified_surfaces`, so one common vocabulary would
+ * let a caller ask here for a card that can never come back.
+ */
+export const SUBNET_PROFILE_SECTIONS = sectionsOf(SubnetProfileArtifactSchema);
 
 /**
  * The captured OpenAPI snapshot's own metadata -- ONE declaration (#10790).

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -340,6 +340,8 @@ import {
   QUERY_ENUMS,
 } from "./contracts.ts";
 import { projectToolSections } from "./section-projection.ts";
+import { SUBNET_DETAIL_SECTIONS } from "../schemas-src/routes/subnet-detail.ts";
+import { SUBNET_PROFILE_SECTIONS } from "../schemas-src/routes/subnet-profiles.ts";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
   GET_ECONOMICS_MCP_TOOL,
@@ -5760,11 +5762,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // exact leak tests/network-routing.test.ts guards on the REST side).
       // Testnet carries its own chain economics inside `subnet.economics`.
       if (network && network !== "finney")
-        return projectToolSections(
-          detail,
-          args,
-          QUERY_ENUMS.subnetDetailSection,
-        );
+        return projectToolSections(detail, args, SUBNET_DETAIL_SECTIONS);
       const { economics } = await loadSubnetEconomics(ctx, netuid);
       // Projected LAST, after the economics overlay, for the same reason the
       // REST seam does: `economics` is itself a selectable section, so
@@ -5773,7 +5771,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       return projectToolSections(
         economics ? { ...detail, economics } : detail,
         args,
-        QUERY_ENUMS.subnetDetailSection,
+        SUBNET_DETAIL_SECTIONS,
       );
     },
   },
@@ -8311,7 +8309,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
             readArtifact: loadArtifactData,
           }),
           args,
-          QUERY_ENUMS.subnetProfileSection,
+          SUBNET_PROFILE_SECTIONS,
         );
       } catch (rawErr) {
         const tagged = taggedLoaderError(rawErr, "profilesMcp");

--- a/src/section-projection.ts
+++ b/src/section-projection.ts
@@ -22,14 +22,13 @@
 // that is not smaller, it is anonymous. A caller asking for `economics` wants a
 // smaller answer, not an unattributable one.
 
-/** Envelope keys every projection keeps, whatever was asked for. */
-export const ALWAYS_KEPT_SECTIONS: readonly string[] = [
-  "schema_version",
-  "contract_version",
-  "generated_at",
-  "operational_observed_at",
-  "health_source",
-];
+// The envelope list itself lives with the schemas, next to the artifact keys
+// it is defined against, and is re-exported here so the projection and the
+// published parameter description cannot name different keys (they used to:
+// this was a hand-written copy, and `sectionsSchema` spelled the same five
+// names out a third time in its prose).
+import { ENVELOPE_SECTIONS } from "../schemas-src/artifact-sections.ts";
+export { ENVELOPE_SECTIONS };
 
 export interface SectionProjection {
   /** The requested section names, in the order given, deduplicated. */
@@ -84,7 +83,7 @@ export function projectSections(
   data: Record<string, unknown>,
   sections: readonly string[],
 ): Record<string, unknown> {
-  const keep = new Set([...ALWAYS_KEPT_SECTIONS, ...sections]);
+  const keep = new Set([...ENVELOPE_SECTIONS, ...sections]);
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
     if (keep.has(key)) out[key] = value;

--- a/tests/subnet-sections.test.ts
+++ b/tests/subnet-sections.test.ts
@@ -14,16 +14,28 @@
 // there would promise a section it can never return.
 import assert from "node:assert/strict";
 import { describe, expect, it, test } from "vitest";
-import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+import { z } from "zod";
+import { sectionsOf } from "../schemas-src/artifact-sections.ts";
+import { sectionsSchema } from "../schemas-src/query-params.ts";
 import {
-  ALWAYS_KEPT_SECTIONS,
+  ENVELOPE_SECTIONS,
   parseSectionsParam,
   projectSections,
   projectToolSections,
 } from "../src/section-projection.ts";
+import {
+  SubnetDetailArtifactSchema,
+  SUBNET_DETAIL_SECTIONS,
+} from "../schemas-src/routes/subnet-detail.ts";
+import {
+  SubnetProfileArtifactSchema,
+  SUBNET_PROFILE_SECTIONS,
+} from "../schemas-src/routes/subnet-profiles.ts";
+import { ArtifactBaseSchema } from "../schemas-src/envelope.ts";
+import { LIVE_HEALTH_OVERLAY } from "../schemas-src/routes/subnet-detail.ts";
 
-const DETAIL = QUERY_ENUMS.subnetDetailSection;
-const PROFILE = QUERY_ENUMS.subnetProfileSection;
+const DETAIL = SUBNET_DETAIL_SECTIONS;
+const PROFILE = SUBNET_PROFILE_SECTIONS;
 
 /** A document shaped like the served artifact: envelope + sections. */
 const document = (): Record<string, unknown> => ({
@@ -77,10 +89,10 @@ describe("parseSectionsParam", () => {
     // `economics` is a real section of the detail route and does not exist on
     // the profile. Accepting it there would promise a section that can never
     // arrive, which is worse than refusing it.
-    // Widened deliberately: QUERY_ENUMS is `as const`, so asking whether the
-    // PROFILE list contains "economics" is a type error rather than a false --
-    // which is the type system making exactly this issue's point, that the two
-    // vocabularies are different sets and not one shared one.
+    // Widened deliberately: both lists are narrow tuples, so asking whether
+    // the PROFILE list contains "economics" is a type error rather than a
+    // false -- which is the type system making exactly this issue's point,
+    // that the two vocabularies are different sets and not one shared one.
     assert.ok((DETAIL as readonly string[]).includes("economics"));
     assert.ok(!(PROFILE as readonly string[]).includes("economics"));
     assert.deepEqual(parseSectionsParam("economics", PROFILE)?.unknown, [
@@ -97,7 +109,7 @@ describe("projectSections", () => {
   test("keeps the requested section and drops the rest", () => {
     const out = projectSections(document(), ["economics"]);
     assert.deepEqual(
-      Object.keys(out).filter((k) => !ALWAYS_KEPT_SECTIONS.includes(k)),
+      Object.keys(out).filter((k) => !ENVELOPE_SECTIONS.includes(k)),
       ["economics"],
     );
     assert.deepEqual(out.economics, { alpha_price_tao: 0.02 });
@@ -108,7 +120,7 @@ describe("projectSections", () => {
     // Without this, `?sections=notes` would return an anonymous blob.
     for (const sections of [[], ["notes"], ["subnet", "gaps"]]) {
       const out = projectSections(document(), sections);
-      for (const key of ALWAYS_KEPT_SECTIONS) {
+      for (const key of ENVELOPE_SECTIONS) {
         assert.ok(
           key in out,
           `${key} must survive ?sections=${sections.join(",")}`,
@@ -276,8 +288,8 @@ describe("the lever is published, not just implemented", () => {
     >;
 
   it.each([
-    ["/api/v1/subnets/{netuid}", QUERY_ENUMS.subnetDetailSection],
-    ["/api/v1/subnets/{netuid}/profile", QUERY_ENUMS.subnetProfileSection],
+    ["/api/v1/subnets/{netuid}", SUBNET_DETAIL_SECTIONS],
+    ["/api/v1/subnets/{netuid}/profile", SUBNET_PROFILE_SECTIONS],
   ])("%s publishes sections with its own closed set", (route, vocabulary) => {
     const parameter = published(route).find((p) => p.name === "sections");
     expect(parameter, `${route} must publish sections`).toBeTruthy();
@@ -352,5 +364,128 @@ describe("projectToolSections (the MCP side)", () => {
       projectToolSections(null, { sections: "economics" }, DETAIL),
       null,
     );
+  });
+});
+
+// The vocabularies are DERIVED from the artifact schemas rather than written
+// out (#10600 follow-up). Deriving removes the drift these tests used to have
+// to watch for, so what is left to pin is the derivation itself: that it reads
+// the document it claims to, and that the envelope it holds back is the
+// envelope the schemas actually declare.
+describe("the section vocabulary cannot drift from the document", () => {
+  // Written out ON PURPOSE, and the only place in the tree that is. Asserting
+  // `sectionsOf(schema)` equals `keys(schema) minus envelope` would just be
+  // sectionsOf restated -- it passes however wrong both sides are, together.
+  // These are the published values of a public query parameter, so widening or
+  // narrowing one should cost a deliberate edit here: add a top-level key to a
+  // served artifact and it silently becomes a new accepted `?sections=` value
+  // otherwise.
+  test.each([
+    [
+      "detail",
+      SUBNET_DETAIL_SECTIONS,
+      [
+        "candidate_surfaces",
+        "candidates",
+        "economics",
+        "endpoints",
+        "gaps",
+        "notes",
+        "subnet",
+        "surfaces",
+        "verified_surfaces",
+      ],
+    ],
+    [
+      "profile",
+      SUBNET_PROFILE_SECTIONS,
+      [
+        "candidate_surfaces",
+        "endpoints",
+        "gaps",
+        "notes",
+        "profile",
+        "subnet",
+        "surfaces",
+      ],
+    ],
+  ])("%s publishes exactly this vocabulary", (_name, vocab, expected) => {
+    // Compared unsorted: `sectionsOf` sorts, so the published order is part of
+    // what this pins.
+    assert.deepEqual([...vocab], expected);
+  });
+
+  test("every offered section is a key the document can actually carry", () => {
+    // The direction that matters to a caller: `?sections=X` must never name a
+    // card the artifact has no slot for, or the 200 comes back missing the one
+    // thing that was asked for.
+    for (const [schema, vocab] of [
+      [SubnetDetailArtifactSchema, SUBNET_DETAIL_SECTIONS],
+      [SubnetProfileArtifactSchema, SUBNET_PROFILE_SECTIONS],
+    ] as const) {
+      for (const section of vocab) {
+        assert.ok(
+          section in schema.shape,
+          `${section} is offered but the artifact declares no such key`,
+        );
+      }
+    }
+  });
+
+  test("ENVELOPE_SECTIONS is what the schemas declare, both directions", () => {
+    // The five names were hand-written in three places before this. They are
+    // exactly the base envelope (minus `notes`, which is public-safe content a
+    // caller may legitimately shed) plus the live-health overlay -- so if a
+    // key is added to either, this fails rather than silently making it
+    // unselectable or projecting it away.
+    const declared = [
+      ...Object.keys(ArtifactBaseSchema.shape).filter((k) => k !== "notes"),
+      ...Object.keys(LIVE_HEALTH_OVERLAY),
+    ].sort();
+    assert.deepEqual([...ENVELOPE_SECTIONS].sort(), declared);
+  });
+
+  test("`notes` is content, not envelope", () => {
+    // It sits in the base alongside the envelope keys, so the one thing that
+    // separates it is this decision. Pinned because losing it would quietly
+    // make `notes` unshakeable on every artifact route at once.
+    assert.ok(!ENVELOPE_SECTIONS.includes("notes"));
+    assert.ok(SUBNET_DETAIL_SECTIONS.includes("notes"));
+    assert.ok(SUBNET_PROFILE_SECTIONS.includes("notes"));
+  });
+});
+
+// Both derivations refuse rather than publish something incoherent. Neither is
+// reachable from the two routes today -- which is the point of pinning them:
+// they are the guardrails a THIRD composite route would hit first.
+describe("the derivation refuses what it cannot publish", () => {
+  test("a document with only envelope keys gets no `sections` parameter", () => {
+    // Deriving an empty vocabulary would publish `?sections=` that accepts
+    // nothing -- a parameter whose every value is a 400.
+    assert.throws(
+      () =>
+        sectionsOf({
+          shape: { schema_version: z.literal(1), generated_at: z.string() },
+        }),
+      /only envelope keys/,
+    );
+  });
+
+  test("an example naming a section the document lacks is refused", () => {
+    // The example is hand-picked for what it teaches, so this is what keeps it
+    // honest: drop `economics` from the artifact and the build fails instead of
+    // shipping a documented example the route now rejects.
+    assert.throws(
+      () => sectionsSchema(["subnet", "gaps"], ["subnet", "economics"]),
+      /economics/,
+    );
+  });
+
+  test("an example the document does carry is accepted", () => {
+    // The other side of the same branch: a valid example must not throw, or
+    // the check would be a guard nothing can pass.
+    const schema = sectionsSchema(["subnet", "gaps"], ["subnet", "gaps"]);
+    assert.equal(schema.safeParse("subnet,gaps").success, true);
+    assert.equal(schema.safeParse("economics").success, false);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -181,19 +181,20 @@ import {
   parseSectionsParam,
   projectSections,
 } from "../src/section-projection.ts";
-import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+import { SUBNET_DETAIL_SECTIONS } from "../schemas-src/routes/subnet-detail.ts";
+import { SUBNET_PROFILE_SECTIONS } from "../schemas-src/routes/subnet-profiles.ts";
 
 /**
  * Route id -> the sections that route serves (#10600).
  *
  * Keyed on the matched route id rather than the path so the lookup cannot drift
- * from the router, and derived from QUERY_ENUMS rather than restated -- the same
- * vocabulary the published schema validates against, so the edge and the handler
- * cannot disagree about what `sections=economics` means.
+ * from the router, and read off each artifact's own schema rather than restated
+ * -- the same vocabulary the published parameter validates against, so the edge
+ * and the handler cannot disagree about what `sections=economics` means.
  */
 const SECTION_VOCABULARIES: Record<string, readonly string[] | undefined> = {
-  "subnet-detail": QUERY_ENUMS.subnetDetailSection,
-  "subnet-profile": QUERY_ENUMS.subnetProfileSection,
+  "subnet-detail": SUBNET_DETAIL_SECTIONS,
+  "subnet-profile": SUBNET_PROFILE_SECTIONS,
 };
 import { csvRequested, csvResponse } from "./csv.ts";
 import {


### PR DESCRIPTION
## Summary

`?sections=` (#10600) validated against two hand-written lists in `QUERY_ENUMS`. Every name in
both was already declared by the artifact schema the route serves. They are now read off those
schemas, so a route cannot advertise a section its document lacks.

## Why these two lists and not the other 19

`QUERY_ENUMS` holds 21 vocabularies. The other 19 are **value** sets — what a field may
contain (`healthStatus: ok|degraded|failed|unknown`, `subnetStatus: active|inactive`).
Literals are their only possible source, which is exactly why that module is documented as
pure literals with zero imports, and why they do not duplicate anything.

These two were **structural** — they named the document's own top-level keys, which
`SubnetDetailArtifactSchema` / `SubnetProfileArtifactSchema` already declare. That difference
is why these two, and only these two, duplicated each other: **6 of the 10 distinct names were
typed twice.**

## Not one global vocabulary

Worth stating because it is the obvious simplification and it is wrong. The profile document
has no `economics`, `candidates` or `verified_surfaces`; the detail has no `profile`. A shared
list would let `/profile?sections=economics` through and answer **200 carrying nothing the
caller asked for**, with no error to explain it. The per-route subset is a fact about the
document, not a policy choice — so it is read off the document rather than decided by hand.

Zero hand-maintained lists, not one:

| | before | after |
| --- | --- | --- |
| section vocabularies | 2 hand-written (6/10 names duplicated) | derived from the 2 artifact schemas |
| envelope key list | 4 copies | 1, asserted against the schemas both ways |

## The envelope was written out four times

`schema_version`, `contract_version`, `generated_at`, `operational_observed_at`,
`health_source` lived in `ALWAYS_KEPT_SECTIONS`, again in `sectionsSchema`'s published prose,
again in the `QUERY_ENUMS` doc comment — and are really `ArtifactBaseSchema` (minus `notes`)
plus `LIVE_HEALTH_OVERLAY`.

One `ENVELOPE_SECTIONS` now, and a test asserting it equals what those two schemas declare **in
both directions**, so adding a key to either fails rather than silently making it unselectable
or projecting it away. `notes` sits in the base beside the envelope keys, so the one thing
separating it is a decision — pinned, because losing it would quietly make `notes` unshakeable
on every artifact route at once.

## Two deliberate choices a reviewer should check

**The example stays hand-picked.** Derivation yields the schema's key order, which puts the
inherited `notes` first and would have published `e.g. notes,candidate_surfaces`.
`sectionsSchema` now takes the example explicitly — and **validates it against the derived
vocabulary**, throwing at module load if it names a section the document does not declare. So
the vocabulary cannot drift and the example cannot lie.

**Derived lists are sorted.** The vocabulary is published verbatim in an OpenAPI `pattern`;
reordering keys inside an artifact schema is a cosmetic edit that should not rewrite a public
contract.

**The contract diff is order-only** — same sets, same examples, same 6 lines of `openapi.json`.

## The snapshot test is written out on purpose

The obvious test — assert `sectionsOf(schema)` equals `keys(schema) minus envelope` — is
`sectionsOf` restated, and passes however wrong both sides are together. I wrote that first and
it stayed green while a deliberately broken `ENVELOPE_SECTIONS` was in the tree. It is now an
explicit snapshot of both published vocabularies: adding a top-level key to a served artifact
would otherwise silently become a new accepted `?sections=` value.

Falsified rather than assumed — with `notes` wrongly declared envelope, 4 tests fail; with a
key added to the profile artifact, 2 fail (including the route's published-contract test).

## Verification

- 32 tests in `tests/subnet-sections.test.ts` (was 24)
- Full `npx vitest run`: **878 files, 20199 passed**, 11 skipped
- Patch coverage by lcov ∩ diff over `src/`+`workers/`+`schemas-src/`+`scripts/`: **0 uncovered
  lines, 0 untaken branches**; the new `schemas-src/artifact-sections.ts` is LF 6/6, BRF 2/2,
  and every changed file was confirmed present in the lcov rather than merely absent from the
  gap list
- `npx tsc --noEmit` · `lint` · `format:check` · `build`
- `validate:contract-drift` · `validate:api` · `validate:openapi` · `validate:mcp` ·
  `validate:schemas` · `validate:schema-vocabularies` · `validate:mcp-input-parity` ·
  `validate:unreferenced-exports` — all pass

Closes #10970