### PR TITLE
fix(api): a failed cache write is a miss, not an incident

### DIFF
--- a/tests/cache-write-best-effort.test.ts
+++ b/tests/cache-write-best-effort.test.ts
@@ -1,0 +1,73 @@
+// #11022. A `cache.put` can reject -- most often `Network connection lost.`
+// when the caller disconnected and the response body being cloned is gone. An
+// unhandled rejection inside `waitUntil` is recorded by the runtime as an
+// exception, so a visitor closing a tab produced an ERROR carrying
+// `outcome: "ok"`: the request succeeded and we filed a fault anyway.
+//
+// That was ~27% of this Worker's entire error channel over a 3-day window, and
+// the routes it named are exactly the cache-eligible ones.
+//
+// The property under test is that a REJECTING put does not produce an
+// unhandled rejection. Asserting the response is still 200 would pass either
+// way -- the response was always fine; the background task was not.
+import assert from "node:assert/strict";
+import { afterEach, describe, test } from "vitest";
+import { handleRequest } from "../workers/api.ts";
+import { createLocalArtifactEnv } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+const globalWithCaches = globalThis as unknown as { caches?: unknown };
+const originalCaches = globalWithCaches.caches;
+afterEach(() => {
+  globalWithCaches.caches = originalCaches;
+});
+
+/** A cache whose every write fails the way a disconnected client's does. */
+function installFailingCache() {
+  let puts = 0;
+  globalWithCaches.caches = {
+    default: {
+      async match() {
+        return undefined;
+      },
+      async put() {
+        puts += 1;
+        throw new Error("Network connection lost.");
+      },
+    },
+  } as unknown as Row;
+  return () => puts;
+}
+
+describe("a failed cache write is a miss, not an incident (#11022)", () => {
+  test("a rejecting put does not escape the waitUntil", async () => {
+    const puts = installFailingCache();
+    const waits: Promise<unknown>[] = [];
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets"),
+      createLocalArtifactEnv() as unknown as Parameters<
+        typeof handleRequest
+      >[1],
+      { waitUntil: (p: Promise<unknown>) => waits.push(p) },
+    );
+    assert.equal(res.status, 200);
+    assert.ok(puts() > 0, "the write must actually have been attempted");
+    // THE assertion: awaiting what was handed to waitUntil must not reject.
+    // Before this, the raw put promise went in and its rejection became an
+    // exception span event.
+    await Promise.all(waits);
+  });
+
+  test("the same holds for a chain-detail answer", async () => {
+    const puts = installFailingCache();
+    const waits: Promise<unknown>[] = [];
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/blocks/777"),
+      {} as unknown as Parameters<typeof handleRequest>[1],
+      { waitUntil: (p: Promise<unknown>) => waits.push(p) },
+    );
+    assert.equal(res.status, 200);
+    void puts;
+    await Promise.all(waits);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3825,6 +3825,41 @@ async function chainEventsCacheKey(
 }
 
 /**
+ * Fire a cache write into `waitUntil` WITHOUT letting its failure surface
+ * (#11022).
+ *
+ * A `cache.put` can reject — most often `Network connection lost.` when the
+ * caller disconnected and the response body being cloned is already gone. An
+ * unhandled rejection inside `waitUntil` is recorded by the runtime as an
+ * exception span event, so a visitor closing a tab produced an ERROR carrying
+ * `outcome: "ok"`: the request succeeded, and we filed a fault anyway.
+ *
+ * That was ~27% of this Worker's entire error channel over a 3-day window, and
+ * the routes it named are exactly the cache-eligible ones — `/api/v1/health`,
+ * `/api/v1/subnets/{n}/health`, `/api/v1/subnets/{n}/endpoints`,
+ * `/api/v1/economics`, `/api/v1/validators/economics`,
+ * `/api/v1/endpoint-incidents`.
+ *
+ * Caching is best-effort by definition: a write we could not make is a cache
+ * miss next time, not an incident. This is the same posture src/icon-proxy.ts
+ * already takes on its own `bucket.put` ("caching is best-effort"), applied to
+ * the four edge-cache writes that never got it.
+ *
+ * Deliberately swallowing rather than logging: the condition is
+ * indistinguishable from an ordinary disconnect, it is not actionable, and a
+ * log line per disconnect just moves the noise rather than removing it.
+ *
+ * Takes a THUNK, not a promise. `ctx?.waitUntil?.(store.put(...))` does not
+ * evaluate its argument when `waitUntil` is nullish -- optional CALL syntax
+ * skips the arguments entirely -- so passing the promise to a helper would
+ * start the write on a context that cannot defer it, which is a behaviour
+ * change and not the one intended.
+ */
+function cacheWrite(ctx: Ctx | undefined, write: () => Promise<unknown>): void {
+  ctx?.waitUntil?.(write().catch(() => {}));
+}
+
+/**
  * Edge-cache TTL for a chain-detail answer the handler has declared immutable
  * (#11001).
  *
@@ -3929,7 +3964,7 @@ export async function withChainDetailEdgeCache(
       "cache-control",
       `public, s-maxage=${CHAIN_DETAIL_EDGE_CACHE_TTL_SECONDS}`,
     );
-    ctx?.waitUntil?.(cacheable.store.put(cacheable.key, stored));
+    cacheWrite(ctx, () => cacheable.store.put(cacheable.key, stored));
   }
   return response;
 }
@@ -4086,7 +4121,7 @@ export async function handleChainEventsFamily(
           }
         : await coldTierChainEventsPayload(env, url, chain);
     if (answer && cacheable) {
-      ctx?.waitUntil?.(
+      cacheWrite(ctx, () =>
         cacheable.store.put(
           cacheable.key,
           new Response(JSON.stringify(answer), {
@@ -9572,7 +9607,7 @@ async function handleApiRequest(
   // to the static artifact. 304/HEAD/non-200 are skipped. The edge entry
   // expires per the response's cache-control max-age.
   if (edgeCacheable && live === null && response.status === 200) {
-    ctx?.waitUntil?.(
+    cacheWrite(ctx, () =>
       edgeCacheable.store.put(edgeCacheable.key, response.clone()),
     );
   }
@@ -9581,7 +9616,7 @@ async function handleApiRequest(
   // never cache a cold-KV fallback, which would pin build-time health under a
   // stable key. The entry busts on the next cron snapshot (key) + max-age.
   if (overlayCacheable && live !== null && response.status === 200) {
-    ctx?.waitUntil?.(
+    cacheWrite(ctx, () =>
       overlayCacheable.store.put(overlayCacheable.key, response.clone()),
     );
   }


### PR DESCRIPTION
Closes #11022 — the half I could not attribute when I filed it.

## What it was

`Network connection lost.` was **~27% of this Worker's entire error channel** over a 3-day window, every occurrence carrying `outcome: "ok"`. The request succeeded and we filed a fault anyway.

I originally could not place it: the span event has no stack and it spanned unrelated routes. **The route list was the tell.**

```
/api/v1/health              /api/v1/economics
/api/v1/subnets/{n}/health  /api/v1/validators/economics
/api/v1/subnets/{n}/endpoints  /api/v1/endpoint-incidents
```

Those are exactly the **cache-eligible** routes. All four edge-cache writes handed the **raw put promise** to `waitUntil`:

```ts
ctx?.waitUntil?.(edgeCacheable.store.put(edgeCacheable.key, response.clone()));
```

A `cache.put` can reject — most often when the caller disconnected and the response body being cloned is already gone. An unhandled rejection inside `waitUntil` is recorded by the runtime as an exception. So **a visitor closing a tab minted an error.**

## The fix

Caching is best-effort by definition: a write we could not make is a cache miss next time, not an incident. `src/icon-proxy.ts` already takes exactly this posture on its own `bucket.put` (*"caching is best-effort"*); the four edge-cache writes never got it.

Swallowed rather than logged, deliberately — the condition is indistinguishable from an ordinary disconnect and is not actionable, so a log line per disconnect moves the noise rather than removing it.

## One subtlety the tests forced

The helper takes a **thunk**, not a promise:

```ts
function cacheWrite(ctx: Ctx | undefined, write: () => Promise<unknown>): void {
  ctx?.waitUntil?.(write().catch(() => {}));
}
```

`ctx?.waitUntil?.(store.put(...))` **does not evaluate its argument** when `waitUntil` is nullish — optional *call* syntax skips the arguments entirely. My first version passed the promise into the helper, which started the write on a context that cannot defer it. `chain-detail-edge-cache.test.ts`'s *"skips the store when there is no waitUntil to defer it to"* caught it; that case exists because `dispatchChainHistoryRoute` defaults `ctx` to `{}`.

## Tests

Two cases, both driving a cache whose every write rejects with the production message, and both asserting that **awaiting what was handed to `waitUntil` does not reject**. Asserting the response is still 200 would pass either way — the response was always fine; the background task was not.

Mutation-checked: removing the `.catch()` fails the first case with `Network connection lost.`

## What this leaves

With this and #11031, the two non-error fingerprints that were ~80% of the channel are both gone. The alerting half of #11022 — setting a threshold on what remains — becomes worth doing once a fresh sample confirms the new base rate, which is the honest next step rather than tuning against a number measured before either fix.

## Validation

```
npm run typecheck · lint · format:check · validate    green
cache-write-best-effort · chain-detail-edge-cache · analytics-edge-cache ·
health-overlay-cache · chain-events-cache-ttl        79 passed
```

Closes #11022