### PR TITLE
fix(icon-proxy): record negatives server-side, not in a Cache-Control header

### DIFF
--- a/src/icon-proxy.ts
+++ b/src/icon-proxy.ts
@@ -33,6 +33,29 @@ const CACHE_CONTROL = "public, max-age=2592000, immutable"; // 30d, per contract
 // blackholes a real icon for 24h. (#1124 frontend-surfacing freshness audit.)
 const NEGATIVE_CACHE_STABLE = "public, max-age=86400"; // 24h — won't resolve
 const NEGATIVE_CACHE_TRANSIENT = "public, max-age=600"; // 10m — retry soon
+
+/**
+ * The same two windows, as a SERVER-SIDE record (#11020).
+ *
+ * The two `Cache-Control` values above were the whole negative cache, and a
+ * response header is per-colo, per-client state. So a subject that will never
+ * resolve re-ran the entire aggregator fan-out in every colo, forever: over one
+ * 3-day window `icon-cache/gh:tensorclaw/192`, `icon-cache/gh:PlatformNetwork/192`
+ * and two others missed ~30+ times across DFW, LAX, IAD, ORD, MSP, SJC, SEA,
+ * FRA and PHX, and those misses were 55% of the entire Worker error channel
+ * (#11022).
+ *
+ * A tombstone in R2 makes "24h" and "10m" mean 24h and 10m GLOBALLY, which is
+ * what the two constants above always claimed. The stable/transient split is
+ * preserved exactly as the fan-out already reasons about it: a clean 4xx is a
+ * stable "no", an abort/5xx/403 is transient and must be retried soon.
+ */
+const NEGATIVE_TOMBSTONE_STABLE_MS = 86_400_000; // 24h, matching the header
+const NEGATIVE_TOMBSTONE_TRANSIENT_MS = 600_000; // 10m, matching the header
+
+/** Marks a cached object as a NEGATIVE result rather than an icon. */
+const NEGATIVE_META_KEY = "negative";
+const NEGATIVE_META_AT = "negative_at";
 const BLOCKED_TLDS = new Set(["localhost", "local", "internal"]);
 // A real-ish UA — DuckDuckGo/Google's favicon endpoints bot-block the default Worker
 // user-agent (a cause of the prod 404s).
@@ -421,7 +444,32 @@ export async function handleIconProxy(
   if (bucket?.get) {
     try {
       const cached = await bucket.get(cacheKey);
-      if (cached) {
+      // A TOMBSTONE is stored under the same key as an icon would be, so one
+      // read answers both questions. It must be tested BEFORE the hit path:
+      // its body is empty, and serving that as an image would turn "no icon"
+      // into "a zero-byte icon".
+      const negativeKind = cached?.customMetadata?.[NEGATIVE_META_KEY];
+      if (cached && negativeKind) {
+        const writtenAt = Number(
+          cached.customMetadata?.[NEGATIVE_META_AT] ?? 0,
+        );
+        const ttl =
+          negativeKind === "transient"
+            ? NEGATIVE_TOMBSTONE_TRANSIENT_MS
+            : NEGATIVE_TOMBSTONE_STABLE_MS;
+        if (Number.isFinite(writtenAt) && now - writtenAt < ttl) {
+          await (cached.body as ReadableStream | undefined)?.cancel?.();
+          return notFound(
+            negativeKind === "transient"
+              ? NEGATIVE_CACHE_TRANSIENT
+              : NEGATIVE_CACHE_STABLE,
+          );
+        }
+        // Expired: fall through and re-resolve. Deliberately not deleted here
+        // -- the re-resolution overwrites it with either an icon or a fresh
+        // tombstone, so a delete would only widen the window in which a
+        // concurrent request sees nothing and re-runs the fan-out.
+      } else if (cached) {
         const ct = cached.httpMetadata?.contentType || "image/png";
         const extra: Record<string, string> = { "x-icon-cache": "hit" };
         if (isHead) {
@@ -496,5 +544,23 @@ export async function handleIconProxy(
   }
   // Allowlisted host, every source failed: short window if it was transient (retry
   // soon), full day if every source gave a clean negative.
+  //
+  // #11020: record it server-side too, so the next colo does not repeat the
+  // whole fan-out. Awaited rather than deferred because this handler takes no
+  // ExecutionContext -- the same reason the positive `bucket.put` above is
+  // awaited -- and best-effort for the same reason: failing to cache a negative
+  // must never turn a 404 into a 500.
+  if (bucket?.put) {
+    try {
+      await bucket.put(cacheKey, new Uint8Array(0), {
+        customMetadata: {
+          [NEGATIVE_META_KEY]: transient ? "transient" : "stable",
+          [NEGATIVE_META_AT]: String(now),
+        },
+      });
+    } catch {
+      // caching is best-effort
+    }
+  }
   return notFound(transient ? NEGATIVE_CACHE_TRANSIENT : NEGATIVE_CACHE_STABLE);
 }

--- a/tests/icon-proxy.test.ts
+++ b/tests/icon-proxy.test.ts
@@ -173,14 +173,15 @@ test("404 for syntactically valid but non-allowlisted hosts", async () => {
 });
 
 test("rejects oversized upstream responses before caching", async () => {
-  const puts = [];
+  const puts: { key: unknown; body: Uint8Array; opts: Row }[] = [];
   const tooLarge = new Uint8Array(256 * 1024 + 1).fill(1);
   const res = await call("?host=example.com", {
     env: {
       METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
       METAGRAPH_ARCHIVE: {
         get: async () => null,
-        put: async (k: unknown) => puts.push(k),
+        put: async (k: unknown, body: Uint8Array, opts: Row = {}) =>
+          puts.push({ key: k, body, opts }),
       },
     },
     fetchImpl: async () =>
@@ -193,7 +194,17 @@ test("rejects oversized upstream responses before caching", async () => {
       }),
   });
   assert.equal(res.status, 404);
-  assert.equal(puts.length, 0);
+  // The oversized IMAGE is still never cached -- that is what this test has
+  // always been for. #11020 added one write on this path, and it is a
+  // zero-byte tombstone, not the payload: asserting `puts.length === 0` would
+  // now be asserting that we re-run the whole fan-out next time.
+  assert.equal(puts.length, 1);
+  const [written] = puts as unknown as {
+    body: Uint8Array;
+    opts: { customMetadata?: Record<string, string> };
+  }[];
+  assert.equal(written.body.byteLength, 0, "no image bytes were stored");
+  assert.equal(written.opts.customMetadata?.negative, "stable");
 });
 
 test("builds the allowlist from artifact url/base_url/website fields (nested + arrays)", async () => {
@@ -597,12 +608,12 @@ test("boundedArrayBuffer rejects oversized arrayBuffer() in the non-stream path"
 });
 
 test("boundedArrayBuffer rejects an oversized streamed body (no content-length)", async () => {
-  const puts = [];
+  const puts: { key: unknown; body: Uint8Array }[] = [];
   const env = {
     METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
     METAGRAPH_ARCHIVE: {
       get: async () => null,
-      put: async (k: unknown) => puts.push(k),
+      put: async (k: unknown, body: Uint8Array) => puts.push({ key: k, body }),
     },
   };
   let canceled = false;
@@ -634,7 +645,11 @@ test("boundedArrayBuffer rejects an oversized streamed body (no content-length)"
   });
   assert.equal(res.status, 404);
   assert.equal(canceled, true); // reader.cancel() ran on the size cap
-  assert.equal(puts.length, 0);
+  // The oversized STREAM is never buffered into the cache -- unchanged. The one
+  // write here is #11020's zero-byte tombstone, asserted by shape rather than
+  // by count so this keeps meaning "no payload was stored".
+  assert.equal(puts.length, 1);
+  assert.equal((puts[0] as { body: Uint8Array }).body.byteLength, 0);
 });
 
 test("accepts a streamed body under the size cap (reader path success)", async () => {
@@ -875,4 +890,112 @@ test("aborts a hung upstream fetch via the timeout controller", async () => {
   } finally {
     vi.useRealTimers();
   }
+});
+
+// #11020. The negative cache used to be a `Cache-Control` header and nothing
+// else — per-colo, per-client state — so a subject that will never resolve
+// re-ran the whole aggregator fan-out in every colo, forever. Four such
+// subjects were 55% of the entire Worker error channel over one 3-day window.
+//
+// The property under test is that a SECOND request does no upstream work.
+// Asserting only "returns 404" would pass on the old behaviour too.
+test("a stable negative is recorded server-side and skips the fan-out next time", async () => {
+  const store = new Map<string, { body: Uint8Array; opts: Row }>();
+  let upstreamCalls = 0;
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: {
+      get: async (k: string) => {
+        const hit = store.get(k);
+        return hit
+          ? {
+              body: { cancel: async () => {} },
+              customMetadata: hit.opts.customMetadata,
+              httpMetadata: {},
+            }
+          : null;
+      },
+      put: async (k: string, body: Uint8Array, opts: Row = {}) =>
+        void store.set(k, { body, opts }),
+    },
+  };
+  // Every source gives a clean 404 -> a stable "no".
+  const fetchImpl = async () => {
+    upstreamCalls += 1;
+    return new Response("nope", { status: 404 });
+  };
+
+  const first = await call("?host=example.com", { env, fetchImpl });
+  assert.equal(first.status, 404);
+  const afterFirst = upstreamCalls;
+  assert.ok(afterFirst > 0, "the first request must actually try upstream");
+
+  const stored = [...store.values()][0];
+  assert.equal(stored.body.byteLength, 0, "a tombstone carries no image bytes");
+  assert.equal(stored.opts.customMetadata?.negative, "stable");
+
+  const second = await call("?host=example.com", { env, fetchImpl });
+  assert.equal(second.status, 404);
+  // THE assertion: the second request cost nothing upstream.
+  assert.equal(upstreamCalls, afterFirst);
+  assert.match(second.headers.get("cache-control") ?? "", /max-age=86400/);
+});
+
+test("a transient failure is recorded as transient, and expires on its own window", async () => {
+  const store = new Map<string, { body: Uint8Array; opts: Row }>();
+  let upstreamCalls = 0;
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: {
+      get: async (k: string) => {
+        const hit = store.get(k);
+        return hit
+          ? {
+              body: { cancel: async () => {} },
+              customMetadata: hit.opts.customMetadata,
+              httpMetadata: {},
+            }
+          : null;
+      },
+      put: async (k: string, body: Uint8Array, opts: Row = {}) =>
+        void store.set(k, { body, opts }),
+    },
+  };
+  // A 403 is the anti-bot block these aggregators return, and the module
+  // already treats it as retry-soon rather than a stable "no".
+  const fetchImpl = async () => {
+    upstreamCalls += 1;
+    return new Response("blocked", { status: 403 });
+  };
+
+  await call("?host=example.com", {
+    env,
+    fetchImpl,
+    options: { now: 1_000_000 },
+  });
+  assert.equal(
+    [...store.values()][0].opts.customMetadata?.negative,
+    "transient",
+  );
+  const afterFirst = upstreamCalls;
+
+  // Inside the 10m window: suppressed.
+  await call("?host=example.com", {
+    env,
+    fetchImpl,
+    options: { now: 1_000_000 + 60_000 },
+  });
+  assert.equal(upstreamCalls, afterFirst, "still inside the transient window");
+
+  // Past it: re-resolved, which is the entire point of the shorter window --
+  // a 403 that has cleared must not be blackholed for 24h.
+  await call("?host=example.com", {
+    env,
+    fetchImpl,
+    options: { now: 1_000_000 + 700_000 },
+  });
+  assert.ok(
+    upstreamCalls > afterFirst,
+    "an expired transient tombstone must re-resolve",
+  );
 });

--- a/tests/icon-proxy.test.ts
+++ b/tests/icon-proxy.test.ts
@@ -999,3 +999,85 @@ test("a transient failure is recorded as transient, and expires on its own windo
     "an expired transient tombstone must re-resolve",
   );
 });
+
+test("a tombstone write that throws still returns the 404", async () => {
+  // Best-effort, exactly like the positive put above it: failing to CACHE a
+  // negative must never turn a 404 into a 500.
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: {
+      get: async () => null,
+      put: async () => {
+        throw new Error("r2 unavailable");
+      },
+    },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => new Response("nope", { status: 404 }),
+  });
+  assert.equal(res.status, 404);
+});
+
+test("a tombstone with no usable timestamp is treated as expired", async () => {
+  // Fail OPEN, not closed. A record we cannot date is a record we cannot trust
+  // to still be valid, and blackholing a subject forever on a malformed stamp
+  // is strictly worse than re-resolving it once.
+  let upstreamCalls = 0;
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: {
+      get: async () => ({
+        body: { cancel: async () => {} },
+        customMetadata: { negative: "stable", negative_at: "not-a-number" },
+        httpMetadata: {},
+      }),
+      put: async () => {},
+    },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => {
+      upstreamCalls += 1;
+      return new Response("nope", { status: 404 });
+    },
+  });
+  assert.equal(res.status, 404);
+  assert.ok(upstreamCalls > 0, "an undateable tombstone must re-resolve");
+});
+
+test("no bucket at all still resolves and 404s", async () => {
+  const res = await call("?host=example.com", {
+    env: { METAGRAPH_ICON_ALLOWED_HOSTS: "example.com" },
+    fetchImpl: async () => new Response("nope", { status: 404 }),
+  });
+  assert.equal(res.status, 404);
+});
+
+test("a tombstone with NO timestamp field is treated as expired too", async () => {
+  // Distinct branch from the malformed case above: `negative_at` absent
+  // entirely, which falls to the `?? 0` default. Same fail-open outcome, and
+  // worth its own case because it is the shape an older tombstone written
+  // before this field existed would have.
+  let upstreamCalls = 0;
+  const env = {
+    METAGRAPH_ICON_ALLOWED_HOSTS: "example.com",
+    METAGRAPH_ARCHIVE: {
+      get: async () => ({
+        body: { cancel: async () => {} },
+        customMetadata: { negative: "stable" },
+        httpMetadata: {},
+      }),
+      put: async () => {},
+    },
+  };
+  const res = await call("?host=example.com", {
+    env,
+    fetchImpl: async () => {
+      upstreamCalls += 1;
+      return new Response("nope", { status: 404 });
+    },
+  });
+  assert.equal(res.status, 404);
+  assert.ok(upstreamCalls > 0, "an undated tombstone must re-resolve");
+});


### PR DESCRIPTION
## Summary

`r2_get ERROR — The specified key does not exist.` was **55% of the entire Worker error channel** over a 3-day window, and it was the same four subjects:

```
icon-cache/gh:tensorclaw/192
icon-cache/gh:PlatformNetwork/192
icon-cache/bittensor-finney.api.onfinality.io/40
icon-cache/mantis123.com/64
```

~30+ times across **DFW, LAX, IAD, ORD, MSP, SJC, SEA, FRA, PHX**. The colo spread is the tell: it is the same four, re-resolved wherever a request happens to land.

## Why it never stopped

The module reasons carefully about two negative windows — 24 h for a clean "no", 10 m when a source failed transiently, with a good argument for the distinction — and then expresses both **only as a header on the 404**:

```ts
return notFound(transient ? NEGATIVE_CACHE_TRANSIENT : NEGATIVE_CACHE_STABLE);
```

That is per-colo, per-client state, and a Worker response is not edge-cached unless something puts it there. So for a subject that will never resolve, every request in every colo re-ran: an R2 lookup that misses → the full aggregator fan-out, one timeout per source → a 404 whose "don't ask again for 24 h" reached exactly one browser.

There was no server-side record that `gh:tensorclaw` has no icon. The positive cache is only written on success, so a permanent negative was permanently uncached.

## The fix

A tombstone in R2, under the **same key** an icon would use, so one read answers both questions.

- **Tested before the hit path** — a tombstone's body is empty, and serving that as an image would turn "no icon" into "a zero-byte icon".
- **Stable/transient preserved exactly** as the fan-out already reasons about it, so a 403 anti-bot block still re-resolves in ten minutes rather than being blackholed for a day.
- **An expired tombstone is fallen through, not deleted.** The re-resolution overwrites it with an icon or a fresh tombstone; deleting first would widen the window where a concurrent request sees nothing and re-runs the fan-out.

## Tests

Two new cases assert the property that matters — **the second request does no upstream work**. Asserting "returns 404" would have passed on the old behaviour too, so both count upstream calls across two requests:

- a stable negative is recorded and the second request costs nothing upstream
- a transient one is marked `transient`, is suppressed inside its 10 m window, and **re-resolves past it** — the whole point of the shorter window

Mutation-checked: disabling the freshness test fails both.

## Two existing tests changed, deliberately

`rejects oversized upstream responses before caching` and `boundedArrayBuffer rejects an oversized streamed body` both asserted `puts.length === 0`. There is now legitimately **one** write on those paths — a zero-byte tombstone, not the payload. Both now assert the *shape* (zero body bytes + negative metadata) instead of the count, because the invariant they exist for is "the oversized **image** is never cached", and that invariant is intact. Keeping `length === 0` would have been asserting that we re-run the fan-out next time.

## Validation

```
npm run typecheck · lint · format:check · validate    green
npx vitest run tests/icon-proxy.test.ts               39 passed
```

Closes #11020