### PR TITLE
feat(lakehouse): the freeze is over — 18 frozen tables down to 3, parity baseline to zero

### DIFF
--- a/generated/lakehouse/schema.json
+++ b/generated/lakehouse/schema.json
@@ -430,7 +430,7 @@
     "table": "nominator_positions",
     "field_id": 4,
     "column": "share_fraction",
-    "type": "float",
+    "type": "double",
     "required": false
   },
   {
@@ -438,6 +438,20 @@
     "field_id": 5,
     "column": "captured_at",
     "type": "long",
+    "required": false
+  },
+  {
+    "table": "nominator_positions",
+    "field_id": 6,
+    "column": "shares",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "nominator_positions",
+    "field_id": 7,
+    "column": "source",
+    "type": "string",
     "required": false
   },
   {
@@ -584,7 +598,7 @@
     "table": "subnet_hyperparams",
     "field_id": 7,
     "column": "weights_version",
-    "type": "int",
+    "type": "long",
     "required": false
   },
   {
@@ -857,7 +871,7 @@
     "table": "subnet_hyperparams_history",
     "field_id": 10,
     "column": "weights_version",
-    "type": "int",
+    "type": "long",
     "required": false
   },
   {
@@ -1326,7 +1340,7 @@
     "table": "neuron_daily",
     "field_id": 22,
     "column": "take",
-    "type": "float",
+    "type": "double",
     "required": false
   },
   {

--- a/generated/lakehouse/types.ts
+++ b/generated/lakehouse/types.ts
@@ -177,6 +177,8 @@ export type NominatorPositionsRow = {
   netuid: number | null;
   share_fraction: number | null;
   captured_at: number | null;
+  shares: number | null;
+  source: string | null;
 };
 
 /** `chain.nominator_positions` columns, in field-id order. */
@@ -186,6 +188,8 @@ export const NOMINATOR_POSITIONS_COLUMNS = [
   "netuid",
   "share_fraction",
   "captured_at",
+  "shares",
+  "source",
 ] as const;
 
 /** `chain.rpc_proxy_events` */

--- a/schemas-src/lakehouse.ts
+++ b/schemas-src/lakehouse.ts
@@ -165,6 +165,8 @@ export const NominatorPositionsRowSchema = z
     netuid: z.int().nullable(),
     share_fraction: z.number().nullable(),
     captured_at: z.int().nullable(),
+    shares: z.number().nullable(),
+    source: z.string().nullable(),
   })
   .partial()
   .catchall(z.unknown());

--- a/scripts/check-lakehouse-freshness.ts
+++ b/scripts/check-lakehouse-freshness.ts
@@ -184,26 +184,23 @@ export const EXPECTED: Readonly<Record<string, FreshnessRule>> = {
  * claim: "this cannot go stale" rather than "this is stale and we know".
  */
 export const KNOWN_FROZEN: ReadonlySet<string> = new Set([
-  "account_balances",
+  // Was eighteen. metagraphed-infra#536 ported the Neon -> Iceberg sink that
+  // the 2026-08-02 host retirement took with it, and fifteen of these came
+  // back on 2026-08-13 -- verified against the catalog, 11 -> 22 chain tables
+  // with a snapshot inside 24h.
+  //
+  // The three left are not waiting on that sink, and none of them is Neon's to
+  // give:
+  //   account_events_daily  a rollup over chain.account_events, which is LIVE
+  //                         here (454M rows) -- derived, not mirrored
+  //   featured_validators   no such table in Neon; it is registry curation
+  //                         published from this repo
+  //   rpc_proxy_events      no such table in Neon; the RPC proxy Worker writes
+  //                         it to D1
   "account_events_daily",
-  "account_identity",
-  "account_identity_history",
   "featured_validators",
-  "neurons",
-  "nominator_positions",
-  "providers",
   "rpc_proxy_events",
-  "self_health_daily",
-  "subnet_hyperparams",
-  "subnet_hyperparams_history",
-  "subnet_identity_history",
-  "subnet_ownership",
-  "subnet_ownership_history",
-  "subnets",
-  "surfaces",
-  "validator_nominator_counts",
 ]);
-
 export interface TableAge {
   table: string;
   newestMs: number | null;

--- a/scripts/validate-store-type-parity.ts
+++ b/scripts/validate-store-type-parity.ts
@@ -81,18 +81,19 @@ const FITS: Readonly<Record<string, ReadonlySet<string>>> = {
  * Iceberg widening is a safe promotion. This is the scoreboard for closing
  * them, not permission to keep them.
  */
-const KNOWN: ReadonlySet<string> = new Set([
-  "neuron_daily.take",
-  "nominator_positions.share_fraction",
-  "subnet_hyperparams.weights_version",
-  "subnet_hyperparams_history.weights_version",
-  // Both arrived in migration 0025, AFTER the 2026-08-02 exodus load, so the
-  // frozen copy predates them. metagraphed-infra#510's restore must include
-  // them or the archive stays lossy.
-  "nominator_positions.shares",
-  "nominator_positions.source",
+const KNOWN: ReadonlySet<string> = new Set<string>([
+  // EMPTY, and it stays that way. All six original divergences were fixed in
+  // the catalog on 2026-08-13 (metagraphed-infra#536): the two float32
+  // narrowings and both int8 -> int32 `weights_version` columns were widened,
+  // and `nominator_positions.shares` / `.source` -- added by migration 0025
+  // AFTER the 2026-08-02 exodus load, so the frozen copy never had them --
+  // were added. Every record count was checked before and after; Iceberg
+  // widening rewrites nothing.
+  //
+  // Emptying this was not optional. The gate fails on a KNOWN entry that has
+  // STOPPED diverging, precisely so a baseline cannot outlive the damage it
+  // describes and quietly overstate it.
 ]);
-
 export interface Column {
   table: string;
   column: string;


### PR DESCRIPTION
Closes #11076

Both ratchets fall, which is the only direction they move.

[metagraphed-infra#536](https://github.com/JSONbored/metagraphed-infra/pull/536) ported the Neon → Iceberg sink that the 2026-08-02 host retirement took with it. Fifteen tables came back on 2026-08-13 — `chain` tables with a snapshot inside 24h went **11 → 22**, verified against the catalog.

## `KNOWN_FROZEN`: 18 → 3

The three that remain are not waiting on that sink, and none is Neon's to give:

| Table | Why it stays frozen |
| --- | --- |
| `account_events_daily` | a rollup over `chain.account_events`, **live** here at 454M rows — derived, not mirrored |
| `featured_validators` | no such table in Neon (checked against `information_schema`); registry curation published from this repo |
| `rpc_proxy_events` | no such table in Neon; the RPC proxy Worker writes it to D1 |

## `KNOWN`: 6 → 0

The parity gate from #11060 flagged itself:

```
0 diverge (0 known, baseline 6), 0 NEW, 6 fixed
FIXED -- delete these from KNOWN so the baseline keeps shrinking
```

That is exactly the case it was built to catch — a baseline that outlives the damage it describes silently overstates it. All six of #11043's divergences are genuinely gone: both float32 narrowings widened to `double`, both `weights_version` columns `int → long` (they would have **overflowed** past 2^31), and `shares` / `source` added to `nominator_positions` — the two columns migration 0025 introduced *after* the exodus load, so the frozen copy never had them.

Record counts were verified either side of every catalog change; Iceberg widening rewrites nothing.

## The snapshot had to be refreshed, not just the baselines

`generated/lakehouse/schema.json` is what `types.ts`, `types.rs` and `schemas-src/lakehouse.ts` are all derived from, and it described a catalog that no longer exists. Re-snapshotted (234 columns, 16 tables) and regenerated, so the widened types and both new columns flow through to the Zod schema. Refreshing the baselines without this would have left every gate green against a stale picture — the same class of failure as the freeze itself.

## Verification

- `validate:store-type-parity` → `186 shared column(s); 0 diverge (0 known, baseline 0), 0 NEW, 0 fixed`
- `validate:lakehouse-types-drift` → generated artifacts match the fresh snapshot
- `validate:contract-drift` passed; `npx tsc --noEmit` and `npm run lint` clean
- Full suite: **20,659 passed, 11 skipped, 901 files**