### PR TITLE
fix(audit): include_points=false is a projection, not drift

### DIFF
--- a/tests/audit-responses.test.ts
+++ b/tests/audit-responses.test.ts
@@ -40,6 +40,34 @@ const DRIFTED = {
   },
 };
 
+const TAO_USD_URL = "https://api.metagraph.sh/api/v1/network/tao-usd";
+
+/** A tao-usd body whose only defect is the absent points array -- exactly what
+ * the #9720 include_points=false toggle serves, and the production fingerprint
+ * #11079 dispositioned. Every other field is a real minimal state: an unwritten
+ * series with no reading. */
+const TAO_USD_WITHOUT_POINTS = {
+  ok: true,
+  schema_version: 1,
+  data: {
+    schema_version: 1,
+    window: "24h",
+    point_count: 0,
+    stale: true,
+    stale_after_ms: 0,
+    age_ms: null,
+    priced_point_count: 0,
+    latest: null,
+    oldest_observed_at: null,
+    change_usd: null,
+    change_pct: null,
+  },
+  meta: {
+    artifact_path: "/metagraph/network/tao-usd.json",
+    contract_version: "2026-08-13",
+  },
+};
+
 function envWith(mode: string | undefined): Row {
   const env = createLocalArtifactEnv() as Row;
   if (mode === undefined) delete env.METAGRAPH_AUDIT_RESPONSES;
@@ -130,6 +158,33 @@ describe("auditResponse (#10984)", () => {
       jsonResponse(DRIFTED),
     );
     assert.equal(out.status, 200);
+  });
+
+  test("include_points=false is a projection: the omitted points are forgiven (#11079)", async () => {
+    // The #9720 "send me less" toggle omits data.points BY REQUEST -- the MCP
+    // tool's default, and the production warn log's only fingerprint. The URL
+    // carries the signal, like ?fields= above.
+    const out = await auditResponse(
+      new Request(`${TAO_USD_URL}?include_points=false`),
+      envWith("enforce") as unknown as Env,
+      { waitUntil: () => {} } as unknown as Parameters<typeof auditResponse>[2],
+      jsonResponse(TAO_USD_WITHOUT_POINTS),
+    );
+    assert.equal(out.status, 200);
+  });
+
+  test("the same absence WITHOUT the toggle is still drift (#11079)", async () => {
+    // Forgiveness must not outlive its reason: a handler that stopped sending
+    // points unasked is the defect the seam exists to catch.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out = await auditResponse(
+      new Request(TAO_USD_URL),
+      envWith("enforce") as unknown as Env,
+      { waitUntil: () => {} } as unknown as Parameters<typeof auditResponse>[2],
+      jsonResponse(TAO_USD_WITHOUT_POINTS),
+    );
+    assert.equal(out.status, 500);
+    error.mockRestore();
   });
 
   test("a body that claims JSON and is not never breaks the response", async () => {

--- a/tests/parsed-query-reads.test.ts
+++ b/tests/parsed-query-reads.test.ts
@@ -51,6 +51,13 @@ const DECLARED: Record<string, number> = {
   // The two by-name generic readers, matched by their parameter variable.
   parameter: 1,
   name: 1,
+  // The audit seam's projection signal (#11079). auditResponse wraps the
+  // default fetch export, OUTSIDE the router's parse, and derives `projected`
+  // from the URL alone -- the same way it reads fields/sections via `.has()`,
+  // which this regex does not see. Not a second copy of a bound:
+  // parseBooleanParam is strict, so the literal "false" is the only value the
+  // read can act on, and any other value never reaches the seam as a 200.
+  include_points: 1,
 };
 
 function rawReads(file: string): string[] {

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -2069,7 +2069,16 @@ export async function auditResponse(
   const matched = matchRoute(url.pathname);
   if (!matched?.artifactTemplate) return response;
   const projected =
-    url.searchParams.has("fields") || url.searchParams.has("sections");
+    url.searchParams.has("fields") ||
+    url.searchParams.has("sections") ||
+    // #9720's "send me less" toggle is a projection lever like the other two:
+    // include_points=false omits data.points BY REQUEST, and the schema's
+    // `required` describes the unprojected response (#10960). parseBooleanParam
+    // is strict -- any value other than the literal "false" either defaults to
+    // true or 400s before this seam sees a 200 -- so string equality here is
+    // exactly the handler's own condition (#11079: every MCP get_tao_usd call
+    // was fingerprinted as drift for asking for less).
+    url.searchParams.get("include_points") === "false";
   const run = async (body: unknown) => {
     await validateResponseTripwire(
       matched.id,


### PR DESCRIPTION
## Summary

Dispositions the #11046 warn log's only fingerprint, deterministically reproduced: `[METAGRAPH_AUDIT_RESPONSES] tao-usd DRIFTED (warn)` fires on **every** `GET /api/v1/network/tao-usd?include_points=false` — the published #9720 "send me less" toggle and the MCP `get_tao_usd` default — reporting `data.points: expected array, received undefined`, the exact omission the caller requested.

`auditResponse` derived its `projected` signal from the URL but only read `fields`/`sections`. `include_points` is the same class of lever; per the settled doctrine (#10960/#10978/#11009) the schema's `required` describes the **unprojected** response and the seam carries the projection signal — never schema loosening. `parseBooleanParam` is strict (anything but the literal `"false"` defaults to true or 400s before the seam sees a 200), so string equality is exactly the handler's own condition. Single consumer verified: `include_points` exists on no other route.

## Falsification

Seam clause neutered → the new forgiveness test fails (`include_points=false is a projection…`); restored → 9/9. The counter-direction is pinned: the same absent `points` **without** the toggle still becomes the enforce refusal.

## Validation

- Reproduced the production fingerprint locally through the identical `validateResponseTripwire` call before and after the fix
- `tsc --noEmit`, `eslint`, `format:check`, source-scanning validator sweep
- `tests/audit-responses.test.ts` 9/9; diff intersection coverage 1/1 lines, 3/3 branches

Not the #11046 flip — this clears its criterion-2 blocker; the flip still waits on its quiet-day window (which this fix is what makes reachable: with the toggle forgiven, the warn lane can actually go quiet).

Closes #11079