### PR TITLE
fix(api): the account family had no rate limit at all

### DIFF
--- a/tests/chain-detail-rate-limit.test.ts
+++ b/tests/chain-detail-rate-limit.test.ts
@@ -226,3 +226,122 @@ describe("chain-detail lookup rate limit", () => {
     }
   });
 });
+
+// #11017. The account family reached production with no ceiling at all: every
+// call to applyTieredRateLimit was per-family, and handleRequest dispatches
+// straight into dispatchRequest with nothing in front of it. Same cost shape as
+// the four above -- unbounded key space, lakehouse-backed, uncached -- and one
+// of them OOMed an isolate at limit=25 (#11019).
+//
+// The placement assertion above (`dataCalls === 0`) is deliberately NOT reused
+// here: these routes read the lakehouse over global fetch, not DATA_API, so
+// that counter would be 0 whether or not the gate ran, and a check that cannot
+// fail is worse than no check. What is asserted instead is the rate-limiter
+// call itself, which is the thing that was missing.
+const ACCOUNT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+
+describe("account family rate limit (#11017)", () => {
+  const gated = [
+    `/api/v1/accounts/${ACCOUNT}`,
+    `/api/v1/accounts/${ACCOUNT}/transfers`,
+    `/api/v1/accounts/${ACCOUNT}/events`,
+    `/api/v1/accounts/${ACCOUNT}/extrinsics`,
+    `/api/v1/accounts/${ACCOUNT}/stake-flow`,
+  ];
+
+  for (const path of gated) {
+    test(`${path.replace(ACCOUNT, "{ss58}")} rejects an over-limit anonymous caller`, async () => {
+      const { env: testEnv, counters } = envWithLimiter(false);
+      const response = await handleRequest(
+        new Request(`https://metagraph.sh${path}`, {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        }),
+        testEnv,
+        {},
+      );
+      assert.equal(response.status, 429);
+      assert.equal((await jsonBody(response)).error.code, "data_rate_limited");
+      // Same bucket as the chain-detail four: one `data:` prefix across the
+      // whole policy, so a caller cannot mint a fresh allowance by switching
+      // families.
+      assert.deepEqual(counters.keys, [`data:${CLIENT_IP}`]);
+      // Gated exactly once -- a second call would halve the real ceiling.
+      assert.equal(counters.rateCalls, 1);
+    });
+  }
+
+  test("an under-limit caller is let through", async () => {
+    const { env: testEnv, counters } = envWithLimiter(true);
+    const response = await handleRequest(
+      new Request(`https://metagraph.sh/api/v1/accounts/${ACCOUNT}/transfers`, {
+        headers: { "cf-connecting-ip": CLIENT_IP },
+      }),
+      testEnv,
+      {},
+    );
+    assert.notEqual(response.status, 429);
+    assert.equal(counters.rateCalls, 1);
+  });
+
+  test("a bad-checksum address still 400s WITHOUT spending the caller's budget", async () => {
+    // The ordering decision, pinned: the checksum guard runs first. A bad
+    // address costs nothing to detect, and charging for it would make the
+    // limiter punish the one mistake it has no reason to.
+    //
+    // ADDRESS-SHAPED but wrong -- one character changed, same length. That is
+    // the case the guard exists for (#10036): a one-character typo used to
+    // answer with a confident empty result. An UNSHAPED segment takes a
+    // different path entirely, asserted below.
+    const badChecksum = `${ACCOUNT.slice(0, -1)}Z`;
+    const { env: testEnv, counters } = envWithLimiter(false);
+    const response = await handleRequest(
+      new Request(
+        `https://metagraph.sh/api/v1/accounts/${badChecksum}/transfers`,
+        {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        },
+      ),
+      testEnv,
+      {},
+    );
+    assert.equal(response.status, 400);
+    assert.equal((await jsonBody(response)).error.code, "invalid_ss58");
+    assert.equal(counters.rateCalls, 0);
+  });
+
+  test("an unshaped segment 404s at the router, also without spending budget", async () => {
+    const { env: testEnv, counters } = envWithLimiter(false);
+    const response = await handleRequest(
+      new Request(
+        `https://metagraph.sh/api/v1/accounts/${ACCOUNT}X/transfers`,
+        {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        },
+      ),
+      testEnv,
+      {},
+    );
+    // Matches no account route at all -- the honest answer for a path that
+    // identifies nothing, and it must not reach the limiter either.
+    assert.equal(response.status, 404);
+    assert.equal(counters.rateCalls, 0);
+  });
+
+  test("the account COLLECTION routes are deliberately NOT gated", async () => {
+    // Bounded reads over a fixed key space, same reasoning as the block and
+    // extrinsic feeds above. If a future change gates these it should update
+    // this test, not happen as a side effect of touching the dispatcher.
+    for (const path of ["/api/v1/accounts", "/api/v1/accounts/top-holders"]) {
+      const { env: testEnv, counters } = envWithLimiter(false);
+      const response = await handleRequest(
+        new Request(`https://metagraph.sh${path}?limit=1`, {
+          headers: { "cf-connecting-ip": CLIENT_IP },
+        }),
+        testEnv,
+        {},
+      );
+      assert.notEqual(response.status, 429);
+      assert.equal(counters.rateCalls, 0);
+    }
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -7038,6 +7038,25 @@ async function dispatchRequest(
         400,
       );
     }
+    // ...and one rate-limit gate for the same 25 routes (#11017), placed here
+    // for the reason stated above: the family is dispatched from this one
+    // function, so a single call covers every member and an account route added
+    // tomorrow inherits the ceiling instead of having to remember it.
+    //
+    // AFTER the checksum guard on purpose. A malformed address is a 400 that
+    // costs nothing to determine, and spending a caller's budget to tell them
+    // they typed their own address wrong would make the limiter punish the one
+    // mistake it has no reason to.
+    //
+    // Deliberately scoped to the ADDRESS-SHAPED routes. The collection routes
+    // (`/api/v1/accounts`, `/api/v1/accounts/top-holders`) are bounded list
+    // reads over a fixed key space -- the same reasoning that leaves `/blocks`
+    // and `/extrinsics` ungated above -- and gating them would spend the
+    // limiter's budget on the part of the family that behaves.
+    if (accountSs58Match) {
+      const limited = await dataRouteRateLimit(request, env, ctx, "account");
+      if (limited) return limited;
+    }
     // Account entity routes (#1347): computed live from the account_events +
     // neurons store tiers. More-specific paths first (each pattern is anchored).
     const accountHistoryMatch = ACCOUNT_HISTORY_PATH_PATTERN.exec(
@@ -8012,11 +8031,28 @@ const PROJECTION_ROUTE_HANDLERS: Record<
  * or "summary" parses as a block reference.
  */
 /**
- * The tiered gate on the four chain-detail LOOKUP routes.
+ * The tiered gate on the per-entity LOOKUP routes: the four chain-detail ones,
+ * and the account family (#11017).
  *
- * WHY THESE FOUR. `/blocks/{ref}`, its `/events` and `/extrinsics`
- * sub-resources, and `/extrinsics/{hash}` were the only Postgres-backed routes
- * on this Worker carrying no limiter at all. Their sibling `/chain-events`
+ * Named for the POLICY it applies (`DATA_TIERED_RATE_LIMIT`), not for one
+ * caller — it was `chainDetailRateLimit` until the account routes were found to
+ * be reaching production with no ceiling at all, and a name that claims a
+ * narrower scope than the function has is how the next unmetered family gets
+ * missed.
+ *
+ * WHY THE ACCOUNTS. The 25 `/api/v1/accounts/{ss58}/*` routes are the same cost
+ * shape as the chain-detail four and had none of the protection: unbounded key
+ * space (every ss58 that has ever touched the chain), lakehouse-backed and
+ * billed per byte scanned, no edge cache, and — until this — no limiter, because
+ * `applyTieredRateLimit` was only ever called per-family and `handleRequest`
+ * dispatches straight into `dispatchRequest` with nothing in front of it. One of
+ * them OOMed an isolate at `limit=25` (#11019), which is what a route with no
+ * ceiling in front of an uncapped read eventually does.
+ *
+ * WHY THESE FOUR (the original set). `/blocks/{ref}`, its `/events` and
+ * `/extrinsics` sub-resources, and `/extrinsics/{hash}` were the only
+ * Postgres-backed routes on this Worker carrying no limiter at all. Their
+ * sibling `/chain-events`
  * family has gated itself since #8386 (handleChainEventsFamily above), so this
  * closes a gap in an existing policy rather than inventing a second one: the
  * same DATA_TIERED_RATE_LIMIT, the same rejection shape, the same
@@ -8050,7 +8086,7 @@ const PROJECTION_ROUTE_HANDLERS: Record<
  *
  * Returns the rejection to serve, or null when the caller may proceed.
  */
-async function chainDetailRateLimit(
+async function dataRouteRateLimit(
   request: Request,
   env: Env,
   ctx: Ctx,
@@ -8098,7 +8134,7 @@ async function dispatchChainHistoryRoute(
   // Sub-resource (#1845) before detail before the feed; each pattern is anchored.
   const blockExtrinsicsMatch = BLOCK_EXTRINSICS_PATH_PATTERN.exec(pathname);
   if (blockExtrinsicsMatch) {
-    const limited = await chainDetailRateLimit(
+    const limited = await dataRouteRateLimit(
       request,
       env,
       ctx,
@@ -8115,18 +8151,13 @@ async function dispatchChainHistoryRoute(
   }
   const blockEventsMatch = BLOCK_EVENTS_PATH_PATTERN.exec(pathname);
   if (blockEventsMatch) {
-    const limited = await chainDetailRateLimit(
-      request,
-      env,
-      ctx,
-      "block-events",
-    );
+    const limited = await dataRouteRateLimit(request, env, ctx, "block-events");
     if (limited) return limited;
     return handleBlockEvents(request, env, blockEventsMatch[1], url, chain);
   }
   const blockDetailMatch = BLOCK_DETAIL_PATH_PATTERN.exec(pathname);
   if (blockDetailMatch) {
-    const limited = await chainDetailRateLimit(request, env, ctx, "block");
+    const limited = await dataRouteRateLimit(request, env, ctx, "block");
     if (limited) return limited;
     return withChainDetailEdgeCache(request, env, url, chain, ctx, () =>
       handleBlock(request, env, blockDetailMatch[1], chain),
@@ -8138,7 +8169,7 @@ async function dispatchChainHistoryRoute(
   // Detail (more specific) before the feed; each pattern is anchored.
   const extrinsicDetailMatch = EXTRINSIC_DETAIL_PATH_PATTERN.exec(pathname);
   if (extrinsicDetailMatch) {
-    const limited = await chainDetailRateLimit(request, env, ctx, "extrinsic");
+    const limited = await dataRouteRateLimit(request, env, ctx, "extrinsic");
     if (limited) return limited;
     return withChainDetailEdgeCache(request, env, url, chain, ctx, () =>
       handleExtrinsic(request, env, extrinsicDetailMatch[1], chain),


### PR DESCRIPTION
## Summary

`applyTieredRateLimit` is called from exactly five places, and every one is a specific family — chain-events, chain-detail, webhook subscriptions, AI search, ask. There is **no entry-level limiter**: `handleRequest` calls `dispatchRequest` directly. The 25 `/api/v1/accounts/{ss58}/*` routes were in none of those families, so they were reachable as fast as a caller could open connections.

Same cost shape as the four chain-detail routes gated in #8386:

| | chain-detail | accounts (before) |
| --- | --- | --- |
| key space | unbounded | unbounded (every ss58 ever seen) |
| store | lakehouse, billed per byte scanned | same |
| edge cache | yes, since #11010 | no |
| rate limit | yes | **no** |

One of them **OOMed an isolate at `limit=25`** (#11019) — 11.6 s, `outcome: exceededMemory`, 503, taking neighbouring requests with it, because the Workers memory limit is per-isolate. That is what a route with no ceiling in front of an uncapped read eventually does. #11005's `Disallow: /api/v1/accounts/` stops a polite crawler and nothing else.

## Placement

In the dispatcher, beside the ss58 checksum guard, for the reason that guard is already there — *"the guard sits here, once, rather than in 21 handlers: an account route added tomorrow inherits it instead of having to remember it."* One call covers all 25.

Two deliberate scoping decisions, both pinned by tests:

- **After the checksum guard.** A malformed address is a 400 that costs nothing to determine; charging for it would make the limiter punish the one mistake it has no reason to.
- **Address-shaped routes only.** `/api/v1/accounts` and `/api/v1/accounts/top-holders` are bounded reads over a fixed key space — the same reasoning that leaves `/blocks` and `/extrinsics` ungated — so gating them would spend the budget on the part of the family that behaves.

## Rename

`chainDetailRateLimit` → `dataRouteRateLimit`. The body was always generic (it applies `DATA_TIERED_RATE_LIMIT`, nothing chain-detail-specific); only the name was narrow. A name claiming less scope than the function has is how the next unmetered family gets missed.

## Tests

Extends `tests/chain-detail-rate-limit.test.ts` — 21 cases now. Five account routes reject an over-limit caller with `data_rate_limited`, on the shared `data:{ip}` bucket (so a caller cannot mint a fresh allowance by switching families), gated **exactly once** (a second call would halve the real ceiling). Plus the two exclusions, and both malformed-address paths.

The chain-detail file's placement assertion (`dataCalls === 0`) is **deliberately not reused** here: these routes read the lakehouse over global `fetch`, not `DATA_API`, so that counter would be 0 whether or not the gate ran — a check that cannot fail is worse than no check. The rate-limiter call itself is asserted instead.

Mutation-checked: removing the gate fails all five rejection cases.

One assumption the tests corrected — appending a character to an ss58 makes it *unshaped*, so it 404s at the router rather than 400ing on checksum. Both paths are now asserted, and neither spends budget.

## Validation

```
npm run typecheck · lint · format:check · validate    green
npx vitest run chain-detail-rate-limit · api-tiers    46 passed
```

Closes #11017