### PR TITLE
refactor(schemas): twenty-six vocabularies were hiding behind type annotations

### DIFF
--- a/apps/ui/src/components/metagraphed/account-holdings-history.tsx
+++ b/apps/ui/src/components/metagraphed/account-holdings-history.tsx
@@ -7,6 +7,7 @@ import { Panel } from "@/components/metagraphed/primitives";
 import { accountPortfolioQuery, accountPositionHistoryQuery } from "@/lib/metagraphed/queries";
 import { classNames, formatNumber } from "@/lib/metagraphed/format";
 import type { AccountPositionHistory, PortfolioPosition } from "@/lib/metagraphed/types";
+import { CHART_PALETTE } from "@/lib/metagraphed/chart-palette";
 
 // The issue's 30d/90d/1y/max control, mapped onto the position-history API's
 // own window enum ("all" is the API spelling of "max").
@@ -35,14 +36,7 @@ const TOP_POSITIONS = 6;
  */
 const POSITIONS_PAGE_SIZE = 6;
 
-const CHART_COLORS = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "var(--chart-6)",
-] as const;
+const CHART_COLORS = CHART_PALETTE;
 
 function taoStr(v?: number | null) {
   if (v == null || !Number.isFinite(v)) return "—";

--- a/apps/ui/src/lib/metagraphed/chart-palette.ts
+++ b/apps/ui/src/lib/metagraphed/chart-palette.ts
@@ -1,0 +1,11 @@
+// The categorical chart palette, declared once (#10987 follow-up): the
+// holdings history chart and the explorer's call-mix legend each carried the
+// six-swatch list privately, and a seventh chart would have made a third.
+export const CHART_PALETTE = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+  "var(--chart-6)",
+] as const;

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -60,6 +60,7 @@ import { rovingTabIndex, useRovingTablist } from "@jsonbored/ui-kit";
 import { useHydrated } from "@/hooks/use-hydrated";
 import { ChainTabActions } from "./-chain-hub";
 import { BlockCard } from "./-blocks-index-page";
+import { CHART_PALETTE } from "@/lib/metagraphed/chart-palette";
 import type {
   ChainCalls,
   ChainEventsStats,
@@ -411,14 +412,7 @@ function MiniSeries({
  */
 // #3384: cycle the shared chart palette across the call-mix donut segments +
 // their legend swatches, matching providers.index.tsx's ProviderOverview.
-const CALL_MIX_PALETTE = [
-  "var(--chart-1)",
-  "var(--chart-2)",
-  "var(--chart-3)",
-  "var(--chart-4)",
-  "var(--chart-5)",
-  "var(--chart-6)",
-];
+const CALL_MIX_PALETTE = CHART_PALETTE;
 
 function CallMixSection({ calls }: { calls: ChainCalls }) {
   const modules = calls.calls.slice(0, 10);

--- a/schemas-src/mcp-tools/compare-subnets.ts
+++ b/schemas-src/mcp-tools/compare-subnets.ts
@@ -15,8 +15,12 @@
 // now publishes.
 import { z } from "zod";
 import { CompareArtifactSchema } from "../routes/compare.ts";
+import { COMPARE_DIMENSIONS as LIVE_COMPARE_DIMENSIONS } from "../../src/analytics-live.ts";
 
-const COMPARE_DIMENSIONS = ["structure", "economics", "health"] as const;
+// The dimensions the live comparator computes, imported from it rather than
+// restated (#10987 follow-up) -- a dimension added there is publishable here
+// the same moment.
+const COMPARE_DIMENSIONS = LIVE_COMPARE_DIMENSIONS;
 
 export const CompareSubnetsInputSchema = z
   .object({

--- a/schemas-src/mcp-tools/list-subnets.ts
+++ b/schemas-src/mcp-tools/list-subnets.ts
@@ -32,7 +32,11 @@ import {
   McpNetworkSchema,
 } from "../shared.ts";
 
-const LIST_SUBNETS_SORT_FIELDS = [
+// The DELIBERATE MCP-narrowed subset of the subnets collection's fourteen
+// sort fields (a tool pays for width in context, cf. the limit-ceiling rule:
+// the narrowing is a declaration, not drift). Exported as the subset's one
+// owner -- graphql and the dispatcher restated it by hand (#10987 follow-up).
+export const LIST_SUBNETS_SORT_FIELDS = [
   "netuid",
   "integration_readiness",
   "surface_count",

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -709,7 +709,10 @@ export const ROUTE_QUERY_SCHEMAS = {
     // recomputed daily. The route's own 400 has always named all six.
     // The enum IS TOP_HOLDERS_SORTS, read from the module that owns it.
     sort: sortSchema(
-      TOP_HOLDERS_SORTS as [string, ...string[]],
+      // Spread, not cast: the owner's tuple is readonly now that it derives
+      // from the route's declaration, and a copy for the schema builder is
+      // exactly what a mutable-cast would have pretended not to make.
+      [...TOP_HOLDERS_SORTS] as [string, ...string[]],
       "total_tao",
     ).optional(),
     limit: limitSchema(

--- a/schemas-src/routes/accounts-list.ts
+++ b/schemas-src/routes/accounts-list.ts
@@ -25,17 +25,10 @@
 // anywhere in schemas/components/*.schema.json (verified via repo-wide $ref
 // grep), so both hand-edited component keys become fully orphaned.
 import { z } from "zod";
+import { ACCOUNTS_LIST_SORTS } from "../../src/accounts-list.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
-export const ACCOUNTS_LIST_LIST_SORTS_VALUES = [
-  "total_stake",
-  "total_emission",
-  "subnet_count",
-  "uid_count",
-  "validator_count",
-  "stake_dominance",
-  "last_active",
-] as const;
+export const ACCOUNTS_LIST_LIST_SORTS_VALUES = ACCOUNTS_LIST_SORTS;
 
 const AccountsListSubnetSchema = z
   .object({

--- a/schemas-src/routes/global-validators.ts
+++ b/schemas-src/routes/global-validators.ts
@@ -12,17 +12,10 @@
 // GlobalValidatorEntry is its only referrer -- so that hand-edited key also
 // becomes fully orphaned.
 import { z } from "zod";
+import { GLOBAL_VALIDATOR_SORTS } from "../../src/metagraph-neurons.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
-export const GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES = [
-  "avg_validator_trust",
-  "max_validator_trust",
-  "stake_dominance",
-  "subnet_count",
-  "total_emission",
-  "total_stake",
-  "uid_count",
-] as const;
+export const GLOBAL_VALIDATORS_VALIDATOR_SORTS_VALUES = GLOBAL_VALIDATOR_SORTS;
 
 export const ColdkeyIdentitySchema = z
   .object({

--- a/schemas-src/routes/subnet-movers.ts
+++ b/schemas-src/routes/subnet-movers.ts
@@ -3,14 +3,10 @@
 // from src/movers.ts's buildMovers()/buildNetworkSummary(), cross-checked
 // against the hand-edited SubnetMoversArtifact component it replaces.
 import { z } from "zod";
+import { MOVERS_SORTS } from "../../src/movers.ts";
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
-export const SUBNET_MOVERS_MOVERS_SORTS_VALUES = [
-  "stake",
-  "emission",
-  "validators",
-  "neurons",
-] as const;
+export const SUBNET_MOVERS_MOVERS_SORTS_VALUES = MOVERS_SORTS;
 
 /** This route's own vocabulary, owned here so its MCP tool imports rather than restates it (#9799). */
 export const SUBNET_MOVERS_WINDOW_VALUES = ["7d", "30d", "90d"] as const;

--- a/scripts/build-network-registry.ts
+++ b/scripts/build-network-registry.ts
@@ -27,6 +27,7 @@ import { buildEconomicsArtifact } from "./lib/economics-artifacts.ts";
 // in the matrix (or the reverse) fails CI instead of silently skewing what we
 // tell agents is available.
 import {
+  EXPECTED_GAP_KINDS,
   artifactOutputPath,
   backfilledIdentityUrl,
   buildTimestamp,
@@ -60,17 +61,7 @@ export const NETWORK_REGISTRIES: NetworkRegistryConfig[] = [
 ];
 
 const SCHEMA_VERSION = 1;
-// Mirrors buildGaps' expected-kinds list in build-artifacts.ts.
-const EXPECTED_GAP_KINDS = [
-  "docs",
-  "source-repo",
-  "website",
-  "dashboard",
-  "openapi",
-  "subnet-api",
-  "sse",
-  "data-artifact",
-];
+// THE list, imported from the gap computation it used to mirror by hand.
 
 function nativeSlug(subnet: Row): string {
   const quality = nativeNameQuality(subnet);

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -2843,6 +2843,20 @@ export function extractAuth(spec: Row): Row {
  * be compared against itself is a bug generator, not a safety net. That is the
  * same shape subnetDisplayName was extracted for in #9767.
  */
+/** The surface kinds a subnet is EXPECTED to publish, whose absence is a gap.
+ * Owned here beside the gap computation; build-network-registry.ts restated
+ * it by hand with a comment admitting the mirror (#10987 follow-up). */
+export const EXPECTED_GAP_KINDS = [
+  "docs",
+  "source-repo",
+  "website",
+  "dashboard",
+  "openapi",
+  "subnet-api",
+  "sse",
+  "data-artifact",
+];
+
 export function buildSubnetGaps(
   surfaces: Row[],
   overlay: (Row & { curation?: Row }) | null | undefined,
@@ -2852,16 +2866,7 @@ export function buildSubnetGaps(
   if (overlay?.source_repo) kinds.add("source-repo");
   if (overlay?.website_url) kinds.add("website");
   if (overlay?.dashboard_url) kinds.add("dashboard");
-  const expectedKinds = [
-    "docs",
-    "source-repo",
-    "website",
-    "dashboard",
-    "openapi",
-    "subnet-api",
-    "sse",
-    "data-artifact",
-  ];
+  const expectedKinds = EXPECTED_GAP_KINDS;
   return {
     missing_kinds: expectedKinds.filter((kind) => !kinds.has(kind)),
     supported_kinds: [...kinds].sort(),

--- a/scripts/lib.ts
+++ b/scripts/lib.ts
@@ -2866,9 +2866,8 @@ export function buildSubnetGaps(
   if (overlay?.source_repo) kinds.add("source-repo");
   if (overlay?.website_url) kinds.add("website");
   if (overlay?.dashboard_url) kinds.add("dashboard");
-  const expectedKinds = EXPECTED_GAP_KINDS;
   return {
-    missing_kinds: expectedKinds.filter((kind) => !kinds.has(kind)),
+    missing_kinds: EXPECTED_GAP_KINDS.filter((kind) => !kinds.has(kind)),
     supported_kinds: [...kinds].sort(),
     // #9746: surfaces whose URL names a moving target, so the operator may
     // publish a parameterized sibling beside them that this registry does not

--- a/scripts/validate-graphql-hand-written-checks.ts
+++ b/scripts/validate-graphql-hand-written-checks.ts
@@ -80,7 +80,9 @@ import { readFileSync } from "node:fs";
 // cross-field semantics the schema cannot express, and saved_query (the one
 // route:null binding). tests/graphql.test.ts pins the dispatch-level
 // rejection for a representative of every deleted class.
-const CEILING = 185;
+// 185 -> 179: four more sort guards proven dispatch-covered and deleted in
+// the annotated-consts sweep (probe log on the PR), same method as #10993.
+const CEILING = 179;
 
 const SOURCE = "src/graphql.ts";
 

--- a/scripts/validate-schema-shape-duplicates.ts
+++ b/scripts/validate-schema-shape-duplicates.ts
@@ -52,7 +52,7 @@ const repoRoot = path.resolve(
 // hand in src/ and stay green forever -- the same blindness #10987 fixed for
 // the enum-vocabulary gate. ts.sys.readDirectory recurses, so "src" covers
 // src/graphql/ and "workers" covers workers/request-handlers/.
-const SCAN_ROOTS = ["schemas-src", "src", "workers"];
+export const SCAN_ROOTS = ["schemas-src", "src", "workers"];
 /** Below this, a shared key set is coincidence rather than lineage. */
 const MIN_KEYS = 4;
 

--- a/scripts/validate-schema-vocabularies.ts
+++ b/scripts/validate-schema-vocabularies.ts
@@ -75,6 +75,11 @@ const COINCIDENT_BY_DOMAIN: Record<string, string[]> = {
     "schemas-src/routes/subnet-turnover.ts",
   ],
   "30d|7d|90d": [
+    // The UI's two deliberate literals, each with its reason in-file: the
+    // subnet page's control drives several routes at once, and the APY
+    // basis's overlap with route windows is coincidence, not lineage (#10994).
+    "apps/ui/src/lib/metagraphed/subnet-window-helpers.ts",
+    "apps/ui/src/routes/-validators-hotkey-page.tsx",
     "schemas-src/routes/account-activity-registrations.ts",
     "schemas-src/routes/account-activity.ts",
     "schemas-src/routes/chain-turnover.ts",
@@ -121,6 +126,9 @@ const COINCIDENT_BY_DOMAIN: Record<string, string[]> = {
   "account_events|blocks|chain_events|extrinsics": [
     "src/decode-watermark.ts",
     "apps/ui/src/hooks/use-chain-stream.ts",
+    // Visible since the extraction learned annotated consts (#11045 tracks
+    // publishing the topics parameter so the UI copy can derive).
+    "scripts/generate-lakehouse-types.ts",
   ],
   "coldkey|hotkey|netuid": [
     "src/evm-precompiles.ts",
@@ -182,7 +190,12 @@ for (const dir of SCHEMA_DIRS) {
     for (const match of source.matchAll(/z\s*\.enum\(\s*\[([^\]]*)\]\s*\)/g))
       push(match[1]);
     for (const match of source.matchAll(
-      /(?:export )?const \w+\s*=\s*\[([^\]]*)\]\s*as const;/g,
+      // The optional type annotation matters: `const X: readonly string[] =`
+      // broke the unannotated form and made DECODER_TABLES invisible -- a
+      // vocabulary could hide from this gate by stating its own type (#11045
+      // records the pair that did). `as const` is optional for the same
+      // reason: an annotated tuple does not need it.
+      /(?:export )?const \w+(?:\s*:[^=]+)?\s*=\s*\[([^\]]*)\]\s*(?:as const)?;/g,
     ))
       push(match[1]);
     // A vocabulary declared as an OBJECT PROPERTY (#10060). This gate matched

--- a/scripts/validate-unreferenced-modules.ts
+++ b/scripts/validate-unreferenced-modules.ts
@@ -25,6 +25,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
+import { SCAN_ROOTS } from "./validate-schema-shape-duplicates.ts";
 
 /**
  * Files that are genuinely unreferenced and stay.
@@ -35,8 +36,10 @@ import { repoRoot } from "./lib.ts";
  */
 const DECLARED: Record<string, string> = {};
 
-/** Directories whose `.ts` files are library modules, reached by import only. */
-const LIBRARY_DIRS = ["src", "workers", "schemas-src"];
+/** Directories whose `.ts` files are library modules, reached by import only.
+ * The same three trees the shape gate scans, and imported from it so the two
+ * gates cannot watch different worlds (#10987 follow-up). */
+const LIBRARY_DIRS = SCAN_ROOTS;
 
 /** Where a script may be named from, beyond an import. */
 const INVOCATION_ROOTS = [

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -705,7 +705,7 @@ export async function loadValidatorNominatorsColdTier(
   const sort = query.sort ?? DEFAULT_NOMINATOR_SORT;
   // A sort this tier cannot express would otherwise silently serve the default
   // ordering under the caller's requested label -- decline instead.
-  if (!NOMINATOR_SORTS.includes(sort)) return null;
+  if (!(NOMINATOR_SORTS as readonly string[]).includes(sort)) return null;
 
   const where = [
     `hotkey = '${addr}'`,

--- a/src/candidates-mcp.ts
+++ b/src/candidates-mcp.ts
@@ -11,13 +11,14 @@ import {
   ListCandidatesOutputSchema,
 } from "../schemas-src/mcp-tools/registry-catalogs-1.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import { CONFIDENCE_LEVEL_VALUES } from "../schemas-src/shared.ts";
 
 export const CANDIDATES_ARTIFACT = "/metagraph/candidates.json";
 
 const CANDIDATES_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
 const CANDIDATE_STATES = QUERY_ENUMS.candidateState;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const CONFIDENCE_LEVELS = CONFIDENCE_LEVEL_VALUES;
 
 export interface CandidatesMcpError extends Error {
   toolError: true;

--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -62,6 +62,7 @@ import {
   type WaitUntilLike,
 } from "./pg-sql.ts";
 import { readStore, type ReadStoreDb } from "./read-store.ts";
+import { CHAIN_DETAIL_HOT_TIER_TABLES } from "./chain-detail-hot-tier.ts";
 
 /** ~6h at the chain's 12s cadence: 3x the hourly decode lane's worst-case lag. */
 export const CHAIN_DETAIL_MIN_RETAINED_BLOCKS = 1_800;
@@ -94,7 +95,21 @@ const PRUNE_TABLES = [
   "chain_detail_chain_events",
   "chain_detail_account_events",
   "chain_detail_blocks",
-];
+  // The ORDER above is this module's meaning (children before blocks, per the
+  // comment) -- so this cannot alias the hot tier's list. The satisfies
+  // clause pins every member to CHAIN_DETAIL_HOT_TIER_TABLES, and
+  // PruneCoversHotTier makes a table added to the hot tier but missing here a
+  // type error: a table served but never pruned grows without bound.
+] as const satisfies readonly (typeof CHAIN_DETAIL_HOT_TIER_TABLES)[number][];
+type PruneCoversHotTier =
+  Exclude<
+    (typeof CHAIN_DETAIL_HOT_TIER_TABLES)[number],
+    (typeof PRUNE_TABLES)[number]
+  > extends never
+    ? true
+    : never;
+const _pruneCoversHotTier: PruneCoversHotTier = true;
+void _pruneCoversHotTier;
 
 export interface PruneWindow {
   /** Lowest block the tier should still hold. */

--- a/src/endpoint-pools-mcp.ts
+++ b/src/endpoint-pools-mcp.ts
@@ -10,11 +10,12 @@ import {
   ListEndpointPoolsOutputSchema,
 } from "../schemas-src/mcp-tools/endpoint-pools-and-provider.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import { RPC_POOL_KIND_VALUES } from "../schemas-src/query-params.ts";
 
 export const ENDPOINT_POOLS_ARTIFACT = "/metagraph/endpoint-pools.json";
 
 const POOL_SORT_FIELDS = API_QUERY_COLLECTIONS["endpoint-pools"].sort_fields;
-const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"];
+const POOL_KINDS = RPC_POOL_KIND_VALUES;
 
 export interface EndpointPoolsMcpError extends Error {
   toolError: true;

--- a/src/enrichment-evidence-mcp.ts
+++ b/src/enrichment-evidence-mcp.ts
@@ -11,6 +11,10 @@ import {
   ListEnrichmentEvidenceOutputSchema,
 } from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import {
+  REVIEW_EVIDENCE_ACTION_VALUES,
+  REVIEW_ENRICHMENT_LANE_VALUES,
+} from "../schemas-src/routes/review-enrichment.ts";
 
 export const ENRICHMENT_EVIDENCE_ARTIFACT =
   "/metagraph/review/enrichment-evidence.json";
@@ -18,21 +22,8 @@ export const ENRICHMENT_EVIDENCE_ARTIFACT =
 const EVIDENCE_SORT_FIELDS =
   API_QUERY_COLLECTIONS["enrichment-evidence"].sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
-const EVIDENCE_ACTIONS = [
-  "submit-new-evidence",
-  "verify-existing-evidence",
-  "replace-stale-evidence",
-  "review-existing-evidence",
-  "maintainer-review-existing-evidence",
-  "monitor",
-];
-const LANES = [
-  "direct-submission",
-  "maintainer-review",
-  "adapter-candidate",
-  "monitoring-followup",
-  "baseline-monitoring",
-];
+const EVIDENCE_ACTIONS = REVIEW_EVIDENCE_ACTION_VALUES;
+const LANES = REVIEW_ENRICHMENT_LANE_VALUES;
 
 export interface EnrichmentEvidenceMcpError extends Error {
   toolError: true;

--- a/src/enrichment-queue-mcp.ts
+++ b/src/enrichment-queue-mcp.ts
@@ -16,6 +16,11 @@ import {
   ListEnrichmentQueueOutputSchema,
 } from "../schemas-src/mcp-tools/enrichment-queue-and-candidates.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import { IDENTITY_LEVEL_VALUES } from "../schemas-src/shared.ts";
+import {
+  REVIEW_EVIDENCE_ACTION_VALUES,
+  REVIEW_ENRICHMENT_LANE_VALUES,
+} from "../schemas-src/routes/review-enrichment.ts";
 
 export const ENRICHMENT_QUEUE_ARTIFACT =
   "/metagraph/review/enrichment-queue.json";
@@ -24,22 +29,9 @@ const QUEUE_SORT_FIELDS = API_QUERY_COLLECTIONS["enrichment-queue"].sort_fields;
 const CURATION_LEVELS = QUERY_ENUMS.curationLevel;
 const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
-const EVIDENCE_ACTIONS = [
-  "submit-new-evidence",
-  "verify-existing-evidence",
-  "replace-stale-evidence",
-  "review-existing-evidence",
-  "maintainer-review-existing-evidence",
-  "monitor",
-];
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
-const LANES = [
-  "direct-submission",
-  "maintainer-review",
-  "adapter-candidate",
-  "monitoring-followup",
-  "baseline-monitoring",
-];
+const EVIDENCE_ACTIONS = REVIEW_EVIDENCE_ACTION_VALUES;
+const IDENTITY_LEVELS = IDENTITY_LEVEL_VALUES;
+const LANES = REVIEW_ENRICHMENT_LANE_VALUES;
 
 export interface EnrichmentQueueMcpError extends Error {
   toolError: true;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -347,7 +347,6 @@ import {
   DEFAULT_TOP_HOLDERS_SORT,
   TOP_HOLDERS_LIMIT_DEFAULT,
   TOP_HOLDERS_LIMIT_MAX,
-  TOP_HOLDERS_SORTS,
 } from "./top-holders.ts";
 import {
   buildSubnetHolders,
@@ -524,7 +523,6 @@ import { computeStakeQuote, STAKE_QUOTE_DIRECTIONS } from "./stake-quote.ts";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
   ACCOUNTS_LIST_LIMIT_MAX,
-  ACCOUNTS_LIST_SORTS,
   DEFAULT_ACCOUNTS_LIST_SORT,
   buildAccountsList,
 } from "./accounts-list.ts";
@@ -633,7 +631,6 @@ import {
 import {
   DEFAULT_MOVERS_SORT,
   DEFAULT_MOVERS_WINDOW,
-  MOVERS_SORTS,
   buildMovers,
 } from "./movers.ts";
 import {
@@ -1942,13 +1939,6 @@ async function loadProviderSubnets(context: GqlContext, netuids: number[]) {
 // delegated wholesale to list_subnets' own categoricalFilterSubnets/
 // rangeFilterSubnets (imported), so the earlier hand-rolled inclusion-only
 // matchesSubnetListFilters is retired in favor of that shared, negation-aware
-// helper -- keeping the two surfaces from drifting.
-const SUBNET_SORT_FIELDS = [
-  "netuid",
-  "integration_readiness",
-  "surface_count",
-  "name",
-];
 
 // Shared list shape: load → optional netuid filter → paginate → wrap. `map`
 // node-wraps rows; `resultKey` is the list field's name (economics uses
@@ -2232,15 +2222,6 @@ const rootValue = {
     // inclusion + negation, min_/max_ range bounds, and sort/order -- by reusing
     // its exact shared helpers rather than reimplementing the filter logic.
     const { netuid, network, limit, cursor, sort, order } = args;
-    // Same allow-lists list_subnets validates against (LIST_SUBNETS_SORT_FIELDS /
-    // asc|desc); an unsupported value is a GraphQL BAD_USER_INPUT error, not a
-    // silently ignored arg.
-    if (sort != null && !SUBNET_SORT_FIELDS.includes(sort)) {
-      throw new GraphQLError(
-        `"${sort}" is not a supported sort. Supported: ${SUBNET_SORT_FIELDS.join(", ")}.`,
-        { extensions: { code: "BAD_USER_INPUT" } },
-      );
-    }
     if (order != null && order !== "asc" && order !== "desc") {
       throw new GraphQLError(
         `"${order}" is not a supported order. Supported: asc, desc.`,
@@ -2580,16 +2561,6 @@ const rootValue = {
     { sort, limit }: QueryTop_HoldersArgs,
     context: GqlContext,
   ) {
-    // Same allowlist REST enforces -- an unknown sort is BAD_USER_INPUT rather
-    // than silently falling back, mirroring the route's invalid_query 400.
-    if (sort != null && !TOP_HOLDERS_SORTS.includes(sort)) {
-      throw new GraphQLError(
-        `sort must be one of: ${TOP_HOLDERS_SORTS.join(", ")}.`,
-        {
-          extensions: { code: "BAD_USER_INPUT" },
-        },
-      );
-    }
     const safeSort = sort ?? DEFAULT_TOP_HOLDERS_SORT;
     const safeLimit = clampLimit(limit, {
       defaultLimit: TOP_HOLDERS_LIMIT_DEFAULT,
@@ -6379,12 +6350,6 @@ const rootValue = {
 
   async accounts({ sort, limit }: QueryAccountsArgs, context: GqlContext) {
     const requestedSort = sort ?? DEFAULT_ACCOUNTS_LIST_SORT;
-    if (!ACCOUNTS_LIST_SORTS.includes(requestedSort)) {
-      throw new GraphQLError(
-        `"${requestedSort}" is not a supported sort. Supported: ${ACCOUNTS_LIST_SORTS.join(", ")}.`,
-        { extensions: { code: "BAD_USER_INPUT" } },
-      );
-    }
     const safeLimit = clampLimit(limit, {
       defaultLimit: ACCOUNTS_LIST_LIMIT_DEFAULT,
       maxLimit: ACCOUNTS_LIST_LIMIT_MAX,
@@ -7713,12 +7678,6 @@ const rootValue = {
   ) {
     const requestedWindow = window ?? DEFAULT_MOVERS_WINDOW;
     const requestedSort = sort ?? DEFAULT_MOVERS_SORT;
-    if (!MOVERS_SORTS.includes(requestedSort)) {
-      throw new GraphQLError(
-        `"${requestedSort}" is not a supported sort. Supported: ${MOVERS_SORTS.join(", ")}.`,
-        { extensions: { code: "BAD_USER_INPUT" } },
-      );
-    }
     // `limit` arrives clamped and defaulted by the dispatch parse (#10316), so
     // neither the `?? MOVERS_LIMIT_DEFAULT` nor the range check that used to
     // stand here can do anything: the value is already inside the range the

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -45,6 +45,7 @@ import {
   SearchSubnetsOutputSchema,
 } from "../schemas-src/mcp-tools/search-subnets.ts";
 import {
+  LIST_SUBNETS_SORT_FIELDS,
   ListSubnetsInputSchema,
   ListSubnetsOutputSchema,
 } from "../schemas-src/mcp-tools/list-subnets.ts";
@@ -1773,6 +1774,7 @@ import {
   TAO_USD_TABLES,
   UPTIME_DAILY_TABLES,
 } from "./read-store-tables.ts";
+import { COVERAGE_DEPTH_SEVERITIES as ROUTE_COVERAGE_DEPTH_SEVERITIES } from "../schemas-src/routes/coverage.ts";
 
 type Row = Record<string, unknown>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -4850,12 +4852,7 @@ function searchResponse(
 
 // Fields list_subnets can sort by. Kept in one place so the inputSchema enum and
 // the runtime validation can't drift.
-const LIST_SUBNETS_SORT_FIELDS = [
-  "netuid",
-  "integration_readiness",
-  "surface_count",
-  "name",
-];
+
 const LIST_SUBNETS_ORDERS = ["asc", "desc"];
 
 /**
@@ -5130,15 +5127,10 @@ function scoreDocument(doc: Row, terms: string[]) {
   );
 }
 
-const COVERAGE_DEPTH_TIERS = [
-  "agent-ready",
-  "machine-usable",
-  "candidate-review",
-  "needs-evidence",
-  "hard-blocked",
-  "missing-interface",
-];
-const COVERAGE_DEPTH_SEVERITIES = ["hard", "missing-data", "needs-review"];
+// Derived from the owners (#10987 follow-up): both were restated here by
+// hand while coverage.ts already single-sourced them.
+const COVERAGE_DEPTH_TIERS = QUERY_ENUMS.coverageDepthTier;
+const COVERAGE_DEPTH_SEVERITIES = ROUTE_COVERAGE_DEPTH_SEVERITIES;
 
 // Generic in the member type so a caller passing a `readonly ["a","b"]` gets
 // back `"a" | "b" | null` rather than a bare string -- the guard already proves

--- a/src/profile-completeness-mcp.ts
+++ b/src/profile-completeness-mcp.ts
@@ -12,6 +12,11 @@ import {
   ListProfileCompletenessOutputSchema,
 } from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import {
+  IDENTITY_LEVEL_VALUES,
+  NATIVE_NAME_QUALITY_VALUES,
+  CONFIDENCE_LEVEL_VALUES,
+} from "../schemas-src/shared.ts";
 
 export const PROFILE_COMPLETENESS_ARTIFACT =
   "/metagraph/review/profile-completeness.json";
@@ -20,9 +25,9 @@ const PROFILE_SORT_FIELDS =
   API_QUERY_COLLECTIONS["profile-completeness"].sort_fields;
 const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"];
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
-const NATIVE_NAME_QUALITIES = ["chain", "placeholder", "empty"];
+const CONFIDENCE_LEVELS = CONFIDENCE_LEVEL_VALUES;
+const IDENTITY_LEVELS = IDENTITY_LEVEL_VALUES;
+const NATIVE_NAME_QUALITIES = NATIVE_NAME_QUALITY_VALUES;
 
 export interface ProfileCompletenessMcpError extends Error {
   toolError: true;

--- a/src/revenue-serving.ts
+++ b/src/revenue-serving.ts
@@ -27,6 +27,7 @@
 // consistent while the number was 200x wrong. That is why the checks below
 // assert things a wrong SUM would fail, not only things a wrong RATIO would.
 import { computeCoverage, type CoverageResult } from "./revenue-coverage.ts";
+import { REVENUE_PROVENANCE_VALUES } from "../schemas-src/routes/revenue-coverage.ts";
 
 /** One observed figure, for one surface, for one period. The probe lane writes
  * these to `revenue_observations` keyed on (surface_id, period). */
@@ -99,7 +100,20 @@ const PROVENANCE_RANK = [
   "third-party-reported",
   "proxy-only",
   "none",
-];
+  // The ORDER is this module's meaning -- strongest evidence first -- so this
+  // cannot simply alias the owner's set. The satisfies clause pins every
+  // member to REVENUE_PROVENANCE_VALUES (a rename or removal fails to
+  // compile), and RankIsComplete makes a MISSING member a type error too.
+] as const satisfies readonly (typeof REVENUE_PROVENANCE_VALUES)[number][];
+type RankIsComplete =
+  Exclude<
+    (typeof REVENUE_PROVENANCE_VALUES)[number],
+    (typeof PROVENANCE_RANK)[number]
+  > extends never
+    ? true
+    : never;
+const _rankIsComplete: RankIsComplete = true;
+void _rankIsComplete;
 
 /**
  * Days one period of each grain covers.

--- a/src/review-enrichment-targets-mcp.ts
+++ b/src/review-enrichment-targets-mcp.ts
@@ -17,6 +17,14 @@ import {
   ListReviewEnrichmentTargetsOutputSchema,
 } from "../schemas-src/mcp-tools/enrichment-evidence-and-targets.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import { IDENTITY_LEVEL_VALUES } from "../schemas-src/shared.ts";
+import {
+  REVIEW_ENRICHMENT_TARGET_TYPE_VALUES,
+  REVIEW_ENRICHMENT_TARGET_ACTION_VALUES,
+  REVIEW_EVIDENCE_ACTION_VALUES,
+  REVIEW_ENRICHMENT_LANE_VALUES,
+  REVIEW_ENRICHMENT_SUBMISSION_ROUTE_VALUES,
+} from "../schemas-src/routes/review-enrichment.ts";
 
 export const REVIEW_ENRICHMENT_TARGETS_ARTIFACT =
   "/metagraph/review/enrichment-targets.json";
@@ -25,43 +33,12 @@ const TARGET_SORT_FIELDS =
   API_QUERY_COLLECTIONS["enrichment-targets"].sort_fields;
 const PROFILE_LEVELS = QUERY_ENUMS.profileLevel;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
-const EVIDENCE_ACTIONS = [
-  "submit-new-evidence",
-  "verify-existing-evidence",
-  "replace-stale-evidence",
-  "review-existing-evidence",
-  "maintainer-review-existing-evidence",
-  "monitor",
-];
-const IDENTITY_LEVELS = ["none", "directory", "partial", "complete"];
-const LANES = [
-  "direct-submission",
-  "maintainer-review",
-  "adapter-candidate",
-  "monitoring-followup",
-  "baseline-monitoring",
-];
-const SUBMISSION_ROUTES = [
-  "direct-candidate-pr",
-  "adapter-request",
-  "maintainer-review",
-  "status-report",
-];
-const TARGET_ACTIONS = [
-  "submit-new-candidate",
-  "replace-stale-candidate",
-  "verify-existing-candidate",
-  "review-existing-candidate",
-  "adapter-review",
-  "maintainer-review",
-  "monitoring-followup",
-];
-const TARGET_TYPES = [
-  "surface-candidate",
-  "adapter-review",
-  "maintainer-review",
-  "monitoring-followup",
-];
+const EVIDENCE_ACTIONS = REVIEW_EVIDENCE_ACTION_VALUES;
+const IDENTITY_LEVELS = IDENTITY_LEVEL_VALUES;
+const LANES = REVIEW_ENRICHMENT_LANE_VALUES;
+const SUBMISSION_ROUTES = REVIEW_ENRICHMENT_SUBMISSION_ROUTE_VALUES;
+const TARGET_ACTIONS = REVIEW_ENRICHMENT_TARGET_ACTION_VALUES;
+const TARGET_TYPES = REVIEW_ENRICHMENT_TARGET_TYPE_VALUES;
 
 export interface ReviewEnrichmentTargetsMcpError extends Error {
   toolError: true;

--- a/src/rpc-pools-mcp.ts
+++ b/src/rpc-pools-mcp.ts
@@ -18,11 +18,12 @@ import {
 } from "../schemas-src/mcp-tools/registry-catalogs-2.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
 import { LIVE_CRON_PROBER } from "./field-provenance.ts";
+import { RPC_POOL_KIND_VALUES } from "../schemas-src/query-params.ts";
 
 export const RPC_POOLS_ARTIFACT = "/metagraph/rpc/pools.json";
 
 const POOL_SORT_FIELDS = API_QUERY_COLLECTIONS["rpc-pools"].sort_fields;
-const POOL_KINDS = ["subtensor-rpc", "subtensor-wss", "archive"];
+const POOL_KINDS = RPC_POOL_KIND_VALUES;
 
 export interface RpcPoolsMcpError extends Error {
   toolError: true;

--- a/src/subnet-candidates-mcp.ts
+++ b/src/subnet-candidates-mcp.ts
@@ -12,11 +12,12 @@ import {
   ListSubnetCandidatesOutputSchema,
 } from "../schemas-src/mcp-tools/subnet-registry-lists.ts";
 import { inputJsonSchema, outputJsonSchema } from "./mcp-input-schema.ts";
+import { CONFIDENCE_LEVEL_VALUES } from "../schemas-src/shared.ts";
 
 const CANDIDATE_SORT_FIELDS = API_QUERY_COLLECTIONS.candidates.sort_fields;
 const SURFACE_KINDS = QUERY_ENUMS.surfaceKind;
 const CANDIDATE_STATES = QUERY_ENUMS.candidateState;
-const CONFIDENCE_LEVELS = ["low", "medium", "high"];
+const CONFIDENCE_LEVELS = CONFIDENCE_LEVEL_VALUES;
 // netuid is the path param (excluded from the REST list query); the remaining
 // candidates filters are all query-string filters, applied over the artifact.
 const SUBNET_CANDIDATES_QUERY_FILTER_NAMES = [

--- a/src/top-holders.ts
+++ b/src/top-holders.ts
@@ -5,6 +5,7 @@ import {
   TOP_HOLDERS_LIMIT_DEFAULT,
   TOP_HOLDERS_LIMIT_MAX,
 } from "./route-limits.ts";
+import { TOP_HOLDERS_SORT_VALUES } from "../schemas-src/routes/top-holders.ts";
 export { TOP_HOLDERS_LIMIT_DEFAULT, TOP_HOLDERS_LIMIT_MAX };
 // Balance-based top-holder leaderboard (#6741/#6743) -- the coldkey/balance-
 // centric counterpart to src/accounts-list.ts (hotkey/neuron-centric,
@@ -60,14 +61,7 @@ export { TOP_HOLDERS_LIMIT_DEFAULT, TOP_HOLDERS_LIMIT_MAX };
 
 type Row = Record<string, unknown>;
 
-export const TOP_HOLDERS_SORTS = [
-  "total_tao",
-  "free_tao",
-  "delegated_tao",
-  "net_flow_7d",
-  "net_flow_30d",
-  "net_flow_90d",
-];
+export const TOP_HOLDERS_SORTS = TOP_HOLDERS_SORT_VALUES;
 export const DEFAULT_TOP_HOLDERS_SORT = "total_tao";
 
 function toIso(ms: unknown): string | null {
@@ -171,7 +165,7 @@ export function buildTopHoldersList(
     limit = TOP_HOLDERS_LIMIT_DEFAULT,
   }: { sort?: string; limit?: unknown } = {},
 ): Row {
-  const normalizedSort = TOP_HOLDERS_SORTS.includes(sort)
+  const normalizedSort = (TOP_HOLDERS_SORTS as readonly string[]).includes(sort)
     ? sort
     : DEFAULT_TOP_HOLDERS_SORT;
   const normalizedLimit = clampRowLimit(

--- a/src/validator-nominators.ts
+++ b/src/validator-nominators.ts
@@ -1,5 +1,6 @@
 import { clampRowLimit } from "../workers/request-params.ts";
 import { round9OrZero, finiteCellOrNull } from "./lib/rao.ts";
+import { VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES } from "../schemas-src/routes/validator-nominators.ts";
 // Nominator list for one validator hotkey (#4334/7.2): who has staked to this
 // validator (across every subnet it operates in), derived from the same
 // StakeAdded/StakeRemoved account_events flow src/account-stake-flow.ts
@@ -23,7 +24,7 @@ export const NOMINATOR_WINDOWS: Record<string, number> = {
 };
 export const DEFAULT_NOMINATOR_WINDOW = "30d";
 
-export const NOMINATOR_SORTS = ["net_staked", "gross_staked", "last_activity"];
+export const NOMINATOR_SORTS = VALIDATOR_NOMINATORS_NOMINATOR_SORTS_VALUES;
 export const DEFAULT_NOMINATOR_SORT = "net_staked";
 export const NOMINATOR_LIMIT_DEFAULT = 20;
 export const NOMINATOR_LIMIT_MAX = 100;
@@ -189,7 +190,7 @@ export function buildValidatorNominators(
     alreadyPaged?: boolean;
   } = {},
 ): Row {
-  const normalizedSort = NOMINATOR_SORTS.includes(sort)
+  const normalizedSort = (NOMINATOR_SORTS as readonly string[]).includes(sort)
     ? sort
     : DEFAULT_NOMINATOR_SORT;
   // NOMINATOR_LIMIT_MAX bounds the IN-MEMORY slice below, and only that. When

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -25008,6 +25008,11 @@ describe("revenue coverage over GraphQL (#10476)", () => {
 // never did).
 describe("deleted resolver guards: the dispatch still refuses, with its own sentence (#10993)", () => {
   const CASES: Array<[string, string]> = [
+    // sort guards found dead in the annotated-consts sweep (4 more deleted)
+    ["subnets", `subnets(sort: "__bogus__") { __typename }`],
+    ["accounts", `accounts(sort: "__bogus__") { __typename }`],
+    ["top_holders_sort", `top_holders(sort: "__bogus__")`],
+    ["subnet_movers_sort", `subnet_movers(sort: "__bogus__") { __typename }`],
     // window guards (27 deleted)
     ["subnet_movers", `subnet_movers(window: "__bogus__") { __typename }`],
     [

--- a/tests/subnet-gaps-expected-kinds.test.ts
+++ b/tests/subnet-gaps-expected-kinds.test.ts
@@ -1,0 +1,39 @@
+// buildSubnetGaps and its expected-kinds vocabulary (#11053).
+//
+// The vocabulary was declared twice (scripts/lib.ts's inline list and
+// build-network-registry's mirror-by-comment); it is EXPECTED_GAP_KINDS now,
+// and this exercises the gap computation the measured suites never called
+// directly -- which is exactly how the duplicate lived unmeasured.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildSubnetGaps, EXPECTED_GAP_KINDS } from "../scripts/lib.ts";
+import type { Row } from "./row-type.ts";
+
+describe("buildSubnetGaps (#11053)", () => {
+  test("a kind the subnet publishes is not a gap; every absent expected kind is", () => {
+    const gaps = buildSubnetGaps(
+      [{ kind: "openapi" }, { kind: "subnet-api" }] as Row[],
+      { docs_url: "https://example.com/docs" } as Row,
+    );
+    const missing = gaps.missing_kinds as string[];
+    assert.ok(!missing.includes("openapi"));
+    assert.ok(!missing.includes("docs"), "overlay docs_url satisfies docs");
+    for (const kind of ["website", "dashboard", "sse", "data-artifact"]) {
+      assert.ok(missing.includes(kind), `${kind} must be reported missing`);
+    }
+    // Every reported gap is a member of the one declared vocabulary.
+    for (const kind of missing) {
+      assert.ok((EXPECTED_GAP_KINDS as readonly string[]).includes(kind));
+    }
+  });
+
+  test("a fully-published subnet has no gaps", () => {
+    const gaps = buildSubnetGaps(
+      (EXPECTED_GAP_KINDS as readonly string[]).map((kind) => ({
+        kind,
+      })) as Row[],
+      null,
+    );
+    assert.deepEqual(gaps.missing_kinds, []);
+  });
+});

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -1169,13 +1169,16 @@ const CHAIN_REGISTRATIONS_CSV_COLUMNS = [
 ];
 
 // The whole row (#10263): five flat scalars, no nested object to serialize.
-const CHAIN_SUBNET_LIFECYCLE_CSV_COLUMNS = [
+// Exported: the per-subnet lifecycle route serves the SAME row shape and
+// restated this list by hand (#10987 follow-up).
+export const LIFECYCLE_CSV_COLUMNS = [
   "netuid",
   "event",
   "block_number",
   "observed_at",
   "predates_capture",
 ];
+const CHAIN_SUBNET_LIFECYCLE_CSV_COLUMNS = LIFECYCLE_CSV_COLUMNS;
 const CHAIN_DEREGISTRATIONS_CSV_COLUMNS = [
   "netuid",
   "distinct_deregistered_hotkeys",

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -52,6 +52,7 @@ import {
   validateResponseTripwire,
 } from "../../src/response-validation-tripwire.ts";
 import {
+  LIFECYCLE_CSV_COLUMNS,
   analyticsQueryError,
   markDataApiTierFallbackResponse,
 } from "./analytics.ts";
@@ -731,13 +732,7 @@ const SUBNET_HYPERPARAMS_HISTORY_CSV_COLUMNS = [
 // `netuid` is kept even on the per-subnet route, so a CSV saved from
 // /subnets/7/lifecycle still says which subnet it describes once detached from
 // the URL it came from.
-const SUBNET_LIFECYCLE_CSV_COLUMNS = [
-  "netuid",
-  "event",
-  "block_number",
-  "observed_at",
-  "predates_capture",
-];
+const SUBNET_LIFECYCLE_CSV_COLUMNS = LIFECYCLE_CSV_COLUMNS;
 const ACCOUNT_EXTRINSICS_CSV_COLUMNS = [
   "extrinsic_id",
   "block_number",


### PR DESCRIPTION
Part of epic #10992. Closes #11053.

## The blindness

The vocabulary gate's declaration extraction required `= [...] as const` — a type annotation
broke the regex, so **`const X: readonly string[] = [...]` could hide from the gate by
stating its own type**. Widening the extraction (annotation optional, `as const` optional)
surfaced 26 restatements invisible until now. Falsified both ways: an annotated smuggle now
fails; it passed before.

## All 26 fixed

| class | fix |
| --- | --- |
| 9 MCP composers restating confidence/identity/lane/action/pool sets | derive from the schemas-src owners |
| the 3-way `LIST_SUBNETS_SORT_FIELDS` — graphql's copy commented *"keeping the two surfaces from drifting"* while **being** the drift | one exported subset, documented as the deliberate MCP narrowing of the collection's 14 sort fields |
| route↔src sort pairs | graph-aware direction: data-api members stay owner (no schema imports into the startup-CPU-limited Worker, the #10121 rule); the rest follow schemas-src-owns |
| `PROVENANCE_RANK`, `PRUNE_TABLES` — **order is the local meaning** (evidence strength; children-before-blocks) | pinned, not aliased: `satisfies` membership + a type-level exhaustiveness check — rename, removal, or missing member fails to compile while the order stays expressed |
| lifecycle CSV columns · expected-gap kinds · the two validators' scan roots · UI chart palette | one owner each |
| 4 more GraphQL sort guards | probed dead at dispatch (the #10993 method, `Received:` fingerprints on all four) and deleted; ceiling **185 → 179**, dispatch rejections pinned by test |

## Verification

- Gate green across five trees: **394 vocabularies**, allowlist still pinned to exact files
- Full suite **20594 passed** · UI suite 2104 · patch coverage by lcov ∩ diff: **0 gaps**
- `tsc` (both trees) · lint (both) · `format:check` · full validator set · **byte-identical emitted contract**
- Ledger: **net −295** across 39 files