### PR TITLE
refactor(scripts): every vocabulary site in scripts/ dispositioned — six copies derived, the pins made structural

### DIFF
--- a/schemas-src/query-enums.ts
+++ b/schemas-src/query-enums.ts
@@ -77,6 +77,10 @@ export const QUERY_ENUMS = {
   // (contracts.ts) cannot afford a schema import: the data-api Worker sits at
   // the startup CPU limit, and this module is the one place guaranteed free.
   responseEnvelopeField: ["ok", "data", "meta", "error"],
+  // The CALLABLE machine-interface subset of surfaceKind -- what integration
+  // readiness, the apis badge metric and the agent catalog count. Declared six
+  // times before this (#10996), one admitting to be an unenforced mirror.
+  callableServiceKind: ["subnet-api", "openapi", "sse", "data-artifact"],
   stakeFlowDirection: ["all", "in", "out"],
   surfaceHistoryAction: ["insert", "update", "delete"],
   providerAuthority: [

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -115,6 +115,8 @@ import {
   artifactStorageTierForRelativePath,
   schemaDetailArtifactRelativePath,
 } from "../src/artifact-storage.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+import { RPC_POOL_KIND_VALUES } from "../schemas-src/query-params.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -872,12 +874,7 @@ const profileArtifacts = buildSubnetProfileArtifacts({
 // live endpoint record by surface_id. Declared here (ahead of the index/profile
 // writes) because integration readiness consumes them via buildSubnetServices;
 // the agent-catalog and per-subnet overview below reuse the same maps.
-const AGENT_SERVICE_KINDS = new Set([
-  "subnet-api",
-  "openapi",
-  "sse",
-  "data-artifact",
-]);
+const AGENT_SERVICE_KINDS = new Set<string>(QUERY_ENUMS.callableServiceKind);
 const FIXTURE_SERVICE_KINDS = new Set([
   "subnet-api",
   "openapi",
@@ -3706,9 +3703,9 @@ function subnetProfileCompleteness({
 
 function operationalKindsForSubnetType(subnetType: unknown): string[] {
   if (subnetType === "root") {
-    return ["subtensor-rpc", "subtensor-wss", "archive"];
+    return [...RPC_POOL_KIND_VALUES];
   }
-  return ["openapi", "subnet-api", "sse", "data-artifact"];
+  return [...QUERY_ENUMS.callableServiceKind];
 }
 
 function surfaceHasArchiveSupport(surface: Row): boolean {
@@ -4163,12 +4160,12 @@ function buildCurationReview(
       const subnetSurfaces = surfacesByNetuid.get(subnet.netuid) || [];
       const subnetCandidates = candidatesByNetuid.get(subnet.netuid) || [];
       const operationalKinds = subnetSurfaces.filter((surface) =>
-        ["openapi", "subnet-api", "sse", "data-artifact"].includes(
+        (QUERY_ENUMS.callableServiceKind as readonly string[]).includes(
           surface.kind,
         ),
       );
       const apiCandidates = subnetCandidates.filter((candidate) =>
-        ["openapi", "subnet-api", "sse", "data-artifact"].includes(
+        (QUERY_ENUMS.callableServiceKind as readonly string[]).includes(
           candidate.kind,
         ),
       );
@@ -5864,7 +5861,9 @@ function reviewPriorityScore(
   );
   const adapterBonus =
     surfacesForSubnet.filter((surface) =>
-      ["openapi", "subnet-api", "sse", "data-artifact"].includes(surface.kind),
+      (QUERY_ENUMS.callableServiceKind as readonly string[]).includes(
+        surface.kind,
+      ),
     ).length * 8;
   const machineReviewPenalty =
     subnet.curation.review_state === "maintainer-reviewed" ? -25 : 20;

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -83,10 +83,6 @@ const COINCIDENT_BY_DOMAIN: Record<string, string[]> = {
     "schemas-src/routes/subnet-detail.ts",
     "schemas-src/routes/subnets.ts",
   ],
-  "bearish|bullish|neutral": [
-    "schemas-src/routes/chain-alpha-volume.ts",
-    "schemas-src/routes/subnet-alpha-volume.ts",
-  ],
   "dual|git|r2": [
     "schemas-src/artifacts/r2-manifest.ts",
     "schemas-src/routes/meta-contracts.ts",

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -37,6 +37,10 @@ const SCHEMA_DIRS = [
   "src/graphql",
   "workers",
   "workers/request-handlers",
+  // And the producers (#10996): a script consuming a vocabulary operationally
+  // must import the owner. Validator assertion-pins are declaration-invisible
+  // here by design -- see the allowlist note below.
+  "scripts",
 ];
 
 /** Vocabularies allowed to coincide, pinned to the EXACT files that do.
@@ -95,6 +99,15 @@ const COINCIDENT_BY_DOMAIN: Record<string, string[]> = {
   // nominator_positions primary-key column list -- the same three words
   // naming two unrelated things. A shared owner would couple an on-chain ABI
   // to a database index.
+  // Inline `[...].includes(...)` assertions in scripts/validate*.ts are PINS:
+  // literal on purpose, and invisible here because this gate matches
+  // declaration forms only -- the right blindness, since deriving a
+  // validator's expectation from the module it validates could never fail
+  // (#10996).
+  "bearish|bullish|neutral": [
+    "schemas-src/routes/chain-alpha-volume.ts",
+    "schemas-src/routes/subnet-alpha-volume.ts",
+  ],
   "coldkey|hotkey|netuid": [
     "src/evm-precompiles.ts",
     "src/nominator-positions-neon-write.ts",
@@ -158,8 +171,13 @@ for (const dir of SCHEMA_DIRS) {
     // `surfaceKind` sat there restating `SURFACE_KIND_VALUES` in a different
     // order: the routes published one and the MCP tools the other, which is 32
     // of the tool-vs-route enum divergences #10060 was counting.
-    for (const match of source.matchAll(/\b\w+:\s*\[([^\]]*)\][,;]/g))
-      push(match[1]);
+    for (const match of source.matchAll(/\b(\w+):\s*\[([^\]]*)\][,;]/g)) {
+      // `stdio: ["pipe", "pipe", "ignore"]` is Node's spawn wiring, not a
+      // domain vocabulary -- five scripts legitimately configure it and no
+      // owner could exist (#10996).
+      if (match[1] === "stdio") continue;
+      push(match[2]);
+    }
   }
 }
 

--- a/scripts/validate-surface.ts
+++ b/scripts/validate-surface.ts
@@ -17,6 +17,7 @@ import {
   readJson,
   repoRoot,
 } from "./lib.ts";
+import { RPC_POOL_KIND_VALUES } from "../schemas-src/query-params.ts";
 
 // ajv-formats' default export resolves to the CJS module namespace rather than
 // the plugin function under this project's NodeNext + esModuleInterop
@@ -44,7 +45,7 @@ const providerIds = new Set(
 // are NOT per-subnet contributor surfaces. Enforce the boundary here (the
 // contributor template already omits these kinds; this closes the hand-crafted
 // PR gap) without touching the probe-derived endpoint pipeline. See issue #1680.
-const BASE_LAYER_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
+const BASE_LAYER_KINDS = new Set<string>(RPC_POOL_KIND_VALUES);
 
 // Pre-existing duplicate-URL registrations, grandfathered so the new
 // duplicate-URL check below (added for #5737) only fails a contributor PR

--- a/src/badge.ts
+++ b/src/badge.ts
@@ -25,6 +25,7 @@
 import { loadReliabilityAggregate } from "./reliability-badge.ts";
 import { ifNoneMatchSatisfied, weakEtag } from "../workers/http.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
+import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 
 const BADGE_CACHE_SECONDS = 3600;
 const BADGE_LABEL = "metagraphed";
@@ -51,14 +52,9 @@ const FOR_THE_BADGE_PAD = 12;
 const FOR_THE_BADGE_LETTER_SPACING = 1.25;
 // shields.io "informational" blue, used for plain-count metrics (e.g. apis).
 const INFO_COLOR = "#007ec6";
-// Surface kinds that are callable machine interfaces (mirrors the build's
-// callable-service set); these are what `metric=apis` counts.
-const CALLABLE_SURFACE_KINDS = new Set([
-  "subnet-api",
-  "openapi",
-  "sse",
-  "data-artifact",
-]);
+// Surface kinds that are callable machine interfaces -- THE declared set,
+// not a mirror of it (#10996); these are what `metric=apis` counts.
+const CALLABLE_SURFACE_KINDS = new Set<string>(QUERY_ENUMS.callableServiceKind);
 // A–F grade → color band (gray for unknown); bands match reliability.ts.
 const GRADE_COLOR: Record<string, string> = {
   A: "#2ea44f",


### PR DESCRIPTION
Part of epic #10992. Closes #10996.

## Every site dispositioned: COPY or PIN, no third category

**COPIES → derived (8 sites):**

| copy | owner |
| --- | --- |
| callable machine-interface kinds — **six** declarations, no owner (`src/badge.ts` admitting "mirrors the build's callable-service set", unenforced; `scripts/build-artifacts.ts` ×5) | new `QUERY_ENUMS.callableServiceKind` |
| `build-artifacts` root-subnet operational kinds | `RPC_POOL_KIND_VALUES` |
| `validate-surface`'s `BASE_LAYER_KINDS` | `RPC_POOL_KIND_VALUES` |

**PINS → kept literal, on purpose:** every inline `[...].includes(...)` assertion in
`scripts/validate*.ts` (sentiment, surface classifications, review states, source tiers,
self-health verdicts…). A validator restating its expected values is what lets it FAIL when
the owner changes; deriving its expectation from the module it validates asserts the code's
own assumption and can never fail. These are declaration-invisible to the gate by design —
the allowlist documents the reasoning so the next audit doesn't re-litigate it.

## The gate now scans `scripts/`

275 vocabularies across four trees. Two honest additions: an extraction exclusion for
`stdio:` arrays (Node spawn wiring five scripts share — no domain owner could exist), and one
pinned coincidence (the four decoder tables, named by the lakehouse generator and the graphql
stream list — coupling a build generator to graphql schemas for four strings buys nothing the
entry's drift detection doesn't).

## Verification

- Falsified: a fresh `scripts/` copy of an owned vocabulary fails the gate; clean tree passes
- **Artifacts byte-identical** after `npm run build` — producer derivations preserved exact values
- Full `npx vitest run`: 20416 passed · `tsc` · `lint` · `format:check` — pass
- Ledger: **+18** disclosed (one-liner copies, enforcement bought); epic sum remains negative