### PR TITLE
fix(seo): withhold the three unbounded per-entity spaces from crawlers, on both hosts

### DIFF
--- a/apps/ui/src/server.robots.test.ts
+++ b/apps/ui/src/server.robots.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { robotsBody } from "./server";
+
+// #11002. These assert CRAWL BEHAVIOUR, not the text of the file. A substring
+// check ("does the body contain Disallow: /accounts/") passes just as happily on
+// a rule set whose precedence is backwards, and precedence is the whole
+// difference between withholding 8.8M block pages and de-indexing the site.
+
+/**
+ * Does one robots.txt rule pattern match `path`?
+ *
+ * Only the two forms this file emits: a plain prefix, and RFC 9309's `$`
+ * end-anchor. No `*` — nothing here uses one, and implementing a wildcard the
+ * production file never emits would be testing fiction.
+ */
+function ruleMatches(pattern: string, path: string): boolean {
+  return pattern.endsWith("$") ? path === pattern.slice(0, -1) : path.startsWith(pattern);
+}
+
+/**
+ * RFC 9309 §2.2.2 evaluation: the most specific (longest) matching rule wins;
+ * on a tie, Allow wins; if nothing matches, the path is allowed.
+ */
+function isCrawlable(body: string, path: string): boolean {
+  let best: { length: number; allow: boolean } = { length: -1, allow: true };
+  for (const line of body.split("\n")) {
+    const match = /^(Allow|Disallow):\s*(\S+)$/.exec(line.trim());
+    if (!match) continue;
+    const [, kind, pattern] = match;
+    if (!ruleMatches(pattern, path)) continue;
+    const allow = kind === "Allow";
+    if (pattern.length > best.length || (pattern.length === best.length && allow)) {
+      best = { length: pattern.length, allow };
+    }
+  }
+  return best.allow;
+}
+
+const CANONICAL = robotsBody("metagraph.sh");
+
+describe("apex robots.txt withholds only the unbounded spaces (#11002)", () => {
+  it("keeps the registry surfaces crawlable — the posture is still allow-all", () => {
+    for (const path of [
+      "/",
+      "/subnets",
+      "/subnets/64",
+      "/apis",
+      "/apis/endpoints",
+      "/docs/economics",
+      "/providers/opentensor",
+      "/health",
+      "/status",
+    ]) {
+      expect(isCrawlable(CANONICAL, path), path).toBe(true);
+    }
+  });
+
+  it("withholds per-block, per-extrinsic and per-account detail", () => {
+    for (const path of [
+      "/blocks/8544380",
+      "/blocks/0x093fa22c78426e23dd70e69ab9403f792b125b289402fe67f19f96af9392dd0a",
+      "/extrinsics/0x58e19156f8fdadbf60f70aaf664e80aa80c9ebb705dffe6a919048798c5c7af0",
+      "/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+    ]) {
+      expect(isCrawlable(CANONICAL, path), path).toBe(false);
+    }
+  });
+
+  // The regression this pair exists to catch: the hub indexes live one segment
+  // away from the withheld detail routes and are the pages actually worth
+  // ranking. A `Disallow: /chain/` slip, or dropping the `$` from the accounts
+  // re-allow, silently de-indexes them.
+  it("leaves the hub indexes and the accounts index itself crawlable", () => {
+    for (const path of [
+      "/chain",
+      "/chain/blocks",
+      "/chain/extrinsics",
+      "/chain/events",
+      "/accounts",
+      "/accounts/",
+    ]) {
+      expect(isCrawlable(CANONICAL, path), path).toBe(true);
+    }
+  });
+
+  it("advertises its own sitemap", () => {
+    expect(CANONICAL).toContain("Sitemap: https://metagraph.sh/sitemap.xml");
+  });
+});
+
+describe("non-canonical hosts are withheld whole (#11002)", () => {
+  // testnet.metagraph.sh is served by this same Worker; #9004 found the
+  // account's workers.dev subdomain serving the entire site in parallel too.
+  const TESTNET = robotsBody("testnet.metagraph.sh");
+
+  it("blocks every path, including the ones the apex publishes", () => {
+    for (const path of ["/", "/subnets", "/chain/blocks", "/accounts", "/docs"]) {
+      expect(isCrawlable(TESTNET, path), path).toBe(false);
+    }
+  });
+
+  it("advertises NO sitemap — a robots.txt may only point at its own host", () => {
+    expect(TESTNET).not.toContain("Sitemap:");
+  });
+
+  it("treats an unrecognised host as non-canonical, so a new one fails closed", () => {
+    // The #9004 class: a hostname nobody added to an allowlist should not become
+    // indexable just by existing.
+    for (const host of [
+      "metagraphed-ui.zeronode.workers.dev",
+      "preview.metagraph.sh",
+      "metagraph.sh.evil.example",
+    ]) {
+      expect(isCrawlable(robotsBody(host), "/subnets"), host).toBe(false);
+    }
+  });
+
+  it("still allows the apex itself — the guard is exact-host, not a prefix", () => {
+    expect(isCrawlable(robotsBody("metagraph.sh"), "/subnets")).toBe(true);
+  });
+});

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -116,7 +116,7 @@ const SITEMAP_STATIC_PATHS = [
 // else (the request falls through to the SSR app).
 async function handleDiscovery(request: Request): Promise<Response | null> {
   const url = new URL(request.url);
-  if (url.pathname === "/robots.txt") return buildRobots();
+  if (url.pathname === "/robots.txt") return buildRobots(url.host);
   if (url.pathname === "/sitemap.xml") return buildSitemap();
   if (!DISCOVERY_PROXY_PATHS.has(url.pathname)) return null;
   if (request.method !== "GET" && request.method !== "HEAD") {
@@ -158,20 +158,79 @@ function buildDiscoveryResponseHeaders(pathname: string, upstreamHeaders: Header
   return headers;
 }
 
-// robots.txt for the apex. metagraphed is a public, agent-ready registry, so all
-// crawlers (including AI agents) are welcome — the machine API + discovery
-// surfaces live on api.metagraph.sh (which serves its own robots.txt). Served
-// here by the Worker because Cloudflare Managed robots.txt is disabled for the
-// zone; advertises the human-page sitemap so crawlers can find it.
-function buildRobots(): Response {
-  const body =
+/**
+ * The one host whose pages are canonical.
+ *
+ * This Worker answers on more than one hostname — `testnet.metagraph.sh` today,
+ * and historically the account's leftover `*.workers.dev` subdomain, which #9004
+ * found serving the entire site in parallel. Every non-canonical hostname is
+ * duplicate content of the apex by construction: same routes, same Worker, and
+ * (for testnet) data nobody searches for.
+ *
+ * Derived from SITE_ORIGIN rather than written out again so the two can never
+ * drift, and matched as an exact host so a NEW hostname is non-canonical by
+ * default. That default is the point: #9004's duplicate host was live and
+ * indexable for as long as it took someone to notice, and an allowlist-of-one
+ * is what makes the next one fail closed instead.
+ */
+const CANONICAL_HOST = new URL(SITE_ORIGIN).host;
+
+/**
+ * robots.txt. Served here by the Worker because Cloudflare Managed robots.txt is
+ * disabled for the zone.
+ *
+ * metagraphed is a public, agent-ready registry, so on the canonical host all
+ * crawlers (including AI agents) stay welcome — `Allow: /` is the posture and
+ * #11002 does not retreat from it. What it withholds is the three UNBOUNDED
+ * per-entity spaces: ~8.8M blocks at the head growing ~7,200/day, every
+ * extrinsic inside each of them, and every ss58 that has ever touched the chain.
+ * None of the three is in the sitemap, each render fans out to the most
+ * expensive query in the project (#11001), and the crawl was measured driving
+ * the SSR rate-limit rejections in #11000. Crawling all of it is a crawl-budget
+ * sink that competes with the registry pages that ARE worth ranking.
+ *
+ * The prefixes are exact, and the three do not behave identically:
+ *   - `/blocks/` and `/extrinsics/` are safe to withhold whole. Their index
+ *     routes are `/chain/blocks` and `/chain/extrinsics` (both in
+ *     SITEMAP_STATIC_PATHS); the bare `/blocks/` and `/extrinsics/` paths are
+ *     permanent redirect stubs into that hub (routes/blocks.index.tsx et al), so
+ *     no live page is lost.
+ *   - `/accounts/` is NOT a stub — it is a real index page, and the one a pasted
+ *     EVM address lands on (`/accounts?h160=…`, metagraphed-infra#373). So the
+ *     index is re-permitted by an end-anchored `Allow`, which beats the broader
+ *     `Disallow` under RFC 9309's longest-match precedence, while every
+ *     `/accounts/<ss58>` below it stays withheld.
+ */
+export function robotsBody(host: string): string {
+  if (host !== CANONICAL_HOST) {
+    // No Sitemap line: a robots.txt may only advertise sitemaps for its OWN
+    // host, so the apex's sitemap URL was never valid here in the first place.
+    return (
+      `# Non-canonical host — this is a duplicate of ${SITE_ORIGIN}, which is\n` +
+      `# the only hostname whose pages should be crawled or indexed.\n` +
+      `User-agent: *\n` +
+      `Disallow: /\n`
+    );
+  }
+  return (
     `# metagraph.sh — public Bittensor subnet integration registry.\n` +
     `# AI agents welcome; the machine API + discovery live on api.metagraph.sh.\n` +
     `User-agent: *\n` +
     `Allow: /\n` +
+    `# Unbounded per-entity detail: not in the sitemap, one uncached scan per URL.\n` +
+    `# The hub indexes (/chain/blocks, /chain/extrinsics) stay crawlable, as does\n` +
+    `# the /accounts index itself — only the per-account pages below it do not.\n` +
+    `Disallow: /blocks/\n` +
+    `Disallow: /extrinsics/\n` +
+    `Disallow: /accounts/\n` +
+    `Allow: /accounts/$\n` +
     `\n` +
-    `Sitemap: ${SITE_ORIGIN}/sitemap.xml\n`;
-  return new Response(body, {
+    `Sitemap: ${SITE_ORIGIN}/sitemap.xml\n`
+  );
+}
+
+function buildRobots(host: string): Response {
+  return new Response(robotsBody(host), {
     status: 200,
     headers: {
       "content-type": "text/plain; charset=utf-8",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,11 @@
 User-agent: *
 Allow: /
+# Unbounded per-entity detail: one uncached scan per URL, not in the sitemap.
+# The collection routes (/api/v1/blocks, /api/v1/extrinsics,
+# /api/v1/accounts) stay crawlable, as do the bounded rollups below them.
+Disallow: /api/v1/blocks/
+Allow: /api/v1/blocks/summary
+Disallow: /api/v1/extrinsics/
+Disallow: /api/v1/accounts/
+Allow: /api/v1/accounts/top-holders
 Sitemap: https://api.metagraph.sh/sitemap.xml

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2341,9 +2341,37 @@ await fs.writeFile(
   sitemapXml,
   "utf8",
 );
+// #11002: allow-all EXCEPT the three unbounded per-entity history spaces,
+// mirroring the apex's own rule in apps/ui/src/server.ts's robotsBody(). Same
+// reasoning: /api/v1/blocks/{ref} (+ its /extrinsics, /events, /chain-events
+// sub-resources), /api/v1/extrinsics/{hash} and /api/v1/accounts/{ss58} (+ its
+// 20 sub-resources) are unbounded, and each request is a full uncached lakehouse
+// scan (#11001) — so a crawl of that space is billed per URL, for pages no one
+// searches for.
+//
+// The COLLECTION routes are what the sitemap and llms.txt advertise and they all
+// stay open, because a trailing-slash prefix does not match the collection
+// itself: `Disallow: /api/v1/blocks/` leaves `/api/v1/blocks` crawlable. The two
+// BOUNDED routes that do sit under a disallowed prefix — /api/v1/blocks/summary
+// and /api/v1/accounts/top-holders — are re-permitted by a longer `Allow`, which
+// wins under RFC 9309's longest-match precedence.
+//
+// BOTH hosts need this. The apex is where the amplification happens (a crawled
+// page SSR-fans-out into these same routes); the API is where the cost lands.
+// Changing one and not the other leaves the walk fully open.
 await fs.writeFile(
   path.join(repoRoot, "public/robots.txt"),
-  `User-agent: *\nAllow: /\nSitemap: ${llmsApiBase}/sitemap.xml\n`,
+  `User-agent: *\n` +
+    `Allow: /\n` +
+    `# Unbounded per-entity detail: one uncached scan per URL, not in the sitemap.\n` +
+    `# The collection routes (/api/v1/blocks, /api/v1/extrinsics,\n` +
+    `# /api/v1/accounts) stay crawlable, as do the bounded rollups below them.\n` +
+    `Disallow: /api/v1/blocks/\n` +
+    `Allow: /api/v1/blocks/summary\n` +
+    `Disallow: /api/v1/extrinsics/\n` +
+    `Disallow: /api/v1/accounts/\n` +
+    `Allow: /api/v1/accounts/top-holders\n` +
+    `Sitemap: ${llmsApiBase}/sitemap.xml\n`,
   "utf8",
 );
 

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -224,4 +224,65 @@ describe("Discovery artifacts", () => {
     // Catches robots.txt and sitemap.xml drifting out of sync with each other.
     assert.equal(sitemapLine, `https://${PRIMARY_DOMAIN}/sitemap.xml`);
   });
+
+  // #11002. Asserts CRAWL BEHAVIOUR, not the text: a substring check passes just
+  // as happily on a rule set whose precedence is backwards, and precedence is
+  // the only thing keeping /api/v1/blocks/summary crawlable while the ~8.8M
+  // /api/v1/blocks/{ref} URLs beneath the same prefix are not. Mirrors
+  // apps/ui/src/server.robots.test.ts, which gates the apex's own copy — the two
+  // hosts are one policy and a change to either alone reopens the walk.
+  test("robots.txt withholds the unbounded per-entity spaces, not the collections", async () => {
+    const txt = await fs.readFile(path.join(publicDir, "robots.txt"), "utf8");
+
+    // RFC 9309 §2.2.2: longest matching rule wins, Allow wins a tie, no match
+    // means allowed.
+    const crawlable = (pathname: string) => {
+      let best = { length: -1, allow: true };
+      for (const line of txt.split("\n")) {
+        const rule = /^(Allow|Disallow):\s*(\S+)$/.exec(line.trim());
+        if (!rule) continue;
+        const [, kind, pattern] = rule;
+        const matches = pattern.endsWith("$")
+          ? pathname === pattern.slice(0, -1)
+          : pathname.startsWith(pattern);
+        if (!matches) continue;
+        const allow = kind === "Allow";
+        if (
+          pattern.length > best.length ||
+          (pattern.length === best.length && allow)
+        ) {
+          best = { length: pattern.length, allow };
+        }
+      }
+      return best.allow;
+    };
+
+    for (const p of [
+      "/api/v1/blocks/8803541",
+      "/api/v1/blocks/8803541/extrinsics",
+      "/api/v1/blocks/8803541/events",
+      "/api/v1/blocks/8803541/chain-events",
+      "/api/v1/extrinsics/0xa6fd0387b5e54ffe8cf753c10720a437e82ad7e4c47a33997cbd68b498d14d95",
+      "/api/v1/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "/api/v1/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY/transfers",
+    ]) {
+      assert.equal(crawlable(p), false, `${p} should be withheld`);
+    }
+
+    // The collections and the two bounded rollups that sit under a disallowed
+    // prefix — these are what the sitemap and llms.txt advertise.
+    for (const p of [
+      "/",
+      "/api/v1/blocks",
+      "/api/v1/blocks/summary",
+      "/api/v1/extrinsics",
+      "/api/v1/accounts",
+      "/api/v1/accounts/top-holders",
+      "/api/v1/subnets",
+      "/api/v1/agent-catalog",
+      "/metagraph/openapi.json",
+    ]) {
+      assert.equal(crawlable(p), true, `${p} should stay crawlable`);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Both hosts served `User-agent: * / Allow: /` with no exceptions, while neither sitemap advertises a single block, extrinsic or account URL. The only way a crawler reaches those pages is link discovery into a space that is unbounded (~8.8M blocks at the head, growing ~7,200/day, times two networks, times every extrinsic and every ss58 beneath them), costs a full uncached lakehouse scan per URL (#11001), and carries no index value.

Measured in Workers Observability on 2026-08-13: `meta-externalagent` walking `/api/v1/blocks/8803541` (3465 ms), `/api/v1/blocks/8800355` (2502 ms), `/api/v1/blocks/8720234` (937 ms), while the same crawl through `metagraph.sh` page renders drove the SSR rate-limit rejections in #11000.

`Allow: /` stays the posture. This withholds three prefixes, not the registry.

## What changed

**Both hosts, because they are one policy** — the apex is where the amplification happens (a crawled page SSR-fans-out into these routes), the API is where the cost lands. Changing either alone leaves the walk open.

| | withheld | still crawlable |
| --- | --- | --- |
| `metagraph.sh` | `/blocks/`, `/extrinsics/`, `/accounts/<ss58>` | `/chain/blocks`, `/chain/extrinsics`, `/chain/events`, `/accounts` + `/accounts/` |
| `api.metagraph.sh` | `/api/v1/blocks/`, `/api/v1/extrinsics/`, `/api/v1/accounts/` | `/api/v1/blocks`, `/api/v1/extrinsics`, `/api/v1/accounts`, `/api/v1/blocks/summary`, `/api/v1/accounts/top-holders` |

The collection routes survive because a trailing-slash prefix does not match the collection itself. The two bounded rollups that *do* sit beneath a disallowed prefix are re-permitted by a longer `Allow`, which wins under RFC 9309's longest-match precedence.

The three apex prefixes are not symmetric: `/blocks/` and `/extrinsics/` are withheld whole because their index routes are `/chain/blocks` and `/chain/extrinsics` and the bare paths are permanent redirect stubs (`routes/blocks.index.tsx`). `/accounts/` is a real index page — the one a pasted EVM address lands on (`/accounts?h160=…`) — so it is re-allowed by an end-anchored rule while every `/accounts/<ss58>` below it is not.

**Non-canonical hosts are withheld entirely.** This Worker also answers on `testnet.metagraph.sh`, which was serving the apex's robots.txt verbatim — including a `Sitemap:` line pointing at another host, which is invalid per RFC 9309, so testnet advertised no sitemap at all while remaining fully crawlable duplicate content. The host check is an exact match against `SITE_ORIGIN`, so a **new** hostname is non-canonical by default. That default is the point: #9004 found the account's leftover `workers.dev` subdomain serving the whole site in parallel, at 82% of `block-detail` traffic, for as long as it took someone to notice.

## Tests

Both suites assert **crawl behaviour** through an RFC 9309 evaluator (longest-match wins, `Allow` breaks a tie), not substring matches — precedence is the entire difference between withholding 8.8M pages and de-indexing the site, and a substring check passes just as happily on a rule set whose precedence is backwards.

Both were mutation-checked: dropping the `$` from the accounts re-allow makes every account page crawlable and fails `apps/ui/src/server.robots.test.ts`; removing the `blocks/summary` re-allow fails `tests/discovery-artifacts.test.ts`.

## Validation

```
npm run typecheck · lint · format:check · validate      all green
npm test                                                883 files, 20390 passed, 11 skipped
npm test --workspace=apps/ui                            254 files, 2098 passed
npm run typecheck --workspace=apps/ui                   green
npm run lint/format:check --workspace=apps/ui           green
npm run build                                           clean tree after (derived artifact fresh)
```

`public/robots.txt` is regenerated by `scripts/build-artifacts.ts`, not hand-edited.

## Notes

- Not a visual change — `robots.txt` is a `text/plain` Worker response, so no screenshot table applies.
- A `Disallow` is a request, not enforcement. If well-behaved crawlers turn out not to be the bulk of this traffic, the lever is Cloudflare bot management on the zone rather than anything in this repo — but robots.txt is the honest first step and costs nothing.

Closes #11002
