### PR TITLE
fix(registry): the link-rot lane required an uptime config to check a link

### DIFF
--- a/src/link-status-core.ts
+++ b/src/link-status-core.ts
@@ -6,19 +6,19 @@
 // data-artifact -- things with uptime. The URLs here are references: a README
 // that proves a subnet publishes an API, a provider's website, a docs page. They
 // have no uptime, they must never enter incidents or the pool breaker, and
-// checking them every 15 minutes would be 1,067 pointless requests an hour.
+// checking them every 15 minutes would be 1,076 pointless requests an hour.
 // They rot on a scale of weeks, so they are checked once a day.
 //
-// The populations overlap heavily -- 777 source_urls + 384 provider URLs + 494
-// non-operational surface URLs is only 1,067 DISTINCT urls -- so everything here
-// is keyed by URL, and citations fan back out to whoever referenced it.
+// The populations overlap heavily -- 777 source_urls + 384 provider URLs + 514
+// non-operational surface URLs is only 1,076 DISTINCT urls -- so everything
+// here is keyed by URL, and citations fan back out to whoever referenced it.
 //
 // Subrequest budget: a Worker invocation may make 1000 subrequests.
 //
 // 102 of the URLs are metagraph.sh/logos/* — OUR OWN static assets. Those are
 // checked against the files on disk by a build gate: free, deterministic, and
 // it attributes a missing logo to the commit that dropped it instead of to a
-// 3am fetch. That leaves 965 network checks.
+// 3am fetch. That leaves 974 network checks.
 //
 // Reusing github-signals for the 165 github.com repo roots was considered and
 // REJECTED: that lane DROPS a gone repo from its artifact (#9969) rather than
@@ -27,7 +27,7 @@
 // #9969 existed to fix. All 429 github.com URLs go through the GitHub API
 // instead, which answers the question directly.
 //
-// 965 exceeds LINK_STATUS_MAX_CHECKS_PER_RUN on purpose: the per-run cap picks
+// 974 exceeds LINK_STATUS_MAX_CHECKS_PER_RUN on purpose: the per-run cap picks
 // the least-recently-checked first, so every URL is still covered every ~2 days
 // and the invocation keeps headroom under the platform ceiling.
 
@@ -61,9 +61,9 @@ export const LINK_CHECK_CONCURRENCY = 8;
 /**
  * Defensive per-run ceiling, mirroring GITHUB_SIGNALS_MAX_REPOS_PER_RUN.
  *
- * The measured population is 965 network-checkable URLs; 900 keeps ~100
+ * The measured population is 974 network-checkable URLs; 900 keeps ~100
  * subrequests of headroom under the 1000-per-invocation platform limit for the
- * two artifact reads, the two store reads, the write and telemetry. The 65-URL
+ * two artifact reads, the two store reads, the write and telemetry. The 74-URL
  * remainder is not dropped — urlsForRun orders by least-recently-checked, so
  * the tail rotates in on the following tick and every URL is covered within
  * about two days.
@@ -249,11 +249,29 @@ export function collectLinkTargets(
       }
       // The surface's own URL, but only for the kinds the prober skips —
       // an operational surface is already checked every 15 minutes.
-      if (
-        surface.public_safe &&
-        (surface.probe as Row | undefined)?.enabled &&
-        !operationalKinds.has(String(surface.kind))
-      ) {
+      //
+      // `probe.enabled` IS NOT CONSULTED, and gating on it here was a bug
+      // (#11007). `probe` is the UPTIME prober's config -- `{enabled, method,
+      // expect, timeout_ms}` in the surface schema, describing how to poll
+      // something that has uptime -- and this lane's whole premise, stated at
+      // the top of this file, is that these URLs have none. Requiring it meant
+      // a reference surface had to opt into a config it has no reason to
+      // carry.
+      //
+      // Measured over registry/subnets/*.json (2026-08-13): 19 of the 514
+      // non-operational public_safe surfaces failed that gate. NINE were
+      // checked by nothing at all -- their URL is not cited as a source_url
+      // anywhere either -- and they are the ordinary case, an examples/ tree
+      // or a docs page nobody thought to give a probe block.
+      //
+      // The other ten were reached only as somebody else's citation, which
+      // checks the URL but attributes the verdict to the CITING surface. Three
+      // of those are surfaces disabled BECAUSE they were broken -- bitads.ai
+      // (DNS lame delegation), oneoneone.io (Cloudflare 1016) -- each carrying
+      // a registry note reading "probe disabled until it recovers". The lane
+      // that would notice a recovery could not name the surface waiting on
+      // one.
+      if (surface.public_safe && !operationalKinds.has(String(surface.kind))) {
         add(surface.url, { kind: "surface", id, netuid });
       }
     }

--- a/src/link-status-sync.ts
+++ b/src/link-status-sync.ts
@@ -11,11 +11,13 @@
 //          means the bar only applies on the way in.
 //   #9917  384 provider URLs — including our own gittensory entry, cited by
 //          five surfaces.
-//   #9907  494 surface URLs whose `kind` keeps them out of the health prober.
+//   #9907  514 surface URLs whose `kind` keeps them out of the health prober
+//          -- every public_safe one, not only those carrying an uptime-probe
+//          config, which had silently excluded 19 of them (#11007).
 //
-// 1,067 distinct URLs between them — the populations overlap heavily. See
+// 1,076 distinct URLs between them — the populations overlap heavily. See
 // link-status-core.ts for why 102 of those are answered from the repo instead
-// of the network, and how the remaining 965 fit one invocation's
+// of the network, and how the remaining 974 fit one invocation's
 // 1000-subrequest budget.
 //
 // WHAT IT DELIBERATELY DOES NOT DO. It never writes health, uptime, latency or

--- a/tests/link-status.test.ts
+++ b/tests/link-status.test.ts
@@ -7,6 +7,7 @@
 // fails here instead of passing on a canned answer.
 
 import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, test, vi } from "vitest";
 import {
   checkLink,
@@ -168,7 +169,17 @@ describe("collectLinkTargets", () => {
           kind: "docs",
           url: "https://off.one.example/",
           public_safe: true,
+          // Disabled BECAUSE the host is broken — the registry's real notes on
+          // bitads.ai and oneoneone.io say exactly this. #11007.
           probe: { enabled: false },
+        },
+        {
+          id: "sn-1-noprobe",
+          kind: "example",
+          url: "https://examples.one.example/",
+          public_safe: true,
+          // No probe block at all — the shape 19 registry surfaces have, and
+          // the reason 9 of them were checked by nothing.
         },
         {
           id: "sn-1-private",
@@ -211,10 +222,33 @@ describe("collectLinkTargets", () => {
     );
   });
 
-  test("skips probe-disabled and non-public surfaces", () => {
+  test("skips non-public surfaces", () => {
     const urls = collectLinkTargets(subnets, [], OP_KINDS).map((t) => t.url);
-    assert.equal(urls.includes("https://off.one.example/"), false);
     assert.equal(urls.includes("https://private.one.example/"), false);
+  });
+
+  // #11007. `probe` configures the 15-minute UPTIME prober — {enabled, method,
+  // expect, timeout_ms}. This lane exists for URLs that HAVE no uptime, so
+  // requiring an uptime config to be link-checked was backwards, and it is the
+  // surface disabled *because* it is broken that most needs the daily re-check.
+  test("checks a reference surface whose probe is disabled or absent", () => {
+    const targets = collectLinkTargets(subnets, [], OP_KINDS);
+    const urls = targets.map((t) => t.url);
+    assert.equal(
+      urls.includes("https://off.one.example/"),
+      true,
+      "probe.enabled:false means 'do not poll it for uptime', never 'do not check the link exists'",
+    );
+    assert.equal(
+      urls.includes("https://examples.one.example/"),
+      true,
+      "a surface with no probe block was nobody's decision, and fell through both lanes",
+    );
+    assert.deepEqual(
+      targets.find((t) => t.url === "https://off.one.example/")?.citations,
+      [{ kind: "surface", id: "sn-1-off", netuid: 1 }],
+      "the verdict must name the broken surface, not only whoever happens to cite its URL",
+    );
   });
 
   test("dedupes across populations and keeps every citation", () => {
@@ -1048,5 +1082,82 @@ describe("default dependencies", () => {
       },
     );
     assert.deepEqual(result, { ok: false, reason: "unreachable" });
+  });
+});
+
+// --- the invariant, over the real registry ------------------------------------
+//
+// #11007. The fixtures above prove the predicate; this proves the POPULATION,
+// which is where the bug actually lived. A gate phrased as "these rules are
+// right" cannot catch "and something is missing from the set they run over" —
+// so this asserts the negative directly: no public_safe non-operational surface
+// URL is left out of the lane, whatever its probe block says.
+describe("collectLinkTargets over registry/subnets", () => {
+  const OPERATIONAL = new Set(OPERATIONAL_SURFACE_KINDS);
+  const manifests = readdirSync("registry/subnets")
+    .filter((file) => file.endsWith(".json"))
+    .map(
+      (file) =>
+        JSON.parse(readFileSync(`registry/subnets/${file}`, "utf8")) as Row,
+    );
+
+  const referenceSurfaces = manifests.flatMap((manifest) =>
+    ((manifest.surfaces as Row[] | undefined) ?? []).filter(
+      (surface) =>
+        surface.public_safe === true &&
+        !OPERATIONAL.has(String(surface.kind)) &&
+        typeof surface.url === "string" &&
+        /^https?:\/\//i.test(surface.url),
+    ),
+  );
+
+  test("every reference surface in the registry is a link target", () => {
+    // Without this the assertion below passes on an empty list, which is how a
+    // coverage sweep reports success for having found nothing to check.
+    assert.ok(
+      referenceSurfaces.length > 400,
+      `expected the reference population, got ${referenceSurfaces.length}`,
+    );
+    const targets = new Set(
+      collectLinkTargets(manifests, [], OPERATIONAL).map((t) => t.url),
+    );
+    const missing = referenceSurfaces
+      .filter((surface) => !targets.has(String(surface.url)))
+      .map((surface) => `${String(surface.id)} -> ${String(surface.url)}`);
+    assert.deepEqual(
+      missing,
+      [],
+      "a registered public surface that no lane checks is a citation nobody can verify",
+    );
+  });
+
+  test("an operational surface's own URL stays with the 15-minute prober", () => {
+    const targets = new Set(
+      collectLinkTargets(manifests, [], OPERATIONAL).map((t) => t.url),
+    );
+    // The reverse direction, so widening the predicate cannot quietly pull the
+    // 612-surface probe population into a daily 1000-subrequest budget. Only
+    // operational URLs that nothing else cites can be asserted absent — a
+    // source_url is evidence and belongs here regardless of its surface's kind.
+    const cited = new Set(
+      manifests.flatMap((manifest) =>
+        ((manifest.surfaces as Row[] | undefined) ?? []).flatMap(
+          (surface) => (surface.source_urls as string[] | undefined) ?? [],
+        ),
+      ),
+    );
+    const operational = manifests.flatMap((manifest) =>
+      ((manifest.surfaces as Row[] | undefined) ?? []).filter(
+        (surface) =>
+          OPERATIONAL.has(String(surface.kind)) &&
+          typeof surface.url === "string" &&
+          !cited.has(surface.url),
+      ),
+    );
+    assert.ok(operational.length > 100, "expected the operational population");
+    assert.deepEqual(
+      operational.filter((surface) => targets.has(String(surface.url))),
+      [],
+    );
   });
 });


### PR DESCRIPTION
`collectLinkTargets` admitted a surface's own URL only when `surface.probe?.enabled` was truthy. `probe` is the **15-minute uptime prober's** config — `{enabled, method, expect, timeout_ms}` in the surface schema — and this lane's own header states its premise: these URLs *have* no uptime. Requiring an uptime config to link-check a reference URL is backwards, and it meant a README, a docs page or an `examples/` tree was checked by nobody.

## Measured, over `registry/subnets/*.json`

| non-operational, `public_safe` surfaces | 514 |
| --- | --- |
| in the link-rot lane | 495 |
| **excluded by the `probe.enabled` gate** | **19** |
| …checked by nothing at all | **9** |
| …reached only as somebody else's citation | 10 |

The ten are worse than the count suggests: a URL reached as a `source_url` citation *is* checked, but the verdict is attributed to the **citing** surface. Three of them are surfaces someone disabled *because they were broken* —

```
sn-16-bitads-website      "probe disabled ... marked degraded until the domain recovers"
sn-111-oneoneone-website  "Cloudflare error 1016 ... probe disabled until it recovers"
```

— so the only lane that would notice a recovery could not name the surface waiting on one. "Until it recovers" is a promise nothing was left able to keep.

## The change

`probe.enabled` is no longer consulted. `public_safe` and the non-operational `kind` remain the gate, so `false` now means what it says: do not poll it for uptime. It was never a claim that the URL should stop existing.

Every figure in both file headers was re-derived, not adjusted: 1,067 → 1,076 distinct URLs, 965 → 974 network checks, 900-per-run cap unchanged, tail rotation still ~2 days.

## How it is proven

The fixtures pin the predicate. A sweep over the real registry pins the **population**, which is where the bug actually lived — a gate phrased as "these rules are right" cannot catch "something is missing from the set they run over". Both new assertions fail against the old predicate, and the reverse direction pins the 612-surface probe population *out* of the daily budget.

100% patch coverage (`src/link-status-core.ts`: 69/69 stmts, 63/63 branches).

## Not done here

No SHA backfill — superseded by `treasury_readings.read_at_sha` (#10933). `min_compute` needed nothing: those surfaces are `data-artifact`, already probed every 15 minutes, and the dead djinn one is already reported as `classification: "dead"`. That falsification is written up on the issue.

Closes #11007