### PR TITLE
refactor(schemas): the vocabulary gate never read the serving tree, and 25 vocabularies lived there twice

### DIFF
--- a/schemas-src/mcp-tools/shared.ts
+++ b/schemas-src/mcp-tools/shared.ts
@@ -21,95 +21,44 @@ import {
 } from "../query-params.ts";
 import { MAX_LIMIT } from "../../workers/request-params.ts";
 import { MCP_LIST_LIMIT_DEFAULT } from "../../src/route-limits.ts";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 
 // The query-parameter vocabulary now lives in schemas-src/query-params.ts so the
 // REST route schemas can use it too (#9986). Re-exported here because ~100 MCP
 // tool modules already import these names from this file.
 export * from "../query-params.ts";
 
-/** Shared across MCP tools that have no single route owner (#9799). */
-export const EVIDENCE_ENTRY_SORT_VALUES = [
-  "claim",
-  "source_url",
-  "subject",
-  "verified_at",
-] as const;
+// --- Sort vocabularies, derived from the route table -----------------------
+//
+// Each of these was a hand-kept copy of one query collection's `sort_fields`,
+// justified by a comment claiming schemas-src cannot import src/ -- which
+// profiles.ts had already disproved by importing API_QUERY_COLLECTIONS
+// directly. Deriving makes the invariant structural: a sort field added to a
+// collection is offered by its MCP tool the same moment, and one removed
+// cannot linger here as a value the route now rejects (#10987).
+export const EVIDENCE_ENTRY_SORT_VALUES =
+  API_QUERY_COLLECTIONS.claims.sort_fields;
 
-/** Shared across MCP tools that have no single route owner (#9799). */
-export const CANDIDATE_SORT_VALUES = [
-  "confidence",
-  "id",
-  "kind",
-  "name",
-  "netuid",
-  "provider",
-  "state",
-] as const;
+export const CANDIDATE_SORT_VALUES =
+  API_QUERY_COLLECTIONS.candidates.sort_fields;
 
-/** Shared across MCP tools that have no single route owner (#9799). */
-export const SURFACE_SORT_VALUES = [
-  "id",
-  "kind",
-  "name",
-  "netuid",
-  "provider",
-] as const;
+export const SURFACE_SORT_VALUES =
+  API_QUERY_COLLECTIONS["curated-surfaces"].sort_fields;
 
-/** Shared across MCP tools that have no single route owner (#9799). */
-export const HEALTH_SURFACE_SORT_VALUES = [
-  "classification",
-  "kind",
-  "last_checked",
-  "last_ok",
-  "latency_ms",
-  "netuid",
-  "provider",
-  "status",
-  "status_code",
-  "surface_id",
-  "verified_at",
-] as const;
+export const HEALTH_SURFACE_SORT_VALUES =
+  API_QUERY_COLLECTIONS["health-surfaces"].sort_fields;
 
 /** Shared across MCP tools that have no single route owner (#9799). */
 export const HEALTH_CLASSIFICATION_VALUES = QUERY_ENUMS.healthClassification;
 
 /** Shared across MCP tools that have no single route owner (#9799). */
-/**
- * Mirrors API_QUERY_COLLECTIONS["coverage-depth"].sort_fields (#10011).
- *
- * A copy because schemas-src imports from neither src/ nor workers/;
- * validate:schema-vocabularies asserts it still matches (#10005).
- */
-export const COVERAGE_DEPTH_SORT_VALUES = [
-  "agent_status",
-  "blocker_level",
-  "name",
-  "netuid",
-  "priority_score",
-  "score",
-  "tier",
-] as const;
+export const COVERAGE_DEPTH_SORT_VALUES =
+  API_QUERY_COLLECTIONS["coverage-depth"].sort_fields;
 
-export const ENDPOINT_SORT_VALUES = [
-  "kind",
-  "last_checked",
-  "latency_ms",
-  "layer",
-  "netuid",
-  "pool_eligible",
-  "provider",
-  "publication_state",
-  "score",
-  "status",
-] as const;
+export const ENDPOINT_SORT_VALUES = API_QUERY_COLLECTIONS.endpoints.sort_fields;
 
-/** Shared across MCP tools that have no single route owner (#9799). */
-export const ENDPOINT_POOL_SORT_VALUES = [
-  "eligible_count",
-  "endpoint_count",
-  "id",
-  "kind",
-] as const;
+export const ENDPOINT_POOL_SORT_VALUES =
+  API_QUERY_COLLECTIONS["endpoint-pools"].sort_fields;
 
 // --- Bounded input primitives --------------------------------------
 //

--- a/schemas-src/query-enums.ts
+++ b/schemas-src/query-enums.ts
@@ -49,6 +49,36 @@ export const QUERY_ENUMS = {
     "wrong-chain",
   ],
   healthStatus: ["ok", "degraded", "failed", "unknown"],
+  // Hoisted from twin declarations found when the vocabulary gate learned to
+  // read the serving tree (#10987): each of these was declared once in a
+  // schemas-src file and again in the src/ module that enforces it, with
+  // nothing detecting a divergence. The owner is here; both sides derive.
+  concentrationLens: [
+    "emission",
+    "stake",
+    "entity_emission",
+    "entity_stake",
+    "validator_stake",
+  ],
+  concentrationRankingSort: [
+    "nakamoto_coefficient",
+    "gini",
+    "holders",
+    "top_1pct_share",
+    "total",
+    "netuid",
+  ],
+  emissionChangeKind: ["param", "subnet", "flow"],
+  feedFormat: ["rss", "atom", "json"],
+  revenueShape: ["flat-array", "keyed-map", "scalar"],
+  searchDocumentType: ["subnet", "surface", "provider"],
+  // The REST envelope's top-level keys. Not a query vocabulary, but owned in
+  // this zero-import file because both declarers need it and one of them
+  // (contracts.ts) cannot afford a schema import: the data-api Worker sits at
+  // the startup CPU limit, and this module is the one place guaranteed free.
+  responseEnvelopeField: ["ok", "data", "meta", "error"],
+  stakeFlowDirection: ["all", "in", "out"],
+  surfaceHistoryAction: ["insert", "update", "delete"],
   providerAuthority: [
     "community",
     "official",

--- a/schemas-src/routes/account-activity.ts
+++ b/schemas-src/routes/account-activity.ts
@@ -17,14 +17,13 @@
 // epic's established convention. AccountStakeFlowArtifact needed no fix at
 // all (diff:openapi-zod reports PASS after cosmetic normalization).
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 import { EventStreamDegradedSchema } from "./event-stream-honesty.ts";
 
-/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
-export const ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES = [
-  "all",
-  "in",
-  "out",
-] as const;
+/** Derived from the vocabulary owner (#10987): the same three directions as
+ * the stake-flow routes, declared once. */
+export const ACCOUNT_ACTIVITY_FLOW_DIRECTIONS_VALUES =
+  QUERY_ENUMS.stakeFlowDirection;
 
 export const WINDOW_ENUM = ["7d", "30d", "90d"] as const;
 

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -29,6 +29,7 @@
 //   callable_service_count} despite additionalProperties:true -- tightened
 //   to .strict() here.
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 import {
   ArtifactBaseSchema,
   ContentHashSchema,
@@ -40,19 +41,8 @@ import { AuthSchema, LIVE_HEALTH_OVERLAY } from "./subnet-detail.ts";
 
 export const AgentReadinessStatusSchema = z
   .object({
-    status: z.enum([
-      "callable",
-      "base-layer",
-      "candidate",
-      "needs-evidence",
-      "blocked",
-    ]),
-    blocker_level: z.enum([
-      "none",
-      "hard-blocked",
-      "needs-review",
-      "missing-data",
-    ]),
+    status: z.enum(QUERY_ENUMS.agentReadinessStatus),
+    blocker_level: z.enum(QUERY_ENUMS.agentBlockerLevel),
     blockers: z.array(AgentReadinessBlockerSchema),
     missing_fields: z.array(z.string()),
     // Only ever set by the live overlay (src/health-serving.ts's

--- a/schemas-src/routes/chain-concentration-subnets.ts
+++ b/schemas-src/routes/chain-concentration-subnets.ts
@@ -8,23 +8,12 @@
 // `row.gini` is the whole point; `row.emission.gini` would need a path syntax
 // no other list surface here has.
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 
-export const CONCENTRATION_LENSES = [
-  "emission",
-  "stake",
-  "entity_emission",
-  "entity_stake",
-  "validator_stake",
-] as const;
-
-export const CONCENTRATION_RANKING_SORTS = [
-  "nakamoto_coefficient",
-  "gini",
-  "holders",
-  "top_1pct_share",
-  "total",
-  "netuid",
-] as const;
+// Derived from the vocabulary owner rather than restated (#10987): this file
+// and src/concentration.ts each declared both lists, and nothing compared them.
+export const CONCENTRATION_LENSES = QUERY_ENUMS.concentrationLens;
+export const CONCENTRATION_RANKING_SORTS = QUERY_ENUMS.concentrationRankingSort;
 
 // Every metric is nullable together: a subnet whose chosen lens has no positive
 // distribution carries nulls across the board and says so via `unmeasured`,

--- a/schemas-src/routes/coverage.ts
+++ b/schemas-src/routes/coverage.ts
@@ -115,20 +115,9 @@ export const COVERAGE_DEPTH_SEVERITIES = [
  * name those two and not this one. API_QUERY_COLLECTIONS["coverage-depth"]
  * declares the same four as a filter.
  */
-export const BLOCKER_LEVELS = [
-  "none",
-  "hard-blocked",
-  "needs-review",
-  "missing-data",
-] as const;
+export const BLOCKER_LEVELS = QUERY_ENUMS.agentBlockerLevel;
 
-export const AGENT_READINESS_STATUSES = [
-  "callable",
-  "base-layer",
-  "candidate",
-  "needs-evidence",
-  "blocked",
-] as const;
+export const AGENT_READINESS_STATUSES = QUERY_ENUMS.agentReadinessStatus;
 
 export const AgentReadinessBlockerSchema = z
   .object({

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -8,6 +8,7 @@
 // hand-edited CurationArtifact/CurationEntry and GapsArtifact/GapsEntry
 // components they replace.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import { COVERAGE_LEVEL_VALUES, CurationLevelSchema } from "../shared.ts";
 import { CurationMetadataSchema, GapsSchema } from "./subnet-detail.ts";
@@ -16,12 +17,7 @@ import { ENDPOINT_INCIDENT_SEVERITY_VALUES } from "./endpoints-pools.ts";
 const COVERAGE_LEVELS = COVERAGE_LEVEL_VALUES;
 export const CoverageLevelSchema = z.enum(COVERAGE_LEVELS);
 
-export const CURATION_SORT_FIELDS = [
-  "coverage_level",
-  "curation_level",
-  "name",
-  "netuid",
-] as const;
+export const CURATION_SORT_FIELDS = API_QUERY_COLLECTIONS.curation.sort_fields;
 
 export const CurationEntrySchema = z
   .object({
@@ -49,13 +45,7 @@ export const CurationArtifactSchema = ArtifactBaseSchema.extend({
   );
 export type CurationArtifact = z.infer<typeof CurationArtifactSchema>;
 
-export const GAPS_SORT_FIELDS = [
-  "coverage_level",
-  "curation_level",
-  "gap_count",
-  "name",
-  "netuid",
-] as const;
+export const GAPS_SORT_FIELDS = API_QUERY_COLLECTIONS.gaps.sort_fields;
 
 export const GapsEntrySchema = z
   .object({

--- a/schemas-src/routes/emission-gate-changes.ts
+++ b/schemas-src/routes/emission-gate-changes.ts
@@ -6,11 +6,12 @@
 // ABSENT rather than null -- an absent field says "this kind has no such thing",
 // where a null would say "it has one and we do not know it".
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 
 /** Shared by every kind. `predates_capture` is the honesty flag: true means the
  * row is the FIRST OBSERVATION of a value, not a change to it. */
 const base = {
-  kind: z.enum(["param", "subnet", "flow"]),
+  kind: z.enum(QUERY_ENUMS.emissionChangeKind),
   observed_at: z.iso.datetime(),
   block_number: z.int().nullable(),
   predates_capture: z.boolean(),

--- a/schemas-src/routes/evidence-search.ts
+++ b/schemas-src/routes/evidence-search.ts
@@ -19,17 +19,15 @@
 // declared -- the served response has always included it; the hand-edited
 // schema was stale. Modeled here as present.
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 import { ArtifactBaseSchema } from "../envelope.ts";
 import { HealthStatusSchema } from "../shared.ts";
 import { AuthoritySchema } from "./subnet-detail.ts";
 import { ProviderKindSchema } from "./providers-rpc.ts";
 
-/** This route's own vocabulary, owned here so its MCP tools import rather than restate it (#9799). */
-export const SEARCH_DOCUMENT_TYPE_VALUES = [
-  "subnet",
-  "surface",
-  "provider",
-] as const;
+/** Derived from the vocabulary owner (#10987): route-limits.ts's
+ * SEMANTIC_TYPES and an inline enum below each restated these three. */
+export const SEARCH_DOCUMENT_TYPE_VALUES = QUERY_ENUMS.searchDocumentType;
 
 const CountMapSchema = z.record(z.string(), z.int().min(0));
 
@@ -198,7 +196,7 @@ export type SearchArtifact = z.infer<typeof SearchArtifactSchema>;
 const SearchIndexDocumentSchema = z
   .object({
     id: z.string(),
-    type: z.enum(["subnet", "surface", "provider"]),
+    type: z.enum(SEARCH_DOCUMENT_TYPE_VALUES),
     netuid: z.int().min(0).optional(),
     slug: z.string().optional(),
     title: z.string(),

--- a/schemas-src/routes/meta-contracts.ts
+++ b/schemas-src/routes/meta-contracts.ts
@@ -20,6 +20,7 @@
 // the hand-edited schema was stale from before diffSubnets() gained name/slug.
 // Modeled here against the real (object) shape.
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 import { CoverageArtifactSchema } from "./coverage.ts";
 import { API_ROUTE_METHODS } from "../../src/contracts.ts";
 import {
@@ -100,7 +101,7 @@ const FeedContractEntrySchema = z
     method: z.literal("GET"),
     path: z.string().regex(/^\/api\/v1\/feeds\//),
     description: z.string(),
-    formats: z.array(z.enum(["rss", "atom", "json"])),
+    formats: z.array(z.enum(QUERY_ENUMS.feedFormat)),
     content_types: z
       .array(z.string())
       .describe(
@@ -155,7 +156,7 @@ const ApiRouteSchema = z
 const ResponseEnvelopeContractSchema = z
   .object({
     error_schema_ref: z.literal("#/components/schemas/ErrorEnvelope"),
-    fields: z.array(z.enum(["ok", "data", "meta", "error"])),
+    fields: z.array(z.enum(QUERY_ENUMS.responseEnvelopeField)),
     notes: z.string(),
     schema_version: z.literal(1),
     success_schema_ref: z.literal("#/components/schemas/SuccessEnvelope"),

--- a/schemas-src/routes/review-enrichment.ts
+++ b/schemas-src/routes/review-enrichment.ts
@@ -12,6 +12,7 @@
 // (+Target/TargetGroup), and ReviewAdapterCandidatesArtifact(+Candidate)
 // components they replace.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { QUERY_ENUMS } from "../query-enums.ts";
 import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { CurationLevelSchema } from "../shared.ts";
@@ -121,26 +122,8 @@ export const ReviewEnrichmentTargetQueueContextSchema = z
   })
   .strict();
 
-export const QUEUE_SORT_FIELDS = [
-  "adapter_score",
-  "candidate_count",
-  "completeness_score",
-  "curation_level",
-  "endpoint_count",
-  "evidence_action",
-  "identity_level",
-  "identity_surface_count",
-  "lane",
-  "name",
-  "netuid",
-  "operational_interface_count",
-  "priority_score",
-  "profile_level",
-  "review_state",
-  "stale_candidate_count",
-  "surface_count",
-  "verified_candidate_count",
-] as const;
+export const QUEUE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["enrichment-queue"].sort_fields;
 
 export const ReviewEnrichmentQueueEntrySchema = z
   .object({
@@ -203,13 +186,8 @@ export type ReviewEnrichmentQueueArtifact = z.infer<
   typeof ReviewEnrichmentQueueArtifactSchema
 >;
 
-export const EVIDENCE_SORT_FIELDS = [
-  "evidence_action",
-  "lane",
-  "name",
-  "netuid",
-  "priority_score",
-] as const;
+export const EVIDENCE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["enrichment-evidence"].sort_fields;
 
 export const ReviewEnrichmentEvidenceEntrySchema = z
   .object({
@@ -248,21 +226,8 @@ export type ReviewEnrichmentEvidenceArtifact = z.infer<
   typeof ReviewEnrichmentEvidenceArtifactSchema
 >;
 
-export const TARGET_SORT_FIELDS = [
-  "auto_review_candidate",
-  "evidence_action",
-  "identity_level",
-  "kind",
-  "lane",
-  "manual_review_required",
-  "name",
-  "netuid",
-  "priority_score",
-  "profile_level",
-  "submission_route",
-  "target_action",
-  "target_type",
-] as const;
+export const TARGET_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["enrichment-targets"].sort_fields;
 
 export const ReviewEnrichmentTargetSchema = z
   .object({
@@ -332,17 +297,8 @@ export type ReviewEnrichmentTargetsArtifact = z.infer<
 >;
 
 export const RECOMMENDED_ADAPTER_KINDS = QUERY_ENUMS.recommendedAdapterKind;
-export const ADAPTER_CANDIDATES_SORT_FIELDS = [
-  "candidate_api_count",
-  "candidate_api_kinds",
-  "curation_level",
-  "name",
-  "netuid",
-  "operational_kinds",
-  "operational_surface_count",
-  "priority_score",
-  "recommended_adapter_kind",
-] as const;
+export const ADAPTER_CANDIDATES_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["adapter-candidates"].sort_fields;
 
 export const ReviewAdapterCandidateSchema = z
   .object({

--- a/schemas-src/routes/review-gaps-profile.ts
+++ b/schemas-src/routes/review-gaps-profile.ts
@@ -10,6 +10,7 @@
 // (+ReviewGapPriority), SubnetGapsArtifact, and
 // ReviewProfileCompletenessArtifact(+Entry) components they replace.
 import { z } from "zod";
+import { API_QUERY_COLLECTIONS } from "../../src/contracts.ts";
 import { ArtifactBaseSchema, CountMapSchema } from "../envelope.ts";
 import { CurationLevelSchema } from "../shared.ts";
 import { ReviewStateSchema, SurfaceKindSchema } from "./subnet-detail.ts";
@@ -21,16 +22,8 @@ import {
   NATIVE_NAME_QUALITY_VALUES,
   PROFILE_LEVEL_VALUES,
 } from "../shared.ts";
-export const PRIORITY_SORT_FIELDS = [
-  "candidate_count",
-  "curation_level",
-  "missing_kinds",
-  "name",
-  "netuid",
-  "priority_score",
-  "surface_count",
-  "verified_candidate_count",
-] as const;
+export const PRIORITY_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["review-gap-priorities"].sort_fields;
 
 export const ReviewGapPrioritySchema = z
   .object({
@@ -64,22 +57,8 @@ export const SubnetGapsArtifactSchema = ArtifactBaseSchema.extend({
 }).strict();
 export type SubnetGapsArtifact = z.infer<typeof SubnetGapsArtifactSchema>;
 
-export const PROFILE_SORT_FIELDS = [
-  "candidate_count",
-  "completeness_score",
-  "identity_level",
-  "identity_promotion_kind_count",
-  "identity_surface_count",
-  "live_identity_candidate_kind_count",
-  "missing_critical_count",
-  "name",
-  "native_identity_signal_count",
-  "native_name_quality",
-  "netuid",
-  "priority_score",
-  "profile_level",
-  "stale_identity_candidate_kind_count",
-] as const;
+export const PROFILE_SORT_FIELDS =
+  API_QUERY_COLLECTIONS["profile-completeness"].sort_fields;
 
 export const ReviewProfileCompletenessEntrySchema = z
   .object({

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -618,7 +618,7 @@ export const SurfaceRevenueSchema = z
       description:
         "The envelope key holding the payload `shape` describes, for a source that wraps its rows (a pagination envelope's `items`). Absent means the payload IS the rows.",
     }),
-    shape: z.enum(["flat-array", "keyed-map", "scalar"]).optional().meta({
+    shape: z.enum(QUERY_ENUMS.revenueShape).optional().meta({
       description:
         "How the payload is arranged, so an extractor does not have to guess. flat-array: a list of records, fields.date/fields.amount naming keys within one. keyed-map: nested {period: {subkey: amount}}, where the period IS the key and there are no field names to point at. scalar: one object carrying a single total.",
     }),

--- a/schemas-src/routes/subnet-stake-flow.ts
+++ b/schemas-src/routes/subnet-stake-flow.ts
@@ -3,13 +3,12 @@
 // src/stake-flow.ts's buildStakeFlow(), cross-checked against the
 // hand-edited SubnetStakeFlowArtifact component it replaces.
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 
-/** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
-export const SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES = [
-  "all",
-  "in",
-  "out",
-] as const;
+/** Derived from the vocabulary owner (#10987): src/stake-flow.ts enforced the
+ * same three values from its own literal, and nothing compared the two. */
+export const SUBNET_STAKE_FLOW_FLOW_DIRECTIONS_VALUES =
+  QUERY_ENUMS.stakeFlowDirection;
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_STAKE_FLOW_WINDOW_VALUES = ["7d", "30d", "90d"] as const;

--- a/schemas-src/routes/subnet-surface-history.ts
+++ b/schemas-src/routes/subnet-surface-history.ts
@@ -1,6 +1,7 @@
 // GET /api/v1/subnets/{netuid}/surface-history (#9612): one subnet's surface
 // audit trail. Modeled from src/surface-history.ts's buildSurfaceHistory().
 import { z } from "zod";
+import { QUERY_ENUMS } from "../query-enums.ts";
 
 export const SurfaceHistoryChangeSchema = z
   .object({
@@ -14,7 +15,7 @@ export const SurfaceHistoryChangeSchema = z
       ),
     /** A DELETE entry is the only evidence a surface ever existed. */
     action: z
-      .enum(["insert", "update", "delete"])
+      .enum(QUERY_ENUMS.surfaceHistoryAction)
       .nullable()
       .describe(
         "insert, update or delete. A delete is the only evidence a surface ever existed.",

--- a/scripts/scan-public-safety.ts
+++ b/scripts/scan-public-safety.ts
@@ -286,6 +286,13 @@ const patterns: SafetyPattern[] = [
     // parenthetical (stored in coldkey (the account...)) -- both common in
     // Rust/SQL comments describing the data model, not suspicious wording.
     //
+    // Extended for #10987: the vocabulary gate keys value sets as
+    // sorted.join("|"), so its allowlist legitimately contains the exact
+    // quoted string "coldkey|hotkey|netuid" (EVM ABI arg names vs a Neon
+    // index). EXACT phrase, not a pipe-blanket -- "coldkey|<anything>" must
+    // still trip, for the same reason "coldkey-only" is exact: a delimiter
+    // must not become a smuggling syntax.
+    //
     // Extended again (#6718): Rust's OWN field-access + method-call syntax
     // (ext.coldkey.is_some(), .coldkey.clone(), .coldkey.unwrap()) wasn't
     // covered by the coldkey?. optional-chaining case above -- that's TS/JS
@@ -295,7 +302,7 @@ const patterns: SafetyPattern[] = [
     // a lowercase identifier + `(` matches the method-call shape without
     // loosening the bare `\bcoldkey\b` trigger itself.
     allow:
-      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bcoldkey\.[a-z_]+\(|\b(?:hotkey(?:\s+or\s+|\s*\/\s*)coldkey|coldkey(?:\s+or\s+|\s*\/\s*)hotkey)\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
+      /"coldkey"\s*:?|\bcoldkey\s*\??\s*:|\bcoldkey\?\.|\bcoldkey\.[a-z_]+\(|\b(?:hotkey(?:\s+or\s+|\s*\/\s*)coldkey|coldkey(?:\s+or\s+|\s*\/\s*)hotkey)\b|\bcoldkey-only(?![-A-Za-z0-9_])|\bcoldkey\s*(?:=|!=|<>|IS\s+(?:NOT\s+)?NULL\b|IN\s*\()|\bcoldkey\s*(?:,|\)|\]|\}|;|`)|\bcoldkey\s+(?:ASC|DESC|AS\b|TEXT|VARCHAR|CHAR|INTEGER|BIGINT|NUMERIC|BOOLEAN)\b|'coldkey'|\bcoldkey\s*\/\s*[a-z_]+\b|\b[a-z_]+\s*\/\s*coldkey\b|"coldkey\|hotkey\|netuid"|\b[a-z]+-coldkey\b|\bcoldkey\s*\(/gi,
     soft: true,
   },
   {

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -26,30 +26,80 @@ const SCHEMA_DIRS = [
   "schemas-src/routes",
   "schemas-src/mcp-tools",
   "schemas-src/artifacts",
+  // The SERVING tree (#10987). This gate watched only the schema tree, while
+  // the copies people actually make live in src/ and workers/ -- contracts.ts
+  // restating a query enum it could import, an MCP composer restating a route
+  // vocabulary in its own literal. A vocabulary owned once in schemas-src and
+  // restated four times in src/ was green here for as long as the gate has
+  // existed, which is how the consolidation epics closed while the drift kept
+  // appearing: the duplication moved to the one tree this never read.
+  "src",
+  "src/graphql",
+  "workers",
+  "workers/request-handlers",
 ];
 
-/** Vocabularies still restated in more than one file. Each is a value set whose
- * owner has not been extracted yet -- delete the entry when it is, never add
- * one to silence a NEW copy. Keyed by the sorted value set, so a copy that
- * merely reorders the list is the same entry. */
-const COINCIDENT_BY_DOMAIN: string[] = [
+/** Vocabularies allowed to coincide, pinned to the EXACT files that do.
+ *
+ * Keyed by the sorted value set, valued by the file list -- because a bare
+ * value-set key hides what it names (#10987): with "all|in|out" allowlisted as
+ * a string, a NEW copy of that list in any file was invisible, which meant the
+ * one mechanism this gate has could be defeated by duplicating a vocabulary
+ * that happened to coincide somewhere else once. A new file joining an entry
+ * now fails the gate and forces the decision it should force; a file leaving
+ * one makes the entry stale, and stale entries fail too. The list may only
+ * shrink. */
+const COINCIDENT_BY_DOMAIN: Record<string, string[]> = {
   // WINDOW SETS. Each route chooses the windows it serves, and schemas-src
   // declares six DIFFERENT sets -- 30d|7d, 30d|7d|90d, 1y|30d|7d|90d|all,
   // 24h|30d|7d|90d, 1h|24h|30d|7d, 1d|1h. Six sets is the proof each route
   // chose: coupling them would let one domain's change silently alter every
-  // other. Each route now owns its own tuple and its MCP tool imports THAT --
-  // what is left below is two routes happening to offer the same three.
-  "1y|30d|7d|90d|all",
-  "30d|7d|90d",
+  // other. Each route owns its own tuple and its MCP tool imports THAT --
+  // what is left is routes happening to offer the same windows.
+  "1y|30d|7d|90d|all": [
+    "schemas-src/routes/economics-trends.ts",
+    "schemas-src/routes/subnet-history.ts",
+    "schemas-src/routes/subnet-turnover.ts",
+  ],
+  "30d|7d|90d": [
+    "schemas-src/routes/account-activity-registrations.ts",
+    "schemas-src/routes/account-activity.ts",
+    "schemas-src/routes/chain-turnover.ts",
+    "schemas-src/routes/subnet-concentration.ts",
+    "schemas-src/routes/subnet-event-summary.ts",
+    "schemas-src/routes/subnet-movers.ts",
+    "schemas-src/routes/subnet-performance.ts",
+    "schemas-src/routes/subnet-stake-flow.ts",
+    "schemas-src/routes/subnet-yield.ts",
+    "schemas-src/routes/validator-nominators.ts",
+  ],
   // Per-domain lifecycle/verdict sets that coincide in value only.
-  "active|deprecated|parked|pending",
-  "all|in|out",
-  "base-layer|blocked|callable|candidate|needs-evidence",
-  "bearish|bullish|neutral",
-  "dual|git|r2",
-  "hard-blocked|missing-data|needs-review|none",
-  "missing-probe|not-monitored|probe-derived",
-];
+  "active|deprecated|parked|pending": [
+    "schemas-src/routes/curation-gaps.ts",
+    "schemas-src/routes/subnet-detail.ts",
+    "schemas-src/routes/subnets.ts",
+  ],
+  "bearish|bullish|neutral": [
+    "schemas-src/routes/chain-alpha-volume.ts",
+    "schemas-src/routes/subnet-alpha-volume.ts",
+  ],
+  "dual|git|r2": [
+    "schemas-src/artifacts/r2-manifest.ts",
+    "schemas-src/routes/meta-contracts.ts",
+  ],
+  "missing-probe|not-monitored|probe-derived": [
+    "schemas-src/routes/endpoints-pools.ts",
+    "schemas-src/routes/providers-rpc.ts",
+  ],
+  // EVM precompile ABI argument names (src/evm-precompiles.ts) vs the Neon
+  // nominator_positions primary-key column list -- the same three words
+  // naming two unrelated things. A shared owner would couple an on-chain ABI
+  // to a database index.
+  "coldkey|hotkey|netuid": [
+    "src/evm-precompiles.ts",
+    "src/nominator-positions-neon-write.ts",
+  ],
+};
 
 const errors: string[] = [];
 
@@ -120,13 +170,21 @@ for (const site of sites) {
   byVocabulary.get(key)!.add(site.file);
 }
 
-const allowed = new Set(COINCIDENT_BY_DOMAIN);
 const duplicated = [...byVocabulary.entries()].filter(
   ([, files]) => files.size > 1,
 );
 
+// An entry excuses exactly the files it names: a NEW file joining an
+// allowlisted coincidence is a violation, reported with the files that are
+// not covered rather than silently absorbed.
 const unlisted = duplicated
-  .filter(([key]) => !allowed.has(key))
+  .map(([key, files]) => {
+    const pinned = COINCIDENT_BY_DOMAIN[key];
+    if (!pinned) return [key, files] as const;
+    const strays = new Set([...files].filter((f) => !pinned.includes(f)));
+    return [key, strays] as const;
+  })
+  .filter(([, files]) => files.size > 0)
   .sort((a, b) => b[1].size - a[1].size);
 if (unlisted.length > 0) {
   errors.push(
@@ -146,13 +204,25 @@ if (unlisted.length > 0) {
   );
 }
 
-const stale = [...allowed]
-  .filter((key) => !byVocabulary.get(key) || byVocabulary.get(key)!.size <= 1)
+// Stale in either dimension: the vocabulary no longer coincides at all, or a
+// pinned FILE no longer declares it. Both mean the entry over-excuses.
+const stale = Object.entries(COINCIDENT_BY_DOMAIN)
+  .flatMap(([key, pinned]) => {
+    const files = byVocabulary.get(key);
+    if (!files || files.size <= 1)
+      return [`    [${key.split("|").join(", ")}] — no longer duplicated`];
+    return pinned
+      .filter((f) => !files.has(f))
+      .map(
+        (f) =>
+          `    [${key.split("|").join(", ")}] — ${f} no longer declares it`,
+      );
+  })
   .sort();
 if (stale.length > 0) {
   errors.push(
-    `${stale.length} allowlist entr(y/ies) no longer name a duplicated vocabulary — delete them (the coincidence resolved itself):\n` +
-      stale.map((key) => `    [${key.split("|").join(", ")}]`).join("\n"),
+    `${stale.length} allowlist entr(y/ies) over-excuse — shrink them (the coincidence resolved itself):\n` +
+      stale.join("\n"),
   );
 }
 
@@ -359,7 +429,7 @@ if (errors.length > 0) {
 
 console.log(
   `Schema-vocabulary validation passed: ${byVocabulary.size} distinct vocabularies, ` +
-    `${duplicated.length} still restated in more than one file (all per-domain coincidences, not debt — see COINCIDENT_BY_DOMAIN); ` +
+    `${duplicated.length} still restated in more than one file (all per-domain coincidences pinned to their exact files — see COINCIDENT_BY_DOMAIN); ` +
     `${Object.keys(MIRRORED_VOCABULARIES).length} cross-boundary mirrors match the collection that owns them; ` +
     `${JSON_SCHEMA_MIRRORS.length} JSON Schema enum(s) match their schemas-src copy.`,
 );

--- a/src/concentration.ts
+++ b/src/concentration.ts
@@ -7,6 +7,7 @@
 
 import { DAY_MS } from "../workers/config.ts";
 import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 
 // The neurons-tier columns the concentration handler reads — the store read contract
 // for buildConcentration (mirrors BLOCK_READ_COLUMNS / EXTRINSIC_READ_COLUMNS). Kept
@@ -406,13 +407,9 @@ export async function loadChainConcentration(
 // is what a sort and a `fields` projection can act on.
 
 /** The distributions a caller can rank subnets by. */
-export const CONCENTRATION_LENSES = [
-  "emission",
-  "stake",
-  "entity_emission",
-  "entity_stake",
-  "validator_stake",
-] as const;
+// The vocabulary, derived from its owner so the route schema, the route
+// table and this enforcement cannot disagree (#10987).
+export const CONCENTRATION_LENSES = QUERY_ENUMS.concentrationLens;
 export type ConcentrationLens = (typeof CONCENTRATION_LENSES)[number];
 export const DEFAULT_CONCENTRATION_LENS: ConcentrationLens = "emission";
 
@@ -424,14 +421,7 @@ export const DEFAULT_CONCENTRATION_LENS: ConcentrationLens = "emission";
  * of the distribution -- and it is an integer count rather than a ratio, so
  * "9 vs 1" is legible where "gini 0.658 vs 0.968" is not.
  */
-export const CONCENTRATION_RANKING_SORTS = [
-  "nakamoto_coefficient",
-  "gini",
-  "holders",
-  "top_1pct_share",
-  "total",
-  "netuid",
-] as const;
+export const CONCENTRATION_RANKING_SORTS = QUERY_ENUMS.concentrationRankingSort;
 export type ConcentrationRankingSort =
   (typeof CONCENTRATION_RANKING_SORTS)[number];
 export const DEFAULT_CONCENTRATION_RANKING_SORT: ConcentrationRankingSort =

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -5061,7 +5061,7 @@ function feedRoute(
     description,
     cache: "medium",
     tags: ["feeds"],
-    formats: ["rss", "atom", "json"],
+    formats: QUERY_ENUMS.feedFormat,
     path_parameters: extra.pathParameters ?? [],
     query_parameters: [
       ...FEED_COMMON_PARAMETERS,
@@ -5589,7 +5589,7 @@ export function buildApiIndexArtifact(
     type_definitions_url: TYPE_DEFINITIONS_PATH,
     response_envelope: {
       schema_version: SCHEMA_VERSION,
-      fields: ["ok", "data", "meta", "error"],
+      fields: QUERY_ENUMS.responseEnvelopeField,
       success_schema_ref: "#/components/schemas/SuccessEnvelope",
       error_schema_ref: "#/components/schemas/ErrorEnvelope",
       notes:

--- a/src/emission-gate-changes.ts
+++ b/src/emission-gate-changes.ts
@@ -40,6 +40,7 @@ import {
   EMISSION_CHANGES_LIMIT_DEFAULT,
   EMISSION_CHANGES_LIMIT_MAX,
 } from "./route-limits.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 
 export { EMISSION_CHANGES_LIMIT_DEFAULT, EMISSION_CHANGES_LIMIT_MAX };
 
@@ -50,7 +51,7 @@ export interface EmissionChangesDb {
 }
 
 /** The three change kinds, which are also the `?kind=` filter's vocabulary. */
-export const EMISSION_CHANGE_KINDS = ["param", "subnet", "flow"] as const;
+export const EMISSION_CHANGE_KINDS = QUERY_ENUMS.emissionChangeKind;
 
 /** How a parameter value came to be, per 0005's CHECK constraint. */
 export const EMISSION_PARAM_SOURCES = [

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -555,11 +555,7 @@ import {
   buildAccountStakeFlow,
 } from "./account-stake-flow.ts";
 import { buildAccountPositionHistory } from "./account-position-history.ts";
-import {
-  DEFAULT_STAKE_FLOW_DIRECTION,
-  STAKE_FLOW_DIRECTIONS,
-  buildStakeFlow,
-} from "./stake-flow.ts";
+import { DEFAULT_STAKE_FLOW_DIRECTION, buildStakeFlow } from "./stake-flow.ts";
 import { loadChainRegistrationsFromArtifact } from "./chain-registrations-artifact.ts";
 import {
   loadAccountDeregistrationsFromArtifact,
@@ -3739,13 +3735,13 @@ const rootValue = {
         { extensions: { code: "BAD_USER_INPUT" } },
       );
     }
+    // No direction guard here: parseArgumentsAtDispatch already rejected a
+    // value outside the route's published enum before this resolver ran
+    // (#10065's rule -- a resolver must not re-validate its own params), and
+    // the guard this replaces was dead code wearing a different error message
+    // than the one a caller actually gets. tests/graphql.test.ts pins the
+    // dispatch-level rejection.
     const directionParam = direction ?? DEFAULT_STAKE_FLOW_DIRECTION;
-    if (!STAKE_FLOW_DIRECTIONS.includes(directionParam)) {
-      throw new GraphQLError(
-        `"${directionParam}" is not a valid direction. Supported: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
-        { extensions: { code: "BAD_USER_INPUT" } },
-      );
-    }
     const params = new URLSearchParams();
     params.set("window", windowParam);
     params.set("direction", directionParam);
@@ -6493,13 +6489,10 @@ const rootValue = {
         { extensions: { code: "BAD_USER_INPUT" } },
       );
     }
+    // No direction guard here -- same reasoning as subnet_stake_flow above:
+    // the dispatch validator rejects against the published enum first (#10065),
+    // and the copy this replaces was unreachable.
     const requestedDirection = direction ?? DEFAULT_STAKE_FLOW_DIRECTION;
-    if (!STAKE_FLOW_DIRECTIONS.includes(requestedDirection)) {
-      throw new GraphQLError(
-        `direction must be one of: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
-        { extensions: { code: "BAD_USER_INPUT" } },
-      );
-    }
     const params = new URLSearchParams();
     params.set("window", requestedWindow);
     params.set("direction", requestedDirection);

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7673,7 +7673,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       }
       const direction =
         optionalString(args, "direction") ?? DEFAULT_STAKE_FLOW_DIRECTION;
-      if (!STAKE_FLOW_DIRECTIONS.includes(direction)) {
+      if (!(STAKE_FLOW_DIRECTIONS as readonly string[]).includes(direction)) {
         throw toolError(
           "invalid_params",
           `direction must be one of: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,
@@ -11010,7 +11010,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       // since account_events is retired (#4772).
       const direction =
         optionalString(args, "direction") ?? DEFAULT_STAKE_FLOW_DIRECTION;
-      if (!STAKE_FLOW_DIRECTIONS.includes(direction)) {
+      if (!(STAKE_FLOW_DIRECTIONS as readonly string[]).includes(direction)) {
         throw toolError(
           "invalid_params",
           `direction must be one of: ${STAKE_FLOW_DIRECTIONS.join(", ")}.`,

--- a/src/revenue-shape.ts
+++ b/src/revenue-shape.ts
@@ -1,4 +1,8 @@
 // #10525: the payload-shape vocabulary, in one place so the extractor and any
 // future consumer import it rather than restating the union.
-export const REVENUE_SHAPES = ["flat-array", "keyed-map", "scalar"] as const;
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+
+// The vocabulary, derived from its owner (#10987): subnet-detail.ts declared
+// the same three shapes inline and nothing compared the two.
+export const REVENUE_SHAPES = QUERY_ENUMS.revenueShape;
 export type RevenueShape = (typeof REVENUE_SHAPES)[number];

--- a/src/route-limits.ts
+++ b/src/route-limits.ts
@@ -1,4 +1,5 @@
 // Per-route `limit` page-size ceilings, in one place (#9127).
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 //
 // Each of these numbers used to be stated three times: the constant the handler
 // enforces, the `maximum` the contract publishes, and the "(default N, max M)"
@@ -355,7 +356,7 @@ export const SEMANTIC_LIMIT_DEFAULT = 10;
  * both sides already read (#9127). ai-search.ts re-exports it, so the handler
  * and the published enum cannot drift.
  */
-export const SEMANTIC_TYPES = ["subnet", "surface", "provider"] as const;
+export const SEMANTIC_TYPES = QUERY_ENUMS.searchDocumentType;
 
 export const SEMANTIC_LIMIT_MAX = 20;
 /** Rejected above this with a 400, not truncated -- an embedded query that was

--- a/src/stake-flow.ts
+++ b/src/stake-flow.ts
@@ -3,6 +3,7 @@ import {
   finiteCellOrNull,
   numberOrZero,
 } from "./lib/rao.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 // Net stake flow (capital in vs out) for one subnet over a recent window: how much
 // TAO entered (StakeAdded) vs left (StakeRemoved), summed from the first-party
 // account_events stream. Pure shaping (buildStakeFlow); the Worker / data-api
@@ -38,7 +39,7 @@ export const DEFAULT_STAKE_FLOW_WINDOW = "30d";
 
 // direction narrows the stake-flow aggregate to one side: in = StakeAdded only,
 // out = StakeRemoved only, all (or omitted) = both kinds summed as today.
-export const STAKE_FLOW_DIRECTIONS = ["all", "in", "out"];
+export const STAKE_FLOW_DIRECTIONS = QUERY_ENUMS.stakeFlowDirection;
 export const DEFAULT_STAKE_FLOW_DIRECTION = "all";
 
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise

--- a/src/surface-history.ts
+++ b/src/surface-history.ts
@@ -34,6 +34,7 @@ import {
   SURFACE_HISTORY_LIMIT_DEFAULT,
   SURFACE_HISTORY_LIMIT_MAX,
 } from "./route-limits.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 
 export { SURFACE_HISTORY_LIMIT_DEFAULT, SURFACE_HISTORY_LIMIT_MAX };
 
@@ -48,7 +49,7 @@ export const SURFACE_HISTORY_TABLE = "surface_history";
 
 /** The mutations the writer records. `delete` is the one that matters most to a
  * consumer: it is the only evidence a surface ever existed. */
-export const SURFACE_HISTORY_ACTIONS = ["insert", "update", "delete"] as const;
+export const SURFACE_HISTORY_ACTIONS = QUERY_ENUMS.surfaceHistoryAction;
 
 /**
  * One subnet's trail, newest first. Null when the read fails.

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8002,6 +8002,20 @@ describe("graphql — account_stake_flow (#5706, Postgres-tier { data, generated
     } }`;
   }
 
+  test("a direction outside the vocabulary is BAD_USER_INPUT, not a default", async () => {
+    // Same derived tuple as the subnet field and the REST route (#10987).
+    const { status, body } = await gql(
+      query(`(ss58: "${SS58}", direction: "sideways")`),
+    );
+    assert.equal(status, 200);
+    const errors = (body.errors ?? []) as Array<{
+      message?: string;
+      extensions?: { code?: string };
+    }>;
+    assert.equal(errors[0]?.extensions?.code, "BAD_USER_INPUT");
+    assert.match(errors[0]?.message ?? "", /direction must be one of/);
+  });
+
   test("cold store: no Postgres flag returns a schema-stable zeroed card, never null", async () => {
     const { status, body } = await gql(query(`(ss58: "${SS58}")`));
     assert.equal(status, 200);
@@ -14175,6 +14189,23 @@ describe("graphql — subnet idle-stake/stake-flow/events/history/prometheus (#7
       idle_neuron_count: 0,
       idle_stake_alpha: 0,
     });
+  });
+
+  test("subnet_stake_flow rejects a direction outside the vocabulary", async () => {
+    // The rejection reads the derived STAKE_FLOW_DIRECTIONS (#10987) -- the
+    // same tuple the REST route publishes -- so the two surfaces cannot
+    // disagree about what a direction is.
+    const { status, body } = await gql(
+      `{ subnet_stake_flow(netuid: 5, direction: "sideways") { schema_version } }`,
+    );
+    assert.equal(status, 200);
+    const errors = (body.errors ?? []) as Array<{
+      message?: string;
+      extensions?: { code?: string };
+    }>;
+    assert.equal(errors[0]?.extensions?.code, "BAD_USER_INPUT");
+    assert.match(errors[0]?.message ?? "", /direction must be one of/);
+    assert.match(errors[0]?.message ?? "", /all, in, out/);
   });
 
   test("subnet_stake_flow cold store returns a schema-stable zeroed card", async () => {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -810,6 +810,7 @@ import {
   type RevenueStoreDb,
 } from "../src/revenue-observations.ts";
 import {
+  EMISSION_CHANGES_TABLES,
   REVENUE_FEED_TABLES,
   REVENUE_OBSERVATION_TABLES,
 } from "../src/read-store-tables.ts";
@@ -4910,12 +4911,13 @@ async function emissionGateSyncRows(
 /** Every table this lane writes. All three or none: one sync derives all three
  * change sets from ONE observation and writes them in ONE batch, so a family
  * split across stores would put a param change and the enabled change it was
- * derived alongside into different databases. */
-const EMISSION_GATE_TABLES = [
-  "emission_gate_param_history",
-  "subnet_emission_enabled_history",
-  "emission_flow_watch",
-] as const;
+ * derived alongside into different databases.
+ *
+ * THE READER'S LIST, not a copy of it (#10987): loadEmissionChanges UNIONs
+ * exactly these tables, and a table written here but missing there would sync
+ * green and never be served. Deriving the write set from the read set makes
+ * that drift unrepresentable. */
+const EMISSION_GATE_TABLES = EMISSION_CHANGES_TABLES;
 
 async function handleEmissionGateSync(
   request: Request,


### PR DESCRIPTION
## Why the consolidation epics closed and the drift kept appearing

`validate:schema-vocabularies` (#9799 — "a vocabulary has ONE owner") scanned four
directories, all under `schemas-src/`. The copies people actually make live in the serving
tree: `contracts.ts` restating a query enum it could import, an MCP composer restating a
route vocabulary as its own literal, a handler enforcing a list its route schema declares. A
vocabulary could be single-sourced in `schemas-src/` and restated four times in `src/` —
green forever. **The duplication moved to the one tree the gate never read.**

The gate now scans `src/`, `src/graphql/`, `workers/`, `workers/request-handlers/`, and
everything it reported is fixed. **252 distinct vocabularies, zero unlisted duplication.**

## What was fixed (all 25)

| class | count | fix |
| --- | --- | --- |
| value vocabularies declared in schemas-src AND the src module enforcing them | 9 | hoisted to `QUERY_ENUMS` (zero-import leaf — adds nothing to the data-api Worker's startup budget, the #10121 constraint), both sides derive |
| sort-field allowlists hand-mirroring `API_QUERY_COLLECTIONS.<collection>.sort_fields` | 13 | derive from the route table — one carried a comment claiming schemas-src cannot import src/, which `profiles.ts` had already disproved |
| old-allowlist entries that were debt wearing the "coincidence" label | 3 | agent-catalog + coverage restated `QUERY_ENUMS.agentReadinessStatus`/`.agentBlockerLevel` inline; account-activity restated the flow directions — all derive now |
| write set ≠ read set | 1 | `workers/api.ts`'s emission-gate table list IS `read-store-tables`' `EMISSION_CHANGES_TABLES` — a table written-but-not-served is now unrepresentable |
| genuine value-coincidence (EVM ABI arg names vs a Neon index column list) | 1 | pinned allowlist entry — a shared owner would couple an on-chain ABI to a database index |

Plus two **dead direction guards deleted from `graphql.ts`**: proven empirically that
`parseArgumentsAtDispatch` rejects against the route's published enum before any resolver
runs (both fields answer with `route-query.ts`'s message, `Received: "sideways"` tail), so
both guards wore an error message no caller could ever receive — hand-rolled validation
duplicating the centralized validator, #10065's exact rule. New tests pin the dispatch-level
rejection on both fields.

## The allowlist now pins files, not value sets

Found by falsification, not review: with `"all|in|out"` allowlisted as a bare string, a NEW
copy of that list anywhere was invisible — the gate's one mechanism, defeated by any
vocabulary that legitimately coincided somewhere else once. An entry now names the exact
files allowed to coincide: a file joining fails the gate, a file leaving makes the entry
stale, and stale entries fail too. The same `src/` copy that slipped through the old form is
a failure under the pinned form — both directions proven live.

## The emitted contract is byte-identical

`openapi.json`, `generated/`, `packages/` — zero diff after `npm run build`. Every
derivation preserved the exact published values and order (verified per-list against
`API_QUERY_COLLECTIONS` before deriving). Internal de-duplication only.

## Verification

- Gate falsified both ways: a non-allowlisted copy fails; a copy of an allowlisted set from
  a new file fails; the clean tree passes
- Full `npx vitest run`: **879 files, 20273 passed** (+2 GraphQL dispatch-rejection tests)
- Patch coverage by lcov ∩ diff: **0 uncovered lines, 0 untaken branches**
- `tsc` · `lint` · `format:check` · `build` · `validate:contract-drift` · `validate:api` ·
  `validate:openapi` · `validate:mcp` · `validate:schemas` · `validate:schema-vocabularies` ·
  `validate:mcp-input-parity` · `validate:query-vocabulary` · `validate:unreferenced-exports`
  · `validate:graphql-*` (all five) — pass
- No pipeline/CI registration needed: the gate was already in `validate.yml` and both
  `pipeline.ts` step lists; only its scan widened

Closes #10987