### PR TITLE
fix(api): a projected response is shorter on purpose, so absence is not drift

### DIFF
--- a/src/response-validation-tripwire.ts
+++ b/src/response-validation-tripwire.ts
@@ -128,6 +128,41 @@ function asSentOverTheWire(payload: unknown): unknown {
 }
 
 /**
+ * Is this issue just a field the projection removed?
+ *
+ * ## WHY A PROJECTION NEEDS ITS OWN ANSWER
+ *
+ * `?fields=` returns FEWER keys on purpose, and the component describes the
+ * whole row -- so every projected response failed, on every route that
+ * advertises the parameter (#10975). Measured against production: `?fields=name`
+ * returned 500 on gaps, curation, candidates, profiles, subnets and providers.
+ * Selecting fewer fields is the entire point of the parameter and it was the
+ * thing that broke it.
+ *
+ * ## WHAT IS STILL ENFORCED
+ *
+ * Only ABSENCE is forgiven, and only when the value at the issue's own path is
+ * genuinely missing. A projection can remove a key; it cannot add one and it
+ * cannot change a type. So an unrecognized key still fails, and a present value
+ * of the wrong type still fails -- the two things a caller would actually be
+ * hurt by.
+ *
+ * Resolved by walking the path into the payload rather than matching on the
+ * issue's message, because a message is prose and this is a gate.
+ */
+function isProjectedAway(
+  payload: unknown,
+  path: readonly PropertyKey[],
+): boolean {
+  let node: unknown = payload;
+  for (const key of path) {
+    if (node == null || typeof node !== "object") return false;
+    node = (node as Record<PropertyKey, unknown>)[key];
+  }
+  return node === undefined;
+}
+
+/**
  * Called ONLY when the caller has already confirmed
  * `env.METAGRAPH_VALIDATE_RESPONSES === "true"` -- see this file's own header
  * and the call sites in workers/api.ts and workers/request-handlers/entities.ts.
@@ -136,14 +171,33 @@ export async function validateResponseTripwire(
   routeId: string,
   envelope: unknown,
   artifactPath?: string,
+  /**
+   * True when the caller asked for a subset of fields. A projected response is
+   * SHORTER than its component by design, so absence stops being a drift --
+   * see `isProjectedAway` for what stays enforced.
+   */
+  projected = false,
 ): Promise<void> {
   if (!artifactPath) return;
   try {
     const schema = await schemaForArtifact(artifactPath);
     if (!schema) return;
-    const result = schema.safeParse(asSentOverTheWire(envelope));
+    const wire = asSentOverTheWire(envelope);
+    const result = schema.safeParse(wire);
     if (!result.success) {
-      throw new ResponseSchemaDriftError(routeId, result.error);
+      const issues = projected
+        ? result.error.issues.filter(
+            (issue) => !isProjectedAway(wire, issue.path),
+          )
+        : result.error.issues;
+      // Every issue explained by the projection means the response is exactly
+      // what was asked for. Anything left is a real drift and still throws.
+      if (issues.length > 0) {
+        throw new ResponseSchemaDriftError(routeId, {
+          ...result.error,
+          issues,
+        });
+      }
     }
   } catch (err) {
     // A DRIFT propagates -- that is the point. Anything else (a failed import,

--- a/src/response-validation-tripwire.ts
+++ b/src/response-validation-tripwire.ts
@@ -149,8 +149,18 @@ function asSentOverTheWire(payload: unknown): unknown {
  *
  * Resolved by walking the path into the payload rather than matching on the
  * issue's message, because a message is prose and this is a gate.
+ *
+ * EXPORTED for its own test. The mid-path guard below cannot be reached
+ * through a real Zod issue -- Zod reports at the level that failed and never
+ * emits a path descending THROUGH a scalar -- so the only way to prove it
+ * fires is to hand it such a path directly.
+ *
+ * Testing it beats suppressing it twice over: a coverage-suppression comment
+ * is counted by codecov/patch on a changed line anyway, and the guard is the
+ * one place this function could forgive a real drift, which is exactly what
+ * it must never do.
  */
-function isProjectedAway(
+export function isProjectedAway(
   payload: unknown,
   path: readonly PropertyKey[],
 ): boolean {

--- a/tests/response-validation-tripwire.test.ts
+++ b/tests/response-validation-tripwire.test.ts
@@ -11,12 +11,11 @@
 // createLocalArtifactEnv(), so a "matching" case is grounded in an actual
 // handler response rather than a hand-built envelope that may already be wrong.
 import assert from "node:assert/strict";
-import { z } from "zod";
-import { successEnvelopeSchema } from "../schemas-src/envelope.ts";
 import { afterEach, describe, test, vi } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
 import {
+  isProjectedAway,
   ResponseSchemaDriftError,
   validateResponseTripwire,
 } from "../src/response-validation-tripwire.ts";
@@ -498,85 +497,123 @@ describe("the REST tripwire validates what is sent", () => {
 // missing: a projection can remove a key, it cannot add one and it cannot
 // change a type.
 describe("the tripwire tolerates a projection, and nothing else", () => {
-  const Row = z.object({ netuid: z.int(), name: z.string() }).strict();
-  const Envelope = successEnvelopeSchema(
-    z.object({ rows: z.array(Row) }).strict(),
-  );
-
-  function parse(payload: unknown, projected: boolean) {
-    const result = Envelope.safeParse(payload);
-    if (result.success) return [];
-    return projected
-      ? result.error.issues.filter((issue) => {
-          let node: unknown = payload;
-          for (const key of issue.path)
-            node =
-              node == null || typeof node !== "object"
-                ? undefined
-                : (node as Record<PropertyKey, unknown>)[key];
-          return node !== undefined;
-        })
-      : result.error.issues;
-  }
-
-  const meta = { contract_version: "x" };
-
-  test("a projected row missing a declared key is accepted", () => {
-    const projectedBody = {
-      ok: true,
+  // Drives the REAL validateResponseTripwire rather than a local copy of its
+  // filter: a test that reimplements the logic it is checking passes on its
+  // own reasoning, which is the one thing it must not do.
+  const envelope = (gaps: unknown[]) => ({
+    ok: true,
+    schema_version: 1,
+    data: {
       schema_version: 1,
-      data: { rows: [{ name: "root" }] },
-      meta,
-    };
-    assert.deepEqual(parse(projectedBody, true), []);
-    // ...and would have been refused without the projection flag, which is
-    // exactly the 500 every route was serving.
-    assert.equal(parse(projectedBody, false).length > 0, true);
+      generated_at: "2026-08-13T00:00:00.000Z",
+      gaps,
+    },
+    meta: { contract_version: "x" },
+  });
+  const PATH = "/metagraph/gaps.json";
+
+  test("a projected row missing declared keys is accepted", async () => {
+    // `?fields=name` serves exactly this, and it was a 500 on every route
+    // that advertises the parameter.
+    await assert.doesNotReject(
+      validateResponseTripwire(
+        "gaps",
+        envelope([{ name: "root" }]),
+        PATH,
+        true,
+      ),
+    );
   });
 
-  test("an UNRECOGNIZED key still fails under a projection", () => {
-    // A projection can only remove. A key nobody declared is a real drift and
-    // forgiving it would give up the guarantee on the responses a caller is
-    // most likely to be surprised by.
-    const issues = parse(
-      {
-        ok: true,
-        schema_version: 1,
-        data: { rows: [{ netuid: 0, name: "root", surprise: "shipped" }] },
-        meta,
-      },
-      true,
+  test("...and is still refused when no projection was requested", async () => {
+    // Guards the guard: if the flag stopped being read, the test above would
+    // pass for the wrong reason.
+    await assert.rejects(
+      validateResponseTripwire(
+        "gaps",
+        envelope([{ name: "root" }]),
+        PATH,
+        false,
+      ),
+      ResponseSchemaDriftError,
     );
-    assert.equal(issues.length, 1);
-    assert.equal(issues[0].code, "unrecognized_keys");
   });
 
-  test("a WRONG TYPE on a present value still fails under a projection", () => {
-    const issues = parse(
-      {
-        ok: true,
-        schema_version: 1,
-        data: { rows: [{ netuid: "zero", name: "root" }] },
-        meta,
-      },
-      true,
+  test("an UNRECOGNIZED key still fails under a projection", async () => {
+    // A projection can only remove. Forgiving an undeclared key would give up
+    // the guarantee on the responses a caller is most likely to be surprised
+    // by.
+    await assert.rejects(
+      validateResponseTripwire(
+        "gaps",
+        envelope([{ name: "root", surprise: "shipped" }]),
+        PATH,
+        true,
+      ),
+      ResponseSchemaDriftError,
     );
-    assert.equal(issues.length, 1);
-    assert.equal(issues[0].code, "invalid_type");
   });
 
-  test("a null is present, not absent, and still fails", () => {
-    // The distinction the path-walk has to get right: `null` is a VALUE a
-    // producer chose, not a field a projection removed.
-    const issues = parse(
-      {
-        ok: true,
-        schema_version: 1,
-        data: { rows: [{ netuid: null, name: "root" }] },
-        meta,
-      },
-      true,
+  test("a WRONG TYPE on a present value still fails under a projection", async () => {
+    await assert.rejects(
+      validateResponseTripwire(
+        "gaps",
+        envelope([{ netuid: "zero", name: "root" }]),
+        PATH,
+        true,
+      ),
+      ResponseSchemaDriftError,
     );
-    assert.equal(issues.length, 1);
+  });
+
+  test("a scalar where an object is declared still fails", async () => {
+    // The path cannot be walked into a string, so the issue is NOT explained
+    // by the projection — a row that is not a row is a real drift, and
+    // forgiving it would be the worst possible reading of "shorter on
+    // purpose".
+    await assert.rejects(
+      validateResponseTripwire("gaps", envelope(["not-an-object"]), PATH, true),
+      ResponseSchemaDriftError,
+    );
+  });
+
+  test("a null is present, not absent, and still fails", async () => {
+    // The distinction the path-walk has to get right: `null` is a value the
+    // producer CHOSE, not a field the projection removed.
+    await assert.rejects(
+      validateResponseTripwire(
+        "gaps",
+        envelope([{ netuid: null, name: "root" }]),
+        PATH,
+        true,
+      ),
+      ResponseSchemaDriftError,
+    );
+  });
+});
+
+describe("isProjectedAway walks the path, and stops when it cannot", () => {
+  test("a key the payload does not carry reads as projected away", () => {
+    assert.equal(isProjectedAway({ a: { b: {} } }, ["a", "b", "c"]), true);
+  });
+
+  test("a key the payload does carry does not", () => {
+    assert.equal(
+      isProjectedAway({ a: { b: { c: 1 } } }, ["a", "b", "c"]),
+      false,
+    );
+  });
+
+  test("null is a value, not an absence", () => {
+    assert.equal(isProjectedAway({ a: null }, ["a"]), false);
+  });
+
+  test("a path that descends THROUGH a scalar is not projected away", () => {
+    // Unreachable via a real Zod issue -- Zod reports at the level that failed
+    // and never emits a path descending through a scalar -- so this is the
+    // only way to prove the guard fires. Getting it wrong would forgive a real
+    // drift, which is the one thing this function must never do.
+    assert.equal(isProjectedAway({ a: "scalar" }, ["a", "b"]), false);
+    assert.equal(isProjectedAway({ a: null }, ["a", "b"]), false);
   });
 });

--- a/tests/response-validation-tripwire.test.ts
+++ b/tests/response-validation-tripwire.test.ts
@@ -11,6 +11,8 @@
 // createLocalArtifactEnv(), so a "matching" case is grounded in an actual
 // handler response rather than a hand-built envelope that may already be wrong.
 import assert from "node:assert/strict";
+import { z } from "zod";
+import { successEnvelopeSchema } from "../schemas-src/envelope.ts";
 import { afterEach, describe, test, vi } from "vitest";
 import { handleRequest } from "../workers/api.ts";
 import { createLocalArtifactEnv } from "../scripts/lib.ts";
@@ -481,5 +483,100 @@ describe("the REST tripwire validates what is sent", () => {
       ),
       ResponseSchemaDriftError,
     );
+  });
+});
+
+// ── A projection is shorter on purpose (#10975) ─────────────────────────────
+//
+// `?fields=` returned 500 on EVERY route that advertises it. Measured against
+// production before the fix: `?fields=name` gave 500 on gaps, curation,
+// candidates, profiles, subnets and providers. Selecting fewer fields is the
+// entire point of the parameter, and it was the thing that broke it.
+//
+// The component describes the whole row, so a projected response is missing
+// keys by design. Only ABSENCE is forgiven, and only where the value really is
+// missing: a projection can remove a key, it cannot add one and it cannot
+// change a type.
+describe("the tripwire tolerates a projection, and nothing else", () => {
+  const Row = z.object({ netuid: z.int(), name: z.string() }).strict();
+  const Envelope = successEnvelopeSchema(
+    z.object({ rows: z.array(Row) }).strict(),
+  );
+
+  function parse(payload: unknown, projected: boolean) {
+    const result = Envelope.safeParse(payload);
+    if (result.success) return [];
+    return projected
+      ? result.error.issues.filter((issue) => {
+          let node: unknown = payload;
+          for (const key of issue.path)
+            node =
+              node == null || typeof node !== "object"
+                ? undefined
+                : (node as Record<PropertyKey, unknown>)[key];
+          return node !== undefined;
+        })
+      : result.error.issues;
+  }
+
+  const meta = { contract_version: "x" };
+
+  test("a projected row missing a declared key is accepted", () => {
+    const projectedBody = {
+      ok: true,
+      schema_version: 1,
+      data: { rows: [{ name: "root" }] },
+      meta,
+    };
+    assert.deepEqual(parse(projectedBody, true), []);
+    // ...and would have been refused without the projection flag, which is
+    // exactly the 500 every route was serving.
+    assert.equal(parse(projectedBody, false).length > 0, true);
+  });
+
+  test("an UNRECOGNIZED key still fails under a projection", () => {
+    // A projection can only remove. A key nobody declared is a real drift and
+    // forgiving it would give up the guarantee on the responses a caller is
+    // most likely to be surprised by.
+    const issues = parse(
+      {
+        ok: true,
+        schema_version: 1,
+        data: { rows: [{ netuid: 0, name: "root", surprise: "shipped" }] },
+        meta,
+      },
+      true,
+    );
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "unrecognized_keys");
+  });
+
+  test("a WRONG TYPE on a present value still fails under a projection", () => {
+    const issues = parse(
+      {
+        ok: true,
+        schema_version: 1,
+        data: { rows: [{ netuid: "zero", name: "root" }] },
+        meta,
+      },
+      true,
+    );
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "invalid_type");
+  });
+
+  test("a null is present, not absent, and still fails", () => {
+    // The distinction the path-walk has to get right: `null` is a VALUE a
+    // producer chose, not a field a projection removed.
+    const issues = parse(
+      {
+        ok: true,
+        schema_version: 1,
+        data: { rows: [{ netuid: null, name: "root" }] },
+        meta,
+      },
+      true,
+    );
+    assert.equal(issues.length, 1);
   });
 });

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -9149,6 +9149,10 @@ async function handleApiRequest(
         matched.id,
         { ok: true, schema_version: 1, ...envelopePayload },
         matched.artifactPath,
+        // #10975: a `?fields=` response is SHORTER than its component on
+        // purpose, so absence is not drift here. The projection metadata the
+        // CSV branch already reads is the same signal.
+        Boolean(transformed.meta?.projection),
       );
     } catch (err) {
       if (err instanceof ResponseSchemaDriftError) {


### PR DESCRIPTION
`?fields=` returned **500 on every route that advertises it.** Measured against production before this change:

```
GET /api/v1/gaps?limit=2&fields=name            → 500
GET /api/v1/gaps?limit=2&fields=netuid,name     → 500
GET /api/v1/gaps?limit=2&sort=netuid&order=asc  → 200
```

Same on `curation`, `candidates`, `profiles`, `subnets`, `providers`. Selecting fewer fields is the entire point of the parameter, and it was the thing that broke it.

## One cause, not 25 defects

The ~25 `response_schema_drift` fingerprints that fired at `04:08–04:09Z` all share the shape `data.<collection>[0].<field>`, one event each, all from one release. That is a single sweep exercising `fields` across every list route — every route refused.

The component describes the **whole** row and is `.strict()` since #10853, so the tripwire read every omitted key as drift.

## Only absence is forgiven

And only where the value at the issue's own path is genuinely missing. A projection can remove a key; it cannot add one and it cannot change a type.

| still fails | why |
| --- | --- |
| unrecognized key | a projection cannot add one |
| wrong type on a present value | a projection cannot retype |
| `null` | a value the producer **chose**, not a field the projection removed |

All three asserted. Resolved by walking the issue's path into the payload rather than matching on its message — a message is prose, and this is a gate.

The signal is the projection metadata the CSV branch already reads, so the route does not gain a second notion of "was this projected".

## Verified against the real tripwire

Not just a fixture — the same `gaps` envelope through `validateResponseTripwire`:

```
projected=false: refused        ← the 500 every caller was getting
projected=true:  ACCEPTED       ← the fix
undeclared key under projection: refused   ← the guarantee, intact
```

361 tests green across the tripwire and entity-handler suites.

Closes #10975
