### PR TITLE
perf(api): serve health from the snapshot-stamped overlay cache

### DIFF
--- a/tests/health-overlay-cache.test.ts
+++ b/tests/health-overlay-cache.test.ts
@@ -1,0 +1,133 @@
+// #11023. /api/v1/health cost 294-660 ms CPU per request in production, and the
+// cost was its INPUT, not its output: loadGlobalOperationalHealth reads KV
+// `health:current` -- a 253 KB value -- with `{ type: "json" }` and parses all
+// of it to project a summary.
+//
+// The property under test is that the expensive read happens ONCE PER SNAPSHOT,
+// not once per request. Asserting response equality would pass on the old
+// behaviour too, so every case here counts reads of `health:current`.
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { KV_HEALTH_CURRENT, KV_HEALTH_META } from "../src/kv-keys.ts";
+import type { Row } from "./row-type.ts";
+
+const globalWithCaches = globalThis as unknown as { caches?: unknown };
+const originalCaches = globalWithCaches.caches;
+afterEach(() => {
+  globalWithCaches.caches = originalCaches;
+});
+
+function installCaches() {
+  const store = new Map<string, Response>();
+  globalWithCaches.caches = {
+    default: {
+      async match(request: Request) {
+        const hit = store.get(request.url);
+        return hit ? hit.clone() : undefined;
+      },
+      async put(request: Request, response: Response) {
+        store.set(request.url, response.clone());
+      },
+    },
+  } as unknown as Row;
+  return store;
+}
+
+/** An env whose KV counts reads of the expensive snapshot. */
+function envWithHealth(lastRunAt: () => string) {
+  const reads = { current: 0, meta: 0 };
+  const env = {
+    METAGRAPH_CONTROL: {
+      get: async (key: string) => {
+        if (key === KV_HEALTH_META) {
+          reads.meta += 1;
+          return { last_run_at: lastRunAt(), status_counts: {} };
+        }
+        if (key === KV_HEALTH_CURRENT) {
+          reads.current += 1;
+          return {
+            generated_at: lastRunAt(),
+            global: { status: "up" },
+            subnets: {},
+          };
+        }
+        return null;
+      },
+      put: async () => {},
+    },
+  } as unknown as Parameters<typeof handleRequest>[1];
+  return { env, reads };
+}
+
+const get = (path: string) =>
+  new Request(`https://api.metagraph.sh${path}`, {
+    headers: { "cf-connecting-ip": "203.0.113.7" },
+  });
+
+describe("health is cached on the snapshot's own stamp (#11023)", () => {
+  test("a second request within one snapshot does NOT re-read the 253 KB value", async () => {
+    installCaches();
+    const { env, reads } = envWithHealth(() => "2026-08-13T07:00:00.000Z");
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+
+    const first = await handleRequest(get("/api/v1/health"), env, ctx);
+    assert.equal(first.status, 200);
+    await Promise.all(waits);
+    const afterFirst = reads.current;
+    assert.ok(afterFirst > 0, "the first request must actually read it");
+
+    const second = await handleRequest(get("/api/v1/health"), env, ctx);
+    assert.equal(second.status, 200);
+    // THE assertion. The cheap meta read still happens (it is the cache key);
+    // the expensive one does not.
+    assert.equal(reads.current, afterFirst);
+  });
+
+  test("a new snapshot invalidates it -- staleness is bounded by the cron", async () => {
+    const store = installCaches();
+    const first = envWithHealth(() => "2026-08-13T07:00:00.000Z");
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+
+    await handleRequest(get("/api/v1/health"), first.env, ctx);
+    await Promise.all(waits);
+    assert.ok(first.reads.current > 0);
+
+    // A SECOND env, deliberately. readHealthMetaKv memoizes the stamp for
+    // HEALTH_META_KV_TTL_MS keyed on `env` IDENTITY, so reusing the same object
+    // would keep serving the old stamp and this test would be asserting the
+    // memo rather than the cache key. A different env is also what reality
+    // looks like: the next request lands in another isolate with its own memo.
+    const next = envWithHealth(() => "2026-08-13T07:02:00.000Z");
+    await handleRequest(get("/api/v1/health"), next.env, ctx);
+    // The prober writes KV_HEALTH_CURRENT and KV_HEALTH_META in one
+    // Promise.all, so a moved stamp means a moved snapshot -- which is what
+    // makes this a safe cache key rather than a guess.
+    assert.ok(
+      next.reads.current > 0,
+      "a new snapshot must not be served from the previous stamp's entry",
+    );
+    // Two stamps, two entries -- the old one is not overwritten, it is simply
+    // no longer addressed.
+    assert.equal(store.size, 2);
+  });
+
+  test("the per-subnet route gets the same treatment", async () => {
+    // Its OUTPUT is small, which is why the endpoints note excludes the small
+    // per-subnet variant -- but its INPUT is the same 253 KB snapshot, so the
+    // small-output argument does not apply to it.
+    installCaches();
+    const { env, reads } = envWithHealth(() => "2026-08-13T07:00:00.000Z");
+    const waits: Promise<unknown>[] = [];
+    const ctx = { waitUntil: (p: Promise<unknown>) => waits.push(p) };
+
+    await handleRequest(get("/api/v1/subnets/1/health"), env, ctx);
+    await Promise.all(waits);
+    const afterFirst = reads.current;
+
+    await handleRequest(get("/api/v1/subnets/1/health"), env, ctx);
+    assert.equal(reads.current, afterFirst);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -1395,7 +1395,36 @@ function isStaticEdgeCacheEligible(
 // Scoped to the large /api/v1/endpoints index (~1.43 MB / 1160 rows) whose
 // overlay output is fully determined by (contract_version, last_run_at) — the
 // per-subnet `subnet-endpoints` variant is small and intentionally excluded.
-const CACHEABLE_OVERLAY_ROUTE_IDS = new Set(["endpoints"]);
+const CACHEABLE_OVERLAY_ROUTE_IDS = new Set([
+  "endpoints",
+  // #11023: the two health routes, for a DIFFERENT reason than `endpoints`.
+  //
+  // `endpoints` is here because its OUTPUT is large (~1.43 MB to re-stringify),
+  // which is why the note above excludes the small per-subnet variant. Health's
+  // cost is not its output -- `/api/v1/health` returns a summary -- it is its
+  // INPUT: `loadGlobalOperationalHealth` reads KV `health:current`, a 253 KB
+  // value, with `{ type: "json" }`, so every request pays a 253 KB fetch plus a
+  // full JSON.parse before projecting a fraction of it. Measured in production
+  // over 3 days: `cpu_time_ms` of 294, 318, 343, 411, 457, 483, 489, 591 and
+  // 660 on plain `GET /api/v1/health`, against `cpu_time_ms: 1` for a
+  // multi-second lakehouse scan on `/blocks/{ref}`. That scan is I/O; this is
+  // CPU, and CPU is the metered resource.
+  //
+  // `subnet-health` is included for the same reason and NOT excluded by the
+  // small-output argument: it parses the identical 253 KB snapshot to answer
+  // for one subnet, so its input cost is the global route's while its output is
+  // a fraction of it -- the worst ratio of the three.
+  //
+  // Correctness rests on `last_run_at` genuinely gating the snapshot, and it
+  // does: src/health-prober.ts writes KV_HEALTH_CURRENT and KV_HEALTH_META in
+  // one `Promise.all`, so a stamp that has not moved means a snapshot that has
+  // not moved. The residual window -- KV being eventually consistent, so the
+  // meta could be visible in a colo slightly before the snapshot it stamps --
+  // is not new: `endpoints` already overlays the same health data under the
+  // same key and has shipped with it.
+  "health",
+  "subnet-health",
+]);
 
 // Reduce a request's query string to its canonical, cache-relevant form: keep
 // only the params that actually steer the response body (the collection's


### PR DESCRIPTION
## Summary

`/api/v1/health` is the most-polled route on the API and one of the most expensive per request. `cpu_time_ms` over a 3-day production sample:

```
294  318  343  411  457  483  489  591  660
```

and `/api/v1/subnets/1/health`: `275, 296, 304, 477`.

For comparison, in the same window a **multi-second** lakehouse scan on `/api/v1/blocks/{ref}` costs `cpu_time_ms: 1`. That scan is I/O. Health is **CPU** — the metered resource, and per-isolate contention shared with every other request in the colo, including the account routes that already OOMed one (#11019 → #11008).

## The cost is the input, not the output

`/api/v1/health` returns a summary. But `loadGlobalOperationalHealth` reads KV `health:current` — a **253 KB** value — with `{ type: "json" }`, so every request pays a 253 KB fetch plus a full `JSON.parse`, then projects a fraction of it. The cost scales with the size of the snapshot, not the size of the answer.

## The machinery already existed

`CACHEABLE_OVERLAY_ROUTE_IDS` keys a response on the health snapshot's own `last_run_at`, read via a cheap meta lookup, and short-circuits **before** the expensive read — *"turning a per-request R2-GET + parse + 3-pass overlay + 1.43 MB re-stringify + SHA-256 into at-most-once-per-cron-tick, staleness bounded to one interval."*

Identical problem. Health was simply never added.

The static edge cache stays correctly excluded (both routes remain in `LIVE_OVERLAY_ROUTE_IDS`) — current health must not be pinned to a fixed TTL. This is the snapshot-stamped cache, which is a different thing.

**`subnet-health` is included**, and the note excluding the small per-subnet *endpoints* variant does not apply to it: that exclusion was about **output** size. `subnet-health` parses the identical 253 KB snapshot to answer for one subnet — its input cost is the global route's while its output is a fraction of it, the worst ratio of the three.

## Correctness

Rests on `last_run_at` genuinely gating the snapshot, which I verified rather than assumed: `src/health-prober.ts` writes `KV_HEALTH_CURRENT` and `KV_HEALTH_META` in **one `Promise.all`**, so a stamp that has not moved means a snapshot that has not moved.

The residual window — KV is eventually consistent, so a meta could be visible in a colo slightly before the snapshot it stamps — is **not new**: `endpoints` already overlays the same health data under the same key and has shipped with it. Stated rather than glossed.

## Tests

Three cases, all counting reads of `health:current` — asserting response equality would have passed on the old behaviour:

- a second request within one snapshot does **not** re-read the 253 KB value
- a new snapshot **does** re-read, and produces a second cache entry rather than overwriting
- the per-subnet route gets the same treatment

Mutation-checked: removing the two ids fails all three.

One thing the tests corrected: `readHealthMetaKv` memoizes the stamp for `HEALTH_META_KV_TTL_MS` **keyed on `env` identity**, so the invalidation case needs a second env — otherwise it asserts the memo rather than the cache key. That is also what reality looks like (the next request lands in another isolate with its own memo), and it means effective staleness is bounded by that memo plus the cron interval, which is what "current health" already meant.

## Validation

```
npm run typecheck · lint · format:check · validate    green
health-overlay-cache · global-operational-health · health-meta-kv-cache ·
api-coverage · analytics-edge-cache                   407 passed
```

Closes #11023
