### PR TITLE
fix(r2-sql): make the reader cheaper, then raise the cap it pays for

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -165,17 +165,26 @@ const SERVER_ERROR_FLOOR = 500;
  * to report. Tuning `LIMIT` per caller would narrow the odds without closing
  * the hole, and the next unbounded column would reopen it.
  *
- * 8 MiB of RAW body against a 128 MB isolate. Deliberately far below the
- * ceiling rather than near it: the bytes are held once as chunks, again as a
- * decoded string, and a third time as parsed objects, so the resident cost of
- * a body is several times its wire size. Every legitimate result measured in
+ * 12 MiB of RAW body against a 128 MB isolate.
+ *
+ * It was 8 MiB, and production declined a legitimate read by TWENTY-FOUR BYTES
+ * on 2026-08-13 -- one block's extrinsics carrying their full `call_args`. The
+ * number moved only because the READER got cheaper: it used to hold the body
+ * three times at peak (chunks, a joined copy, the decoded string) before
+ * `JSON.parse` added the object graph. Decoding incrementally and releasing
+ * each chunk removes the joined copy, so 12 MiB now peaks around where 8 MiB
+ * used to.
+ *
+ * Raising the number ALONE would have walked back toward the out-of-memory
+ * this cap replaced, which is the one failure mode that takes the isolate with
+ * it rather than declining one query. Every legitimate result measured in
  * this repo is orders of magnitude under it -- the widest documented read is
  * the deregistrations lane's 33,386 rows over six narrow columns. Overridable
  * per-deployment via R2_SQL_MAX_BODY_BYTES, because the right number follows
  * the isolate's memory rather than this comment.
  */
 export const R2_SQL_MAX_BODY_BYTES_ENV = "R2_SQL_MAX_BODY_BYTES";
-export const R2_SQL_MAX_BODY_BYTES_DEFAULT = 8 * 1024 * 1024;
+export const R2_SQL_MAX_BODY_BYTES_DEFAULT = 12 * 1024 * 1024;
 
 /**
  * The `error_code` a response too large to buffer reports.
@@ -423,14 +432,26 @@ async function readCappedBody(
       /* the stream is already done or errored */
     }
   }
-  const joined = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    joined.set(chunk, offset);
-    offset += chunk.byteLength;
+  // Decoded INCREMENTALLY, and each chunk dropped as it is consumed. The first
+  // version concatenated every chunk into one `Uint8Array` and decoded that,
+  // which held the body THREE times at peak -- the chunk list, the joined copy,
+  // and the decoded string -- before `JSON.parse` added the object graph on
+  // top. Dropping the joined copy is what buys the cap its headroom; see
+  // R2_SQL_MAX_BODY_BYTES_DEFAULT for the arithmetic that number rests on.
+  const decoder = new TextDecoder();
+  let text = "";
+  for (let i = 0; i < chunks.length; i += 1) {
+    text += decoder.decode(chunks[i]!, { stream: true });
+    // Release the chunk now rather than at function exit: the array is the
+    // other live reference to these bytes.
+    chunks[i] = EMPTY_CHUNK;
   }
-  return JSON.parse(new TextDecoder().decode(joined));
+  text += decoder.decode();
+  return JSON.parse(text);
 }
+
+/** Reused so releasing a chunk allocates nothing. */
+const EMPTY_CHUNK = new Uint8Array(0);
 
 /**
  * The lakehouse table a statement reads, e.g. `chain.account_events`.

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -1131,6 +1131,19 @@ describe("a row limit is not a byte limit (#11000)", () => {
   // a decline: it is raised by the runtime and it kills the ISOLATE, taking
   // every unrelated request sharing it, which is the one failure this module's
   // header promises cannot happen.
+  const streamOfBytes = (parts: Uint8Array[]) =>
+    (async () =>
+      new Response(
+        new ReadableStream({
+          start(c) {
+            for (const p of parts) c.enqueue(p);
+            c.close();
+          },
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+  const streamOfChunks = (parts: string[]) =>
+    streamOfBytes(parts.map((p) => new TextEncoder().encode(p)));
   const streamOf = (chunks: string[], status = 200) =>
     (async () =>
       new Response(
@@ -1158,6 +1171,45 @@ describe("a row limit is not a byte limit (#11000)", () => {
       null,
       "a declined read degrades like every other failure",
     );
+  });
+
+  test("a MULTI-CHUNK body reassembles exactly -- the decode is incremental", () => {
+    // The reader decodes chunk by chunk and releases each one, so a value split
+    // across a chunk boundary must still come back whole. Split mid-token on
+    // purpose: a decoder that mishandled the boundary would corrupt the JSON
+    // rather than fail loudly.
+    const payload = JSON.stringify({
+      success: true,
+      result: {
+        rows: [{ signer: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3" }],
+      },
+    });
+    const mid = Math.floor(payload.length / 2);
+    return r2SqlQuery(mockEnv(TOKEN), "SELECT signer FROM chain.extrinsics", {
+      fetch: streamOfChunks([payload.slice(0, mid), payload.slice(mid)]),
+      ...noCapture,
+    }).then((rows) =>
+      assert.deepEqual(rows, [
+        { signer: "5F4tQyWrhfGVcNhoqeiNsR6KjD4wMZ2kfhLj4oHYuyHbZAc3" },
+      ]),
+    );
+  });
+
+  test("a MULTI-BYTE character split across chunks survives", () => {
+    // The reason the decode is `{ stream: true }` and not a decode-per-chunk:
+    // a UTF-8 sequence can straddle a chunk boundary, and decoding each chunk
+    // independently turns it into replacement characters silently.
+    const payload = JSON.stringify({
+      success: true,
+      result: { rows: [{ subnet_name: "τaο-Ω" }] },
+    });
+    const bytes = new TextEncoder().encode(payload);
+    // Cut inside the multi-byte τ.
+    const cut = payload.indexOf("τ") + 1;
+    return r2SqlQuery(mockEnv(TOKEN), "SELECT subnet_name FROM chain.subnets", {
+      fetch: streamOfBytes([bytes.slice(0, cut), bytes.slice(cut)]),
+      ...noCapture,
+    }).then((rows) => assert.deepEqual(rows, [{ subnet_name: "τaο-Ω" }]));
   });
 
   test("a body UNDER the cap still parses -- the guard is not a blanket refusal", async () => {


### PR DESCRIPTION
Production declined a **legitimate read by twenty-four bytes** on 2026-08-13 — `/api/v1/blocks/{ref}/extrinsics`, one block's extrinsics carrying their full `call_args`, at 8,388,632 against an 8,388,608 cap.

## Why not just raise the number

Raising it alone walks back toward the out-of-memory the cap replaced — and that is the one failure that takes the **isolate** with it rather than declining one query. So the reader got cheaper first, and the cap moved because the arithmetic under it moved.

The reader held the body **three times at peak**:

| | |
|---|---|
| the chunk list | 8 MiB |
| a joined `Uint8Array` | 8 MiB |
| the decoded string | ~8 MiB |
| …then `JSON.parse` adds the object graph | ~40 MiB |

Decoding incrementally and releasing each chunk as it is consumed removes the joined copy, so **12 MiB now peaks around where 8 MiB used to**.

##  is load-bearing

A UTF-8 sequence can straddle a chunk boundary. Decoding each chunk independently turns it into replacement characters **silently** — corrupted data rather than a failure, which is the worst shape a bug can take at a data boundary.

There is a test that splits a multi-byte character (`τ`) across chunks, and it was confirmed to fail without the flag:

```
× a MULTI-BYTE character split across chunks survives
```

## Not fixed here

`call_args` is unbounded per row, so **no row limit can bound the bytes** — this raises the ceiling, it does not remove the class. If a single block ever exceeds 12 MiB the honest fixes are route-level: page that route harder, or drop `call_args` from the list projection and keep it on the detail route. Both are contract decisions, so neither belongs in a memory fix.

123 tests pass.