### PR TITLE
fix(monitor): a tripwire refusal is drift wearing a 500, not an outage

### DIFF
--- a/scripts/check-response-conformance.ts
+++ b/scripts/check-response-conformance.ts
@@ -99,28 +99,71 @@ export function buildValidator(
 }
 
 /**
+ * The envelope's own admission that it refused itself.
+ *
+ * `workers/api.ts` answers a tripwire refusal with a 500 whose body is a normal
+ * error envelope carrying `response_schema_drift` -- and the detail rides in
+ * the message, because the drifted keys ARE the diagnosis. Reading it here is
+ * what lets a refusal be reported as the drift it is rather than skipped as an
+ * outage.
+ */
+export function driftRefusal(body: unknown): string | null {
+  if (typeof body !== "object" || body === null) return null;
+  const error = (body as { error?: unknown }).error;
+  if (typeof error !== "object" || error === null) return null;
+  const { code, message } = error as { code?: unknown; message?: unknown };
+  if (code !== "response_schema_drift") return null;
+  return typeof message === "string" && message.length > 0
+    ? `the route refused its own response: ${message}`
+    : "the route refused its own response (response_schema_drift)";
+}
+
+/**
  * The verdict for one fetched route, as a pure function (#9141).
  *
- * Split out so the rule is testable without a network or a spec. The edges are
- * the entire point, and every one of them is a decision to SKIP rather than to
- * fail -- a conformance check that also reports availability becomes a check
- * nobody trusts, because it goes red for reasons that are not drift.
+ * Split out so the rule is testable without a network or a spec. Every edge
+ * here is a decision to SKIP rather than to fail -- a conformance check that
+ * also reports availability becomes a check nobody trusts, because it goes red
+ * for reasons that are not drift. The ONE exception is a tripwire refusal,
+ * which arrives wearing a 500 but is this monitor's own subject.
  */
 export function evaluateResponse({
   status,
   body,
   validator,
+  route = "",
 }: {
   status: number;
   body: unknown;
   // Carries its own route path, so violations name it without this function
   // needing to know it.
   validator: Validator | null;
+  /** Only needed to name a refusal, which no validator produced. */
+  route?: string;
 }): { skipped: string | null; violations: Violation[] } {
   // No declared JSON schema means nothing to check -- not a failure.
   if (!validator) return { skipped: "no declared 200 schema", violations: [] };
-  // Only a 200 is judged. Availability is check-self-health's job; a 503 here
-  // would make this monitor red for something it is not measuring.
+  // A route the TRIPWIRE already refused is this monitor's subject, not an
+  // availability blip -- and it arrives as a 500, which the rule below would
+  // otherwise skip.
+  //
+  // That combination is how this check reported "OK: all 204 checked routes
+  // match their published schemas" on 2026-08-13 while
+  // /api/v1/subnets/{netuid}/overview was answering 500 to EVERY caller,
+  // for the exact drift this monitor exists to find. The serve-time tripwire
+  // (src/response-validation-tripwire.ts) turns drift into a 500; skipping
+  // non-200 then blinds the sweep to precisely the routes that are hardest
+  // down. Two correct rules, and between them a route can be completely
+  // broken by drift and reported green.
+  const refusal = driftRefusal(body);
+  if (refusal) {
+    return {
+      skipped: null,
+      violations: [{ route, path: "(response)", message: refusal }],
+    };
+  }
+  // Only a 200 is judged otherwise. Availability is check-self-health's job; a
+  // 503 here would make this monitor red for something it is not measuring.
   if (status !== 200) return { skipped: `http ${status}`, violations: [] };
   // NOTE a degraded tier answers with a schema-stable EMPTY body, and that
   // passes -- correctly. This checks shape, not content.
@@ -156,9 +199,13 @@ async function main(): Promise<void> {
       const response = await fetch(new URL(url, BASE), {
         signal: AbortSignal.timeout(30_000),
       });
+      // The body is read whatever the status: a tripwire refusal arrives as a
+      // 500 whose envelope names the drift, and discarding it was half of why
+      // a fully-broken route reported green. Non-JSON (an edge error page) is
+      // still nothing to judge.
       fetched = {
         status: response.status,
-        body: response.status === 200 ? await response.json() : null,
+        body: await response.json().catch(() => null),
       };
     } catch {
       skipped += 1; // network/timeout: not drift
@@ -168,6 +215,7 @@ async function main(): Promise<void> {
     const verdict = evaluateResponse({
       ...fetched,
       validator: buildValidator(spec, route.path),
+      route: route.path,
     });
     if (verdict.skipped) {
       skipped += 1;

--- a/tests/check-response-conformance.test.ts
+++ b/tests/check-response-conformance.test.ts
@@ -12,6 +12,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   buildValidator,
+  driftRefusal,
   evaluateResponse,
 } from "../scripts/check-response-conformance.ts";
 
@@ -164,6 +165,84 @@ describe("the response-conformance rule (#9141)", () => {
       verdict.violations.length > 0,
       "a body missing a required property must be reported -- a validator " +
         "that never reports is indistinguishable from a healthy API",
+    );
+  });
+});
+
+describe("a tripwire refusal is drift wearing a 500 (#10987)", () => {
+  // On 2026-08-13 this check reported "OK: all 204 checked routes match their
+  // published schemas" while /api/v1/subnets/{netuid}/overview answered 500 to
+  // every caller -- for the exact drift it exists to find. The serve-time
+  // tripwire turns drift into a 500, and "skip non-200" then hid the route
+  // that was hardest down. Both rules were individually right.
+  const refusalBody = (message: string) => ({
+    ok: false,
+    schema_version: 1,
+    data: null,
+    error: { code: "response_schema_drift", message },
+  });
+
+  test("a refusal is a VIOLATION, not a skip", () => {
+    const verdict = evaluateResponse({
+      status: 500,
+      body: refusalBody("The subnet-overview response did not match."),
+      validator,
+      route: "/api/v1/subnets/{netuid}/overview",
+    });
+    assert.equal(verdict.skipped, null, "a refusal must not be skipped");
+    assert.equal(verdict.violations.length, 1);
+    assert.equal(
+      verdict.violations[0]!.route,
+      "/api/v1/subnets/{netuid}/overview",
+      "the violation must name the route -- no validator produced it",
+    );
+  });
+
+  test("the refusal's own message rides along, because it IS the diagnosis", () => {
+    const verdict = evaluateResponse({
+      status: 500,
+      body: refusalBody("unrecognized_keys: name, latency_sample_count"),
+      validator,
+    });
+    assert.match(verdict.violations[0]!.message, /latency_sample_count/);
+  });
+
+  test("a refusal with no message still reports, naming the code", () => {
+    const verdict = evaluateResponse({
+      status: 500,
+      body: { error: { code: "response_schema_drift" } },
+      validator,
+    });
+    assert.equal(verdict.violations.length, 1);
+    assert.match(verdict.violations[0]!.message, /response_schema_drift/);
+  });
+
+  test("availability is STILL not this monitor's job", () => {
+    // The original rule, preserved: a 503 or a non-drift 500 is an outage, and
+    // going red for it is what makes a monitor ignorable.
+    for (const body of [
+      { ok: false, error: { code: "unavailable", message: "cold store" } },
+      { ok: false, error: { code: "internal_error", message: "boom" } },
+    ]) {
+      const verdict = evaluateResponse({ status: 503, body, validator });
+      assert.equal(verdict.skipped, "http 503");
+      assert.deepEqual(verdict.violations, []);
+    }
+  });
+
+  test("driftRefusal reads only a real refusal envelope", () => {
+    // Every shape a live 500 body can arrive in, including the edge error page
+    // that parses to null.
+    assert.equal(driftRefusal(null), null);
+    assert.equal(driftRefusal("<!doctype html>"), null);
+    assert.equal(driftRefusal({}), null);
+    assert.equal(driftRefusal({ error: null }), null);
+    assert.equal(driftRefusal({ error: "boom" }), null);
+    assert.equal(driftRefusal({ error: { code: "not_found" } }), null);
+    assert.equal(
+      driftRefusal({ error: { code: "response_schema_drift", message: 42 } }),
+      "the route refused its own response (response_schema_drift)",
+      "a non-string message falls back to the code rather than throwing",
     );
   });
 });


### PR DESCRIPTION
At **05:29 UTC today**, `/api/v1/subnets/{netuid}/overview` was answering **500 to every caller** with `response_schema_drift`. Minutes later this check ran against that same production and printed:

```
OK: all 204 checked routes match their published schemas.
```

## Two rules, each right, and a hole between them

- The serve-time tripwire (`src/response-validation-tripwire.ts`) turns drift into a **500**, so a response the published contract does not describe never reaches a caller. Correct.
- This monitor **skips any non-200**, because reporting availability is what makes a conformance check go red for reasons that are not drift — and a monitor that cries wolf gets ignored. Also correct.

Together they mean a route can be **completely broken by drift and reported green** — and the *harder* the drift, the more certain the silence. Drift is the one failure this check exists to find, and it was the one failure the skip rule guaranteed it would miss.

## The fix

A refusal is now read for what it says. `workers/api.ts` answers one with a normal error envelope carrying `response_schema_drift`, and the drifted keys ride in the message because **they are the diagnosis** — so the alert names the route *and* what drifted.

Availability is untouched: a 503, or any 500 that is **not** a refusal, is still skipped. `main()` now reads the body whatever the status — discarding it on non-200 was the other half of the blindness — and a non-JSON body (an edge error page) is still nothing to judge.

## Verification

Run against **live `api.metagraph.sh`**, same production, minutes apart, one rule changed:

| | checked | skipped | violations | verdict |
|---|---|---|---|---|
| before | 204 | 6 | 0 | `OK: all 204 checked routes match their published schemas.` |
| after | 205 | 5 | **1** | `ALERT: /api/v1/subnets/{netuid}/overview (response) the route refused its own response: …` |

The route it names is the one #10986 fixes. Once that deploys the sweep returns to green — for the right reason this time, rather than because the failure was invisible.

## Note on scope

This is the monitor, not the tripwire. #10985 widened what the tripwire can see (109 templated paths); this makes sure that when the tripwire acts on what it now sees, the daily sweep does not report the resulting outage as a clean bill of health.