### PR TITLE
refactor(lib): the round-helper family, collapsed onto its six real behaviours

### DIFF
--- a/src/account-axon-removals.ts
+++ b/src/account-axon-removals.ts
@@ -13,6 +13,7 @@
 // (axon announcements) — an account announces an axon, then removes it — operational activity
 // orthogonal to /accounts/{ss58}/subnets (registration state).
 
+import { roundBelowOne } from "./lib/stats.ts";
 import {
   AXON_REMOVALS_DEGRADED_NEVER_EMITTED,
   type EventStreamDegraded,
@@ -36,10 +37,6 @@ export const DEFAULT_AXON_REMOVAL_WINDOW = "30d";
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
 // (roundConcentration in account-stake-flow.ts, #2327). An account removing across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -157,7 +154,7 @@ export function buildAccountAxonRemovals(
   // spreads evenly; null when the account has no removals to concentrate.
   const concentration =
     totalRemovals > 0
-      ? roundConcentration(squares / (totalRemovals * totalRemovals))
+      ? roundBelowOne(squares / (totalRemovals * totalRemovals))
       : null;
 
   const card: AccountAxonRemovalsResult = {

--- a/src/account-deregistrations.ts
+++ b/src/account-deregistrations.ts
@@ -19,6 +19,7 @@
 
 import type { DeregistrationDerivation } from "./deregistration-derivation.ts";
 import type { EventStreamDegraded } from "./uncurated-event-streams.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -43,10 +44,6 @@ export const DEFAULT_DEREGISTRATION_WINDOW = "30d";
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
 // (roundConcentration in account-stake-flow.ts, #2327). An account deregistered across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -169,9 +166,7 @@ export function buildAccountDeregistrations(
   // it spreads evenly; null when the account has no deregistrations to concentrate.
   const concentration =
     totalDeregistrations > 0
-      ? roundConcentration(
-          squares / (totalDeregistrations * totalDeregistrations),
-        )
+      ? roundBelowOne(squares / (totalDeregistrations * totalDeregistrations))
       : null;
 
   return {

--- a/src/account-nominator-positions.ts
+++ b/src/account-nominator-positions.ts
@@ -1,4 +1,4 @@
-import { RAO_PER_TAO_NUMBER, nonNegativeCellOrNull } from "./lib/rao.ts";
+import { round9OrNull, nonNegativeCellOrNull } from "./lib/rao.ts";
 // Nominator-side (coldkey) position reconstruction (#5233): "what does this
 // coldkey actually hold, across every hotkey/subnet it delegates to" — the
 // coldkey-scoped counterpart to buildAccountPortfolio's hotkey-scoped view
@@ -71,10 +71,6 @@ function nullableFraction(value: unknown): number | null {
 
 // 1 TAO = 1e9 rao; round tao outputs to that precision (matches the sibling
 // account-tier modules' own round9/roundTao helpers).
-function roundTao(value: number | null): number | null {
-  if (value == null || !Number.isFinite(value)) return null;
-  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
 
 function round6(value: number | null): number | null {
   if (value == null || !Number.isFinite(value)) return null;
@@ -218,7 +214,7 @@ export function buildAccountPositions(
       continue;
     }
 
-    const stakeTao = roundTao(fraction * hotkeyStake);
+    const stakeTao = round9OrNull(fraction * hotkeyStake);
     if (stakeTao == null) continue;
     totalStakeAlpha += stakeTao;
 
@@ -251,7 +247,7 @@ export function buildAccountPositions(
     ss58,
     captured_at: latestCapturedAt != null ? toIso(latestCapturedAt) : null,
     position_count: positions.length,
-    total_stake_alpha: roundTao(totalStakeAlpha) ?? 0,
+    total_stake_alpha: round9OrNull(totalStakeAlpha) ?? 0,
     positions,
   };
   // The two provenance stamps belong to the LEDGER and to this coldkey's chain

--- a/src/account-prometheus.ts
+++ b/src/account-prometheus.ts
@@ -14,6 +14,7 @@
 // /accounts/{ss58}/serving (axon endpoints), operational activity orthogonal to
 // /accounts/{ss58}/subnets (registration state).
 
+import { roundBelowOne } from "./lib/stats.ts";
 import {
   PROMETHEUS_DEGRADED_NOT_CURATED,
   type EventStreamDegraded,
@@ -37,10 +38,6 @@ export const DEFAULT_PROMETHEUS_WINDOW = "30d";
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
 // (roundConcentration in account-stake-flow.ts, #2327). An account announcing across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -160,7 +157,7 @@ export function buildAccountPrometheus(
   // spreads evenly; null when the account has no announcements to concentrate.
   const concentration =
     totalAnnouncements > 0
-      ? roundConcentration(squares / (totalAnnouncements * totalAnnouncements))
+      ? roundBelowOne(squares / (totalAnnouncements * totalAnnouncements))
       : null;
 
   const card: AccountPrometheusResult = {

--- a/src/account-registrations.ts
+++ b/src/account-registrations.ts
@@ -1,3 +1,4 @@
+import { roundBelowOne } from "./lib/stats.ts";
 // Per-account registration footprint: which subnets one account (hotkey) registered a neuron on
 // over a recent window, broken down per subnet and rolled up into a registration scorecard. Pure
 // shaping (buildAccountRegistrations) + a thin store loader (loadAccountRegistrations); the Worker adds
@@ -31,10 +32,6 @@ export const DEFAULT_REGISTRATION_WINDOW = "30d";
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
 // (roundConcentration in account-stake-flow.ts, #2327). An account registered across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -152,7 +149,7 @@ export function buildAccountRegistrations(
   // spreads evenly; null when the account has no registrations to concentrate.
   const concentration =
     totalRegistrations > 0
-      ? roundConcentration(squares / (totalRegistrations * totalRegistrations))
+      ? roundBelowOne(squares / (totalRegistrations * totalRegistrations))
       : null;
 
   return {

--- a/src/account-serving.ts
+++ b/src/account-serving.ts
@@ -1,3 +1,4 @@
+import { roundBelowOne } from "./lib/stats.ts";
 // Per-account axon-serving footprint: which subnets one account (hotkey) announced an axon endpoint
 // on over a recent window, broken down per subnet and rolled up into a serving scorecard. Pure
 // shaping (buildAccountServing) + a thin store loader (loadAccountServing); the Worker adds the REST
@@ -31,10 +32,6 @@ export const DEFAULT_SERVING_WINDOW = "30d";
 // an exact 1 — the same anti-overstatement invariant the shared concentration ratios enforce
 // (roundConcentration in account-stake-flow.ts, #2327). An account serving across two or more
 // subnets (HHI < 1) must never render as 1, which this card's contract defines as "all in one".
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -152,7 +149,7 @@ export function buildAccountServing(
   // spreads evenly; null when the account has no announcements to concentrate.
   const concentration =
     totalAnnouncements > 0
-      ? roundConcentration(squares / (totalAnnouncements * totalAnnouncements))
+      ? roundBelowOne(squares / (totalAnnouncements * totalAnnouncements))
       : null;
 
   return {

--- a/src/account-stake-flow.ts
+++ b/src/account-stake-flow.ts
@@ -1,8 +1,5 @@
-import {
-  RAO_PER_TAO_NUMBER,
-  finiteCellOrNull,
-  numberOrZero,
-} from "./lib/rao.ts";
+import { round9OrZero, finiteCellOrNull, numberOrZero } from "./lib/rao.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 // Per-account stake flow: how one account's capital moved in (StakeAdded) vs out
 // (StakeRemoved) over a recent window, broken down per subnet and rolled up into a
 // staking-behavior scorecard. Pure shaping (buildAccountStakeFlow); the Worker /
@@ -40,21 +37,12 @@ const DIRECTIONAL_RATIO = 0.2;
 
 // 1 TAO = 1e9 rao. Round every TAO output to rao precision to shed IEEE-754 noise
 // below the rao floor (the same rounding the per-subnet stake-flow scorecard applies).
-function roundTao(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
 
 // Round the HHI concentration ratio to 4 decimals WITHOUT letting a sub-perfect
 // value round up to an exact 1 — the same anti-overstatement invariant the shared
 // concentration/turnover/reliability ratios enforce (roundRatio in concentration.ts,
 // #2327). A wallet spread across two or more subnets (HHI < 1) must never render as
 // 1, which this card's own contract defines as "all flow in one subnet".
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank cells
 // coerce via Number("") → 0; skip those rows rather than counting phantom zero-TAO
@@ -189,10 +177,10 @@ export function buildAccountStakeFlow(
     grossSquares += gross * gross;
     subnets.push({
       netuid,
-      staked_tao: roundTao(b.staked),
-      unstaked_tao: roundTao(b.unstaked),
-      net_flow_tao: roundTao(net),
-      gross_flow_tao: roundTao(gross),
+      staked_tao: round9OrZero(b.staked),
+      unstaked_tao: round9OrZero(b.unstaked),
+      net_flow_tao: round9OrZero(net),
+      gross_flow_tao: round9OrZero(gross),
       flow_ratio: flowRatio(net, gross),
       direction: classifyDirection(net, gross),
       stake_events: b.stakeEvents,
@@ -214,17 +202,17 @@ export function buildAccountStakeFlow(
   // subnet, -> 1/n as it spreads evenly; null when there is no flow to concentrate.
   const concentration =
     totalGross > 0
-      ? roundConcentration(grossSquares / (totalGross * totalGross))
+      ? roundBelowOne(grossSquares / (totalGross * totalGross))
       : null;
 
   return {
     schema_version: 1,
     address,
     window: window ?? null,
-    total_staked_tao: roundTao(totalStaked),
-    total_unstaked_tao: roundTao(totalUnstaked),
-    net_flow_tao: roundTao(totalNet),
-    gross_flow_tao: roundTao(totalGross),
+    total_staked_tao: round9OrZero(totalStaked),
+    total_unstaked_tao: round9OrZero(totalUnstaked),
+    net_flow_tao: round9OrZero(totalNet),
+    gross_flow_tao: round9OrZero(totalGross),
     flow_ratio: flowRatio(totalNet, totalGross),
     direction: classifyDirection(totalNet, totalGross),
     stake_events: totalStakeEvents,

--- a/src/account-stake-moves.ts
+++ b/src/account-stake-moves.ts
@@ -1,3 +1,4 @@
+import { roundBelowOne } from "./lib/stats.ts";
 // Per-account stake-movement (re-delegation) footprint: which subnets one account
 // (coldkey) moved stake out of over a recent window, broken down per subnet and
 // rolled up into a movement scorecard. Pure shaping (buildAccountStakeMoves) + a
@@ -32,11 +33,6 @@ export const ACCOUNT_STAKE_MOVES_WINDOWS: Record<string, number> = {
   "90d": 90,
 };
 export const DEFAULT_ACCOUNT_STAKE_MOVES_WINDOW = "30d";
-
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 function toCount(value: unknown): number {
   const n = Number(value);
@@ -173,7 +169,7 @@ export function buildAccountStakeMoves(
 
   const concentration =
     totalMovements > 0
-      ? roundConcentration(squares / (totalMovements * totalMovements))
+      ? roundBelowOne(squares / (totalMovements * totalMovements))
       : null;
 
   return {

--- a/src/account-weight-setters.ts
+++ b/src/account-weight-setters.ts
@@ -15,6 +15,7 @@
 // routes): WeightsSet fires every tempo, so a 90d window would be an unbounded row scan.
 
 import { WEIGHTS_EVENT_KIND } from "./chain-weights.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -24,11 +25,6 @@ export const ACCOUNT_WEIGHT_SETTERS_WINDOWS: Record<string, number> = {
   "30d": 30,
 };
 export const DEFAULT_ACCOUNT_WEIGHT_SETTERS_WINDOW = "7d";
-
-function roundConcentration(value: number): number {
-  const rounded = Math.round(value * 10000) / 10000;
-  return rounded >= 1 && value < 1 ? 0.9999 : rounded;
-}
 
 function toCount(value: unknown): number {
   const n = Number(value);
@@ -129,7 +125,7 @@ export function buildAccountWeightSetters(
   const dominantNetuid = subnets.length > 0 ? subnets[0].netuid : null;
   const concentration =
     totalWeightSets > 0
-      ? roundConcentration(squares / (totalWeightSets * totalWeightSets))
+      ? roundBelowOne(squares / (totalWeightSets * totalWeightSets))
       : null;
 
   return {

--- a/src/accounts-list.ts
+++ b/src/accounts-list.ts
@@ -30,7 +30,7 @@
 import { loadStoreAlphaPricesByNetuid } from "./metagraph-neurons.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
-  RAO_PER_TAO_NUMBER,
+  round9NonNegative,
   nonNegativeOrZero,
   raoBigToTao,
   toRaoBig,
@@ -75,13 +75,6 @@ function nonNegativeInt(value: unknown): number | null {
   if (typeof value === "string" && value.trim() === "") return null;
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
-}
-
-function roundTao(value: unknown): number {
-  return (
-    Math.round(nonNegativeOrZero(value) * RAO_PER_TAO_NUMBER) /
-    RAO_PER_TAO_NUMBER
-  );
 }
 
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
@@ -171,8 +164,8 @@ function buildAccountEntry(entry: AccountAccumulator): AccountsListEntry {
     uid_count: entry.uidCount,
     validator_count: entry.validatorCount,
     miner_count: entry.uidCount - entry.validatorCount,
-    total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
-    total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
+    total_stake_tao: round9NonNegative(raoBigToTao(entry.stakeTotalRao)),
+    total_emission_tao: round9NonNegative(raoBigToTao(entry.emissionTotalRao)),
     latest_captured_at: toIso(entry.latestCapturedAt),
     latest_block_number: entry.latestBlockNumber,
     subnets,
@@ -335,8 +328,8 @@ export function buildAccountsList(
     entry.subnets.push({
       netuid,
       uid,
-      stake_alpha: roundTao(stake),
-      emission_alpha: roundTao(emission),
+      stake_alpha: round9NonNegative(stake),
+      emission_alpha: round9NonNegative(emission),
     });
   }
 

--- a/src/chain-axon-removals.ts
+++ b/src/chain-axon-removals.ts
@@ -9,7 +9,7 @@
 // same account_events [netuid, hotkey] tuple AxonServed uses — the network-wide companion to the
 // per-subnet /api/v1/subnets/{netuid}/axon-removals.
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
   AXON_REMOVALS_DEGRADED_NEVER_EMITTED,
@@ -27,10 +27,6 @@ export const DEFAULT_CHAIN_AXON_REMOVALS_WINDOW = "7d";
 
 // Round a removals-per-remover ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -73,7 +69,7 @@ function toIso(value: unknown): string | null {
 // re-announcing). A subnet with no removers has no defined intensity (null), not a divide-by-zero.
 function removalsPerRemover(removals: number, removers: number): number | null {
   if (removers <= 0) return null;
-  return round(removals / removers);
+  return roundDp(removals / removers);
 }
 
 export interface IntensityDistribution {
@@ -97,10 +93,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-deregistrations.ts
+++ b/src/chain-deregistrations.ts
@@ -12,7 +12,7 @@
 // tryDataApiTier() ?? buildChainDeregistrations([]). The field semantics live in
 // schemas-src/routes/chain-network-rollups.ts (ChainDeregistrationsArtifact).
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import type { DeregistrationDerivation } from "./deregistration-derivation.ts";
 import type { EventStreamDegraded } from "./uncurated-event-streams.ts";
@@ -36,10 +36,6 @@ export const DEFAULT_CHAIN_DEREGISTRATIONS_WINDOW = "7d";
 
 // Round a deregistrations-per-hotkey ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -86,7 +82,7 @@ function deregistrationsPerHotkey(
   hotkeys: number,
 ): number | null {
   if (hotkeys <= 0) return null;
-  return round(deregistrations / hotkeys);
+  return roundDp(deregistrations / hotkeys);
 }
 
 export interface IntensityDistribution {
@@ -110,10 +106,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-performance.ts
+++ b/src/chain-performance.ts
@@ -9,7 +9,7 @@
 // envelope. Null-safe: an empty snapshot yields a schema-stable `null` block.
 
 import { computeConcentration } from "./concentration.ts";
-import { percentile } from "./lib/stats.ts";
+import { roundDp, percentile } from "./lib/stats.ts";
 
 // The neurons-tier columns the network performance handler reads — like the
 // per-subnet read but with `netuid`, so the artifact can report how many subnets
@@ -25,10 +25,6 @@ const SCORE_PERCENTILES = [10, 25, 50, 75, 90];
 // Round a score/mean to 6 dp so JSON never carries a long floating-point tail.
 // Callers only ever pass finite values (finiteValues drops non-finite cells and
 // scoreDistribution guards count > 0), so no null-guard is needed here.
-function round(value: number): number {
-  const factor = 1e6;
-  return Math.round(value * factor) / factor;
-}
 
 interface CaptureStamp {
   ms: number;
@@ -93,12 +89,12 @@ export function scoreDistribution(values: unknown[]): ScoreDistribution | null {
   const total = finite.reduce((sum, v) => sum + v, 0);
   const summary: ScoreDistribution = {
     count,
-    mean: round(total / count),
-    min: round(ascending[0]),
-    max: round(ascending[count - 1]),
+    mean: roundDp(total / count, 6),
+    min: roundDp(ascending[0], 6),
+    max: roundDp(ascending[count - 1], 6),
   };
   for (const p of SCORE_PERCENTILES) {
-    summary[`p${p}`] = round(percentile(ascending, p)!);
+    summary[`p${p}`] = roundDp(percentile(ascending, p)!, 6);
   }
   return summary;
 }

--- a/src/chain-prometheus.ts
+++ b/src/chain-prometheus.ts
@@ -7,7 +7,7 @@
 // the metrics endpoint a neuron exposes (which subnets run observability infrastructure), read from
 // the same account_events [netuid, hotkey] tuple AxonServed uses.
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
   PROMETHEUS_DEGRADED_NOT_CURATED,
@@ -25,10 +25,6 @@ export const DEFAULT_CHAIN_PROMETHEUS_WINDOW = "7d";
 
 // Round an announcements-per-exporter ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -74,7 +70,7 @@ function announcementsPerExporter(
   exporters: number,
 ): number | null {
   if (exporters <= 0) return null;
-  return round(announcements / exporters);
+  return roundDp(announcements / exporters);
 }
 
 export interface IntensityDistribution {
@@ -98,10 +94,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-registrations.ts
+++ b/src/chain-registrations.ts
@@ -7,7 +7,7 @@
 // -- see #6013). Callers now go tryDataApiTier() ?? buildChainRegistrations([]). The field
 // semantics live in schemas-src/routes/chain-network-rollups.ts (ChainRegistrationsArtifact).
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a neuron registers (or re-registers) on a subnet.
@@ -23,10 +23,6 @@ export const DEFAULT_CHAIN_REGISTRATIONS_WINDOW = "7d";
 
 // Round a registrations-per-registrant ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct registrants, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -72,7 +68,7 @@ function registrationsPerRegistrant(
   registrants: number,
 ): number | null {
   if (registrants <= 0) return null;
-  return round(registrations / registrants);
+  return roundDp(registrations / registrants);
 }
 
 export interface IntensityDistribution {
@@ -96,10 +92,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-serving.ts
+++ b/src/chain-serving.ts
@@ -4,7 +4,7 @@
 // in #4772, so it always missed -- see #6013). Callers now go tryDataApiTier() ?? buildChainServing([]).
 // The field semantics live in schemas-src/routes/chain-network-rollups.ts (ChainServingArtifact).
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 
 export const CHAIN_SERVING_LIMIT_DEFAULT = 20;
@@ -18,10 +18,6 @@ export const DEFAULT_CHAIN_SERVING_WINDOW = "7d";
 
 // Round a announcements-per-hotkey ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct hotkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -67,7 +63,7 @@ function announcementsPerHotkey(
   hotkeys: number,
 ): number | null {
   if (hotkeys <= 0) return null;
-  return round(announcements / hotkeys);
+  return roundDp(announcements / hotkeys);
 }
 
 export interface IntensityDistribution {
@@ -91,10 +87,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-stake-flow.ts
+++ b/src/chain-stake-flow.ts
@@ -9,11 +9,7 @@
 
 import { median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
-import {
-  RAO_PER_TAO_NUMBER,
-  finiteCellOrNull,
-  numberOrZero,
-} from "./lib/rao.ts";
+import { round9OrZero, finiteCellOrNull, numberOrZero } from "./lib/rao.ts";
 
 // The two account_events kinds that move stake: StakeAdded is capital entering a subnet,
 // StakeRemoved is capital leaving. Both carry a positive amount_tao, so net = staked - unstaked.
@@ -32,11 +28,6 @@ export const DEFAULT_CHAIN_STAKE_FLOW_WINDOW = "7d";
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise below the
 // rao floor; round every TAO output to rao precision (the same rounding the sibling scorecards
 // apply). A non-finite sum can only arise from a malformed direct call — coerce it to 0.
-function roundTao(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric.
 
@@ -98,10 +89,10 @@ function netFlowDistribution(values: number[]): NetFlowDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: roundTao(sum / ascending.length),
+    mean: round9OrZero(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: roundTao(median(ascending)!),
+    p50: round9OrZero(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
@@ -220,10 +211,10 @@ export function buildChainStakeFlow(
     const direction = classifyDirection(net, gross);
     subnets.push({
       netuid,
-      total_staked_tao: roundTao(bucket.staked),
-      total_unstaked_tao: roundTao(bucket.unstaked),
-      net_flow_tao: roundTao(net),
-      gross_flow_tao: roundTao(gross),
+      total_staked_tao: round9OrZero(bucket.staked),
+      total_unstaked_tao: round9OrZero(bucket.unstaked),
+      net_flow_tao: round9OrZero(net),
+      gross_flow_tao: round9OrZero(gross),
       stake_events: bucket.stakeEvents,
       unstake_events: bucket.unstakeEvents,
       direction,
@@ -244,10 +235,10 @@ export function buildChainStakeFlow(
   );
 
   const network: ChainStakeFlowNetwork = {
-    total_staked_tao: roundTao(totalStaked),
-    total_unstaked_tao: roundTao(totalUnstaked),
-    net_flow_tao: roundTao(totalStaked - totalUnstaked),
-    gross_flow_tao: roundTao(totalStaked + totalUnstaked),
+    total_staked_tao: round9OrZero(totalStaked),
+    total_unstaked_tao: round9OrZero(totalUnstaked),
+    net_flow_tao: round9OrZero(totalStaked - totalUnstaked),
+    gross_flow_tao: round9OrZero(totalStaked + totalUnstaked),
     stake_events: totalStakeEvents,
     unstake_events: totalUnstakeEvents,
     gaining,

--- a/src/chain-stake-moves.ts
+++ b/src/chain-stake-moves.ts
@@ -12,7 +12,7 @@
 // the table is dropped in production (#4772 / #4909), so serving goes tryDataApiTier →
 // schema-stable empty stub, never the store.
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a coldkey moves stake between hotkeys/subnets (move_stake).
@@ -29,10 +29,6 @@ export const DEFAULT_CHAIN_STAKE_MOVES_WINDOW = "7d";
 
 // Round a movements-per-mover ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct coldkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -75,7 +71,7 @@ function toIso(value: unknown): string | null {
 // (null) rather than a divide-by-zero.
 function movementsPerMover(movements: number, movers: number): number | null {
   if (movers <= 0) return null;
-  return round(movements / movers);
+  return roundDp(movements / movers);
 }
 
 export interface IntensityDistribution {
@@ -99,10 +95,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-stake-transfers.ts
+++ b/src/chain-stake-transfers.ts
@@ -14,7 +14,7 @@
 // and the table is dropped in production (#4772 / #4909), so serving goes tryDataApiTier →
 // schema-stable empty stub, never the store.
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a coldkey transfers stake to another coldkey (transfer_stake).
@@ -31,10 +31,6 @@ export const DEFAULT_CHAIN_STAKE_TRANSFERS_WINDOW = "7d";
 
 // Round a transfers-per-sender ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct coldkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -77,7 +73,7 @@ function toIso(value: unknown): string | null {
 // no defined intensity (null) rather than a divide-by-zero.
 function transfersPerSender(transfers: number, senders: number): number | null {
   if (senders <= 0) return null;
-  return round(transfers / senders);
+  return roundDp(transfers / senders);
 }
 
 export interface IntensityDistribution {
@@ -101,10 +97,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/chain-transfer-pairs.ts
+++ b/src/chain-transfer-pairs.ts
@@ -1,4 +1,5 @@
-import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
+import { round9OrZero, numberOrZero } from "./lib/rao.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 // Network-wide native-TAO transfer-pair analytics: over a recent window, which
 // sender -> receiver corridors dominate Balances.Transfer flow. This is the pair
 // companion to /chain/transfers (top individual senders/receivers) and
@@ -22,13 +23,8 @@ function toBlockNumber(value: unknown): number | null {
   return Number.isSafeInteger(n) && n >= 0 ? n : null;
 }
 
-function roundTao(value: unknown): number {
-  const n = numberOrZero(value);
-  return Math.round(n * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
-
 function toNonNegativeTao(value: unknown): number {
-  return Math.max(0, roundTao(value));
+  return Math.max(0, round9OrZero(value));
 }
 
 // Round a 0..1 dominance ratio to a stable precision WITHOUT letting a
@@ -39,11 +35,6 @@ function toNonNegativeTao(value: unknown): number {
 // near-monopoly (e.g. 249990/250000 = 0.99996, with other pairs still present in
 // unique_pairs/pairs[]) must not surface as a flat 1 ("100% of volume"). A
 // genuine single-corridor window where top == total keeps a true 1.
-function roundShare(value: number, dp = 4): number {
-  const factor = 10 ** dp;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
 
 function toIso(value: unknown): string | null {
   if (value == null) return null;
@@ -141,7 +132,7 @@ export function buildChainTransferPairs({
     ? toNonNegativeTao(totals?.top_pair_volume_tao)
     : returnedTopPairVolume;
   const topPairShare =
-    totalVolume > 0 ? roundShare(topPairVolume / totalVolume) : null;
+    totalVolume > 0 ? roundBelowOne(topPairVolume / totalVolume) : null;
 
   return {
     schema_version: 1,

--- a/src/chain-transfers.ts
+++ b/src/chain-transfers.ts
@@ -1,4 +1,5 @@
-import { RAO_PER_TAO_NUMBER, numberOrZero } from "./lib/rao.ts";
+import { round9OrZero, numberOrZero } from "./lib/rao.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 // Network-wide native-TAO transfer analytics: over a recent window, how much TAO moved
 // via Balances.Transfer across the whole chain, who moved the most out (top senders) and
 // in (top receivers), and how concentrated that flow is among the top accounts. Pure
@@ -19,10 +20,6 @@ export const CHAIN_TRANSFER_LIMIT_MAX = 100;
 
 // 1 TAO = 1e9 rao; round every TAO output to that precision to shed IEEE-754 noise from
 // summing many REAL amount_tao values (the same rounding the chain/fees market applies).
-function roundTao(value: unknown): number {
-  const n = numberOrZero(value);
-  return Math.round(n * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
 
 // A whole non-negative count (D1 COUNT is integer; truncate defensively for direct callers).
 function toCount(value: unknown): number {
@@ -37,11 +34,6 @@ function toCount(value: unknown): number {
 // a near-monopoly (e.g. 249990/250000 = 0.99996, with other senders still present
 // in unique_senders) must not surface as a flat 1 ("100% of outflow"). A genuine
 // single-sender window where the top senders ARE the whole volume keeps a true 1.
-function roundShare(value: number, dp = 4): number {
-  const factor = 10 ** dp;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
 
 export interface ChainTransferParty {
   address: string;
@@ -58,7 +50,7 @@ function shapeParties(
     .filter((row) => typeof row?.address === "string" && row.address.length > 0)
     .map((row) => ({
       address: row.address as string,
-      volume_tao: roundTao(row?.volume_tao),
+      volume_tao: round9OrZero(row?.volume_tao),
       transfer_count: toCount(row?.transfer_count),
     }));
 }
@@ -94,14 +86,14 @@ export function buildChainTransfers({
   senders?: Array<Record<string, unknown>>;
   receivers?: Array<Record<string, unknown>>;
 } = {}): ChainTransfersResult {
-  const totalVolume = roundTao(totals?.total_volume_tao);
+  const totalVolume = round9OrZero(totals?.total_volume_tao);
   const topSenders = shapeParties(senders);
   const topReceivers = shapeParties(receivers);
-  const topSenderVolume = roundTao(
+  const topSenderVolume = round9OrZero(
     topSenders.reduce((sum, s) => sum + s.volume_tao, 0),
   );
   const topSenderShare =
-    totalVolume > 0 ? roundShare(topSenderVolume / totalVolume) : null;
+    totalVolume > 0 ? roundBelowOne(topSenderVolume / totalVolume) : null;
   return {
     schema_version: 1,
     window: window ?? null,

--- a/src/chain-turnover.ts
+++ b/src/chain-turnover.ts
@@ -6,7 +6,7 @@
 // for unit tests; the Worker does the store reads + envelope. Scoped to validator_permit rows
 // so the two-snapshot read stays bounded (validators, not every neuron across the network).
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundBelowOne, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 
 // Page-size ceiling, single-sourced in route-limits.ts so the contract's
@@ -34,11 +34,6 @@ export const DEFAULT_CHAIN_TURNOVER_WINDOW = "30d";
 // Round a retention ratio (a finite 0..1 jaccard result) to a stable precision WITHOUT
 // letting a sub-perfect ratio round up to an exact 1 — the same anti-overstatement invariant
 // src/turnover.ts enforces: a set that actually churned must never report a flawless 1.
-function round(value: number, dp = 4): number {
-  const factor = 10 ** dp;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
 
 // Jaccard similarity |A∩B| / |A∪B| — the retained fraction across two sets. Two empty sets
 // are defined as 1 (nothing to lose ⇒ perfectly retained), reached for the network set when a
@@ -83,7 +78,7 @@ function stabilityDistribution(scores: number[]): StabilityDistribution | null {
     mean: Math.round((sum / ascending.length) * 100) / 100,
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundBelowOne(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],
@@ -271,7 +266,7 @@ export function buildChainTurnover(
       validators_end: ev.size,
       validators_entered: churn.entered,
       validators_exited: churn.exited,
-      validator_retention: round(churn.retention),
+      validator_retention: roundBelowOne(churn.retention),
       stability_score: churn.stability,
     });
   }
@@ -290,7 +285,7 @@ export function buildChainTurnover(
     validators_end: end.network.size,
     validators_entered: netChurn.entered,
     validators_exited: netChurn.exited,
-    validator_retention: round(netChurn.retention),
+    validator_retention: roundBelowOne(netChurn.retention),
     stability_score: netChurn.stability,
   };
 

--- a/src/chain-weight-setters.ts
+++ b/src/chain-weight-setters.ts
@@ -1,4 +1,5 @@
 import { clampRowLimit } from "../workers/request-params.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 // Network-wide weight-setter leaderboard: across EVERY subnet over a 7d/30d window, the
 // individual validators driving consensus network-wide — each setter's total WeightsSet event
 // count (summed across every subnet it operates on), its share of the network total, and when it
@@ -32,11 +33,6 @@ export const CHAIN_WEIGHT_SETTERS_LIMIT_MAX = 100;
 // another setter still holds activity (e.g. 49999/50000 = 0.99998 -> 1.0000). Mirrors the
 // anti-overstatement guard in subnet-weight-setters.ts. A genuine sole setter (its count == the
 // network total) keeps a true 1.
-function round(value: number, dp = 4): number {
-  const factor = 10 ** dp;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -129,7 +125,7 @@ export function buildChainWeightSetters(
         netuid: toHotkey(row?.hotkey) == null ? toNetuid(row?.netuid) : null,
         uid: toUid(row?.uid),
         weight_sets: weightSets,
-        share: totalSets > 0 ? round(weightSets / totalSets) : null,
+        share: totalSets > 0 ? roundBelowOne(weightSets / totalSets) : null,
         first_set_at: toIso(row?.first_set),
         last_set_at: toIso(row?.last_set),
       };

--- a/src/chain-weights.ts
+++ b/src/chain-weights.ts
@@ -3,7 +3,7 @@
 // kind-filtered sibling of chain-transfers / chain-stake-flow. Pure shaping + a thin store loader; the
 // Worker adds the envelope. See the schema/contracts for the full response contract.
 
-import { median, percentile } from "./lib/stats.ts";
+import { roundDp, median, percentile } from "./lib/stats.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 
 // The account_events kind emitted when a validator sets weights on a subnet.
@@ -20,10 +20,6 @@ export const DEFAULT_CHAIN_WEIGHTS_WINDOW = "7d";
 
 // Round an updates-per-validator ratio to a stable precision (2dp). Always finite and
 // non-negative here (events / distinct setters, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -65,7 +61,7 @@ function toIso(value: unknown): string | null {
 // with no setters has no defined intensity (null) rather than a divide-by-zero.
 function setsPerSetter(sets: number, setters: number): number | null {
   if (setters <= 0) return null;
-  return round(sets / setters);
+  return roundDp(sets / setters);
 }
 
 export interface IntensityDistribution {
@@ -90,10 +86,10 @@ function intensityDistribution(values: number[]): IntensityDistribution | null {
   const sum = ascending.reduce((total, value) => total + value, 0);
   return {
     count: ascending.length,
-    mean: round(sum / ascending.length),
+    mean: roundDp(sum / ascending.length),
     min: ascending[0],
     p25: percentile(ascending, 25)!,
-    p50: round(median(ascending)!),
+    p50: roundDp(median(ascending)!),
     p75: percentile(ascending, 75)!,
     p90: percentile(ascending, 90)!,
     max: ascending[ascending.length - 1],

--- a/src/concentration.ts
+++ b/src/concentration.ts
@@ -8,6 +8,8 @@
 import { DAY_MS } from "../workers/config.ts";
 import { raoBigToTao, toRaoBig } from "./lib/rao.ts";
 import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
+import { roundDpOrNull } from "./lib/stats.ts";
+import { captureStamp, type CaptureStamp } from "./lib/capture-stamp.ts";
 
 // The neurons-tier columns the concentration handler reads — the store read contract
 // for buildConcentration (mirrors BLOCK_READ_COLUMNS / EXTRINSIC_READ_COLUMNS). Kept
@@ -20,11 +22,6 @@ const TOP_PERCENTILES = [1, 5, 10, 20];
 
 // Round a ratio/amount to a stable decimal precision; null/non-finite → null so the
 // schema stays `number|null` and JSON never carries a long floating-point tail.
-function round(value: number | null | undefined, dp = 6): number | null {
-  if (value == null || !Number.isFinite(value)) return null;
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // Round a 0..1 concentration ratio (gini, hhi, normalized variants, top-K share)
 // WITHOUT letting a sub-perfect value round up to an exact 1 — a near-monopoly
@@ -41,34 +38,6 @@ function roundRatio(value: number | null | undefined, dp = 6): number | null {
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
 // for why, and for the overflow guard that lived in only one of the nine copies
 // this used to be.
-
-interface CaptureStamp {
-  ms: number;
-  value: string;
-}
-
-function epochMsStamp(ms: number): CaptureStamp | null {
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  if (!Number.isFinite(date.getTime())) return null;
-  return { ms, value: date.toISOString() };
-}
-
-function captureStamp(value: unknown): CaptureStamp | null {
-  if (value == null) return null;
-  if (typeof value === "string") {
-    if (/^\d+$/.test(value)) {
-      return epochMsStamp(Number(value));
-    }
-    const ms = Date.parse(value);
-    if (Number.isFinite(ms)) return { ms, value };
-    return null;
-  }
-  if (typeof value === "number") {
-    return epochMsStamp(value);
-  }
-  return null;
-}
 
 // Coerce a raw column array to the finite, strictly-positive values that actually
 // make up a distribution. Zero / negative / NaN / null entries carry no share and
@@ -198,13 +167,13 @@ export function computeConcentration(
   const { bits, normalized } = entropy(descending, total);
   return {
     holders,
-    total: round(total, 4),
+    total: roundDpOrNull(total, 4),
     gini: roundRatio(gini(ascending, total)),
     hhi: roundRatio(h),
     hhi_normalized: roundRatio(hhiNormalized(h, holders)),
     nakamoto_coefficient: nakamoto(descending, total),
     ...topShares(descending, total),
-    entropy: round(bits),
+    entropy: roundDpOrNull(bits, 6),
     entropy_normalized: roundRatio(normalized),
   };
 }
@@ -296,7 +265,9 @@ export function buildConcentration(
     // UIDs per controlling entity — a Sybil/consolidation signal (1.0 = every UID
     // a distinct owner; higher = fewer operators each running many hotkeys).
     uids_per_entity:
-      entities.count > 0 ? round(list.length / entities.count, 4) : null,
+      entities.count > 0
+        ? roundDpOrNull(list.length / entities.count, 4)
+        : null,
     captured_at: capturedAt?.value ?? null,
     stake: computeConcentration(list.map((row) => row?.stake_tao)),
     emission: computeConcentration(list.map((row) => row?.emission_tao)),
@@ -368,7 +339,9 @@ export function buildChainConcentration(
     // UIDs per controlling entity network-wide — a consolidation signal (1.0 =
     // every UID a distinct owner; higher = fewer operators each running many).
     uids_per_entity:
-      entities.count > 0 ? round(list.length / entities.count, 4) : null,
+      entities.count > 0
+        ? roundDpOrNull(list.length / entities.count, 4)
+        : null,
     captured_at: capturedAt?.value ?? null,
     stake: computeConcentration(list.map((row) => row?.stake_tao)),
     emission: computeConcentration(list.map((row) => row?.emission_tao)),
@@ -701,7 +674,7 @@ export function buildSubnetConcentrationRanking(
     neuron_count: list.length,
     captured_at: capturedAt?.value ?? null,
     network: {
-      median_gini: round(
+      median_gini: roundDpOrNull(
         median(
           measured
             .map((row) => row.gini)
@@ -713,7 +686,7 @@ export function buildSubnetConcentrationRanking(
           .map((row) => row.nakamoto_coefficient)
           .filter((value): value is number => value != null),
       ),
-      median_top_1pct_share: round(
+      median_top_1pct_share: roundDpOrNull(
         median(
           measured
             .map((row) => row.top_1pct_share)

--- a/src/lib/capture-stamp.ts
+++ b/src/lib/capture-stamp.ts
@@ -1,0 +1,33 @@
+// A capture timestamp as both epoch-ms and its serialized form (#10948).
+//
+// Extracted from the pair of "deliberate byte-for-byte copies" in
+// src/concentration.ts and src/subnet-idle-stake.ts -- which were, in the
+// tradition this issue exists to end, not byte-for-byte (formatting and
+// annotation drift only; behaviour was identical, verified before the
+// extraction). Accepts an epoch-ms number, a numeric-string epoch (Postgres
+// hands a BIGINT column back as a string), or a parseable date string;
+// anything else, or a non-positive / non-finite epoch, is not a real
+// timestamp and reads as null.
+
+export interface CaptureStamp {
+  ms: number;
+  value: string;
+}
+
+export function epochMsStamp(ms: number): CaptureStamp | null {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const date = new Date(ms);
+  if (!Number.isFinite(date.getTime())) return null;
+  return { ms, value: date.toISOString() };
+}
+
+export function captureStamp(value: unknown): CaptureStamp | null {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    if (/^\d+$/.test(value)) return epochMsStamp(Number(value));
+    const ms = Date.parse(value);
+    return Number.isFinite(ms) ? { ms, value } : null;
+  }
+  if (typeof value === "number") return epochMsStamp(value);
+  return null;
+}

--- a/src/lib/rao.ts
+++ b/src/lib/rao.ts
@@ -224,3 +224,18 @@ export function nonNegativeCellOrNull(value: unknown): number | null {
   const n = finiteCellOrNull(value);
   return n != null && n >= 0 ? n : null;
 }
+
+/**
+ * `round9OrZero` with negatives clamped to zero first (#10948).
+ *
+ * Two modules (accounts-list, metagraph-neurons) rounded
+ * `nonNegativeOrZero(value)` -- a DIFFERENT contract from round9OrZero, which
+ * passes a negative through: these callers aggregate stake totals where a
+ * negative is a data error and must read as zero, not as negative TAO. Kept
+ * as its own export rather than unified, because the clamp is the meaning.
+ */
+export function round9NonNegative(value: unknown): number {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return round9(n);
+}

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -23,3 +23,50 @@ export function median(ascending: number[]): number | null {
     ? ascending[mid]
     : (ascending[mid - 1] + ascending[mid]) / 2;
 }
+
+/**
+ * Round to `dp` decimal places (#10948).
+ *
+ * THE sixteen-way copy: `round(value, dp = 2)` with this exact body was
+ * declared byte-identically in sixteen chain/subnet analytics modules -- the
+ * one shape of the family with no behavioural spread at all, which is why it
+ * collapses without a decision. The variants that DIFFER (a null-guard, a
+ * clamp-below-one, a fixed 1e6 factor) are different contracts and stay
+ * separate -- see roundBelowOne below and the issue for the survivor table.
+ *
+ * The default is the caller's to state: the copies defaulted dp = 2, and the
+ * callers that meant something else always passed it explicitly.
+ */
+export function roundDp(value: number, dp = 2): number {
+  const factor = 10 ** dp;
+  return Math.round(value * factor) / factor;
+}
+
+/**
+ * Round to `dp` places, clamped strictly below 1 for a value that was below 1
+ * (#10948). A share of 0.99996 rounded at 4dp is 1.0 -- which reads as "all of
+ * it" in every ratio column this serves, so a sub-1 input saturates at
+ * 0.9999... instead of crossing the boundary rounding alone would invent.
+ * Four modules declared this byte-identically as their own `round`.
+ */
+export function roundBelowOne(value: number, dp = 4): number {
+  const factor = 10 ** dp;
+  const rounded = Math.round(value * factor) / factor;
+  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
+}
+
+/**
+ * `roundDp`, but null in and null out (#10948).
+ *
+ * The null-preserving generic of the family: concentration ratios and
+ * hyperparameter readings where "not computable" must survive the rounding
+ * rather than become a rounded NaN or an invented zero. Four modules carried
+ * this shape privately (two as `round`, two as `roundTaoOrNull` at 6dp).
+ */
+export function roundDpOrNull(
+  value: number | null | undefined,
+  dp = 2,
+): number | null {
+  if (value == null || !Number.isFinite(value)) return null;
+  return roundDp(value, dp);
+}

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -21,7 +21,7 @@ import {
 } from "./field-projection.ts";
 import type { Neurons } from "../generated/db/types.ts";
 import {
-  RAO_PER_TAO_NUMBER,
+  round9NonNegative,
   finiteCellOrNull,
   nonNegativeOrZero,
   raoBigToTao,
@@ -328,13 +328,6 @@ function nonNegativeInt(value: unknown): number | null {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
-function roundTao(value: unknown): number {
-  return (
-    Math.round(nonNegativeOrZero(value) * RAO_PER_TAO_NUMBER) /
-    RAO_PER_TAO_NUMBER
-  );
-}
-
 // Sums run in rao-integer BigInt space, not float space -- see src/lib/rao.ts
 // for why, and for the overflow guard that lived in only one of the nine copies
 // this used to be.
@@ -378,7 +371,7 @@ interface ImmunityWindow {
 // string-typed uid/registered_at_block into real integers, and roundTao
 // rounds stake_tao / emission_tao to rao precision). The explicit null
 // guards preserve the previous null-on-missing contract: Number(null) is
-// 0 (not NaN), so nonNegativeInt(null) / finiteCellOrNull(null) / roundTao(null)
+// 0 (not NaN), so nonNegativeInt(null) / finiteCellOrNull(null) / round9NonNegative(null)
 // would otherwise serialize as 0 instead of null. roundTao itself falls
 // back to nonNegativeOrZero(0) for null/non-finite, so the wrapping guards here
 // are what keep "missing cell" cells flowing through as null. Mirrors the
@@ -467,8 +460,9 @@ export function formatNeuron(
       row.incentive == null ? null : round(finiteCellOrNull(row.incentive)),
     dividends:
       row.dividends == null ? null : round(finiteCellOrNull(row.dividends)),
-    emission_tao: row.emission_tao == null ? null : roundTao(row.emission_tao),
-    stake_tao: row.stake_tao == null ? null : roundTao(row.stake_tao),
+    emission_tao:
+      row.emission_tao == null ? null : round9NonNegative(row.emission_tao),
+    stake_tao: row.stake_tao == null ? null : round9NonNegative(row.stake_tao),
     registered_at_block:
       row.registered_at_block == null
         ? null
@@ -822,10 +816,10 @@ function buildGlobalValidatorEntry(
     subnet_count: entry.netuids.size,
     uid_count: entry.uidCount,
     take: round(entry.take),
-    total_stake_tao: roundTao(raoBigToTao(entry.stakeTotalRao)),
-    root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
-    alpha_stake_tao: roundTao(raoBigToTao(alphaStakeRao)),
-    total_emission_tao: roundTao(raoBigToTao(entry.emissionTotalRao)),
+    total_stake_tao: round9NonNegative(raoBigToTao(entry.stakeTotalRao)),
+    root_stake_tao: round9NonNegative(raoBigToTao(rootStakeRao)),
+    alpha_stake_tao: round9NonNegative(raoBigToTao(alphaStakeRao)),
+    total_emission_tao: round9NonNegative(raoBigToTao(entry.emissionTotalRao)),
     // #2549: from the separate validator_nominator_counts side table, joined
     // by hotkey. Null when that table has no row for this hotkey yet (cold
     // table, or a hotkey the last low-frequency scan hasn't covered) --
@@ -1042,8 +1036,8 @@ export function buildGlobalValidators(
       // ALPHA on every non-root subnet, and named so since #10514: the entry
       // carries a PRICED total_stake_tao, and a row field sharing that suffix
       // across a different unit is the trap the rename removes.
-      stake_alpha: roundTao(stake),
-      emission_alpha: roundTao(emission),
+      stake_alpha: round9NonNegative(stake),
+      emission_alpha: round9NonNegative(emission),
       validator_trust: round(trust),
     });
   }
@@ -1404,10 +1398,12 @@ export function buildValidatorDetail(
     coldkey_count: coldkeys.size,
     subnet_count: subnets.length,
     take: round(take),
-    total_stake_tao: roundTao(raoBigToTao(stakeTotalRao)),
-    root_stake_tao: roundTao(raoBigToTao(rootStakeRao)),
-    alpha_stake_tao: roundTao(raoBigToTao(stakeTotalRao - rootStakeRao)),
-    total_emission_tao: roundTao(raoBigToTao(emissionTotalRao)),
+    total_stake_tao: round9NonNegative(raoBigToTao(stakeTotalRao)),
+    root_stake_tao: round9NonNegative(raoBigToTao(rootStakeRao)),
+    alpha_stake_tao: round9NonNegative(
+      raoBigToTao(stakeTotalRao - rootStakeRao),
+    ),
+    total_emission_tao: round9NonNegative(raoBigToTao(emissionTotalRao)),
     nominator_count: nominatorCount,
     ...finalizeApy(apyAcc),
     ...realizedReturns(stakeTotalRao, realizedStake),

--- a/src/movers.ts
+++ b/src/movers.ts
@@ -3,10 +3,10 @@
 import { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX } from "./route-limits.ts";
 import { clampRowLimit } from "../workers/request-params.ts";
 import {
+  round9OrZero,
   RAO_PER_TAO,
   RAO_PER_TAO_NUMBER,
   finiteCellOrNull,
-  numberOrZero,
   toRaoBig,
 } from "./lib/rao.ts";
 export { MOVERS_LIMIT_DEFAULT, MOVERS_LIMIT_MAX };
@@ -37,11 +37,6 @@ export const DEFAULT_MOVERS_SORT = "stake";
 
 // 1 TAO = 1e9 rao. Round every TAO output to rao precision; IEEE-754 noise below the rao
 // floor is artifact (mirrors the rounding the turnover/history scorecards apply).
-function roundTao(value: unknown): number {
-  return (
-    Math.round(numberOrZero(value) * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER
-  );
-}
 
 // Exact rao-integer BigInt for one subnet's TAO value, for summation across every subnet
 // (#5290, mirrors toRaoBig/raoBigToTao in chain-yield.ts and stake_sum_rao in
@@ -195,15 +190,15 @@ export function computeMovers(
     const e = endMap.get(netuid) ?? ZERO;
     movers.push({
       netuid,
-      stake_start_alpha: roundTao(s.stake),
-      stake_end_alpha: roundTao(e.stake),
-      stake_delta_alpha: roundTao(e.stake - s.stake),
+      stake_start_alpha: round9OrZero(s.stake),
+      stake_end_alpha: round9OrZero(e.stake),
+      stake_delta_alpha: round9OrZero(e.stake - s.stake),
       stake_pct_change: pctChange(s.stake, e.stake),
       // Dominance: this subnet's share of network stake at the end snapshot.
       stake_share_pct: pctShare(e.stake, raoToTaoNumber(endTotals.stakeRao)),
-      emission_start_alpha: roundTao(s.emission),
-      emission_end_alpha: roundTao(e.emission),
-      emission_delta_alpha: roundTao(e.emission - s.emission),
+      emission_start_alpha: round9OrZero(s.emission),
+      emission_end_alpha: round9OrZero(e.emission),
+      emission_delta_alpha: round9OrZero(e.emission - s.emission),
       emission_pct_change: pctChange(s.emission, e.emission),
       emission_share_pct: pctShare(
         e.emission,

--- a/src/neuron-history.ts
+++ b/src/neuron-history.ts
@@ -22,6 +22,7 @@ export { DEFAULT_HISTORY_WINDOW, HISTORY_WINDOW_DAYS } from "./route-limits.ts";
 import { HISTORY_WINDOW_DAYS, DEFAULT_HISTORY_WINDOW } from "./route-limits.ts";
 import type { NeuronDaily } from "../generated/db/types.ts";
 import { RAO_PER_TAO, round9 } from "./lib/rao.ts";
+import { roundDpOrNull, roundDp } from "./lib/stats.ts";
 // Bounds any single time-series response (1y = 365 daily points < this cap).
 export const MAX_HISTORY_POINTS = 400;
 
@@ -269,7 +270,7 @@ export function buildEconomicsTrends(
     miner_count: acc.miner_seen ? acc.miner_sum : null,
     mean_emission_share:
       acc.emission_seen > 0
-        ? roundShare(acc.emission_sum / acc.emission_seen)
+        ? roundDp(acc.emission_sum / acc.emission_seen, 6)
         : null,
   }));
   return {
@@ -290,9 +291,6 @@ function toFiniteOrNull(v: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function roundTao(v: number): number {
-  return Math.round(v * 1e6) / 1e6;
-}
 // Exact rao-precision decimal string, never a JS number (#2924): a network-
 // wide daily total_stake_tao sum is already well past 2^53-1's exact-double
 // ceiling (~9,007,199 TAO at rao precision) -- confirmed live 2026-07-14 at
@@ -312,14 +310,6 @@ function raoToTaoString(rao: bigint): string {
 // Round a TAO sum, preserving null — so an unrounded D1 SUM(stake_tao)/SUM(
 // emission_tao) never leaks accumulated float noise, while a null SUM (cold/
 // sparse day) stays null rather than collapsing to 0.
-function roundTaoOrNull(v: unknown): number | null {
-  const n = toFiniteOrNull(v);
-  return n == null ? null : roundTao(n);
-}
-
-function roundShare(v: number): number {
-  return Math.round(v * 1e6) / 1e6;
-}
 
 function median(values: number[]): number | null {
   if (!values.length) return null;
@@ -349,8 +339,11 @@ export function buildSubnetHistory(
       validator_count: toNonNegativeInt(r.validator_count),
       // Round the per-day SUM(stake_tao)/SUM(emission_tao) to stop accumulated
       // float noise from leaking, matching buildEconomicsTrends above.
-      total_stake_alpha: roundTaoOrNull(r.total_stake_tao),
-      total_emission_alpha: roundTaoOrNull(r.total_emission_tao),
+      total_stake_alpha: roundDpOrNull(toFiniteOrNull(r.total_stake_tao), 6),
+      total_emission_alpha: roundDpOrNull(
+        toFiniteOrNull(r.total_emission_tao),
+        6,
+      ),
     }));
   return {
     schema_version: 1,

--- a/src/stake-flow.ts
+++ b/src/stake-flow.ts
@@ -1,8 +1,4 @@
-import {
-  RAO_PER_TAO_NUMBER,
-  finiteCellOrNull,
-  numberOrZero,
-} from "./lib/rao.ts";
+import { round9OrZero, finiteCellOrNull, numberOrZero } from "./lib/rao.ts";
 import { QUERY_ENUMS } from "../schemas-src/query-enums.ts";
 // Net stake flow (capital in vs out) for one subnet over a recent window: how much
 // TAO entered (StakeAdded) vs left (StakeRemoved), summed from the first-party
@@ -45,11 +41,6 @@ export const DEFAULT_STAKE_FLOW_DIRECTION = "all";
 // 1 TAO = 1e9 rao. Summing many REAL amount_tao values accumulates IEEE-754 noise
 // below the rao floor; round every TAO output to rao precision, the smallest real
 // unit (the same rounding the turnover/account-summary scorecards apply).
-function roundTao(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric.
 
@@ -85,10 +76,10 @@ export function buildStakeFlow(
     schema_version: 1,
     netuid,
     window: window ?? null,
-    total_staked_tao: roundTao(stakedTao),
-    total_unstaked_tao: roundTao(unstakedTao),
+    total_staked_tao: round9OrZero(stakedTao),
+    total_unstaked_tao: round9OrZero(unstakedTao),
     // Positive = net capital inflow over the window; negative = net outflow.
-    net_flow_tao: roundTao(stakedTao - unstakedTao),
+    net_flow_tao: round9OrZero(stakedTao - unstakedTao),
     stake_events: stakeEvents,
     unstake_events: unstakeEvents,
   };

--- a/src/subnet-axon-removals.ts
+++ b/src/subnet-axon-removals.ts
@@ -8,6 +8,7 @@
 // envelope. Null-safe: a cold store or a subnet with no AxonInfoRemoved events yields the zeroed card.
 
 import { AXON_REMOVALS_DEGRADED_NEVER_EMITTED } from "./uncurated-event-streams.ts";
+import { roundDp } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 type SqlRunner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -26,10 +27,6 @@ export const DEFAULT_SUBNET_AXON_REMOVALS_WINDOW = "7d";
 
 // Round a removals-per-remover ratio to a stable 2dp precision. Always finite and non-negative
 // here (removals / distinct removers, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -54,7 +51,7 @@ function toIso(value: unknown): string | null {
 // re-announcing). A subnet with no removers has no defined intensity (null), not a divide-by-zero.
 function removalsPerRemover(removals: number, removers: number): number | null {
   if (removers <= 0) return null;
-  return round(removals / removers);
+  return roundDp(removals / removers);
 }
 
 // Shape one subnet's axon-removal scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-deregistrations.ts
+++ b/src/subnet-deregistrations.ts
@@ -1,3 +1,4 @@
+import { roundDp } from "./lib/stats.ts";
 // Per-subnet neuron-deregistration activity, DERIVED from UID reuse in the NeuronRegistered stream
 // (#9307 -- NeuronDeregistered has never been emitted; see src/deregistration-derivation.ts): for
 // ONE subnet over a 7d/30d window, the distinct deregistered hotkeys, NeuronDeregistered event
@@ -31,10 +32,6 @@ export const DEFAULT_SUBNET_DEREGISTRATIONS_WINDOW = "7d";
 
 // Round a deregistrations-per-hotkey ratio to a stable 2dp precision. Always finite and
 // non-negative here (deregistrations / distinct hotkeys, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -63,7 +60,7 @@ function deregistrationsPerHotkey(
   hotkeys: number,
 ): number | null {
   if (hotkeys <= 0) return null;
-  return round(deregistrations / hotkeys);
+  return roundDp(deregistrations / hotkeys);
 }
 
 // Shape one subnet's deregistration scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-hyperparams.ts
+++ b/src/subnet-hyperparams.ts
@@ -1,4 +1,5 @@
 import { finiteCellOrNull } from "./lib/rao.ts";
+import { roundDpOrNull } from "./lib/stats.ts";
 // Subnet hyperparameters (#4303, epic #4301): one row per netuid, latest-only.
 // Field mapping documented in
 // apps/indexer-rs/src/bin/poller/jobs/subnet_hyperparams.rs and
@@ -68,19 +69,13 @@ function nonNegativeInt(value: unknown): number | null {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
-function round(value: number | null, dp: number): number | null {
-  if (value == null || !Number.isFinite(value)) return null;
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
-
 // *_ratio columns are already a 0..1 U16-derived ratio by the time they reach
 // D1 (apps/indexer-rs/src/bin/poller/jobs/subnet_hyperparams.rs's u16_ratio,
 // rounded to 9dp there
 // too) — round again here as defense-in-depth against a future writer that
 // skips that rounding, not because this path expects dirty data.
 function ratio(value: unknown): number | null {
-  return round(finiteCellOrNull(value), 9);
+  return roundDpOrNull(finiteCellOrNull(value), 9);
 }
 
 // A flag column as a real boolean, in any store's spelling. The reasoning --
@@ -109,8 +104,8 @@ export function formatSubnetHyperparams(
     // rao/1e9-exact-split TAO values (rao_to_tao_exact) — round to rao
     // precision (9dp), not formatNeuron's 6dp roundTao, so no low-order rao
     // digits are lost re-serializing an already-exact value.
-    min_burn_tao: round(finiteCellOrNull(row.min_burn_tao), 9),
-    max_burn_tao: round(finiteCellOrNull(row.max_burn_tao), 9),
+    min_burn_tao: roundDpOrNull(finiteCellOrNull(row.min_burn_tao), 9),
+    max_burn_tao: roundDpOrNull(finiteCellOrNull(row.max_burn_tao), 9),
     burn_half_life: nonNegativeInt(row.burn_half_life),
     // Already float-decoded fixed-point on the SDK side — passed through.
     burn_increase_mult: finiteCellOrNull(row.burn_increase_mult),

--- a/src/subnet-idle-stake.ts
+++ b/src/subnet-idle-stake.ts
@@ -1,4 +1,5 @@
 import { raoBigToTao, toRaoBig } from "./lib/rao.ts"; // Per-subnet / network-wide idle-stake rollup (#6789, follow-up to #6645's
+import { captureStamp } from "./lib/capture-stamp.ts";
 // design spike -- docs/idle-stake-mechanism.md). Dividends are the ONLY
 // stream delegated stake ever receives in dTAO (incentive goes to the
 // hotkey owner alone, never split with delegators); dividends are zero for
@@ -16,28 +17,8 @@ type Row = Record<string, unknown>;
 // this used to be.
 
 // The rows share one cron capture, but don't assume an order -- take the
-// newest captured_at (mirrors src/concentration.ts's own captureStamp/
-// epochMsStamp, a deliberate byte-for-byte copy per this codebase's
-// per-module convention). Accepts an epoch-ms number, a numeric-string
-// epoch (D1/Postgres often hand back a BIGINT column as a string), or an
-// ISO string; anything else (or a non-positive/non-finite epoch) is not a
-// real timestamp and is ignored.
-function epochMsStamp(ms: number): { ms: number; value: string } | null {
-  if (!Number.isFinite(ms) || ms <= 0) return null;
-  const date = new Date(ms);
-  if (!Number.isFinite(date.getTime())) return null;
-  return { ms, value: date.toISOString() };
-}
-function captureStamp(value: unknown): { ms: number; value: string } | null {
-  if (value == null) return null;
-  if (typeof value === "string") {
-    if (/^\d+$/.test(value)) return epochMsStamp(Number(value));
-    const ms = Date.parse(value);
-    return Number.isFinite(ms) ? { ms, value } : null;
-  }
-  if (typeof value === "number") return epochMsStamp(value);
-  return null;
-}
+// newest captured_at, parsed by the shared stamp helpers (#10948; the
+// "byte-for-byte copy" this comment used to license had, of course, drifted).
 function newestCapturedAt(rows: Row[]): string | null {
   let newest: { ms: number; value: string } | null = null;
   for (const row of rows) {

--- a/src/subnet-performance.ts
+++ b/src/subnet-performance.ts
@@ -9,7 +9,7 @@
 // `null` block (never throws), matching the concentration tier it mirrors.
 
 import { computeConcentration } from "./concentration.ts";
-import { percentile } from "./lib/stats.ts";
+import { roundDp, percentile } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 type SqlRunner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -39,10 +39,6 @@ const SCORE_PERCENTILES = [10, 25, 50, 75, 90];
 // Round a score/mean to 6 dp so JSON never carries a long floating-point tail.
 // Callers only ever pass finite values (finiteValues drops non-finite cells and
 // scoreDistribution guards count > 0), so no null-guard is needed here.
-function round(value: number): number {
-  const factor = 1e6;
-  return Math.round(value * factor) / factor;
-}
 
 // Guard 0/negative epoch ms (a blank/sentinel cell) so a captured_at never
 // stamps the 1970 epoch. Mirrors epochMsStamp in concentration.ts / the
@@ -98,8 +94,8 @@ function scoreMedian(values: unknown[]): number | null {
   if (n === 0) return null;
   const mid = Math.floor(n / 2);
   return n % 2 === 1
-    ? round(ascending[mid])
-    : round((ascending[mid - 1] + ascending[mid]) / 2);
+    ? roundDp(ascending[mid], 6)
+    : roundDp((ascending[mid - 1] + ascending[mid]) / 2, 6);
 }
 
 export interface ScoreDistribution {
@@ -123,12 +119,12 @@ export function scoreDistribution(
   const total = finite.reduce((sum, v) => sum + v, 0);
   const summary: ScoreDistribution = {
     count,
-    mean: round(total / count),
-    min: round(ascending[0]),
-    max: round(ascending[count - 1]),
+    mean: roundDp(total / count, 6),
+    min: roundDp(ascending[0], 6),
+    max: roundDp(ascending[count - 1], 6),
   };
   for (const p of SCORE_PERCENTILES) {
-    summary[`p${p}`] = round(percentile(ascending, p)!);
+    summary[`p${p}`] = roundDp(percentile(ascending, p)!, 6);
   }
   return summary;
 }

--- a/src/subnet-prometheus.ts
+++ b/src/subnet-prometheus.ts
@@ -9,6 +9,7 @@
 // envelope. Null-safe: a cold store or a subnet with no PrometheusServed events yields the zeroed card.
 
 import { PROMETHEUS_DEGRADED_NOT_CURATED } from "./uncurated-event-streams.ts";
+import { roundDp } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 type SqlRunner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -27,10 +28,6 @@ export const DEFAULT_SUBNET_PROMETHEUS_WINDOW = "7d";
 
 // Round an announcements-per-exporter ratio to a stable 2dp precision. Always finite and
 // non-negative here (announcements / distinct exporters, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -58,7 +55,7 @@ function announcementsPerExporter(
   exporters: number,
 ): number | null {
   if (exporters <= 0) return null;
-  return round(announcements / exporters);
+  return roundDp(announcements / exporters);
 }
 
 // Shape one subnet's Prometheus scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-registrations.ts
+++ b/src/subnet-registrations.ts
@@ -1,3 +1,4 @@
+import { roundDp } from "./lib/stats.ts";
 // Per-subnet neuron-registration activity from the account_events NeuronRegistered stream: for
 // ONE subnet over a 7d/30d window, the distinct registrants (hotkeys), NeuronRegistered event
 // count, and average registrations per registrant. This is raw registration DEMAND/activity —
@@ -24,10 +25,6 @@ export const DEFAULT_SUBNET_REGISTRATIONS_WINDOW = "7d";
 
 // Round a registrations-per-registrant ratio to a stable 2dp precision. Always finite and
 // non-negative here (events / distinct registrants, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -55,7 +52,7 @@ function registrationsPerRegistrant(
   registrants: number,
 ): number | null {
   if (registrants <= 0) return null;
-  return round(registrations / registrants);
+  return roundDp(registrations / registrants);
 }
 
 // Shape one subnet's registration scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-serving.ts
+++ b/src/subnet-serving.ts
@@ -1,3 +1,4 @@
+import { roundDp } from "./lib/stats.ts";
 // Per-subnet axon-serving announcement activity from the account_events AxonServed stream:
 // for ONE subnet over a 7d/30d window, the distinct servers (hotkeys), AxonServed event count,
 // and average announcements per server. The direct per-subnet lookup companion to the network-wide
@@ -24,10 +25,6 @@ export const DEFAULT_SUBNET_SERVING_WINDOW = "7d";
 
 // Round an announcements-per-server ratio to a stable 2dp precision. Always finite and
 // non-negative here (announcements / distinct servers, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -55,7 +52,7 @@ function announcementsPerServer(
   servers: number,
 ): number | null {
   if (servers <= 0) return null;
-  return round(announcements / servers);
+  return roundDp(announcements / servers);
 }
 
 // Shape one subnet's serving scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-stake-moves.ts
+++ b/src/subnet-stake-moves.ts
@@ -1,3 +1,4 @@
+import { roundDp } from "./lib/stats.ts";
 // Per-subnet stake-movement (re-delegation) activity from the account_events StakeMoved stream:
 // for ONE subnet over a 7d/30d window, the distinct movers (accounts), StakeMoved event count, and
 // average movements per mover. The direct per-subnet lookup companion to the network-wide
@@ -27,10 +28,6 @@ export const DEFAULT_SUBNET_STAKE_MOVES_WINDOW = "7d";
 
 // Round a movements-per-mover ratio to a stable 2dp precision. Always finite and
 // non-negative here (movements / distinct movers, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -55,7 +52,7 @@ function toIso(value: unknown): string | null {
 // (null) rather than a divide-by-zero.
 function movementsPerMover(movements: number, movers: number): number | null {
   if (movers <= 0) return null;
-  return round(movements / movers);
+  return roundDp(movements / movers);
 }
 
 // Shape one subnet's stake-movement scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-stake-transfers.ts
+++ b/src/subnet-stake-transfers.ts
@@ -1,3 +1,4 @@
+import { roundDp } from "./lib/stats.ts";
 // Per-subnet stake-transfer activity from the account_events StakeTransferred stream: for ONE subnet
 // over a 7d/30d window, the distinct senders (accounts), StakeTransferred event count, and average
 // transfers per sender. The direct per-subnet lookup companion to the network-wide leaderboard at
@@ -28,10 +29,6 @@ export const DEFAULT_SUBNET_STAKE_TRANSFERS_WINDOW = "7d";
 
 // Round a transfers-per-sender ratio to a stable 2dp precision. Always finite and
 // non-negative here (transfers / distinct senders, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -56,7 +53,7 @@ function toIso(value: unknown): string | null {
 // defined intensity (null) rather than a divide-by-zero.
 function transfersPerSender(transfers: number, senders: number): number | null {
   if (senders <= 0) return null;
-  return round(transfers / senders);
+  return roundDp(transfers / senders);
 }
 
 // Shape one subnet's stake-transfer scorecard from the single-row account_events aggregate. `row`

--- a/src/subnet-weight-setters.ts
+++ b/src/subnet-weight-setters.ts
@@ -8,6 +8,7 @@
 // store or a subnet with no WeightsSet events yields a schema-stable empty leaderboard.
 
 import { WEIGHTS_EVENT_KIND } from "./subnet-weights.ts";
+import { roundBelowOne } from "./lib/stats.ts";
 
 type Row = Record<string, unknown>;
 type SqlRunner = (sql: string, params: unknown[]) => Promise<Row[]>;
@@ -39,11 +40,6 @@ const SETTER_IDENTITY =
 // flat 1 while another setter still holds activity (e.g. 49999/50000 = 0.99998 -> 1.0000).
 // The same anti-overstatement guard the sibling share/ratio rounders apply. A genuine sole
 // setter (its count == the subnet total) keeps a true 1.
-function round(value: number, dp = 4): number {
-  const factor = 10 ** dp;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -202,7 +198,7 @@ export function buildSubnetWeightSetters(
       hotkey: toHotkey(row?.hotkey),
       uid: toUid(row?.uid),
       weight_sets: weightSets,
-      share: totalSets > 0 ? round(weightSets / totalSets) : null,
+      share: totalSets > 0 ? roundBelowOne(weightSets / totalSets) : null,
       first_set_at: toIso(row?.first_set),
       last_set_at: toIso(row?.last_set),
       ...overdueView(

--- a/src/subnet-weights.ts
+++ b/src/subnet-weights.ts
@@ -1,3 +1,4 @@
+import { roundDp } from "./lib/stats.ts";
 // Per-subnet validator weight-setting activity from the account_events WeightsSet stream:
 // for ONE subnet over a 7d/30d window, the distinct weight-setting validators, WeightsSet
 // event count, and average updates per validator. The direct per-subnet lookup companion to
@@ -21,10 +22,6 @@ export const DEFAULT_SUBNET_WEIGHTS_WINDOW = "7d";
 
 // Round an updates-per-validator ratio to a stable 2dp precision. Always finite and
 // non-negative here (events / distinct setters, with the divisor guarded below).
-function round(value: number, dp = 2): number {
-  const factor = 10 ** dp;
-  return Math.round(value * factor) / factor;
-}
 
 // A non-negative whole count from a COUNT() cell (number, numeric string, or null),
 // defaulting to 0 for anything non-finite or negative.
@@ -48,7 +45,7 @@ function toIso(value: unknown): string | null {
 // with no setters has no defined intensity (null) rather than a divide-by-zero.
 function setsPerSetter(sets: number, setters: number): number | null {
   if (setters <= 0) return null;
-  return round(sets / setters);
+  return roundDp(sets / setters);
 }
 
 // Shape one subnet's weight-setting scorecard from the single-row account_events aggregate.

--- a/src/turnover.ts
+++ b/src/turnover.ts
@@ -1,3 +1,4 @@
+import { roundBelowOne } from "./lib/stats.ts";
 // Validator-set & registration turnover (churn) for one subnet: how much its
 // validator set and neuron population rotate between two dated snapshots of the
 // neuron_daily rollup (start vs end of a window). Pure + exported for unit tests;
@@ -20,11 +21,6 @@ export const TURNOVER_READ_COLUMNS =
 // for the badge (#1796): a set that actually churned must never report a flawless
 // `retention: 1`. Only a genuine ratio of exactly 1 (nothing rotated) keeps the
 // perfect value; any sub-1 ratio clamps to the largest dp-decimal value below 1.
-function round(value: number, dp = 4): number {
-  const factor = 10 ** dp;
-  const rounded = Math.round(value * factor) / factor;
-  return rounded >= 1 && value < 1 ? (factor - 1) / factor : rounded;
-}
 
 // Jaccard similarity |A∩B| / |A∪B| — the retained fraction across two sets. Two
 // empty sets are defined as 1 (nothing to lose ⇒ perfectly retained); past that
@@ -223,11 +219,11 @@ export function buildTurnover(
     validators_end: endValidators.size,
     validators_entered: entered,
     validators_exited: exited,
-    validator_retention: round(validatorRetention),
+    validator_retention: roundBelowOne(validatorRetention),
     neurons_start: startMap.size,
     neurons_end: endMap.size,
     uids_deregistered: deregistered,
-    neuron_retention: round(neuronRetention),
+    neuron_retention: roundBelowOne(neuronRetention),
     stability_score: stabilityScore,
   };
 }

--- a/src/validator-history.ts
+++ b/src/validator-history.ts
@@ -1,3 +1,4 @@
+import { roundDpOrNull, roundDp } from "./lib/stats.ts";
 // Cross-subnet daily history for one validator hotkey (#4334/7.3): staked-
 // over-time + a rewards-per-1000-TAO rate, rolled up from the neuron_daily
 // tier the same way buildSubnetHistory rolls up a subnet's daily totals
@@ -19,17 +20,9 @@ function toNonNegativeInt(v: unknown): number | null {
   return n != null && Number.isSafeInteger(n) && n >= 0 ? n : null;
 }
 
-function roundTao(v: number): number {
-  return Math.round(v * 1e6) / 1e6;
-}
-
 // Round a TAO sum, preserving null -- mirrors neuron-history.ts's
 // roundTaoOrNull so an unrounded D1 SUM() never leaks float noise while a
 // null/cold-day SUM stays null rather than collapsing to 0.
-function roundTaoOrNull(v: unknown): number | null {
-  const n = toFiniteOrNull(v);
-  return n == null ? null : roundTao(n);
-}
 
 // emission / stake scaled to a per-1000-TAO reward rate for that day -- null
 // when stake is zero/absent (the rate is undefined with nothing staked),
@@ -166,8 +159,8 @@ function toRateOrNull(v: unknown): number | null {
  * inventing a cross-subnet reading (#9383).
  */
 function subnetScopedFields(r: Row): Row {
-  const stakeAlpha = roundTaoOrNull(r.stake_alpha);
-  const emissionAlpha = roundTaoOrNull(r.emission_alpha);
+  const stakeAlpha = roundDpOrNull(toFiniteOrNull(r.stake_alpha), 6);
+  const emissionAlpha = roundDpOrNull(toFiniteOrNull(r.emission_alpha), 6);
   return {
     netuid: toNonNegativeInt(r.netuid),
     uid: toNonNegativeInt(r.uid),
@@ -248,8 +241,11 @@ export function buildValidatorHistory(
   const points = (Array.isArray(rows) ? rows : [])
     .filter((r) => r && typeof r === "object")
     .map((r) => {
-      const totalStakeTao = roundTaoOrNull(r.total_stake_tao);
-      const totalEmissionTao = roundTaoOrNull(r.total_emission_tao);
+      const totalStakeTao = roundDpOrNull(toFiniteOrNull(r.total_stake_tao), 6);
+      const totalEmissionTao = roundDpOrNull(
+        toFiniteOrNull(r.total_emission_tao),
+        6,
+      );
       return {
         snapshot_date: r.snapshot_date,
         subnet_count: toNonNegativeInt(r.subnet_count),

--- a/src/validator-history.ts
+++ b/src/validator-history.ts
@@ -1,4 +1,4 @@
-import { roundDpOrNull, roundDp } from "./lib/stats.ts";
+import { roundDpOrNull } from "./lib/stats.ts";
 // Cross-subnet daily history for one validator hotkey (#4334/7.3): staked-
 // over-time + a rewards-per-1000-TAO rate, rolled up from the neuron_daily
 // tier the same way buildSubnetHistory rolls up a subnet's daily totals

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -1,5 +1,5 @@
 import { clampRowLimit } from "../workers/request-params.ts";
-import { RAO_PER_TAO_NUMBER, finiteCellOrNull } from "./lib/rao.ts";
+import { round9OrZero, finiteCellOrNull } from "./lib/rao.ts";
 // Nominator list for one validator hotkey (#4334/7.2): who has staked to this
 // validator (across every subnet it operates in), derived from the same
 // StakeAdded/StakeRemoved account_events flow src/account-stake-flow.ts
@@ -27,11 +27,6 @@ export const NOMINATOR_SORTS = ["net_staked", "gross_staked", "last_activity"];
 export const DEFAULT_NOMINATOR_SORT = "net_staked";
 export const NOMINATOR_LIMIT_DEFAULT = 20;
 export const NOMINATOR_LIMIT_MAX = 100;
-function roundTao(value: number): number {
-  /* v8 ignore next -- defensive: callers only pass finite toNumber-guarded sums */
-  if (!Number.isFinite(value)) return 0;
-  return Math.round(value * RAO_PER_TAO_NUMBER) / RAO_PER_TAO_NUMBER;
-}
 
 // A finite TAO aggregate cell, or null when absent/blank/non-numeric. Blank D1
 // cells coerce via Number("") -> 0; skip those rather than counting a
@@ -257,10 +252,10 @@ export function buildValidatorNominators(
 
   const nominators: Nominator[] = [...perColdkey.values()].map((bucket) => ({
     coldkey: bucket.coldkey,
-    staked_tao: roundTao(bucket.staked_tao),
-    unstaked_tao: roundTao(bucket.unstaked_tao),
-    net_staked_tao: roundTao(bucket.staked_tao - bucket.unstaked_tao),
-    gross_staked_tao: roundTao(bucket.staked_tao + bucket.unstaked_tao),
+    staked_tao: round9OrZero(bucket.staked_tao),
+    unstaked_tao: round9OrZero(bucket.unstaked_tao),
+    net_staked_tao: round9OrZero(bucket.staked_tao - bucket.unstaked_tao),
+    gross_staked_tao: round9OrZero(bucket.staked_tao + bucket.unstaked_tao),
     event_count: bucket.event_count,
     last_observed_at: toIso(bucket.last_observed_ms),
     last_observed_ms: bucket.last_observed_ms,

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -51,3 +51,84 @@ describe("median", () => {
     assert.equal(median([10, 20, 30, 100]), 25);
   });
 });
+
+// ── the round-family survivors (#10948) ─────────────────────────────────────
+import { roundDp, roundBelowOne, roundDpOrNull } from "../src/lib/stats.ts";
+import { round9NonNegative } from "../src/lib/rao.ts";
+import { captureStamp, epochMsStamp } from "../src/lib/capture-stamp.ts";
+
+describe("roundDp (#10948 -- the sixteen-way copy)", () => {
+  test("rounds at the requested precision, default 2", () => {
+    assert.equal(roundDp(1.005 + Number.EPSILON), 1.01);
+    assert.equal(roundDp(1.23456), 1.23);
+    assert.equal(roundDp(1.23456, 4), 1.2346);
+    // -1.235 * 100 is -123.50000000000001 in floats, so this rounds
+    // away from zero -- pinned as the real behaviour every copy always had.
+    assert.equal(roundDp(-1.235, 2), -1.24);
+  });
+  test("preserves the copies' non-finite behaviour: NaN in, NaN out", () => {
+    // The copies did NOT guard non-finite input -- callers guaranteed it.
+    // The survivor keeps that contract rather than quietly adding one.
+    assert.ok(Number.isNaN(roundDp(Number.NaN)));
+  });
+});
+
+describe("roundBelowOne (#10948 -- the sub-1 clamp family)", () => {
+  test("a sub-1 value that would round to 1 saturates below it", () => {
+    assert.equal(roundBelowOne(0.99996, 4), 0.9999);
+    assert.equal(roundBelowOne(0.99996), 0.9999);
+  });
+  test("a value at or above 1 passes through the plain rounding", () => {
+    assert.equal(roundBelowOne(1, 4), 1);
+    assert.equal(roundBelowOne(1.00004, 4), 1);
+    assert.equal(roundBelowOne(2.34567, 4), 2.3457);
+  });
+  test("an ordinary sub-1 value is just rounded", () => {
+    assert.equal(roundBelowOne(0.12345, 4), 0.1235);
+  });
+});
+
+describe("roundDpOrNull (#10948 -- null survives the rounding)", () => {
+  test("null, undefined and non-finite read as null, not 0 and not NaN", () => {
+    assert.equal(roundDpOrNull(null, 6), null);
+    assert.equal(roundDpOrNull(undefined, 6), null);
+    assert.equal(roundDpOrNull(Number.NaN, 6), null);
+    assert.equal(roundDpOrNull(Number.POSITIVE_INFINITY, 6), null);
+  });
+  test("a finite value rounds at the requested precision", () => {
+    assert.equal(roundDpOrNull(0.1234567, 6), 0.123457);
+    assert.equal(roundDpOrNull(0, 6), 0);
+  });
+});
+
+describe("round9NonNegative (#10948 -- the clamp IS the contract)", () => {
+  test("a negative reads as zero, unlike round9OrZero", () => {
+    assert.equal(round9NonNegative(-1.5), 0);
+  });
+  test("non-numeric and non-finite read as zero", () => {
+    assert.equal(round9NonNegative("nope"), 0);
+    assert.equal(round9NonNegative(Number.NaN), 0);
+    assert.equal(round9NonNegative(null), 0);
+  });
+  test("a positive rounds at 9dp", () => {
+    assert.equal(round9NonNegative("1.23456789012"), 1.23456789);
+  });
+});
+
+describe("captureStamp (#10948 -- the pair whose 'byte-for-byte' had drifted)", () => {
+  test("numeric-string epochs parse as epochs, not dates", () => {
+    const stamp = captureStamp("1723500000000");
+    assert.equal(stamp?.ms, 1723500000000);
+  });
+  test("an ISO string keeps its own serialization", () => {
+    const iso = "2026-08-13T00:00:00.000Z";
+    assert.deepEqual(captureStamp(iso), { ms: Date.parse(iso), value: iso });
+  });
+  test("garbage, null, and non-positive epochs read as null", () => {
+    assert.equal(captureStamp("not a date"), null);
+    assert.equal(captureStamp(null), null);
+    assert.equal(captureStamp(0), null);
+    assert.equal(captureStamp(-5), null);
+    assert.equal(epochMsStamp(Number.NaN), null);
+  });
+});


### PR DESCRIPTION
Part of epic #10992. Closes #10948.

## Measured fresh, hashed before touching

The issue's numbers predate #10947/#10966–#10969 (which already killed the RAO/round9/
toNumber/nullable families — verified zero remaining). The real remainder: **eleven
duplicate body-groups across ~44 files**, every group SHA-hashed before collapsing, migrated
in four batches with each touched family's suite run per batch.

## Six survivors, one per distinct behaviour

| survivor | replaces |
| --- | --- |
| `roundDp` (new) | the **16-way byte-identical** `round(value, dp=2)` + three 6dp `roundTao`/`roundShare` wearing domain names |
| `roundBelowOne` (new) | the sub-1 saturation clamp: 4× `round`, **8× `roundConcentration`** (`0.9999` IS `(10⁴−1)/10⁴`), 2× `roundShare` |
| `round9OrZero` (existing) | seven `roundTao` copies exactly — the finite-guard quad + the `numberOrZero` trio |
| `round9NonNegative` (new) | two copies that clamp negatives first — a **different contract kept separate**: the clamp is the meaning |
| `round9OrNull` (existing) | the null-preserving nominator-positions copy |
| `roundDpOrNull` (new) | the null-in-null-out generic four modules carried privately |

Plus the pair the issue's history predicted: `captureStamp`/`epochMsStamp`, annotated
*"a deliberate byte-for-byte copy"* — and **not byte-for-byte**, in the exact tradition this
issue exists to end (behaviour verified identical before extraction; the licensing comment
is deleted). Now `src/lib/capture-stamp.ts`.

## The per-batch suites caught my own bug

A mechanical rewrite turned the median average in two performance modules into a comma
expression — the *"conventional median, not the lower-middle p50"* test failed exactly as
designed, and every rewritten call site was then re-audited for the same mangle class with a
paren-balanced parser, not the regex that caused it.

## Verification

- **Falsifiable outcome met**: zero duplicate round-family body groups remain (13 single-copy
  locals stay — legitimately distinct per-module helpers, per the issue's own rule)
- Survivor tests pin non-finite / negative / null / float-edge paths — including the real
  float behaviour (−1.235 rounds away from zero at 2dp, and the test says why)
- Full `npx vitest run`: **20510 passed** · patch coverage by lcov ∩ diff: 0 gaps
- `tsc` · `lint` · `format:check` · byte-identical emitted contract
- Ledger: **net −64** including the 90-line survivor suite (src alone **−154**)