### PR TITLE
perf(api): the two block sub-resources #11010 left behind

### DIFF
--- a/tests/chain-detail-edge-cache.test.ts
+++ b/tests/chain-detail-edge-cache.test.ts
@@ -290,6 +290,9 @@ describe("the dispatch actually routes through the cache (#11001)", () => {
       "extrinsic",
       "/api/v1/extrinsics/0x58e19156f8fdadbf60f70aaf664e80aa80c9ebb705dffe6a919048798c5c7af0",
     ],
+    // #11018: the two sub-resources #11010 left behind.
+    ["block-extrinsics", "/api/v1/blocks/777/extrinsics"],
+    ["block-events", "/api/v1/blocks/777/events"],
   ] as const) {
     test(`${label} detail consults the edge cache, and a cold ref is not stored`, async () => {
       const cache = mockCaches();

--- a/tests/extrinsic-cache-profile.test.ts
+++ b/tests/extrinsic-cache-profile.test.ts
@@ -71,3 +71,56 @@ describe("extrinsic detail names the immutability its tier knows (#11001)", () =
     assert.equal(res.headers.get("x-metagraph-cache-profile"), "short");
   });
 });
+
+// #11018. The two block sub-resources got the same treatment, and the
+// non-empty half of the condition matters more here than anywhere: an empty
+// extrinsics/events array and a block that genuinely had none are the same
+// bytes (#9208), so caching the empty one manufactures a measurement.
+import {
+  handleBlockEvents,
+  handleBlockExtrinsics,
+} from "../workers/request-handlers/entities.ts";
+
+const BLOCK = "8281545";
+const blockUrl = (sub: string) =>
+  new URL(`https://api.metagraph.sh/api/v1/blocks/${BLOCK}/${sub}`);
+const blockReq = (sub: string) => new Request(blockUrl(sub).toString());
+
+describe("block sub-resources name their settledness (#11018)", () => {
+  test("a lakehouse answer WITH rows is settled", async () => {
+    sqlFetch([extrinsicRow()], []);
+    const res = await handleBlockExtrinsics(
+      blockReq("extrinsics"),
+      TOKEN as never,
+      BLOCK,
+      blockUrl("extrinsics"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "static");
+  });
+
+  test("a lakehouse answer with NO rows is NOT storable", async () => {
+    // The one that matters. Pinning this for an hour would answer a later
+    // caller with a confident "this block had no extrinsics" nobody measured.
+    sqlFetch([]);
+    const res = await handleBlockExtrinsics(
+      blockReq("extrinsics"),
+      TOKEN as never,
+      BLOCK,
+      blockUrl("extrinsics"),
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-cache-profile"), "short");
+  });
+
+  test("the events sub-resource follows the identical rule", async () => {
+    sqlFetch([]);
+    const empty = await handleBlockEvents(
+      blockReq("events"),
+      TOKEN as never,
+      BLOCK,
+      blockUrl("events"),
+    );
+    assert.equal(empty.headers.get("x-metagraph-cache-profile"), "short");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -8105,12 +8105,8 @@ async function dispatchChainHistoryRoute(
       "block-extrinsics",
     );
     if (limited) return limited;
-    return handleBlockExtrinsics(
-      request,
-      env,
-      blockExtrinsicsMatch[1],
-      url,
-      chain,
+    return withChainDetailEdgeCache(request, env, url, chain, ctx, () =>
+      handleBlockExtrinsics(request, env, blockExtrinsicsMatch[1], url, chain),
     );
   }
   const blockEventsMatch = BLOCK_EVENTS_PATH_PATTERN.exec(pathname);
@@ -8122,7 +8118,9 @@ async function dispatchChainHistoryRoute(
       "block-events",
     );
     if (limited) return limited;
-    return handleBlockEvents(request, env, blockEventsMatch[1], url, chain);
+    return withChainDetailEdgeCache(request, env, url, chain, ctx, () =>
+      handleBlockEvents(request, env, blockEventsMatch[1], url, chain),
+    );
   }
   const blockDetailMatch = BLOCK_DETAIL_PATH_PATTERN.exec(pathname);
   if (blockDetailMatch) {

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -6742,6 +6742,26 @@ export async function handleBlockExtrinsics(
     answer?.kind === "answer"
       ? answer.data
       : buildBlockExtrinsics([], ref, null, { limit, offset });
+  // #11018: name the settledness withChainDetailEdgeCache reads off this
+  // response. COLD *and* NON-EMPTY, and the second half is the one that matters
+  // here. answerBlockDetail returns `tier: "cold"` whenever the lakehouse
+  // loader returned anything, and that loader answers a confirmed absence with
+  // the schema-stable empty payload rather than null (#11016 found the same
+  // trap on handleExtrinsic) -- so `cold` alone is also true for "the lakehouse
+  // looked and this block is not there".
+  //
+  // On THIS route that distinction is the whole point of #9208: an empty
+  // extrinsics array and a block that genuinely had none are the same bytes.
+  // Pinning an empty answer for an hour would convert "we cannot see it yet"
+  // into "this block had none", which is exactly what chainDetailGapResponse
+  // exists to prevent. isEmptyExtrinsicPayload is already in scope for the
+  // ladder's own use, so the condition is expressible without inventing one.
+  const cacheProfile =
+    answer?.kind === "answer" &&
+    answer.tier === "cold" &&
+    !isEmptyExtrinsicPayload(answer.data)
+      ? "static"
+      : "short";
   // CSV reuses handleExtrinsics's transform + columns — buildBlockExtrinsics maps
   // the same formatExtrinsic row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
@@ -6766,7 +6786,7 @@ export async function handleBlockExtrinsics(
           ?.observed_at ?? null,
       ),
     },
-    "short",
+    cacheProfile,
   );
 }
 
@@ -6807,6 +6827,16 @@ export async function handleBlockEvents(
     answer?.kind === "answer"
       ? answer.data
       : buildBlockEvents([], ref, null, { limit, offset });
+  // #11018, same rule and same reason as handleBlockExtrinsics above: cold AND
+  // non-empty. An empty event list and a block that genuinely emitted none are
+  // the same bytes, so caching the empty one would answer a later caller with a
+  // confident "this block had no events" we never measured.
+  const cacheProfile =
+    answer?.kind === "answer" &&
+    answer.tier === "cold" &&
+    !isEmptyEventPayload(answer.data)
+      ? "static"
+      : "short";
   // CSV reuses the account-events EVENTS_CSV_COLUMNS — buildBlockEvents maps the
   // same formatAccountEvent row shape (#5746). Cold block → empty → header-only.
   if (csvRequested(url, request)) {
@@ -6829,7 +6859,7 @@ export async function handleBlockEvents(
           ?.observed_at ?? null,
       ),
     },
-    "short",
+    cacheProfile,
   );
 }
 


### PR DESCRIPTION
## Summary

`/api/v1/blocks/{ref}/extrinsics` and `/api/v1/blocks/{ref}/events` are dispatched **in the same function, immediately above** the two routes #11010 wrapped:

```ts
blockExtrinsicsMatch → handleBlockExtrinsics(...)              // uncached
blockEventsMatch     → handleBlockEvents(...)                  // uncached
blockDetailMatch     → withChainDetailEdgeCache(... handleBlock)      // #11010
extrinsicDetailMatch → withChainDetailEdgeCache(... handleExtrinsic)  // #11010
```

Identical properties — block-scoped, unbounded (~8.8M × 2), lakehouse-backed, immutable once settled. Neither is in `LIVE_OVERLAY_ROUTE_IDS`, the set that names deliberate exclusions, so nothing had decided this. Dispatch order had. They *are* rate-limited, so this is cost and latency rather than an abuse gap.

## Wrapping them alone would have changed nothing

Both hardcoded `"short"`, and `withChainDetailEdgeCache` only stores a response whose `x-metagraph-cache-profile` is `static`. So each handler names its own settledness first — the same fix #11016 made to `handleExtrinsic`.

## Cold **and** non-empty

`answerBlockDetail` returns `tier: "cold"` whenever the lakehouse loader returned anything, and that loader answers a **confirmed absence** with the schema-stable empty payload rather than `null`. So `cold` alone is also true for *"the lakehouse looked and this block is not there"*.

On these two routes that ambiguity is the entire argument of #9208: **an empty extrinsics array and a block that genuinely had none are the same bytes.** Pinning the empty one for an hour converts "we cannot see it yet" into "this block had none" — precisely what `chainDetailGapResponse` exists to prevent.

Both handlers are already handed an `isEmpty` predicate (`isEmptyExtrinsicPayload` / `isEmptyEventPayload`) for exactly this distinction, so the condition needed nothing new.

## Tests

- `chain-detail-edge-cache.test.ts` — the dispatch-wiring loop now covers all four routes, asserting **positively** that the lookup happened against the chain-detail key before asserting nothing was stored.
- `extrinsic-cache-profile.test.ts` — a lakehouse answer *with* rows is `static`; **with no rows is `short`**; the events sub-resource follows the identical rule.

Mutation-checked: dropping `!isEmptyExtrinsicPayload(...)` makes the empty answer storable and fails the second test.

## Validation

```
npm run typecheck · lint · format:check · validate    green
npx vitest run chain-detail-edge-cache · extrinsic-cache-profile · blocks ·
                chain-detail-serving · chain-detail-rate-limit    109 passed
```

Closes #11018