### PR TITLE
feat(conformance): sweep every published response through the audit seam's own validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "smoke:mcp": "node scripts/mcp-smoke-sweep.ts",
     "conformance:cross-surface": "node scripts/check-cross-surface-values.ts",
     "conformance:latency": "node scripts/check-operation-latency.ts",
+    "conformance:tripwire": "node scripts/check-tripwire-conformance.ts",
     "conformance:adversarial": "node scripts/check-adversarial-surface.ts",
     "conformance:graphql": "node scripts/check-graphql-conformance.ts",
     "conformance:mcp": "node scripts/check-mcp-conformance.ts",

--- a/scripts/check-tripwire-conformance.ts
+++ b/scripts/check-tripwire-conformance.ts
@@ -1,0 +1,136 @@
+// Does every published response pass the audit seam's own validation? (#11046)
+//
+// The response tripwire enforces in-path on the generic seam and audits the
+// entity handlers at the fetch seam -- but a fingerprint only fires when
+// TRAFFIC exercises the shape that drifts, and each late discovery resets the
+// warn-stage's quiet-day clock. Both production fingerprints the seam ever
+// produced (#11079's include_points omission, #11082's null artifact_path)
+// were findable in one pass by simply asking every route and validating the
+// answer with the seam's own call -- which is exactly what this sweep does.
+//
+// WHAT IT CHECKS. Every REST route in `API_ROUTES` whose path parameters have
+// a subject, one call each, validated through the SAME
+// `validateResponseTripwire(id, body, artifact_path, projected=false)` the
+// Worker's auditResponse makes. A route that answers anything but 200 JSON is
+// counted as skipped, because that is what the seam itself does with it.
+//
+// The subjects come from `conformance-subjects.ts`, shared with the other
+// sweeps, and a route whose parameter has no subject is SKIPPED rather than
+// filled with a placeholder -- validating a 404 body validates nothing. The
+// three routes with a REQUIRED query parameter get it from the same table
+// (`REQUIRED_QUERY` below), so they are swept rather than written off as 400s.
+//
+// SERIAL AND SPACED, for the reason the MCP sweep records: the endpoint
+// rate-limits per client, and a parallel run manufactures failures that read
+// exactly like real defects.
+//
+// Out of band, like its siblings: it needs production, and a check that cannot
+// run on a pull request should not pretend to. Run it before flipping
+// `METAGRAPH_AUDIT_RESPONSES` to enforce, and after any change that touches a
+// served value -- a drift here is a warn fingerprint waiting for traffic, and
+// an enforce-mode 500.
+import { pathToFileURL } from "node:url";
+import { API_ROUTES } from "../src/contracts.ts";
+import { validateResponseTripwire } from "../src/response-validation-tripwire.ts";
+import { concreteRoute, SUBJECTS } from "./conformance-subjects.ts";
+
+const BASE = "https://api.metagraph.sh";
+const USER_AGENT = "metagraphed-tripwire-conformance/1.0";
+const SPACING_MS = 250;
+
+/**
+ * The routes that 400 without a query parameter, and the subject-backed fill
+ * that turns each into a real answer. Everything else is probed bare: an
+ * optional parameter left off IS the default shape production serves most.
+ */
+const REQUIRED_QUERY: Readonly<Record<string, string>> = {
+  "subnet-stake-quote": "amount=1",
+  compare: `netuids=${(SUBJECTS.netuids as readonly number[]).join(",")}`,
+  "compare-validators": `hotkeys=${String(SUBJECTS.hotkeys)}`,
+};
+
+export interface TripwireSweepResult {
+  clean: number;
+  drift: string[];
+  skipped: string[];
+}
+
+export type RouteVerdict =
+  | { kind: "clean" }
+  | { kind: "skip"; reason: string }
+  | { kind: "drift"; detail: string };
+
+/**
+ * One route's verdict: exactly the seam's own decision rule. Anything but a
+ * 200 JSON answer is a SKIP because `auditResponse` never sees it either; a
+ * body the tripwire refuses is the finding.
+ */
+export async function evaluateRoute(
+  route: { id: string; path: string; artifact_path: string },
+  fetchImpl: typeof fetch,
+): Promise<RouteVerdict> {
+  const path = concreteRoute(route.path);
+  if (path === null) return { kind: "skip", reason: "no subject" };
+  const query = REQUIRED_QUERY[route.id];
+  const url = `${BASE}${path}${query ? `?${query}` : ""}`;
+  const response = await fetchImpl(url, {
+    headers: { "user-agent": USER_AGENT },
+  });
+  if (
+    response.status !== 200 ||
+    !response.headers.get("content-type")?.includes("json")
+  ) {
+    return { kind: "skip", reason: String(response.status) };
+  }
+  try {
+    await validateResponseTripwire(
+      route.id,
+      await response.json(),
+      route.artifact_path,
+      false,
+    );
+    return { kind: "clean" };
+  } catch (error: unknown) {
+    const detail = (error as { detail?: unknown }).detail;
+    return { kind: "drift", detail: JSON.stringify(detail) };
+  }
+}
+
+export async function sweepTripwireConformance(
+  fetchImpl: typeof fetch = fetch,
+): Promise<TripwireSweepResult> {
+  const result: TripwireSweepResult = { clean: 0, drift: [], skipped: [] };
+  for (const route of API_ROUTES) {
+    const verdict = await evaluateRoute(route, fetchImpl);
+    if (verdict.kind === "clean") result.clean += 1;
+    else if (verdict.kind === "skip")
+      result.skipped.push(`${route.path} (${verdict.reason})`);
+    else result.drift.push(`${route.path} :: ${verdict.detail}`);
+    await new Promise((resolve) => setTimeout(resolve, SPACING_MS));
+  }
+  return result;
+}
+
+// Runs only when EXECUTED, never when imported -- same contract as the other
+// out-of-band sweeps, so a test can exercise the pieces without calling
+// production.
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (invokedDirectly) {
+  const result = await sweepTripwireConformance();
+  console.log(
+    `Tripwire conformance: ${result.clean} route(s) clean, ` +
+      `${result.drift.length} drifted, ${result.skipped.length} skipped ` +
+      `(non-200/non-JSON or no subject -- the seam skips those too).`,
+  );
+  for (const line of result.skipped) console.log(`  skip ${line}`);
+  if (result.drift.length > 0) {
+    console.error(
+      "These responses would be warn fingerprints today and 500s under enforce:",
+    );
+    for (const line of result.drift) console.error(`  DRIFT ${line}`);
+    process.exit(1);
+  }
+}

--- a/scripts/conformance-subjects.ts
+++ b/scripts/conformance-subjects.ts
@@ -61,6 +61,22 @@ export const SUBJECTS: Readonly<
   crowdloan_id: 0,
   query: "inference",
   q: "inference",
+  // A decoded extrinsic (block 8,832,459). Decode history is complete and
+  // immutable, so a hash once served is served forever -- this cannot rotate
+  // out of a window the way a "latest" subject would.
+  hash: "0x3e59f2cdc12f4a47ad37b02aa04d9de650caa405d58f58b4e3c2ed50996ca450",
+  // A domain tag from the fixed 14-tag taxonomy (src/domain-tags.ts).
+  tag: "agents",
+  // A registered surface with probe history (SN7 allways, the api-health
+  // surface) -- the id `surface:add` derives, stable while the surface stays
+  // registered.
+  surface_id: "allways-api-health",
+  // Shape-valid and UNMAPPED on purpose: /evm/address/{h160} answers a mapping
+  // lookup, and "no mapping" is a real 200 answer with the full response
+  // shape. No stable real mapping exists to pin instead -- an H160 that is
+  // mapped today can unmap tomorrow, which would turn the sweep's subject
+  // stale in a way this one cannot be.
+  h160: `0x${"12".repeat(20)}`,
   // The two PLURAL arguments, which only the comparison tools take. No route
   // spells either as a path parameter, so they exist for
   // `argumentsForRequired` alone.

--- a/tests/check-tripwire-conformance.test.ts
+++ b/tests/check-tripwire-conformance.test.ts
@@ -1,0 +1,103 @@
+// The tripwire conformance sweep's decision rule (#11046), tested without a
+// network -- same discipline as check-response-conformance's suite: every skip
+// is a decision (the seam itself never audits a non-200 or non-JSON answer),
+// and the one thing the sweep must never forgive is a body the audit seam's
+// own validation refuses.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { evaluateRoute } from "../scripts/check-tripwire-conformance.ts";
+
+/** The tao-usd route row, as API_ROUTES declares it -- the same subject the
+ * audit suite pins, so a drift here reads identically to the production
+ * fingerprint #11079 dispositioned. */
+const TAO_USD_ROUTE = {
+  id: "tao-usd",
+  path: "/api/v1/network/tao-usd",
+  artifact_path: "/metagraph/network/tao-usd.json",
+};
+
+/** A minimal body the TaoUsd component accepts whole: an unwritten series. */
+const VALID_BODY = {
+  ok: true,
+  schema_version: 1,
+  data: {
+    schema_version: 1,
+    window: "24h",
+    point_count: 0,
+    stale: true,
+    stale_after_ms: 0,
+    age_ms: null,
+    priced_point_count: 0,
+    latest: null,
+    oldest_observed_at: null,
+    change_usd: null,
+    change_pct: null,
+    points: [],
+  },
+  meta: {
+    artifact_path: "/metagraph/network/tao-usd.json",
+    contract_version: "2026-08-13",
+  },
+};
+
+const respond = (body: unknown, init: ResponseInit = {}) =>
+  (async () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      ...init,
+    })) as unknown as typeof fetch;
+
+describe("evaluateRoute (#11046)", () => {
+  test("a 200 JSON body its component accepts is clean", async () => {
+    const verdict = await evaluateRoute(TAO_USD_ROUTE, respond(VALID_BODY));
+    assert.deepEqual(verdict, { kind: "clean" });
+  });
+
+  test("a body the seam's validation refuses is the finding, with its detail", async () => {
+    const drifted = structuredClone(VALID_BODY) as Record<string, unknown>;
+    delete (drifted.data as Record<string, unknown>).points;
+    const verdict = await evaluateRoute(TAO_USD_ROUTE, respond(drifted));
+    assert.equal(verdict.kind, "drift");
+    // The detail names the path, so the report is actionable without a rerun.
+    assert.match((verdict as { detail: string }).detail, /points/);
+  });
+
+  test("a non-200 answer is a skip carrying the status, never a drift", async () => {
+    const verdict = await evaluateRoute(
+      TAO_USD_ROUTE,
+      (async () =>
+        new Response("nope", { status: 503 })) as unknown as typeof fetch,
+    );
+    assert.deepEqual(verdict, { kind: "skip", reason: "503" });
+  });
+
+  test("a 200 that is not JSON is a skip -- the seam never audits it either", async () => {
+    const verdict = await evaluateRoute(
+      TAO_USD_ROUTE,
+      (async () =>
+        new Response("<xml/>", {
+          status: 200,
+          headers: { "content-type": "application/xml" },
+        })) as unknown as typeof fetch,
+    );
+    assert.deepEqual(verdict, { kind: "skip", reason: "200" });
+  });
+
+  test("a route with an unfixtured parameter is skipped, never fetched", async () => {
+    let fetched = false;
+    const verdict = await evaluateRoute(
+      {
+        id: "x",
+        path: "/api/v1/x/{no_such_subject}",
+        artifact_path: "/x.json",
+      },
+      (async () => {
+        fetched = true;
+        return new Response("{}");
+      }) as unknown as typeof fetch,
+    );
+    assert.deepEqual(verdict, { kind: "skip", reason: "no subject" });
+    assert.equal(fetched, false);
+  });
+});


### PR DESCRIPTION
## Summary

Commits the pre-flip verification that found and dispositioned both of the response audit's production fingerprints (#11079 `include_points`, #11082 verify's null `artifact_path`) as a repeatable `conformance:*` tool instead of a scratchpad script.

`npm run conformance:tripwire` fetches every `API_ROUTES` route with a subject from production — one call each, serial and spaced like its siblings — and validates each body through the **exact** `validateResponseTripwire` call `auditResponse` makes. It skips precisely what the seam skips (non-200, non-JSON, unfixtured parameter) and exits 1 on any body the seam would refuse: a drift here is a warn fingerprint waiting for traffic and an enforce-mode 500.

The shared `conformance-subjects.ts` table gains four subjects (`hash` — a decoded extrinsic, immutable history so it cannot rotate stale; `tag`; `surface_id`; a deliberately-unmapped `h160`, documented), which also widens the latency and cross-surface sweeps to five routes they were silently skipping. Current production run: **210 routes clean, 0 drifted, 5 skipped** (POST-shaped `/ask`, per-user webhook/alert ids, AI-gated semantic search, and the documented provider/adapter `slug` name collision).

## Testing

`evaluateRoute` is exported and network-free tested (`tests/check-tripwire-conformance.test.ts`, 5 tests): clean body counts clean; a body the seam refuses is a drift carrying its instancePath; non-200 and non-JSON are skips carrying the status; an unfixtured route is skipped without fetching. The drift case is the falsification — the same `points` omission #11079 dispositioned, detected by the tool.

## Net LOC

+~200: a new out-of-band tool, additive by nature (disclosed, same as the family it joins). It is the "production validation" step epic #10992's definition-of-done names, made one command.

## Validation

- `tsc --noEmit`, lint, format, vocab/shape/public-safety/unreferenced gates
- Live run against production (210 clean / 0 drift), sibling conformance tests still green