### PR TITLE
docs(contract): required describes the unprojected response, and the contract now says so

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -18473,7 +18473,7 @@ export interface operations {
     subnetDetailByNetwork: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -39931,7 +39931,7 @@ export interface operations {
     subnetDetail: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -45647,7 +45647,7 @@ export interface operations {
     subnetProfile: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -2873,7 +2873,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
-          "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
           "name": "sections",
           "schema": {
             "pattern": "^(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces)(?:,(?:candidate_surfaces|candidates|economics|endpoints|gaps|notes|subnet|surfaces|verified_surfaces))*$",
@@ -3059,7 +3059,7 @@
       "query_filter_names": [],
       "query_parameters": [
         {
-          "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
           "name": "sections",
           "schema": {
             "pattern": "^(?:candidate_surfaces|endpoints|gaps|notes|profile|subnet|surfaces)(?:,(?:candidate_surfaces|endpoints|gaps|notes|profile|subnet|surfaces))*$",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -66833,7 +66833,7 @@
             }
           },
           {
-            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
             "in": "query",
             "name": "sections",
             "required": false,
@@ -91650,7 +91650,7 @@
             }
           },
           {
-            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
             "in": "query",
             "name": "sections",
             "required": false,
@@ -97381,7 +97381,7 @@
             }
           },
           {
-            "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "description": "Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
             "in": "query",
             "name": "sections",
             "required": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -18473,7 +18473,7 @@ export interface operations {
     subnetDetailByNetwork: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -39931,7 +39931,7 @@ export interface operations {
     subnetDetail: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,economics`. One of: candidate_surfaces, candidates, economics, endpoints, gaps, notes, subnet, surfaces, verified_surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;
@@ -45647,7 +45647,7 @@ export interface operations {
     subnetProfile: {
         parameters: {
             query?: {
-                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                /** @description Comma-separated top-level sections to return, e.g. `subnet,profile`. One of: candidate_surfaces, endpoints, gaps, notes, profile, subnet, surfaces. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
                 sections?: string;
             };
             header?: never;

--- a/schemas-src/query-params.ts
+++ b/schemas-src/query-params.ts
@@ -565,7 +565,11 @@ export const fieldsSchema = () =>
     .describe(
       "Comma-separated row field names to project, e.g. `netuid,name,slug`. " +
         "Bare identifiers only — not a JSON array, no paths or indices. " +
-        "An unknown name is rejected rather than ignored.",
+        "An unknown name is rejected rather than ignored. A projected row " +
+        "omits every non-selected property, including ones the row schema " +
+        "marks required: `required` describes the unprojected response " +
+        "(#10960), so a client validating responses should skip validation " +
+        "or treat row properties as optional when it sends this parameter.",
     )
     .meta({ examples: ["netuid,name,slug"] });
 
@@ -901,8 +905,13 @@ export const sectionsSchema = (
         `One of: ${allowed.join(", ")}. Selecting sections never removes the ` +
         `response envelope (${ENVELOPE_SECTIONS.join(", ")}) -- a smaller ` +
         `document still has to say what it is. An unknown name is rejected ` +
-        `rather than ignored. NOT the same parameter as \`fields\`, which ` +
-        `projects columns out of the rows of a list.`,
+        `rather than ignored. A projected document omits every non-selected ` +
+        `section, including ones the document schema marks required: ` +
+        `\`required\` describes the unprojected response (#10960), so a ` +
+        `client validating responses should skip validation or treat ` +
+        `sections as optional when it sends this parameter. NOT the same ` +
+        `parameter as \`fields\`, which projects columns out of the rows ` +
+        `of a list.`,
     )
     .meta({ examples: [example[0], example.join(",")] });
 };


### PR DESCRIPTION
Part of epic #10992. Closes #10960.

## The decision, and why the alternatives lost

A projected response (`?fields=`, `?sections=`) omits properties its component marks
`required`, so a generated client that validates responses rejects a documented 200. Three
options were on the issue; the runtime work settled it:

- **Loosen `required`** (MCP's `projectableRows` answer): one Zod source feeds BOTH the
  published contract and the response tripwire (`z.toJSONSchema(openApiComponentRegistry)`),
  so loosening for clients would cost the tripwire its drift detection on *unprojected*
  responses — the strictness #10978/#10985 just made real across all 225 contracts.
- **Projected variant components**: OpenAPI cannot select a schema by query value, and it
  doubles the component count for a client that may never exist.
- **Document it** — the only option that keeps the runtime's strict/forgiving split intact.
  ~289 properties stay truthfully required for the default response.

## The edit

The two shared parameter declarations (`fieldsSchema`, `sectionsSchema`) — the single
source every projecting operation's prose comes from — now state: a projected response
omits every non-selected property including required ones, `required` describes the
unprojected response, and a validating client should skip validation or treat the projected
level as optional when it sends the parameter. Published to all 47 operations from one edit
each.

## Verification

- Full `npx vitest run`: 20402 passed · `tsc` · `format:check` · `validate:contract-drift` ·
  `validate:api` · `validate:openapi` · `validate:mcp` · `validate:schemas` — pass
- Contract diff is exactly the two description strings (3 lines in `openapi.json` + the
  regenerated types)
- Ledger: +9 lines — a pure addition of published contract prose; the epic's summed ledger
  remains strongly negative (#11006 −3, #10990's serving-tree collapse, the deletions ahead)