### PR TITLE
fix(surfaces): verify against the schema it serves, instead of nulling three fields it promises

### DIFF
--- a/src/surface-verify.ts
+++ b/src/surface-verify.ts
@@ -8,6 +8,7 @@
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { probeSurface, type ProbeSurface } from "./health-probe-core.ts";
 import { resolveSurfaceAlias } from "./surface-aliases.ts";
+import { SurfaceVerifyArtifactSchema } from "../schemas-src/routes/ai-native.ts";
 
 type Row = Record<string, unknown>;
 type Prober = (
@@ -60,6 +61,18 @@ export function primarySurfaceForNetuid(
   );
 }
 
+/**
+ * The served contract, minus the one field this function does not set.
+ *
+ * `from_cache` is stamped by verifySurfaceWithCache after the fact, so the
+ * shape produced HERE is the artifact without it -- `.omit()` rather than a
+ * second object literal, so this stays the same schema the route and
+ * `verify_integration` serve rather than a fourth description of it.
+ */
+const VerifiedSurfaceSchema = SurfaceVerifyArtifactSchema.omit({
+  from_cache: true,
+});
+
 // Probe one surface and shape the verify result. `prober` is injectable for
 // tests (defaults to the real network probe).
 export async function verifySurface(
@@ -76,24 +89,30 @@ export async function verifySurface(
     probe.status !== "failed" &&
     probe.classification !== "dead" &&
     probe.classification !== "unsafe";
-  return {
+  // Parsed, not hand-checked (#11040). `surface_key`, `netuid` and
+  // `classification` are non-nullable in the served contract, so the `?? null`
+  // these three used to carry could never render -- it travelled to the
+  // response tripwire and came back as a 500 naming the ROUTE. Validating
+  // against the schema that is actually served names the field instead, and
+  // covers every field rather than the three I happened to notice.
+  return VerifiedSurfaceSchema.parse({
     schema_version: 1,
     surface_id: surface.surface_id,
-    surface_key: surface.surface_key ?? null,
-    netuid: typeof surface.netuid === "number" ? surface.netuid : null,
+    surface_key: surface.surface_key,
+    netuid: surface.netuid,
     kind: surface.kind,
     url: surface.url,
     provider: surface.provider ?? null,
     auth_required: Boolean(surface.auth_required),
     status: probe.status,
-    classification: probe.classification ?? null,
+    classification: probe.classification,
     callable,
     latency_ms: typeof probe.latency_ms === "number" ? probe.latency_ms : null,
     status_code:
       typeof probe.status_code === "number" ? probe.status_code : null,
     error: probe.error ?? null,
     probed_at: probe.last_checked || probe.verified_at || null,
-  };
+  });
 }
 
 export const VERIFY_CACHE_TTL_SECONDS = 60;

--- a/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
+++ b/tests/request-handlers-rpc-proxy-branch-coverage.test.ts
@@ -13,6 +13,7 @@ import {
   rpcCachePolicy,
 } from "../workers/request-handlers/rpc-proxy.ts";
 import { MAX_STATE_QUERY_KEYS_PAGE_SIZE } from "../workers/config.ts";
+import { verifyCacheRequest } from "../src/surface-verify.ts";
 import type { AnyFn, Row } from "./row-type.ts";
 
 const OBSERVED_AT = "2026-06-24T12:00:00.000Z";
@@ -1127,60 +1128,23 @@ describe("handleSurfaceVerify alias + cache branches", () => {
     assert.equal(body.error.code, "surface_not_found");
   });
 
-  test("a matched surface lacking a surface_key falls back to its surface_id", async () => {
-    // findSurface matches on surface_id; with no surface_key the canonical id
-    // is `surface.surface_key || surface.surface_id` → the surface_id arm.
-    const matchEnv = {
-      // No Cache API binding so the cache match/put path is skipped and the
-      // probe runs directly through the stubbed fetch.
-      ASSETS: {
-        async fetch(request: Request) {
-          const target = new URL(request.url);
-          if (target.pathname === "/metagraph/operational-surfaces.json") {
-            return Response.json({
-              surfaces: [
-                {
-                  surface_id: "keyless-surface",
-                  kind: "subnet-api",
-                  url: "https://keyless.example.com/health",
-                  provider: "fixture",
-                  auth_required: false,
-                  public_safe: true,
-                  probe: { expect: "json", method: "GET", timeout_ms: 10000 },
-                },
-              ],
-            });
-          }
-          return new Response("nope", { status: 404 });
-        },
-      },
-    } as unknown as Env;
-    const originalCaches = (globalThis as Row).caches;
-    const originalFetch = globalThis.fetch;
-    (globalThis as Row).caches = undefined; // no Cache API → skip the 60s cache layer
-    globalThis.fetch = async () =>
-      new Response("{}", {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    try {
-      const res = await handleSurfaceVerify(
-        req("/api/v1/surfaces/keyless-surface/verify", {
-          headers: { "cf-connecting-ip": "203.0.113.10" },
-        }),
-        matchEnv,
-        "keyless-surface",
-        {},
-      );
-      assert.equal(res.status, 200);
-      const body = (await res.json()) as Row;
-      assert.equal(body.ok, true);
-      assert.equal(body.data.surface_id, "keyless-surface");
-      assert.equal(body.data.surface_key, null);
-      assert.equal(body.data.from_cache, false);
-    } finally {
-      (globalThis as Row).caches = originalCaches;
-      globalThis.fetch = originalFetch;
-    }
+  // Covers both arms of `surface.surface_key || surface.surface_id` in
+  // verifyCacheRequest. This used to be driven through handleSurfaceVerify with
+  // a surface that had neither a surface_key nor a netuid -- an artifact
+  // OperationalSurfacesArtifactSchema itself rejects, since both are required
+  // there. That fixture then asserted `surface_key: null` came back on the
+  // wire, which is the contract violation #11040 was filed about: the served
+  // schema declares it non-nullable, so the response tripwire turns that into a
+  // 500 in production. verifySurface now parses against that schema, so the
+  // only honest way to reach this branch is the function that owns it.
+  test("verifyCacheRequest keys on surface_key, falling back to surface_id", () => {
+    const keyed = verifyCacheRequest({
+      surface_key: "srf-abc123",
+      surface_id: "7:subnet-api:x",
+    });
+    assert.equal(new URL(keyed.url).pathname, "/srf-abc123");
+
+    const keyless = verifyCacheRequest({ surface_id: "keyless-surface" });
+    assert.equal(new URL(keyless.url).pathname, "/keyless-surface");
   });
 });

--- a/tests/surface-verify.test.ts
+++ b/tests/surface-verify.test.ts
@@ -133,16 +133,63 @@ describe("surface-verify core (#358)", () => {
       latency_ms: 10,
     }));
     assert.equal(unsafe.callable, false);
-    // a surface with no provider/auth → defaults
+    // a surface with no provider/auth → defaults. `provider` is the only one of
+    // the three that is genuinely optional (`.nullable()` in the served
+    // contract); surface_key/netuid/classification are not, and are supplied
+    // here because omitting them is now an error rather than a null (#11040).
     const bare = await verifySurface(
-      { surface_id: "z", kind: "subnet-api", url: "https://z" },
+      {
+        surface_id: "z",
+        surface_key: "srf-z",
+        netuid: 0,
+        kind: "subnet-api",
+        url: "https://z",
+      },
       {},
-      async () => ({ status: "ok", verified_at: "2026-06-16T01:00:00Z" }),
+      async () => ({
+        status: "ok",
+        classification: "live",
+        verified_at: "2026-06-16T01:00:00Z",
+      }),
     );
     assert.equal(bare.provider, null);
     assert.equal(bare.auth_required, false);
-    assert.equal(bare.netuid, null);
+    assert.equal(bare.netuid, 0); // netuid 0 is root, not "missing"
     assert.equal(bare.probed_at, "2026-06-16T01:00:00Z"); // verified_at fallback
+  });
+
+  // The served contract declares these three non-nullable, so a null could
+  // never have been rendered -- it travelled to the response tripwire and came
+  // back as a 500 naming the route. Each now names the field instead (#11040).
+  test("verifySurface: a missing non-nullable field names itself, not the route", async () => {
+    const live = async () => ({ status: "ok", classification: "live" });
+    const full = {
+      surface_id: "z",
+      surface_key: "srf-z",
+      netuid: 7,
+      kind: "subnet-api",
+      url: "https://z",
+    };
+
+    // netuid 0 is falsy but valid -- the old `typeof === "number"` guard got
+    // this right and a `??`-shaped rewrite would not.
+    const root = await verifySurface({ ...full, netuid: 0 }, {}, live);
+    assert.equal(root.netuid, 0);
+
+    for (const field of ["surface_key", "netuid"] as const) {
+      const missing: Row = { ...full };
+      delete missing[field];
+      await assert.rejects(
+        () => verifySurface(missing, {}, live),
+        new RegExp(`"${field}"`),
+        `dropping ${field} should name ${field}, not the route`,
+      );
+    }
+
+    await assert.rejects(
+      () => verifySurface(full, {}, async () => ({ status: "ok" })),
+      /"classification"/,
+    );
   });
 
   test("verifySurfaceWithCache serves a 60s cache keyed by surface_key", async () => {


### PR DESCRIPTION
Closes #11040

`SurfaceVerifyArtifactSchema` declares `surface_key`, `netuid` and `classification` non-nullable. `verifySurface` wrote `?? null` into all three.

Those cannot both be right, and the null is the wrong half. A value the served contract forbids does not degrade — it travels three layers and comes back as an invalid-type 500 from the response tripwire, naming the **route** rather than the field or the surface that broke.

## None of the three can actually be null

- `OperationalSurfaceSchema` — the artifact this reads — declares `surface_key: z.string()` and `netuid: z.int().min(0)`.
- All **631** production surfaces parse clean against it, including the 4 `subtensor-rpc` surfaces and the 8 on netuid `0` — root, not "missing", which is why the old `typeof === "number"` guard was right where a `??`-shaped rewrite would not be.
- `classifyProbe` and `classifyRpcProbe` are both declared `: string` with no undefined branch, and both probe paths set it unconditionally.

So the coalesces were dead code that misdescribed the contract.

## Parsed, not hand-checked

My first version of this was a `required()` helper — three hand-written null checks, which is the exact duplication this repo has spent months ratcheting out. Replaced with the schema itself:

```ts
const VerifiedSurfaceSchema = SurfaceVerifyArtifactSchema.omit({ from_cache: true });
```

The same schema the route and `verify_integration` serve, minus the one field the cache layer stamps afterwards. `.omit()` rather than a second object literal, so this does not become a fourth description of the same shape — and it covers every field rather than the three I happened to notice.

**Safe in the bundle.** `schemas-src/routes/ai-native.ts` is *already* in the api worker's module graph, so this adds an edge, not a module. And `src/surface-verify.ts` is not reachable from `workers/data-api.ts` at all (verified by walking both import graphs), so the startup-CPU ceiling that makes route-schema imports dangerous there does not apply here.

## The test that was pinning the bug

`request-handlers-rpc-proxy-branch-coverage` drove `handleSurfaceVerify` with a surface carrying neither a `surface_key` nor a `netuid` — an artifact `OperationalSurfacesArtifactSchema` rejects outright — and then asserted `surface_key: null` came back on the wire. It was asserting the violation.

The branch it actually wanted is `surface_key || surface_id` in `verifyCacheRequest`, so it now tests that function directly: both arms covered, no invalid artifact required.

## Verification

- `npx tsc --noEmit`, `npm run lint`, `validate:contract-drift`, `validate:schema-shape-duplicates` (3 pinned by design, unchanged).
- `npm run build` green; no generated artifact drifted.
- Full suite: **20,648 passed, 11 skipped, 900 files**.