### PR TITLE
test(mcp): cover the drift detail's non-Error arm

### DIFF
--- a/tests/mcp-response-tripwire.test.ts
+++ b/tests/mcp-response-tripwire.test.ts
@@ -275,6 +275,24 @@ describe("the drift alarm carries its diagnosis", () => {
     );
   });
 
+  test("a non-Error detail is serialised rather than dropped", () => {
+    // `validateMcpResponseTripwire` always hands a ZodError, so this arm is
+    // unreachable through it — and it is the arm that decides whether a
+    // future caller passing a plain object gets a diagnosis or a bare
+    // sentence. Constructed directly, for the same reason `isProjectedAway`
+    // is: an unreachable branch in an alarm is where the diagnosis goes to
+    // die, and codecov/patch counts it either way.
+    const error = new McpResponseSchemaDriftError("get_card", {
+      unrecognized: ["surprise"],
+    });
+    assert.match(error.message, /surprise/);
+    assert.ok(
+      error.message.startsWith(
+        "get_card result drifted from its published outputSchema",
+      ),
+    );
+  });
+
   test("the tool name still leads, so grouping is unchanged", () => {
     // The fingerprint keys on tool + message; a diagnosis appended AFTER the
     // stable prefix keeps every drift of one tool in one issue.


### PR DESCRIPTION
`codecov/patch` flagged #10979 and was right.

`validateMcpResponseTripwire` always hands a `ZodError`, so the `: JSON.stringify(detail)` arm is unreachable through it — and that arm decides whether a future caller passing a plain object gets a diagnosis or the bare sentence this whole thread has been about.

Constructed directly rather than suppressed, for the same reason `isProjectedAway` was in #10978: an unreachable branch **inside an alarm** is exactly where a diagnosis goes to die, and `codecov/patch` counts a suppressed branch on a changed line anyway.

100% lines, branches and functions on the file.