### PR TITLE
refactor(ui): the UI reads the contract's vocabularies instead of restating them

### DIFF
--- a/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/account-position-history-chart.tsx
@@ -7,10 +7,13 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { AccountPositionHistoryPoint } from "@/lib/metagraphed/types";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
 // Lowercase windows, matching the /history API's window enum.
-type Win = "7d" | "30d" | "90d" | "1y" | "all";
-const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+// The route's own published windows (#10994) -- restating them here is
+// how a chart offers a window its route rejects.
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/accounts/{ss58}/subnets/{netuid}/history"].window;
+type Win = (typeof WINDOWS)[number];
 
 function taoStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";

--- a/apps/ui/src/components/metagraphed/concentration-panel.tsx
+++ b/apps/ui/src/components/metagraphed/concentration-panel.tsx
@@ -12,14 +12,16 @@ import { Skeleton, EmptyState, ErrorState } from "@/components/metagraphed/state
 import { classNames } from "@/lib/metagraphed/format";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
 import { Panel } from "@/components/metagraphed/primitives";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 import type {
   ConcentrationMetrics,
   ConcentrationHistoryPoint,
   PerformanceHistoryPoint,
 } from "@/lib/metagraphed/types";
 
-type Win = "7d" | "30d" | "90d";
-const WINDOWS: Win[] = ["7d", "30d", "90d"];
+// The route's own published windows (#10994).
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/subnets/{netuid}/concentration/history"].window;
+type Win = (typeof WINDOWS)[number];
 
 function numStr(v?: number | null, digits = 3): string {
   if (v == null || !Number.isFinite(v)) return "—";

--- a/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/neuron-history-chart.tsx
@@ -6,9 +6,12 @@ import { EmptyState, ErrorState, Skeleton } from "@/components/metagraphed/state
 import { Panel } from "@/components/metagraphed/primitives";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetNeuronHistoryPoint } from "@/lib/metagraphed/types";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
-type Win = "7d" | "30d" | "90d" | "1y" | "all";
-const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+// The route's own published windows (#10994) -- restating them here is
+// how a chart offers a window its route rejects.
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/subnets/{netuid}/neurons/{uid}/history"].window;
+type Win = (typeof WINDOWS)[number];
 
 function scoreStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";

--- a/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-history-chart.tsx
@@ -7,11 +7,14 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber, formatTao } from "@/lib/metagraphed/format";
 import type { SubnetHistoryPoint } from "@/lib/metagraphed/types";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
 // Lowercase windows, mirroring the /history API + the inline toggle conventions
 // used by health-trends.tsx. "all" maps to the API's widest supported window.
-type Win = "7d" | "30d" | "90d" | "1y" | "all";
-const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+// The route's own published windows (#10994) -- restating them here is
+// how a chart offers a window its route rejects.
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/subnets/{netuid}/history"].window;
+type Win = (typeof WINDOWS)[number];
 
 /**
  * Per-subnet on-chain history (#1302). A window selector drives a daily snapshot

--- a/apps/ui/src/components/metagraphed/validator-history-chart.tsx
+++ b/apps/ui/src/components/metagraphed/validator-history-chart.tsx
@@ -7,10 +7,13 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { healthColorVar } from "@/lib/health-tokens";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { ValidatorHistoryPoint } from "@/lib/metagraphed/types";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
 // Lowercase windows, matching the /history API's window enum.
-type Win = "7d" | "30d" | "90d" | "1y" | "all";
-const WINDOWS: Win[] = ["7d", "30d", "90d", "1y", "all"];
+// The route's own published windows (#10994) -- restating them here is
+// how a chart offers a window its route rejects.
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/validators/{hotkey}/history"].window;
+type Win = (typeof WINDOWS)[number];
 
 function taoStr(v?: number) {
   if (v == null || !Number.isFinite(v)) return "—";

--- a/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
+++ b/apps/ui/src/components/metagraphed/validator-nominators-table.tsx
@@ -12,8 +12,10 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { formatNumber } from "@/lib/metagraphed/format";
 import type { validatorNominatorsQuery } from "@/lib/metagraphed/queries";
 import type { ValidatorNominatorEntry } from "@/lib/metagraphed/types";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
-const WINDOWS = ["7d", "30d", "90d"] as const;
+// The route's own published windows (#10994).
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/validators/{hotkey}/nominators"].window;
 const SORTS = [
   { value: "net_staked", label: "Net staked" },
   { value: "gross_staked", label: "Gross staked" },

--- a/apps/ui/src/components/metagraphed/yield-panel.tsx
+++ b/apps/ui/src/components/metagraphed/yield-panel.tsx
@@ -17,9 +17,11 @@ import { classNames } from "@/lib/metagraphed/format";
 import { AddressDisplay } from "@/components/metagraphed/address-display";
 import { PROFILE_KPI_GRID_CLASS } from "@/components/metagraphed/profile-kpi-grid";
 import type { SubnetYieldNeuron, YieldHistoryPoint } from "@/lib/metagraphed/types";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
-type Win = "7d" | "30d" | "90d";
-const WINDOWS: Win[] = ["7d", "30d", "90d"];
+// The route's own published windows (#10994).
+const WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/subnets/{netuid}/yield/history"].window;
+type Win = (typeof WINDOWS)[number];
 const TOP_N = 15;
 
 function VsMedian({ vs }: { vs: SubnetYieldNeuron["vs_median"] }) {

--- a/apps/ui/src/hooks/use-chain-stream.ts
+++ b/apps/ui/src/hooks/use-chain-stream.ts
@@ -18,7 +18,12 @@ export type { SseStatus };
 export const CHAIN_STREAM_DOWNGRADE_AFTER_FAILURES = 3;
 export const CHAIN_STREAM_DOWNGRADE_RETRY_MS = 5 * 60_000;
 
-/** Tables the chain firehose can filter on via `?topics=` (#4980 / ADR 0015). */
+/** Tables the chain firehose can filter on via `?topics=` (#4980 / ADR 0015).
+ * DELIBERATELY literal (#10994): the SSE firehose's `topics` parameter is not
+ * published in openapi.json (a contract gap noted on the issue), and the
+ * vocabulary's owner is the graphql/stream schema tree the UI cannot import
+ * at runtime. When the parameter is published, derive this from
+ * QUERY_PARAMETER_ENUMS like every other repointed site. */
 export const CHAIN_FIREHOSE_TOPICS = [
   "blocks",
   "extrinsics",

--- a/apps/ui/src/lib/metagraphed/money-map-model.ts
+++ b/apps/ui/src/lib/metagraphed/money-map-model.ts
@@ -1,3 +1,4 @@
+import type { ApiSchema } from "@jsonbored/metagraphed";
 /**
  * #10511: the money-map panel's display decisions, extracted so the ones with
  * consequences are testable without rendering.
@@ -15,13 +16,22 @@
  * side by side; the panel states the difference and stops.
  */
 
+// CHECKED AGAINST THE CONTRACT, not restated blind (#10994): the buckets are
+// the property KEYS of SubnetOwnerCutArtifact.disposition.buckets, so the
+// `satisfies` clause makes a renamed or removed bucket a compile error here
+// the moment the contract package updates -- a runtime import is impossible
+// (component keys have no runtime emit), and an unchecked literal is how the
+// panel would keep charting a bucket the contract dropped.
+type ContractBuckets = NonNullable<
+  NonNullable<ApiSchema<"SubnetOwnerCutArtifact">["disposition"]>["buckets"]
+>;
 export const DISPOSITION_BUCKETS = [
   "held-as-stake",
   "unstaked",
   "transferred-out",
   "burned",
   "unresolved",
-] as const;
+] as const satisfies readonly (keyof ContractBuckets)[];
 
 export type DispositionBucket = (typeof DISPOSITION_BUCKETS)[number];
 

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -6,6 +6,7 @@ import { extrinsicHashPathSegment } from "./extrinsics";
 import { isValidSs58, ss58PathSegment } from "./accounts";
 import { isSchemaDrift, normalizeDriftStatus } from "./schema-drift";
 import { isUsableTimestamp } from "./format";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 import type {
   AdapterSnapshot,
   AgentResource,
@@ -7776,15 +7777,8 @@ function normalizeSubnetValidators(netuid: number, raw: unknown): SubnetValidato
   };
 }
 
-const GLOBAL_VALIDATOR_SORTS: GlobalValidatorSort[] = [
-  "avg_validator_trust",
-  "max_validator_trust",
-  "stake_dominance",
-  "subnet_count",
-  "total_emission",
-  "total_stake",
-  "uid_count",
-];
+// The /api/v1/validators route's own published sort enum (#10994).
+const GLOBAL_VALIDATOR_SORTS = QUERY_PARAMETER_ENUMS["/api/v1/validators"].sort;
 
 function normalizeColdkeyIdentity(raw: unknown): ColdkeyIdentity | null {
   if (raw == null) return null;

--- a/apps/ui/src/lib/metagraphed/subnet-window-helpers.ts
+++ b/apps/ui/src/lib/metagraphed/subnet-window-helpers.ts
@@ -1,3 +1,10 @@
+// DELIBERATELY literal, not derived from one route (#10994): the subnet
+// page's shared window control drives several routes at once (stake-flow,
+// event summary, movers, ...), each of which owns its window set separately
+// -- ten routes coincide on these three by choice, and the schema tree pins
+// that coincidence rather than coupling them. Deriving this from any single
+// route would encode a lineage that does not exist; if one route ever
+// diverges, the control must split per panel, not silently follow one route.
 export type SubnetWindow = "7d" | "30d" | "90d";
 
 export const SUBNET_WINDOWS: SubnetWindow[] = ["7d", "30d", "90d"];

--- a/apps/ui/src/routes/-accounts-ss58-page.tsx
+++ b/apps/ui/src/routes/-accounts-ss58-page.tsx
@@ -123,6 +123,7 @@ import type {
   Transfer,
 } from "@/lib/metagraphed/types";
 import { DEFAULT_EVENTS_LIMIT } from "./accounts.$ss58";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
 
 // #8358: detail-page template tabs. Overview carries the KPI band's context
 // plus a bounded recent-activity preview; everything else is a full,
@@ -1889,7 +1890,8 @@ function AccountEntitiesSection({ ss58 }: { ss58: string }) {
   );
 }
 
-const STAKE_FLOW_WINDOWS = ["7d", "30d", "90d"] as const;
+// The route's own published windows (#10994).
+const STAKE_FLOW_WINDOWS = QUERY_PARAMETER_ENUMS["/api/v1/accounts/{ss58}/stake-flow"].window;
 
 // Direction label → tone, reusing the health-ok/warn/muted convention the
 // transfers section uses for sent/received direction. `exiting` and `churning`

--- a/apps/ui/src/routes/-validators-hotkey-page.tsx
+++ b/apps/ui/src/routes/-validators-hotkey-page.tsx
@@ -282,6 +282,9 @@ function NominatorsSection({ hotkey }: { hotkey: string }) {
   );
 }
 
+// NOT a route enum (#10994): ValidatorApyWindow is the UI-computed APY basis
+// (7d/30d/90d plus "snapshot"), and this selector offers the trailing three.
+// The value overlap with route windows is coincidence, not lineage.
 const APY_WINDOWS: ValidatorApyWindow[] = ["7d", "30d", "90d"];
 
 // #8251: ONE APY tile with a 7d/30d/90d window toggle, replacing the three

--- a/apps/ui/src/routes/chain.emissions.tsx
+++ b/apps/ui/src/routes/chain.emissions.tsx
@@ -2,23 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ChainEmissionsPage } from "./-chain-emissions-page";
+import { EMISSION_SORT_KEYS } from "@/lib/metagraphed/emission-pipeline";
 
 // Filter/sort state lives in the URL so a specific view of the decomposition
 // ("the subnets the gate took the most from") is shareable — the same reason
 // /chain/governance puts its `view` toggle there.
 const emissionsSearchSchema = z.object({
   state: fallback(z.enum(["all", "eligible", "disabled", "ineligible"]), "all").default("all"),
-  sort: fallback(
-    z.enum([
-      "final_share",
-      "emission_share",
-      "gate_delta",
-      "tao_total",
-      "liquidity_fraction",
-      "netuid",
-    ]),
-    "final_share",
-  ).default("final_share"),
+  sort: fallback(z.enum(EMISSION_SORT_KEYS), "final_share").default("final_share"),
   dir: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
   limit: fallback(z.number().int().min(1).max(200), 50).default(50),
   netuid: fallback(z.string(), "").default(""),

--- a/apps/ui/src/routes/revenue.tsx
+++ b/apps/ui/src/routes/revenue.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RevenuePage } from "./-revenue-page";
+import { COVERAGE_SORT_FIELDS } from "@/lib/metagraphed/coverage-leaderboard-model";
 
 // Sort/filter state lives in the URL so a specific view ("the probe-derived
 // subnets, by revenue") is shareable — the same reason /chain/emissions puts
@@ -14,10 +15,7 @@ import { RevenuePage } from "./-revenue-page";
 // was measured but whose emission failed to price sorts to the BOTTOM of a
 // table it legitimately belongs in — ranked last on a column it cannot answer.
 const revenueSearchSchema = z.object({
-  sort: fallback(
-    z.enum(["subsidy_multiple", "coverage_ratio", "emission_usd", "revenue_usd", "netuid"]),
-    "revenue_usd",
-  ).default("revenue_usd"),
+  sort: fallback(z.enum(COVERAGE_SORT_FIELDS), "revenue_usd").default("revenue_usd"),
   dir: fallback(z.enum(["asc", "desc"]), "desc").default("desc"),
   // Empty means every tier, which is the default: the counts beside each tier
   // are how a reader learns the headline-eligible set is two subnets wide, and

--- a/apps/ui/src/routes/validators.$hotkey.tsx
+++ b/apps/ui/src/routes/validators.$hotkey.tsx
@@ -10,15 +10,17 @@ import { formatTao } from "@/lib/metagraphed/format";
 import { logoHostFrom, ogImageMeta } from "@/lib/metagraphed/og-card";
 import { validatorDetailQuery } from "@/lib/metagraphed/queries";
 import { ValidatorDetailPage } from "./-validators-hotkey-page";
+import { QUERY_PARAMETER_ENUMS } from "@jsonbored/metagraphed";
+
+const NOMINATOR_ENUMS = QUERY_PARAMETER_ENUMS["/api/v1/validators/{hotkey}/nominators"];
 
 const validatorDetailSearchSchema = z.object({
   // #8251: which detail tab is active (Per-subnet performance / Nominators /
   // History) — same `tab` convention subnets.$netuid.tsx uses.
   tab: fallback(z.string(), "subnets").default("subnets"),
-  window: fallback(z.enum(["7d", "30d", "90d"]), "30d").default("30d"),
-  sort: fallback(z.enum(["net_staked", "gross_staked", "last_activity"]), "net_staked").default(
-    "net_staked",
-  ),
+  // The nominators route's own published enums (#10994).
+  window: fallback(z.enum(NOMINATOR_ENUMS.window), "30d").default("30d"),
+  sort: fallback(z.enum(NOMINATOR_ENUMS.sort), "net_staked").default("net_staked"),
   limit: fallback(z.number().int().min(1).max(100), 20).default(20),
   offset: fallback(z.number().int().min(0), 0).default(0),
   coldkey: fallback(z.string(), "").default(""),

--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -804,3 +804,799 @@ export function createMetagraphedClient(
     health: (options) => request("/api/v1/health", { ...options }),
   };
 }
+
+/**
+ * Every string-enum query parameter the published contract declares, keyed by
+ * route path then parameter name. "as const", so a consumer derives literal
+ * unions instead of restating them (#10994).
+ */
+export const QUERY_PARAMETER_ENUMS = {
+  "/api/v1/accounts": {
+    "format": ["json","csv"],
+    "sort": ["total_stake","total_emission","subnet_count","uid_count","validator_count","stake_dominance","last_active"],
+  },
+  "/api/v1/accounts/top-holders": {
+    "format": ["json","csv"],
+    "sort": ["total_tao","free_tao","delegated_tao","net_flow_7d","net_flow_30d","net_flow_90d"],
+  },
+  "/api/v1/accounts/{ss58}/axon-removals": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/counterparties": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/accounts/{ss58}/deregistrations": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/events": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/accounts/{ss58}/extrinsics": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/accounts/{ss58}/history": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/accounts/{ss58}/identity-history": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/accounts/{ss58}/prometheus": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/registrations": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/serving": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/stake-flow": {
+    "direction": ["all","in","out"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/stake-moves": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/accounts/{ss58}/subnets/{netuid}/history": {
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/accounts/{ss58}/transfers": {
+    "direction": ["all","sent","received"],
+    "format": ["json","csv"],
+  },
+  "/api/v1/accounts/{ss58}/weight-setters": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/agent-catalog": {
+    "order": ["asc","desc"],
+    "sort": ["netuid","callable_count","completeness_score","example_count"],
+  },
+  "/api/v1/blocks": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/blocks/{ref}/events": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/blocks/{ref}/extrinsics": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/candidates": {
+    "confidence": ["low","medium","high"],
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["confidence","id","kind","name","netuid","provider","state"],
+    "state": ["schema-invalid","schema-valid","maintainer-review","verified","stale","rejected"],
+  },
+  "/api/v1/chain-events": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/chain/activity": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/alpha-volume": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/chain/axon-removals": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/calls": {
+    "format": ["json","csv"],
+    "group_by": ["module","module_function"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/concentration/history": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/chain/concentration/subnets": {
+    "lens": ["emission","stake","entity_emission","entity_stake","validator_stake"],
+    "order": ["asc","desc"],
+    "sort": ["nakamoto_coefficient","gini","holders","top_1pct_share","total","netuid"],
+  },
+  "/api/v1/chain/deregistrations": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/emission-pipeline": {
+    "order": ["asc","desc"],
+    "sort": ["final_share","emission_share","weighted_share","gated_share","gate_delta","distance_to_bar","tao_in_emission","excess_tao","tao_total","liquidity_fraction","miner_burned","netuid"],
+  },
+  "/api/v1/chain/fees": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/governance/emission-changes": {
+    "kind": ["param","subnet","flow"],
+  },
+  "/api/v1/chain/holders": {
+    "sort": ["top1_share","top5_share","top10_share","top20_share","holder_count","total_alpha"],
+  },
+  "/api/v1/chain/prometheus": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/registrations": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/revenue-coverage": {
+    "window": ["1d","7d","30d"],
+  },
+  "/api/v1/chain/serving": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/signers": {
+    "format": ["json","csv"],
+    "sort": ["tx_count","total_fee_tao"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/stake-flow": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/stake-moves": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/stake-transfers": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/subnet-lifecycle": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/chain/transfer-pairs": {
+    "format": ["json","csv"],
+    "sort": ["volume","count"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/transfers": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/turnover": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/chain/weights": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/chain/weights/setters": {
+    "format": ["json","csv"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/contracts": {
+    "order": ["asc","desc"],
+    "sort": ["id","path","contract_version"],
+  },
+  "/api/v1/coverage-depth": {
+    "agent_status": ["callable","base-layer","candidate","needs-evidence","blocked"],
+    "blocker_level": ["none","hard-blocked","needs-review","missing-data"],
+    "format": ["json","csv"],
+    "order": ["asc","desc"],
+    "sort": ["agent_status","blocker_level","name","netuid","priority_score","score","tier"],
+    "tier": ["agent-ready","machine-usable","candidate-review","needs-evidence","hard-blocked","missing-interface"],
+  },
+  "/api/v1/curation": {
+    "coverage_level": ["native-only","manifested","probed"],
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "order": ["asc","desc"],
+    "sort": ["coverage_level","curation_level","name","netuid"],
+  },
+  "/api/v1/domains/{tag}/summary": {
+    "tag": ["agents","compute","data","finance","inference","media","prediction","privacy","robotics","science","search","security","storage","training"],
+  },
+  "/api/v1/economics": {
+    "format": ["json","csv"],
+    "order": ["asc","desc"],
+    "registration_allowed": ["true","false"],
+    "sort": ["alpha_fdv_tao","alpha_market_cap_tao","alpha_price_change_1d","alpha_price_change_1h","alpha_price_change_1m","alpha_price_change_7d","alpha_price_tao","block","emission_share","max_stake_alpha","max_uids","max_validators","miner_count","miner_readiness","name","netuid","open_slots","registration_cost_tao","subnet_volume_tao","total_stake_alpha","validator_count"],
+  },
+  "/api/v1/economics/trends": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/endpoint-incidents": {
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "severity": ["critical","warning","info"],
+    "sort": ["detected_at","endpoint_id","kind","last_checked","netuid","provider","severity","state","status"],
+    "state": ["active","resolved"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/endpoint-pools": {
+    "kind": ["subtensor-rpc","subtensor-wss","archive"],
+    "order": ["asc","desc"],
+    "sort": ["eligible_count","endpoint_count","id","kind"],
+  },
+  "/api/v1/endpoints": {
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "layer": ["bittensor-base","data-provider","docs-provider","subnet-app"],
+    "order": ["asc","desc"],
+    "pool_eligible": ["true","false"],
+    "publication_state": ["candidate","verified","monitored","pool-eligible","disabled","rejected"],
+    "sort": ["kind","last_checked","latency_ms","layer","netuid","pool_eligible","provider","publication_state","score","status"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/evidence": {
+    "order": ["asc","desc"],
+    "sort": ["claim","source_url","subject","verified_at"],
+  },
+  "/api/v1/extrinsics": {
+    "format": ["json","csv"],
+    "success": ["true","false"],
+  },
+  "/api/v1/fixtures": {
+    "order": ["asc","desc"],
+    "sort": ["captured_at","netuid","surface_id"],
+  },
+  "/api/v1/gaps": {
+    "coverage_level": ["native-only","manifested","probed"],
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "order": ["asc","desc"],
+    "sort": ["coverage_level","curation_level","gap_count","name","netuid"],
+  },
+  "/api/v1/governance/config-changes": {
+    "format": ["json","csv"],
+    "success": ["true","false"],
+  },
+  "/api/v1/health": {
+    "order": ["asc","desc"],
+    "sort": ["avg_latency_ms","degraded_count","failed_count","last_checked","last_ok","name","netuid","ok_count","status","surface_count","unknown_count"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/health/failure-reasons": {
+    "window": ["7d","30d","90d","180d"],
+  },
+  "/api/v1/health/history/{date}": {
+    "classification": ["auth-required","content-mismatch","dead","live","rate-limited","redirected","timeout","transient","unsupported","unsafe","wrong-chain"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["classification","kind","last_checked","last_ok","latency_ms","netuid","provider","status","status_code","surface_id","verified_at"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/health/trends": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/incidents": {
+    "order": ["asc","desc"],
+    "sort": ["downtime_ms","incident_count","netuid","surface_id"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/network/tao-usd": {
+    "window": ["1h","24h","7d","30d"],
+  },
+  "/api/v1/profiles": {
+    "confidence": ["low","medium","high"],
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "format": ["json","csv"],
+    "order": ["asc","desc"],
+    "profile_level": ["directory-only","identity-partial","identity-complete","operational","adapter-backed"],
+    "sort": ["candidate_count","completeness_score","curation_level","interface_count","missing_critical_count","name","netuid","operational_interface_count","profile_level","review_state"],
+    "subnet_type": ["root","application"],
+  },
+  "/api/v1/providers": {
+    "authority": ["community","official","provider-claimed","registry-observed"],
+    "format": ["json","csv"],
+    "kind": ["data-provider","docs-provider","infrastructure-provider","registry","subnet-team"],
+    "order": ["asc","desc"],
+    "sort": ["authority","id","kind","name"],
+  },
+  "/api/v1/providers/{slug}/endpoints": {
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "layer": ["bittensor-base","data-provider","docs-provider","subnet-app"],
+    "order": ["asc","desc"],
+    "pool_eligible": ["true","false"],
+    "publication_state": ["candidate","verified","monitored","pool-eligible","disabled","rejected"],
+    "sort": ["kind","last_checked","latency_ms","layer","netuid","pool_eligible","provider","publication_state","score","status"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/registry/leaderboards": {
+    "board": ["healthiest","fastest-rpc","most-complete","most-enriched","fastest-growing","most-reliable","open-slots","cheapest-registration","highest-emission","validator-headroom","biggest-alpha-gain-1d","biggest-alpha-gain-7d"],
+  },
+  "/api/v1/review/adapter-candidates": {
+    "candidate_api_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "format": ["json","csv"],
+    "operational_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "recommended_adapter_kind": ["custom-adapter","data-artifact-adapter","generic-openapi-or-custom","stream-adapter"],
+    "sort": ["candidate_api_count","candidate_api_kinds","curation_level","name","netuid","operational_kinds","operational_surface_count","priority_score","recommended_adapter_kind"],
+  },
+  "/api/v1/review/enrichment-evidence": {
+    "direct_submission_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "evidence_action": ["submit-new-evidence","verify-existing-evidence","replace-stale-evidence","review-existing-evidence","maintainer-review-existing-evidence","monitor"],
+    "lane": ["direct-submission","maintainer-review","adapter-candidate","monitoring-followup","baseline-monitoring"],
+    "missing_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["evidence_action","lane","name","netuid","priority_score"],
+  },
+  "/api/v1/review/enrichment-queue": {
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "direct_submission_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "evidence_action": ["submit-new-evidence","verify-existing-evidence","replace-stale-evidence","review-existing-evidence","maintainer-review-existing-evidence","monitor"],
+    "format": ["json","csv"],
+    "identity_level": ["none","directory","partial","complete"],
+    "lane": ["direct-submission","maintainer-review","adapter-candidate","monitoring-followup","baseline-monitoring"],
+    "manual_review_required": ["true","false"],
+    "missing_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "profile_level": ["directory-only","identity-partial","identity-complete","operational","adapter-backed"],
+    "sort": ["adapter_score","candidate_count","completeness_score","curation_level","endpoint_count","evidence_action","identity_level","identity_surface_count","lane","name","netuid","operational_interface_count","priority_score","profile_level","review_state","stale_candidate_count","surface_count","verified_candidate_count"],
+  },
+  "/api/v1/review/enrichment-targets": {
+    "auto_review_candidate": ["true","false"],
+    "evidence_action": ["submit-new-evidence","verify-existing-evidence","replace-stale-evidence","review-existing-evidence","maintainer-review-existing-evidence","monitor"],
+    "identity_level": ["none","directory","partial","complete"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "lane": ["direct-submission","maintainer-review","adapter-candidate","monitoring-followup","baseline-monitoring"],
+    "manual_review_required": ["true","false"],
+    "missing_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "profile_level": ["directory-only","identity-partial","identity-complete","operational","adapter-backed"],
+    "sort": ["auto_review_candidate","evidence_action","identity_level","kind","lane","manual_review_required","name","netuid","priority_score","profile_level","submission_route","target_action","target_type"],
+    "submission_route": ["direct-candidate-pr","adapter-request","maintainer-review","status-report"],
+    "target_action": ["submit-new-candidate","replace-stale-candidate","verify-existing-candidate","review-existing-candidate","adapter-review","maintainer-review","monitoring-followup"],
+    "target_type": ["surface-candidate","adapter-review","maintainer-review","monitoring-followup"],
+  },
+  "/api/v1/review/gaps": {
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "format": ["json","csv"],
+    "missing_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["candidate_count","curation_level","missing_kinds","name","netuid","priority_score","surface_count","verified_candidate_count"],
+  },
+  "/api/v1/review/profile-completeness": {
+    "confidence": ["low","medium","high"],
+    "format": ["json","csv"],
+    "identity_level": ["none","directory","partial","complete"],
+    "identity_promotion_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "native_name_quality": ["chain","placeholder","empty"],
+    "order": ["asc","desc"],
+    "profile_level": ["directory-only","identity-partial","identity-complete","operational","adapter-backed"],
+    "sort": ["candidate_count","completeness_score","identity_level","identity_promotion_kind_count","identity_surface_count","live_identity_candidate_kind_count","missing_critical_count","name","native_identity_signal_count","native_name_quality","netuid","priority_score","profile_level","stale_identity_candidate_kind_count"],
+  },
+  "/api/v1/rpc/endpoints": {
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "layer": ["bittensor-base","data-provider","docs-provider","subnet-app"],
+    "order": ["asc","desc"],
+    "pool_eligible": ["true","false"],
+    "publication_state": ["candidate","verified","monitored","pool-eligible","disabled","rejected"],
+    "sort": ["kind","last_checked","latency_ms","layer","netuid","pool_eligible","provider","publication_state","score","status"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/rpc/pools": {
+    "kind": ["subtensor-rpc","subtensor-wss","archive"],
+    "order": ["asc","desc"],
+    "sort": ["eligible_count","endpoint_count","id","kind"],
+  },
+  "/api/v1/rpc/usage": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/runtime": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/search": {
+    "order": ["asc","desc"],
+    "sort": ["netuid","slug","title","type"],
+    "type": ["subnet","surface","provider"],
+  },
+  "/api/v1/search-index": {
+    "order": ["asc","desc"],
+    "sort": ["netuid","slug","title","type"],
+    "type": ["subnet","surface","provider"],
+  },
+  "/api/v1/search/semantic": {
+    "type": ["subnet","surface","provider"],
+  },
+  "/api/v1/source-snapshots": {
+    "order": ["asc","desc"],
+    "sort": ["id","kind","path","record_count"],
+  },
+  "/api/v1/subnets": {
+    "coverage_level": ["native-only","manifested","probed"],
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "domain": ["agents","compute","data","finance","inference","media","prediction","privacy","robotics","science","search","security","storage","training"],
+    "format": ["json","csv"],
+    "order": ["asc","desc"],
+    "sort": ["block","candidate_count","coverage_level","curation_level","integration_readiness","mechanism_count","name","netuid","participant_count","probed_surface_count","status","subnet_type","surface_count","tempo"],
+    "status": ["active","inactive"],
+    "subnet_type": ["root","application"],
+  },
+  "/api/v1/subnets/movers": {
+    "format": ["json","csv"],
+    "sort": ["stake","emission","validators","neurons"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/axon-removals": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/burn/history": {
+    "window": ["24h","7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/candidates": {
+    "confidence": ["low","medium","high"],
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["confidence","id","kind","name","netuid","provider","state"],
+    "state": ["schema-invalid","schema-valid","maintainer-review","verified","stale","rejected"],
+  },
+  "/api/v1/subnets/{netuid}/concentration/history": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/deregistrations": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/emission-pipeline/history": {
+    "window": ["7d","30d","90d","180d"],
+  },
+  "/api/v1/subnets/{netuid}/emission-split/history": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/endpoints": {
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "layer": ["bittensor-base","data-provider","docs-provider","subnet-app"],
+    "order": ["asc","desc"],
+    "pool_eligible": ["true","false"],
+    "publication_state": ["candidate","verified","monitored","pool-eligible","disabled","rejected"],
+    "sort": ["kind","last_checked","latency_ms","layer","netuid","pool_eligible","provider","publication_state","score","status"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/subnets/{netuid}/event-summary": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/events": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/subnets/{netuid}/evidence": {
+    "order": ["asc","desc"],
+    "sort": ["claim","source_url","subject","verified_at"],
+  },
+  "/api/v1/subnets/{netuid}/gaps": {
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "format": ["json","csv"],
+    "missing_kinds": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["candidate_count","curation_level","missing_kinds","name","netuid","priority_score","surface_count","verified_candidate_count"],
+  },
+  "/api/v1/subnets/{netuid}/health": {
+    "classification": ["auth-required","content-mismatch","dead","live","rate-limited","redirected","timeout","transient","unsupported","unsafe","wrong-chain"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "sort": ["classification","kind","last_checked","last_ok","latency_ms","netuid","provider","status","status_code","surface_id","verified_at"],
+    "status": ["ok","degraded","failed","unknown"],
+  },
+  "/api/v1/subnets/{netuid}/health/incidents": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/health/percentiles": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/history": {
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/subnets/{netuid}/hyperparameters/history": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/subnets/{netuid}/identity-history": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/subnets/{netuid}/lifecycle": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/subnets/{netuid}/metagraph": {
+    "format": ["json","csv"],
+    "validator_permit": ["true"],
+  },
+  "/api/v1/subnets/{netuid}/miner-fairness": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/neurons/{uid}/history": {
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/subnets/{netuid}/ohlc": {
+    "interval": ["1h","1d"],
+  },
+  "/api/v1/subnets/{netuid}/owner-capture": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/performance/history": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/prometheus": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/registrations": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/revenue": {
+    "window": ["1d","7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/serving": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/stake-flow": {
+    "direction": ["all","in","out"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/stake-moves": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/stake-quote": {
+    "direction": ["stake","unstake"],
+  },
+  "/api/v1/subnets/{netuid}/stake-transfers": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/surfaces": {
+    "auth_required": ["true","false"],
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "public_safe": ["true","false"],
+    "rate_limited": ["true","false"],
+    "sort": ["id","kind","name","netuid","provider"],
+  },
+  "/api/v1/subnets/{netuid}/trajectory": {
+    "format": ["json","csv"],
+    "order": ["asc","desc"],
+    "sort": ["date","completeness_score","surface_count","endpoint_count"],
+  },
+  "/api/v1/subnets/{netuid}/turnover": {
+    "changes": ["true","false"],
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/subnets/{netuid}/uptime": {
+    "format": ["json","csv"],
+    "window": ["90d","1y"],
+  },
+  "/api/v1/subnets/{netuid}/validator-economics/history": {
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/subnets/{netuid}/validators": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/subnets/{netuid}/weights": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/weights/setters": {
+    "window": ["7d","30d"],
+  },
+  "/api/v1/subnets/{netuid}/yield": {
+    "format": ["json","csv"],
+  },
+  "/api/v1/subnets/{netuid}/yield/history": {
+    "format": ["json","csv"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/sudo": {
+    "format": ["json","csv"],
+    "success": ["true","false"],
+  },
+  "/api/v1/surfaces": {
+    "auth_required": ["true","false"],
+    "format": ["json","csv"],
+    "kind": ["archive","dashboard","data-artifact","docs","example","openapi","repo-registry","sdk","source-repo","sse","subnet-api","subtensor-rpc","subtensor-wss","website"],
+    "order": ["asc","desc"],
+    "public_safe": ["true","false"],
+    "rate_limited": ["true","false"],
+    "sort": ["id","kind","name","netuid","provider"],
+  },
+  "/api/v1/validators": {
+    "format": ["json","csv"],
+    "sort": ["avg_validator_trust","max_validator_trust","stake_dominance","subnet_count","total_emission","total_stake","uid_count"],
+  },
+  "/api/v1/validators/economics": {
+    "sort": ["earning_floor_cost_tao","permit_floor_cost_tao","permit_to_earning_multiple","tao_inflow_per_day","validator_headroom"],
+  },
+  "/api/v1/validators/{hotkey}/history": {
+    "window": ["7d","30d","90d","1y","all"],
+  },
+  "/api/v1/validators/{hotkey}/nominators": {
+    "basis": ["flow","positions"],
+    "format": ["json","csv"],
+    "sort": ["net_staked","gross_staked","last_activity"],
+    "window": ["7d","30d","90d"],
+  },
+  "/api/v1/{network}/accounts/{ss58}/balance": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/accounts/{ss58}/children": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/accounts/{ss58}/parents": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/accounts/{ss58}/root-claim": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/blocks": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/blocks/summary": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/blocks/{ref}": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/blocks/{ref}/chain-events": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/blocks/{ref}/events": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/blocks/{ref}/extrinsics": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/chain-events": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/chain-events/stats": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/chain/activity": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/alpha-volume": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/chain/burn": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/chain/calls": {
+    "format": ["json","csv"],
+    "group_by": ["module","module_function"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/deregistrations": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/fees": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/registrations": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/signers": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "sort": ["tx_count","total_fee_tao"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/stake-flow": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/stake-moves": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/stake-transfers": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/transfer-pairs": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "sort": ["volume","count"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/chain/transfers": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "window": ["7d","30d"],
+  },
+  "/api/v1/{network}/coverage": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/crowdloans": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/crowdloans/{crowdloan_id}": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/economics": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "order": ["asc","desc"],
+    "registration_allowed": ["true","false"],
+    "sort": ["alpha_fdv_tao","alpha_market_cap_tao","alpha_price_change_1d","alpha_price_change_1h","alpha_price_change_1m","alpha_price_change_7d","alpha_price_tao","block","emission_share","max_stake_alpha","max_uids","max_validators","miner_count","miner_readiness","name","netuid","open_slots","registration_cost_tao","subnet_volume_tao","total_stake_alpha","validator_count"],
+  },
+  "/api/v1/{network}/evm/address/{h160}": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/extrinsics": {
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "success": ["true","false"],
+  },
+  "/api/v1/{network}/extrinsics/{hash}": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/network/parameters": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/network/randomness": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/networks": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/search/resolve": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/subnets": {
+    "coverage_level": ["native-only","manifested","probed"],
+    "curation_level": ["native","candidate-discovered","community-seeded","machine-verified","maintainer-reviewed","adapter-backed"],
+    "domain": ["agents","compute","data","finance","inference","media","prediction","privacy","robotics","science","search","security","storage","training"],
+    "format": ["json","csv"],
+    "network": ["finney","mainnet","test","testnet"],
+    "order": ["asc","desc"],
+    "sort": ["block","candidate_count","coverage_level","curation_level","integration_readiness","mechanism_count","name","netuid","participant_count","probed_surface_count","status","subnet_type","surface_count","tempo"],
+    "status": ["active","inactive"],
+    "subnet_type": ["root","application"],
+  },
+  "/api/v1/{network}/subnets/{netuid}": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/subnets/{netuid}/burn": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/subnets/{netuid}/lease": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/subnets/{netuid}/recycled": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+  "/api/v1/{network}/sudo/key": {
+    "network": ["finney","mainnet","test","testnet"],
+  },
+} as const;

--- a/packages/client/dist/index.cjs
+++ b/packages/client/dist/index.cjs
@@ -451,8 +451,799 @@ function createMetagraphedClient(clientOptions = {}) {
     health: (options) => request("/api/v1/health", { ...options })
   };
 }
+var QUERY_PARAMETER_ENUMS = {
+  "/api/v1/accounts": {
+    "format": ["json", "csv"],
+    "sort": ["total_stake", "total_emission", "subnet_count", "uid_count", "validator_count", "stake_dominance", "last_active"]
+  },
+  "/api/v1/accounts/top-holders": {
+    "format": ["json", "csv"],
+    "sort": ["total_tao", "free_tao", "delegated_tao", "net_flow_7d", "net_flow_30d", "net_flow_90d"]
+  },
+  "/api/v1/accounts/{ss58}/axon-removals": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/counterparties": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/deregistrations": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/extrinsics": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/identity-history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/prometheus": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/registrations": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/serving": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/stake-flow": {
+    "direction": ["all", "in", "out"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/stake-moves": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/subnets/{netuid}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/accounts/{ss58}/transfers": {
+    "direction": ["all", "sent", "received"],
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/weight-setters": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/agent-catalog": {
+    "order": ["asc", "desc"],
+    "sort": ["netuid", "callable_count", "completeness_score", "example_count"]
+  },
+  "/api/v1/blocks": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/blocks/{ref}/events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/blocks/{ref}/extrinsics": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/candidates": {
+    "confidence": ["low", "medium", "high"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
+    "state": ["schema-invalid", "schema-valid", "maintainer-review", "verified", "stale", "rejected"]
+  },
+  "/api/v1/chain-events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/chain/activity": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/alpha-volume": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/chain/axon-removals": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/calls": {
+    "format": ["json", "csv"],
+    "group_by": ["module", "module_function"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/concentration/history": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/chain/concentration/subnets": {
+    "lens": ["emission", "stake", "entity_emission", "entity_stake", "validator_stake"],
+    "order": ["asc", "desc"],
+    "sort": ["nakamoto_coefficient", "gini", "holders", "top_1pct_share", "total", "netuid"]
+  },
+  "/api/v1/chain/deregistrations": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/emission-pipeline": {
+    "order": ["asc", "desc"],
+    "sort": ["final_share", "emission_share", "weighted_share", "gated_share", "gate_delta", "distance_to_bar", "tao_in_emission", "excess_tao", "tao_total", "liquidity_fraction", "miner_burned", "netuid"]
+  },
+  "/api/v1/chain/fees": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/governance/emission-changes": {
+    "kind": ["param", "subnet", "flow"]
+  },
+  "/api/v1/chain/holders": {
+    "sort": ["top1_share", "top5_share", "top10_share", "top20_share", "holder_count", "total_alpha"]
+  },
+  "/api/v1/chain/prometheus": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/registrations": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/revenue-coverage": {
+    "window": ["1d", "7d", "30d"]
+  },
+  "/api/v1/chain/serving": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/signers": {
+    "format": ["json", "csv"],
+    "sort": ["tx_count", "total_fee_tao"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/stake-flow": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/stake-moves": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/stake-transfers": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/subnet-lifecycle": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/chain/transfer-pairs": {
+    "format": ["json", "csv"],
+    "sort": ["volume", "count"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/transfers": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/turnover": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/chain/weights": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/weights/setters": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/contracts": {
+    "order": ["asc", "desc"],
+    "sort": ["id", "path", "contract_version"]
+  },
+  "/api/v1/coverage-depth": {
+    "agent_status": ["callable", "base-layer", "candidate", "needs-evidence", "blocked"],
+    "blocker_level": ["none", "hard-blocked", "needs-review", "missing-data"],
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "sort": ["agent_status", "blocker_level", "name", "netuid", "priority_score", "score", "tier"],
+    "tier": ["agent-ready", "machine-usable", "candidate-review", "needs-evidence", "hard-blocked", "missing-interface"]
+  },
+  "/api/v1/curation": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "order": ["asc", "desc"],
+    "sort": ["coverage_level", "curation_level", "name", "netuid"]
+  },
+  "/api/v1/domains/{tag}/summary": {
+    "tag": ["agents", "compute", "data", "finance", "inference", "media", "prediction", "privacy", "robotics", "science", "search", "security", "storage", "training"]
+  },
+  "/api/v1/economics": {
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "registration_allowed": ["true", "false"],
+    "sort": ["alpha_fdv_tao", "alpha_market_cap_tao", "alpha_price_change_1d", "alpha_price_change_1h", "alpha_price_change_1m", "alpha_price_change_7d", "alpha_price_tao", "block", "emission_share", "max_stake_alpha", "max_uids", "max_validators", "miner_count", "miner_readiness", "name", "netuid", "open_slots", "registration_cost_tao", "subnet_volume_tao", "total_stake_alpha", "validator_count"]
+  },
+  "/api/v1/economics/trends": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/endpoint-incidents": {
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "severity": ["critical", "warning", "info"],
+    "sort": ["detected_at", "endpoint_id", "kind", "last_checked", "netuid", "provider", "severity", "state", "status"],
+    "state": ["active", "resolved"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/endpoint-pools": {
+    "kind": ["subtensor-rpc", "subtensor-wss", "archive"],
+    "order": ["asc", "desc"],
+    "sort": ["eligible_count", "endpoint_count", "id", "kind"]
+  },
+  "/api/v1/endpoints": {
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/evidence": {
+    "order": ["asc", "desc"],
+    "sort": ["claim", "source_url", "subject", "verified_at"]
+  },
+  "/api/v1/extrinsics": {
+    "format": ["json", "csv"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/fixtures": {
+    "order": ["asc", "desc"],
+    "sort": ["captured_at", "netuid", "surface_id"]
+  },
+  "/api/v1/gaps": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "order": ["asc", "desc"],
+    "sort": ["coverage_level", "curation_level", "gap_count", "name", "netuid"]
+  },
+  "/api/v1/governance/config-changes": {
+    "format": ["json", "csv"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/health": {
+    "order": ["asc", "desc"],
+    "sort": ["avg_latency_ms", "degraded_count", "failed_count", "last_checked", "last_ok", "name", "netuid", "ok_count", "status", "surface_count", "unknown_count"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/health/failure-reasons": {
+    "window": ["7d", "30d", "90d", "180d"]
+  },
+  "/api/v1/health/history/{date}": {
+    "classification": ["auth-required", "content-mismatch", "dead", "live", "rate-limited", "redirected", "timeout", "transient", "unsupported", "unsafe", "wrong-chain"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["classification", "kind", "last_checked", "last_ok", "latency_ms", "netuid", "provider", "status", "status_code", "surface_id", "verified_at"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/health/trends": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/incidents": {
+    "order": ["asc", "desc"],
+    "sort": ["downtime_ms", "incident_count", "netuid", "surface_id"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/network/tao-usd": {
+    "window": ["1h", "24h", "7d", "30d"]
+  },
+  "/api/v1/profiles": {
+    "confidence": ["low", "medium", "high"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["candidate_count", "completeness_score", "curation_level", "interface_count", "missing_critical_count", "name", "netuid", "operational_interface_count", "profile_level", "review_state"],
+    "subnet_type": ["root", "application"]
+  },
+  "/api/v1/providers": {
+    "authority": ["community", "official", "provider-claimed", "registry-observed"],
+    "format": ["json", "csv"],
+    "kind": ["data-provider", "docs-provider", "infrastructure-provider", "registry", "subnet-team"],
+    "order": ["asc", "desc"],
+    "sort": ["authority", "id", "kind", "name"]
+  },
+  "/api/v1/providers/{slug}/endpoints": {
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/registry/leaderboards": {
+    "board": ["healthiest", "fastest-rpc", "most-complete", "most-enriched", "fastest-growing", "most-reliable", "open-slots", "cheapest-registration", "highest-emission", "validator-headroom", "biggest-alpha-gain-1d", "biggest-alpha-gain-7d"]
+  },
+  "/api/v1/review/adapter-candidates": {
+    "candidate_api_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "operational_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "recommended_adapter_kind": ["custom-adapter", "data-artifact-adapter", "generic-openapi-or-custom", "stream-adapter"],
+    "sort": ["candidate_api_count", "candidate_api_kinds", "curation_level", "name", "netuid", "operational_kinds", "operational_surface_count", "priority_score", "recommended_adapter_kind"]
+  },
+  "/api/v1/review/enrichment-evidence": {
+    "direct_submission_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "evidence_action": ["submit-new-evidence", "verify-existing-evidence", "replace-stale-evidence", "review-existing-evidence", "maintainer-review-existing-evidence", "monitor"],
+    "lane": ["direct-submission", "maintainer-review", "adapter-candidate", "monitoring-followup", "baseline-monitoring"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["evidence_action", "lane", "name", "netuid", "priority_score"]
+  },
+  "/api/v1/review/enrichment-queue": {
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "direct_submission_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "evidence_action": ["submit-new-evidence", "verify-existing-evidence", "replace-stale-evidence", "review-existing-evidence", "maintainer-review-existing-evidence", "monitor"],
+    "format": ["json", "csv"],
+    "identity_level": ["none", "directory", "partial", "complete"],
+    "lane": ["direct-submission", "maintainer-review", "adapter-candidate", "monitoring-followup", "baseline-monitoring"],
+    "manual_review_required": ["true", "false"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["adapter_score", "candidate_count", "completeness_score", "curation_level", "endpoint_count", "evidence_action", "identity_level", "identity_surface_count", "lane", "name", "netuid", "operational_interface_count", "priority_score", "profile_level", "review_state", "stale_candidate_count", "surface_count", "verified_candidate_count"]
+  },
+  "/api/v1/review/enrichment-targets": {
+    "auto_review_candidate": ["true", "false"],
+    "evidence_action": ["submit-new-evidence", "verify-existing-evidence", "replace-stale-evidence", "review-existing-evidence", "maintainer-review-existing-evidence", "monitor"],
+    "identity_level": ["none", "directory", "partial", "complete"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "lane": ["direct-submission", "maintainer-review", "adapter-candidate", "monitoring-followup", "baseline-monitoring"],
+    "manual_review_required": ["true", "false"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["auto_review_candidate", "evidence_action", "identity_level", "kind", "lane", "manual_review_required", "name", "netuid", "priority_score", "profile_level", "submission_route", "target_action", "target_type"],
+    "submission_route": ["direct-candidate-pr", "adapter-request", "maintainer-review", "status-report"],
+    "target_action": ["submit-new-candidate", "replace-stale-candidate", "verify-existing-candidate", "review-existing-candidate", "adapter-review", "maintainer-review", "monitoring-followup"],
+    "target_type": ["surface-candidate", "adapter-review", "maintainer-review", "monitoring-followup"]
+  },
+  "/api/v1/review/gaps": {
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["candidate_count", "curation_level", "missing_kinds", "name", "netuid", "priority_score", "surface_count", "verified_candidate_count"]
+  },
+  "/api/v1/review/profile-completeness": {
+    "confidence": ["low", "medium", "high"],
+    "format": ["json", "csv"],
+    "identity_level": ["none", "directory", "partial", "complete"],
+    "identity_promotion_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "native_name_quality": ["chain", "placeholder", "empty"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["candidate_count", "completeness_score", "identity_level", "identity_promotion_kind_count", "identity_surface_count", "live_identity_candidate_kind_count", "missing_critical_count", "name", "native_identity_signal_count", "native_name_quality", "netuid", "priority_score", "profile_level", "stale_identity_candidate_kind_count"]
+  },
+  "/api/v1/rpc/endpoints": {
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/rpc/pools": {
+    "kind": ["subtensor-rpc", "subtensor-wss", "archive"],
+    "order": ["asc", "desc"],
+    "sort": ["eligible_count", "endpoint_count", "id", "kind"]
+  },
+  "/api/v1/rpc/usage": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/runtime": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/search": {
+    "order": ["asc", "desc"],
+    "sort": ["netuid", "slug", "title", "type"],
+    "type": ["subnet", "surface", "provider"]
+  },
+  "/api/v1/search-index": {
+    "order": ["asc", "desc"],
+    "sort": ["netuid", "slug", "title", "type"],
+    "type": ["subnet", "surface", "provider"]
+  },
+  "/api/v1/search/semantic": {
+    "type": ["subnet", "surface", "provider"]
+  },
+  "/api/v1/source-snapshots": {
+    "order": ["asc", "desc"],
+    "sort": ["id", "kind", "path", "record_count"]
+  },
+  "/api/v1/subnets": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "domain": ["agents", "compute", "data", "finance", "inference", "media", "prediction", "privacy", "robotics", "science", "search", "security", "storage", "training"],
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "sort": ["block", "candidate_count", "coverage_level", "curation_level", "integration_readiness", "mechanism_count", "name", "netuid", "participant_count", "probed_surface_count", "status", "subnet_type", "surface_count", "tempo"],
+    "status": ["active", "inactive"],
+    "subnet_type": ["root", "application"]
+  },
+  "/api/v1/subnets/movers": {
+    "format": ["json", "csv"],
+    "sort": ["stake", "emission", "validators", "neurons"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/axon-removals": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/burn/history": {
+    "window": ["24h", "7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/candidates": {
+    "confidence": ["low", "medium", "high"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
+    "state": ["schema-invalid", "schema-valid", "maintainer-review", "verified", "stale", "rejected"]
+  },
+  "/api/v1/subnets/{netuid}/concentration/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/deregistrations": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/emission-pipeline/history": {
+    "window": ["7d", "30d", "90d", "180d"]
+  },
+  "/api/v1/subnets/{netuid}/emission-split/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/endpoints": {
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/subnets/{netuid}/event-summary": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/evidence": {
+    "order": ["asc", "desc"],
+    "sort": ["claim", "source_url", "subject", "verified_at"]
+  },
+  "/api/v1/subnets/{netuid}/gaps": {
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["candidate_count", "curation_level", "missing_kinds", "name", "netuid", "priority_score", "surface_count", "verified_candidate_count"]
+  },
+  "/api/v1/subnets/{netuid}/health": {
+    "classification": ["auth-required", "content-mismatch", "dead", "live", "rate-limited", "redirected", "timeout", "transient", "unsupported", "unsafe", "wrong-chain"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["classification", "kind", "last_checked", "last_ok", "latency_ms", "netuid", "provider", "status", "status_code", "surface_id", "verified_at"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/subnets/{netuid}/health/incidents": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/health/percentiles": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/subnets/{netuid}/hyperparameters/history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/identity-history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/lifecycle": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/metagraph": {
+    "format": ["json", "csv"],
+    "validator_permit": ["true"]
+  },
+  "/api/v1/subnets/{netuid}/miner-fairness": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/neurons/{uid}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/subnets/{netuid}/ohlc": {
+    "interval": ["1h", "1d"]
+  },
+  "/api/v1/subnets/{netuid}/owner-capture": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/performance/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/prometheus": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/registrations": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/revenue": {
+    "window": ["1d", "7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/serving": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/stake-flow": {
+    "direction": ["all", "in", "out"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/stake-moves": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/stake-quote": {
+    "direction": ["stake", "unstake"]
+  },
+  "/api/v1/subnets/{netuid}/stake-transfers": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/surfaces": {
+    "auth_required": ["true", "false"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "public_safe": ["true", "false"],
+    "rate_limited": ["true", "false"],
+    "sort": ["id", "kind", "name", "netuid", "provider"]
+  },
+  "/api/v1/subnets/{netuid}/trajectory": {
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "sort": ["date", "completeness_score", "surface_count", "endpoint_count"]
+  },
+  "/api/v1/subnets/{netuid}/turnover": {
+    "changes": ["true", "false"],
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/subnets/{netuid}/uptime": {
+    "format": ["json", "csv"],
+    "window": ["90d", "1y"]
+  },
+  "/api/v1/subnets/{netuid}/validator-economics/history": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/validators": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/weights": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/weights/setters": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/yield": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/yield/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/sudo": {
+    "format": ["json", "csv"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/surfaces": {
+    "auth_required": ["true", "false"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "public_safe": ["true", "false"],
+    "rate_limited": ["true", "false"],
+    "sort": ["id", "kind", "name", "netuid", "provider"]
+  },
+  "/api/v1/validators": {
+    "format": ["json", "csv"],
+    "sort": ["avg_validator_trust", "max_validator_trust", "stake_dominance", "subnet_count", "total_emission", "total_stake", "uid_count"]
+  },
+  "/api/v1/validators/economics": {
+    "sort": ["earning_floor_cost_tao", "permit_floor_cost_tao", "permit_to_earning_multiple", "tao_inflow_per_day", "validator_headroom"]
+  },
+  "/api/v1/validators/{hotkey}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/validators/{hotkey}/nominators": {
+    "basis": ["flow", "positions"],
+    "format": ["json", "csv"],
+    "sort": ["net_staked", "gross_staked", "last_activity"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/balance": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/children": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/parents": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/root-claim": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/summary": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}/chain-events": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}/events": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}/extrinsics": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain-events": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain-events/stats": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain/activity": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/alpha-volume": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain/burn": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain/calls": {
+    "format": ["json", "csv"],
+    "group_by": ["module", "module_function"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/deregistrations": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/fees": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/registrations": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/signers": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "sort": ["tx_count", "total_fee_tao"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/stake-flow": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/stake-moves": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/stake-transfers": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/transfer-pairs": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "sort": ["volume", "count"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/transfers": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/coverage": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/crowdloans": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/crowdloans/{crowdloan_id}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/economics": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "order": ["asc", "desc"],
+    "registration_allowed": ["true", "false"],
+    "sort": ["alpha_fdv_tao", "alpha_market_cap_tao", "alpha_price_change_1d", "alpha_price_change_1h", "alpha_price_change_1m", "alpha_price_change_7d", "alpha_price_tao", "block", "emission_share", "max_stake_alpha", "max_uids", "max_validators", "miner_count", "miner_readiness", "name", "netuid", "open_slots", "registration_cost_tao", "subnet_volume_tao", "total_stake_alpha", "validator_count"]
+  },
+  "/api/v1/{network}/evm/address/{h160}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/extrinsics": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/{network}/extrinsics/{hash}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/network/parameters": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/network/randomness": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/networks": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/search/resolve": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "domain": ["agents", "compute", "data", "finance", "inference", "media", "prediction", "privacy", "robotics", "science", "search", "security", "storage", "training"],
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "order": ["asc", "desc"],
+    "sort": ["block", "candidate_count", "coverage_level", "curation_level", "integration_readiness", "mechanism_count", "name", "netuid", "participant_count", "probed_surface_count", "status", "subnet_type", "surface_count", "tempo"],
+    "status": ["active", "inactive"],
+    "subnet_type": ["root", "application"]
+  },
+  "/api/v1/{network}/subnets/{netuid}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets/{netuid}/burn": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets/{netuid}/lease": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets/{netuid}/recycled": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/sudo/key": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  }
+};
 
 exports.MetagraphedError = MetagraphedError;
+exports.QUERY_PARAMETER_ENUMS = QUERY_PARAMETER_ENUMS;
 exports.createLruEtagCache = createLruEtagCache;
 exports.createMetagraphedClient = createMetagraphedClient;
 exports.metagraphedFetch = metagraphedFetch;

--- a/packages/client/dist/index.js
+++ b/packages/client/dist/index.js
@@ -449,5 +449,795 @@ function createMetagraphedClient(clientOptions = {}) {
     health: (options) => request("/api/v1/health", { ...options })
   };
 }
+var QUERY_PARAMETER_ENUMS = {
+  "/api/v1/accounts": {
+    "format": ["json", "csv"],
+    "sort": ["total_stake", "total_emission", "subnet_count", "uid_count", "validator_count", "stake_dominance", "last_active"]
+  },
+  "/api/v1/accounts/top-holders": {
+    "format": ["json", "csv"],
+    "sort": ["total_tao", "free_tao", "delegated_tao", "net_flow_7d", "net_flow_30d", "net_flow_90d"]
+  },
+  "/api/v1/accounts/{ss58}/axon-removals": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/counterparties": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/deregistrations": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/extrinsics": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/identity-history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/prometheus": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/registrations": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/serving": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/stake-flow": {
+    "direction": ["all", "in", "out"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/stake-moves": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/accounts/{ss58}/subnets/{netuid}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/accounts/{ss58}/transfers": {
+    "direction": ["all", "sent", "received"],
+    "format": ["json", "csv"]
+  },
+  "/api/v1/accounts/{ss58}/weight-setters": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/agent-catalog": {
+    "order": ["asc", "desc"],
+    "sort": ["netuid", "callable_count", "completeness_score", "example_count"]
+  },
+  "/api/v1/blocks": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/blocks/{ref}/events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/blocks/{ref}/extrinsics": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/candidates": {
+    "confidence": ["low", "medium", "high"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
+    "state": ["schema-invalid", "schema-valid", "maintainer-review", "verified", "stale", "rejected"]
+  },
+  "/api/v1/chain-events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/chain/activity": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/alpha-volume": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/chain/axon-removals": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/calls": {
+    "format": ["json", "csv"],
+    "group_by": ["module", "module_function"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/concentration/history": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/chain/concentration/subnets": {
+    "lens": ["emission", "stake", "entity_emission", "entity_stake", "validator_stake"],
+    "order": ["asc", "desc"],
+    "sort": ["nakamoto_coefficient", "gini", "holders", "top_1pct_share", "total", "netuid"]
+  },
+  "/api/v1/chain/deregistrations": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/emission-pipeline": {
+    "order": ["asc", "desc"],
+    "sort": ["final_share", "emission_share", "weighted_share", "gated_share", "gate_delta", "distance_to_bar", "tao_in_emission", "excess_tao", "tao_total", "liquidity_fraction", "miner_burned", "netuid"]
+  },
+  "/api/v1/chain/fees": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/governance/emission-changes": {
+    "kind": ["param", "subnet", "flow"]
+  },
+  "/api/v1/chain/holders": {
+    "sort": ["top1_share", "top5_share", "top10_share", "top20_share", "holder_count", "total_alpha"]
+  },
+  "/api/v1/chain/prometheus": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/registrations": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/revenue-coverage": {
+    "window": ["1d", "7d", "30d"]
+  },
+  "/api/v1/chain/serving": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/signers": {
+    "format": ["json", "csv"],
+    "sort": ["tx_count", "total_fee_tao"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/stake-flow": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/stake-moves": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/stake-transfers": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/subnet-lifecycle": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/chain/transfer-pairs": {
+    "format": ["json", "csv"],
+    "sort": ["volume", "count"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/transfers": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/turnover": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/chain/weights": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/chain/weights/setters": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/contracts": {
+    "order": ["asc", "desc"],
+    "sort": ["id", "path", "contract_version"]
+  },
+  "/api/v1/coverage-depth": {
+    "agent_status": ["callable", "base-layer", "candidate", "needs-evidence", "blocked"],
+    "blocker_level": ["none", "hard-blocked", "needs-review", "missing-data"],
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "sort": ["agent_status", "blocker_level", "name", "netuid", "priority_score", "score", "tier"],
+    "tier": ["agent-ready", "machine-usable", "candidate-review", "needs-evidence", "hard-blocked", "missing-interface"]
+  },
+  "/api/v1/curation": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "order": ["asc", "desc"],
+    "sort": ["coverage_level", "curation_level", "name", "netuid"]
+  },
+  "/api/v1/domains/{tag}/summary": {
+    "tag": ["agents", "compute", "data", "finance", "inference", "media", "prediction", "privacy", "robotics", "science", "search", "security", "storage", "training"]
+  },
+  "/api/v1/economics": {
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "registration_allowed": ["true", "false"],
+    "sort": ["alpha_fdv_tao", "alpha_market_cap_tao", "alpha_price_change_1d", "alpha_price_change_1h", "alpha_price_change_1m", "alpha_price_change_7d", "alpha_price_tao", "block", "emission_share", "max_stake_alpha", "max_uids", "max_validators", "miner_count", "miner_readiness", "name", "netuid", "open_slots", "registration_cost_tao", "subnet_volume_tao", "total_stake_alpha", "validator_count"]
+  },
+  "/api/v1/economics/trends": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/endpoint-incidents": {
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "severity": ["critical", "warning", "info"],
+    "sort": ["detected_at", "endpoint_id", "kind", "last_checked", "netuid", "provider", "severity", "state", "status"],
+    "state": ["active", "resolved"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/endpoint-pools": {
+    "kind": ["subtensor-rpc", "subtensor-wss", "archive"],
+    "order": ["asc", "desc"],
+    "sort": ["eligible_count", "endpoint_count", "id", "kind"]
+  },
+  "/api/v1/endpoints": {
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/evidence": {
+    "order": ["asc", "desc"],
+    "sort": ["claim", "source_url", "subject", "verified_at"]
+  },
+  "/api/v1/extrinsics": {
+    "format": ["json", "csv"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/fixtures": {
+    "order": ["asc", "desc"],
+    "sort": ["captured_at", "netuid", "surface_id"]
+  },
+  "/api/v1/gaps": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "order": ["asc", "desc"],
+    "sort": ["coverage_level", "curation_level", "gap_count", "name", "netuid"]
+  },
+  "/api/v1/governance/config-changes": {
+    "format": ["json", "csv"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/health": {
+    "order": ["asc", "desc"],
+    "sort": ["avg_latency_ms", "degraded_count", "failed_count", "last_checked", "last_ok", "name", "netuid", "ok_count", "status", "surface_count", "unknown_count"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/health/failure-reasons": {
+    "window": ["7d", "30d", "90d", "180d"]
+  },
+  "/api/v1/health/history/{date}": {
+    "classification": ["auth-required", "content-mismatch", "dead", "live", "rate-limited", "redirected", "timeout", "transient", "unsupported", "unsafe", "wrong-chain"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["classification", "kind", "last_checked", "last_ok", "latency_ms", "netuid", "provider", "status", "status_code", "surface_id", "verified_at"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/health/trends": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/incidents": {
+    "order": ["asc", "desc"],
+    "sort": ["downtime_ms", "incident_count", "netuid", "surface_id"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/network/tao-usd": {
+    "window": ["1h", "24h", "7d", "30d"]
+  },
+  "/api/v1/profiles": {
+    "confidence": ["low", "medium", "high"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["candidate_count", "completeness_score", "curation_level", "interface_count", "missing_critical_count", "name", "netuid", "operational_interface_count", "profile_level", "review_state"],
+    "subnet_type": ["root", "application"]
+  },
+  "/api/v1/providers": {
+    "authority": ["community", "official", "provider-claimed", "registry-observed"],
+    "format": ["json", "csv"],
+    "kind": ["data-provider", "docs-provider", "infrastructure-provider", "registry", "subnet-team"],
+    "order": ["asc", "desc"],
+    "sort": ["authority", "id", "kind", "name"]
+  },
+  "/api/v1/providers/{slug}/endpoints": {
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/registry/leaderboards": {
+    "board": ["healthiest", "fastest-rpc", "most-complete", "most-enriched", "fastest-growing", "most-reliable", "open-slots", "cheapest-registration", "highest-emission", "validator-headroom", "biggest-alpha-gain-1d", "biggest-alpha-gain-7d"]
+  },
+  "/api/v1/review/adapter-candidates": {
+    "candidate_api_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "operational_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "recommended_adapter_kind": ["custom-adapter", "data-artifact-adapter", "generic-openapi-or-custom", "stream-adapter"],
+    "sort": ["candidate_api_count", "candidate_api_kinds", "curation_level", "name", "netuid", "operational_kinds", "operational_surface_count", "priority_score", "recommended_adapter_kind"]
+  },
+  "/api/v1/review/enrichment-evidence": {
+    "direct_submission_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "evidence_action": ["submit-new-evidence", "verify-existing-evidence", "replace-stale-evidence", "review-existing-evidence", "maintainer-review-existing-evidence", "monitor"],
+    "lane": ["direct-submission", "maintainer-review", "adapter-candidate", "monitoring-followup", "baseline-monitoring"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["evidence_action", "lane", "name", "netuid", "priority_score"]
+  },
+  "/api/v1/review/enrichment-queue": {
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "direct_submission_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "evidence_action": ["submit-new-evidence", "verify-existing-evidence", "replace-stale-evidence", "review-existing-evidence", "maintainer-review-existing-evidence", "monitor"],
+    "format": ["json", "csv"],
+    "identity_level": ["none", "directory", "partial", "complete"],
+    "lane": ["direct-submission", "maintainer-review", "adapter-candidate", "monitoring-followup", "baseline-monitoring"],
+    "manual_review_required": ["true", "false"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["adapter_score", "candidate_count", "completeness_score", "curation_level", "endpoint_count", "evidence_action", "identity_level", "identity_surface_count", "lane", "name", "netuid", "operational_interface_count", "priority_score", "profile_level", "review_state", "stale_candidate_count", "surface_count", "verified_candidate_count"]
+  },
+  "/api/v1/review/enrichment-targets": {
+    "auto_review_candidate": ["true", "false"],
+    "evidence_action": ["submit-new-evidence", "verify-existing-evidence", "replace-stale-evidence", "review-existing-evidence", "maintainer-review-existing-evidence", "monitor"],
+    "identity_level": ["none", "directory", "partial", "complete"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "lane": ["direct-submission", "maintainer-review", "adapter-candidate", "monitoring-followup", "baseline-monitoring"],
+    "manual_review_required": ["true", "false"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["auto_review_candidate", "evidence_action", "identity_level", "kind", "lane", "manual_review_required", "name", "netuid", "priority_score", "profile_level", "submission_route", "target_action", "target_type"],
+    "submission_route": ["direct-candidate-pr", "adapter-request", "maintainer-review", "status-report"],
+    "target_action": ["submit-new-candidate", "replace-stale-candidate", "verify-existing-candidate", "review-existing-candidate", "adapter-review", "maintainer-review", "monitoring-followup"],
+    "target_type": ["surface-candidate", "adapter-review", "maintainer-review", "monitoring-followup"]
+  },
+  "/api/v1/review/gaps": {
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["candidate_count", "curation_level", "missing_kinds", "name", "netuid", "priority_score", "surface_count", "verified_candidate_count"]
+  },
+  "/api/v1/review/profile-completeness": {
+    "confidence": ["low", "medium", "high"],
+    "format": ["json", "csv"],
+    "identity_level": ["none", "directory", "partial", "complete"],
+    "identity_promotion_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "native_name_quality": ["chain", "placeholder", "empty"],
+    "order": ["asc", "desc"],
+    "profile_level": ["directory-only", "identity-partial", "identity-complete", "operational", "adapter-backed"],
+    "sort": ["candidate_count", "completeness_score", "identity_level", "identity_promotion_kind_count", "identity_surface_count", "live_identity_candidate_kind_count", "missing_critical_count", "name", "native_identity_signal_count", "native_name_quality", "netuid", "priority_score", "profile_level", "stale_identity_candidate_kind_count"]
+  },
+  "/api/v1/rpc/endpoints": {
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/rpc/pools": {
+    "kind": ["subtensor-rpc", "subtensor-wss", "archive"],
+    "order": ["asc", "desc"],
+    "sort": ["eligible_count", "endpoint_count", "id", "kind"]
+  },
+  "/api/v1/rpc/usage": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/runtime": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/search": {
+    "order": ["asc", "desc"],
+    "sort": ["netuid", "slug", "title", "type"],
+    "type": ["subnet", "surface", "provider"]
+  },
+  "/api/v1/search-index": {
+    "order": ["asc", "desc"],
+    "sort": ["netuid", "slug", "title", "type"],
+    "type": ["subnet", "surface", "provider"]
+  },
+  "/api/v1/search/semantic": {
+    "type": ["subnet", "surface", "provider"]
+  },
+  "/api/v1/source-snapshots": {
+    "order": ["asc", "desc"],
+    "sort": ["id", "kind", "path", "record_count"]
+  },
+  "/api/v1/subnets": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "domain": ["agents", "compute", "data", "finance", "inference", "media", "prediction", "privacy", "robotics", "science", "search", "security", "storage", "training"],
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "sort": ["block", "candidate_count", "coverage_level", "curation_level", "integration_readiness", "mechanism_count", "name", "netuid", "participant_count", "probed_surface_count", "status", "subnet_type", "surface_count", "tempo"],
+    "status": ["active", "inactive"],
+    "subnet_type": ["root", "application"]
+  },
+  "/api/v1/subnets/movers": {
+    "format": ["json", "csv"],
+    "sort": ["stake", "emission", "validators", "neurons"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/axon-removals": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/burn/history": {
+    "window": ["24h", "7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/candidates": {
+    "confidence": ["low", "medium", "high"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
+    "state": ["schema-invalid", "schema-valid", "maintainer-review", "verified", "stale", "rejected"]
+  },
+  "/api/v1/subnets/{netuid}/concentration/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/deregistrations": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/emission-pipeline/history": {
+    "window": ["7d", "30d", "90d", "180d"]
+  },
+  "/api/v1/subnets/{netuid}/emission-split/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/endpoints": {
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "layer": ["bittensor-base", "data-provider", "docs-provider", "subnet-app"],
+    "order": ["asc", "desc"],
+    "pool_eligible": ["true", "false"],
+    "publication_state": ["candidate", "verified", "monitored", "pool-eligible", "disabled", "rejected"],
+    "sort": ["kind", "last_checked", "latency_ms", "layer", "netuid", "pool_eligible", "provider", "publication_state", "score", "status"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/subnets/{netuid}/event-summary": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/events": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/evidence": {
+    "order": ["asc", "desc"],
+    "sort": ["claim", "source_url", "subject", "verified_at"]
+  },
+  "/api/v1/subnets/{netuid}/gaps": {
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "format": ["json", "csv"],
+    "missing_kinds": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["candidate_count", "curation_level", "missing_kinds", "name", "netuid", "priority_score", "surface_count", "verified_candidate_count"]
+  },
+  "/api/v1/subnets/{netuid}/health": {
+    "classification": ["auth-required", "content-mismatch", "dead", "live", "rate-limited", "redirected", "timeout", "transient", "unsupported", "unsafe", "wrong-chain"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "sort": ["classification", "kind", "last_checked", "last_ok", "latency_ms", "netuid", "provider", "status", "status_code", "surface_id", "verified_at"],
+    "status": ["ok", "degraded", "failed", "unknown"]
+  },
+  "/api/v1/subnets/{netuid}/health/incidents": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/health/percentiles": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/subnets/{netuid}/hyperparameters/history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/identity-history": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/lifecycle": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/metagraph": {
+    "format": ["json", "csv"],
+    "validator_permit": ["true"]
+  },
+  "/api/v1/subnets/{netuid}/miner-fairness": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/neurons/{uid}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/subnets/{netuid}/ohlc": {
+    "interval": ["1h", "1d"]
+  },
+  "/api/v1/subnets/{netuid}/owner-capture": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/performance/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/prometheus": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/registrations": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/revenue": {
+    "window": ["1d", "7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/serving": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/stake-flow": {
+    "direction": ["all", "in", "out"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/stake-moves": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/stake-quote": {
+    "direction": ["stake", "unstake"]
+  },
+  "/api/v1/subnets/{netuid}/stake-transfers": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/surfaces": {
+    "auth_required": ["true", "false"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "public_safe": ["true", "false"],
+    "rate_limited": ["true", "false"],
+    "sort": ["id", "kind", "name", "netuid", "provider"]
+  },
+  "/api/v1/subnets/{netuid}/trajectory": {
+    "format": ["json", "csv"],
+    "order": ["asc", "desc"],
+    "sort": ["date", "completeness_score", "surface_count", "endpoint_count"]
+  },
+  "/api/v1/subnets/{netuid}/turnover": {
+    "changes": ["true", "false"],
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/subnets/{netuid}/uptime": {
+    "format": ["json", "csv"],
+    "window": ["90d", "1y"]
+  },
+  "/api/v1/subnets/{netuid}/validator-economics/history": {
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/subnets/{netuid}/validators": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/weights": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/weights/setters": {
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/subnets/{netuid}/yield": {
+    "format": ["json", "csv"]
+  },
+  "/api/v1/subnets/{netuid}/yield/history": {
+    "format": ["json", "csv"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/sudo": {
+    "format": ["json", "csv"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/surfaces": {
+    "auth_required": ["true", "false"],
+    "format": ["json", "csv"],
+    "kind": ["archive", "dashboard", "data-artifact", "docs", "example", "openapi", "repo-registry", "sdk", "source-repo", "sse", "subnet-api", "subtensor-rpc", "subtensor-wss", "website"],
+    "order": ["asc", "desc"],
+    "public_safe": ["true", "false"],
+    "rate_limited": ["true", "false"],
+    "sort": ["id", "kind", "name", "netuid", "provider"]
+  },
+  "/api/v1/validators": {
+    "format": ["json", "csv"],
+    "sort": ["avg_validator_trust", "max_validator_trust", "stake_dominance", "subnet_count", "total_emission", "total_stake", "uid_count"]
+  },
+  "/api/v1/validators/economics": {
+    "sort": ["earning_floor_cost_tao", "permit_floor_cost_tao", "permit_to_earning_multiple", "tao_inflow_per_day", "validator_headroom"]
+  },
+  "/api/v1/validators/{hotkey}/history": {
+    "window": ["7d", "30d", "90d", "1y", "all"]
+  },
+  "/api/v1/validators/{hotkey}/nominators": {
+    "basis": ["flow", "positions"],
+    "format": ["json", "csv"],
+    "sort": ["net_staked", "gross_staked", "last_activity"],
+    "window": ["7d", "30d", "90d"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/balance": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/children": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/parents": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/accounts/{ss58}/root-claim": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/summary": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}/chain-events": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}/events": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/blocks/{ref}/extrinsics": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain-events": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain-events/stats": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain/activity": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/alpha-volume": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain/burn": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/chain/calls": {
+    "format": ["json", "csv"],
+    "group_by": ["module", "module_function"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/deregistrations": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/fees": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/registrations": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/signers": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "sort": ["tx_count", "total_fee_tao"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/stake-flow": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/stake-moves": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/stake-transfers": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/transfer-pairs": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "sort": ["volume", "count"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/chain/transfers": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "window": ["7d", "30d"]
+  },
+  "/api/v1/{network}/coverage": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/crowdloans": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/crowdloans/{crowdloan_id}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/economics": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "order": ["asc", "desc"],
+    "registration_allowed": ["true", "false"],
+    "sort": ["alpha_fdv_tao", "alpha_market_cap_tao", "alpha_price_change_1d", "alpha_price_change_1h", "alpha_price_change_1m", "alpha_price_change_7d", "alpha_price_tao", "block", "emission_share", "max_stake_alpha", "max_uids", "max_validators", "miner_count", "miner_readiness", "name", "netuid", "open_slots", "registration_cost_tao", "subnet_volume_tao", "total_stake_alpha", "validator_count"]
+  },
+  "/api/v1/{network}/evm/address/{h160}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/extrinsics": {
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "success": ["true", "false"]
+  },
+  "/api/v1/{network}/extrinsics/{hash}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/network/parameters": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/network/randomness": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/networks": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/search/resolve": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets": {
+    "coverage_level": ["native-only", "manifested", "probed"],
+    "curation_level": ["native", "candidate-discovered", "community-seeded", "machine-verified", "maintainer-reviewed", "adapter-backed"],
+    "domain": ["agents", "compute", "data", "finance", "inference", "media", "prediction", "privacy", "robotics", "science", "search", "security", "storage", "training"],
+    "format": ["json", "csv"],
+    "network": ["finney", "mainnet", "test", "testnet"],
+    "order": ["asc", "desc"],
+    "sort": ["block", "candidate_count", "coverage_level", "curation_level", "integration_readiness", "mechanism_count", "name", "netuid", "participant_count", "probed_surface_count", "status", "subnet_type", "surface_count", "tempo"],
+    "status": ["active", "inactive"],
+    "subnet_type": ["root", "application"]
+  },
+  "/api/v1/{network}/subnets/{netuid}": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets/{netuid}/burn": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets/{netuid}/lease": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/subnets/{netuid}/recycled": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  },
+  "/api/v1/{network}/sudo/key": {
+    "network": ["finney", "mainnet", "test", "testnet"]
+  }
+};
 
-export { MetagraphedError, createLruEtagCache, createMetagraphedClient, metagraphedFetch, metagraphedPaginate, metagraphedRpc };
+export { MetagraphedError, QUERY_PARAMETER_ENUMS, createLruEtagCache, createMetagraphedClient, metagraphedFetch, metagraphedPaginate, metagraphedRpc };

--- a/scripts/generate-client.ts
+++ b/scripts/generate-client.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { repoRoot } from "./lib.ts";
@@ -15,6 +16,58 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
   } else {
     process.stdout.write(content);
   }
+}
+
+/**
+ * Every string-enum query parameter the published contract declares, keyed by
+ * route path then parameter name (#10994).
+ *
+ * Emitted as \`as const\` so a consumer gets the literal tuple -- the UI's
+ * window selectors and stream-topic lists derive their unions from these
+ * instead of restating them, which is how a chart stopped being able to offer
+ * a window its route rejects. Derived from openapi.json at generation time:
+ * the published contract is the source, not a hand-kept mirror of it.
+ */
+function emitQueryParameterEnums(): string {
+  const spec = JSON.parse(
+    readFileSync(path.join(repoRoot, "public/metagraph/openapi.json"), "utf8"),
+  ) as {
+    paths: Record<
+      string,
+      Record<
+        string,
+        { parameters?: Array<{ name: string; schema?: { enum?: unknown[] } }> }
+      >
+    >;
+  };
+  const byRoute: Record<string, Record<string, string[]>> = {};
+  for (const [route, operations] of Object.entries(spec.paths)) {
+    for (const operation of Object.values(operations)) {
+      if (typeof operation !== "object" || operation === null) continue;
+      for (const parameter of operation.parameters ?? []) {
+        const values = parameter.schema?.enum;
+        if (
+          !Array.isArray(values) ||
+          values.length === 0 ||
+          !values.every((value) => typeof value === "string")
+        )
+          continue;
+        (byRoute[route] ??= {})[parameter.name] = values as string[];
+      }
+    }
+  }
+  const lines: string[] = [];
+  for (const route of Object.keys(byRoute).sort()) {
+    const parameters = byRoute[route];
+    lines.push(`  ${JSON.stringify(route)}: {`);
+    for (const name of Object.keys(parameters).sort()) {
+      lines.push(
+        `    ${JSON.stringify(name)}: ${JSON.stringify(parameters[name])},`,
+      );
+    }
+    lines.push("  },");
+  }
+  return lines.join("\n");
 }
 
 export function generateClientSource(): string {
@@ -824,5 +877,14 @@ export function createMetagraphedClient(
     health: (options) => request("/api/v1/health", { ...options }),
   };
 }
+
+/**
+ * Every string-enum query parameter the published contract declares, keyed by
+ * route path then parameter name. "as const", so a consumer derives literal
+ * unions instead of restating them (#10994).
+ */
+export const QUERY_PARAMETER_ENUMS = {
+${emitQueryParameterEnums()}
+} as const;
 `;
 }

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -41,6 +41,15 @@ const SCHEMA_DIRS = [
   // must import the owner. Validator assertion-pins are declaration-invisible
   // here by design -- see the allowlist note below.
   "scripts",
+  // And the UI (#10994): a chart restating a route's window enum is how a
+  // selector offers a window its route rejects. The repointed sites read
+  // QUERY_PARAMETER_ENUMS from the client package; what stays literal is
+  // pinned below with its reason (a UI-domain vocabulary, a multi-route
+  // control, an unpublished parameter).
+  "apps/ui/src/components/metagraphed",
+  "apps/ui/src/lib/metagraphed",
+  "apps/ui/src/hooks",
+  "apps/ui/src/routes",
 ];
 
 /** Vocabularies allowed to coincide, pinned to the EXACT files that do.
@@ -104,6 +113,15 @@ const COINCIDENT_BY_DOMAIN: Record<string, string[]> = {
     "schemas-src/routes/chain-alpha-volume.ts",
     "schemas-src/routes/subnet-alpha-volume.ts",
   ],
+  // The four decoder tables: one chain fact named by the decode lane's
+  // watermark list and the UI's firehose topics -- the SSE `topics` parameter
+  // is unpublished in openapi.json (the contract gap noted on #10994), so the
+  // UI cannot derive it yet. graphql-only.ts and the lakehouse generator name
+  // the same set in forms this gate's extraction does not currently match.
+  "account_events|blocks|chain_events|extrinsics": [
+    "src/decode-watermark.ts",
+    "apps/ui/src/hooks/use-chain-stream.ts",
+  ],
   "coldkey|hotkey|netuid": [
     "src/evm-precompiles.ts",
     "src/nominator-positions-neon-write.ts",
@@ -123,7 +141,9 @@ for (const dir of SCHEMA_DIRS) {
     continue;
   }
   for (const name of entries) {
-    if (!name.endsWith(".ts")) continue;
+    if (!name.endsWith(".ts") && !name.endsWith(".tsx")) continue;
+    // Assertion pins live in tests; the gate polices source only.
+    if (name.includes(".test.")) continue;
     const file = `${dir}/${name}`;
     const source = await fs.readFile(path.join(absolute, name), "utf8");
     // JSON Schema's own type names. A `type: ["array","string","null"]` union
@@ -139,11 +159,17 @@ for (const dir of SCHEMA_DIRS) {
       "string",
     ]);
     const push = (raw: string) => {
+      // An array of OBJECT literals (select options, column configs) is not a
+      // value list -- the property-form regex can capture into one.
+      if (raw.includes("{")) return;
       const values = [...raw.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
       // Two members is a boolean in disguise (asc/desc, in/out) and carries no
       // vocabulary worth owning; three is where a real domain list starts.
       if (values.length < 3) return;
       if (values.every((value) => JSON_SCHEMA_TYPES.has(value))) return;
+      // Namespaced platform names (og:title, twitter:card) are standards
+      // vocabulary, not ours -- no owner could exist.
+      if (values.some((value) => value.includes(":"))) return;
       sites.push({ file, values });
     };
     // `z\s*\.enum`, not `z\.enum`: prettier breaks a chain across lines once it


### PR DESCRIPTION
Part of epic #10992. Closes #10994.

## The channel is the published contract

`generate-client.ts` now emits **`QUERY_PARAMETER_ENUMS`** — every string-enum query
parameter `openapi.json` declares, keyed by route then parameter, `as const` so literal
unions survive: **430 parameters across 179 routes**. The client package's committed runtime
bundle carries it; the UI imports it like any other contract fact. The derivation proved
itself mid-work: a wrong route key became a compile error carrying the correct suggestion.

## All fifteen non-test sites dispositioned — none skipped

| disposition | count | detail |
| --- | --- | --- |
| repointed at `QUERY_PARAMETER_ENUMS` | 10 | four history charts, three panels, two route search-schemas, the global-validators sort list |
| `satisfies`-checked against the contract type | 1 | money-map buckets are component **keys** (no runtime emit) — a renamed bucket now fails to compile |
| documented pins | 4 | UI-computed APY basis (coincidence, not lineage) · the multi-route subnet window control (ten routes coincide **by choice**; deriving from one encodes false lineage) · chain-stream topics — whose SSE `topics` parameter is **unpublished in openapi.json**, a contract gap recorded on the issue |
| bonus: UI-internal duplications the extended gate caught | 2 | revenue + emissions sort enums restated beside their models — now derived |

## The gate reads the UI now

`validate:schema-vocabularies` scans `apps/ui/src/**` (`.tsx` included; test files excluded —
an assertion restating a value IS the pin), with two extraction refinements found by running
it (object-literal arrays; namespaced platform names). **Falsified live**: a literal window
list dropped into a component fails the gate naming that file. Five trees, 268 vocabularies.

## Verification

- UI `tsc` clean · lint clean · **2104 unit tests** · **104/104 hermetic e2e** on the
  refreshed fixtures · root `validate:contract-drift` green
- **Zero visual diff**: every derived value is byte-equal to the literal it replaced; no
  selector gained or lost an option — follows the normal gate per house rules
- Ledger: **source +163 −45**; the generated remainder is the parameter map + the client
  package's committed runtime bundles (the documented exception that lets the UI import
  contract facts without a build-time schema dependency)