### PR TITLE
perf(api): chain-events TTL follows the tier and the scope, not a constant

### DIFF
--- a/tests/chain-detail-edge-cache.test.ts
+++ b/tests/chain-detail-edge-cache.test.ts
@@ -212,6 +212,25 @@ describe("chain-detail edge cache (#11001)", () => {
     assert.equal(cache.putKeys.length, 0);
   });
 
+  test("skips the store when there is no waitUntil to defer it to", async () => {
+    // dispatchChainHistoryRoute defaults `ctx` to `{}`, and several internal
+    // call paths pass one — so the storable branch has to survive a context
+    // with no waitUntil rather than throwing on it mid-response.
+    const cache = mockCaches();
+    cache.install();
+    const res = await withChainDetailEdgeCache(
+      get(),
+      env,
+      url,
+      "mainnet",
+      {},
+      async () => answer("static"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '{"ok":true}');
+    assert.equal(cache.putKeys.length, 0);
+  });
+
   test("runs the handler when the runtime has no cache at all", async () => {
     globalWithCaches.caches = undefined;
     const handler = producer(() => answer("static"));

--- a/tests/chain-events-cache-ttl.test.ts
+++ b/tests/chain-events-cache-ttl.test.ts
@@ -1,0 +1,51 @@
+// #11003. The flat 60 s TTL was discarding answers incapable of changing:
+// production showed a `cache_status: STALE` on finalized block 8803453, an
+// answer we computed, stored, threw away 60 seconds later, and re-derived with
+// another lakehouse scan.
+//
+// Two conditions earn the long TTL and the second is the easy one to miss — the
+// same handler serves the /api/v1/chain-events FEED, which is a window over a
+// growing stream and is not immutable at any tier.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { chainEventsCacheTtlSeconds } from "../workers/api.ts";
+
+const SHORT = 60;
+const LONG = 3600;
+
+const at = (pathname: string) => new URL(`https://api.metagraph.sh${pathname}`);
+const cold = { source: "lakehouse-cold-tier" };
+const hot = { source: "chain-detail-hot-tier" };
+
+const BLOCK = "/api/v1/blocks/8803453/chain-events";
+const BLOCK_BY_HASH = `/api/v1/blocks/0x${"ab".repeat(32)}/chain-events`;
+const FEED = "/api/v1/chain-events";
+const STATS = "/api/v1/chain-events/stats";
+
+describe("chain-events edge TTL follows the tier AND the scope (#11003)", () => {
+  test("a settled single block earns the long TTL — it cannot change in its own key", () => {
+    assert.equal(chainEventsCacheTtlSeconds(at(BLOCK), cold), LONG);
+    assert.equal(chainEventsCacheTtlSeconds(at(BLOCK_BY_HASH), cold), LONG);
+  });
+
+  test("a hot-window block keeps the short TTL — it may still move", () => {
+    assert.equal(chainEventsCacheTtlSeconds(at(BLOCK), hot), SHORT);
+  });
+
+  // The regression this file exists to prevent. Keying the TTL on the tier
+  // ALONE would pin a feed page — whose correct answer changes as events land —
+  // for an hour, which is a correctness bug, not merely a stale cache.
+  test("the feed and its stats keep the short TTL even on a cold answer", () => {
+    assert.equal(chainEventsCacheTtlSeconds(at(FEED), cold), SHORT);
+    assert.equal(chainEventsCacheTtlSeconds(at(STATS), cold), SHORT);
+    assert.equal(
+      chainEventsCacheTtlSeconds(at(`${FEED}?limit=100&netuid=64`), cold),
+      SHORT,
+    );
+  });
+
+  test("an answer with no source, or none at all, keeps the short TTL", () => {
+    assert.equal(chainEventsCacheTtlSeconds(at(BLOCK), {}), SHORT);
+    assert.equal(chainEventsCacheTtlSeconds(at(BLOCK), null), SHORT);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3707,6 +3707,41 @@ const CHAIN_EVENTS_CSV_COLUMNS = [
 // version) since this tier has no publish-time snapshot to key off of.
 const CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS = 60;
 
+/**
+ * How long one chain-events answer may sit at the edge (#11003).
+ *
+ * The flat 60 s this replaces was throwing away answers incapable of changing.
+ * `chainEventsCacheKey` is namespaced by contract version, network and the block
+ * ref, so a LAKEHOUSE answer for ONE BLOCK cannot go stale within its own key —
+ * it is decoded, settled history. Production showed the cost of pretending
+ * otherwise: a `cache_status: STALE` on finalized block 8803453, i.e. an answer
+ * we computed, stored, discarded 60 seconds later, and re-derived with another
+ * scan.
+ *
+ * BOTH conditions are required, and the second is the one that is easy to miss.
+ *
+ *  - COLD TIER, because a hot-window answer is still inside the live-follow
+ *    range and may yet move. This is the same signal #11001's chain-detail cache
+ *    reads, deliberately: the tier IS the immutability, and neither cache
+ *    derives a block-depth rule of its own that would then have to agree.
+ *
+ *  - BLOCK-SCOPED, because this handler also serves the /api/v1/chain-events
+ *    FEED and its /stats aggregate, and those are not immutable at all. A feed
+ *    page is a window over a growing stream: new events land, and the same
+ *    key's correct answer changes. Only a single block's events are fixed, so
+ *    only they earn the long TTL — the feed keeps 60 s.
+ */
+export function chainEventsCacheTtlSeconds(
+  url: URL,
+  answer: { source?: string } | null,
+): number {
+  const blockScoped = BLOCK_CHAIN_EVENTS_PATH_PATTERN.test(url.pathname);
+  const settled = answer?.source === "lakehouse-cold-tier";
+  return blockScoped && settled
+    ? CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS
+    : CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS;
+}
+
 // A service binding can REJECT, not merely return a bad status. An unreachable
 // DATA_API -- Hyperdrive down, the upstream Worker over its duration limit, the
 // binding absent at runtime -- makes `fetch` throw. Every proxy below used to
@@ -4023,7 +4058,7 @@ export async function handleChainEventsFamily(
             status: 200,
             headers: {
               "content-type": "application/json",
-              "cache-control": `public, s-maxage=${CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS}`,
+              "cache-control": `public, s-maxage=${chainEventsCacheTtlSeconds(url, answer)}`,
             },
           }),
         ),


### PR DESCRIPTION
## Summary

`CHAIN_EVENTS_PROXY_CACHE_TTL_SECONDS = 60` was discarding answers **incapable of changing**. `chainEventsCacheKey` is already namespaced by contract version, network *and* block ref, so a lakehouse answer for one block cannot go stale within its own key.

Production showed the cost, 2026-08-13 06:37:47 UTC:

```
cache_match  STALE  edge-cache.metagraph.sh/chain-events/2026-07-03.2/mainnet/api/v1/blocks/8803453/chain-events
```

`STALE` is the telling one: that entry **existed and expired**. We computed the events for a finalized block, stored them, threw them away 60 seconds later, and re-derived them with another lakehouse scan.

The constant's header comment justified itself as *"this tier has no publish-time snapshot to key off of"* — but it does, and it is already in the key. The observed keys carry it literally: `chain-events/**2026-07-03.2**/mainnet/…`.

## Two conditions, and the second is the easy one to miss

**COLD TIER** — a hot-window answer is still inside the live-follow range and may yet move. This is the same signal #11001's chain-detail cache reads, deliberately: *the tier is the immutability*, and neither cache derives a block-depth rule of its own that would then have to agree with the other. (Both #11001 and #11003 originally asked for a shared "how deep is this block" rule; the tier makes that unnecessary.)

**BLOCK-SCOPED** — this handler also serves the `/api/v1/chain-events` **feed** and its `/stats` aggregate, and those are **not immutable at any tier**. A feed page is a window over a growing stream: new events land and the same key's correct answer changes. Keying the TTL on the tier alone would pin a feed page for an hour, which is a correctness bug rather than a stale cache. Only a single block's events are fixed, so only they earn the hour.

The transient case was already handled correctly and is untouched: a not-yet-decoded block returns through `chainDetailGapResponse` *before* the `cache.put` and is never cached.

## Tests

`tests/chain-events-cache-ttl.test.ts`, 4 cases — settled block (by number and by hash) → 3600; hot-window block → 60; **feed and stats → 60 even on a cold answer**; no-source and null answers → 60.

That third case is the regression this file exists to prevent, and it is the one a tier-only implementation fails.

Also **backfills a test #11001 landed without**: `dispatchChainHistoryRoute` defaults `ctx` to `{}`, so the storable branch has to survive a context with no `waitUntil` rather than throwing mid-response. That was the gap behind #11010's `codecov/patch` failure.

## Validation

```
npm run lint · format:check · typecheck · validate    green
npx vitest run chain-events-cache-ttl · chain-detail-edge-cache · chain-detail-serving   37 passed
```

Closes #11003
