### PR TITLE
fix(ui): a rate-limited read is throttled, not broken

### DIFF
--- a/apps/ui/src/components/metagraphed/states.tsx
+++ b/apps/ui/src/components/metagraphed/states.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Database,
   ExternalLink as ExternalLinkIcon,
+  Hourglass,
   WifiOff,
 } from "lucide-react";
 import { useState } from "react";
@@ -55,6 +56,34 @@ function OfflineNotice({ context }: { context?: string }) {
       <p className="mt-2 text-xs leading-relaxed text-ink-muted">
         Couldn't load {context ?? "this data"} — you're offline. It'll refresh automatically once
         you're back online.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * A 429 is not a fault (#11000).
+ *
+ * The API meters anonymous callers at 60 requests/minute, and a page render
+ * spends several of them, so an ordinary visitor moving fast — and every
+ * crawler — will meet this ceiling. Until now it fell through to the red
+ * "Couldn't load this data / HTTP 429" card, which says the wrong thing twice:
+ * nothing is broken, and the data is not unavailable. It is throttled, it is
+ * the caller's own budget, and it works again shortly.
+ *
+ * Every interactive surface already drew this distinction (search-box.tsx,
+ * ask-box.tsx, watch-alert-form.tsx, api-keys-manager.tsx); the read paths were
+ * the ones left saying "couldn't load". `role="status"` rather than
+ * `role="alert"` for the same reason the copy changed — this is not an error
+ * condition to announce as one.
+ */
+function RateLimitedNotice({ context }: { context?: string }) {
+  return (
+    <div role="status" className="rounded border border-border bg-surface p-4 text-center">
+      <Hourglass className="mx-auto size-4 text-ink-muted" />
+      <p className="mt-2 text-xs leading-relaxed text-ink-muted">
+        Rate-limited while loading {context ?? "this data"} — you've hit the public API's per-minute
+        ceiling. It'll work again in under a minute.
       </p>
     </div>
   );
@@ -116,6 +145,10 @@ export function ErrorState({
   // function's catch block in client.ts.
   if (isApi && error.status === 0) {
     return <OfflineNotice context={context} />;
+  }
+  // #11000: throttled, not broken. See RateLimitedNotice.
+  if (isApi && error.status === 429) {
+    return <RateLimitedNotice context={context} />;
   }
   const message = (error as Error)?.message ?? "Unknown error";
   const url = isApi ? error.url : undefined;

--- a/apps/ui/src/lib/metagraphed/rate-limited-response.test.ts
+++ b/apps/ui/src/lib/metagraphed/rate-limited-response.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "./client";
+import { RATE_LIMITED_RETRY_AFTER_SECONDS, rateLimitedResponse } from "./rate-limited-response";
+
+const throttled = () =>
+  new ApiError("Too many data API requests from this client; slow down.", {
+    status: 429,
+    code: "data_rate_limited",
+    url: "/api/v1/blocks/8803541",
+  });
+
+describe("a throttled primary query answers 429, not 200 (#11000)", () => {
+  it("carries the status a crawler acts on", () => {
+    const res = rateLimitedResponse(throttled());
+    expect(res?.status).toBe(429);
+  });
+
+  it("carries Retry-After, so the back-off is bounded and not guessed", () => {
+    // The API's anonymous window is a fixed 60 s, so this is a fact about the
+    // limiter rather than a hedge.
+    expect(rateLimitedResponse(throttled())?.headers.get("retry-after")).toBe(
+      String(RATE_LIMITED_RETRY_AFTER_SECONDS),
+    );
+  });
+
+  it("is never stored — the next caller's budget is not this one's", () => {
+    expect(rateLimitedResponse(throttled())?.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("serves a real HTML page, so a human does not get an empty 429", async () => {
+    const res = rateLimitedResponse(throttled());
+    expect(res?.headers.get("content-type")).toContain("text/html");
+    const body = await res!.text();
+    expect(body).toContain("<!doctype html>");
+    expect(body).toMatch(/rate-limited/i);
+    // The copy must not claim a fault: that is the whole point of the change.
+    expect(body).not.toMatch(/went wrong|didn't load|error/i);
+  });
+});
+
+describe("it declines everything that is not a 429 (#11000)", () => {
+  // The loader keeps its existing not-found and transient-failure handling
+  // underneath this, so a helper that over-matched would silently convert a
+  // missing entity — or an outage — into a throttling claim.
+  it("passes through other API statuses", () => {
+    for (const status of [0, 404, 500, 503]) {
+      expect(
+        rateLimitedResponse(new ApiError("nope", { status, url: "/api/v1/blocks/1" })),
+        `status ${status}`,
+      ).toBeNull();
+    }
+  });
+
+  it("passes through a non-ApiError throw", () => {
+    expect(rateLimitedResponse(new Error("boom"))).toBeNull();
+    expect(rateLimitedResponse(undefined)).toBeNull();
+    expect(rateLimitedResponse({ status: 429 })).toBeNull();
+  });
+});

--- a/apps/ui/src/lib/metagraphed/rate-limited-response.ts
+++ b/apps/ui/src/lib/metagraphed/rate-limited-response.ts
@@ -1,0 +1,83 @@
+import { ApiError } from "./client";
+
+/**
+ * `Retry-After` for a throttled document (#11000).
+ *
+ * The public API meters anonymous callers with a fixed 60-request / 60-second
+ * window (`DATA_TIERED_RATE_LIMIT.anonymous` in workers/api.ts), so the caller's
+ * budget always clears inside a minute. Stated as a concrete number rather than
+ * an HTTP-date because the window is a duration, not an instant, and a duration
+ * cannot skew against a client's clock.
+ */
+export const RATE_LIMITED_RETRY_AFTER_SECONDS = 60;
+
+/**
+ * Turn a rate-limited primary query into the response a crawler acts on.
+ *
+ * A route whose OWN data was throttled has nothing to render, and until now it
+ * answered `200` with a red "Couldn't load this data / HTTP 429" card in the
+ * body. That is the worst of both outcomes: a human is told something is broken
+ * when nothing is, and a crawler — which reads the status, not the card — is
+ * told the page rendered fine and indexes the error.
+ *
+ * `429` + `Retry-After` is the documented signal for exactly this, and both
+ * Google and Bing act on it: back off, keep the URL, come back. It is also
+ * strictly better than `noindex`, which would drop a real page over a transient
+ * ceiling — the failure mode this codebase already warned about in
+ * blocks.$ref.tsx's loader ("marking a page noindex on a transient blip would
+ * de-index real entities during an outage").
+ *
+ * Returns null for anything that is not a 429, so a caller can keep its existing
+ * error handling underneath.
+ */
+export function rateLimitedResponse(error: unknown): Response | null {
+  if (!(error instanceof ApiError) || error.status !== 429) return null;
+  return new Response(renderRateLimitedPage(), {
+    status: 429,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "retry-after": String(RATE_LIMITED_RETRY_AFTER_SECONDS),
+      // A throttled render must never be stored as if it were the page: the
+      // next caller's budget is not this one's.
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/**
+ * Standalone HTML for a throttled page.
+ *
+ * Deliberately static and dependency-free, like renderErrorPage(): this is
+ * returned INSTEAD of the React render (the loader throws it before streaming
+ * begins), so it cannot rely on the app shell having booted.
+ */
+export function renderRateLimitedPage(): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Rate-limited — Metagraphed</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { font: 15px/1.5 system-ui, -apple-system, sans-serif; background: #fafafa; color: #111; display: grid; place-items: center; min-height: 100vh; margin: 0; padding: 1.5rem; }
+      .card { max-width: 28rem; width: 100%; text-align: center; padding: 2rem; }
+      h1 { font-size: 1.25rem; margin: 0 0 0.5rem; }
+      p { color: #4b5563; margin: 0 0 1.5rem; }
+      .actions { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
+      a, button { padding: 0.5rem 1rem; border-radius: 0.375rem; font: inherit; cursor: pointer; text-decoration: none; border: 1px solid transparent; }
+      .primary { background: #111; color: #fff; }
+      .secondary { background: #fff; color: #111; border-color: #d1d5db; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Rate-limited</h1>
+      <p>You've hit the public API's per-minute ceiling. Nothing is broken — this page will load again in under a minute.</p>
+      <div class="actions">
+        <button class="primary" onclick="location.reload()">Try again</button>
+        <a class="secondary" href="/">Go home</a>
+      </div>
+    </div>
+  </body>
+</html>`;
+}

--- a/apps/ui/src/routes/blocks.$ref.tsx
+++ b/apps/ui/src/routes/blocks.$ref.tsx
@@ -5,6 +5,7 @@ import { blockQuery } from "@/lib/metagraphed/queries";
 import { isValidBlockRef } from "@/lib/metagraphed/blocks";
 import { BlockDetailPage } from "./-blocks-ref-page";
 import { entityNotFoundMeta, isMissingEntityError } from "@/lib/metagraphed/entity-not-found-meta";
+import { rateLimitedResponse } from "@/lib/metagraphed/rate-limited-response";
 
 export const Route = createFileRoute("/blocks/$ref")({
   // #3422: validate the ref at the router level so an invalid one renders the
@@ -23,6 +24,13 @@ export const Route = createFileRoute("/blocks/$ref")({
       const { data } = await context.queryClient.ensureQueryData(blockQuery(params.ref));
       return { blockNumber: data?.block_number ?? null };
     } catch (error) {
+      // #11000: a throttled PRIMARY query has no page to render, and answering
+      // 200-with-an-error-card tells a crawler the render succeeded. Throw the
+      // 429 + Retry-After instead, which is the signal that makes it back off
+      // and keep the URL. Panel-level 429s inside an otherwise-good page are
+      // untouched and still render states.tsx's in-place notice.
+      const throttled = rateLimitedResponse(error);
+      if (throttled) throw throttled;
       // #8624: only a 404 from our own API means "no such entity". Any other
       // failure keeps returning null so the page still renders and the
       // component's own query drives the error path -- marking a page noindex

--- a/apps/ui/src/routes/extrinsics.$hash.tsx
+++ b/apps/ui/src/routes/extrinsics.$hash.tsx
@@ -6,6 +6,7 @@ import { shortHash } from "@/lib/metagraphed/blocks";
 import { extrinsicCall, isValidExtrinsicHash } from "@/lib/metagraphed/extrinsics";
 import { ExtrinsicDetailPage } from "./-extrinsics-hash-page";
 import { entityNotFoundMeta, isMissingEntityError } from "@/lib/metagraphed/entity-not-found-meta";
+import { rateLimitedResponse } from "@/lib/metagraphed/rate-limited-response";
 
 export const Route = createFileRoute("/extrinsics/$hash")({
   // #3422: validate the hash at the router level so an invalid one renders the
@@ -26,6 +27,13 @@ export const Route = createFileRoute("/extrinsics/$hash")({
         call: data ? extrinsicCall(data.call_module, data.call_function) : null,
       };
     } catch (error) {
+      // #11000: a throttled PRIMARY query has no page to render, and answering
+      // 200-with-an-error-card tells a crawler the render succeeded. Throw the
+      // 429 + Retry-After instead, which is the signal that makes it back off
+      // and keep the URL. Panel-level 429s inside an otherwise-good page are
+      // untouched and still render states.tsx's in-place notice.
+      const throttled = rateLimitedResponse(error);
+      if (throttled) throw throttled;
       // #8624: only a 404 from our own API means "no such entity". Any other
       // failure keeps returning null so the page still renders and the
       // component's own query drives the error path -- marking a page noindex


### PR DESCRIPTION
## Summary

Measured in production 2026-08-13 06:37:40–06:37:45 UTC: **eleven SSR render failures in 5.2 seconds** on `/blocks/{n}` and `/extrinsics/{hash}`, six of them paired to a `429` on the matching API path **53–79 ms earlier**. The API meters anonymous callers at 60 req/min keyed on the visitor's own IP, and one page render spends several of them.

**The 429 stays, and SSR is not exempted from it.** Rate limiting is what stops a caller walking 8.8M blocks. Two options were considered and rejected:

- ~~a service binding from `metagraphed-ui` to the API Worker~~
- ~~a shared secret on SSR fetches, exempted in `chainDetailRateLimit`~~

Either would make `metagraph.sh` an **unmetered proxy** to the most expensive query in the project — a scanner walking `/blocks/{n}` pages instead of `/api/v1/blocks/{n}` would get unlimited access. That is the scan the limit exists to prevent. (The shared-secret variant has a second problem: `apiFetch` is shared by server and client, so the secret is one bundling mistake from being public.)

What was wrong is that **a correct 429 was presented as a fault, and served as an indexable `200`.**

## Two presentation changes

**1. `states.tsx` gets a 429 branch.** Every interactive surface already drew this distinction — `search-box.tsx:15`, `ask-box.tsx:13`, `watch-alert-form.tsx:32`, `api-keys-manager.tsx:61`. The read paths were the ones falling through to the red card:

> ⚠ **Couldn't load this data** `HTTP 429` — Too many data API requests from this client; slow down.

which says the wrong thing twice: nothing is broken, and the data is not unavailable. It is throttled, it is the caller's own budget, and it clears in under a minute. `role="status"`, not `role="alert"`, for the same reason.

**2. A throttled *primary* query answers `429` + `Retry-After` instead of `200`.** The block and extrinsic loaders run that query before streaming begins, so the status is still reachable, and `createStartHandler` returns a thrown `Response` verbatim (`createStartHandler.js:398`). That is the signal Google and Bing act on — back off, keep the URL, come back — and serving `200` actively suppresses it, which is how error cards end up indexed.

Strictly better than `noindex` here, which would drop a real page over a transient ceiling — the exact failure mode those loaders already warn about in their `#8624` comment.

**Panel-level 429s inside an otherwise-good page are untouched** and still render the in-place notice. Only the query the route cannot render without escalates to a document status.

`Retry-After` is a fixed `60` rather than a plumbed header because the limiter's window is a fixed 60-second *duration*; a duration cannot skew against a client clock the way an HTTP-date can. The response is `no-store` — the next caller's budget is not this one's.

## Tests

`rate-limited-response.test.ts`, 6 cases: the status, `Retry-After`, `no-store`, a real HTML body (so a human does not get an empty 429) whose copy contains no fault language, and — the one that matters for safety — that it **declines** every non-429 status and every non-`ApiError` throw, so the loaders' existing not-found and transient-failure handling underneath is untouched. A helper that over-matched would silently convert a missing entity, or an outage, into a throttling claim.

`RateLimitedNotice` itself has no render test, matching its three sibling branches (`OfflineNotice`, `DataTierUnavailableNotice`, `NativeOnlyNotice`) — `apps/ui` has no render-testing library and is excluded from `vitest.config.ts`'s `coverage.include`.

## Validation

```
npm run typecheck/lint/format:check --workspace=apps/ui    green
npm test --workspace=apps/ui                               255 files, 2104 passed
npm run build --workspace=apps/ui                          green
```

## Note

Visual change (the notice replaces the red card), maintainer PR — no screenshot table.

Closes #11000
