### PR TITLE
fix(alarm): a dead-letter lane names what was lost, not a cadence it does not have

### DIFF
--- a/src/dead-letter.ts
+++ b/src/dead-letter.ts
@@ -45,6 +45,19 @@ export const DEAD_LETTER_LANES: Readonly<Record<string, string>> = {
   "revenue-probes-dlq": "revenue-probes-dlq",
 };
 
+/**
+ * The LANE names a dead-letter queue reports under, as a set.
+ *
+ * Derived from the mapping above rather than re-listed, so a queue added there
+ * is recognised here without a second edit. `laneAlarmSummary` reads this to
+ * tell a DLQ lane from a producer: their durations mean different things, and
+ * labelling one with the other's cadence is how a lost message got triaged as
+ * a missed cycle (#10809's lesson, in the other direction).
+ */
+export const DEAD_LETTER_LANE_NAMES: ReadonlySet<string> = new Set(
+  Object.values(DEAD_LETTER_LANES),
+);
+
 /** Whether a delivered batch came from a dead-letter queue.
  *
  * THE FIRST THING EITHER HANDLER MUST ASK. Both Workers bind their DLQ to the

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -49,6 +49,7 @@
 // ever be wrong for most of them.
 
 import { laneSilenceCadenceMs } from "./producer-cadence.ts";
+import { DEAD_LETTER_LANE_NAMES } from "./dead-letter.ts";
 import {
   loadLatestLaneHealth,
   staleLanes,
@@ -153,13 +154,49 @@ export const LANE_ALARM_MAX_VERDICT_AGE_MS = LANE_ALARM_CADENCE_WINDOW_MS;
  *
  * Silence is left alone: its bound IS the cadence (three intervals), so its
  * duration is already expressed in the unit that matters.
+ *
+ * ## AND A DEAD-LETTER LANE IS NEITHER
+ *
+ * `lane revenue-probes-dlq is stale: 41.0h (producer cadence 1.0h)` reads as
+ * FORTY-ONE MISSED CYCLES, and it is not that. A DLQ writes `stale` when a
+ * message is lost and never writes `ok`, because nothing un-loses one -- so
+ * the duration is "how long ago something was lost and nobody looked", and the
+ * cadence has nothing to do with it. It ages out after seven days on its own.
+ *
+ * The cadence suffix therefore does to this lane exactly what the bare
+ * duration did to a producer: invites a confident wrong reading. Measured
+ * 2026-08-12, it worked -- 41.0h against a 1.0h cadence was triaged as the
+ * most urgent lane in the fleet, ahead of six that were genuinely silent.
+ *
+ * What a reader needs here is the SUBJECT, and the alarm has been carrying it
+ * in `detail` unread since #10739 taught the summariser to name it (`2
+ * dead-lettered message(s) on revenue-probes-dlq (sn-64-...)`). Same lesson as
+ * the drift alarm two floors down: the thing that was lost IS the diagnosis.
  */
 export function laneAlarmSummary(alarm: LaneAlarm, nowMs: number): string {
   const elapsed = humanDuration(nowMs - alarm.since);
   const base = `lane ${alarm.lane} is ${alarm.kind}: ${elapsed}`;
+  // A DEAD-LETTER lane's duration is not cycles-behind, so the cadence that
+  // makes a producer's duration readable makes this one MISLEADING -- see
+  // isDeadLetterLane. Its subject is what a reader needs instead, and the
+  // alarm has been carrying it in `detail` unread.
+  if (isDeadLetterLane(alarm.lane)) {
+    return alarm.detail ? `${base} -- ${alarm.detail}` : base;
+  }
   return alarm.kind === "stale" && alarm.cadence_ms
     ? `${base} (producer cadence ${humanDuration(alarm.cadence_ms)})`
     : base;
+}
+
+/**
+ * Is this lane a dead-letter queue rather than a producer?
+ *
+ * Derived from `DEAD_LETTER_LANES` rather than matched on a `-dlq` suffix: the
+ * mapping is already the one place that says which queues report as lanes, and
+ * a suffix convention is a second one that can disagree with it.
+ */
+function isDeadLetterLane(lane: string): boolean {
+  return DEAD_LETTER_LANE_NAMES.has(lane);
 }
 
 /** Title prefix. The dedup key: stable across ticks, and greppable by a human. */

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -1243,6 +1243,51 @@ describe("the summary a capture carries (#10809)", () => {
     assert.doesNotMatch(summary, /cadence/);
   });
 
+  test("a dead-letter lane names WHAT was lost, not a cadence", () => {
+    // `lane revenue-probes-dlq is stale: 41.0h (producer cadence 1.0h)` reads
+    // as forty-one missed cycles and is not that: a DLQ writes `stale` when a
+    // message is lost and never writes `ok`, so the duration is "how long ago
+    // something was lost and nobody looked". Measured 2026-08-12, that reading
+    // worked -- it was triaged as the most urgent lane in the fleet, ahead of
+    // six that were genuinely silent.
+    const summary = laneAlarmSummary(
+      {
+        ...staleFor(41, 3_600_000),
+        lane: "revenue-probes-dlq",
+        detail: "2 dead-lettered message(s) on revenue-probes-dlq (sn-64-x)",
+      },
+      NOW,
+    );
+    assert.doesNotMatch(
+      summary,
+      /cadence/,
+      `a DLQ duration is not cycles-behind: ${summary}`,
+    );
+    assert.match(
+      summary,
+      /sn-64-x/,
+      "the subject IS the diagnosis, and the alarm has been carrying it unread",
+    );
+  });
+
+  test("a dead-letter lane with no detail still says what it can", () => {
+    const summary = laneAlarmSummary(
+      { ...staleFor(41, 3_600_000), lane: "revenue-probes-dlq", detail: null },
+      NOW,
+    );
+    assert.match(summary, /lane revenue-probes-dlq is stale: 41\.0h/);
+    assert.doesNotMatch(summary, /cadence/);
+  });
+
+  test("a producer lane is unaffected by the dead-letter branch", () => {
+    // Guards the guard: if the DLQ check widened to every lane, the cadence
+    // that #10809 added would silently vanish from the alarms that need it.
+    assert.match(
+      laneAlarmSummary(staleFor(7.9, 86_400_000), NOW),
+      /producer cadence 24\.0h/,
+    );
+  });
+
   test("silence is left alone -- its bound already IS the cadence", () => {
     const summary = laneAlarmSummary(
       { ...staleFor(4, 86_400_000), kind: "silent" as const },


### PR DESCRIPTION
`lane revenue-probes-dlq is stale: 41.0h (producer cadence 1.0h)` reads as **forty-one missed cycles**. It is not that.

A DLQ writes `stale` when a message is lost and **never writes `ok`**, because nothing un-loses one — so its duration is *"how long ago something was lost and nobody looked"*, and it ages out after seven days on its own. The cadence has nothing to do with it.

## The suffix caused exactly the misreading it was added to prevent

#10809 added the cadence because a bare duration read as a worsening outage. For a DLQ it does the opposite: it manufactures a cycle count out of a number that isn't cycles.

Measured today, it worked on me — I triaged `41.0h against 1.0h` as **the most urgent lane in the fleet**, ahead of six that were genuinely silent, and only found otherwise by reading the module that writes the verdict.

## What a reader needs is the subject

And the alarm has been carrying it in `detail` **unread** since #10739 taught the summariser to name it:

```
2 dead-lettered message(s) on revenue-probes-dlq (sn-64-…)
```

Production has emitted the duration and dropped the surface id every half hour for 41 hours. Same lesson as the drift alarm in #10979: the thing that was lost *is* the diagnosis.

## Details

Recognised via `DEAD_LETTER_LANE_NAMES`, derived from the existing `DEAD_LETTER_LANES` mapping rather than matched on a `-dlq` suffix — that mapping is already the one place saying which queues report as lanes, and a suffix convention is a second one that can disagree with it.

Includes the guard-the-guard case: a **producer** lane must keep its cadence, or widening this branch would silently undo #10809.

Verified by deleting the new branch and watching exactly the two dead-letter tests fail:

```
FAIL  a dead-letter lane names WHAT was lost, not a cadence
FAIL  a dead-letter lane with no detail still says what it can
```

90 tests green across the lane-alarm and dead-letter suites.
