### PR TITLE
feat(lakehouse): snapshot what the mirror WRITES, not only what routes read

### DIFF
--- a/generated/lakehouse/schema.json
+++ b/generated/lakehouse/schema.json
@@ -525,6 +525,13 @@
     "required": false
   },
   {
+    "table": "rpc_proxy_events",
+    "field_id": 11,
+    "column": "sample_interval",
+    "type": "int",
+    "required": false
+  },
+  {
     "table": "self_health_daily",
     "field_id": 1,
     "column": "day",
@@ -1635,6 +1642,489 @@
     "field_id": 27,
     "column": "pipeline_block_hash",
     "type": "string",
+    "required": false
+  },
+  {
+    "table": "account_balances",
+    "field_id": 1,
+    "column": "ss58",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "account_balances",
+    "field_id": 2,
+    "column": "free_tao",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "account_balances",
+    "field_id": 3,
+    "column": "reserved_tao",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "account_balances",
+    "field_id": 4,
+    "column": "captured_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 1,
+    "column": "netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 2,
+    "column": "uid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 3,
+    "column": "hotkey",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 4,
+    "column": "coldkey",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 5,
+    "column": "active",
+    "type": "boolean",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 6,
+    "column": "validator_permit",
+    "type": "boolean",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 7,
+    "column": "rank",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 8,
+    "column": "trust",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 9,
+    "column": "validator_trust",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 10,
+    "column": "consensus",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 11,
+    "column": "incentive",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 12,
+    "column": "dividends",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 13,
+    "column": "emission_tao",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 14,
+    "column": "stake_tao",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 15,
+    "column": "registered_at_block",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 16,
+    "column": "is_immunity_period",
+    "type": "boolean",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 17,
+    "column": "axon",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 18,
+    "column": "block_number",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 19,
+    "column": "captured_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "neurons",
+    "field_id": 20,
+    "column": "take",
+    "type": "double",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 1,
+    "column": "netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 2,
+    "column": "block_number",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 3,
+    "column": "captured_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 4,
+    "column": "subnet_name",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 5,
+    "column": "symbol",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 6,
+    "column": "description",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 7,
+    "column": "github_repo",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 8,
+    "column": "subnet_url",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 9,
+    "column": "discord",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 10,
+    "column": "logo_url",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_identity",
+    "field_id": 11,
+    "column": "identity_hash",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_ownership",
+    "field_id": 1,
+    "column": "netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "subnet_ownership",
+    "field_id": 2,
+    "column": "owner_hotkey",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_ownership",
+    "field_id": 3,
+    "column": "owner_coldkey",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnet_ownership",
+    "field_id": 4,
+    "column": "captured_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 1,
+    "column": "netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 2,
+    "column": "slug",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 3,
+    "column": "name",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 4,
+    "column": "source",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 5,
+    "column": "overlay",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 6,
+    "column": "source_commit",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 7,
+    "column": "updated_at",
+    "type": "timestamptz",
+    "required": false
+  },
+  {
+    "table": "subnets",
+    "field_id": 9,
+    "column": "observed_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 1,
+    "column": "id",
+    "type": "uuid",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 2,
+    "column": "subnet_netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 3,
+    "column": "provider_id",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 4,
+    "column": "surface_key",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 5,
+    "column": "kind",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 6,
+    "column": "url",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 7,
+    "column": "authority",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 8,
+    "column": "review_state",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 9,
+    "column": "probe_eligible",
+    "type": "boolean",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 10,
+    "column": "public_safe",
+    "type": "boolean",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 11,
+    "column": "overlay",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 12,
+    "column": "source_commit",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 13,
+    "column": "updated_at",
+    "type": "timestamptz",
+    "required": false
+  },
+  {
+    "table": "surfaces",
+    "field_id": 15,
+    "column": "observed_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "providers",
+    "field_id": 1,
+    "column": "id",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "providers",
+    "field_id": 2,
+    "column": "overlay",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "providers",
+    "field_id": 3,
+    "column": "source_commit",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "providers",
+    "field_id": 4,
+    "column": "updated_at",
+    "type": "timestamptz",
+    "required": false
+  },
+  {
+    "table": "providers",
+    "field_id": 6,
+    "column": "observed_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "validator_nominator_counts",
+    "field_id": 1,
+    "column": "hotkey",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "validator_nominator_counts",
+    "field_id": 2,
+    "column": "nominator_count",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "validator_nominator_counts",
+    "field_id": 3,
+    "column": "captured_at",
+    "type": "long",
     "required": false
   }
 ]

--- a/generated/lakehouse/types.ts
+++ b/generated/lakehouse/types.ts
@@ -204,6 +204,7 @@ export type RpcProxyEventsRow = {
   attempts: number | null;
   latency_ms: number | null;
   cache: string | null;
+  sample_interval: number | null;
 };
 
 /** `chain.rpc_proxy_events` columns, in field-id order. */
@@ -218,6 +219,7 @@ export const RPC_PROXY_EVENTS_COLUMNS = [
   "attempts",
   "latency_ms",
   "cache",
+  "sample_interval",
 ] as const;
 
 /** `chain.self_health_daily` */
@@ -602,6 +604,208 @@ export const SUBNET_SNAPSHOTS_COLUMNS = [
   "pipeline_block_hash",
 ] as const;
 
+/** `chain.account_balances` */
+export type AccountBalancesRow = {
+  ss58: string | null;
+  free_tao: number | null;
+  reserved_tao: number | null;
+  captured_at: number | null;
+};
+
+/** `chain.account_balances` columns, in field-id order. */
+export const ACCOUNT_BALANCES_COLUMNS = [
+  "ss58",
+  "free_tao",
+  "reserved_tao",
+  "captured_at",
+] as const;
+
+/** `chain.neurons` */
+export type NeuronsRow = {
+  netuid: number | null;
+  uid: number | null;
+  hotkey: string | null;
+  coldkey: string | null;
+  active: boolean | null;
+  validator_permit: boolean | null;
+  rank: number | null;
+  trust: number | null;
+  validator_trust: number | null;
+  consensus: number | null;
+  incentive: number | null;
+  dividends: number | null;
+  emission_tao: number | null;
+  stake_tao: number | null;
+  registered_at_block: number | null;
+  is_immunity_period: boolean | null;
+  axon: string | null;
+  block_number: number | null;
+  captured_at: number | null;
+  take: number | null;
+};
+
+/** `chain.neurons` columns, in field-id order. */
+export const NEURONS_COLUMNS = [
+  "netuid",
+  "uid",
+  "hotkey",
+  "coldkey",
+  "active",
+  "validator_permit",
+  "rank",
+  "trust",
+  "validator_trust",
+  "consensus",
+  "incentive",
+  "dividends",
+  "emission_tao",
+  "stake_tao",
+  "registered_at_block",
+  "is_immunity_period",
+  "axon",
+  "block_number",
+  "captured_at",
+  "take",
+] as const;
+
+/** `chain.subnet_identity` */
+export type SubnetIdentityRow = {
+  netuid: number | null;
+  block_number: number | null;
+  captured_at: number | null;
+  subnet_name: string | null;
+  symbol: string | null;
+  description: string | null;
+  github_repo: string | null;
+  subnet_url: string | null;
+  discord: string | null;
+  logo_url: string | null;
+  identity_hash: string | null;
+};
+
+/** `chain.subnet_identity` columns, in field-id order. */
+export const SUBNET_IDENTITY_COLUMNS = [
+  "netuid",
+  "block_number",
+  "captured_at",
+  "subnet_name",
+  "symbol",
+  "description",
+  "github_repo",
+  "subnet_url",
+  "discord",
+  "logo_url",
+  "identity_hash",
+] as const;
+
+/** `chain.subnet_ownership` */
+export type SubnetOwnershipRow = {
+  netuid: number | null;
+  owner_hotkey: string | null;
+  owner_coldkey: string | null;
+  captured_at: number | null;
+};
+
+/** `chain.subnet_ownership` columns, in field-id order. */
+export const SUBNET_OWNERSHIP_COLUMNS = [
+  "netuid",
+  "owner_hotkey",
+  "owner_coldkey",
+  "captured_at",
+] as const;
+
+/** `chain.subnets` */
+export type SubnetsRow = {
+  netuid: number | null;
+  slug: string | null;
+  name: string | null;
+  source: string | null;
+  overlay: string | null;
+  source_commit: string | null;
+  updated_at: string | null;
+  observed_at: number | null;
+};
+
+/** `chain.subnets` columns, in field-id order. */
+export const SUBNETS_COLUMNS = [
+  "netuid",
+  "slug",
+  "name",
+  "source",
+  "overlay",
+  "source_commit",
+  "updated_at",
+  "observed_at",
+] as const;
+
+/** `chain.surfaces` */
+export type SurfacesRow = {
+  id: string | null;
+  subnet_netuid: number | null;
+  provider_id: string | null;
+  surface_key: string | null;
+  kind: string | null;
+  url: string | null;
+  authority: string | null;
+  review_state: string | null;
+  probe_eligible: boolean | null;
+  public_safe: boolean | null;
+  overlay: string | null;
+  source_commit: string | null;
+  updated_at: string | null;
+  observed_at: number | null;
+};
+
+/** `chain.surfaces` columns, in field-id order. */
+export const SURFACES_COLUMNS = [
+  "id",
+  "subnet_netuid",
+  "provider_id",
+  "surface_key",
+  "kind",
+  "url",
+  "authority",
+  "review_state",
+  "probe_eligible",
+  "public_safe",
+  "overlay",
+  "source_commit",
+  "updated_at",
+  "observed_at",
+] as const;
+
+/** `chain.providers` */
+export type ProvidersRow = {
+  id: string | null;
+  overlay: string | null;
+  source_commit: string | null;
+  updated_at: string | null;
+  observed_at: number | null;
+};
+
+/** `chain.providers` columns, in field-id order. */
+export const PROVIDERS_COLUMNS = [
+  "id",
+  "overlay",
+  "source_commit",
+  "updated_at",
+  "observed_at",
+] as const;
+
+/** `chain.validator_nominator_counts` */
+export type ValidatorNominatorCountsRow = {
+  hotkey: string | null;
+  nominator_count: number | null;
+  captured_at: number | null;
+};
+
+/** `chain.validator_nominator_counts` columns, in field-id order. */
+export const VALIDATOR_NOMINATOR_COUNTS_COLUMNS = [
+  "hotkey",
+  "nominator_count",
+  "captured_at",
+] as const;
+
 /** Every Iceberg table this repo reads, by name. */
 export const LAKEHOUSE_TABLES = [
   "blocks",
@@ -620,4 +824,12 @@ export const LAKEHOUSE_TABLES = [
   "neuron_daily",
   "account_position_daily",
   "subnet_snapshots",
+  "account_balances",
+  "neurons",
+  "subnet_identity",
+  "subnet_ownership",
+  "subnets",
+  "surfaces",
+  "providers",
+  "validator_nominator_counts",
 ] as const;

--- a/schemas-src/lakehouse.ts
+++ b/schemas-src/lakehouse.ts
@@ -191,6 +191,7 @@ export const RpcProxyEventsRowSchema = z
     attempts: z.int().nullable(),
     latency_ms: z.int().nullable(),
     cache: z.string().nullable(),
+    sample_interval: z.int().nullable(),
   })
   .partial()
   .catchall(z.unknown());
@@ -466,6 +467,187 @@ export const SubnetSnapshotsRowSchema = z
   .partial()
   .catchall(z.unknown());
 
+/**
+ * `chain.account_balances` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const AccountBalancesRowSchema = z
+  .object({
+    ss58: z.string().nullable(),
+    free_tao: z.number().nullable(),
+    reserved_tao: z.number().nullable(),
+    captured_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.neurons` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const NeuronsRowSchema = z
+  .object({
+    netuid: z.int().nullable(),
+    uid: z.int().nullable(),
+    hotkey: z.string().nullable(),
+    coldkey: z.string().nullable(),
+    active: z.boolean().nullable(),
+    validator_permit: z.boolean().nullable(),
+    rank: z.number().nullable(),
+    trust: z.number().nullable(),
+    validator_trust: z.number().nullable(),
+    consensus: z.number().nullable(),
+    incentive: z.number().nullable(),
+    dividends: z.number().nullable(),
+    emission_tao: z.number().nullable(),
+    stake_tao: z.number().nullable(),
+    registered_at_block: z.int().nullable(),
+    is_immunity_period: z.boolean().nullable(),
+    axon: z.string().nullable(),
+    block_number: z.int().nullable(),
+    captured_at: z.int().nullable(),
+    take: z.number().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.subnet_identity` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const SubnetIdentityRowSchema = z
+  .object({
+    netuid: z.int().nullable(),
+    block_number: z.int().nullable(),
+    captured_at: z.int().nullable(),
+    subnet_name: z.string().nullable(),
+    symbol: z.string().nullable(),
+    description: z.string().nullable(),
+    github_repo: z.string().nullable(),
+    subnet_url: z.string().nullable(),
+    discord: z.string().nullable(),
+    logo_url: z.string().nullable(),
+    identity_hash: z.string().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.subnet_ownership` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const SubnetOwnershipRowSchema = z
+  .object({
+    netuid: z.int().nullable(),
+    owner_hotkey: z.string().nullable(),
+    owner_coldkey: z.string().nullable(),
+    captured_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.subnets` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const SubnetsRowSchema = z
+  .object({
+    netuid: z.int().nullable(),
+    slug: z.string().nullable(),
+    name: z.string().nullable(),
+    source: z.string().nullable(),
+    overlay: z.string().nullable(),
+    source_commit: z.string().nullable(),
+    updated_at: z.iso.datetime().nullable(),
+    observed_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.surfaces` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const SurfacesRowSchema = z
+  .object({
+    id: z.base64().nullable(),
+    subnet_netuid: z.int().nullable(),
+    provider_id: z.string().nullable(),
+    surface_key: z.string().nullable(),
+    kind: z.string().nullable(),
+    url: z.string().nullable(),
+    authority: z.string().nullable(),
+    review_state: z.string().nullable(),
+    probe_eligible: z.boolean().nullable(),
+    public_safe: z.boolean().nullable(),
+    overlay: z.string().nullable(),
+    source_commit: z.string().nullable(),
+    updated_at: z.iso.datetime().nullable(),
+    observed_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.providers` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const ProvidersRowSchema = z
+  .object({
+    id: z.string().nullable(),
+    overlay: z.string().nullable(),
+    source_commit: z.string().nullable(),
+    updated_at: z.iso.datetime().nullable(),
+    observed_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
+/**
+ * `chain.validator_nominator_counts` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const ValidatorNominatorCountsRowSchema = z
+  .object({
+    hotkey: z.string().nullable(),
+    nominator_count: z.int().nullable(),
+    captured_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
 /** Every table's row schema, by table name. */
 export const LAKEHOUSE_ROW_SCHEMAS = {
   blocks: BlocksRowSchema,
@@ -484,4 +666,12 @@ export const LAKEHOUSE_ROW_SCHEMAS = {
   neuron_daily: NeuronDailyRowSchema,
   account_position_daily: AccountPositionDailyRowSchema,
   subnet_snapshots: SubnetSnapshotsRowSchema,
+  account_balances: AccountBalancesRowSchema,
+  neurons: NeuronsRowSchema,
+  subnet_identity: SubnetIdentityRowSchema,
+  subnet_ownership: SubnetOwnershipRowSchema,
+  subnets: SubnetsRowSchema,
+  surfaces: SurfacesRowSchema,
+  providers: ProvidersRowSchema,
+  validator_nominator_counts: ValidatorNominatorCountsRowSchema,
 } as const;

--- a/scripts/check-lakehouse-freshness.ts
+++ b/scripts/check-lakehouse-freshness.ts
@@ -136,6 +136,13 @@ export const EXPECTED: Readonly<Record<string, FreshnessRule>> = {
     maxAgeMs: 2 * DAY,
     reason: "identity poller, restore pending",
   },
+  // Created 2026-08-13 so the archive holds the current-state table it already
+  // held the HISTORY of -- the lakehouse could say what a subnet's identity used
+  // to be and not what it is (#11089).
+  subnet_identity: {
+    maxAgeMs: 2 * DAY,
+    reason: "state mirror, digest-gated: identity changes are rare",
+  },
   subnet_ownership: {
     maxAgeMs: 2 * DAY,
     reason: "ownership poller, restore pending",

--- a/scripts/generate-lakehouse-types.ts
+++ b/scripts/generate-lakehouse-types.ts
@@ -78,6 +78,18 @@ export function readSnapshot(): LakehouseColumn[] {
  * ~9.01e15, so the representable range is not close.
  */
 const TS_TYPE: Readonly<Record<string, string>> = {
+  // Iceberg uuid, which R2 SQL returns as BASE64-ENCODED BYTES
+  // ("AA2+kG8JRdOnBgo8lnnc5Q==") rather than canonical uuid text -- verified
+  // against chain.surfaces.id. A reader expecting "0a0dbe90-..." gets a string
+  // that is the right type and the wrong value, which is why this is mapped
+  // explicitly rather than left to fall back to string.
+  uuid: "string",
+  // Iceberg timestamptz. R2 SQL renders it as an ISO-8601 string with
+  // MICROSECOND precision ("2026-08-02T00:00:35.111100Z"), not as an epoch
+  // number -- verified against chain.subnets.updated_at. Everything else
+  // temporal in this lakehouse is `long` epoch-ms; these three registry tables
+  // are the exception, inherited from the 2026-08-02 exodus load.
+  timestamptz: "string",
   boolean: "boolean",
   // `date` IS `string`, and that is read off the reader rather than assumed.
   // R2 SQL serializes an Iceberg date as 'YYYY-MM-DD', and
@@ -210,6 +222,8 @@ export const DECODER_TABLES: readonly string[] = CHAIN_FIREHOSE_TOPICS;
  * column that changes shape changes both or neither.
  */
 const ZOD_TYPE: Readonly<Record<string, string>> = {
+  uuid: "z.base64()",
+  timestamptz: "z.iso.datetime()",
   boolean: "z.boolean()",
   // 'YYYY-MM-DD' over the wire -- see TS_TYPE's note. `z.iso.date()` rather
   // than a bare string: the format is not assumed, it is the one

--- a/scripts/refresh-lakehouse-schema.ts
+++ b/scripts/refresh-lakehouse-schema.ts
@@ -61,12 +61,7 @@ export const TABLES = [
   "extrinsics",
   "chain_events",
   "account_events",
-  // The nine the cold tiers read. Taken from the FROM/JOIN targets in `src/`
-  // with comments STRIPPED -- a plain grep for `chain.<name>` also matches
-  // prose, and `chain.account_events_daily` is exactly that trap: it is named
-  // in four comments and one route description, and queried by nothing.
-  // src/account-history-cold-tier.ts computes its own day bucket from
-  // `account_events` instead, which its header says in as many words.
+  // The nine the cold tiers read.
   "account_identity",
   "account_identity_history",
   "nominator_positions",
@@ -76,20 +71,32 @@ export const TABLES = [
   "subnet_hyperparams_history",
   "subnet_identity_history",
   "subnet_ownership_history",
-  // The two daily rollups. Listed the moment they became READABLE rather than
-  // when they became present: they have existed since the 2026-08-02 seed, but
-  // that seed is a strict SUBSET of Neon (lakehouse 07-10..08-02, Neon
-  // 07-10..08-11, measured), so nothing could have been served from them. The
-  // continuous producer (metagraphed-infra#445) is what changes that.
-  //
-  // Neither is written by the decoder, so neither belongs in DECODER_TABLES --
-  // they are derived in the Worker from one metagraph snapshot and copied out
-  // of Postgres. The generator's `decoderTables` subset test is what keeps that
-  // distinction honest.
+  // The two daily rollups, and the snapshot that prices them in TAO.
   "neuron_daily",
   "account_position_daily",
-  // Joined by src/neuron-daily-cold-tier.ts to price stake and emission in TAO.
   "subnet_snapshots",
+  // WRITTEN BUT NOT (YET) READ. This list used to be READ tables only, on the
+  // rule that a type for a table nothing queries is dead code the moment it is
+  // generated. That rule was right when the only consumer was a cold-tier
+  // query, and it stopped being right when the lakehouse became the archive.
+  //
+  // Two things changed. `validate:store-type-parity` (#11060) compares Neon
+  // against THIS snapshot, so a table absent here is a table whose column types
+  // nothing compares -- it saw 16 tables and 186 columns while the archive held
+  // 26. And the state mirror now WRITES these, so their shape is load-bearing
+  // whether or not a route reads them.
+  //
+  // The dead-code objection does not apply either: the generator emits into
+  // `LAKEHOUSE_ROW_SCHEMAS`, a registry, so every schema it produces is
+  // referenced and none of this touches the unreferenced-exports ceiling.
+  "account_balances",
+  "neurons",
+  "subnet_identity",
+  "subnet_ownership",
+  "subnets",
+  "surfaces",
+  "providers",
+  "validator_nominator_counts",
 ];
 
 // Guarded, so importing TABLES does not reach for the catalog. Before this the

--- a/scripts/validate-store-type-parity.ts
+++ b/scripts/validate-store-type-parity.ts
@@ -52,7 +52,12 @@ const LAKE_SNAPSHOT = "generated/lakehouse/schema.json";
 const FITS: Readonly<Record<string, ReadonlySet<string>>> = {
   int2: new Set(["int", "long"]),
   int4: new Set(["int", "long"]),
-  int8: new Set(["long"]),
+  // int8 also fits timestamptz/timestamp: the mirror converts epoch-ms to the
+  // instant Iceberg declares (align_epoch_columns), which is a representation
+  // change and not a reinterpretation -- same milliseconds either way. Three
+  // registry tables inherited timestamptz columns from the exodus load while
+  // Neon holds bigint, and that pairing is CORRECT rather than tolerated.
+  int8: new Set(["long", "timestamptz", "timestamp"]),
   float4: new Set(["float", "double"]),
   float8: new Set(["double"]),
   // Arbitrary precision on one side, 64-bit float on the other. `double` is
@@ -60,7 +65,11 @@ const FITS: Readonly<Record<string, ReadonlySet<string>>> = {
   // narrowing is inherent to the format, not a mistake this gate can fix.
   numeric: new Set(["double"]),
   bool: new Set(["boolean"]),
-  text: new Set(["string", "date"]),
+  // text -> uuid is enforced at write rather than assumed: chain.surfaces.id is
+  // uuid in Iceberg and text in Neon, and the mirror packs it to 16 bytes. A
+  // value that is not a uuid raises there instead of being silently truncated,
+  // which is what makes this a fit rather than a narrowing.
+  text: new Set(["string", "date", "uuid"]),
   varchar: new Set(["string", "date"]),
   date: new Set(["date", "string"]),
   json: new Set(["string"]),

--- a/tests/lakehouse-schema.test.ts
+++ b/tests/lakehouse-schema.test.ts
@@ -52,31 +52,52 @@ describe("the committed snapshot", () => {
     // comments and a route description and queried by nothing, because
     // src/account-history-cold-tier.ts computes its own day bucket from
     // account_events instead.
-    assert.deepEqual([...new Set(snapshot.map((c) => c.table))].sort(), [
-      "account_events",
-      "account_identity",
-      "account_identity_history",
-      // The per-(account, netuid, day) position rollup #4908 added;
-      // src/account-position-history.ts serves from it.
-      "account_position_daily",
-      "blocks",
-      "chain_events",
-      "extrinsics",
-      // The per-(uid, day) neuron rollup the history routes read.
-      "neuron_daily",
-      "nominator_positions",
-      "rpc_proxy_events",
-      "self_health_daily",
-      "subnet_hyperparams",
-      "subnet_hyperparams_history",
-      "subnet_identity_history",
-      "subnet_ownership_history",
-      // Joined by src/neuron-daily-cold-tier.ts to price stake and emission in
-      // TAO. It was read for months with no snapshot at all -- #11049 added the
-      // gate that now fails on a read-without-snapshot rather than leaving it
-      // to the comment above.
-      "subnet_snapshots",
-    ]);
+    assert.deepEqual(
+      [...new Set(snapshot.map((c) => c.table))].sort(),
+      [
+        "account_events",
+        "account_identity",
+        "account_identity_history",
+        // The per-(account, netuid, day) position rollup #4908 added;
+        // src/account-position-history.ts serves from it.
+        "account_position_daily",
+        "blocks",
+        "chain_events",
+        "extrinsics",
+        // The per-(uid, day) neuron rollup the history routes read.
+        "neuron_daily",
+        "nominator_positions",
+        "rpc_proxy_events",
+        "self_health_daily",
+        "subnet_hyperparams",
+        "subnet_hyperparams_history",
+        "subnet_identity_history",
+        "subnet_ownership_history",
+        // Joined by src/neuron-daily-cold-tier.ts to price stake and emission in
+        // TAO. It was read for months with no snapshot at all -- #11049 added the
+        // gate that now fails on a read-without-snapshot rather than leaving it
+        // to the comment above.
+        "subnet_snapshots",
+        // WRITTEN BY THE MIRROR, NOT READ BY A ROUTE. The list stopped being
+        // "tables this repo reads" when the lakehouse became the archive: these
+        // eight are mirrored from Neon, so their shape is load-bearing whether or
+        // not a route queries them, and leaving them out meant
+        // `validate:store-type-parity` compared 186 columns while the archive
+        // held 252. Extending it immediately caught `neurons.take` as a real
+        // float32 narrowing.
+        //
+        // Still hand-written for the reason above: a table reaching the snapshot
+        // is a decision, and this is where the decision is recorded.
+        "account_balances",
+        "neurons",
+        "providers",
+        "subnet_identity",
+        "subnet_ownership",
+        "subnets",
+        "surfaces",
+        "validator_nominator_counts",
+      ].sort(),
+    );
     // The TS side mirrors the snapshot -- it is the READER's list.
     assert.deepEqual(
       [...LAKEHOUSE_TABLES].sort(),
@@ -186,7 +207,12 @@ describe("emitTypes", () => {
         table: "blocks",
         field_id: 9999,
         column: "when",
-        type: "timestamptz",
+        // `decimal(38,9)` rather than `timestamptz`, which this used to poison
+        // with: timestamptz is now MAPPED (the registry tables inherited it
+        // from the exodus load), so the old poison silently stopped poisoning
+        // and the test passed for the wrong reason. Pick a type we genuinely
+        // do not emit, and one Iceberg really has.
+        type: "decimal(38,9)",
         required: false,
       },
     ];


### PR DESCRIPTION
Part of #11089.

Extending the snapshot from **16 tables to 24** took `store-type-parity` from **186 columns to 252** — and immediately found a real narrowing that had been invisible to it.

## Why the rule changed

`refresh-lakehouse-schema.ts` snapshotted READ tables only, on the rule that *a type for a table nothing queries is dead code the moment it is generated*. That was right when the only consumer was a cold-tier query. It stopped being right when the lakehouse became the archive:

- `validate:store-type-parity` (#11060) compares Neon against **this snapshot**, so a table absent here is a table whose column types nothing compares. It saw 16 tables while the archive held 26.
- metagraphed-infra's state mirror **writes** these, so their shape is load-bearing whether or not a route reads them.

The dead-code objection does not survive either: the generator emits into `LAKEHOUSE_ROW_SCHEMAS`, a registry, so every schema it produces is referenced. **Unreferenced exports untouched at 731.**

## What the wider net caught

```
neurons.take: Neon float8 stored as lakehouse float
```

A real float32 narrowing on a live table — and precisely the source/rollup mismatch metagraphed-infra#542 predicted: `neuron_daily.take` had been widened and `neurons.take` had not. Fixed in the catalog; parity is back to **0 across 252 columns**.

The other four were the mirror's own conversions, and `FITS` now knows them rather than reporting them as loss:

| conversion | why it is a fit |
| --- | --- |
| `int8 → timestamptz` | `align_epoch_columns` converts epoch-ms to the instant Iceberg declares — same milliseconds, different representation. Three registry tables inherited `timestamptz` from the exodus load. |
| `text → uuid` | `chain.surfaces.id`, enforced at **write**: a value that is not a uuid raises rather than truncating. |

## Two wire types were assumptions until measured

- `timestamptz` renders as an ISO string with **microsecond** precision: `2026-08-02T00:00:35.111100Z`
- `uuid` renders as **base64 bytes**: `AA2+kG8JRdOnBgo8lnnc5Q==` — *not* canonical uuid text

So anything reading `surfaces.id` expecting `0a0dbe90-…` gets the right type and the wrong value. Both verified against R2 SQL and mapped explicitly rather than falling back to `string`.

## `chain.subnet_identity`

The archive held `subnet_identity_history` and **not the current-state table it is the history of** — so the lakehouse could say what a subnet's identity used to be and not what it is. Created with types matching both Neon and its own history table, mirrored (124 rows), and classified in the freshness watchdog's `EXPECTED` — which failed until it was, exactly as intended. First of the 16 in #11089.

## A test that had stopped testing

`emitTypes` poisoned its unmapped-type case with `timestamptz`. That type is now mapped, so **the poison stopped poisoning and the test passed for the wrong reason.** Repointed at `decimal(38,9)`.

## Verification

`store-type-parity` 0/252 · `lakehouse-types-drift` clean · `validate:lakehouse-readers` clean · `npx tsc --noEmit` · `npm run lint` · unreferenced exports 731 (at ceiling). **20,683 tests pass, 904 files.**