### PR TITLE
docs(schemas): concentration total states its unit where it is declared and where it is embedded

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -1790,6 +1790,10 @@ Concentration metrics over a value distribution -- Gini, HHI (raw + holder-count
 """
 type ConcentrationMetrics {
   holders: Int!
+
+  """
+  The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit.
+  """
   total: Float
   gini: Float
   hhi: Float
@@ -2698,12 +2702,12 @@ type SubnetMinerFairnessPersistence {
 
 type SubnetMinerFairnessConcentration {
   """
-  THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that.
+  THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's \`days_covered\` days, where each day contributes that day's captured PER-TEMPO alpha rate (the \`emission_tao\` convention) -- so \`total\` is a within-subnet ranking mass, not a window payout total, and never TAO.
   """
   entity: ConcentrationMetrics
 
   """
-  The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator.
+  The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples.
   """
   uid: ConcentrationMetrics
 }
@@ -3432,6 +3436,10 @@ One distribution's concentration scorecard, passed through from the stored card 
 """
 type ChainConcentrationScorecard {
   holders: Int!
+
+  """
+  The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit.
+  """
   total: Float
   gini: Float
   hhi: Float
@@ -5475,6 +5483,10 @@ type BlocksSummary {
   block_time: BlockTimeDistribution
   throughput: BlocksThroughput
   distinct_authors: Int!
+
+  """
+  Block-authorship decentralization: the shared concentration measures over each distinct author's BLOCK COUNT in the window (\`total\` is the counted blocks). Null when no block in the window carried an author.
+  """
   author_concentration: ConcentrationMetrics
   distinct_spec_versions: Int!
   latest_spec_version: Int

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -866,6 +866,7 @@ export type BlockTimeDistribution = {
 /** Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary. */
 export type BlocksSummary = {
   __typename?: 'BlocksSummary';
+  /** Block-authorship decentralization: the shared concentration measures over each distinct author's BLOCK COUNT in the window (`total` is the counted blocks). Null when no block in the window carried an author. */
   author_concentration?: Maybe<ConcentrationMetrics>;
   block_count: Scalars['Int']['output'];
   block_time?: Maybe<BlockTimeDistribution>;
@@ -1205,6 +1206,7 @@ export type ChainConcentrationScorecard = {
   top_5pct_share?: Maybe<Scalars['Float']['output']>;
   top_10pct_share?: Maybe<Scalars['Float']['output']>;
   top_20pct_share?: Maybe<Scalars['Float']['output']>;
+  /** The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
   total?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -2107,6 +2109,7 @@ export type ConcentrationMetrics = {
   top_5pct_share?: Maybe<Scalars['Float']['output']>;
   top_10pct_share?: Maybe<Scalars['Float']['output']>;
   top_20pct_share?: Maybe<Scalars['Float']['output']>;
+  /** The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
   total?: Maybe<Scalars['Float']['output']>;
 };
 
@@ -6802,9 +6805,9 @@ export type SubnetMinerFairness = {
 
 export type SubnetMinerFairnessConcentration = {
   __typename?: 'SubnetMinerFairnessConcentration';
-  /** THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. */
+  /** THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO. */
   entity?: Maybe<ConcentrationMetrics>;
-  /** The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. */
+  /** The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples. */
   uid?: Maybe<ConcentrationMetrics>;
 };
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6286,6 +6286,7 @@ export interface components {
         };
         /** @description Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary. */
         BlocksSummaryArtifact: {
+            /** @description Block-authorship decentralization: the shared concentration measures over each distinct author's BLOCK COUNT in the window (`total` is the counted blocks). Null when no block in the window carried an author. */
             author_concentration: components["schemas"]["ConcentrationMetrics"] | null;
             block_count: number;
             block_time: {
@@ -6648,6 +6649,7 @@ export interface components {
             top_1pct_share: number | null;
             top_20pct_share: number | null;
             top_5pct_share: number | null;
+            /** @description The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
             total: number | null;
         };
         ChainConcentrationSubnetsArtifact: {
@@ -7521,6 +7523,7 @@ export interface components {
             top_1pct_share?: number | null;
             top_20pct_share?: number | null;
             top_5pct_share?: number | null;
+            /** @description The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
             total?: number | null;
         } | null;
         ContractsArtifact: {
@@ -7903,6 +7906,7 @@ export interface components {
                 top_1pct_share: number | null;
                 top_20pct_share: number | null;
                 top_5pct_share: number | null;
+                /** @description The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
                 total: number | null;
             } | null;
             netuids: number[];
@@ -11746,9 +11750,9 @@ export interface components {
         /** @description Whether a subnet's registered miners actually earn, measured over a 7d/30d/90d window rather than from a snapshot. Reports the daily zero-emission rate, how many days each miner UID earned on (persistent-zero and occasionally-zero are different facts a snapshot collapses), and emission concentration across controlling entities as the headline lens with the per-UID lens beside it. DESCRIPTIVE ONLY — there is no fairness score and no grade: a high Gini on a subnet whose task genuinely has one best answer is not misconduct, and that context is not in this data. A subnet with no daily rollup resolves to a schema-stable empty series (days_covered 0), never null. Mirrors GET /api/v1/subnets/{netuid}/miner-fairness. */
         SubnetMinerFairnessArtifact: {
             concentration?: {
-                /** @description THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. */
+                /** @description THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO. */
                 entity?: components["schemas"]["ConcentrationMetrics"];
-                /** @description The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. */
+                /** @description The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples. */
                 uid?: components["schemas"]["ConcentrationMetrics"];
             };
             /** @description How many days the series actually covers. Published beside every distribution figure: a distribution over 3 days and one over 31 are not the same claim, and `neuron_daily` is only ~27-33 days deep, so a 90d window is answered with the depth found rather than refused. */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -20586,7 +20586,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Block-authorship decentralization: the shared concentration measures over each distinct author's BLOCK COUNT in the window (`total` is the counted blocks). Null when no block in the window carried an author."
           },
           "block_count": {
             "maximum": 9007199254740991,
@@ -22607,7 +22608,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit."
           }
         },
         "required": [
@@ -28201,7 +28203,8 @@
                   {
                     "type": "null"
                   }
-                ]
+                ],
+                "description": "The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit."
               }
             },
             "required": [
@@ -30081,7 +30084,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit."
                   }
                 },
                 "required": [
@@ -51821,11 +51825,11 @@
             "properties": {
               "entity": {
                 "$ref": "#/components/schemas/ConcentrationMetrics",
-                "description": "THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that."
+                "description": "THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO."
               },
               "uid": {
                 "$ref": "#/components/schemas/ConcentrationMetrics",
-                "description": "The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator."
+                "description": "The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples."
               }
             },
             "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6286,6 +6286,7 @@ export interface components {
         };
         /** @description Block-production summary (#5664) over the recent-block window. Every aggregate is null on a cold retired-D1 store (schema-stable, never a GraphQL error). Mirrors GET /api/v1/blocks/summary. */
         BlocksSummaryArtifact: {
+            /** @description Block-authorship decentralization: the shared concentration measures over each distinct author's BLOCK COUNT in the window (`total` is the counted blocks). Null when no block in the window carried an author. */
             author_concentration: components["schemas"]["ConcentrationMetrics"] | null;
             block_count: number;
             block_time: {
@@ -6648,6 +6649,7 @@ export interface components {
             top_1pct_share: number | null;
             top_20pct_share: number | null;
             top_5pct_share: number | null;
+            /** @description The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
             total: number | null;
         };
         ChainConcentrationSubnetsArtifact: {
@@ -7521,6 +7523,7 @@ export interface components {
             top_1pct_share?: number | null;
             top_20pct_share?: number | null;
             top_5pct_share?: number | null;
+            /** @description The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
             total?: number | null;
         } | null;
         ContractsArtifact: {
@@ -7903,6 +7906,7 @@ export interface components {
                 top_1pct_share: number | null;
                 top_20pct_share: number | null;
                 top_5pct_share: number | null;
+                /** @description The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
                 total: number | null;
             } | null;
             netuids: number[];
@@ -11746,9 +11750,9 @@ export interface components {
         /** @description Whether a subnet's registered miners actually earn, measured over a 7d/30d/90d window rather than from a snapshot. Reports the daily zero-emission rate, how many days each miner UID earned on (persistent-zero and occasionally-zero are different facts a snapshot collapses), and emission concentration across controlling entities as the headline lens with the per-UID lens beside it. DESCRIPTIVE ONLY — there is no fairness score and no grade: a high Gini on a subnet whose task genuinely has one best answer is not misconduct, and that context is not in this data. A subnet with no daily rollup resolves to a schema-stable empty series (days_covered 0), never null. Mirrors GET /api/v1/subnets/{netuid}/miner-fairness. */
         SubnetMinerFairnessArtifact: {
             concentration?: {
-                /** @description THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. */
+                /** @description THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO. */
                 entity?: components["schemas"]["ConcentrationMetrics"];
-                /** @description The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. */
+                /** @description The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples. */
                 uid?: components["schemas"]["ConcentrationMetrics"];
             };
             /** @description How many days the series actually covers. Published beside every distribution figure: a distribution over 3 days and one over 31 are not the same claim, and `neuron_daily` is only ~27-33 days deep, so a 90d window is answered with the depth found rather than refused. */

--- a/schemas-src/routes/blocks-summary.ts
+++ b/schemas-src/routes/blocks-summary.ts
@@ -48,7 +48,9 @@ export const BlocksSummaryArtifactSchema = z
       )
       .nullable(),
     distinct_authors: z.int().min(0),
-    author_concentration: ConcentrationMetricsSchema.nullable(),
+    author_concentration: ConcentrationMetricsSchema.nullable().describe(
+      "Block-authorship decentralization: the shared concentration measures over each distinct author's BLOCK COUNT in the window (`total` is the counted blocks). Null when no block in the window carried an author.",
+    ),
     distinct_spec_versions: z.int().min(0),
     latest_spec_version: z.int().min(0).nullable(),
   })

--- a/schemas-src/routes/miner-fairness.ts
+++ b/schemas-src/routes/miner-fairness.ts
@@ -66,11 +66,11 @@ const FairnessConcentrationSchema = z
   .object({
     entity: ConcentrationMetricsSchema.optional().meta({
       description:
-        "THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that.",
+        "THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO.",
     }),
     uid: ConcentrationMetricsSchema.optional().meta({
       description:
-        "The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator.",
+        "The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples.",
     }),
   })
   .strict();

--- a/schemas-src/shared.ts
+++ b/schemas-src/shared.ts
@@ -650,7 +650,13 @@ export const ConcentrationMetricsSchema = z
     // old `.nullable().optional()` spelling predates the typed producers and
     // described no writer.
     holders: z.int().min(0),
-    total: z.number().nullable().optional(),
+    total: z
+      .number()
+      .nullable()
+      .optional()
+      .describe(
+        "The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit.",
+      ),
     gini: z.number().nullable().optional(),
     hhi: z.number().nullable().optional(),
     hhi_normalized: z.number().nullable().optional(),


### PR DESCRIPTION
## Summary

Field-report P0 (#11093): the shared `ConcentrationMetricsSchema.total` had no description, and the lens embeds over different distributions per route — irreconcilable across routes by design, but nothing said so.

- **Shared owner** (`schemas-src/shared.ts`): `total` now states the rule — the sum of the distribution the lens was computed over, in that distribution's own unit and window; the embedding names both; never comparable across routes.
- **The one undescribed embedding** (`blocks-summary.author_concentration`): described — block counts per author, null when authorless.
- **The motivating case** (`miner-fairness`): both lens descriptions now state the distribution precisely — each day contributes that day's captured **per-tempo** alpha rate, so `total` is a within-subnet ranking mass, not a payout total and not TAO. Verified numerically before writing: SN13's emission-split `uid_alpha` = 294.86/point = exactly one tempo (360 × 0.82 post-owner-cut), confirming the daily rollup samples the per-tempo rate.

Description-only: the openapi diff is descriptions + the trailing-comma shifts they introduce; no shape or value changes. GraphQL SDL/types regenerated (descriptions ride them).

## Validation

- `npm run build` + contract-drift/openapi/ui-docs-drift/contract-doc-sync/graphql-component-parity all green
- Full suite: 20,683 passed
- tsc, lint, format clean

Closes #11093