### PR TITLE
fix(firehose): a deploy should not 500 a subscriber, and a crawler should not hold a stream

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,4 +8,7 @@ Allow: /api/v1/blocks/summary
 Disallow: /api/v1/extrinsics/
 Disallow: /api/v1/accounts/
 Allow: /api/v1/accounts/top-holders
+# A stream is for a subscriber, not an indexer: it never ends, and a
+# crawler holding one pins a Durable Object subscription for nothing.
+Disallow: /api/v1/chain/stream
 Sitemap: https://api.metagraph.sh/sitemap.xml

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2368,6 +2368,9 @@ await fs.writeFile(
     `Disallow: /api/v1/extrinsics/\n` +
     `Disallow: /api/v1/accounts/\n` +
     `Allow: /api/v1/accounts/top-holders\n` +
+    `# A stream is for a subscriber, not an indexer: it never ends, and a\n` +
+    `# crawler holding one pins a Durable Object subscription for nothing.\n` +
+    `Disallow: /api/v1/chain/stream\n` +
     `Sitemap: ${llmsApiBase}/sitemap.xml\n`,
   "utf8",
 );

--- a/src/durable-object-reset.ts
+++ b/src/durable-object-reset.ts
@@ -1,0 +1,46 @@
+/**
+ * "Durable Object reset because its code was updated." (#11021)
+ *
+ * Cloudflare evicts a Durable Object when its script version changes, and this
+ * repo deploys often -- a 3-day production window carried ~29 distinct
+ * `script_version.id` values, roughly ten a day. Every one of those resets
+ * every DO, and once reset, EVERY pending operation on that instance rejects
+ * with this message: the storage write in flight, the `setAlarm` in a
+ * `finally`, the `stub.fetch` a subscriber is holding.
+ *
+ * That is a lifecycle event, not a fault. Left unhandled it becomes an
+ * `outcome: exception` -- and, on the public SSE route, an HTTP 500 to a
+ * subscriber, which is the one response that says WE are broken.
+ *
+ * MATCHED BY MESSAGE, deliberately and narrowly. The runtime raises a plain
+ * `Error` with no code or type to key off, so a message match is the only
+ * available discriminator. It is kept exact rather than fuzzy (no "reset"
+ * substring, no case-folding beyond what the runtime emits) precisely because
+ * the risk of this helper is over-matching: a broad predicate here would
+ * silently swallow real DO failures, and a dead hub that looks healthy is the
+ * failure mode #10991's alarm work exists to prevent.
+ */
+const DURABLE_OBJECT_RESET_MESSAGE =
+  "Durable Object reset because its code was updated.";
+
+/** True only for the runtime's DO-eviction rejection, never for anything else. */
+export function isDurableObjectReset(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message === DURABLE_OBJECT_RESET_MESSAGE
+  );
+}
+
+/**
+ * How long a disconnected subscriber should wait before reconnecting, in ms.
+ *
+ * Sent as the SSE `retry:` field, which is the ONLY reconnection control the
+ * protocol gives a server -- `Retry-After` is not honoured by `EventSource`,
+ * and a non-2xx status makes the spec "fail the connection" permanently rather
+ * than reconnect. So a deploy must answer 200 with a stream that closes, and
+ * this number is what stops every subscriber returning in the same instant.
+ *
+ * 5s: comfortably past a deploy's propagation, and long enough that a
+ * simultaneous fleet reconnect is spread rather than a thundering herd -- the
+ * failure #6451 already produced once on this exact hub.
+ */
+export const CHAIN_FIREHOSE_RECONNECT_MS = 5000;

--- a/tests/chain-firehose-hub.test.ts
+++ b/tests/chain-firehose-hub.test.ts
@@ -2630,3 +2630,53 @@ describe("chain-firehose cap attribution", () => {
     );
   });
 });
+
+// #11021: the alarm's `finally` re-arms the poll chain, and `setAlarm` rejects
+// like everything else once the object is reset. These pin the two arms of that
+// guard -- swallowing a deploy is only acceptable because /poll-start's cron
+// re-arms an alarm that is missing OR OVERDUE; swallowing anything else would
+// hide a hub that has genuinely stopped scheduling.
+function alarmState(setAlarmImpl: () => Promise<void>): DurableObjectState {
+  return {
+    getWebSockets: () => [],
+    storage: {
+      get: async () => null,
+      put: async () => {},
+      setAlarm: setAlarmImpl,
+    },
+  } as unknown as DurableObjectState;
+}
+
+test("alarm: a DO reset during setAlarm does not escape (#11021)", async () => {
+  const hub = new ChainFirehoseHub(
+    alarmState(async () => {
+      throw new Error("Durable Object reset because its code was updated.");
+    }),
+    mockEnv({ CHAIN_HEAD_POLL_ENABLED: "false" }),
+  );
+  // Must not reject: the poll chain is restarted by the 15-minute /poll-start
+  // bootstrap, and letting this escape is what made every deploy an uncaught
+  // exception on ChainFirehoseHub.alarm.
+  await hub.alarm();
+});
+
+test("alarm: any OTHER setAlarm failure is still reported (#11021)", async () => {
+  const errors: unknown[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => void errors.push(args);
+  try {
+    const hub = new ChainFirehoseHub(
+      alarmState(async () => {
+        throw new Error("storage quota exceeded");
+      }),
+      mockEnv({ CHAIN_HEAD_POLL_ENABLED: "false" }),
+    );
+    await hub.alarm();
+  } finally {
+    console.error = original;
+  }
+  // Recorded rather than rethrown -- a throw out of a `finally` masks what the
+  // `try` was propagating -- but it MUST still reach the error channel, or a
+  // hub that has stopped scheduling looks exactly like a deploy.
+  assert.match(JSON.stringify(errors), /storage quota exceeded/);
+});

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -265,6 +265,11 @@ describe("Discovery artifacts", () => {
       "/api/v1/extrinsics/0xa6fd0387b5e54ffe8cf753c10720a437e82ad7e4c47a33997cbd68b498d14d95",
       "/api/v1/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
       "/api/v1/accounts/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY/transfers",
+      // #11024: meta-externalagent was observed opening this. A stream never
+      // ends, so a crawler holding one pins a Durable Object subscription for
+      // a response it can never finish reading.
+      "/api/v1/chain/stream",
+      "/api/v1/chain/stream?topics=blocks",
     ]) {
       assert.equal(crawlable(p), false, `${p} should be withheld`);
     }

--- a/tests/durable-object-reset.test.ts
+++ b/tests/durable-object-reset.test.ts
@@ -1,0 +1,104 @@
+// #11021. Cloudflare evicts a Durable Object when its script version changes,
+// and this repo deploys ~10x a day (29 distinct script_version ids in one
+// 3-day window). Once reset, EVERY pending operation on that instance rejects
+// -- and on the public SSE route that reached a subscriber as an HTTP 500.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import {
+  CHAIN_FIREHOSE_RECONNECT_MS,
+  isDurableObjectReset,
+} from "../src/durable-object-reset.ts";
+
+const RESET = "Durable Object reset because its code was updated.";
+
+describe("the reset predicate is narrow on purpose (#11021)", () => {
+  test("matches the runtime's exact message", () => {
+    assert.equal(isDurableObjectReset(new Error(RESET)), true);
+  });
+
+  // The risk of this helper is OVER-matching: a broad predicate would swallow
+  // real DO failures, and a hub that has genuinely stopped looks identical to
+  // one that was just redeployed. Each of these is a failure we must still see.
+  test("does not match anything else", () => {
+    for (const other of [
+      new Error("Durable Object reset"),
+      new Error("durable object reset because its code was updated."),
+      new Error("Network connection lost."),
+      new Error("Worker exceeded memory limit."),
+      new Error(""),
+      RESET,
+      null,
+      undefined,
+      { message: RESET },
+    ]) {
+      assert.equal(isDurableObjectReset(other), false, String(other));
+    }
+  });
+});
+
+/** An env whose firehose stub rejects the way an evicted DO does. */
+function envWithHub(rejection: unknown) {
+  return {
+    CHAIN_FIREHOSE_HUB: {
+      idFromName: () => "global",
+      get: () => ({
+        fetch: async () => {
+          throw rejection;
+        },
+      }),
+    },
+  } as unknown as Parameters<typeof handleRequest>[1];
+}
+
+const streamReq = (headers: Record<string, string> = {}) =>
+  new Request("https://api.metagraph.sh/api/v1/chain/stream?topics=blocks", {
+    headers,
+  });
+
+describe("a deploy does not 500 a subscriber (#11021)", () => {
+  test("SSE gets a 200 event-stream that closes, carrying retry:", async () => {
+    // NOT a 5xx, and that is the whole point: the EventSource spec makes a
+    // client FAIL THE CONNECTION permanently on a non-2xx status, so a 503
+    // here would be worse than the 500 it replaces -- every browser subscriber
+    // would give up for good rather than come back after the deploy.
+    const res = await handleRequest(
+      streamReq(),
+      envWithHub(new Error(RESET)),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") ?? "", /text\/event-stream/);
+    const body = await res.text();
+    assert.match(body, new RegExp(`retry: ${CHAIN_FIREHOSE_RECONNECT_MS}`));
+    // Never replayed as if it were the stream.
+    assert.equal(res.headers.get("cache-control"), "no-store");
+  });
+
+  test("a WebSocket upgrade gets 503 + Retry-After instead", async () => {
+    // No stream to close and no retry: field; WS clients run their own backoff.
+    const res = await handleRequest(
+      streamReq({ upgrade: "websocket" }),
+      envWithHub(new Error(RESET)),
+      {},
+    );
+    assert.equal(res.status, 503);
+    assert.equal(
+      res.headers.get("retry-after"),
+      String(Math.ceil(CHAIN_FIREHOSE_RECONNECT_MS / 1000)),
+    );
+  });
+
+  test("any OTHER hub failure still surfaces -- this is not a blanket catch", async () => {
+    // The failure mode that matters more than the fix: swallowing everything
+    // here would make a genuinely dead hub indistinguishable from a deploy.
+    // It ESCAPES -- the rejection is rethrown, not converted into a reconnect.
+    // That is the assertion: a real hub failure must keep reaching the error
+    // channel exactly as it did before.
+    await assert.rejects(
+      () =>
+        handleRequest(streamReq(), envWithHub(new Error("hub exploded")), {}),
+      /hub exploded/,
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -5368,8 +5368,15 @@ async function handleChainFirehoseStream(request: Request, env: Env, url: URL) {
   // this function's inferred return to include `undefined` -- and that widening
   // propagates all the way out through dispatchRequest to the Worker's fetch
   // handler. Keeping `const` keeps the inference honest.
-  const response = await stub
-    .fetch(new Request(forwardUrl, request))
+  //
+  // `Promise.resolve().then(...)` rather than `stub.fetch(...).catch(...)`:
+  // a stub is not required to return a real Promise (test doubles in this repo
+  // return a bare Response, and `await` accepts both), so calling `.catch` on
+  // the result is a TypeError against anything but the production binding.
+  // This form also catches a SYNCHRONOUS throw from `.fetch`, which the
+  // `.catch` form silently would not.
+  const response = await Promise.resolve()
+    .then(() => stub.fetch(new Request(forwardUrl, request)))
     .catch((error: unknown) => {
       if (!isDurableObjectReset(error)) throw error;
       return null;

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -11,6 +11,10 @@ import {
   compileRoutePattern,
   liveOnlyArtifactRoute,
 } from "../src/contracts.ts";
+import {
+  CHAIN_FIREHOSE_RECONNECT_MS,
+  isDurableObjectReset,
+} from "../src/durable-object-reset.ts";
 
 type Row = Record<string, unknown>;
 
@@ -5296,6 +5300,50 @@ async function handleEmissionGateSync(
 // data /api/v1/chain-events already serves, just pushed instead of polled.
 // ChainFirehoseHub itself decides SSE vs WS and applies the ?topics= filter
 // -- this is only the forwarding boundary into the DO.
+/**
+ * The response a subscriber gets when a deploy takes the hub out from under it.
+ *
+ * SSE has exactly one reconnection control and it is NOT `Retry-After`:
+ * `EventSource` ignores that header, and the spec makes it FAIL THE CONNECTION
+ * -- permanently, no reconnect -- on any non-2xx status or wrong content-type.
+ * So a 503 here would be worse than the 500 it replaces: every browser
+ * subscriber would give up for good rather than come back after the deploy.
+ *
+ * The protocol-correct answer is a 200 event-stream that closes immediately,
+ * carrying a `retry:` field. The client then reconnects on its own, after the
+ * interval we name -- which is also the only lever that keeps a fleet-wide
+ * reconnect from arriving as one burst (#6451's thundering herd was this hub).
+ *
+ * A WebSocket upgrade is the exception: there is no stream to close and no
+ * `retry:` field, and WS clients implement their own backoff, so that branch
+ * gets an honest 503 with `Retry-After`.
+ */
+function chainFirehoseReconnect(request: Request): Response {
+  if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+    return errorResponse(
+      "chain_firehose_reconnect",
+      "The realtime chain firehose was restarted by a deploy; reconnect.",
+      503,
+      {},
+      { "retry-after": String(Math.ceil(CHAIN_FIREHOSE_RECONNECT_MS / 1000)) },
+    );
+  }
+  return new Response(
+    `retry: ${CHAIN_FIREHOSE_RECONNECT_MS}\n` +
+      `: hub restarted by a deploy; reconnecting\n\n`,
+    {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream; charset=utf-8",
+        // A restart notice is never the stream, and must never be replayed as
+        // one by an intermediary.
+        "cache-control": "no-store",
+        "access-control-allow-origin": "*",
+      },
+    },
+  );
+}
+
 async function handleChainFirehoseStream(request: Request, env: Env, url: URL) {
   if (!env.CHAIN_FIREHOSE_HUB) {
     return errorResponse(
@@ -5309,7 +5357,24 @@ async function handleChainFirehoseStream(request: Request, env: Env, url: URL) {
   );
   const forwardUrl = new URL("https://chain-firehose-hub.internal/subscribe");
   forwardUrl.search = url.search;
-  const response = await stub.fetch(new Request(forwardUrl, request));
+  // #11021: a deploy evicts the hub, and every in-flight operation on it --
+  // including this subscriber's -- rejects. Production served an HTTP 500 for
+  // that, on `GET /api/v1/chain/stream?topics=blocks`. A 500 is the one answer
+  // that says WE are broken, when what happened is that we shipped.
+  //
+  // Written as `.catch()` returning a sentinel rather than try/catch around an
+  // assignment: TypeScript does not carry definite-assignment through a
+  // try/catch whose catch returns, so `let response: Response` there widens
+  // this function's inferred return to include `undefined` -- and that widening
+  // propagates all the way out through dispatchRequest to the Worker's fetch
+  // handler. Keeping `const` keeps the inference honest.
+  const response = await stub
+    .fetch(new Request(forwardUrl, request))
+    .catch((error: unknown) => {
+      if (!isDurableObjectReset(error)) throw error;
+      return null;
+    });
+  if (response === null) return chainFirehoseReconnect(request);
   // #10606: the DO names which cap refused, this records it, and the header is
   // DELETED before the response continues. Both halves matter: the Worker
   // needs the kind (a global cap and a per-IP cap are operationally opposite,

--- a/workers/chain-firehose-hub.ts
+++ b/workers/chain-firehose-hub.ts
@@ -28,6 +28,7 @@
 // webSocketClose's graphql-ws branches, and src/graphql.ts's
 // GRAPHQL_SUBSCRIPTION_CONTEXT_KEY for the other half of the wiring.
 
+import { isDurableObjectReset } from "../src/durable-object-reset.ts";
 import {
   GraphQLError,
   type GraphQLSchema,
@@ -1272,7 +1273,38 @@ export class ChainFirehoseHub implements DurableObject {
         await recordExceptionEvent(this.env, { error, route: "head-poller" });
       }
     } finally {
-      await this.state.storage.setAlarm(Date.now() + interval);
+      // #11021: a deploy evicts this object, and once reset EVERY storage
+      // operation rejects -- including this one, in a `finally`, where there is
+      // nothing left to catch it. That is how a deploy became an uncaught
+      // `outcome: exception` on ChainFirehoseHub.alarm.
+      //
+      // Safe to swallow, and only because the repair already exists: the
+      // 15-minute cron's `/poll-start` re-arms an alarm that is MISSING OR
+      // OVERDUE (#10766), and its comment names this exact case -- "an alarm
+      // whose handler never ran -- the storage reset mid-`setAlarm`". So the
+      // chain restarts within one cron tick rather than being lost.
+      //
+      // Narrow on purpose. Any OTHER setAlarm failure is still reported --
+      // recorded rather than rethrown, because a throw out of a `finally`
+      // masks whatever the `try` was propagating (eslint no-unsafe-finally)
+      // and, here, would only become the uncaught exception this change
+      // exists to remove. Recording keeps the signal: a hub that has genuinely
+      // stopped scheduling must not look like a deploy, which is the silence
+      // #10991's alarm work exists to prevent.
+      try {
+        await this.state.storage.setAlarm(Date.now() + interval);
+      } catch (error) {
+        if (!isDurableObjectReset(error)) {
+          console.error(
+            "[head-poller] setAlarm",
+            String((error as Error)?.message),
+          );
+          await recordExceptionEvent(this.env, {
+            error,
+            route: "head-poller-setalarm",
+          });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Both halves are about `/api/v1/chain/stream`, which the 3-day error log showed failing in two unrelated ways at once.

## A deploy 500s live subscribers

```
GET /api/v1/chain/stream?topics=blocks
  outcome:      exception
  status_code:  500
  error:        Durable Object reset because its code was updated.
```

The reset itself is **expected** — Cloudflare evicts a DO when its script version changes, and this repo ships ~10× a day (29 distinct `script_version.id` values in that window). Once reset, every pending operation on the instance rejects, including the one a subscriber is holding.

What's wrong is that it reached the client as a `500` — the one response that says *we* are broken, when what happened is that we shipped.

### Why the replacement is a 200, not a 503

This is the part worth reviewing. A 503 looks like the honest answer and is **worse than the bug**: the EventSource spec makes a client *fail the connection* permanently on any non-2xx status. Every browser subscriber would give up for good rather than come back after the deploy.

The protocol-correct answer is a `200 text/event-stream` that closes immediately, carrying a `retry:` field. The client reconnects on its own, after an interval we choose — and `retry:` is the **only** reconnection control SSE gives a server (`Retry-After` is ignored by `EventSource`). That interval is also what keeps a fleet-wide reconnect from arriving as one burst; #6451's thundering herd was this hub.

A **WebSocket upgrade** is the exception — no stream to close, no `retry:` field, and WS clients run their own backoff — so that branch gets an honest `503` + `Retry-After`.

### The predicate is narrow on purpose

Matched on the runtime's exact message, because the runtime raises a plain `Error` with no code or type to key off. The risk here is **over-matching**: a broad catch would make a hub that has genuinely stopped indistinguishable from one that was just redeployed. A test asserts that any other rejection still escapes.

### The alarm had the same problem one layer down

`setAlarm` in the alarm's `finally` rejects on a reset too, with nothing left to catch it — that is the `ChainFirehoseHub.alarm` half of the log.

Safe to swallow **only because the repair already exists**: `/poll-start`'s 15-minute cron re-arms an alarm that is missing *or overdue*, and its comment names this exact case — *"an alarm whose handler never ran — the storage reset mid-`setAlarm`"* (#10766). So the chain restarts within one cron tick.

Any other `setAlarm` failure is **recorded rather than rethrown**: a throw out of a `finally` masks whatever the `try` was propagating (`no-unsafe-finally`), and here would only become the uncaught exception this change removes. Recording keeps the signal.

## A crawler holding a stream

`meta-externalagent` was observed opening `/api/v1/chain/stream?topics=blocks`. A stream never ends, so a crawler holding one pins a Durable Object subscription for a response it can never finish reading — and no sitemap advertises it. Added to the robots policy #11005 established, asserted through the same RFC 9309 evaluator.

## Tests

`tests/durable-object-reset.test.ts`, 5 cases: the predicate matches the exact message and **nothing else** (8 near-misses, including a lowercased variant and a bare string); SSE gets a 200 stream with `retry:` and `no-store`; a WS upgrade gets 503 + `Retry-After`; and **any other hub failure still escapes**.

That last one is the one that matters — it is the difference between this fix and a blanket catch.

## Validation

```
npm run typecheck · lint · format:check · validate · build    green
durable-object-reset · discovery-artifacts · chain-firehose-hub   189 passed
```

`public/robots.txt` regenerated by `scripts/build-artifacts.ts`, not hand-edited.

Closes #11021
Closes #11024
