### PR TITLE
feat(revenue): the owner-cut disposition reads the flow streams it names

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -262,6 +262,7 @@ export async function loadAccountStakeFlowColdTier(
 ): Promise<{
   data: ReturnType<typeof buildAccountStakeFlow>;
   generatedAt: string | null;
+  rows: Array<Record<string, unknown>>;
 } | null> {
   const addr = safeSs58Literal(ss58);
   if (addr === null) return null;
@@ -290,9 +291,17 @@ export async function loadAccountStakeFlowColdTier(
     DEFAULT_STAKE_FLOW_WINDOW,
     query.window,
   );
+  // ALSO SUMS alpha_amount (#10930). `account_events` carries both units on
+  // every StakeAdded/StakeRemoved row, so one query yields both -- the same
+  // rationale src/alpha-volume.ts states for its own read. The owner-cut
+  // disposition needs the ALPHA leg specifically: its buckets are alpha, and
+  // pricing a TAO figure into them would put a reconstruction where the
+  // reconciliation needs a reading. `buildAccountStakeFlow` ignores the extra
+  // column, so the published stake-flow card is unchanged.
   const rows = await r2SqlQuery(
     env,
     `SELECT netuid, event_kind, SUM(amount_tao) AS total_tao, ` +
+      `SUM(alpha_amount) AS total_alpha, ` +
       `COUNT(*) AS event_count, MAX(observed_at) AS last_observed ` +
       `FROM chain.account_events ` +
       `WHERE (hotkey = '${addr}' OR coldkey = '${addr}') AND ${kind} ` +
@@ -309,6 +318,10 @@ export async function loadAccountStakeFlowColdTier(
   return {
     data: buildAccountStakeFlow(coalesced, ss58, { window: label }),
     generatedAt: latestObservedIso(rows),
+    // The raw grouped rows, so a caller needing the alpha leg does not have to
+    // re-read the table. Returned beside the card rather than folded into it,
+    // because the card's shape is a published contract.
+    rows,
   };
 }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1661,6 +1661,10 @@ import {
   SUBNET_WALLETS_FIELD_SOURCES,
 } from "./wallets-load.ts";
 import {
+  ownerCutFlowLegs,
+  OWNER_CUT_FLOW_WINDOW,
+} from "./owner-cut-disposition.ts";
+import {
   GetSubnetOwnerCutInputSchema,
   GetSubnetOwnerCutOutputSchema,
   GetSubnetWalletsInputSchema,
@@ -9607,6 +9611,28 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           .loadNetworkParameters ?? loadNetworkParameters;
       const parameters = await loadParams(ctx.env as never);
       const ownerCut = parameters?.subnet_owner_cut_effective;
+      // #10930: the same flow read REST does, from the same cold-tier
+      // function over the same window. Wiring this on one surface only would
+      // have left an agent and a browser disagreeing about whether a subnet's
+      // owner has moved anything -- the divergence class this repo keeps
+      // finding, and the issue names it as a deliverable.
+      const ownerColdkey =
+        typeof economics?.owner_coldkey === "string" && economics.owner_coldkey
+          ? economics.owner_coldkey
+          : null;
+      // Injected off ctx exactly like loadNetworkParameters above, so a test
+      // drives the flow read without a lakehouse binding -- the same seam REST
+      // gets through its `deps` argument. Without it this arm is unreachable
+      // in the suite, and an unreachable arm reads as a tested one.
+      const loadFlows =
+        (ctx as { loadStakeFlow?: typeof loadAccountStakeFlowColdTier })
+          .loadStakeFlow ?? loadAccountStakeFlowColdTier;
+      const flows = ownerColdkey
+        ? await loadFlows(ctx.env as never, ownerColdkey, {
+            window: OWNER_CUT_FLOW_WINDOW,
+          })
+        : null;
+      const legs = ownerCutFlowLegs(flows?.rows ?? null, netuid);
       const view = loadSubnetOwnerCut({
         netuid,
         window_days: ATTRIBUTION_WINDOW_DAYS,
@@ -9615,6 +9641,8 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         // #10926: the rate. Without it `accrual.usd` was null on every MCP
         // call while REST priced the same subnet from the same index.
         usd_per_tao: await mcpUsdPerTao(ctx),
+        unstaked_alpha: legs.observed ? legs.unstaked_alpha : null,
+        flows_observed: legs.observed,
       });
       return {
         schema_version: 1,

--- a/src/owner-cut-disposition.ts
+++ b/src/owner-cut-disposition.ts
@@ -80,6 +80,16 @@ export interface DispositionResult {
   notes: string[];
 }
 
+/**
+ * The flow window the disposition reads, as a stake-flow window LABEL.
+ *
+ * Must resolve to the same span as the accrual's `ATTRIBUTION_WINDOW_DAYS`
+ * (30). Named here, beside the classifier that depends on the alignment,
+ * rather than spelled at the call site -- requirement 4 of #10930 is that the
+ * windows line up, and a literal at one of two call sites is how they stop.
+ */
+export const OWNER_CUT_FLOW_WINDOW = "30d";
+
 /** Alpha is 9dp on chain; anything under this is rounding, not a gap. */
 export const DISPOSITION_TOLERANCE_ALPHA = 1e-6;
 
@@ -144,6 +154,21 @@ export function classifyOwnerCutDisposition(
     };
   }
 
+  // #10930: the two things a reader must not conclude from a populated
+  // disposition, stated in the payload rather than left to the field names.
+  // These ride on EVERY observed classification, because the row that gets
+  // quoted is the one with numbers in it.
+  notes.push(
+    "`unstaked` means alpha left stake over this window. It does NOT mean " +
+      "sold: on dTAO removing stake returns TAO through the subnet's own " +
+      "pool, and this surface reports the movement, not an intent behind it",
+  );
+  notes.push(
+    "scoped to the subnet's declared owner_coldkey only. An owner operating " +
+      "several addresses would show less movement here than they made, and " +
+      "resolving which other addresses are theirs is not done on this surface",
+  );
+
   const unstaked = finite(input.unstaked_alpha) ?? 0;
   const transferred = finite(input.transferred_alpha) ?? 0;
   const burned = finite(input.burned_alpha) ?? 0;
@@ -204,5 +229,49 @@ export function classifyOwnerCutDisposition(
     residual_alpha: round9(residual),
     reconciles: Math.abs(residual) <= DISPOSITION_TOLERANCE_ALPHA,
     notes,
+  };
+}
+
+/**
+ * The alpha legs of one subnet's stake flow for the owner address (#10930).
+ *
+ * PURE. Takes the grouped `(netuid, event_kind)` rows the stake-flow cold-tier
+ * read already returns and picks the ONE subnet's alpha sums out of them —
+ * there is no second flow reader here, because a second reader is a second
+ * window, a second filter and a second chance to disagree.
+ *
+ * ALPHA, NOT TAO. `account_events` carries both units per row and the buckets
+ * are alpha-denominated, so this reads `alpha_amount`. Pricing the TAO column
+ * into an alpha bucket would put a reconstruction where the reconciliation
+ * needs a reading, and the residual would then be an artefact of the price
+ * rather than a statement about the owner.
+ *
+ * `observed: false` when the read returned nothing AT ALL — which is different
+ * from a subnet whose owner moved nothing, and the caller must keep them
+ * apart: the first resolves to `unresolved`, the second to a measured 0.
+ */
+export function ownerCutFlowLegs(
+  rows: Array<Record<string, unknown>> | null | undefined,
+  netuid: number,
+): { observed: boolean; staked_alpha: number; unstaked_alpha: number } {
+  if (!Array.isArray(rows)) {
+    return { observed: false, staked_alpha: 0, unstaked_alpha: 0 };
+  }
+  let staked = 0;
+  let unstaked = 0;
+  for (const row of rows) {
+    if (Number(row?.netuid) !== netuid) continue;
+    const alpha = Number(row?.total_alpha);
+    if (!Number.isFinite(alpha) || alpha < 0) continue;
+    if (row?.event_kind === "StakeAdded") staked += alpha;
+    else if (row?.event_kind === "StakeRemoved") unstaked += alpha;
+  }
+  // The READ happened even when this subnet has no rows in it — an owner who
+  // moved nothing is a measurement, and reporting it as unread would leave a
+  // real answer sitting in `unresolved` forever.
+  return {
+    observed: true,
+    staked_alpha: round9(staked),
+    unstaked_alpha: round9(unstaked),
   };
 }

--- a/tests/owner-cut-disposition.test.ts
+++ b/tests/owner-cut-disposition.test.ts
@@ -12,6 +12,7 @@ import {
   classifyOwnerCutDisposition,
   DISPOSITION_BUCKETS,
   DISPOSITION_TOLERANCE_ALPHA,
+  ownerCutFlowLegs,
 } from "../src/owner-cut-disposition.ts";
 
 const BASE = { netuid: 64, accrued_alpha: 1000, flows_observed: true };
@@ -153,5 +154,146 @@ describe("five buckets, not six", () => {
     assert.equal(r.buckets.unstaked, 1000);
     assert.equal(r.buckets["held-as-stake"], 0);
     assert.equal(r.reconciles, true);
+  });
+});
+
+// ── #10930: the flow legs, and what a populated disposition may not say ─────
+describe("ownerCutFlowLegs", () => {
+  const rows = [
+    { netuid: 64, event_kind: "StakeAdded", total_alpha: 100, total_tao: 9 },
+    { netuid: 64, event_kind: "StakeRemoved", total_alpha: 40, total_tao: 3.5 },
+    { netuid: 7, event_kind: "StakeRemoved", total_alpha: 999, total_tao: 80 },
+  ];
+
+  test("picks ONE subnet's alpha legs out of the grouped rows", () => {
+    const legs = ownerCutFlowLegs(rows, 64);
+    assert.equal(legs.observed, true);
+    assert.equal(legs.staked_alpha, 100);
+    assert.equal(legs.unstaked_alpha, 40);
+  });
+
+  test("READS ALPHA, NOT TAO", () => {
+    // The buckets are alpha-denominated. Pricing the TAO column into them
+    // would make the residual an artefact of the price rather than a
+    // statement about the owner -- and the two columns differ by ~11x here,
+    // so a mix-up is not subtle once you look for it.
+    const legs = ownerCutFlowLegs(rows, 64);
+    assert.notEqual(legs.unstaked_alpha, 3.5, "that is the TAO column");
+    assert.equal(legs.unstaked_alpha, 40);
+  });
+
+  test("another subnet's rows never leak in", () => {
+    // netuid 7 unstaked 999 alpha in the same read. Attributing that to 64
+    // would report a sale the owner did not make on this subnet.
+    assert.equal(ownerCutFlowLegs(rows, 64).unstaked_alpha, 40);
+    assert.equal(ownerCutFlowLegs(rows, 7).unstaked_alpha, 999);
+  });
+
+  test("AN EMPTY READ IS OBSERVED; A FAILED READ IS NOT", () => {
+    // The distinction the whole surface turns on. An owner who moved nothing
+    // is a MEASUREMENT and must reach a 0 bucket; a read that did not happen
+    // must reach `unresolved`. Both look like "no rows for this subnet".
+    assert.deepEqual(ownerCutFlowLegs([], 64), {
+      observed: true,
+      staked_alpha: 0,
+      unstaked_alpha: 0,
+    });
+    assert.equal(ownerCutFlowLegs(null, 64).observed, false);
+    assert.equal(ownerCutFlowLegs(undefined, 64).observed, false);
+  });
+
+  test("unusable amounts are skipped rather than read as zero", () => {
+    const legs = ownerCutFlowLegs(
+      [
+        { netuid: 64, event_kind: "StakeRemoved", total_alpha: null },
+        { netuid: 64, event_kind: "StakeRemoved", total_alpha: -5 },
+        { netuid: 64, event_kind: "StakeRemoved", total_alpha: "nope" },
+        { netuid: 64, event_kind: "StakeRemoved", total_alpha: 10 },
+        { netuid: 64, event_kind: "SomethingElse", total_alpha: 500 },
+      ],
+      64,
+    );
+    assert.equal(legs.unstaked_alpha, 10);
+  });
+});
+
+describe("a populated disposition (#10930)", () => {
+  const observed = (over = {}) =>
+    classifyOwnerCutDisposition({
+      netuid: 64,
+      window_days: 30,
+      accrued_alpha: 100,
+      flows_observed: true,
+      unstaked_alpha: 40,
+      held_alpha: 60,
+      ...over,
+    });
+
+  test("reconciles when the buckets cover the accrual", () => {
+    const out = observed();
+    assert.equal(out.buckets.unstaked, 40);
+    assert.equal(out.buckets["held-as-stake"], 60);
+    assert.equal(out.buckets.unresolved, 0);
+    assert.equal(out.residual_alpha, 0);
+    assert.equal(out.reconciles, true);
+  });
+
+  test("A PARTIAL ATTRIBUTION LEAVES THE REMAINDER UNRESOLVED", () => {
+    // Requirement 3: `unresolved` is not a bucket of last resort to minimise,
+    // and the remainder is never redistributed to make the row look complete.
+    const out = observed({ held_alpha: null });
+    assert.equal(out.buckets.unstaked, 40);
+    assert.equal(out.buckets["held-as-stake"], null);
+    assert.equal(out.buckets.unresolved, 60);
+    assert.equal(out.reconciles, false);
+    // ...and it is NOT proportionally spread across the other buckets.
+    assert.equal(out.buckets["transferred-out"], 0);
+    assert.equal(out.buckets.burned, 0);
+  });
+
+  test("A ZERO-MOVEMENT OWNER IS MEASURED 0, NOT null", () => {
+    // The issue's second falsifiable claim: an owner who moved nothing and an
+    // unread window must be distinguishable in the payload.
+    const moved = observed({ unstaked_alpha: 0, held_alpha: 100 });
+    assert.equal(moved.buckets.unstaked, 0, "measured zero");
+    assert.equal(moved.reconciles, true);
+
+    const unread = classifyOwnerCutDisposition({
+      netuid: 64,
+      window_days: 30,
+      accrued_alpha: 100,
+      flows_observed: false,
+    });
+    assert.equal(unread.buckets.unstaked, null, "unread stays null");
+    assert.equal(unread.buckets.unresolved, 100);
+    assert.equal(unread.reconciles, false);
+  });
+
+  test("THE NOTES REFUSE THE TWO READINGS THE NUMBERS INVITE", () => {
+    // Requirement 5 (movement, not intent) and 6 (one address only), in the
+    // payload rather than the docs -- on the populated row, which is the one
+    // that gets quoted.
+    const notes = observed().notes.join(" ");
+    assert.match(notes, /does NOT mean sold/i);
+    assert.match(notes, /owner_coldkey only/);
+  });
+
+  test("the stale 'not read' note is gone once they are read", () => {
+    // Requirement: keep notes[] truthful. Leaving "streams not read for this
+    // window" beside populated buckets is a payload contradicting itself.
+    assert.equal(
+      observed().notes.some((n) => n.includes("not read for this window")),
+      false,
+    );
+    assert.equal(
+      classifyOwnerCutDisposition({
+        netuid: 64,
+        window_days: 30,
+        accrued_alpha: 100,
+        flows_observed: false,
+      }).notes.some((n) => n.includes("not read for this window")),
+      true,
+      "and it is still there when they genuinely were not",
+    );
   });
 });

--- a/tests/wallets-api-surface.test.ts
+++ b/tests/wallets-api-surface.test.ts
@@ -198,10 +198,13 @@ describe("GET /api/v1/subnets/{netuid}/owner-cut", () => {
     assert.equal(((await jsonBody(res)).error as Row)?.code, "invalid_netuid");
   });
 
-  test("prices the accrual and reports the disposition as UNRESOLVED", async () => {
-    // The route does not read the stake streams, so every accrued alpha is
-    // unresolved. Reporting `held-as-stake` from a read we did not perform is
-    // the false negative #10485 exists to prevent.
+  test("an UNAVAILABLE flow read leaves the accrual unresolved", async () => {
+    // The route DOES read the stake streams now (#10930) -- but this env binds
+    // no lakehouse, so the cold-tier read answers null and the disposition
+    // stays unresolved. That is the correct answer for a read that could not
+    // happen: reporting `held-as-stake` from a read we did not perform is the
+    // false negative #10485 exists to prevent, and it must survive the streams
+    // being wired.
     const res = await handleSubnetOwnerCut(
       req("/api/v1/subnets/64/owner-cut"),
       artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
@@ -220,6 +223,70 @@ describe("GET /api/v1/subnets/{netuid}/owner-cut", () => {
     assert.equal((disposition.buckets as Row)["held-as-stake"], null);
     assert.ok(((disposition.buckets as Row).unresolved as number) > 0);
     assert.equal(disposition.reconciles, false);
+  });
+
+  test("A REAL FLOW READ POPULATES THE UNSTAKED BUCKET", async () => {
+    // #10930's headline: the classifier has been complete since #10485 and was
+    // handed nothing. `loadFlows` is injected the same way `loadParams` is, so
+    // the wiring is driven without a lakehouse binding.
+    const res = await handleSubnetOwnerCut(
+      req("/api/v1/subnets/64/owner-cut"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      64,
+      {
+        ...params(OWNER_CUT_EFFECTIVE),
+        loadFlows: async () =>
+          ({
+            data: null,
+            generatedAt: null,
+            rows: [
+              { netuid: 64, event_kind: "StakeAdded", total_alpha: 900 },
+              { netuid: 64, event_kind: "StakeRemoved", total_alpha: 250 },
+              // Another subnet in the same read, which must not leak in.
+              { netuid: 7, event_kind: "StakeRemoved", total_alpha: 5000 },
+            ],
+          }) as never,
+      },
+    );
+    assert.equal(res.status, 200);
+    const disposition = ((await jsonBody(res)).data as Row).disposition as Row;
+    const buckets = disposition.buckets as Row;
+    assert.equal(buckets.unstaked, 250, "netuid 7's 5000 must not appear");
+    // Held is still unread on this surface, so the remainder is unresolved
+    // rather than assumed -- a partial attribution is a real answer.
+    assert.equal(buckets["held-as-stake"], null);
+    assert.ok((buckets.unresolved as number) > 0);
+    assert.equal(disposition.reconciles, false);
+  });
+
+  test("an owner who moved NOTHING reports a measured 0", async () => {
+    // The distinction the payload has to carry: a read that returned no rows
+    // for this subnet is a measurement, and it must not sit in `unresolved`
+    // alongside a read that never happened.
+    const res = await handleSubnetOwnerCut(
+      req("/api/v1/subnets/64/owner-cut"),
+      artifactEnv({ [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] } }),
+      64,
+      {
+        ...params(OWNER_CUT_EFFECTIVE),
+        loadFlows: async () =>
+          ({ data: null, generatedAt: null, rows: [] }) as never,
+      },
+    );
+    const disposition = ((await jsonBody(res)).data as Row).disposition as Row;
+    assert.equal(
+      (disposition.buckets as Row).unstaked,
+      0,
+      "measured, not null",
+    );
+    const notes = (disposition.notes as string[]).join(" ");
+    assert.equal(
+      notes.includes("not read for this window"),
+      false,
+      "the streams WERE read; the note would contradict the payload",
+    );
+    assert.match(notes, /does NOT mean sold/i);
+    assert.match(notes, /owner_coldkey only/);
   });
 
   test("reconstructs the share from the runtime default, and accrues", async () => {
@@ -320,6 +387,34 @@ describe("MCP get_subnet_owner_cut", () => {
     // become a zero-dollar accrual.
     assert.equal((out.accrual as Row).usd, null);
     assert.equal(((out.disposition as Row).buckets as Row).unstaked, null);
+  });
+
+  test("THE MCP TOOL READS THE SAME FLOWS AS REST", async () => {
+    // #10930's deliverable: not a REST-only disposition. Same cold-tier
+    // function, same window, same classifier -- so an agent and a browser
+    // cannot disagree about whether a subnet's owner has moved anything.
+    const out = (await tool("get_subnet_owner_cut").handler({ netuid: 64 }, {
+      ...(mcpCtx({
+        [ECONOMICS_PATH]: { subnets: [SN64_ECONOMICS] },
+      }) as object),
+      loadStakeFlow: async () => ({
+        data: null,
+        generatedAt: null,
+        rows: [
+          { netuid: 64, event_kind: "StakeRemoved", total_alpha: 250 },
+          { netuid: 7, event_kind: "StakeRemoved", total_alpha: 5000 },
+        ],
+      }),
+    } as never)) as Row;
+    const disposition = out.disposition as Row;
+    assert.equal(
+      (disposition.buckets as Row).unstaked,
+      250,
+      "netuid 7's rows must not leak into this subnet",
+    );
+    const notes = (disposition.notes as string[]).join(" ");
+    assert.match(notes, /does NOT mean sold/i);
+    assert.equal(notes.includes("not read for this window"), false);
   });
 
   test("reconstructs the share rather than reporting it unread", async () => {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -101,6 +101,10 @@ import {
 } from "../../src/subnet-yield.ts";
 import { buildSubnetEmissionSplitHistory } from "../../src/emission-split.ts";
 import { buildSubnetOwnerCapture } from "../../src/owner-capture.ts";
+import {
+  ownerCutFlowLegs,
+  OWNER_CUT_FLOW_WINDOW,
+} from "../../src/owner-cut-disposition.ts";
 import { buildSubnetMinerFairness } from "../../src/miner-fairness.ts";
 import {
   DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
@@ -7372,7 +7376,10 @@ export async function handleSubnetOwnerCut(
   netuid: number,
   // Injected the same way /network/parameters' own siblings inject it, so the
   // share can be driven in a test without a KV binding or an RPC.
-  deps: { loadParams?: typeof loadNetworkParameters } = {},
+  deps: {
+    loadParams?: typeof loadNetworkParameters;
+    loadFlows?: typeof loadAccountStakeFlowColdTier;
+  } = {},
 ) {
   if (!Number.isInteger(netuid) || netuid < 0 || netuid > 65535) {
     return errorResponse(
@@ -7392,12 +7399,42 @@ export async function handleSubnetOwnerCut(
   // rather than an RPC per request.
   const parameters = await (deps.loadParams ?? loadNetworkParameters)(env);
   const ownerCut = parameters?.subnet_owner_cut_effective;
+  // #10930: THE FLOW STREAMS, FINALLY READ. The disposition classifier has been
+  // complete since #10485 and was handed nothing, so every subnet answered
+  // `unresolved` with a note saying the streams "were not read for this
+  // window" -- accurate about the handler and wrong about what was possible.
+  //
+  // Reuses the stake-flow cold-tier read rather than adding a second one, and
+  // takes its ALPHA leg: the buckets are alpha-denominated, and pricing the TAO
+  // column into them would make the residual an artefact of the price rather
+  // than a statement about the owner.
+  //
+  // ONE COLDKEY, the declared one. An owner operating several addresses is out
+  // of scope and the payload says so rather than quietly under-reporting.
+  const ownerColdkey =
+    typeof row?.owner_coldkey === "string" && row.owner_coldkey
+      ? row.owner_coldkey
+      : null;
+  const flows = ownerColdkey
+    ? await (deps.loadFlows ?? loadAccountStakeFlowColdTier)(
+        env,
+        ownerColdkey,
+        {
+          // The SAME window as the accrual. A 30-day accrual against a 7-day flow
+          // read is a reconciliation that cannot balance.
+          window: OWNER_CUT_FLOW_WINDOW,
+        },
+      )
+    : null;
+  const legs = ownerCutFlowLegs(flows?.rows ?? null, netuid);
   const view = loadSubnetOwnerCut({
     netuid,
     window_days: ATTRIBUTION_WINDOW_DAYS,
     economics: row,
     owner_cut: typeof ownerCut === "number" ? ownerCut : null,
     usd_per_tao: await usdPerTaoOrNull(env),
+    unstaked_alpha: legs.observed ? legs.unstaked_alpha : null,
+    flows_observed: legs.observed,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
Closes #10930

## The schema was complete and the handler filled none of it

Every subnet answered:

```json
"buckets": { "held-as-stake": null, "unstaked": null, "transferred-out": null,
             "burned": null, "unresolved": 38879.011215381 },
"reconciles": false,
"notes": ["stake-move and transfer streams not read for this window, so no
          disposition can be attributed; this is unresolved, not held"]
```

The classifier has been complete since #10485. The note was accurate about the
handler and wrong about what was possible — the streams exist and answer.

## Alpha, not TAO — the part that could have been confidently wrong

The buckets are alpha-denominated; the stake-flow read summed `amount_tao`.
Feeding TAO into an alpha bucket produces a full-looking reconciliation whose
residual is an artefact of the **price** rather than a statement about the
owner — the exact class of confident-wrong answer this epic exists to avoid.

`account_events` carries `alpha_amount` on every StakeAdded/StakeRemoved row
(verified against live `/chain/alpha-volume`, which reports 13.1M alpha of
volume from that column), so the fix is a **column, not a conversion**. The
existing cold-tier read now sums both units in one query — the same "one query
yields both" `src/alpha-volume.ts` already does — and the disposition takes the
alpha leg. `buildAccountStakeFlow` ignores the extra column, so the published
stake-flow card is unchanged.

There is a test asserting the alpha figure is **not** the TAO one; the two
differ ~11x in the fixture, so a mix-up is unmissable once something looks.

## One reader, one window

`ownerCutFlowLegs` is pure and picks one subnet's legs out of the rows
`loadAccountStakeFlowColdTier` already returns — no second flow reader, because
a second reader is a second window, a second filter and a second chance to
disagree. `OWNER_CUT_FLOW_WINDOW` is named beside the classifier that depends
on it: a 30-day accrual against a 7-day flow read is a reconciliation that
cannot balance (requirement 4).

Another subnet's rows appearing in the same read must not leak in — asserted at
both the unit and surface level.

## The distinction the surface turns on

| state | bucket | why |
| --- | --- | --- |
| read returned no rows for this subnet | `unstaked: 0` | a **measurement** — that owner moved nothing |
| read did not happen | `unstaked: null`, all in `unresolved` | not a measurement |

Both look like "no rows". `ownerCutFlowLegs` returns `observed` separately from
the sums so a caller cannot collapse them, and there is a test for each — this
is the issue's second falsifiable claim.

## Nothing was done to make `reconciles` look better

`held-as-stake` is still unread on this surface, so a subnet with real
unstaking now reports a populated `unstaked`, a **null** `held-as-stake`, and
the remainder in `unresolved` — `reconciles: false`. That is the honest state,
not a failure, and there is a test asserting the remainder is not spread
proportionally across the other buckets to tie the row out (requirement 3).

## Two notes on every populated row

Because the row that gets quoted is the one with numbers in it:

- **`unstaked` is movement, not a sale.** On dTAO removing stake returns TAO
  through the subnet's own pool; this reports the movement, not an intent
  (requirement 5).
- **Declared `owner_coldkey` only.** An owner operating several addresses shows
  less movement here than they made, and resolving which addresses are theirs
  is not done on this surface (requirement 6).

The stale "not read" note is gone where the streams were read and still fires
where they were not — asserted **both** ways, because a payload contradicting
its own numbers is worse than a blank one. The existing surface test whose
rationale said "the route does not read the stake streams" was rewritten rather
than left standing: it still passes (the hermetic env binds no lakehouse) but
it was passing for a reason that had stopped being true.

## MCP moves with REST

Same function, same window, same classifier — the issue is explicit that this
must not ship REST-only. Driven in tests through a ctx seam mirroring the one
`loadNetworkParameters` already uses there; without it the populated arm was
unreachable in the suite, and an unreachable arm reads as a tested one. No
GraphQL exposure exists for this route, so REST + MCP is the whole surface.

## Verification

**20,402 tests pass** (883 files, unsharded), full CI step set green including
`scan:public-safety`, **patch coverage 100%** (58/58 lines and branches,
diff-intersected). Rebuilt on current main with zero drift.

One unrelated flake seen mid-run (`tests/r2-upload.test.ts` under parallelism);
it passes in isolation and touches nothing here.