### PR TITLE
fix(ui): /revenue was in the sitemap and nowhere else

### DIFF
--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -17,6 +17,7 @@ import {
   Braces,
   BookOpen,
   Code2,
+  Coins,
   Compass,
   Copy,
   ExternalLink,
@@ -164,6 +165,15 @@ const STATIC_ROUTES_HEAD: RouteEntry[] = [
     to: "/apis/schemas",
     hint: "OpenAPI, contracts, drift",
     icon: FileJson,
+    scope: "route",
+  },
+  // #10927: the palette is the other discovery surface, and it was missing this
+  // route for the same reason the mega-menu was.
+  {
+    label: "Revenue coverage",
+    to: "/revenue",
+    hint: "External earnings vs emission",
+    icon: Coins,
     scope: "route",
   },
 ];

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.test.ts
@@ -29,6 +29,19 @@ describe("MEGA_PANELS catalogue", () => {
     ]);
   });
 
+  it("REACHES /revenue, which had zero inbound links (#10927)", () => {
+    // It was in the sitemap and nowhere else — the only way to it was typing
+    // the URL. Asserted on the catalogue rather than on the rendered menu so
+    // the guard survives a markup change; the panel body renders whatever this
+    // list holds.
+    const everyLink = MEGA_PANELS.flatMap((p) => [
+      p.to,
+      ...p.browse.map((l) => l.to),
+      ...p.filters.map((l) => l.to),
+    ]);
+    expect(everyLink).toContain("/revenue");
+  });
+
   it("has unique keys and self-consistent route/api fields", () => {
     const keys = new Set<string>();
     for (const p of MEGA_PANELS) {

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-data.ts
@@ -32,6 +32,14 @@ export const MEGA_PANELS: MegaPanel[] = [
       { to: "/subnets/0", label: "Root (netuid 0)", hint: "Base-layer Subtensor" },
       { to: "/subnets/7", label: "Allways · SN7", hint: "Adapter-backed pilot" },
       { to: "/subnets/74", label: "Gittensor · SN74", hint: "Adapter-backed pilot" },
+      // #10927: /revenue had zero inbound links — it was in the sitemap and
+      // nowhere else, reachable only by typing the URL. It belongs here rather
+      // than under Chain: the page's rows ARE subnets, one per netuid.
+      {
+        to: "/revenue",
+        label: "Revenue coverage",
+        hint: "External earnings vs emission",
+      },
     ],
     filters: [
       { to: "/subnets", search: { kind: "api" }, label: "Has APIs" },

--- a/apps/ui/src/routes/-revenue-page.tsx
+++ b/apps/ui/src/routes/-revenue-page.tsx
@@ -89,7 +89,7 @@ export function RevenuePage() {
 
   const sortField = COVERAGE_SORT_FIELDS.includes(search.sort)
     ? search.sort
-    : ("subsidy_multiple" as CoverageSortField);
+    : ("revenue_usd" as CoverageSortField);
 
   return (
     <div className="space-y-6">

--- a/apps/ui/src/routes/revenue.tsx
+++ b/apps/ui/src/routes/revenue.tsx
@@ -4,13 +4,20 @@ import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RevenuePage } from "./-revenue-page";
 
 // Sort/filter state lives in the URL so a specific view ("the probe-derived
-// subnets, by subsidy multiple") is shareable — the same reason /chain/emissions
-// puts its own sort there.
+// subnets, by revenue") is shareable — the same reason /chain/emissions puts
+// its own sort there.
+//
+// #10927: the default is `revenue_usd`, not `subsidy_multiple`. `isMeasured`
+// partitions on `revenue_usd`, so it is the one column non-null for every row
+// in the ranked group BY CONSTRUCTION. `subsidy_multiple` is a derived ratio
+// needing both a revenue figure and a priced emission side, so a subnet that
+// was measured but whose emission failed to price sorts to the BOTTOM of a
+// table it legitimately belongs in — ranked last on a column it cannot answer.
 const revenueSearchSchema = z.object({
   sort: fallback(
     z.enum(["subsidy_multiple", "coverage_ratio", "emission_usd", "revenue_usd", "netuid"]),
-    "subsidy_multiple",
-  ).default("subsidy_multiple"),
+    "revenue_usd",
+  ).default("revenue_usd"),
   dir: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
   // Empty means every tier, which is the default: the counts beside each tier
   // are how a reader learns the headline-eligible set is two subnets wide, and


### PR DESCRIPTION
Closes #10927

## The page had zero inbound links

`/revenue` — the leaderboard this whole epic feeds — was registered in the
sitemap and reachable **only by typing the URL**. No nav entry, no footer link,
no command-palette entry; `grep -rn 'to="/revenue"' apps/ui/src` matched
nothing but the route's own `createFileRoute` call.

Fixed in both discovery surfaces:

- **Subnets mega-menu panel**, not Chain — the page's rows *are* subnets, one
  per netuid.
- **Command palette**, which was missing it for the same reason and is the
  other way people find pages here.

## Default sort: `revenue_usd`, measured against the live payload first

Requirement 2 asked for this to be checked against a real response rather than
assumed. `GET /api/v1/chain/revenue-coverage`, 129 subnets:

| column | non-null |
| --- | --- |
| `emission.tao` | 129 |
| `emission.usd` | 129 |
| `revenue_usd` | 1 |
| `coverage_ratio` | 1 |
| `subsidy_multiple` | 1 |

The raw counts are the less interesting half. `isMeasured` partitions on
`revenue_usd`, so inside the **ranked** group `subsidy_multiple` is non-null
for 1 of 1 — every null sits in the unranked partition, exactly as designed.
On that reading the old default was not broken.

The reason to move it is narrower and survives the table filling up:
`revenue_usd` is the partition key, so it is non-null for every ranked row **by
construction**. `subsidy_multiple` is a derived ratio needing both a revenue
figure *and* a priced emission side — so a subnet that was measured but whose
emission failed to price sorts to the **bottom** of a table it belongs in,
ranked last on a column it cannot answer. That is the same "null is not zero"
failure the partition exists to prevent, one level down.

`emission_usd` was the other candidate (129/129) and is deliberately not the
default: it would order the table by subnet size, which is not what the page is
about.

**The unmeasured group is untouched** — still partitioned out, still ordered by
netuid, still never ranked by a figure nobody measured.

## Verification

- Live: `/revenue` now 307s to `?sort=revenue_usd&dir=desc&provenance=`,
  confirming the new default through the router rather than through the source.
- `nav-mega-menu-data.test.ts` asserts `/revenue` is reachable from the
  catalogue. Asserted there rather than against rendered markup, matching the
  file's existing rationale: the panel body is lazily loaded and renders
  whatever `MEGA_PANELS` holds, so the catalogue is where a link guard survives
  a markup change.
- `validate:ui-docs-drift` and `validate:ui-route-coverage` green.
- **2,090 UI tests pass** (253 files), `tsc` and prettier clean from the
  `apps/ui` workspace.

No `src/**` or `workers/**` lines changed, so there is no patch-coverage
surface on this one.

## Noted, not fixed here

A sweep for routes with no inbound link anywhere in `apps/ui/src` turns up more
than this one — `/leaderboards`, `/explorer`, `/graphql/explorer`,
`/tools/ss58`, `/domains` and others are in the sitemap with no link either.
Some are deliberate (`/admin-changes`, `/sudo`), several are the same defect.
Left out of scope rather than bundled: each needs its own placement judgement,
and a nav change touching ten panels is not one reviewable diff.