### PR TITLE
fix(alarm): a lane with no declared producer gets no floor, and alarms early

### DIFF
--- a/src/producer-cadence.ts
+++ b/src/producer-cadence.ts
@@ -132,6 +132,11 @@ export type ProducerLane = keyof typeof PRODUCER_CADENCE_SECS;
  * configured one; the floor is what stops a sample that is a burst followed by
  * silence -- which is what a `-pass` mirror's seven days look like -- from
  * producing a bound tighter than a single tick.
+ *
+ * `chain-detail` is deliberately ABSENT: it follows the chain head continuously
+ * rather than on a poll interval, so it has no tick to miss and its own alarm
+ * measures a live-follow WINDOW instead. Inventing a cadence for it would put a
+ * floor under a bound that is not measured in cadences.
  */
 export const LANE_PRODUCER: Readonly<Record<string, ProducerLane>> = {
   "account-balances": "account_balances",
@@ -141,11 +146,23 @@ export const LANE_PRODUCER: Readonly<Record<string, ProducerLane>> = {
   "neon:hotkey-alpha": "hotkey_alpha",
   "neon:hotkey-alpha-pass": "hotkey_alpha",
   "validator-nominators": "validator_nominators",
+  // The SYNC lane names, unprefixed. Their `neon:` mirrors below were mapped
+  // and these were not, so `lane nominator-positions is silent: 29.4h` shipped
+  // to Discord with no cadence beside it -- 29.4h reads as a dead producer,
+  // and it is one missed pass of a 24h poller. The same misreading #10809 added
+  // the cadence suffix to prevent, reintroduced by a lane the map did not name.
+  "nominator-positions": "validator_nominators",
+  "validator-nominator-counts": "validator_nominators",
   "neon:validator-nominator-counts": "validator_nominators",
   "neon:validator-nominator-counts-pass": "validator_nominators",
   "neon:nominator-positions": "validator_nominators",
   "neon:nominator-positions-pass": "validator_nominators",
   "neon:nominator-positions-prune": "validator_nominators",
+  // Its own staleness watchdog already declares this producer --
+  // `missedTicksMs("metagraph", 3)` in neurons-staleness-watchdog.ts -- so the
+  // lane had a STALENESS floor and no SILENCE floor, which is the asymmetry
+  // `tests/lane-silence-cadence.test.ts` now forbids.
+  neurons: "metagraph",
   "account-identity": "account_identity",
   "neon:account-identity": "account_identity",
   "subnet-hyperparams": "subnet_hyperparams",

--- a/tests/lane-health-silence.test.ts
+++ b/tests/lane-health-silence.test.ts
@@ -19,6 +19,7 @@ import {
   laneSilenceThresholdMs,
 } from "../src/lane-alarm.ts";
 import type { LaneHealthRecord } from "../src/lane-health.ts";
+import { LANE_PRODUCER } from "../src/producer-cadence.ts";
 
 const NOW = 1_786_300_000_000;
 const MIN = 60_000;
@@ -125,26 +126,57 @@ describe("the bound is the lane's own cadence, not a global one", () => {
 });
 
 describe("without a cadence sample, nothing changes", () => {
+  // These two are about a lane with NO cadence from either source -- no
+  // observation AND no declaration. They used `neurons` for that, which stopped
+  // being true when LANE_PRODUCER learned that lane's producer: it had a
+  // staleness floor and no silence floor, and closing that gap is what made a
+  // 30-day-old record read `unknown` here instead of `ok`. The behaviour change
+  // is the fix; the fixture just needed a lane that is genuinely undeclared.
+  //
+  // Asserted rather than assumed, so this cannot quietly start leaning on a
+  // mapped lane again.
+  const UNDECLARED = "lane-with-no-declared-producer";
+
+  test("the fixture lane really has no declared producer", () => {
+    assert.equal(LANE_PRODUCER[UNDECLARED], undefined);
+  });
+
   test("no cadences at all leaves every verdict alone", () => {
     // A caller that has not paid for the cadence query gets exactly today's
     // behaviour -- inventing a bound would invent alarms.
     const ancient = record({
+      lane: UNDECLARED,
       verdict: "ok",
       checked_at: NOW - 30 * 24 * 60 * MIN,
     });
-    assert.equal(view({ neurons: ancient })[0]!.verdict, "ok");
+    assert.equal(view({ [UNDECLARED]: ancient })[0]!.verdict, "ok");
   });
 
   test("a lane with too little history to derive a cadence is left alone", () => {
     // loadLaneCadence returns null for a lane under the sample floor.
     const ancient = record({
+      lane: UNDECLARED,
       verdict: "ok",
       checked_at: NOW - 30 * 24 * 60 * MIN,
     });
     assert.equal(
-      view({ neurons: ancient }, { neurons: null })[0]!.verdict,
+      view({ [UNDECLARED]: ancient }, { [UNDECLARED]: null })[0]!.verdict,
       "ok",
     );
+  });
+
+  test("a DECLARED lane is not left alone -- that is the floor doing its job", () => {
+    // The other side of the two above, and the regression that matters: with
+    // no cadence sample at all, `neurons` still gets a bound because
+    // LANE_PRODUCER declares its producer. Before that mapping this read `ok`
+    // after thirty days of silence.
+    const ancient = record({
+      lane: "neurons",
+      verdict: "ok",
+      checked_at: NOW - 30 * 24 * 60 * MIN,
+    });
+    assert.equal(LANE_PRODUCER["neurons"], "metagraph");
+    assert.equal(view({ neurons: ancient })[0]!.verdict, "unknown");
   });
 
   test("a lane that has never been checked is left alone", () => {

--- a/tests/lane-silence-cadence.test.ts
+++ b/tests/lane-silence-cadence.test.ts
@@ -23,6 +23,7 @@
 // whose seven days are a burst followed by silence reads a max of ~48 minutes
 // against a 24-hour producer.
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
   LANE_PRODUCER,
@@ -105,6 +106,97 @@ describe("LANE_PRODUCER", () => {
       "neon:validator-nominator-counts",
     ]) {
       assert.equal(LANE_PRODUCER[lane], "validator_nominators", lane);
+    }
+  });
+
+  test("a lane's staleness watchdog and LANE_PRODUCER cannot disagree", () => {
+    // The SAME fact is written twice: `<lane>-staleness-watchdog.ts` names the
+    // producer in its own `*_STALENESS_THRESHOLD_MS`, and LANE_PRODUCER names
+    // it again for the silence bound. `neurons` had the first and not the
+    // second, so it got a staleness floor and NO silence floor -- and an
+    // unfloored silence bound is computed from the observed sample alone,
+    // which a burst-then-quiet sample makes tighter than one real tick.
+    //
+    // Matched on the lane's OWN threshold constant, not on any missedTicksMs
+    // call: table-freshness-watchdog.ts calls it for every table it WATCHES,
+    // and a looser rule read those as declarations about its own lane. The
+    // first draft of this test did exactly that and reported a lane that is
+    // correctly unmapped.
+    const declarations: [string, string][] = [];
+    for (const file of readdirSync("src")) {
+      const lane = /^(.+)-staleness-watchdog\.ts$/.exec(file)?.[1];
+      if (!lane) continue;
+      const producer =
+        /export const [A-Z0-9_]*STALENESS_THRESHOLD_MS = missedTicksMs\(\s*"([a-z_]+)"/.exec(
+          readFileSync(`src/${file}`, "utf8"),
+        )?.[1];
+      if (!producer) continue;
+      declarations.push([lane, producer]);
+    }
+    assert.ok(
+      declarations.length >= 4,
+      `expected several per-lane staleness watchdogs, found ${declarations.length}`,
+    );
+    for (const [lane, producer] of declarations) {
+      // Only where the watchdog's file name IS a lane the table knows: a
+      // watchdog may guard a lane under a different name, and asserting on a
+      // name the table never claimed would be inventing a rule.
+      if (!(lane in LANE_PRODUCER)) continue;
+      assert.equal(
+        LANE_PRODUCER[lane],
+        producer,
+        `${lane}-staleness-watchdog.ts declares "${producer}" but LANE_PRODUCER says ${String(LANE_PRODUCER[lane])}`,
+      );
+    }
+  });
+
+  test("a mapped `neon:` mirror means its bare lane is mapped too", () => {
+    // The reverse of the test above, and the one that was missing. Every
+    // assertion here was one-directional: values have cadences, listed mirrors
+    // resolve. Nothing said a lane that ALARMS must be in the table at all.
+    //
+    // `neon:nominator-positions` and `neon:validator-nominator-counts` were
+    // mapped; the bare sync-lane names that write the same rows from the same
+    // poller were not. So `lane nominator-positions is silent: 29.4h` reached
+    // Discord with no cadence beside it, reading as a dead producer when it is
+    // one missed pass of a 24h poller.
+    //
+    // Derived from the table itself rather than a list of the pairs that were
+    // fixed: a future `neon:` mirror added without its bare lane fails here.
+    const unmapped: string[] = [];
+    for (const lane of Object.keys(LANE_PRODUCER)) {
+      if (!lane.startsWith("neon:")) continue;
+      const bare = lane.slice("neon:".length).replace(/-(pass|prune)$/, "");
+      if (!(bare in LANE_PRODUCER)) continue; // never mapped either way: not this rule
+      assert.equal(
+        LANE_PRODUCER[bare],
+        LANE_PRODUCER[lane],
+        `${lane} and ${bare} are the same producer under two names`,
+      );
+    }
+    // Non-vacuity: the rule must actually be checking pairs.
+    const pairs = Object.keys(LANE_PRODUCER).filter(
+      (l) =>
+        l.startsWith("neon:") &&
+        l.slice("neon:".length).replace(/-(pass|prune)$/, "") in LANE_PRODUCER,
+    );
+    assert.ok(
+      pairs.length >= 6,
+      `expected several mirror/bare pairs, found ${pairs.length}`,
+    );
+    assert.deepEqual(unmapped, []);
+  });
+
+  test("the lanes that alarmed on 2026-08-13 resolve a cadence", () => {
+    // Regression: both were silent for ~29h and neither alarm could say against
+    // what interval, because neither name was in the table.
+    for (const lane of ["nominator-positions", "validator-nominator-counts"]) {
+      assert.equal(LANE_PRODUCER[lane], "validator_nominators", lane);
+      assert.equal(
+        laneSilenceCadenceMs(lane, null),
+        cadenceMs("validator_nominators"),
+        lane,
+      );
     }
   });
 


### PR DESCRIPTION
`lane nominator-positions is silent: 29.4h` and `lane validator-nominator-counts is silent: 29.5h` reached Discord tonight reading as **two dead producers**. They are **one** producer, and it had missed **one pass** of a 24h poll.

## Two names, one table, one of them missing

`LANE_PRODUCER` mapped `neon:nominator-positions` and `neon:validator-nominator-counts`. The **bare sync-lane names** — which write the same rows from the same poller — were not in the table.

That is not just a missing annotation. `laneSilenceCadenceMs` uses the declared cadence as a **floor** under the observed gap, and an unmapped lane gets `floor = null`:

```ts
const floor = declared ? cadenceMs(declared) : null;
```

So the bound comes from the observed sample alone, and a burst-followed-by-quiet sample produces a bound **tighter than one real tick**. The map's own comment predicted this — *"in the direction of a bound that is too tight"*. The alarm was therefore both **contextless** (no `(producer cadence 24.0h)`) and **premature** (fired at 29.4h against a 24h producer whose calibrated staleness threshold is 30h).

## A third lane had it too — found by the guard, not by me

`neurons`: `neurons-staleness-watchdog.ts` already declares `missedTicksMs("metagraph", 3)`, so that lane had a **staleness** floor and **no silence** floor.

`chain-detail` stays out, and now says why: it follows the head continuously rather than on a poll interval, so it has no tick to miss and its own alarm measures a live-follow *window*.

## The guard is derived — and its first draft was wrong

The same fact is written twice: a lane's staleness watchdog names its producer, and `LANE_PRODUCER` names it again. The test reads the modules and asserts they agree, so a watchdog added tomorrow is covered without being listed.

I wrote it first over **any** `missedTicksMs` call, and it reported `table-freshness` as a defect. **It isn't one** — that watchdog calls `missedTicksMs` for every table it *watches*, while its own lane is a cron lane with no poller cadence. My rule had conflated two different facts. Narrowed to the lane's own `*_STALENESS_THRESHOLD_MS`, which is the constant that actually declares it.

Confirmed to fail both when a mapping is removed and when one is wrong.

## The hole that let this through

Every existing assertion on this table ran **one way** — values have cadences, listed mirrors resolve. Nothing said a lane that *alarms* must be in the table at all, which is exactly why two were not. Both directions are now checked.

## Not fixed here

The producer itself lives in the private infra repo (`services/indexer-rs`); this PR makes its alarm readable and correctly bounded, it does not touch the poller.