### PR TITLE
fix(schema): the concentration scorecard is one vocabulary, not two

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -2876,13 +2876,20 @@ type ChainConcentrationHistoryPoint {
   validator_stake: ChainConcentrationScorecard
 }
 
+"""
+One distribution's concentration scorecard, passed through from the stored card -- identical by construction to the live /chain/concentration card, because it is the same card.
+"""
 type ChainConcentrationScorecard {
   holders: Int!
-  total: Float!
+  total: Float
   gini: Float
   hhi: Float
   hhi_normalized: Float
-  nakamoto_coefficient: Int
+  nakamoto_coefficient: Int!
+  top_1pct_share: Float
+  top_5pct_share: Float
+  top_10pct_share: Float
+  top_20pct_share: Float
   entropy: Float
   entropy_normalized: Float
 }

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -1179,6 +1179,7 @@ export type ChainConcentrationHistoryPoint = {
   validator_stake?: Maybe<ChainConcentrationScorecard>;
 };
 
+/** One distribution's concentration scorecard, passed through from the stored card -- identical by construction to the live /chain/concentration card, because it is the same card. */
 export type ChainConcentrationScorecard = {
   __typename?: 'ChainConcentrationScorecard';
   entropy?: Maybe<Scalars['Float']['output']>;
@@ -1187,8 +1188,12 @@ export type ChainConcentrationScorecard = {
   hhi?: Maybe<Scalars['Float']['output']>;
   hhi_normalized?: Maybe<Scalars['Float']['output']>;
   holders: Scalars['Int']['output'];
-  nakamoto_coefficient?: Maybe<Scalars['Int']['output']>;
-  total: Scalars['Float']['output'];
+  nakamoto_coefficient: Scalars['Int']['output'];
+  top_1pct_share?: Maybe<Scalars['Float']['output']>;
+  top_5pct_share?: Maybe<Scalars['Float']['output']>;
+  top_10pct_share?: Maybe<Scalars['Float']['output']>;
+  top_20pct_share?: Maybe<Scalars['Float']['output']>;
+  total?: Maybe<Scalars['Float']['output']>;
 };
 
 export type ChainDeregistrations = {
@@ -9723,8 +9728,12 @@ export type ChainConcentrationScorecardResolvers<ContextType = GqlContext, Paren
   hhi?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   hhi_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   holders?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  nakamoto_coefficient?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
-  total?: Resolver<ResolversTypes['Float'], ParentType, ContextType>;
+  nakamoto_coefficient?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  top_1pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_5pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_10pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_20pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type ChainDeregistrationsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['ChainDeregistrations'] = ResolversParentTypes['ChainDeregistrations']> = ResolversObject<{

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6546,6 +6546,7 @@ export interface components {
             uids_per_entity: number | null;
             validator_stake: components["schemas"]["ChainConcentrationScorecard"] | null;
         };
+        /** @description One distribution's concentration scorecard, passed through from the stored card -- identical by construction to the live /chain/concentration card, because it is the same card. */
         ChainConcentrationScorecard: {
             entropy: number | null;
             entropy_normalized: number | null;
@@ -6553,8 +6554,12 @@ export interface components {
             hhi: number | null;
             hhi_normalized: number | null;
             holders: number;
-            nakamoto_coefficient: number | null;
-            total: number;
+            nakamoto_coefficient: number;
+            top_10pct_share: number | null;
+            top_1pct_share: number | null;
+            top_20pct_share: number | null;
+            top_5pct_share: number | null;
+            total: number | null;
         };
         ChainConcentrationSubnetsArtifact: {
             captured_at: string | null;
@@ -25537,6 +25542,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "entity_count": 1,
@@ -25548,6 +25557,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "entity_stake": {
@@ -25558,6 +25571,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "neuron_count": 1,
@@ -25570,6 +25587,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "subnet_count": 1,
@@ -25582,6 +25603,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             }
                      *           }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2783,6 +2783,10 @@
                   "hhi_normalized": 0.5,
                   "holders": 1,
                   "nakamoto_coefficient": 1,
+                  "top_10pct_share": 0.5,
+                  "top_1pct_share": 0.5,
+                  "top_20pct_share": 0.5,
+                  "top_5pct_share": 0.5,
                   "total": 1
                 },
                 "entity_count": 1,
@@ -2794,6 +2798,10 @@
                   "hhi_normalized": 0.5,
                   "holders": 1,
                   "nakamoto_coefficient": 1,
+                  "top_10pct_share": 0.5,
+                  "top_1pct_share": 0.5,
+                  "top_20pct_share": 0.5,
+                  "top_5pct_share": 0.5,
                   "total": 1
                 },
                 "entity_stake": {
@@ -2804,6 +2812,10 @@
                   "hhi_normalized": 0.5,
                   "holders": 1,
                   "nakamoto_coefficient": 1,
+                  "top_10pct_share": 0.5,
+                  "top_1pct_share": 0.5,
+                  "top_20pct_share": 0.5,
+                  "top_5pct_share": 0.5,
                   "total": 1
                 },
                 "neuron_count": 1,
@@ -2816,6 +2828,10 @@
                   "hhi_normalized": 0.5,
                   "holders": 1,
                   "nakamoto_coefficient": 1,
+                  "top_10pct_share": 0.5,
+                  "top_1pct_share": 0.5,
+                  "top_20pct_share": 0.5,
+                  "top_5pct_share": 0.5,
                   "total": 1
                 },
                 "subnet_count": 1,
@@ -2828,6 +2844,10 @@
                   "hhi_normalized": 0.5,
                   "holders": 1,
                   "nakamoto_coefficient": 1,
+                  "top_10pct_share": 0.5,
+                  "top_1pct_share": 0.5,
+                  "top_20pct_share": 0.5,
+                  "top_5pct_share": 0.5,
                   "total": 1
                 }
               }
@@ -22179,6 +22199,7 @@
       },
       "ChainConcentrationScorecard": {
         "additionalProperties": false,
+        "description": "One distribution's concentration scorecard, passed through from the stored card -- identical by construction to the live /chain/concentration card, because it is the same card.",
         "properties": {
           "entropy": {
             "anyOf": [
@@ -22236,11 +22257,44 @@
             "type": "integer"
           },
           "nakamoto_coefficient": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "top_10pct_share": {
             "anyOf": [
               {
-                "maximum": 9007199254740991,
-                "minimum": -9007199254740991,
-                "type": "integer"
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "top_1pct_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "top_20pct_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "top_5pct_share": {
+            "anyOf": [
+              {
+                "type": "number"
               },
               {
                 "type": "null"
@@ -22248,7 +22302,14 @@
             ]
           },
           "total": {
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -22258,6 +22319,10 @@
           "hhi",
           "hhi_normalized",
           "nakamoto_coefficient",
+          "top_1pct_share",
+          "top_5pct_share",
+          "top_10pct_share",
+          "top_20pct_share",
           "entropy",
           "entropy_normalized"
         ],

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6546,6 +6546,7 @@ export interface components {
             uids_per_entity: number | null;
             validator_stake: components["schemas"]["ChainConcentrationScorecard"] | null;
         };
+        /** @description One distribution's concentration scorecard, passed through from the stored card -- identical by construction to the live /chain/concentration card, because it is the same card. */
         ChainConcentrationScorecard: {
             entropy: number | null;
             entropy_normalized: number | null;
@@ -6553,8 +6554,12 @@ export interface components {
             hhi: number | null;
             hhi_normalized: number | null;
             holders: number;
-            nakamoto_coefficient: number | null;
-            total: number;
+            nakamoto_coefficient: number;
+            top_10pct_share: number | null;
+            top_1pct_share: number | null;
+            top_20pct_share: number | null;
+            top_5pct_share: number | null;
+            total: number | null;
         };
         ChainConcentrationSubnetsArtifact: {
             captured_at: string | null;
@@ -25537,6 +25542,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "entity_count": 1,
@@ -25548,6 +25557,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "entity_stake": {
@@ -25558,6 +25571,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "neuron_count": 1,
@@ -25570,6 +25587,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             },
                      *             "subnet_count": 1,
@@ -25582,6 +25603,10 @@ export interface operations {
                      *               "hhi_normalized": 0.5,
                      *               "holders": 1,
                      *               "nakamoto_coefficient": 1,
+                     *               "top_10pct_share": 0.5,
+                     *               "top_1pct_share": 0.5,
+                     *               "top_20pct_share": 0.5,
+                     *               "top_5pct_share": 0.5,
                      *               "total": 1
                      *             }
                      *           }

--- a/schemas-src/routes/chain-concentration-history.ts
+++ b/schemas-src/routes/chain-concentration-history.ts
@@ -2,23 +2,42 @@
 // concentrated? Modeled from src/chain-concentration-history.ts's
 // buildChainConcentrationHistory().
 import { z } from "zod";
+import { ConcentrationMetricsSchema } from "../shared.ts";
 import { UnavailableDegradedSchema } from "./event-stream-honesty.ts";
 
-/** One distribution's scorecard, as computeConcentration produced it. Passed
- * through from the stored card rather than re-shaped, so a historical point and
- * the live /chain/concentration card carry identical fields. */
-export const ChainConcentrationScorecardSchema = z
-  .object({
-    holders: z.int().min(0),
-    total: z.number(),
-    gini: z.number().nullable(),
-    hhi: z.number().nullable(),
-    hhi_normalized: z.number().nullable(),
-    nakamoto_coefficient: z.int().nullable(),
-    entropy: z.number().nullable(),
-    entropy_normalized: z.number().nullable(),
-  })
-  .strict();
+/**
+ * One distribution's scorecard, as computeConcentration produced it.
+ *
+ * DERIVED, because the sentence below was already the contract and the copy
+ * that used to sit here was not. The cron stores exactly the card
+ * /chain/concentration serves -- src/chain-concentration-history.ts's header
+ * says so, and that route declares `ConcentrationMetricsSchema`: twelve
+ * measures. This re-listed eight, dropping `top_1pct_share`,
+ * `top_5pct_share`, `top_10pct_share`, and `top_20pct_share`, under a
+ * docstring promising "identical fields". Every stored card therefore carried
+ * four keys its own schema forbade -- 441 conformance violations across the
+ * 147 cards in a 30-day window, all of them the same four.
+ *
+ * #10786 already caught these two schemas disagreeing about NULLABILITY and
+ * fixed that half, writing "one shape, two schemas, and only one of them
+ * true". The field lists stayed divergent, because fixing a copy leaves it a
+ * copy. Deriving is what makes the promise enforceable instead of
+ * aspirational.
+ *
+ * `.required()`, the same spelling routes/domains.ts uses, and for the same
+ * reason: `computeConcentration()` returns one fixed shape or null, so a card
+ * that exists carries every measure. Deriving withOUT it would have quietly
+ * dropped this component's `required` list from eight keys to two -- fixing
+ * the missing four by weakening the eight that were already right. Checked
+ * against production before choosing: all 147 cards in the live 30-day window
+ * carry all twelve keys, none of them null.
+ */
+export const ChainConcentrationScorecardSchema =
+  ConcentrationMetricsSchema.unwrap()
+    .required()
+    .describe(
+      "One distribution's concentration scorecard, passed through from the stored card -- identical by construction to the live /chain/concentration card, because it is the same card.",
+    );
 
 export const ChainConcentrationHistoryPointSchema = z
   .object({

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -206,6 +206,7 @@ import {
 } from "../schemas-src/routes/chain-network-rollups.ts";
 import { ChainAlphaVolumeArtifactSchema } from "../schemas-src/routes/chain-alpha-volume.ts";
 import { ChainConcentrationArtifactSchema } from "../schemas-src/routes/chain-concentration.ts";
+import { ChainConcentrationScorecardSchema } from "../schemas-src/routes/chain-concentration-history.ts";
 import {
   ChainEventsFeedArtifactSchema,
   ChainEventsStatsArtifactSchema,
@@ -4911,6 +4912,87 @@ describe("agent-readiness-status: hand-edited copy no longer shadows the Zod own
     assert.equal(
       description,
       "Agent-facing readiness status and blocker taxonomy for one subnet.",
+    );
+  });
+});
+
+describe("chain-concentration-history: the scorecard is derived, not re-listed (#10982)", () => {
+  // The docstring on ChainConcentrationScorecardSchema always promised that a
+  // historical point and the live /chain/concentration card "carry identical
+  // fields". Underneath it sat a hand-written eight-key object, while the live
+  // card declares the twelve-measure ConcentrationMetrics vocabulary -- so
+  // every stored card served four top-percentile keys its own schema forbade.
+  // These assertions are the promise, made executable: re-list the fields in
+  // either place and the key sets stop matching here.
+  const objectArm = (schema: Record<string, unknown>) =>
+    ("properties" in schema
+      ? schema
+      : (schema.anyOf as Record<string, unknown>[]).find(
+          (arm) => "properties" in arm,
+        )) as { properties: Record<string, unknown>; required?: string[] };
+
+  test("the published component declares exactly the shared concentration vocabulary", () => {
+    const components = generateOpenApiZodComponents();
+    const scorecard = objectArm(
+      components.ChainConcentrationScorecard as Record<string, unknown>,
+    );
+    const shared = objectArm(
+      components.ConcentrationMetrics as Record<string, unknown>,
+    );
+    assert.deepEqual(
+      Object.keys(scorecard.properties).sort(),
+      Object.keys(shared.properties).sort(),
+    );
+  });
+
+  test("all twelve measures stay REQUIRED -- deriving must not weaken the eight that were already right", () => {
+    const components = generateOpenApiZodComponents();
+    const scorecard = objectArm(
+      components.ChainConcentrationScorecard as Record<string, unknown>,
+    );
+    assert.deepEqual(
+      [...(scorecard.required ?? [])].sort(),
+      Object.keys(scorecard.properties).sort(),
+    );
+  });
+
+  test("a real stored card parses -- the four top-percentile shares included", () => {
+    // Shape taken from the live /api/v1/chain/concentration/history response;
+    // the four top_Npct_share keys are what the hand-written copy rejected.
+    const card = {
+      holders: 8185,
+      total: 338420962.9214,
+      gini: 0.954764,
+      hhi: 0.003471,
+      hhi_normalized: 0.003349,
+      nakamoto_coefficient: 101,
+      top_1pct_share: 0.445044,
+      top_5pct_share: 0.866741,
+      top_10pct_share: 0.971802,
+      top_20pct_share: 0.999149,
+      entropy: 8.908676,
+      entropy_normalized: 0.685348,
+    };
+    assert.deepEqual(ChainConcentrationScorecardSchema.parse(card), card);
+  });
+
+  test("strictness survives the derivation -- an unknown measure is still refused", () => {
+    assert.throws(() =>
+      ChainConcentrationScorecardSchema.parse({
+        holders: 1,
+        total: 1,
+        gini: 0,
+        hhi: 0,
+        hhi_normalized: 0,
+        nakamoto_coefficient: 1,
+        top_1pct_share: 0,
+        top_5pct_share: 0,
+        top_10pct_share: 0,
+        top_20pct_share: 0,
+        entropy: 0,
+        entropy_normalized: 0,
+        top_50pct_share: 0,
+      }),
     );
   });
 });


### PR DESCRIPTION
`/api/v1/chain/concentration/history` served four keys its own published schema forbade — `top_1pct_share`, `top_5pct_share`, `top_10pct_share`, `top_20pct_share` — on **every card, in production, since the route shipped**.

## The 441 is one bug counted 441 times

The daily conformance sweep went red with `"violations": 445` across `"checked": 201`, which reads as a network-wide event. It is three routes, and this one is 441 of them: **147 stored cards** in the live 30-day window (30 days × 5 metric blocks − 3 null cards), the **same four keys** on each, and AJV reporting every `anyOf` failure three ways (`must NOT have additional properties` / `must be null` / `must match a schema in anyOf`). 147 × 3 = 441.

## Why the copy was wrong and the data was right

The cron stores exactly the card `/chain/concentration` serves — `src/chain-concentration-history.ts`'s own header says so — and that route declares `ConcentrationMetricsSchema`, twelve measures. This route re-listed eight of them, under a docstring promising the two carry *"identical fields"*.

[#10786](https://github.com/JSONbored/metagraphed/pull/10786) already caught these two schemas disagreeing — about **nullability** — and fixed that half, writing *"one shape, two schemas, and only one of them true"*. The field lists stayed divergent, because fixing a copy leaves it a copy. Derived now, so the sentence is enforceable rather than aspirational.

## The choice inside the fix

Deriving plainly would have dropped this component's `required` list **from eight keys to two** — repairing the four that were missing by weakening the eight that were already right. `.required()` (the spelling `routes/domains.ts` uses for the same vocabulary) keeps all twelve required. Production carries all twelve keys, non-null, on all 147 cards, so this is the stronger contract, not a looser one.

## Verification

Run against **live `api.metagraph.sh`** through the sweep's own `buildValidator` — not a reimplementation:

| route | before | after |
|---|---|---|
| `/api/v1/chain/concentration/history` | 441 | **0** |

Each new guard was confirmed to fail against the hand-written version: re-listing the eight keys fails the vocabulary and parse guards; removing `.required()` fails the required-list guard.

## Regenerated artifacts

`ChainConcentrationScorecard` gains the four fields; `nakamoto_coefficient` becomes non-null and `total` becomes nullable, both matching the shared vocabulary and the live card.

## Not fixed here

The sweep's other two routes are separate changes. `/subnets/{netuid}/overview` hand-rolls its own copy of `HealthSubnetSummary` (missing `latency_sample_count` and `name`) and is next; `/agent-catalog/{netuid}` reported one violation at 08:01 and does not reproduce now, so I am not guessing at it.


