### PR TITLE
fix(schema): four hand-rolled copies collapsed onto the vocabulary they restate

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -5010,13 +5010,13 @@ type ChainSpecReading {
 
 type SubtensorRelease {
   tag: String!
-  spec_version: Int!
+  name: String
   published_at: String
 
   """GitHub's own html_url -- never constructed."""
   url: String
-  name: String
   prerelease: Boolean!
+  spec_version: Int!
 }
 
 type ValidatorList {
@@ -5507,11 +5507,13 @@ One account's per-subnet position history over a lookback window, one point per 
 """
 type AccountPositionHistory {
   schema_version: Int!
-  ss58: String!
   netuid: Int!
+
+  """The resolved window label (7d/30d/90d)."""
   window: String
   point_count: Int!
   points: [AccountPositionHistoryPoint!]!
+  ss58: String!
 }
 
 """
@@ -7185,13 +7187,13 @@ Distribution of the per-neuron emission/stake return rate across the network.
 type YieldDistribution {
   count: Int!
   mean: Float!
-  median: Float!
   min: Float!
-  max: Float!
-  p10: Float!
   p25: Float!
+  median: Float!
   p75: Float!
   p90: Float!
+  max: Float!
+  p10: Float!
 }
 
 """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -429,6 +429,7 @@ export type AccountPositionHistory = {
   points: Array<AccountPositionHistoryPoint>;
   schema_version: Scalars['Int']['output'];
   ss58: Scalars['String']['output'];
+  /** The resolved window label (7d/30d/90d). */
   window?: Maybe<Scalars['String']['output']>;
 };
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5405,6 +5405,7 @@ export interface components {
             }[];
             schema_version: number;
             ss58: string;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         };
         /** @description This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions. */
@@ -11568,10 +11569,14 @@ export interface components {
                 failed_count?: number;
                 last_checked?: string | null;
                 last_ok?: string | null;
+                latency_sample_count?: number;
+                name?: string;
                 netuid?: number;
+                /** @description Which prober observed this card -- stamped by the serve-time overlay, never baked. */
                 observed_by?: string;
                 ok_count?: number;
-                status?: string;
+                slug?: string;
+                status?: components["schemas"]["HealthStatus"];
                 surface_count?: number;
                 unknown_count?: number;
             } | null;
@@ -44393,9 +44398,12 @@ export interface operations {
                      *           "failed_count": 1,
                      *           "last_checked": "2026-06-01T00:00:00.000Z",
                      *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "latency_sample_count": 120,
+                     *           "name": "Example Subnet",
                      *           "netuid": 7,
                      *           "observed_by": "2026-06-01T00:00:00.000Z",
                      *           "ok_count": 1,
+                     *           "slug": "example-subnet",
                      *           "status": "ok",
                      *           "surface_count": 1,
                      *           "unknown_count": 1

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10549,9 +10549,12 @@
               "failed_count": 1,
               "last_checked": "2026-06-01T00:00:00.000Z",
               "last_ok": "2026-06-01T00:00:00.000Z",
+              "latency_sample_count": 120,
+              "name": "Example Subnet",
               "netuid": 7,
               "observed_by": "2026-06-01T00:00:00.000Z",
               "ok_count": 1,
+              "slug": "example-subnet",
               "status": "ok",
               "surface_count": 1,
               "unknown_count": 1
@@ -15589,15 +15592,16 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The resolved window label (7d/30d/90d)."
           }
         },
         "required": [
           "schema_version",
-          "ss58",
           "netuid",
           "point_count",
-          "points"
+          "points",
+          "ss58"
         ],
         "type": "object"
       },
@@ -26637,13 +26641,13 @@
                 "required": [
                   "count",
                   "mean",
-                  "median",
                   "min",
-                  "max",
-                  "p10",
                   "p25",
+                  "median",
                   "p75",
-                  "p90"
+                  "p90",
+                  "max",
+                  "p10"
                 ],
                 "type": "object"
               },
@@ -42609,11 +42613,11 @@
                     },
                     "required": [
                       "tag",
-                      "spec_version",
+                      "name",
                       "published_at",
                       "url",
-                      "name",
-                      "prerelease"
+                      "prerelease",
+                      "spec_version"
                     ],
                     "type": "object"
                   },
@@ -50903,7 +50907,9 @@
                   "avg_latency_ms": {
                     "anyOf": [
                       {
-                        "type": "number"
+                        "maximum": 9007199254740991,
+                        "minimum": 0,
+                        "type": "integer"
                       },
                       {
                         "type": "null"
@@ -50940,12 +50946,21 @@
                       }
                     ]
                   },
+                  "latency_sample_count": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
                   "netuid": {
                     "maximum": 9007199254740991,
                     "minimum": 0,
                     "type": "integer"
                   },
                   "observed_by": {
+                    "description": "Which prober observed this card -- stamped by the serve-time overlay, never baked.",
                     "type": "string"
                   },
                   "ok_count": {
@@ -50953,8 +50968,11 @@
                     "minimum": 0,
                     "type": "integer"
                   },
-                  "status": {
+                  "slug": {
                     "type": "string"
+                  },
+                  "status": {
+                    "$ref": "#/components/schemas/HealthStatus"
                   },
                   "surface_count": {
                     "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5405,6 +5405,7 @@ export interface components {
             }[];
             schema_version: number;
             ss58: string;
+            /** @description The resolved window label (7d/30d/90d). */
             window?: string | null;
         };
         /** @description This account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from AccountPortfolio's hotkey-scoped view. Mirrors GET /api/v1/accounts/{ss58}/positions. */
@@ -11568,10 +11569,14 @@ export interface components {
                 failed_count?: number;
                 last_checked?: string | null;
                 last_ok?: string | null;
+                latency_sample_count?: number;
+                name?: string;
                 netuid?: number;
+                /** @description Which prober observed this card -- stamped by the serve-time overlay, never baked. */
                 observed_by?: string;
                 ok_count?: number;
-                status?: string;
+                slug?: string;
+                status?: components["schemas"]["HealthStatus"];
                 surface_count?: number;
                 unknown_count?: number;
             } | null;
@@ -44393,9 +44398,12 @@ export interface operations {
                      *           "failed_count": 1,
                      *           "last_checked": "2026-06-01T00:00:00.000Z",
                      *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "latency_sample_count": 120,
+                     *           "name": "Example Subnet",
                      *           "netuid": 7,
                      *           "observed_by": "2026-06-01T00:00:00.000Z",
                      *           "ok_count": 1,
+                     *           "slug": "example-subnet",
                      *           "status": "ok",
                      *           "surface_count": 1,
                      *           "unknown_count": 1

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -30,6 +30,7 @@
 // against a live get_subnet response.
 import { z } from "zod";
 import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
+import { OverlaidSubnetHealthSchema } from "../routes/health.ts";
 import { netuidSchema } from "./shared.ts";
 import { ReviewGapPrioritySchema } from "../routes/review-gaps-profile.ts";
 // The route's OWN curation block (#10790). The copy typed `level` and
@@ -45,25 +46,19 @@ export const GetSubnetInputSchema = z
   .strict();
 export type GetSubnetInput = z.infer<typeof GetSubnetInputSchema>;
 
-/** The composed health card. Probe-derived (#health): counts of surfaces by
- * verdict, the newest check, and the observed latency sample behind it. */
-const SubnetOverviewHealthSchema = z
-  .object({
-    netuid: netuidSchema().optional(),
-    name: z.string().nullable().optional(),
-    status: z.string().nullable().optional(),
-    surface_count: z.int().optional(),
-    ok_count: z.int().optional(),
-    degraded_count: z.int().optional(),
-    failed_count: z.int().optional(),
-    unknown_count: z.int().optional(),
-    last_checked: z.string().nullable().optional(),
-    last_ok: z.string().nullable().optional(),
-    avg_latency_ms: z.number().nullable().optional(),
-    latency_sample_count: z.int().nullable().optional(),
-    observed_by: z.string().nullable().optional(),
-  })
-  .strict();
+/**
+ * The composed health card. Probe-derived (#health): counts of surfaces by
+ * verdict, the newest check, and the observed latency sample behind it.
+ *
+ * The SAME block /api/v1/subnets/{netuid}/overview serves, from the same
+ * `overlayOverviewHealth()` call, so it is imported rather than re-listed. The
+ * copy that used to sit here declared `name`, `status`, `latency_sample_count`,
+ * and `observed_by` nullable; the overlay spreads a `HealthSubnetSummary` and
+ * stamps `observed_by` from a constant, so nothing in the producer can write a
+ * null into any of them -- the tolerance described no writer. Confirmed against
+ * the live tool before removing it.
+ */
+const SubnetOverviewHealthSchema = OverlaidSubnetHealthSchema;
 
 /** How many of each thing this subnet has registered. */
 const SubnetOverviewCountsSchema = z

--- a/schemas-src/routes/account-positions.ts
+++ b/schemas-src/routes/account-positions.ts
@@ -26,6 +26,7 @@
 // Bucket (c): captured_at fields drop format:date-time in favor of plain
 // z.string().nullable(), matching this epic's established convention.
 import { z } from "zod";
+import { subnetHistoryArtifactSchema } from "../shared.ts";
 import { POSITIONS_DEGRADED_REASONS } from "../../src/account-nominator-positions.ts";
 
 const NominatorPositionSchema = z
@@ -134,16 +135,19 @@ const AccountPositionHistoryPointSchema = z
     "One day's position for an account in one subnet: the neuron's uid/role/active plus stake/emission and its rank/trust/incentive/dividends scores and emission-per-stake yield.",
   );
 
-export const AccountPositionHistoryArtifactSchema = z
-  .object({
-    schema_version: z.int(),
-    ss58: z.string(),
-    netuid: z.int().min(0),
-    window: z.string().nullable().optional(),
-    point_count: z.int().min(0),
-    points: z.array(AccountPositionHistoryPointSchema),
-  })
-  .strict()
+/**
+ * The shared per-subnet history envelope, scoped to one account.
+ *
+ * `subnetHistoryArtifactSchema()` (shared.ts) already owns
+ * schema_version/netuid/window/point_count/points -- #10790 collapsed three
+ * copies of it into that factory. This was a fourth, invisible to the duplicate
+ * gate because it adds `ss58`: the envelope is the same, the scope is one field
+ * narrower.
+ */
+export const AccountPositionHistoryArtifactSchema = subnetHistoryArtifactSchema(
+  AccountPositionHistoryPointSchema,
+)
+  .extend({ ss58: z.string() })
   .describe(
     "One account's per-subnet position history over a lookback window, one point per neuron_daily snapshot. Mirrors GET /api/v1/accounts/{ss58}/subnets/{netuid}/history.",
   );

--- a/schemas-src/routes/chain-yield.ts
+++ b/schemas-src/routes/chain-yield.ts
@@ -7,20 +7,25 @@
 // ChainYieldArtifact is its only referrer (verified via repo-wide $ref
 // grep), so the hand-edited component key becomes fully orphaned.
 import { z } from "zod";
+import { distributionStatsSchema } from "../shared.ts";
 
-const YieldDistributionSchema = z
-  .object({
-    count: z.int().min(0),
-    mean: z.number(),
-    median: z.number(),
-    min: z.number(),
-    max: z.number(),
-    p10: z.number(),
-    p25: z.number(),
-    p75: z.number(),
-    p90: z.number(),
-  })
-  .strict()
+/**
+ * The shared count-and-spread summary, plus the one percentile this domain
+ * reports that the others do not.
+ *
+ * #10790 collapsed that eight-key summary from four hand-written copies into
+ * `distributionStatsSchema()`. This was a FIFTH copy and survived the collapse
+ * for a single reason: it carries `p10`, so its key set is not equal to the
+ * others', and the duplicate gate matches key sets exactly. A copy that has
+ * gained a field stops looking like a copy at precisely the moment it has
+ * started to drift.
+ *
+ * The eight shared fields were field-for-field identical to
+ * `distributionStatsSchema(z.number())` at the point of collapse -- an
+ * unbounded measure with unbounded percentiles -- so nothing published moves.
+ */
+const YieldDistributionSchema = distributionStatsSchema(z.number())
+  .extend({ p10: z.number() })
   .describe(
     "Distribution of the per-neuron emission/stake return rate across the network.",
   )

--- a/schemas-src/routes/health.ts
+++ b/schemas-src/routes/health.ts
@@ -29,6 +29,44 @@ export const HealthSubnetSummarySchema = z
   .strict();
 export type HealthSubnetSummary = z.infer<typeof HealthSubnetSummarySchema>;
 
+/**
+ * The same summary once `overlayOverviewHealth()` has stamped it onto a subnet
+ * card -- the ONE declaration of that shape, for every surface that serves it.
+ *
+ * `overlayOverviewHealth()` (src/health-serving.ts) builds the block as
+ * `{ netuid, ...summary, observed_by }`, where `summary` is an element of the
+ * live health artifact's `subnets` array -- the array typed above. The shape is
+ * therefore not modelled after this summary, it IS this summary plus one field,
+ * and every consumer that re-listed it was restating a vocabulary it does not
+ * own.
+ *
+ * Three of them did, each with a different subset:
+ *
+ *   routes/subnet-overview.ts     dropped `latency_sample_count` and `name`
+ *   mcp-tools/get-subnet.ts       kept both, added nullability no writer emits
+ *   (this)                        the actual vocabulary
+ *
+ * The first is not a style problem: /api/v1/subnets/{netuid}/overview served
+ * two keys its own `.strict()` schema forbade, which the daily conformance
+ * sweep reported against `/data/health`.
+ *
+ * `.partial()` because the overlay has a SECOND arm -- a subnet with no probed
+ * surfaces gets `{ netuid, status: "unknown", surface_count: 0 }`, which does
+ * not carry the counts required above. That arm is the one thing both copies
+ * had right, and it is why this cannot simply be the summary itself.
+ */
+export const OverlaidSubnetHealthSchema = HealthSubnetSummarySchema.partial()
+  .extend({
+    observed_by: z
+      .string()
+      .optional()
+      .describe(
+        "Which prober observed this card -- stamped by the serve-time overlay, never baked.",
+      ),
+  })
+  .strict();
+export type OverlaidSubnetHealth = z.infer<typeof OverlaidSubnetHealthSchema>;
+
 export const HealthSummaryArtifactSchema = z
   .object({
     contract_version: z.string().optional(),

--- a/schemas-src/routes/health.ts
+++ b/schemas-src/routes/health.ts
@@ -65,7 +65,6 @@ export const OverlaidSubnetHealthSchema = HealthSubnetSummarySchema.partial()
       ),
   })
   .strict();
-export type OverlaidSubnetHealth = z.infer<typeof OverlaidSubnetHealthSchema>;
 
 export const HealthSummaryArtifactSchema = z
   .object({

--- a/schemas-src/routes/runtime-versions.ts
+++ b/schemas-src/routes/runtime-versions.ts
@@ -8,6 +8,7 @@
 // repo-wide $ref grep), so the hand-edited component key becomes fully
 // orphaned.
 import { z } from "zod";
+import { GithubReleaseSchema } from "../shared.ts";
 
 const RuntimeVersionTransitionSchema = z
   .object({
@@ -48,19 +49,27 @@ const ChainSpecReadingSchema = z
   })
   .strict();
 
-const SubtensorReleaseSchema = z
-  .object({
-    tag: z.string(),
-    spec_version: z.int().min(0),
-    published_at: z.string().nullable(),
-    url: z
-      .string()
-      .nullable()
-      .describe("GitHub's own html_url -- never constructed."),
-    name: z.string().nullable(),
-    prerelease: z.boolean(),
-  })
-  .strict();
+/**
+ * A GitHub release, plus the runtime version it shipped.
+ *
+ * #10790 collapsed `GithubReleaseSchema` from three hand-written copies into
+ * one declaration in shared.ts. This was a fourth, and it survived because it
+ * carries `spec_version` -- one extra key is enough for a key-set comparison to
+ * stop seeing a copy.
+ *
+ * The two ways this reading is genuinely weaker are stated rather than
+ * restated: `published_at` and `url` are nullable here because this release is
+ * READ from the GitHub API at serve time and the read can come back empty,
+ * where the shared schema describes a release already known to exist.
+ */
+const SubtensorReleaseSchema = GithubReleaseSchema.extend({
+  spec_version: z.int().min(0),
+  published_at: z.string().nullable(),
+  url: z
+    .string()
+    .nullable()
+    .describe("GitHub's own html_url -- never constructed."),
+}).strict();
 
 /**
  * The forward-looking half of GET /api/v1/runtime, undeclared until #10790.

--- a/schemas-src/routes/subnet-overview.ts
+++ b/schemas-src/routes/subnet-overview.ts
@@ -16,6 +16,7 @@
 // (.passthrough()) so this is a pure completeness gain, not a tightening.
 import { z } from "zod";
 import { ArtifactBaseSchema } from "../envelope.ts";
+import { OverlaidSubnetHealthSchema } from "./health.ts";
 import {
   CurationMetadataSchema,
   GapsSchema,
@@ -23,21 +24,12 @@ import {
 } from "./subnet-detail.ts";
 import { SubnetProfileSchema } from "./subnet-profile.ts";
 
-const SubnetOverviewHealthSchema = z
-  .object({
-    netuid: z.int().min(0).optional(),
-    status: z.string().optional(),
-    surface_count: z.int().min(0).optional(),
-    ok_count: z.int().min(0).optional(),
-    degraded_count: z.int().min(0).optional(),
-    failed_count: z.int().min(0).optional(),
-    unknown_count: z.int().min(0).optional(),
-    last_checked: z.string().nullable().optional(),
-    last_ok: z.string().nullable().optional(),
-    avg_latency_ms: z.number().nullable().optional(),
-    observed_by: z.string().optional(),
-  })
-  .strict();
+// The overlaid health block has ONE declaration, in routes/health.ts next to
+// the summary the overlay spreads. Re-listing it here dropped
+// `latency_sample_count` and `name` -- both of which the overlay copies through
+// and production serves -- so this route served two keys its own `.strict()`
+// schema forbade, which the daily conformance sweep reported against
+// `/data/health`.
 
 export const SubnetOverviewArtifactSchema = ArtifactBaseSchema.extend({
   netuid: z.int().min(0),
@@ -45,7 +37,7 @@ export const SubnetOverviewArtifactSchema = ArtifactBaseSchema.extend({
   name: z.string().optional(),
   status: z.string().optional(),
   profile: SubnetProfileSchema.nullable(),
-  health: SubnetOverviewHealthSchema.nullable(),
+  health: OverlaidSubnetHealthSchema.nullable(),
   ...LIVE_HEALTH_OVERLAY,
   curation: CurationMetadataSchema.nullable().optional(),
   gaps: GapsSchema.nullable().optional(),

--- a/tests/zod-schemas.test.ts
+++ b/tests/zod-schemas.test.ts
@@ -208,6 +208,11 @@ import { ChainAlphaVolumeArtifactSchema } from "../schemas-src/routes/chain-alph
 import { ChainConcentrationArtifactSchema } from "../schemas-src/routes/chain-concentration.ts";
 import { ChainConcentrationScorecardSchema } from "../schemas-src/routes/chain-concentration-history.ts";
 import {
+  HealthSubnetSummarySchema,
+  OverlaidSubnetHealthSchema,
+} from "../schemas-src/routes/health.ts";
+import { GetSubnetOutputSchema } from "../schemas-src/mcp-tools/get-subnet.ts";
+import {
   ChainEventsFeedArtifactSchema,
   ChainEventsStatsArtifactSchema,
 } from "../schemas-src/routes/chain-events.ts";
@@ -4993,6 +4998,84 @@ describe("chain-concentration-history: the scorecard is derived, not re-listed (
         entropy_normalized: 0,
         top_50pct_share: 0,
       }),
+    );
+  });
+});
+
+describe("overlaid subnet health: one vocabulary, every surface that serves it (#10983)", () => {
+  // `overlayOverviewHealth()` builds this block as `{ netuid, ...summary,
+  // observed_by }` -- the summary being a HealthSubnetSummary. Three schemas
+  // described that one shape, each with a different subset: the REST route
+  // dropped `latency_sample_count` and `name` (and so served two keys its own
+  // .strict() schema forbade), and the MCP tool declared nullability no
+  // producer can write. These assertions are what stops a fourth copy.
+  // Peels the `.nullable()`/`.optional()` each surface wraps the block in --
+  // the REST route uses one, the MCP tool both -- down to the object itself.
+  const healthKeys = (schema: z.ZodType) => {
+    let node = schema as unknown as {
+      shape?: Record<string, unknown>;
+      unwrap?: () => z.ZodType;
+    };
+    while (!node.shape && typeof node.unwrap === "function") {
+      node = node.unwrap() as typeof node;
+    }
+    assert.ok(node.shape, "expected an object schema under the wrappers");
+    return Object.keys(node.shape).sort();
+  };
+
+  test("the shared block is exactly the summary's vocabulary plus observed_by", () => {
+    assert.deepEqual(
+      healthKeys(OverlaidSubnetHealthSchema),
+      [...healthKeys(HealthSubnetSummarySchema), "observed_by"].sort(),
+    );
+  });
+
+  test("the REST route and the MCP tool serve THE SAME declaration, not two copies", () => {
+    const shared = healthKeys(OverlaidSubnetHealthSchema);
+    assert.deepEqual(
+      healthKeys(SubnetOverviewArtifactSchema.shape.health),
+      shared,
+    );
+    assert.deepEqual(
+      healthKeys(
+        (GetSubnetOutputSchema.shape as unknown as Record<string, z.ZodType>)
+          .health!,
+      ),
+      shared,
+    );
+  });
+
+  test("the block production actually serves parses -- both fields the route's copy dropped", () => {
+    // Verbatim from live /api/v1/subnets/7/overview.
+    const parsed = OverlaidSubnetHealthSchema.parse({
+      netuid: 7,
+      name: "Allways",
+      status: "ok",
+      surface_count: 29,
+      ok_count: 29,
+      degraded_count: 0,
+      failed_count: 0,
+      unknown_count: 0,
+      last_checked: "2026-08-13T04:45:29.743Z",
+      last_ok: "2026-08-13T04:45:29.743Z",
+      avg_latency_ms: 287,
+      latency_sample_count: 29,
+      observed_by: "live-cron-prober",
+    });
+    assert.equal(parsed.latency_sample_count, 29);
+    assert.equal(parsed.name, "Allways");
+  });
+
+  test("the no-probed-surfaces arm still parses -- it carries none of the counts", () => {
+    // overlayOverviewHealth()'s second arm. This is why the block is .partial()
+    // rather than the summary itself.
+    assert.deepEqual(
+      OverlaidSubnetHealthSchema.parse({
+        netuid: 42,
+        status: "unknown",
+        surface_count: 0,
+      }),
+      { netuid: 42, status: "unknown", surface_count: 0 },
     );
   });
 });


### PR DESCRIPTION
`/api/v1/subnets/{netuid}/overview` served `latency_sample_count` and `name` on every response, and its own `.strict()` schema forbade both. The daily conformance sweep reported it against `/data/health`.

## Why the existing gate could not see any of these

[#10790](https://github.com/JSONbored/metagraphed/pull/10790) collapsed 42 duplicated object vocabularies. `validate-schema-shape-duplicates.ts` holds that line — but it matches key sets **exactly**, so a copy stops looking like a copy the moment it gains or loses a field. That is the moment it has started to drift.

Every schema in this PR was invisible to that gate for precisely that reason. Each one is a copy **plus one key**:

| copy | canonical | survived because it adds |
|---|---|---|
| `routes/subnet-overview.ts` health | `HealthSubnetSummarySchema` | `observed_by` (and it had *dropped* two) |
| `mcp-tools/get-subnet.ts` health | `HealthSubnetSummarySchema` | `observed_by` |
| `YieldDistributionSchema` | `distributionStatsSchema()` | `p10` |
| `SubtensorReleaseSchema` | `GithubReleaseSchema` | `spec_version` |
| `AccountPositionHistoryArtifactSchema` | `subnetHistoryArtifactSchema()` | `ss58` |

Object literals in `schemas-src/`: **549 → 545**.

## The health block, three ways

`overlayOverviewHealth()` builds it as `{ netuid, ...summary, observed_by }` where `summary` is a `HealthSubnetSummary` — so the shape is not *modelled after* that summary, it **is** that summary plus one field. Two schemas restated it and disagreed:

- `routes/subnet-overview.ts` — dropped `latency_sample_count` and `name`. This is the production bug.
- `mcp-tools/get-subnet.ts` — kept both, but declared nullability **no producer can write**. Read off the live MCP tool before removing it.

Now one exported `OverlaidSubnetHealthSchema`, imported by both. `.partial()` because the overlay has a second arm: a subnet with no probed surfaces answers `{ netuid, status: "unknown", surface_count: 0 }`, which carries none of the required counts. That arm is the one thing both copies had right.

## Contract impact

The health block **gains** `latency_sample_count`, `name`, and `slug` (all optional), and its `status` tightens from a bare `z.string()` to the shared `HealthStatus` vocabulary — the same values `/api/v1/health` has validated these very objects against all along.

The other three move **field order only** — same fields, same types, same nullability, which is what a mechanical collapse should look like. **Nothing is removed.**

## Verification

Against **live `api.metagraph.sh`**, through the conformance sweep's own `buildValidator`:

| route | before | after |
|---|---|---|
| `/api/v1/subnets/{netuid}/overview` | 3 | **0** |

Each new guard was confirmed to fail against the copies: reintroducing the MCP copy fails the identity guard; re-listing the route's copy fails the vocabulary guard.

## What I deliberately did NOT change

A near-duplicate sweep over all 545 literals found **70 cross-file pairs** at Jaccard ≥ 0.7, and most are legitimate — `chain`-vs-`subnet` variants differing only by `netuid`/`subnet_count`, and MCP inputs lacking `format` because MCP has no CSV. That noise is *why* the gate keys on exact equality, and a blunt near-duplicate gate would cry wolf. The ones fixed here are the ones where a **producer provably spreads a canonical shape**.

One real inconsistency is left alone on purpose: `ScoreDistributionSchema` spells its median `p50` while `distributionStatsSchema()` spells it `median`. Reconciling them renames a **published** field, which is a contract change and not a cleanup.