### PR TITLE
fix(api): an unresolved extrinsic is not settled, and was advertising itself as storable

### DIFF
--- a/tests/chain-detail-serving.test.ts
+++ b/tests/chain-detail-serving.test.ts
@@ -267,6 +267,11 @@ describe("REST extrinsic detail", () => {
     assert.equal(res.status, 200);
     // The hot tier DOES hold this hash in the stub, so it answers with the row.
     assert.equal((await json(res)).data.extrinsic.extrinsic_hash, XT_HASH);
+    // #11001: and because it came from the LIVE-FOLLOW window rather than the
+    // lakehouse, it is not settled — withChainDetailEdgeCache reads this header
+    // to decide what may sit at the edge for an hour, so a hot answer must not
+    // advertise itself as storable.
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "short");
   });
 });
 

--- a/tests/extrinsic-cache-profile.test.ts
+++ b/tests/extrinsic-cache-profile.test.ts
@@ -1,0 +1,73 @@
+// #11001 backfill. handleExtrinsic's cache profile is not cosmetic any more:
+// withChainDetailEdgeCache reads `x-metagraph-cache-profile` to decide what may
+// be stored at the edge for an hour, so getting this wrong caches a moving
+// answer rather than merely mis-advertising one. #11010 landed the ternary
+// without covering either tier arm.
+//
+// The COLD arm is here (it needs only the R2 SQL stub, no module mock); the HOT
+// arm is asserted in tests/chain-detail-serving.test.ts, which already owns the
+// pg double that makes the live-follow window answer.
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { handleExtrinsic } from "../workers/request-handlers/entities.ts";
+import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+
+const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
+const HASH = `0x${"ab".repeat(32)}`;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/** Stubs the lakehouse so the cold tier answers; mirrors extrinsics-cold-tier.test.ts. */
+function sqlFetch(...responses: unknown[][]) {
+  let call = 0;
+  globalThis.fetch = (async () => {
+    const rows = responses[Math.min(call, responses.length - 1)] ?? [];
+    call += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ success: true, result: { rows } }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+function extrinsicRow() {
+  return {
+    block_number: 8_281_545,
+    extrinsic_index: 0,
+    extrinsic_hash: HASH,
+    signer: "5EYCAe5jLQhn6ofDSvqF6iY53erXNkwhyE1aCEgvi1NNs91F",
+    call_module: "SubtensorModule",
+    call_function: "set_weights",
+    success: true,
+    fee_tao: null,
+    tip_tao: null,
+    call_args: null,
+    observed_at: 1_700_000_000_000,
+  };
+}
+
+const req = () =>
+  new Request(`https://api.metagraph.sh/api/v1/extrinsics/${HASH}`);
+
+describe("extrinsic detail names the immutability its tier knows (#11001)", () => {
+  test("a lakehouse answer is settled, so it takes the storable profile", async () => {
+    sqlFetch([extrinsicRow()], []);
+    const res = await handleExtrinsic(req(), TOKEN as never, HASH);
+    assert.equal(res.status, 200);
+    // The one assertion that matters: this is the header the edge cache reads.
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "static");
+  });
+
+  test("an unresolved hash stays short — absence from a window proves nothing", async () => {
+    // The schema-stable `extrinsic: null`, which a client must be able to
+    // re-check rather than have pinned at the edge for an hour.
+    sqlFetch([]);
+    const res = await handleExtrinsic(req(), TOKEN as never, HASH);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "short");
+  });
+});

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -7286,8 +7286,18 @@ export async function handleExtrinsic(
   // — a client must re-check both. withChainDetailEdgeCache reads this profile
   // to decide what may be stored at the edge, so getting it wrong here would
   // cache a moving answer, not merely mis-advertise one.
+  // ...and RESOLVED, not merely cold. `loadExtrinsicColdTier` returns the
+  // schema-stable payload for a confirmed absence rather than null, so
+  // `tier === "cold"` alone is true for "the lakehouse looked and this hash is
+  // not there" — which is exactly the answer that must NOT be pinned for an
+  // hour. A hash absent from the decoded range proves nothing (it may land, or
+  // sit outside it), which is the same reason this route keeps its
+  // `extrinsic: null` instead of 404ing. handleBlock draws the line in the same
+  // place with `data.block ? "static" : "short"`.
   const cacheProfile =
-    answer?.kind === "answer" && answer.tier === "cold" ? "static" : "short";
+    answer?.kind === "answer" && answer.tier === "cold" && data.extrinsic
+      ? "static"
+      : "short";
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
## Summary

#11010 landed `handleExtrinsic`'s cache profile keyed on the tier alone, and **neither arm of that ternary was covered** — that was the `codecov/patch` failure on it. Covering it found a real defect rather than just filling a number.

`loadExtrinsicColdTier` returns the schema-stable payload for a **confirmed absence** rather than `null` (`tests/extrinsics-cold-tier.test.ts`: *"a confirmed absence is the shared payload, not null"*). So `tier === "cold"` is *also* true for "the lakehouse looked and this hash is not there" — and that answer was taking the `static` profile.

`withChainDetailEdgeCache` reads exactly that header to decide what may sit at the edge for an hour. So **an unresolved hash pinned `extrinsic: null` for an hour.**

## Why that is the one outcome the design forbids

A hash absent from the decoded range proves nothing — it may land later, or sit outside the range entirely. That is precisely why this route keeps its schema-stable `extrinsic: null` instead of 404ing (`handleExtrinsic`'s own #9208 comment). Caching that absence is the failure mode that reasoning exists to prevent.

The profile now requires the answer to be cold **and resolved**, which is where `handleBlock` already draws the line: `data.block ? "static" : "short"`.

## Coverage

Both tier arms, split by what each needs:

- **cold → `static`**, and **unresolved → `short`** — `tests/extrinsic-cache-profile.test.ts`, which needs only the R2 SQL stub.
- **hot → `short`** — asserted in `tests/chain-detail-serving.test.ts`, which already owns the `pg` double that makes the live-follow window answer. Added to the existing hash-form test rather than duplicating that harness.

The unresolved case is the one that failed before the fix.

## Validation

```
npm run lint · format:check · typecheck · validate    green
npx vitest run chain-detail-serving · extrinsic-cache-profile · extrinsics · chain-detail-edge-cache   83 passed
```

Follow-up to #11001 / #11010.