### PR TITLE
perf(api): serve block and extrinsic detail from the edge cache

### DIFF
--- a/tests/chain-detail-edge-cache.test.ts
+++ b/tests/chain-detail-edge-cache.test.ts
@@ -1,0 +1,301 @@
+// #11001. /api/v1/blocks/{ref} and /api/v1/extrinsics/{hash} reached no cache at
+// all: both return from dispatchChainHistoryRoute, upstream of the artifact
+// path's `edgeCacheable` lookup, so every request paid a full lakehouse scan.
+//
+// What may be STORED is decided by the handler's cache profile, not by this
+// wrapper re-deriving a freshness rule of its own — so these tests drive the
+// wrapper with each profile a handler can emit and assert what reaches the
+// store, plus the dispatch-level property that a cold (unresolved) block is not
+// cached at all.
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import {
+  chainDetailCacheKey,
+  handleRequest,
+  withChainDetailEdgeCache,
+} from "../workers/api.ts";
+import type { Row } from "./row-type.ts";
+
+const globalWithCaches = globalThis as unknown as { caches?: unknown };
+const originalCaches = globalWithCaches.caches;
+
+afterEach(() => {
+  globalWithCaches.caches = originalCaches;
+});
+
+/** Minimal stand-in for `caches.default`, mirroring tests/analytics-edge-cache.test.ts. */
+function mockCaches() {
+  const store = new Map<string, Response>();
+  const putKeys: string[] = [];
+  const matchKeys: string[] = [];
+  return {
+    store,
+    putKeys,
+    matchKeys,
+    install() {
+      globalWithCaches.caches = {
+        default: {
+          async match(request: Request) {
+            matchKeys.push(request.url);
+            const cached = store.get(request.url);
+            return cached ? cached.clone() : undefined;
+          },
+          async put(request: Request, response: Response) {
+            putKeys.push(request.url);
+            store.set(request.url, response.clone());
+          },
+        },
+      } as unknown as Row;
+    },
+  };
+}
+
+const env = {} as unknown as Parameters<typeof chainDetailCacheKey>[0];
+const url = new URL("https://api.metagraph.sh/api/v1/blocks/8803541");
+const get = () => new Request(url.toString());
+
+/** A handler response carrying `profile`, shaped like envelopeResponse's. */
+function answer(profile: "static" | "short", body = '{"ok":true}') {
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "x-metagraph-cache-profile": profile,
+      etag: 'W/"abc"',
+    },
+  });
+}
+
+/** Counts how many times the underlying handler actually ran. */
+function producer(response: () => Response) {
+  let calls = 0;
+  return {
+    get calls() {
+      return calls;
+    },
+    produce: async () => {
+      calls += 1;
+      return response();
+    },
+  };
+}
+
+describe("chain-detail edge cache (#11001)", () => {
+  test("stores a settled (static) answer and serves the next request from it", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+    const handler = producer(() => answer("static"));
+
+    const first = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(first.status, 200);
+    // The response handed to the CLIENT must still be readable — a naive
+    // implementation that puts the original body leaves this locked.
+    assert.equal(await first.text(), '{"ok":true}');
+    await Promise.all(waits);
+    assert.equal(cache.putKeys.length, 1);
+
+    const second = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      ctx,
+      handler.produce,
+    );
+    assert.equal(await second.text(), '{"ok":true}');
+    // The whole point: the lakehouse scan did not run a second time.
+    assert.equal(handler.calls, 1);
+  });
+
+  test("stores with OUR ttl, not the client-facing max-age", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      { waitUntil: (p: Promise<unknown>) => waits.push(p) },
+      async () => answer("static"),
+    );
+    await Promise.all(waits);
+    const stored = [...cache.store.values()][0];
+    assert.equal(stored.headers.get("cache-control"), "public, s-maxage=3600");
+  });
+
+  test("does NOT store an unsettled (short) answer", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      { waitUntil: (p: Promise<unknown>) => waits.push(p) },
+      async () => answer("short"),
+    );
+    await Promise.all(waits);
+    assert.equal(cache.putKeys.length, 0);
+  });
+
+  test("does NOT store a gap (503) — it is transient by definition", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      { waitUntil: (p: Promise<unknown>) => waits.push(p) },
+      async () =>
+        new Response('{"error":{"code":"block_detail_unavailable"}}', {
+          status: 503,
+          headers: { "x-metagraph-cache-profile": "static" },
+        }),
+    );
+    await Promise.all(waits);
+    assert.equal(cache.putKeys.length, 0);
+  });
+
+  test("answers a conditional request off a warm entry with 304", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+    await withChainDetailEdgeCache(get(), env, url, "mainnet", ctx, async () =>
+      answer("static"),
+    );
+    await Promise.all(waits);
+
+    const conditional = new Request(url.toString(), {
+      headers: { "if-none-match": 'W/"abc"' },
+    });
+    const res = await withChainDetailEdgeCache(
+      conditional,
+      env,
+      url,
+      "mainnet",
+      ctx,
+      async () => {
+        throw new Error("handler must not run on a warm conditional hit");
+      },
+    );
+    assert.equal(res.status, 304);
+  });
+
+  test("bypasses the cache for a non-GET request", async () => {
+    const cache = mockCaches();
+    cache.install();
+    const handler = producer(() => answer("static"));
+    const res = await withChainDetailEdgeCache(
+      new Request(url.toString(), { method: "HEAD" }),
+      env,
+      url,
+      "mainnet",
+      {},
+      handler.produce,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(handler.calls, 1);
+    assert.equal(cache.putKeys.length, 0);
+  });
+
+  test("runs the handler when the runtime has no cache at all", async () => {
+    globalWithCaches.caches = undefined;
+    const handler = producer(() => answer("static"));
+    const res = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      {},
+      handler.produce,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(handler.calls, 1);
+  });
+});
+
+describe("chain-detail cache key (#11001)", () => {
+  // The two chains' block numbers overlap and the /{network}/ prefix is stripped
+  // before dispatch, so a key built from the path alone would serve a testnet
+  // block to the next mainnet caller with nothing downstream able to tell.
+  test("is network-scoped", () => {
+    assert.notEqual(
+      chainDetailCacheKey(env, url, "mainnet").url,
+      chainDetailCacheKey(env, url, "testnet").url,
+    );
+  });
+
+  test("distinguishes two refs on the same chain", () => {
+    assert.notEqual(
+      chainDetailCacheKey(env, url, "mainnet").url,
+      chainDetailCacheKey(
+        env,
+        new URL("https://api.metagraph.sh/api/v1/blocks/8803542"),
+        "mainnet",
+      ).url,
+    );
+  });
+
+  test("namespaces by contract version, so a contract change invalidates", () => {
+    assert.match(
+      chainDetailCacheKey(env, url, "mainnet").url,
+      /\/chain-detail\//,
+    );
+  });
+});
+
+describe("the dispatch actually routes through the cache (#11001)", () => {
+  // These two are the wiring assertions, and they are POSITIVE on purpose. The
+  // interesting property — a cold ref is not stored — is a zero-put assertion
+  // that would pass just as well if the wrapper had never been wired into
+  // dispatchChainHistoryRoute at all. So each test first proves the lookup
+  // happened, against the chain-detail key, and only then that nothing was
+  // stored.
+  for (const [label, path] of [
+    ["block", "/api/v1/blocks/777"],
+    [
+      "extrinsic",
+      "/api/v1/extrinsics/0x58e19156f8fdadbf60f70aaf664e80aa80c9ebb705dffe6a919048798c5c7af0",
+    ],
+  ] as const) {
+    test(`${label} detail consults the edge cache, and a cold ref is not stored`, async () => {
+      const cache = mockCaches();
+      cache.install();
+      const waits: Promise<unknown>[] = [];
+      const res = await handleRequest(
+        new Request(`https://api.metagraph.sh${path}`),
+        {} as unknown as Parameters<typeof handleRequest>[1],
+        { waitUntil: (p: Promise<unknown>) => waits.push(p) },
+      );
+      assert.equal(res.status, 200);
+      await Promise.all(waits);
+
+      // Wired: the lookup happened, and against THIS route's key.
+      assert.equal(
+        cache.matchKeys.some(
+          (k) => k.includes("/chain-detail/") && k.endsWith(path),
+        ),
+        true,
+        `expected a chain-detail cache lookup for ${path}, saw ${JSON.stringify(cache.matchKeys)}`,
+      );
+      // Correct: an unresolved ref takes the `short` profile, so pinning a
+      // `block: null` / `extrinsic: null` at the edge for an hour is exactly
+      // what must not happen.
+      assert.equal(cache.putKeys.length, 0);
+    });
+  }
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3755,6 +3755,116 @@ async function chainEventsCacheKey(
 }
 
 /**
+ * Edge-cache TTL for a chain-detail answer the handler has declared immutable
+ * (#11001).
+ *
+ * One hour, and the bound is the decode lane's own reconciliation window rather
+ * than a guess: chainDetailGapResponse states the lane "closes [a gap] within
+ * the hour", so an hour is the longest a re-decode can leave a stored answer
+ * disagreeing with the store behind it. The key is already namespaced by
+ * contract version, so a contract change invalidates independently of this.
+ *
+ * Deliberately longer than the 600 s `static` profile the response advertises to
+ * clients: that number is a browser's revalidation interval, this one is how
+ * long OUR edge may answer without re-paying a lakehouse scan. They are
+ * different questions and were never the same number.
+ */
+const CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS = 3600;
+
+/**
+ * Edge-cache key for one chain-detail answer (block / extrinsic detail).
+ *
+ * NETWORK-SCOPED for the same reason chainEventsCacheKey is: the `/{network}/`
+ * prefix is stripped before dispatch, so mainnet and testnet reach these
+ * handlers with byte-identical pathnames and the two chains' block numbers
+ * overlap. A key built from the path alone would serve a testnet block to the
+ * next mainnet caller and nothing downstream could tell.
+ */
+export function chainDetailCacheKey(
+  env: Env,
+  url: URL,
+  network: ChainNetworkId,
+) {
+  return new Request(
+    `https://edge-cache.metagraph.sh/chain-detail/${encodeURIComponent(
+      contractVersion(env),
+    )}/${network}${url.pathname}${url.search}`,
+  );
+}
+
+/**
+ * Serve one chain-detail route through the edge cache (#11001).
+ *
+ * `/api/v1/blocks/{ref}` and `/api/v1/extrinsics/{hash}` reached NO cache at
+ * all before this. They return from dispatchChainHistoryRoute, which is upstream
+ * of handleNetworkScopedRequest's `edgeCacheable` lookup, so every request paid a
+ * full lakehouse scan — measured at 747–3465 ms TTFB, on what #9004 measured as
+ * the single largest route in the project at 758,995 requests/day. Neither route
+ * is in LIVE_OVERLAY_ROUTE_IDS, the set that names deliberate exclusions, so
+ * nothing had decided this; dispatch order had.
+ *
+ * WHAT MAY BE STORED is decided by the handler, not here. Each one already knows
+ * which tier answered — `answerBlockDetail`/`answerExtrinsicDetail` return
+ * `tier: "hot" | "cold"` — and encodes it in the response's cache profile: a
+ * COLD (lakehouse) answer is settled and gets `static`, a hot-window or
+ * unresolved one gets `short`. So this reads one header rather than re-deriving
+ * a "how deep is this block" rule that would then have to agree with three
+ * handlers' independent judgement. A gap (503) and a 304 are excluded by the
+ * same test, without naming either.
+ *
+ * The rate limiter stays UPSTREAM of this, on purpose. A cache hit is cheap for
+ * us but a caller walking 8.8M blocks is still a caller walking 8.8M blocks, and
+ * metering that is the whole point of #11000's ceiling — serving it from cache
+ * must not make it free.
+ */
+export async function withChainDetailEdgeCache(
+  request: Request,
+  env: Env,
+  url: URL,
+  network: ChainNetworkId,
+  ctx: Ctx,
+  produce: () => Promise<Response>,
+): Promise<Response> {
+  const cacheable =
+    request.method === "GET"
+      ? cacheableWith(chainDetailCacheKey(env, url, network))
+      : null;
+  if (!cacheable) return produce();
+
+  const hit = await cacheable.store.match(cacheable.key);
+  if (hit) {
+    // Honour a conditional request against the stored body's weak ETag, so a
+    // polling agent gets a 304 off a warm edge rather than the whole payload
+    // (mirrors envelopeResponse and the artifact cache's own hit path).
+    if (ifNoneMatchSatisfied(request, hit.headers.get("etag"))) {
+      return new Response(null, { status: 304, headers: hit.headers });
+    }
+    return hit;
+  }
+
+  const response = await produce();
+  if (
+    response.status === 200 &&
+    response.headers.get("x-metagraph-cache-profile") === "static"
+  ) {
+    // Stored with OUR ttl, not the client-facing one. Built explicitly rather
+    // than by passing the Response as an init so the headers are copied into a
+    // fresh Headers and mutating them cannot reach the response we return.
+    const stored = new Response(response.clone().body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+    stored.headers.set(
+      "cache-control",
+      `public, s-maxage=${CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS}`,
+    );
+    ctx?.waitUntil?.(cacheable.store.put(cacheable.key, stored));
+  }
+  return response;
+}
+
+/**
  * The chain-events family: the all-events feed, its stats aggregate, one
  * block's raw events, and the three per-subnet histories that read the same
  * store.
@@ -7983,7 +8093,9 @@ async function dispatchChainHistoryRoute(
   if (blockDetailMatch) {
     const limited = await chainDetailRateLimit(request, env, ctx, "block");
     if (limited) return limited;
-    return handleBlock(request, env, blockDetailMatch[1], chain);
+    return withChainDetailEdgeCache(request, env, url, chain, ctx, () =>
+      handleBlock(request, env, blockDetailMatch[1], chain),
+    );
   }
   if (BLOCKS_FEED_PATH_PATTERN.test(pathname)) {
     return handleBlocks(request, env, url, chain);
@@ -7993,7 +8105,9 @@ async function dispatchChainHistoryRoute(
   if (extrinsicDetailMatch) {
     const limited = await chainDetailRateLimit(request, env, ctx, "extrinsic");
     if (limited) return limited;
-    return handleExtrinsic(request, env, extrinsicDetailMatch[1], chain);
+    return withChainDetailEdgeCache(request, env, url, chain, ctx, () =>
+      handleExtrinsic(request, env, extrinsicDetailMatch[1], chain),
+    );
   }
   if (EXTRINSICS_FEED_PATH_PATTERN.test(pathname)) {
     return handleExtrinsics(request, env, url, chain);

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -7277,6 +7277,17 @@ export async function handleExtrinsic(
   if (answer?.kind === "gap") return chainDetailGapResponse(answer);
   const data =
     answer?.kind === "answer" ? answer.data : buildExtrinsic(undefined, ref);
+  // #11001: name the immutability the tier already knows, the way handleBlock
+  // above does. A COLD (lakehouse) answer is decoded and settled, so it cannot
+  // change within a contract version and takes the `static` profile. Everything
+  // else stays `short`: a HOT-window answer is still inside the live-follow
+  // range and may yet move, and an unresolved hash keeps its schema-stable
+  // `extrinsic: null` precisely because absence from that window proves nothing
+  // — a client must re-check both. withChainDetailEdgeCache reads this profile
+  // to decide what may be stored at the edge, so getting it wrong here would
+  // cache a moving answer, not merely mis-advertise one.
+  const cacheProfile =
+    answer?.kind === "answer" && answer.tier === "cold" ? "static" : "short";
   return envelopeResponse(
     request,
     {
@@ -7287,7 +7298,7 @@ export async function handleExtrinsic(
         data.extrinsic?.observed_at ?? null,
       ),
     },
-    "short",
+    cacheProfile,
   );
 }
 


### PR DESCRIPTION
## Summary

`/api/v1/blocks/{ref}` and `/api/v1/extrinsics/{hash}` reached **no cache at all**. Both return from `dispatchChainHistoryRoute`, which is upstream of `handleNetworkScopedRequest`'s `edgeCacheable` lookup, so every request paid a full lakehouse scan.

Measured in Workers Observability, 2026-08-13 06:37:39–06:37:50 UTC — no `cache_match` span on any of these traces, and the R2 SQL call is essentially the whole request:

| route | TTFB | R2 SQL span |
| --- | --- | --- |
| `/api/v1/blocks/8803541` | 3465 ms | 3463 ms |
| `/api/v1/extrinsics/0xa6fd0387…` | 3329 ms | 1840 ms |
| `/api/v1/blocks/8800355` | 2502 ms | 2501 ms |
| `/api/v1/blocks/8803453` | 2260 ms | 2260 ms |
| `/api/v1/blocks/8720234` | 937 ms | 937 ms |

Every ref above is historic and finalized, and #9004 measured `block-detail` at **758,995 requests/day** — the single largest route in the project. Nothing had decided these routes were uncacheable: neither is in `LIVE_OVERLAY_ROUTE_IDS`, the set that names deliberate exclusions. Dispatch order had.

## The design decision worth reviewing

#11001 and #11003 both asked for a shared "how deep is this block" rule. **That was the wrong shape.** The handlers already know: `answerBlockDetail` and `answerExtrinsicDetail` return `tier: "hot" | "cold"`, and a cold (lakehouse) answer is decoded and settled by construction.

So each handler encodes settledness in its **cache profile**, and the wrapper reads one header:

- cold answer → `static` → storable
- hot-window or unresolved answer → `short` → not stored

That keeps one rule instead of a depth calculation that would then have to agree with three handlers' independent judgement, and it needs no chain-head tracking. A gap (503) and a 304 are excluded by the same test without either being named.

`handleBlock` already drew this distinction and is unchanged. `handleExtrinsic` did **not** — it returned `short` even for a settled answer — so it now names the immutability its own tier already knows.

## Key, TTL, and the limiter

**Key** is namespaced by contract version *and network*, for the reason `chainEventsCacheKey` is: the `/{network}/` prefix is stripped before dispatch, the two chains' block numbers overlap, and a path-only key would serve a testnet block to the next mainnet caller with nothing downstream able to tell.

**TTL is one hour, and deliberately not the 600 s `static` profile** the response advertises to clients — that number is a browser's revalidation interval, this one is how long our edge may answer without re-paying a scan. The bound is the decode lane's own reconciliation window, which `chainDetailGapResponse` already states as "within the hour".

**The rate limiter stays upstream of the cache**, on purpose. A cache hit is cheap for us, but a caller walking 8.8M blocks is still that caller, and metering it is the point of the ceiling in #11000 — serving from cache must not make it free.

## Tests

`tests/chain-detail-edge-cache.test.ts`, 12 cases: stores a settled answer and skips the second scan; stores with our TTL not the client's; does **not** store `short`; does **not** store a 503 gap; 304 off a warm entry; non-GET bypass; no-`caches` runtime; key is network-scoped and ref-scoped.

The two dispatch-level tests assert **positively** that the lookup happened against the chain-detail key *before* asserting nothing was stored — a zero-put assertion alone would pass just as well if the wrapper had never been wired in.

## Validation

```
npm run typecheck · lint · format:check · validate              green
npm run validate:contract-drift · api · openapi · types · mcp · schemas   green
npx vitest run chain-detail-edge-cache · blocks · extrinsics · chain-detail-serving   138 passed
npm run build                                                   clean tree after
```

Closes #11001
