### PR TITLE
fix(mcp): restore the drift alarm's diagnosis, and pin it so it cannot vanish again

### DIFF
--- a/src/mcp-response-tripwire.ts
+++ b/src/mcp-response-tripwire.ts
@@ -78,7 +78,28 @@ export class McpResponseSchemaDriftError extends Error {
   readonly code = MCP_RESPONSE_DRIFT_CODE;
   readonly captureAsFault = true;
   constructor(tool: string, detail: unknown) {
-    super(`${tool} result drifted from its published outputSchema`);
+    // The issues ride IN the message (bounded), because the message is the
+    // only thing the exception pipeline serializes: `detail` never leaves
+    // this object, and `cause` is `this`, so the captured fault read
+    // "drifted from its published outputSchema" with the diagnosis -- WHICH
+    // keys, at WHICH path -- discarded. Measured 2026-08-12: get_subnet_health
+    // drifted on netuid 0 for hours and neither PostHog nor a tail could say
+    // on what. Same lesson as the REST tripwire's alarm (#10897): the
+    // unrecognized keys ARE the diagnosis.
+    //
+    // RESTORED, and pinned by a test this time. #10914 added it and #10917 --
+    // a store refactor branched before that landed -- removed it again with
+    // ZERO conflicts, because nothing asserted the message carried anything.
+    // A silent revert is what an unasserted behaviour invites, and the cost
+    // was measured: production emitted a 64-character alarm naming no key for
+    // six hours, and diagnosing #10972 needed a local reproduction to recover
+    // what this line already knew.
+    super(
+      `${tool} result drifted from its published outputSchema: ` +
+        String(
+          detail instanceof Error ? detail.message : JSON.stringify(detail),
+        ).slice(0, 400),
+    );
     this.name = "McpResponseSchemaDriftError";
     this.tool = tool;
     this.detail = detail;

--- a/tests/mcp-response-tripwire.test.ts
+++ b/tests/mcp-response-tripwire.test.ts
@@ -218,3 +218,70 @@ describe("the tripwire validates what is sent, not what was built", () => {
     );
   });
 });
+
+// ── The alarm carries its diagnosis, and stays carrying it ─────────────────
+//
+// #10914 put the unrecognized keys into the message, because the message is
+// the only thing the exception pipeline serializes -- `detail` never leaves
+// the error object. #10917, a store refactor branched before that landed,
+// removed it again with ZERO conflicts.
+//
+// Nothing asserted it, so nothing noticed. Production emitted a 64-character
+// alarm naming no key for six hours, and diagnosing #10972 needed a local
+// reproduction to recover what the error already knew.
+//
+// These exist so the next stale-base merge fails instead of passing.
+describe("the drift alarm carries its diagnosis", () => {
+  const published = outputJsonSchema(Card);
+
+  function driftMessage(payload: unknown): string {
+    try {
+      validateMcpResponseTripwire("get_card", published, payload);
+    } catch (err) {
+      return (err as Error).message;
+    }
+    throw new Error("expected a drift");
+  }
+
+  test("the message names the unrecognized key", () => {
+    const message = driftMessage({
+      netuid: 0,
+      name: "root",
+      surprise: "shipped",
+    });
+    assert.match(
+      message,
+      /surprise/,
+      "the unrecognized key IS the diagnosis — an alarm without it sends " +
+        "whoever reads it to a local reproduction",
+    );
+  });
+
+  test("the message names the path of a wrong type", () => {
+    assert.match(driftMessage({ netuid: "zero", name: "root" }), /netuid/);
+  });
+
+  test("it is bounded, so one alarm cannot carry a whole payload", () => {
+    const message = driftMessage({
+      netuid: 0,
+      name: "root",
+      ...Object.fromEntries(
+        Array.from({ length: 200 }, (_, i) => [`extra_${i}`, i]),
+      ),
+    });
+    assert.ok(
+      message.length < 600,
+      `the alarm must stay bounded; got ${message.length} characters`,
+    );
+  });
+
+  test("the tool name still leads, so grouping is unchanged", () => {
+    // The fingerprint keys on tool + message; a diagnosis appended AFTER the
+    // stable prefix keeps every drift of one tool in one issue.
+    assert.ok(
+      driftMessage({ netuid: 0, name: "root", surprise: 1 }).startsWith(
+        "get_card result drifted from its published outputSchema",
+      ),
+    );
+  });
+});


### PR DESCRIPTION
#10914 put the unrecognized keys into the drift message, because **the message is the only thing the exception pipeline serializes** — `detail` never leaves the error object, and `cause` is `this`.

#10917 removed it again:

```diff
-    super(
-      `${tool} result drifted from its published outputSchema: ` +
-        String(detail instanceof Error ? detail.message : JSON.stringify(detail)).slice(0, 400),
-    );
+    super(`${tool} result drifted from its published outputSchema`);
```

That PR is a **store refactor**. It was branched before #10914 landed, touched the same file, and merged with **zero conflicts**. Four hours of the fix, then silently back to where it started.

## Nothing asserted it, so nothing noticed

Measured cost: production emitted a **64-character alarm naming no key** for six hours, and diagnosing #10972 today needed a local reproduction to recover what the error already knew and had been made to forget.

```
msg_len | msg                                                              | release
     64 | get_subnet_health result drifted from its published outputSchema | 117b4b35…
```

## Restoring it is the small half

The reason it could be reverted invisibly is that **no test read the message**. So the tests are the actual fix:

- the message names the **unrecognized key**
- it names the **path** of a wrong type
- it stays **bounded**, so one alarm cannot carry a whole payload
- it still **leads with the stable prefix** — the fingerprint keys on tool + message, so a diagnosis appended *after* that prefix keeps every drift of one tool in one issue rather than fragmenting into one per payload

## Verified by repeating the mistake

Reproducing #10917's exact edit fails two of the four:

```
FAIL  the message names the unrecognized key
FAIL  the message names the path of a wrong type
Tests  2 failed | 16 passed (18)
```

Undo it and all 18 pass. A stale-base merge that repeats this now breaks CI instead of shipping.

Also checked that this PR is not itself doing what it describes: the diff against main is **+89 / −1**, and the one deletion is the constructor line being replaced.
