### PR TITLE
fix(verify): stamp the concrete artifact path, never null

### DIFF
--- a/tests/request-handlers-rpc-proxy.test.ts
+++ b/tests/request-handlers-rpc-proxy.test.ts
@@ -16,6 +16,7 @@ import {
   handleSurfaceVerify,
 } from "../workers/request-handlers/rpc-proxy.ts";
 import { MAX_RPC_BODY_BYTES } from "../workers/config.ts";
+import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
 
 // The health-meta KV's `last_run_at`, which is what this route hands the zeroed
 // floor as its freshness stamp. It is an ISO string here because that is what
@@ -402,6 +403,22 @@ describe("handleSurfaceVerify", () => {
       assert.equal(typeof body.data.callable, "boolean");
       assert.equal(body.meta.source, "live-probe");
       assert.equal(body.meta.cache, "short");
+      // #11082: the envelope's artifact_path is a string or absent, never
+      // null -- and this route stamps the concrete form of its declared
+      // computed-live template, like every sibling meta builder.
+      assert.equal(
+        body.meta.artifact_path,
+        `/metagraph/surfaces/${SURFACE_ID}/verify.json`,
+      );
+      // The audit seam's own validation must accept the envelope whole: this
+      // is the exact call auditResponse makes, and the null stamp it replaces
+      // was a warn fingerprint on every verify (enforce would have 500'd).
+      await validateResponseTripwire(
+        "surface-verify",
+        body,
+        "/metagraph/surfaces/{surface_id}/verify.json",
+        false,
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/workers/request-handlers/rpc-proxy.ts
+++ b/workers/request-handlers/rpc-proxy.ts
@@ -234,9 +234,14 @@ export async function handleRpcUsage(
   );
 }
 
-async function verifyMeta(env: Env) {
+async function verifyMeta(env: Env, surfaceId: string) {
   return {
-    artifact_path: null,
+    // The concrete form of the declared computed-live template
+    // (/metagraph/surfaces/{surface_id}/verify.json), like every sibling meta
+    // builder. It was `null` -- the tree's only null stamper -- which the
+    // envelope's `artifact_path: z.string().optional()` refuses: absence is
+    // legal, null is not, and the audit seam fingerprinted it (#11082).
+    artifact_path: `/metagraph/surfaces/${surfaceId}/verify.json`,
     cache: "short",
     contract_version: contractVersion(env),
     generated_at: null,
@@ -339,7 +344,7 @@ export async function handleSurfaceVerify(
   );
   return envelopeResponse(
     request,
-    { data: result, meta: await verifyMeta(env) },
+    { data: result, meta: await verifyMeta(env, surfaceId) },
     "short",
   );
 }


### PR DESCRIPTION
## Summary

Second latent fingerprint found and dispositioned by the pre-flip full-surface tripwire sweep for #11046 — every GET route fetched from production and validated through the exact `validateResponseTripwire` call `auditResponse` makes. Result: 209/215 routes CLEAN; the remaining non-clean are non-200/POST-shaped probes the seam skips. The one drift: `GET /api/v1/surfaces/{surface_id}/verify` stamps `meta.artifact_path: null` — the tree's **only** null stamper (`verifyMeta`), against an envelope contract of `artifact_path: z.string().optional()` where absence is legal and null is not. Every verify call was a warn fingerprint waiting for traffic, and an enforce-mode 500.

`verifyMeta` now stamps the concrete form of the route's declared computed-live template (`/metagraph/surfaces/${surfaceId}/verify.json`), exactly like its sibling `analyticsMeta`.

## Falsification

Stamp reverted to `null` → the extended "probes a catalogued surface and returns live-probe meta" test fails on both new pins (the literal path, and the tripwire round-trip on the whole envelope); restored → 30/30.

## Validation

- Full-surface production sweep re-run locally over the fixed handler path (the tripwire round-trip in the test is the same call)
- `tsc --noEmit`, lint, format, parsed-query gate, validator spot-checks
- `tests/request-handlers-rpc-proxy*.test.ts` 66/66

Together with #11081 this clears every fingerprint the audit seam can currently produce: the sweep found nothing else on the whole published surface.

Closes #11082