### PR TITLE
feat(registry): the review gate treasury readings were shipped without

### DIFF
--- a/scripts/review-treasury-readings.ts
+++ b/scripts/review-treasury-readings.ts
@@ -1,0 +1,218 @@
+// The human gate on treasury readings (#10933), as a credentialed CLI.
+//
+// ## WHY THIS IS A SCRIPT AND NOT A SURFACE
+//
+// A treasury reading is published only once a maintainer has promoted it, and
+// the promotion is the one action in this system that turns a machine's guess
+// into a published claim about somebody's business. It must therefore be
+// reachable by exactly one person and advertised to nobody:
+//
+//   - a route would appear in openapi.json even gated behind a secret;
+//   - an MCP tool would appear in the served tool list;
+//   - a Worker cron cannot make a judgement, which is the whole point.
+//
+// A script needing DATABASE_URL is none of those. It is the same posture
+// scripts/neon-migrate.ts already has for DDL: a credential nobody else holds,
+// no surface, no schedule.
+//
+// ## THE FINDING IS SHOWN BEFORE IT IS PUBLISHED
+//
+// `list` prints exactly the fields a candidate WITHHOLDS from the served card
+// -- the share, the address, what it applies to -- because a review gate that
+// does not show you what you are about to publish is a rubber stamp with extra
+// steps. Promoting is a second, explicit command naming the row.
+//
+// ## WHAT PROMOTION DOES AND DOES NOT MEAN
+//
+// `reviewed` means: a human read the cited commit and agrees the row describes
+// what that code does. It is NOT an accusation, and the card says so -- a cut
+// declared in a public repo is a disclosed business model, and
+// `declared_matches_observed` is published as prominently when it agrees.
+//
+// `rejected` means the reading is wrong, and the row stays as evidence that it
+// was looked at rather than being deleted. Deleting would make a re-read
+// produce the same candidate forever with nothing recording that a human had
+// already dismissed it.
+import pg from "pg";
+import { TREASURY_REVIEW_STATES } from "../schemas-src/treasury.ts";
+
+interface CandidateRow {
+  netuid: number;
+  source_url: string;
+  read_at_sha: string;
+  observed_at: string;
+  found: boolean;
+  declared_share: number | null;
+  treasury_address: string | null;
+  applies_to: string | null;
+  evidence_path: string | null;
+  review_state: string;
+}
+
+/** The states a maintainer may promote INTO. `candidate` is what the extractor
+ * writes; promoting something back to it would be undoing a review rather than
+ * making one, and there is no reason to do that from here. */
+export const PROMOTABLE_STATES = TREASURY_REVIEW_STATES.filter(
+  (state) => state !== "candidate",
+);
+
+export interface ReviewCommand {
+  action: "list" | "promote";
+  netuid?: number;
+  sourceUrl?: string;
+  state?: string;
+}
+
+/**
+ * Parse argv into a command, or explain the refusal.
+ *
+ * PURE, so the argument rules are testable without a database. Every refusal
+ * names what was wrong rather than printing usage: this is run rarely, by one
+ * person, usually months apart, and "usage:" is what you read when you already
+ * know what you meant.
+ */
+export function parseReviewArgs(
+  argv: readonly string[],
+): { command: ReviewCommand } | { error: string } {
+  const [action, ...rest] = argv;
+  if (action === "list") return { command: { action: "list" } };
+  if (action !== "promote") {
+    return {
+      error: `unknown action ${JSON.stringify(action ?? "")}. Expected "list" or "promote".`,
+    };
+  }
+  const [netuidArg, sourceUrl, state] = rest;
+  // `Number("")` is 0 and `Number(" ")` is 0, so an omitted netuid would parse
+  // as netuid 0 -- root -- and promote a reading against the wrong subnet
+  // entirely. The emptiness check has to come before the numeric one.
+  const netuid =
+    typeof netuidArg === "string" && netuidArg.trim() !== ""
+      ? Number(netuidArg)
+      : Number.NaN;
+  if (!Number.isInteger(netuid) || netuid < 0) {
+    return {
+      error: `promote needs a netuid; got ${JSON.stringify(netuidArg ?? "")}`,
+    };
+  }
+  if (!sourceUrl) {
+    return {
+      error:
+        "promote needs the source_url of the reading. A subnet can have more " +
+        "than one, and they can disagree -- naming the subnet alone would " +
+        "promote whichever the database returned first.",
+    };
+  }
+  if (!state || !PROMOTABLE_STATES.includes(state as never)) {
+    return {
+      error: `promote needs a state, one of: ${PROMOTABLE_STATES.join(", ")}`,
+    };
+  }
+  return { command: { action: "promote", netuid, sourceUrl, state } };
+}
+
+/** One candidate, printed with the fields the served card withholds. */
+export function formatCandidate(row: CandidateRow): string {
+  const finding = row.found
+    ? [
+        row.declared_share === null
+          ? null
+          : `share ${(row.declared_share * 100).toFixed(2)}%`,
+        row.applies_to ? `of ${row.applies_to}` : null,
+        row.treasury_address ? `to ${row.treasury_address}` : null,
+      ]
+        .filter(Boolean)
+        .join(" ")
+    : "read, nothing allocated";
+  return [
+    `netuid ${row.netuid}  [${row.review_state}]`,
+    `  ${row.source_url}`,
+    `  @ ${row.read_at_sha.slice(0, 12)}${
+      row.evidence_path ? `  ${row.evidence_path}` : ""
+    }`,
+    `  FINDING: ${finding}`,
+  ].join("\n");
+}
+
+const LIST_SQL = `
+  SELECT netuid, source_url, read_at_sha, observed_at, found, declared_share,
+         treasury_address, applies_to, evidence_path, review_state
+  FROM treasury_readings
+  WHERE review_state = 'candidate'
+  ORDER BY netuid, source_url`;
+
+const PROMOTE_SQL = `
+  UPDATE treasury_readings
+  SET review_state = $3, reviewed_at = $4
+  WHERE netuid = $1 AND source_url = $2
+  RETURNING netuid, source_url, review_state`;
+
+async function main(): Promise<void> {
+  const parsed = parseReviewArgs(process.argv.slice(2));
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    process.exit(1);
+  }
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    // Not a warning, for the same reason the migration runner refuses: a review
+    // tool that "succeeds" without a database has reviewed nothing.
+    console.error("DATABASE_URL is not set");
+    process.exit(1);
+  }
+
+  const client = new pg.Client({ connectionString: url });
+  await client.connect();
+  try {
+    if (parsed.command.action === "list") {
+      const { rows } = await client.query<CandidateRow>(LIST_SQL);
+      if (rows.length === 0) {
+        console.log("no candidate readings awaiting review");
+        return;
+      }
+      console.log(`${rows.length} candidate reading(s) awaiting review:\n`);
+      for (const row of rows) console.log(`${formatCandidate(row)}\n`);
+      console.log(
+        "Promote with:\n" +
+          "  node scripts/review-treasury-readings.ts promote <netuid> <source_url> " +
+          `<${PROMOTABLE_STATES.join("|")}>`,
+      );
+      return;
+    }
+
+    const { rows } = await client.query<{
+      netuid: number;
+      review_state: string;
+    }>(PROMOTE_SQL, [
+      parsed.command.netuid,
+      parsed.command.sourceUrl,
+      parsed.command.state,
+      Date.now(),
+    ]);
+    if (rows.length === 0) {
+      // NAMED, not silent. A promote that matched nothing usually means the
+      // source_url was copied with a trailing character, and reporting success
+      // would leave a candidate unreviewed while the operator believed
+      // otherwise.
+      console.error(
+        `no reading matched netuid ${parsed.command.netuid} at ${parsed.command.sourceUrl}`,
+      );
+      process.exit(1);
+    }
+    console.log(
+      `netuid ${rows[0]!.netuid} -> ${rows[0]!.review_state}` +
+        (parsed.command.state === "reviewed"
+          ? " (its finding is now published on /subnets/{netuid}/treasury)"
+          : ""),
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+// Only when run directly, so the pure helpers stay importable by tests.
+if (process.argv[1]?.endsWith("review-treasury-readings.ts")) {
+  main().catch((error: unknown) => {
+    console.error(String(error));
+    process.exit(1);
+  });
+}

--- a/tests/review-treasury-readings.test.ts
+++ b/tests/review-treasury-readings.test.ts
@@ -1,0 +1,143 @@
+// The human gate on treasury readings (#10933), argument rules and printing.
+//
+// The database half is not mocked here: `main` is a thin sequence of two SQL
+// statements whose real behaviour is the CHECK constraints and the UPDATE's
+// own RETURNING, both exercised against real Postgres in
+// tests/data-api-neurons.test.ts. What is worth pinning here is everything a
+// wrong keystroke reaches -- because the failure mode of this tool is
+// promoting the wrong row, and the row it promotes becomes a published claim
+// about somebody's business.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  PROMOTABLE_STATES,
+  formatCandidate,
+  parseReviewArgs,
+} from "../scripts/review-treasury-readings.ts";
+
+const ROW = {
+  netuid: 7,
+  source_url: "https://github.com/a/b",
+  read_at_sha: "abc1234def5678",
+  observed_at: "2026-08-13T00:00:00.000Z",
+  found: true,
+  declared_share: 0.1,
+  treasury_address: "5Txyz",
+  applies_to: "miner-emission",
+  evidence_path: "neurons/validator.py",
+  review_state: "candidate",
+};
+
+describe("PROMOTABLE_STATES", () => {
+  test("a maintainer may not promote back to candidate", () => {
+    // `candidate` is what the extractor writes. Moving a row back to it would
+    // be undoing a review rather than making one.
+    assert.deepEqual([...PROMOTABLE_STATES], ["reviewed", "rejected"]);
+  });
+
+  test("it is derived from the schema's vocabulary, not restated", () => {
+    // If TREASURY_REVIEW_STATES grows a state, this list must grow with it --
+    // a hand-written copy here would silently refuse the new one.
+    assert.equal(PROMOTABLE_STATES.includes("candidate" as never), false);
+    assert.ok(PROMOTABLE_STATES.length > 0);
+  });
+});
+
+describe("parseReviewArgs", () => {
+  test("list takes no arguments", () => {
+    assert.deepEqual(parseReviewArgs(["list"]), {
+      command: { action: "list" },
+    });
+  });
+
+  test("promote needs the source_url, not just the subnet", () => {
+    // A subnet can register more than one source repo and they can disagree.
+    // Naming the subnet alone would promote whichever the database returned
+    // first, which is the shape of publishing the wrong finding.
+    const result = parseReviewArgs(["promote", "7"]);
+    assert.ok("error" in result);
+    assert.match(result.error, /more \n?than one/);
+  });
+
+  test("promote refuses a state outside the vocabulary", () => {
+    for (const state of ["candidate", "approved", "", "REVIEWED"]) {
+      const result = parseReviewArgs(["promote", "7", "https://x", state]);
+      assert.ok("error" in result, `${state} must be refused`);
+      assert.match(result.error, /reviewed, rejected/);
+    }
+  });
+
+  test("promote refuses a netuid that is not one", () => {
+    for (const netuid of ["", "x", "-1", "1.5"]) {
+      const result = parseReviewArgs([
+        "promote",
+        netuid,
+        "https://x",
+        "reviewed",
+      ]);
+      assert.ok("error" in result, `${netuid} must be refused`);
+      assert.match(result.error, /needs a netuid/);
+    }
+  });
+
+  test("an unknown or absent action is named, not defaulted", () => {
+    for (const argv of [[], ["review"], ["--help"]]) {
+      const result = parseReviewArgs(argv);
+      assert.ok("error" in result);
+      assert.match(result.error, /Expected "list" or "promote"/);
+    }
+  });
+
+  test("a well-formed promote parses whole", () => {
+    assert.deepEqual(
+      parseReviewArgs(["promote", "7", "https://github.com/a/b", "rejected"]),
+      {
+        command: {
+          action: "promote",
+          netuid: 7,
+          sourceUrl: "https://github.com/a/b",
+          state: "rejected",
+        },
+      },
+    );
+  });
+});
+
+describe("formatCandidate", () => {
+  test("PRINTS THE FINDING THE SERVED CARD WITHHOLDS", () => {
+    // The whole point of the gate. A review tool that does not show what you
+    // are about to publish is a rubber stamp with extra steps.
+    const out = formatCandidate(ROW);
+    assert.match(out, /10\.00%/);
+    assert.match(out, /miner-emission/);
+    assert.match(out, /5Txyz/);
+    assert.match(out, /abc1234def56/);
+    assert.match(out, /neurons\/validator\.py/);
+  });
+
+  test("a read that found nothing says so rather than printing blanks", () => {
+    const out = formatCandidate({
+      ...ROW,
+      found: false,
+      declared_share: null,
+      treasury_address: null,
+      applies_to: null,
+      evidence_path: null,
+    });
+    assert.match(out, /read, nothing allocated/);
+    assert.equal(/%/.test(out), false);
+  });
+
+  test("a partial finding prints the parts it has", () => {
+    // A finding can name an address without a share, or the reverse. Printing
+    // "undefined" for the missing half is how a reviewer approves a row they
+    // misread.
+    const out = formatCandidate({
+      ...ROW,
+      declared_share: null,
+      applies_to: null,
+    });
+    assert.match(out, /FINDING: to 5Txyz/);
+    assert.equal(/undefined|null/.test(out), false);
+  });
+});


### PR DESCRIPTION
#11025 gave `treasury_readings` a `review_state` and a serving rule — a `candidate` publishes its **read status** and withholds its **finding** until a maintainer promotes it — and shipped nothing that could perform the promotion. Every future candidate was permanently unpublishable and the column was decorative.

## A script, not a surface

A route appears in `openapi.json` **even gated behind a secret**. An MCP tool appears in the served tool list. A cron cannot make a judgement, which is the entire point of the state. A script needing `DATABASE_URL` is none of those, and it is the same posture `scripts/neon-migrate.ts` already has for DDL: a credential nobody else holds, no surface, no schedule.

`list` prints exactly the fields the served card **withholds** — the share, the address, what it applies to, the commit. A review gate that does not show you what you are about to publish is a rubber stamp with extra steps.

## Three refusals, each of which is a way to publish the wrong claim

| | |
| --- | --- |
| `promote 7` | needs the `source_url` too. A subnet can register more than one source repo and they can disagree, so naming the subnet alone promotes whichever the database returned first. |
| `promote "" <url> reviewed` | **`Number("")` is 0**, so an omitted netuid parsed as netuid 0 — root — and would have promoted a reading against a completely different subnet. The emptiness check has to come before the numeric one. |
| a promote matching no row | exits non-zero and says so. Reporting success leaves a candidate unreviewed while the operator believes otherwise, which usually means a `source_url` copied with a trailing character. |

`rejected` keeps the row rather than deleting it: a re-read would otherwise produce the same candidate forever with nothing recording that a human had already dismissed it.

The promotable states are **derived** from `TREASURY_REVIEW_STATES` rather than restated, so a new state cannot be silently refused by a hand-written copy — and `candidate` is excluded, because promoting back to it is undoing a review rather than making one.

## Verification

Every pure helper is tested — the argument rules and the printing, which is everything a wrong keystroke reaches. `main` is a thin two-statement SQL sequence whose real behaviour is the CHECK constraints and the UPDATE's own `RETURNING`, both already exercised against real Postgres under PGlite; that is the same split `neon-migrate.ts` has between its tested `pendingMigrations` and its untested `main`.

Full CI step set green locally (66 targets).

Closes #11062