### PR TITLE
refactor(schemas): the shape gate reads the serving tree, and its one exemption is pinned by name

### DIFF
--- a/scripts/validate-schema-shape-duplicates.ts
+++ b/scripts/validate-schema-shape-duplicates.ts
@@ -47,7 +47,12 @@ const repoRoot = path.resolve(
   "..",
 );
 
-const SCHEMA_ROOT = "schemas-src";
+// The schema tree AND the serving tree (#10995). This gate watched only
+// schemas-src/ while an MCP composer or a handler could re-model a shape by
+// hand in src/ and stay green forever -- the same blindness #10987 fixed for
+// the enum-vocabulary gate. ts.sys.readDirectory recurses, so "src" covers
+// src/graphql/ and "workers" covers workers/request-handlers/.
+const SCAN_ROOTS = ["schemas-src", "src", "workers"];
 /** Below this, a shared key set is coincidence rather than lineage. */
 const MIN_KEYS = 4;
 
@@ -171,10 +176,12 @@ export function findDuplicates(sites: readonly ShapeSite[]): ShapeDuplicate[] {
 }
 
 function schemaFiles(): string[] {
-  return ts.sys
-    .readDirectory(path.join(repoRoot, SCHEMA_ROOT), [".ts"], ["node_modules"])
-    .map((file) => path.relative(repoRoot, file).split(path.sep).join("/"))
-    .filter((file) => !file.endsWith(".d.ts"));
+  return SCAN_ROOTS.flatMap((root) =>
+    ts.sys
+      .readDirectory(path.join(repoRoot, root), [".ts"], ["node_modules"])
+      .map((file) => path.relative(repoRoot, file).split(path.sep).join("/"))
+      .filter((file) => !file.endsWith(".d.ts")),
+  );
 }
 
 /**
@@ -204,22 +211,63 @@ function schemaFiles(): string[] {
  * make the input accept anything the echo can carry -- which is the input/
  * output conflation #10790 was explicitly told to keep separate.
  *
- * So the ceiling is 1, and it is a rule in all but name.
+ * So the pair is pinned BY NAME -- not held behind a bare count. A count of 1
+ * would stay 1 if the feed pair resolved and a NEW duplicate appeared the same
+ * week, and the gate would pass while its own prose lied (#10995, the same
+ * hides-what-it-names fix as #10990's allowlist). An entry names the exact
+ * key set and the exact files allowed to share it; a new file joining fails,
+ * a file leaving makes the entry stale, and stale entries fail too.
  */
-const CEILING = 1;
+const COINCIDENT_BY_DESIGN: Record<string, string[]> = {
+  "limit,since,tag,until": [
+    "schemas-src/mcp-tools/feed.ts",
+    "schemas-src/route-queries.ts",
+  ],
+};
 
 function main(): void {
   const files = schemaFiles();
   const sites = findObjectShapes(files);
   const duplicates = findDuplicates(sites);
+  // A pinned entry excuses exactly the files it names; anything else is new.
+  const unlisted = duplicates
+    .map((duplicate) => {
+      const pinned = COINCIDENT_BY_DESIGN[duplicate.keys];
+      if (!pinned) return duplicate;
+      const sites = duplicate.sites.filter(
+        (site) => !pinned.includes(site.file),
+      );
+      return { ...duplicate, sites };
+    })
+    .filter((duplicate) => duplicate.sites.length > 0);
+  const stale = Object.entries(COINCIDENT_BY_DESIGN).flatMap(
+    ([keys, pinned]) => {
+      const match = duplicates.find((duplicate) => duplicate.keys === keys);
+      if (!match)
+        return [
+          `  {${keys}} — no longer duplicated anywhere; delete the entry`,
+        ];
+      return pinned
+        .filter((file) => !match.sites.some((site) => site.file === file))
+        .map((file) => `  {${keys}} — ${file} no longer declares it`);
+    },
+  );
   const report =
     `schema-shape-duplicates: ${duplicates.length} object vocabular(ies) ` +
     `declared in more than one schema file, across ${sites.length} literal(s) ` +
-    `of ${MIN_KEYS}+ keys in ${files.length} file(s) (ceiling ${CEILING}).`;
-  if (duplicates.length > CEILING) {
+    `of ${MIN_KEYS}+ keys in ${files.length} file(s) ` +
+    `(${Object.keys(COINCIDENT_BY_DESIGN).length} pinned by design).`;
+  if (stale.length > 0) {
     console.error(
-      `${report}\n\nNEW duplicate(s) -- the ceiling is ${CEILING}:\n` +
-        duplicates
+      `${report}\n\nStale pinned entr(y/ies) — they over-excuse, shrink them:\n` +
+        stale.join("\n"),
+    );
+    process.exit(1);
+  }
+  if (unlisted.length > 0) {
+    console.error(
+      `${report}\n\nNEW duplicate(s):\n` +
+        unlisted
           .map(
             (duplicate) =>
               `  {${duplicate.keys}}\n` +
@@ -237,12 +285,6 @@ function main(): void {
     process.exit(1);
   }
   console.log(report);
-  if (duplicates.length < CEILING) {
-    console.log(
-      `  ${CEILING - duplicates.length} below the ceiling -- lower CEILING to ` +
-        `${duplicates.length} so it cannot come back.`,
-    );
-  }
 }
 
 /* v8 ignore next 3 -- the CLI entry, exercised by the pipeline not the suite. */


### PR DESCRIPTION
Part of epic #10992. Closes #10995.

## The extension

`validate-schema-shape-duplicates` scanned only `schemas-src/` — the same blindness #10987
fixed for the enum-vocabulary gate. It now reads `src/` and `workers/` too (recursively):
**708 files, 549 object literals of 4+ keys** — and the serving tree turned out to be
**clean**. The same single feed input/echo pair remains, so this lands as pure enforcement
with nothing to collapse.

## The exemption is pinned by name now

The gate held its line with a bare `CEILING = 1` whose one entry lived in prose. That has
the exact hides-what-it-names failure #10990's allowlist fixed: if the feed pair resolved
and a NEW duplicate appeared the same week, the count would still read 1 and the gate would
pass while its own comment lied. `COINCIDENT_BY_DESIGN` now names the key set and the exact
files allowed to share it — a new file joining fails, a file leaving goes stale, stale
entries fail.

## Falsified in all three directions

| probe | result |
| --- | --- |
| a `src/` file declaring the pinned `{limit,since,tag,until}` set | FAILS, naming the stray file only |
| a fresh duplicate across `src/` and `workers/` | FAILS |
| a pinned file that no longer declares the shape | FAILS as stale |
| the clean tree | PASSES |

## Ledger disclosure

**+42 lines**, against the epic's net-negative rule — disclosed rather than gamed: this PR
had nothing to delete because prior PRs already did the collapsing (42→1), and the gate
exists to keep it that way. The epic's summed ledger remains negative. The two `report:*`
diagnostic scripts were audited for deletion and kept: both are imported and unit-tested
tooling, not dead code.

## Verification

- Full `npx vitest run`: 20404 passed · `tests/schema-strictness-gates.test.ts` (the gate's
  own suite): 14 passed
- `tsc` · `lint` · `format:check` · `validate:schema-shape-duplicates` — pass
- No emitted-contract change (the gate is build-side only)