### PR TITLE
chore: drop the p50 deploy-window shim, and a header that outlived its design

### DIFF
--- a/apps/ui/src/lib/metagraphed/queries.chain-axon-removals.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-axon-removals.test.ts
@@ -42,7 +42,7 @@ describe("normalizeChainAxonRemovals", () => {
           mean: 12.5,
           min: 10,
           p25: 10,
-          median: 10,
+          p50: 10,
           p75: 15,
           p90: 15,
           max: 15,

--- a/apps/ui/src/lib/metagraphed/queries.chain-deregistrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-deregistrations.test.ts
@@ -46,7 +46,7 @@ describe("normalizeChainDeregistrations", () => {
           mean: 12.5,
           min: 10,
           p25: 10,
-          median: 10,
+          p50: 10,
           p75: 15,
           p90: 15,
           max: 15,

--- a/apps/ui/src/lib/metagraphed/queries.chain-registrations.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-registrations.test.ts
@@ -46,7 +46,7 @@ describe("normalizeChainRegistrations", () => {
           mean: 12.5,
           min: 10,
           p25: 10,
-          median: 10,
+          p50: 10,
           p75: 15,
           p90: 15,
           max: 15,

--- a/apps/ui/src/lib/metagraphed/queries.chain-stake-transfers.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-stake-transfers.test.ts
@@ -42,7 +42,7 @@ describe("normalizeChainStakeTransfers", () => {
           mean: 12.5,
           min: 10,
           p25: 10,
-          median: 10,
+          p50: 10,
           p75: 15,
           p90: 15,
           max: 15,

--- a/apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-weights.test.ts
@@ -46,7 +46,7 @@ describe("normalizeChainWeights", () => {
           mean: 13.5,
           min: 12,
           p25: 12,
-          median: 12,
+          p50: 12,
           p75: 15,
           p90: 15,
           max: 15,

--- a/apps/ui/src/lib/metagraphed/queries.chain-yield.test.ts
+++ b/apps/ui/src/lib/metagraphed/queries.chain-yield.test.ts
@@ -46,7 +46,7 @@ describe("normalizeChainYield", () => {
         distribution: {
           count: 80,
           mean: 0.01,
-          median: 0.002,
+          p50: 0.002,
           min: 0,
           max: 5,
           p10: 0,

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -4245,10 +4245,7 @@ function normalizeChainIntensityDistribution(raw: unknown): ChainIntensityDistri
     mean: firstFiniteNumber(raw.mean) ?? 0,
     min: firstFiniteNumber(raw.min) ?? 0,
     p25: firstFiniteNumber(raw.p25) ?? 0,
-    // p50 is the wire name; `raw.median` is the pre-rename spelling, read as a
-    // fallback because the API worker and this app deploy separately and either
-    // can land first. Remove once both are deployed.
-    median: firstFiniteNumber(raw.p50 ?? raw.median) ?? 0,
+    median: firstFiniteNumber(raw.p50) ?? 0,
     p75: firstFiniteNumber(raw.p75) ?? 0,
     p90: firstFiniteNumber(raw.p90) ?? 0,
     max: firstFiniteNumber(raw.max) ?? 0,
@@ -4637,7 +4634,7 @@ function normalizeChainStakeFlowDistribution(raw: unknown): ChainStakeFlowDistri
     mean: coerceFiniteNumber(raw.mean) ?? null,
     min: coerceFiniteNumber(raw.min) ?? null,
     p25: coerceFiniteNumber(raw.p25) ?? null,
-    median: coerceFiniteNumber(raw.p50 ?? raw.median) ?? null,
+    median: coerceFiniteNumber(raw.p50) ?? null,
     p75: coerceFiniteNumber(raw.p75) ?? null,
     p90: coerceFiniteNumber(raw.p90) ?? null,
     max: coerceFiniteNumber(raw.max) ?? null,
@@ -4706,7 +4703,7 @@ function normalizeChainStakeMovesDistribution(raw: unknown): ChainStakeMovesDist
     mean: coerceFiniteNumber(raw.mean) ?? null,
     min: coerceFiniteNumber(raw.min) ?? null,
     p25: coerceFiniteNumber(raw.p25) ?? null,
-    median: coerceFiniteNumber(raw.p50 ?? raw.median) ?? null,
+    median: coerceFiniteNumber(raw.p50) ?? null,
     p75: coerceFiniteNumber(raw.p75) ?? null,
     p90: coerceFiniteNumber(raw.p90) ?? null,
     max: coerceFiniteNumber(raw.max) ?? null,
@@ -8468,10 +8465,7 @@ function normalizeChainYieldDistribution(raw: unknown): ChainYieldDistribution |
   return {
     count,
     mean: firstFiniteNumber(raw.mean) ?? 0,
-    // p50 is the wire name; `raw.median` is the pre-rename spelling, read as a
-    // fallback because the API worker and this app deploy separately and either
-    // can land first. Remove once both are deployed.
-    median: firstFiniteNumber(raw.p50 ?? raw.median) ?? 0,
+    median: firstFiniteNumber(raw.p50) ?? 0,
     min: firstFiniteNumber(raw.min) ?? 0,
     max: firstFiniteNumber(raw.max) ?? 0,
     p10: firstFiniteNumber(raw.p10) ?? 0,

--- a/schemas-src/mcp-tools/get-subnet-health.ts
+++ b/schemas-src/mcp-tools/get-subnet-health.ts
@@ -1,7 +1,21 @@
-// MCP tool `get_subnet_health` (types-epic E batch 2, #8065). "Mirrors" the
-// health domain conceptually but the REST route it names isn't one of
-// schemas-src/routes/'s covered pilot routes -- no existing Zod schema to
-// reuse. Modeled fresh, shallow, from the hand-written literal it replaces.
+// MCP tool `get_subnet_health` (types-epic E batch 2, #8065).
+//
+// This file DERIVES its shapes from the route schemas below -- the summary
+// from HealthSubnetSummarySchema (#9797), the rows from
+// HealthSubnetSurfaceSchema (#10904), the input from
+// ListSubnetHealthInputSchema (#9998).
+//
+// It did not always. The header here used to read "no existing Zod schema to
+// reuse -- modeled fresh, shallow, from the hand-written literal it replaces",
+// which was true at #8065 and false from #10904 onward, when the copied row
+// schema was replaced by the route's own for the reason that commit records:
+// the copy "sat five fields behind the route's", so the outbound tripwire
+// refused every netuid-0 call the moment the fallback tier answered.
+//
+// The sentence survived the fix it described. A header that still advertises a
+// design the file abandoned costs more than a stale comment usually does: it is
+// read as the reason for a drift, and it sends the reader looking for a
+// hand-copied schema that is no longer here.
 import { z } from "zod";
 import { McpUnsortedPageFields, netuidSchema } from "./shared.ts";
 import { ListSubnetHealthInputSchema } from "./subnet-scoped-lists.ts";


### PR DESCRIPTION
Two leftovers from tonight's work, both verified against production before removing.

## The shim

#10989 renamed `median` → `p50` on 12 route surfaces, and `apps/ui` read `raw.p50 ?? raw.median` because the API worker and this app deploy separately and **either could land first**.

The API is deployed. Checked every ladder-bearing route live:

| | |
|---|---|
| serve `p50`, no `median` | 10 routes |
| block currently `null` (no activity in window) | `chain/prometheus`, `chain/axon-removals` |
| serve `median` | **0** |

The two null ones can't be proven by probe — a null block satisfies any schema — but they share the renamed producer and pass their unit tests. Stating that rather than implying all twelve were observed.

The fallback is now dead code, and a compatibility read left in place is indistinguishable from one that is still needed.

## The header

`get-subnet-health.ts` opened with:

> no existing Zod schema to reuse — modeled fresh, shallow, from the hand-written literal it replaces

True at #8065. **False since #10904**, which replaced the copied row schema with the route's own for the reason that commit records — the copy *"sat five fields behind the route's"*, so the outbound tripwire refused every netuid-0 call the moment the fallback tier answered. Today the file derives its summary (#9797), rows (#10904) and input (#9998) from route schemas.

The sentence survived the fix it described. That is worse than an ordinary stale comment: read during an investigation it becomes *the explanation for a drift*, and sends the reader hunting a hand-copied schema that is not there.

It did exactly that to me tonight — I read it and reported to the maintainer that the MCP schemas were hand-copied. They are not: **113 of 121** MCP tool files import a route schema.

## Verification

- `validate:contract-drift` passed, `validate:ui-docs-drift` passed
- 364 schema/MCP tests, 15 UI normalizer tests
- No emitted artifact changes — the header is a file comment, not a `.describe()`