### PR TITLE
feat(api): the revenue window is a caller's choice, resolved in one place

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -786,14 +786,14 @@ type Query {
   economics_trends(window: String): EconomicsTrends!
 
   """
-  One subnet's external revenue against the TAO the network emits to it. ALWAYS read provenance and verification.verified: only chain-verified and probe-derived figures reach the headline, and revenue_usd/coverage_ratio/subsidy_multiple are NULL whenever revenue is unobserved -- the normal case, true of 127 of 129 subnets. NULL MEANS NOT OBSERVED, NEVER ZERO: rendering an unmeasured subnet as '0% covered' is a false claim about it. A declared surface that did not reach the headline is still reported in sources, with excluded_reason saying why. Never errors for a subnet with no revenue data. Mirrors GET /api/v1/subnets/{netuid}/revenue.
+  One subnet's external revenue against the TAO the network emits to it. ALWAYS read provenance and verification.verified: only chain-verified and probe-derived figures reach the headline, and revenue_usd/coverage_ratio/subsidy_multiple are NULL whenever revenue is unobserved -- the normal case, true of 127 of 129 subnets. NULL MEANS NOT OBSERVED, NEVER ZERO: rendering an unmeasured subnet as '0% covered' is a false claim about it. A declared surface that did not reach the headline is still reported in sources, with excluded_reason saying why. Never errors for a subnet with no revenue data. Mirrors GET /api/v1/subnets/{netuid}/revenue Takes ?window=1d|7d|30d (default 1d): a surface contributes only when the window is a whole number of its declared grain's periods, so a monthly figure needs 30d and is invisible at 1d.
   """
-  subnet_revenue(netuid: Int!): SubnetRevenueCard!
+  subnet_revenue(netuid: Int!, window: String): SubnetRevenueCard!
 
   """
-  Every subnet's revenue coverage in one response. Subnets with no observed revenue are INCLUDED with null ratios rather than dropped, because omitting them would make the covered set look like the whole network -- observed_count against subnet_count is the honest headline. Mirrors GET /api/v1/chain/revenue-coverage.
+  Every subnet's revenue coverage in one response. Subnets with no observed revenue are INCLUDED with null ratios rather than dropped, because omitting them would make the covered set look like the whole network -- observed_count against subnet_count is the honest headline. Mirrors GET /api/v1/chain/revenue-coverage Takes ?window=1d|7d|30d (default 1d): a surface contributes only when the window is a whole number of its declared grain's periods, so a monthly figure needs 30d and is invisible at 1d.
   """
-  chain_revenue_coverage: ChainRevenueCoverage!
+  chain_revenue_coverage(window: String): ChainRevenueCoverage!
 
   """
   The v440 emission pipeline decomposed per subnet at the block the economics capture was pinned to: each subnet's stage-1 price share, its MinerBurned-reweighted and Hill-gated shares, its final share of block emission, and the split of its TAO intake between pool injection (tao_in_emission) and chain buys (excess_tao). netuid narrows the per-subnet rows only -- aggregate and verification stay network-wide, since a one-subnet slice of a network identity cannot be verified. ALWAYS read verification.verified: false means the four identities did not hold on these exact rows and the response is not defensible. field_sources labels every field measured or reconstructed. A capture with no chain_state is an EMISSION_PIPELINE_UNAVAILABLE error, never a partial body. Mirrors GET /api/v1/chain/emission-pipeline.

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3454,7 +3454,7 @@ export type Query = {
   chain_prometheus: ChainPrometheus;
   /** Network-wide neuron-registration leaderboard over a 7d/30d window (default 7d): subnets ranked by NeuronRegistered events with each's distinct-hotkey count and registrations-per-registrant re-registration intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide, entry-side counterpart of subnet_registrations -- where neurons are joining. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/registrations. */
   chain_registrations: ChainRegistrations;
-  /** Every subnet's revenue coverage in one response. Subnets with no observed revenue are INCLUDED with null ratios rather than dropped, because omitting them would make the covered set look like the whole network -- observed_count against subnet_count is the honest headline. Mirrors GET /api/v1/chain/revenue-coverage. */
+  /** Every subnet's revenue coverage in one response. Subnets with no observed revenue are INCLUDED with null ratios rather than dropped, because omitting them would make the covered set look like the whole network -- observed_count against subnet_count is the honest headline. Mirrors GET /api/v1/chain/revenue-coverage Takes ?window=1d|7d|30d (default 1d): a surface contributes only when the window is a whole number of its declared grain's periods, so a monthly figure needs 30d and is invisible at 1d. */
   chain_revenue_coverage: ChainRevenueCoverage;
   /** Network-wide axon-serving announcement leaderboard over a 7d/30d window (default 7d): subnets ranked by AxonServed announcements with each's distinct-server count and announcements-per-server re-announcement intensity, plus a network rollup and the per-subnet intensity spread, summed live from the account_events stream. The network-wide counterpart of subnet_serving. limit caps the leaderboard (default 20, max 100). A cold store yields a schema-stable zeroed card, never a GraphQL error. Mirrors GET /api/v1/chain/serving. */
   chain_serving: ChainServing;
@@ -3686,7 +3686,7 @@ export type Query = {
   subnet_recycled?: Maybe<SubnetRecycled>;
   /** Per-subnet neuron-registration activity over a 7d/30d window (distinct registrants, NeuronRegistered count, and registrations per registrant); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/registrations. */
   subnet_registrations: SubnetRegistrations;
-  /** One subnet's external revenue against the TAO the network emits to it. ALWAYS read provenance and verification.verified: only chain-verified and probe-derived figures reach the headline, and revenue_usd/coverage_ratio/subsidy_multiple are NULL whenever revenue is unobserved -- the normal case, true of 127 of 129 subnets. NULL MEANS NOT OBSERVED, NEVER ZERO: rendering an unmeasured subnet as '0% covered' is a false claim about it. A declared surface that did not reach the headline is still reported in sources, with excluded_reason saying why. Never errors for a subnet with no revenue data. Mirrors GET /api/v1/subnets/{netuid}/revenue. */
+  /** One subnet's external revenue against the TAO the network emits to it. ALWAYS read provenance and verification.verified: only chain-verified and probe-derived figures reach the headline, and revenue_usd/coverage_ratio/subsidy_multiple are NULL whenever revenue is unobserved -- the normal case, true of 127 of 129 subnets. NULL MEANS NOT OBSERVED, NEVER ZERO: rendering an unmeasured subnet as '0% covered' is a false claim about it. A declared surface that did not reach the headline is still reported in sources, with excluded_reason saying why. Never errors for a subnet with no revenue data. Mirrors GET /api/v1/subnets/{netuid}/revenue Takes ?window=1d|7d|30d (default 1d): a surface contributes only when the window is a whole number of its declared grain's periods, so a monthly figure needs 30d and is invisible at 1d. */
   subnet_revenue: SubnetRevenueCard;
   /** Per-subnet axon-serving activity over a 7d/30d window (distinct servers, AxonServed announcement count, and announcements per server); a subnet with no events in the window resolves to a schema-stable zeroed card, never null. Mirrors GET /api/v1/subnets/{netuid}/serving. */
   subnet_serving: SubnetServing;
@@ -4091,6 +4091,11 @@ export type QueryChain_PrometheusArgs = {
 export type QueryChain_RegistrationsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   network?: InputMaybe<Network>;
+  window?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryChain_Revenue_CoverageArgs = {
   window?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -4988,6 +4993,7 @@ export type QuerySubnet_RegistrationsArgs = {
 
 export type QuerySubnet_RevenueArgs = {
   netuid: Scalars['Int']['input'];
+  window?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -11490,7 +11496,7 @@ export type QueryResolvers<ContextType = GqlContext, ParentType extends Resolver
   chain_performance?: Resolver<ResolversTypes['ChainPerformance'], ParentType, ContextType>;
   chain_prometheus?: Resolver<ResolversTypes['ChainPrometheus'], ParentType, ContextType, Partial<QueryChain_PrometheusArgs>>;
   chain_registrations?: Resolver<ResolversTypes['ChainRegistrations'], ParentType, ContextType, Partial<QueryChain_RegistrationsArgs>>;
-  chain_revenue_coverage?: Resolver<ResolversTypes['ChainRevenueCoverage'], ParentType, ContextType>;
+  chain_revenue_coverage?: Resolver<ResolversTypes['ChainRevenueCoverage'], ParentType, ContextType, Partial<QueryChain_Revenue_CoverageArgs>>;
   chain_serving?: Resolver<ResolversTypes['ChainServing'], ParentType, ContextType, Partial<QueryChain_ServingArgs>>;
   chain_signers?: Resolver<ResolversTypes['ChainSigners'], ParentType, ContextType, Partial<QueryChain_SignersArgs>>;
   chain_stake_flow?: Resolver<ResolversTypes['ChainStakeFlow'], ParentType, ContextType, Partial<QueryChain_Stake_FlowArgs>>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -27462,7 +27462,10 @@ export interface operations {
     };
     chainRevenueCoverage: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1d`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
+                window?: "1d" | "7d" | "30d";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -45941,7 +45944,10 @@ export interface operations {
     };
     subnetRevenue: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1d`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
+                window?: "1d" | "7d" | "30d";
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -9916,7 +9916,20 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "default": "1d",
+            "enum": [
+              "1d",
+              "7d",
+              "30d"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/chain/revenue-coverage.json",
@@ -9932,7 +9945,20 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "default": "1d",
+            "enum": [
+              "1d",
+              "7d",
+              "30d"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/subnets/{netuid}/recycled.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -75055,7 +75055,23 @@
     "/api/v1/chain/revenue-coverage": {
       "get": {
         "operationId": "chainRevenueCoverage",
-        "parameters": [],
+        "parameters": [
+          {
+            "description": "Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1d`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed.",
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "default": "1d",
+              "enum": [
+                "1d",
+                "7d",
+                "30d"
+              ],
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -96753,6 +96769,21 @@
               "maximum": 65535,
               "minimum": 0,
               "type": "integer"
+            }
+          },
+          {
+            "description": "Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1d`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed.",
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "default": "1d",
+              "enum": [
+                "1d",
+                "7d",
+                "30d"
+              ],
+              "type": "string"
             }
           }
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -27462,7 +27462,10 @@ export interface operations {
     };
     chainRevenueCoverage: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1d`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
+                window?: "1d" | "7d" | "30d";
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -45941,7 +45944,10 @@ export interface operations {
     };
     subnetRevenue: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Trailing lookback window the response is computed over, ending at the most recent data point rather than at today. Accepts `1d`, `7d`, `30d`. A longer window is not a superset of a shorter one -- rankings and rates are recomputed over the whole window, not summed. */
+                window?: "1d" | "7d" | "30d";
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/schemas-src/graphql/query-exposures.ts
+++ b/schemas-src/graphql/query-exposures.ts
@@ -1171,14 +1171,14 @@ export const GRAPHQL_EXPOSURES: readonly GraphqlExposure[] = [
     operation: "subnet-revenue",
     returns: "SubnetRevenueCard!",
     description:
-      "One subnet's external revenue against the TAO the network emits to it. ALWAYS read provenance and verification.verified: only chain-verified and probe-derived figures reach the headline, and revenue_usd/coverage_ratio/subsidy_multiple are NULL whenever revenue is unobserved -- the normal case, true of 127 of 129 subnets. NULL MEANS NOT OBSERVED, NEVER ZERO: rendering an unmeasured subnet as '0% covered' is a false claim about it. A declared surface that did not reach the headline is still reported in sources, with excluded_reason saying why. Never errors for a subnet with no revenue data. Mirrors GET /api/v1/subnets/{netuid}/revenue.",
+      "One subnet's external revenue against the TAO the network emits to it. ALWAYS read provenance and verification.verified: only chain-verified and probe-derived figures reach the headline, and revenue_usd/coverage_ratio/subsidy_multiple are NULL whenever revenue is unobserved -- the normal case, true of 127 of 129 subnets. NULL MEANS NOT OBSERVED, NEVER ZERO: rendering an unmeasured subnet as '0% covered' is a false claim about it. A declared surface that did not reach the headline is still reported in sources, with excluded_reason saying why. Never errors for a subnet with no revenue data. Mirrors GET /api/v1/subnets/{netuid}/revenue Takes ?window=1d|7d|30d (default 1d): a surface contributes only when the window is a whole number of its declared grain's periods, so a monthly figure needs 30d and is invisible at 1d.",
   },
   {
     field: "chain_revenue_coverage",
     operation: "chain-revenue-coverage",
     returns: "ChainRevenueCoverage!",
     description:
-      "Every subnet's revenue coverage in one response. Subnets with no observed revenue are INCLUDED with null ratios rather than dropped, because omitting them would make the covered set look like the whole network -- observed_count against subnet_count is the honest headline. Mirrors GET /api/v1/chain/revenue-coverage.",
+      "Every subnet's revenue coverage in one response. Subnets with no observed revenue are INCLUDED with null ratios rather than dropped, because omitting them would make the covered set look like the whole network -- observed_count against subnet_count is the honest headline. Mirrors GET /api/v1/chain/revenue-coverage Takes ?window=1d|7d|30d (default 1d): a surface contributes only when the window is a whole number of its declared grain's periods, so a monthly figure needs 30d and is invisible at 1d.",
   },
   {
     field: "emission_pipeline",

--- a/schemas-src/mcp-tools/get-subnet-revenue.ts
+++ b/schemas-src/mcp-tools/get-subnet-revenue.ts
@@ -14,13 +14,24 @@
 // "not observed" can be mistaken for zero.
 import { z } from "zod";
 import { netuidSchema } from "./shared.ts";
+import { ROUTE_QUERY_SCHEMAS } from "../route-queries.ts";
 import {
   ChainRevenueCoverageArtifactSchema,
   SubnetRevenueArtifactSchema,
 } from "../routes/revenue-coverage.ts";
 
+// #10925: `window` is pulled off the ROUTE's own query schema rather than
+// restated, so the three surfaces cannot disagree about which windows exist.
+const RouteQuery_subnets_netuid_revenue =
+  ROUTE_QUERY_SCHEMAS["/api/v1/subnets/{netuid}/revenue"];
+const RouteQuery_chain_revenue_coverage =
+  ROUTE_QUERY_SCHEMAS["/api/v1/chain/revenue-coverage"];
+
 export const GetSubnetRevenueInputSchema = z
-  .object({ netuid: netuidSchema() })
+  .object({
+    netuid: netuidSchema(),
+    window: RouteQuery_subnets_netuid_revenue.shape.window,
+  })
   .strict();
 export type GetSubnetRevenueInput = z.infer<typeof GetSubnetRevenueInputSchema>;
 
@@ -29,7 +40,9 @@ export type GetSubnetRevenueOutput = z.infer<
   typeof GetSubnetRevenueOutputSchema
 >;
 
-export const ListRevenueCoverageInputSchema = z.object({}).strict();
+export const ListRevenueCoverageInputSchema = z
+  .object({ window: RouteQuery_chain_revenue_coverage.shape.window })
+  .strict();
 export type ListRevenueCoverageInput = z.infer<
   typeof ListRevenueCoverageInputSchema
 >;

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -65,6 +65,7 @@ import {
   BULK_HEALTH_TRENDS_LIMIT_MAX,
   CHAIN_CONCENTRATION_HISTORY_WINDOWS,
   DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
+  DEFAULT_SUBNET_REVENUE_WINDOW,
   CHAIN_CALL_MODULE_MAX_LENGTH,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_DEFAULT,
   CHAIN_CONCENTRATION_SUBNETS_LIMIT_MAX,
@@ -96,6 +97,7 @@ import {
   SEMANTIC_QUERY_MAX_LENGTH,
   SEMANTIC_TYPES,
   SUBNET_EMISSION_SPLIT_HISTORY_WINDOWS,
+  SUBNET_REVENUE_WINDOWS,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_DEFAULT,
   SUBNET_EVENT_SUMMARY_RECENT_LIMIT_MAX,
   UPTIME_WINDOWS,
@@ -306,17 +308,11 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
   "/api/v1/network/parameters",
   "/api/v1/network/randomness",
   "/api/v1/subnets/{netuid}/recycled",
-  // #10447: both revenue routes take no query parameters. The window is
-  // fixed at one day for now -- a ?window= that silently changed the
-  // denominator would make two callers quoting "the" ratio mean different
-  // things, so it waits until the series exists to make it meaningful.
-  "/api/v1/subnets/{netuid}/revenue",
   // #10488: both wallet routes take no query parameters. The window is fixed
   // by the loader, so an accepted-but-ignored ?window= would be worse than a
   // 400 -- the caller would believe it narrowed something.
   "/api/v1/subnets/{netuid}/wallets",
   "/api/v1/subnets/{netuid}/owner-cut",
-  "/api/v1/chain/revenue-coverage",
   "/api/v1/subnets/{netuid}/burn",
   "/api/v1/chain/indexer-lag",
   "/api/v1/chain/burn",
@@ -814,6 +810,22 @@ export const ROUTE_QUERY_SCHEMAS = {
   "/api/v1/subnets/{netuid}/yield/history": z.object({
     window: windowSchema(["7d", "30d", "90d"] as const, "30d").optional(),
     format: formatSchema().optional(),
+  }),
+  // #10925: the window a revenue figure is compared against. It was hardcoded
+  // to one day at nine sites, which capped `observed_count` by ARITHMETIC
+  // rather than by coverage -- SN51 publishes a real monthly figure that no
+  // served window could express, because 1 % 30 != 0.
+  "/api/v1/subnets/{netuid}/revenue": z.object({
+    window: windowSchema(
+      SUBNET_REVENUE_WINDOWS as [string, ...string[]],
+      DEFAULT_SUBNET_REVENUE_WINDOW,
+    ).optional(),
+  }),
+  "/api/v1/chain/revenue-coverage": z.object({
+    window: windowSchema(
+      SUBNET_REVENUE_WINDOWS as [string, ...string[]],
+      DEFAULT_SUBNET_REVENUE_WINDOW,
+    ).optional(),
   }),
   "/api/v1/subnets/{netuid}/emission-split/history": z.object({
     window: windowSchema(

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -952,6 +952,7 @@ import type {
 import { readStore } from "./read-store.ts";
 import {
   loadSubnetRevenue,
+  revenueWindowDays,
   SUBNET_REVENUE_FIELD_SOURCES,
 } from "./revenue-load.ts";
 import { loadRevenueObservations } from "./revenue-observations.ts";
@@ -1561,6 +1562,7 @@ async function taoUsdForRevenue(context: GqlContext): Promise<number | null> {
 async function revenueForNetuid(
   context: GqlContext,
   netuid: number,
+  window?: unknown,
 ): Promise<SubnetRevenueView> {
   const rows = (await loadEconomicsRows(context)) as Row[];
   const economics = rows.find((row) => Number(row?.netuid) === netuid) ?? null;
@@ -1570,7 +1572,7 @@ async function revenueForNetuid(
   );
   return loadSubnetRevenue({
     netuid,
-    window_days: 1,
+    window_days: revenueWindowDays(window),
     economics,
     surfaces: await surfacesForNetuid(context, netuid),
     usd_per_tao: await taoUsdForRevenue(context),
@@ -7617,8 +7619,11 @@ const rootValue = {
   // endpoint and a caller sweeping the network would see 127 failures instead
   // of 127 answers. Every missing piece degrades to a null ratio with the
   // emission side still served.
-  async subnet_revenue({ netuid }: { netuid: number }, context: GqlContext) {
-    const revenue = await revenueForNetuid(context, netuid);
+  async subnet_revenue(
+    { netuid, window }: { netuid: number; window?: string | null },
+    context: GqlContext,
+  ) {
+    const revenue = await revenueForNetuid(context, netuid, window);
     return {
       schema_version: 1,
       generated_at: new Date().toISOString(),
@@ -7632,7 +7637,8 @@ const rootValue = {
   // null ratios rather than dropped -- omitting them would make the covered set
   // look like the whole network, which is the single most misleading thing this
   // field could do.
-  async chain_revenue_coverage(_args: Row, context: GqlContext) {
+  async chain_revenue_coverage(args: Row, context: GqlContext) {
+    const windowDays = revenueWindowDays(args?.window);
     const rows = await loadEconomicsRows(context);
     const usd = await taoUsdForRevenue(context);
     // ONE observation read for the whole network rather than one per subnet:
@@ -7648,7 +7654,7 @@ const rootValue = {
       subnets.push(
         loadSubnetRevenue({
           netuid,
-          window_days: 1,
+          window_days: windowDays,
           economics: row,
           surfaces: await surfacesForNetuid(context, netuid),
           usd_per_tao: usd,
@@ -7659,7 +7665,7 @@ const rootValue = {
     return {
       schema_version: 1,
       generated_at: new Date().toISOString(),
-      window_days: 1,
+      window_days: windowDays,
       observed_count: subnets.filter((s) => s.revenue_usd !== null).length,
       subnet_count: subnets.length,
       subnets,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1570,6 +1570,11 @@ import {
 } from "./emission-pipeline-history.ts";
 import { DEFAULT_PIPELINE_HISTORY_WINDOW } from "./route-limits.ts";
 import {
+  ATTRIBUTION_WINDOW_DAYS,
+  DEFAULT_SUBNET_REVENUE_WINDOW,
+  SUBNET_REVENUE_WINDOWS,
+} from "./route-limits.ts";
+import {
   EMISSION_PIPELINE_LIMIT_MAX,
   EMISSION_PIPELINE_MCP_LIMIT_DEFAULT,
 } from "./route-limits.ts";
@@ -1631,6 +1636,7 @@ import { isU16Netuid, loadSubnetRecycled } from "./subnet-recycled.ts";
 import {
   SUBNET_REVENUE_FIELD_SOURCES,
   loadSubnetRevenue,
+  revenueWindowDays,
 } from "./revenue-load.ts";
 import {
   loadSubnetOwnerCut,
@@ -4463,6 +4469,40 @@ function requireNetuid(args: Row) {
     );
   }
   return netuid;
+}
+
+/**
+ * An enum-valued argument, checked against the vocabulary the tool PUBLISHES.
+ *
+ * SAME REASON AS requireNetuid: dispatch does not validate against the Zod
+ * input schema, so an `enum` in a published inputSchema is documentation until
+ * a handler enforces it. An out-of-enum value does not error -- it matches
+ * nothing and falls through to whatever default the handler had, which returns
+ * a real, confident, WRONG answer. `window: "90d"` handed back the 1-day
+ * figure labelled as though the caller had been served.
+ *
+ * The message is built FROM the vocabulary rather than typed out beside it, so
+ * a value added to the enum cannot leave the error text listing the old set.
+ * 43 hand-written copies of this guard remain, 10 of which restate their
+ * vocabulary in prose and are one edit away from exactly that drift (they all
+ * agree with their enums today). Those are #10973; this is the shape they
+ * should collapse onto.
+ */
+function requireEnumArgument<T extends string>(
+  args: Row,
+  key: string,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  const value = args?.[key];
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be one of: ${allowed.join(", ")}.`,
+    );
+  }
+  return value as T;
 }
 
 function optionalBoolean(args: Row, key: string) {
@@ -9404,7 +9444,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         schema_version: 1,
         generated_at: new Date().toISOString(),
         netuid,
-        window_days: 30,
+        window_days: ATTRIBUTION_WINDOW_DAYS,
         wallet_count: wallets.length,
         wallets,
         // #10489-#10509: whether anyone has looked, and when. An empty wallet
@@ -9463,7 +9503,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const ownerCut = parameters?.subnet_owner_cut_effective;
       const view = loadSubnetOwnerCut({
         netuid,
-        window_days: 30,
+        window_days: ATTRIBUTION_WINDOW_DAYS,
         economics,
         owner_cut: typeof ownerCut === "number" ? ownerCut : null,
         // #10926: the rate. Without it `accrual.usd` was null on every MCP
@@ -9512,7 +9552,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         netuid,
         revenue: loadSubnetRevenue({
           netuid,
-          window_days: 1,
+          window_days: revenueWindowDays(
+            requireEnumArgument(
+              args as Row,
+              "window",
+              SUBNET_REVENUE_WINDOWS,
+              DEFAULT_SUBNET_REVENUE_WINDOW,
+            ),
+          ),
           economics,
           surfaces: await mcpSubnetSurfaces(ctx, netuid),
           usd_per_tao: await mcpUsdPerTao(ctx),
@@ -9538,7 +9585,10 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       "rather than dropped: omitting them would make the covered set look like the whole " +
       "network. Mirrors GET /api/v1/chain/revenue-coverage.",
     inputSchema: inputJsonSchema(ListRevenueCoverageInputSchema),
-    async handler(_args: unknown, ctx: McpCtx) {
+    async handler(
+      args: z.infer<typeof ListRevenueCoverageInputSchema>,
+      ctx: McpCtx,
+    ) {
       const blob = await mcpEconomicsBlob(ctx);
       const rows = Array.isArray(blob?.subnets)
         ? (blob.subnets as Array<Record<string, unknown>>)
@@ -9546,6 +9596,14 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       const usd = await mcpUsdPerTao(ctx);
       // ONE read for every subnet, matching the REST handler: the whole series
       // is cheaper than the first dozen per-netuid queries.
+      const windowDays = revenueWindowDays(
+        requireEnumArgument(
+          args as Row,
+          "window",
+          SUBNET_REVENUE_WINDOWS,
+          DEFAULT_SUBNET_REVENUE_WINDOW,
+        ),
+      );
       const allObservations = await mcpRevenueObservations(ctx, null);
       const subnets = [];
       for (const row of rows) {
@@ -9554,7 +9612,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         subnets.push(
           loadSubnetRevenue({
             netuid,
-            window_days: 1,
+            window_days: windowDays,
             economics: row,
             surfaces: await mcpSubnetSurfaces(ctx, netuid),
             usd_per_tao: usd,
@@ -9565,7 +9623,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       return {
         schema_version: 1,
         generated_at: new Date().toISOString(),
-        window_days: 1,
+        window_days: windowDays,
         observed_count: subnets.filter((s) => s.revenue_usd !== null).length,
         subnet_count: subnets.length,
         subnets,

--- a/src/revenue-load.ts
+++ b/src/revenue-load.ts
@@ -13,6 +13,10 @@
 // endpoint, and a caller sweeping the network would see 127 failures instead of
 // 127 answers.
 import {
+  DEFAULT_SUBNET_REVENUE_WINDOW,
+  SUBNET_REVENUE_WINDOW_DAYS,
+} from "./route-limits.ts";
+import {
   type SubnetRevenueView,
   buildSubnetRevenue,
   type RevenueObservation,
@@ -154,4 +158,26 @@ export function loadSubnetRevenue(
     searched_at: input.searched_at ?? null,
   });
   return view;
+}
+
+/**
+ * The window a revenue caller asked for, in DAYS.
+ *
+ * Lives beside the loader every surface calls, so REST, MCP and GraphQL cannot
+ * resolve the same `?window=` to different denominators -- which is the exact
+ * failure the hardcoded `1` was hiding at nine sites. An unrecognised value
+ * falls back to the default rather than throwing: the router, the MCP input
+ * schema and the GraphQL dispatch have all already rejected anything outside
+ * the published enum by the time this runs, so a throw here would be
+ * unreachable, and a silent default is the safer unreachable branch.
+ */
+export function revenueWindowDays(window: unknown): number {
+  const label =
+    typeof window === "string" && window
+      ? window
+      : DEFAULT_SUBNET_REVENUE_WINDOW;
+  return (
+    SUBNET_REVENUE_WINDOW_DAYS[label] ??
+    SUBNET_REVENUE_WINDOW_DAYS[DEFAULT_SUBNET_REVENUE_WINDOW]
+  );
 }

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -465,3 +465,46 @@ export const SUBNET_EMISSION_SPLIT_HISTORY_WINDOWS = Object.keys(
   SUBNET_EMISSION_SPLIT_HISTORY_WINDOW_DAYS,
 );
 export const DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW = "30d";
+
+/**
+ * `/api/v1/subnets/{netuid}/revenue` and `/api/v1/chain/revenue-coverage`
+ * -- the window a revenue figure is compared against (#10925).
+ *
+ * THE VALUES ARE THE GRAINS THE REGISTRY DECLARES. `GRAIN_DAYS` in
+ * src/revenue-serving.ts maps `daily -> 1`, `weekly -> 7`, `monthly -> 30`, and
+ * a surface contributes only when the window is a whole number of its periods.
+ * So these three are not a taste: they are exactly the windows any declared
+ * surface can answer, and a fourth value would be a window nothing could fill.
+ *
+ * 1d REMAINS THE DEFAULT. The window was hardcoded to 1 at nine call sites, and
+ * every caller quoting "the" coverage ratio today is quoting a one-day one --
+ * changing the default would silently re-denominate all of them.
+ *
+ * `cumulative` is still unreachable at every window, deliberately: a lifetime
+ * total is a running sum with no period, and dividing it by a window compares a
+ * subnet's whole history against one day of emission.
+ */
+export const SUBNET_REVENUE_WINDOW_DAYS: Record<string, number> = {
+  "1d": 1,
+  "7d": 7,
+  "30d": 30,
+};
+export const SUBNET_REVENUE_WINDOWS = Object.keys(SUBNET_REVENUE_WINDOW_DAYS);
+export const DEFAULT_SUBNET_REVENUE_WINDOW = "1d";
+
+/**
+ * `/api/v1/subnets/{netuid}/wallets` and `/api/v1/subnets/{netuid}/owner-cut`
+ * -- the window those two publish, which the CALLER DOES NOT CHOOSE (#10925).
+ *
+ * Named here rather than left as a literal because it was stated four times --
+ * once in each route's REST handler and once in each of their MCP tools -- and
+ * four copies of a number two surfaces must agree on is how a surface starts
+ * reporting a 30-day accrual beside a `window_days` of 7. They agreed at the
+ * time this was extracted; nothing was making them.
+ *
+ * Deliberately NOT folded into SUBNET_REVENUE_WINDOW_DAYS. That vocabulary is a
+ * menu a caller picks from; this is a fixed property of two attribution
+ * surfaces, and giving them a `?window=` they cannot honour would publish a
+ * lever that does nothing -- the exact defect #10925 exists to remove.
+ */
+export const ATTRIBUTION_WINDOW_DAYS = 30;

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -24778,6 +24778,62 @@ describe("revenue coverage over GraphQL (#10476)", () => {
     assert.match(String(subset.excluded_reason), /superseded/);
   });
 
+  // #10925: the window is an argument on both revenue fields now. GraphQL is
+  // the one surface of the three that does NOT need a hand-written guard --
+  // parseArgumentsAtDispatch resolves each field's args against the route's own
+  // query schema and raises BAD_USER_INPUT -- but that is a claim about wiring,
+  // and wiring is exactly what was wrong here. Proven, not assumed.
+  test("the window reaches window_days through the field argument", async () => {
+    for (const [window, days] of [
+      ["1d", 1],
+      ["7d", 7],
+      ["30d", 30],
+    ] as const) {
+      const { body } = await gql(
+        `query { subnet_revenue(netuid: 64, window: "${window}") { revenue { window_days } } }`,
+        revenueEnv(),
+      );
+      assert.equal(body.errors, undefined, `errored on ${window}`);
+      const r = (body.data.subnet_revenue as Row).revenue as Row;
+      assert.equal(r.window_days, days, `on ${window}`);
+    }
+  });
+
+  test("AN OUT-OF-ENUM WINDOW IS REJECTED, not silently defaulted", async () => {
+    const { body } = await gql(
+      `query { subnet_revenue(netuid: 64, window: "90d") { revenue { window_days } } }`,
+      revenueEnv(),
+    );
+    assert.ok(body.errors, "90d was accepted");
+    assert.equal((body.errors as Row[])[0].extensions?.code, "BAD_USER_INPUT");
+  });
+
+  test("an omitted window is the published default", async () => {
+    const { body } = await gql(
+      `query { subnet_revenue(netuid: 64) { revenue { window_days } } }`,
+      revenueEnv(),
+    );
+    assert.equal(body.errors, undefined);
+    assert.equal(
+      ((body.data.subnet_revenue as Row).revenue as Row).window_days,
+      1,
+    );
+  });
+
+  test("chain_revenue_coverage takes the same argument, same vocabulary", async () => {
+    const ok = await gql(
+      `query { chain_revenue_coverage(window: "30d") { window_days } }`,
+      revenueEnv(),
+    );
+    assert.equal(ok.body.errors, undefined);
+    assert.equal((ok.body.data.chain_revenue_coverage as Row).window_days, 30);
+    const bad = await gql(
+      `query { chain_revenue_coverage(window: "90d") { window_days } }`,
+      revenueEnv(),
+    );
+    assert.ok(bad.body.errors, "90d was accepted on the coverage field");
+  });
+
   test("a surface with no revenue block is not listed as a source", () => {
     // Asserted through the query above rather than separately: a response
     // listing a models endpoint among its revenue "sources" invites exactly

--- a/tests/revenue-api-surface.test.ts
+++ b/tests/revenue-api-surface.test.ts
@@ -203,6 +203,65 @@ describe("GET /api/v1/subnets/{netuid}/revenue", () => {
     assert.equal((body.error as Row)?.code, "invalid_netuid");
   });
 
+  // #10925: the third surface. REST needs no hand-written guard either -- the
+  // router validates against the published query schema and answers
+  // `invalid_query` -- but the point of this issue is that all three surfaces
+  // resolve ONE vocabulary, and "they must agree" is worth an assertion on each
+  // rather than an argument about the wiring.
+  test("each published window reaches window_days", async () => {
+    for (const [window, days] of [
+      ["1d", 1],
+      ["7d", 7],
+      ["30d", 30],
+    ] as const) {
+      const res = await handleRequest(
+        req(`/api/v1/subnets/64/revenue?window=${window}`),
+        artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      );
+      assert.equal(res.status, 200, `on ${window}`);
+      const body = await jsonBody(res);
+      assert.equal(
+        ((body.data as Row).revenue as Row).window_days,
+        days,
+        `on ${window}`,
+      );
+    }
+  });
+
+  test("an out-of-enum window is a 400, not the default window", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/64/revenue?window=90d"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    );
+    assert.equal(res.status, 400);
+    const body = await jsonBody(res);
+    assert.equal((body.error as Row)?.code, "invalid_query");
+    assert.equal((body.meta as Row)?.parameter, "window");
+  });
+
+  test("an omitted window is the default, unchanged from before #10925", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/64/revenue"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    );
+    const body = await jsonBody(res);
+    assert.equal(((body.data as Row).revenue as Row).window_days, 1);
+  });
+
+  test("the coverage route takes the same vocabulary", async () => {
+    const ok = await handleRequest(
+      req("/api/v1/chain/revenue-coverage?window=30d"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    );
+    assert.equal(ok.status, 200);
+    assert.equal((await jsonBody(ok)).data.window_days, 30);
+    const bad = await handleRequest(
+      req("/api/v1/chain/revenue-coverage?window=90d"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    );
+    assert.equal(bad.status, 400);
+  });
+
   test("serves the ratio when economics, surfaces and a TAO price are all present", async () => {
     const res = await handleRequest(
       req("/api/v1/subnets/64/revenue"),
@@ -439,6 +498,60 @@ describe("the get_subnet_revenue MCP tool", () => {
     );
   });
 
+  // #10925: the window is a real argument here, and MCP dispatch does not
+  // validate against the published input schema -- so these two tools are the
+  // only thing standing between an out-of-enum window and a confidently wrong
+  // answer. `revenueWindowDays` falls back to 1d by design (the REST router has
+  // already rejected anything else by the time it runs), which on this path
+  // would mean `window: "90d"` silently returns the ONE-DAY figure.
+  test("an out-of-enum window is an error, NOT the default window", async () => {
+    await assert.rejects(
+      () =>
+        tool("get_subnet_revenue").handler(
+          { netuid: 64, window: "90d" },
+          mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+        ),
+      /must be one of: 1d, 7d, 30d/,
+    );
+  });
+
+  test("a non-string window is rejected too", async () => {
+    // `30` is the shape a caller reaches for after reading `window_days` in the
+    // response body, and `allowed.includes(30)` is false -- but only because
+    // the guard checks the type first. Without that check the number would
+    // reach the day map and miss, i.e. the 1d answer again.
+    await assert.rejects(
+      () =>
+        tool("get_subnet_revenue").handler(
+          { netuid: 64, window: 30 },
+          mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+        ),
+      /must be one of/,
+    );
+  });
+
+  test("each published window is accepted and reaches the body", async () => {
+    for (const [window, days] of [
+      ["1d", 1],
+      ["7d", 7],
+      ["30d", 30],
+    ] as const) {
+      const out = (await tool("get_subnet_revenue").handler(
+        { netuid: 64, window },
+        mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      )) as Row;
+      assert.equal((out.revenue as Row).window_days, days, `on ${window}`);
+    }
+  });
+
+  test("an omitted window is the default, not an error", async () => {
+    const out = (await tool("get_subnet_revenue").handler(
+      { netuid: 64 },
+      mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    )) as Row;
+    assert.equal((out.revenue as Row).window_days, 1);
+  });
+
   test("returns the composed view when every artifact is present", async () => {
     const out = (await tool("get_subnet_revenue").handler(
       { netuid: 64 },
@@ -523,6 +636,25 @@ describe("the list_revenue_coverage MCP tool", () => {
     assert.equal(out.subnet_count, 2);
     assert.equal(out.observed_count, 0);
     assert.equal((out.subnets as unknown[]).length, 2);
+  });
+
+  test("rejects an out-of-enum window rather than defaulting", async () => {
+    await assert.rejects(
+      () =>
+        tool("list_revenue_coverage").handler(
+          { window: "90d" },
+          mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+        ),
+      /must be one of: 1d, 7d, 30d/,
+    );
+  });
+
+  test("carries the requested window into every row", async () => {
+    const out = (await tool("list_revenue_coverage").handler(
+      { window: "30d" },
+      mcpCtx({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+    )) as Row;
+    assert.equal(out.window_days, 30);
   });
 
   test("skips a row whose netuid does not parse", async () => {

--- a/tests/revenue-window.test.ts
+++ b/tests/revenue-window.test.ts
@@ -1,0 +1,221 @@
+// #10925: `window_days` was the literal `1` at nine call sites.
+//
+// The surface of the bug was that `?window=` did nothing. The SHAPE of it is
+// worse: `windowedAmount` refuses a grain that does not divide the window, so a
+// subnet publishing a MONTHLY revenue figure was permanently excluded with the
+// reason "grain \"monthly\" does not divide a 1-day window" -- a correct
+// sentence, published forever, for a window nobody chose and no caller could
+// change. The decline was accurate and the answer was still wrong.
+//
+// These tests are written against that failure rather than against the enum:
+// the vocabulary cases would pass on a `revenueWindowDays` that every caller
+// ignored, which is exactly the state this issue describes.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, relative } from "node:path";
+import { loadSubnetRevenue, revenueWindowDays } from "../src/revenue-load.ts";
+import {
+  ATTRIBUTION_WINDOW_DAYS,
+  DEFAULT_SUBNET_REVENUE_WINDOW,
+  SUBNET_REVENUE_WINDOWS,
+  SUBNET_REVENUE_WINDOW_DAYS,
+} from "../src/route-limits.ts";
+import {
+  ROUTE_QUERY_SCHEMAS,
+  NO_QUERY_PARAMETERS,
+} from "../schemas-src/route-queries.ts";
+import {
+  GetSubnetRevenueInputSchema,
+  ListRevenueCoverageInputSchema,
+} from "../schemas-src/mcp-tools/get-subnet-revenue.ts";
+
+const ROUTES = [
+  "/api/v1/subnets/{netuid}/revenue",
+  "/api/v1/chain/revenue-coverage",
+] as const;
+
+/** A subnet whose only revenue surface reports once a month. */
+function monthlySubnet(window_days: number) {
+  return loadSubnetRevenue({
+    netuid: 51,
+    window_days,
+    economics: { tao_in_emission_tao: 0.0636, excess_tao: 0 },
+    surfaces: [
+      {
+        id: "s-monthly",
+        revenue: {
+          role: "external-revenue",
+          provenance: "probe-derived",
+          currency: "USD",
+          grain: "monthly",
+        },
+      },
+    ],
+    usd_per_tao: 204.03,
+    observations: new Map([
+      [
+        "s-monthly",
+        [{ surface_id: "s-monthly", period: "2026-07", amount_usd: 30_000 }],
+      ],
+    ]),
+  });
+}
+
+describe("the window a caller asks for reaches the denominator", () => {
+  test("A MONTHLY SURFACE IS INVISIBLE AT 1d AND CONTRIBUTES AT 30d", () => {
+    // THE BUG. Both calls are the same subnet, the same surface and the same
+    // observation; only the window differs. Under the hardcoded `1` the second
+    // case was unreachable.
+    const day = monthlySubnet(revenueWindowDays("1d"));
+    assert.equal(day.sources[0].contributes, false);
+    assert.match(day.sources[0].excluded_reason as string, /does not divide/);
+    assert.equal(day.sources[0].amount_usd, null);
+    assert.equal(day.revenue_usd, null);
+
+    const month = monthlySubnet(revenueWindowDays("30d"));
+    assert.equal(month.sources[0].contributes, true);
+    assert.equal(month.sources[0].excluded_reason, null);
+    assert.equal(month.sources[0].amount_usd, 30_000);
+    assert.equal(month.revenue_usd, 30_000);
+  });
+
+  test("the exclusion NAMES the window, so the reason is not a constant", () => {
+    // A reason that never mentions the window reads as a property of the
+    // surface. It is a property of the QUESTION, and the text has to say so or
+    // a reader will conclude the subnet publishes nothing usable.
+    const seven = monthlySubnet(revenueWindowDays("7d"));
+    assert.match(seven.sources[0].excluded_reason as string, /7-day window/);
+    assert.match(
+      monthlySubnet(revenueWindowDays("1d")).sources[0]
+        .excluded_reason as string,
+      /1-day window/,
+    );
+  });
+
+  test("the emission denominator scales with the window too", () => {
+    // Not just the numerator. If only the revenue side moved, a 30-day figure
+    // would be compared against one day of emission -- the 200x class of error
+    // #10565 already fixed once, reintroduced through the window.
+    const day = monthlySubnet(revenueWindowDays("1d"));
+    const month = monthlySubnet(revenueWindowDays("30d"));
+    assert.ok(month.emission.tao > 0);
+    assert.ok(
+      Math.abs(month.emission.tao / day.emission.tao - 30) < 1e-6,
+      `30d emission was ${month.emission.tao / day.emission.tao}x the 1d one`,
+    );
+  });
+});
+
+describe("the vocabulary", () => {
+  test("maps each published label to its day count", () => {
+    assert.deepEqual(SUBNET_REVENUE_WINDOWS, ["1d", "7d", "30d"]);
+    assert.equal(revenueWindowDays("1d"), 1);
+    assert.equal(revenueWindowDays("7d"), 7);
+    assert.equal(revenueWindowDays("30d"), 30);
+  });
+
+  test("every published label has a denominator, and nothing else does", () => {
+    // The two lists are one source, so this cannot drift -- but a label added
+    // to the enum without a day count would resolve to the DEFAULT rather than
+    // failing, which is a wrong answer that looks like a right one.
+    assert.deepEqual(
+      SUBNET_REVENUE_WINDOWS.slice().sort(),
+      Object.keys(SUBNET_REVENUE_WINDOW_DAYS).sort(),
+    );
+    assert.ok(SUBNET_REVENUE_WINDOWS.includes(DEFAULT_SUBNET_REVENUE_WINDOW));
+  });
+
+  test("an absent or unparseable window is the default, not a throw", () => {
+    const fallback = SUBNET_REVENUE_WINDOW_DAYS[DEFAULT_SUBNET_REVENUE_WINDOW];
+    for (const bad of [undefined, null, "", "90d", 7, {}, []]) {
+      assert.equal(revenueWindowDays(bad), fallback, `on ${String(bad)}`);
+    }
+  });
+
+  test("the default is 1d, so the pre-#10925 answer is still the default one", () => {
+    // The migration claim: every caller that passed nothing before now gets
+    // the identical number. This is what makes the change non-breaking.
+    assert.equal(revenueWindowDays(undefined), 1);
+  });
+});
+
+describe("one vocabulary, three surfaces", () => {
+  for (const path of ROUTES) {
+    test(`${path} publishes window and no longer claims to take nothing`, () => {
+      const shape = ROUTE_QUERY_SCHEMAS[path]?.shape;
+      assert.ok(shape?.window, "the route declares no window");
+      assert.equal(
+        NO_QUERY_PARAMETERS.includes(path),
+        false,
+        "still listed as taking no parameters",
+      );
+      for (const label of SUBNET_REVENUE_WINDOWS) {
+        assert.equal(shape.window.parse(label), label);
+      }
+      assert.equal(shape.window.safeParse("90d").success, false);
+    });
+  }
+
+  test("the MCP inputs ARE the route schemas, by identity", () => {
+    // Not "equivalent to" -- the same object. A copy is how the MCP argument
+    // vocabulary drifted from its route before (#10925's sibling failure).
+    assert.equal(
+      GetSubnetRevenueInputSchema.shape.window,
+      ROUTE_QUERY_SCHEMAS[ROUTES[0]].shape.window,
+    );
+    assert.equal(
+      ListRevenueCoverageInputSchema.shape.window,
+      ROUTE_QUERY_SCHEMAS[ROUTES[1]].shape.window,
+    );
+  });
+
+  test("NO SERVING SITE WRITES A LITERAL DAY COUNT", () => {
+    // THE NEGATIVE INVARIANT, and the only assertion here that found anything.
+    // Every check above passes on a codebase that still hardcodes the window at
+    // a tenth site, because a test can only check the call sites it names.
+    //
+    // This one names none of them, and it caught four the issue did not list:
+    // `window_days: 30` restated in the wallets and owner-cut handlers and
+    // again in both of their MCP tools. Those windows are genuinely fixed --
+    // the caller does not pick them -- so the fix there is
+    // ATTRIBUTION_WINDOW_DAYS rather than a `?window=`. Either way the rule is
+    // the same: the number is named once, and a serving file that writes a
+    // digit is asserting a denominator nothing else can see.
+    // DERIVED, not listed. A hardcoded file list is the same failure one level
+    // up: it goes stale the moment a serving file is added or renamed, and it
+    // goes stale silently. Walk src/ and workers/ instead.
+    const root = fileURLToPath(new URL("..", import.meta.url));
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (entry.name.endsWith(".ts")) files.push(full);
+      }
+    };
+    walk(join(root, "src"));
+    walk(join(root, "workers"));
+    assert.ok(files.length > 100, `only swept ${files.length} files`);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(file, "utf8");
+      for (const [i, line] of source.split("\n").entries()) {
+        // A literal day count assigned to the field, in any spacing. A
+        // constant or an expression is fine; a digit is not.
+        if (/window_days\s*:\s*\d/.test(line)) {
+          offenders.push(`${relative(root, file)}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+    assert.deepEqual(offenders, [], offenders.join("\n"));
+  });
+
+  test("the fixed-window routes still publish 30, via the constant", () => {
+    // The other half: the sweep above is satisfied by DELETING the field, and
+    // a wallets response with no `window_days` would pass it. Pin the value.
+    assert.equal(ATTRIBUTION_WINDOW_DAYS, 30);
+  });
+});

--- a/tests/route-query-parity.test.ts
+++ b/tests/route-query-parity.test.ts
@@ -205,8 +205,13 @@ describe("each route's schema emits exactly what it publishes (#10062)", () => {
     );
     const declared = Object.keys(ROUTE_QUERY_SCHEMAS).length;
     assert.ok(declared >= 100, `only ${declared} routes are declared`);
+    // 67, down from 69 (#10925): the two revenue routes moved OUT of this list
+    // because they now take a real `?window=`. This is a vacuity floor, not a
+    // ratchet -- it exists so the sweep above cannot pass on an empty set, and
+    // a route legitimately gaining a parameter is the one reason it should
+    // fall. `withParameters` rises by the same two.
     assert.ok(
-      NO_QUERY_PARAMETERS.length >= 69,
+      NO_QUERY_PARAMETERS.length >= 67,
       `only ${NO_QUERY_PARAMETERS.length} routes declare that they take none`,
     );
     assert.ok(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -7590,10 +7590,10 @@ async function dispatchLiveChainRoute(
 
   const revenueMatch = SUBNET_REVENUE_PATH_PATTERN.exec(pathname);
   if (revenueMatch) {
-    return handleSubnetRevenue(request, env, Number(revenueMatch[1]));
+    return handleSubnetRevenue(request, env, Number(revenueMatch[1]), url);
   }
   if (pathname === CHAIN_REVENUE_COVERAGE_PATH) {
-    return handleChainRevenueCoverage(request, env);
+    return handleChainRevenueCoverage(request, env, url);
   }
   const recycledMatch = SUBNET_RECYCLED_PATH_PATTERN.exec(pathname);
   if (recycledMatch) {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -102,7 +102,9 @@ import {
 import { buildSubnetEmissionSplitHistory } from "../../src/emission-split.ts";
 import {
   DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
+  DEFAULT_SUBNET_REVENUE_WINDOW,
   SUBNET_EMISSION_SPLIT_HISTORY_WINDOW_DAYS,
+  SUBNET_REVENUE_WINDOW_DAYS,
 } from "../../src/route-limits.ts";
 import {
   buildNeuronHistory,
@@ -217,7 +219,7 @@ import {
   type ValidatorEconomicsRow,
   type ValidatorNeuron,
 } from "../../src/validator-economics.ts";
-import {} from "../../src/route-limits.ts";
+import { ATTRIBUTION_WINDOW_DAYS } from "../../src/route-limits.ts";
 import { loadSubnetLease } from "../../src/subnet-lease.ts";
 import {
   isCrowdloanId,
@@ -7230,7 +7232,7 @@ export async function handleSubnetWallets(
         schema_version: 1,
         generated_at: new Date().toISOString(),
         netuid,
-        window_days: 30,
+        window_days: ATTRIBUTION_WINDOW_DAYS,
         wallet_count: wallets.length,
         wallets,
         attribution_search: attributionSearch,
@@ -7277,7 +7279,7 @@ export async function handleSubnetOwnerCut(
   const ownerCut = parameters?.subnet_owner_cut_effective;
   const view = loadSubnetOwnerCut({
     netuid,
-    window_days: 30,
+    window_days: ATTRIBUTION_WINDOW_DAYS,
     economics: row,
     owner_cut: typeof ownerCut === "number" ? ownerCut : null,
     usd_per_tao: await usdPerTaoOrNull(env),
@@ -7301,6 +7303,7 @@ export async function handleSubnetRevenue(
   request: Request,
   env: Env,
   netuid: number,
+  url: URL,
 ) {
   if (!Number.isInteger(netuid) || netuid < 0 || netuid > 65535) {
     return errorResponse(
@@ -7318,9 +7321,18 @@ export async function handleSubnetRevenue(
     readStore(env, REVENUE_OBSERVATION_TABLES) as RevenueStoreDb | undefined,
     netuid,
   );
+  // #10925: the window is a parameter now, not a constant. The DEFAULT is
+  // still one day -- every caller quoting "the" coverage ratio today is
+  // quoting a one-day one, and re-denominating them silently would be worse
+  // than leaving the wider windows unreachable.
+  const { days: windowDays } = resolveWindow(
+    url,
+    SUBNET_REVENUE_WINDOW_DAYS,
+    DEFAULT_SUBNET_REVENUE_WINDOW,
+  );
   const revenue = loadSubnetRevenue({
     netuid,
-    window_days: 1,
+    window_days: windowDays,
     economics: row,
     surfaces: await subnetSurfacesFor(env, netuid),
     usd_per_tao: await usdPerTaoOrNull(env),
@@ -7345,7 +7357,16 @@ export async function handleSubnetRevenue(
 /** Every subnet's coverage in one response. Subnets with no observed revenue
  * are INCLUDED with null ratios rather than dropped: omitting them would make
  * the covered set look like the whole network. */
-export async function handleChainRevenueCoverage(request: Request, env: Env) {
+export async function handleChainRevenueCoverage(
+  request: Request,
+  env: Env,
+  url: URL,
+) {
+  const { days: windowDays } = resolveWindow(
+    url,
+    SUBNET_REVENUE_WINDOW_DAYS,
+    DEFAULT_SUBNET_REVENUE_WINDOW,
+  );
   const blob = await resolveEconomicsBlob(env, async () => {
     const artifact = await readArtifact(env, "/metagraph/economics.json");
     return artifact.ok
@@ -7370,7 +7391,7 @@ export async function handleChainRevenueCoverage(request: Request, env: Env) {
     subnets.push(
       loadSubnetRevenue({
         netuid,
-        window_days: 1,
+        window_days: windowDays,
         economics: row,
         surfaces: await subnetSurfacesFor(env, netuid),
         usd_per_tao: usd,
@@ -7384,7 +7405,7 @@ export async function handleChainRevenueCoverage(request: Request, env: Env) {
       data: {
         schema_version: 1,
         generated_at: new Date().toISOString(),
-        window_days: 1,
+        window_days: windowDays,
         observed_count: subnets.filter((s) => s.revenue_usd !== null).length,
         subnet_count: subnets.length,
         subnets,


### PR DESCRIPTION
Closes #10925

## The bug is narrower and worse than "the parameter does nothing"

`window_days` was the literal `1` at nine serving sites. The visible symptom is
that `?window=` had no effect on the two revenue routes. The real one:

`windowedAmount` only lets a surface contribute when the window is a whole
number of its declared grain's periods — a monthly figure cannot answer
"yesterday", and apportioning one across a boundary is modelling, which #10439
forbids. So a subnet publishing a **monthly** revenue figure was excluded, for
every caller, forever, with the reason:

```
grain "monthly" does not divide a 1-day window
```

That sentence is true. It is also a statement about a window nobody chose and
no caller could change. The decline was correct and the answer was wrong — the
same shape as #10566 and #10926, where a well-formed refusal stood in for a
read that never happened.

## What changed

Both routes take `?window=1d|7d|30d`, and all three surfaces resolve it through
one `revenueWindowDays()` sitting beside the loader they already share.

| | before | after |
| --- | --- | --- |
| REST | `window_days: 1` inline | `resolveWindow(url, …)`, `invalid_query` 400 on anything else |
| MCP | `window_days: 1` inline | `requireEnumArgument` → `invalid_params` |
| GraphQL | `window_days: 1` inline | `window` arg, `BAD_USER_INPUT` on anything else |

**`?window=`, not `?window_days=`.** The issue named the latter. Every other
windowed route on this API publishes `window` with a `1d`/`7d`/`30d`-style
vocabulary, and `ROUTE_QUERY_SCHEMAS` is where that vocabulary is enforced — a
second spelling for the same concept is precisely the duplication this change
exists to remove. The MCP inputs are the route schema objects *by identity*, so
the three surfaces cannot drift.

**1d stays the default**, so every caller quoting a coverage ratio today gets
the identical number. The change is additive.

## The MCP leg needed a guard the other two did not

Dispatch does not validate against the published `inputSchema` — a settled
decision — so an `enum` there is documentation until a handler enforces it.
Without a guard, `window: "90d"` would fall through to the default and return
the **one-day figure** as a confident answer. `tests/mcp-schema-enforcement.ts`
caught this before it shipped.

`requireEnumArgument` builds its message *from* the vocabulary rather than
restating it beside it, so the error text cannot drift from the enum. 43
hand-written copies of that guard remain, 10 of them restating their vocabulary
in prose — filed as #10973 with the conversion scope; this is the shape they
should collapse onto.

## Two things found while here, fixed rather than filed

- **`window_days: 30` written out four times** — the wallets and owner-cut REST
  handlers, and both of their MCP tools. Those windows are genuinely fixed (the
  caller does not pick them), so the fix is `ATTRIBUTION_WINDOW_DAYS`, not a
  `?window=` they cannot honour. They agreed at the time; nothing was making
  them.
- `workers/request-handlers/entities.ts` carried an empty `import {}` from
  route-limits.

Both were found by the one test here that names no call sites. Every other
assertion passes on a codebase that still hardcodes the window somewhere it did
not think to look, so that sweep walks `src/` and `workers/` and fails on any
literal day count assigned to the field. It is derived rather than listed for
the same reason — a hardcoded file list goes stale silently.

## Verification

- `tests/revenue-window.test.ts` (new) — a monthly surface is excluded at `1d`
  with a reason that names the window, and contributes `$30,000` at `30d`. Same
  subnet, same surface, same observation; only the window differs. Under the
  hardcoded `1`, the second case was unreachable.
- The emission **denominator** scales too, asserted as a ratio — if only the
  numerator moved, a 30-day figure would be compared against one day of
  emission, which is the 200x class of error #10565 already fixed once.
- Each surface proven separately (REST 400 + `meta.parameter: "window"`,
  GraphQL `BAD_USER_INPUT`, MCP `invalid_params`), because "they share a
  vocabulary" is a claim about wiring and wiring is what was wrong.
- `NO_QUERY_PARAMETERS` vacuity floor 69 → 67, with the reasoning inline: two
  routes legitimately moved out of it, and `withParameters` rises by the same
  two. This is a floor guarding against an empty comparison, not a ratchet.

**20,230 tests pass** (879 files, unsharded). Full CI validator set green,
lint + format + typecheck clean, rebuilt on `f9e4e162f` with zero drift.
**Patch coverage 100%** (32/32 lines and branches, measured unsharded and
intersected against the diff).