### PR TITLE
fix(api): the tripwires validate what is sent, not what the handler built

### DIFF
--- a/src/mcp-response-tripwire.ts
+++ b/src/mcp-response-tripwire.ts
@@ -87,6 +87,47 @@ export class McpResponseSchemaDriftError extends Error {
 }
 
 /**
+ * The payload AS THE CLIENT RECEIVES IT, not as the handler built it.
+ *
+ * ## WHY THIS EXISTS
+ *
+ * `get_subnet_health` failed 46% of its calls with `response_schema_drift`
+ * (13 of 28 in 24h, #10972) on a response that was never wrong. A handler that
+ * spreads an object built from an absent artifact leaves keys present with
+ * `undefined` -- `overlaySubnetHealth(null, ...)` produces
+ * `contract_version`, `generated_at`, `slug` and `name` that way. Zod
+ * `.strict()` keys on `Object.keys()`, so it counted all four as unrecognized;
+ * `JSON.stringify` DROPS them, so the client never saw one.
+ *
+ * The tripwire was therefore stricter than the contract it enforces, and
+ * turned a correct answer into a tool error for every agent that called it.
+ *
+ * ## WHY THE ROUND-TRIP, AND NOT A KEY FILTER
+ *
+ * The published `outputSchema` describes JSON. A conformant MCP client parses
+ * the JSON it received and validates THAT -- so the only shape worth checking
+ * is the one serialization produces. A shallow "delete undefined keys" pass
+ * would fix this call site and miss a nested one, a `Date`, a `Map`, or
+ * anything else whose serialized form differs from its in-memory form; the
+ * round-trip is the definition rather than an approximation of it.
+ *
+ * It costs one clone per validated response, paid only while
+ * `METAGRAPH_VALIDATE_RESPONSES` is on -- the same trade that flag already
+ * exists to make.
+ *
+ * A payload that cannot be serialized at all is a real fault and is left to
+ * the parse, which will fail on the untouched value rather than silently
+ * validating something else.
+ */
+function asSentOverTheWire(payload: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(payload));
+  } catch {
+    return payload;
+  }
+}
+
+/**
  * Parse one tool's structured result against the schema it publishes.
  *
  * Called ONLY when the caller has confirmed
@@ -115,7 +156,7 @@ export function validateMcpResponseTripwire(
     );
     return;
   }
-  const result = schema.safeParse(structuredContent);
+  const result = schema.safeParse(asSentOverTheWire(structuredContent));
   if (!result.success) {
     throw new McpResponseSchemaDriftError(tool, result.error);
   }

--- a/src/response-validation-tripwire.ts
+++ b/src/response-validation-tripwire.ts
@@ -99,6 +99,35 @@ async function schemaForArtifact(artifactPath: string) {
 }
 
 /**
+ * The envelope AS THE CLIENT RECEIVES IT, not as the handler built it.
+ *
+ * Same reasoning as the MCP tripwire's own copy of this (#10972), and the same
+ * one-line change, made here even though REST does not currently trip on it:
+ * an artifact composed from an absent source leaves keys present with
+ * `undefined` (`overlaySubnetHealth(null, ...)` produces four), Zod
+ * `.strict()` counts those as unrecognized, and `JSON.stringify` drops them
+ * before the client sees anything.
+ *
+ * REST escapes it today only because the components involved happen to declare
+ * those fields optional. That is a property of which fields drifted first, not
+ * a difference in kind -- the next strict component that omits a key some
+ * composer leaves undefined would fail a response that serializes correctly,
+ * exactly as `get_subnet_health` did on 46% of its calls.
+ *
+ * NOT shared with the MCP copy: this module is imported by the Worker entry
+ * and that one by the MCP dispatch, and a shared import for eight lines would
+ * couple two tripwires that are deliberately independent (see this file's
+ * header on why they are one decision but not one implementation).
+ */
+function asSentOverTheWire(payload: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(payload));
+  } catch {
+    return payload;
+  }
+}
+
+/**
  * Called ONLY when the caller has already confirmed
  * `env.METAGRAPH_VALIDATE_RESPONSES === "true"` -- see this file's own header
  * and the call sites in workers/api.ts and workers/request-handlers/entities.ts.
@@ -112,7 +141,7 @@ export async function validateResponseTripwire(
   try {
     const schema = await schemaForArtifact(artifactPath);
     if (!schema) return;
-    const result = schema.safeParse(envelope);
+    const result = schema.safeParse(asSentOverTheWire(envelope));
     if (!result.success) {
       throw new ResponseSchemaDriftError(routeId, result.error);
     }

--- a/tests/mcp-response-tripwire.test.ts
+++ b/tests/mcp-response-tripwire.test.ts
@@ -135,3 +135,86 @@ describe("validateMcpResponseTripwire", () => {
     );
   });
 });
+
+// ── It validates the wire, not the handler's object (#10972) ────────────────
+//
+// `get_subnet_health` failed 46% of its calls (13 of 28 in 24h) with
+// `response_schema_drift` on a response that was never wrong. A handler that
+// spreads an object built from an ABSENT source leaves keys present with
+// `undefined` -- `overlaySubnetHealth(null, ...)` produces `contract_version`,
+// `generated_at`, `slug` and `name` that way. Zod `.strict()` keys on
+// `Object.keys()` and counted all four; `JSON.stringify` drops them, so the
+// client never saw one.
+//
+// The tripwire exists so a caller never receives a shape the contract does not
+// describe. Rejecting a correct answer is the opposite of that, and it reached
+// every agent calling the tool as a hard error.
+describe("the tripwire validates what is sent, not what was built", () => {
+  const published = outputJsonSchema(Card);
+
+  test("an undefined-valued key does not fail a response that serializes clean", () => {
+    // Exactly the shape a `{...spread}` of an absent artifact produces.
+    const built = { netuid: 0, name: "root", contract_version: undefined };
+    assert.equal(
+      JSON.stringify(built),
+      '{"netuid":0,"name":"root"}',
+      "the premise: serialization drops the key, so the client never sees it",
+    );
+    assert.doesNotThrow(() =>
+      validateMcpResponseTripwire("get_card", published, built),
+    );
+  });
+
+  test("a key with a REAL value still fails", () => {
+    // Guards the guard. If the fix had stripped keys rather than serializing,
+    // or had loosened the schema, this is the case that would stop failing --
+    // and undeclared keys reaching a caller is the whole reason this exists.
+    assert.throws(
+      () =>
+        validateMcpResponseTripwire("get_card", published, {
+          netuid: 0,
+          name: "root",
+          surprise: "shipped",
+        }),
+      McpResponseSchemaDriftError,
+    );
+  });
+
+  test("a nested undefined-valued key is covered too", () => {
+    // Why the round-trip rather than a shallow key filter: a one-level pass
+    // would fix the case above and miss this one.
+    const Nested = z
+      .object({ netuid: z.int(), inner: z.object({ a: z.int() }).strict() })
+      .strict();
+    assert.doesNotThrow(() =>
+      validateMcpResponseTripwire("get_nested", outputJsonSchema(Nested), {
+        netuid: 0,
+        inner: { a: 1, b: undefined },
+      }),
+    );
+  });
+
+  test("a genuinely missing required field still fails", () => {
+    // Serializing must not paper over an absent value: `undefined` for a
+    // REQUIRED key is a real drift, and it survives the round-trip as absence.
+    assert.throws(
+      () =>
+        validateMcpResponseTripwire("get_card", published, {
+          netuid: 0,
+          name: undefined,
+        }),
+      McpResponseSchemaDriftError,
+    );
+  });
+
+  test("a payload that cannot be serialized is left to the parse", () => {
+    // A circular structure is a real fault; swallowing it would make the
+    // tripwire report success on something it never checked.
+    const circular: Record<string, unknown> = { netuid: 0, name: "root" };
+    circular.self = circular;
+    assert.throws(
+      () => validateMcpResponseTripwire("get_card", published, circular),
+      McpResponseSchemaDriftError,
+    );
+  });
+});

--- a/tests/response-validation-tripwire.test.ts
+++ b/tests/response-validation-tripwire.test.ts
@@ -431,3 +431,55 @@ describe("workers/api.ts fails the request on drift", () => {
     }
   });
 });
+
+// ── The REST tripwire validates the wire too (#10972) ───────────────────────
+//
+// It does not currently trip on an undefined-valued key, and only because the
+// components involved happen to declare those fields optional. That is which
+// fields drifted first, not a difference in kind — so the same round-trip
+// applies here, and these pin it rather than leaving it to luck.
+describe("the REST tripwire validates what is sent", () => {
+  const envelope = (data: unknown) => ({
+    ok: true,
+    schema_version: 1,
+    data,
+    meta: { contract_version: "x" },
+  });
+
+  test("an undefined-valued key does not fail a response that serializes clean", async () => {
+    const built = {
+      schema_version: 1,
+      generated_at: "2026-08-13T00:00:00.000Z",
+      gaps: [],
+      // The shape a `{...spread}` of an absent artifact produces.
+      notes: undefined,
+    };
+    assert.equal(
+      JSON.stringify(built).includes("notes"),
+      false,
+      "the premise: serialization drops the key, so the client never sees it",
+    );
+    await assert.doesNotReject(
+      validateResponseTripwire("gaps", envelope(built), "/metagraph/gaps.json"),
+    );
+  });
+
+  test("a payload that cannot be serialized is left to the parse", async () => {
+    // Swallowing a circular structure would make the tripwire report success
+    // on something it never checked.
+    const circular: Record<string, unknown> = {
+      schema_version: 1,
+      generated_at: "2026-08-13T00:00:00.000Z",
+      gaps: [],
+    };
+    circular.self = circular;
+    await assert.rejects(
+      validateResponseTripwire(
+        "gaps",
+        envelope(circular),
+        "/metagraph/gaps.json",
+      ),
+      ResponseSchemaDriftError,
+    );
+  });
+});


### PR DESCRIPTION
`get_subnet_health` failed **46% of its calls** (13 of 28 in 24h) with `response_schema_drift`, on a response that was never wrong.

## The bug

A handler that spreads an object built from an **absent** source leaves keys present with `undefined`. `overlaySubnetHealth(null, ...)` produces four that way. Zod `.strict()` keys on `Object.keys()` and counted all four; `JSON.stringify` **drops** them, so the client never saw one.

```
RAW object (what the tripwire parsed): Unrecognized keys: "contract_version", "generated_at", "slug", "name"
JSON wire (what the client receives):  OK
```

The guard was stricter than the contract it enforces, and turned a correct answer into a hard tool error for every agent that called it.

It is also stricter than the standard: a conformant MCP client validates the `structuredContent` it **received** — that is JSON, and JSON has no `undefined`.

## Why the round-trip and not a key filter

A shallow "delete undefined keys" pass fixes this call site and misses a nested one, a `Date`, a `Map` — anything whose serialized form differs from its in-memory form. The round-trip *is* the definition of "what is sent" rather than an approximation. It costs one clone per validated response, paid only while `METAGRAPH_VALIDATE_RESPONSES` is on — the trade that flag exists to make.

## Applied to REST too, deliberately

The REST tripwire does not trip today, and only because the components involved happen to declare those four fields optional. That is *which fields drifted first*, not a difference in kind — the next strict component that omits a key some composer leaves undefined would fail a response that serializes correctly.

## What still fails, asserted

- a key with a **real** value → still refused
- a genuinely **missing required** field → still refused
- a **circular** payload → still refused, rather than silently waved through (swallowing it would make the tripwire report success on something it never checked)

## Verification

The actual `get_subnet_health` payload is now accepted. Reverting the one-line change fails exactly the two tests written for it:

```
FAIL  an undefined-valued key does not fail a response that serializes clean
FAIL  a nested undefined-valued key is covered too
```

1,373 MCP tests plus both tripwire suites green.

Closes #10972
