### PR TITLE
fix(registry): SN29 points at Cacheon's repo — revert it, regenerate the catalog, and gate it

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/curation-playbook.md`](docs/
 - **[Perturb](https://metagraph.sh/subnets/26)** `SN26` — `adversarial-robustness` `computer-vision` · [site](https://www.perturbai.io/) · [docs](https://www.perturbai.io/whitepaper) · [repo](https://github.com/0xsigurd/Perturb)
 - **[NI Compute](https://metagraph.sh/subnets/27)** `SN27` — `compute` `dashboard`
 - **[gm](https://metagraph.sh/subnets/28)** `SN28` — `llm-inference` `marketplace` `tee` · [site](https://saygm.com/) · [repo](https://github.com/taostat/gm-miner)
-- **[Coldint](https://metagraph.sh/subnets/29)** `SN29` — `data` `distributed-training` · [site](https://coldint.io/) · [docs](https://github.com/coldint/coldint_validator/blob/main/README.md) · [repo](https://github.com/coldint/hotfloat)
+- **[Coldint](https://metagraph.sh/subnets/29)** `SN29` — `data` `distributed-training` · [site](https://coldint.io/) · [docs](https://github.com/coldint/coldint_validator/blob/main/README.md) · [repo](https://github.com/coldint/coldint_validator)
 - **[Endure Network](https://metagraph.sh/subnets/30)** `SN30` — `defi` `risk-intelligence` · [site](https://endure.network/) · [docs](https://docs.endure.network/)
 - **[Recall](https://metagraph.sh/subnets/31)** `SN31` — `rag` `retrieval`
 - **[ItsAI](https://metagraph.sh/subnets/32)** `SN32` · [site](https://its-ai.org/en) · [repo](https://github.com/It-s-AI/llm-detection)

--- a/apps/ui/content/docs/catalog.mdx
+++ b/apps/ui/content/docs/catalog.mdx
@@ -3,7 +3,7 @@ title: Subnet catalog
 description: 128 curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.
 ---
 
-**128 curated subnets** — 117 with a site, 46 with docs, 117 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.
+**128 curated subnets** — 117 with a site, 46 with docs, 116 with a public repo. Live health, search, and the full list (every active subnet, not just the curated ones) at **[metagraph.sh](https://metagraph.sh)**; per-subnet JSON at `https://api.metagraph.sh/api/v1/subnets/{netuid}`. Root (SN0) is base-layer chain infrastructure, listed separately below, not counted as a subnet.
 
 **Focus areas:** `compute` 9 · `data` 7 · `defi` 6 · `inference` 6 · `language-models` 4 · `prediction-markets` 4 · `computer-vision` 3 · `finance` 3 · `dashboard` 2 · `data-artifact` 2 · `decentralized-training` 2 · `depin` 2
 
@@ -36,14 +36,14 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[Perturb](https://metagraph.sh/subnets/26)** `SN26` — `adversarial-robustness` `computer-vision` · [site](https://www.perturbai.io/) · [docs](https://www.perturbai.io/whitepaper) · [repo](https://github.com/0xsigurd/Perturb)
 - **[NI Compute](https://metagraph.sh/subnets/27)** `SN27` — `compute` `dashboard`
 - **[gm](https://metagraph.sh/subnets/28)** `SN28` — `llm-inference` `marketplace` `tee` · [site](https://saygm.com/) · [repo](https://github.com/taostat/gm-miner)
-- **[Coldint](https://metagraph.sh/subnets/29)** `SN29` — `data` `distributed-training` · [site](https://coldint.io/) · [docs](https://github.com/coldint/coldint_validator/blob/main/README.md) · [repo](https://github.com/coldint/hotfloat)
+- **[Coldint](https://metagraph.sh/subnets/29)** `SN29` — `data` `distributed-training` · [site](https://coldint.io/) · [docs](https://github.com/coldint/coldint_validator/blob/main/README.md) · [repo](https://github.com/coldint/coldint_validator)
 - **[Endure Network](https://metagraph.sh/subnets/30)** `SN30` — `defi` `risk-intelligence` · [site](https://endure.network/) · [docs](https://docs.endure.network/)
 - **[Recall](https://metagraph.sh/subnets/31)** `SN31` — `rag` `retrieval`
 - **[ItsAI](https://metagraph.sh/subnets/32)** `SN32` · [site](https://its-ai.org/en) · [repo](https://github.com/It-s-AI/llm-detection)
 - **[ReadyAI](https://metagraph.sh/subnets/33)** `SN33` — `conversation-data` `data` · [site](https://readyai.ai/) · [docs](https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md) · [repo](https://github.com/afterpartyai/bittensor-conversation-genome-project)
 - **[BitMind](https://metagraph.sh/subnets/34)** `SN34` — `deepfake-detection` · [site](https://bitmind.ai/) · [docs](https://docs.bitmind.ai/) · [repo](https://github.com/BitMind-AI/bitmind-subnet)
 - **[OxMarkets](https://metagraph.sh/subnets/35)** `SN35` — `defi` · [site](https://www.0xmarkets.io/) · [repo](https://github.com/General-Tao-Ventures/cartha-validator)
-- **[Eirel](https://metagraph.sh/subnets/36)** `SN36` — `llm-evaluation` · [site](https://eirel.ai/) · [repo](https://github.com/RendixNetwork/eirel-ai)
+- **[Leoma](https://metagraph.sh/subnets/36)** `SN36` · [site](https://leoma.ai/) · [repo](https://github.com/RendixNetwork/leoma)
 - **[Aurelius](https://metagraph.sh/subnets/37)** `SN37` — `alignment` · [site](https://aureliusaligned.ai/) · [repo](https://github.com/Aurelius-Protocol/Aurelius-Protocol)
 - **[ChronoLLM](https://metagraph.sh/subnets/38)** `SN38` — `language-models` · [site](https://chronollm.com/) · [docs](https://github.com/chronollm/sn38/blob/main/docs/miner.md) · [repo](https://github.com/chronollm/sn38)
 - **[Basilica](https://metagraph.sh/subnets/39)** `SN39` — `compute` · [site](https://www.basilica.ai/) · [repo](https://github.com/one-covenant/basilica)
@@ -73,7 +73,7 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[Enigma](https://metagraph.sh/subnets/63)** `SN63` — `quantum` · [site](https://www.qbittensorlabs.com/) · [repo](https://github.com/qbittensor-labs/enigma)
 - **[Chutes](https://metagraph.sh/subnets/64)** `SN64` — `compute` `inference` · [site](https://chutes.ai/) · [docs](https://chutes.ai/docs) · [repo](https://github.com/chutesai/chutes)
 - **[TAO Private Network](https://metagraph.sh/subnets/65)** `SN65` — `networking` · [site](https://tpn.taofu.xyz/) · [repo](https://github.com/taofu-labs/tpn-subnet)
-- **[ninja](https://metagraph.sh/subnets/66)** `SN66` — `software-engineering` `workflow` · [site](https://ninja66.ai/) · [docs](https://github.com/ninja-subnet/ninja/blob/main/README.md) · [repo](https://github.com/ninja-subnet/ninja)
+- **[ninja](https://metagraph.sh/subnets/66)** `SN66` — `software-engineering` `workflow` · [site](https://ninja66.ai/) · [docs](https://github.com/ninja-subnet/ninja/blob/main/README.md) · [repo](https://github.com/conjectures-io/conjectures-validator)
 - **[Harnyx](https://metagraph.sh/subnets/67)** `SN67` · [site](https://harnyx.ai/) · [repo](https://github.com/harnyx/harnyx)
 - **[NOVA](https://metagraph.sh/subnets/68)** `SN68` · [site](https://www.metanova-labs.ai/) · [repo](https://github.com/metanova-labs/nova)
 - **[ain](https://metagraph.sh/subnets/69)** `SN69` · [site](https://www.heraldmedia.ai/) · [repo](https://github.com/HeraldMedia/herald)
@@ -83,11 +83,11 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[MetaHash](https://metagraph.sh/subnets/73)** `SN73` — `defi` `otc` `treasury`
 - **[Gittensor](https://metagraph.sh/subnets/74)** `SN74` — `developer-tools` `repositories` · [site](https://gittensor.io/) · [docs](https://docs.gittensor.io/) · [repo](https://github.com/entrius/gittensor)
 - **[Hippius](https://metagraph.sh/subnets/75)** `SN75` — `depin` `storage` · [site](https://hippius.com/) · [docs](https://docs.hippius.com/) · [repo](https://github.com/thenervelab/thebrain)
-- **[Byzantium](https://metagraph.sh/subnets/76)** `SN76` · [site](https://www.byzantiumai.net/) · [repo](https://github.com/byzantiumaitao-arch/byzantium)
+- **[Byzantium](https://metagraph.sh/subnets/76)** `SN76` · [site](https://www.byzantiumai.net/) · [repo](https://github.com/praxi-labs/phylax-subnet)
 - **[Liquidity](https://metagraph.sh/subnets/77)** `SN77` — `defi` · [site](https://sn77.xyz/) · [repo](https://github.com/creativebuilds/sn77)
 - **[Vocence](https://metagraph.sh/subnets/78)** `SN78` · [site](https://www.vocence.ai/) · [repo](https://github.com/vocence-78/vocence)
 - **[MVTRX](https://metagraph.sh/subnets/79)** `SN79` · [site](https://taos.im/) · [docs](https://simulate.trading/taos-im-paper) · [repo](https://github.com/taos-im/sn-79)
-- **[dogelayer](https://metagraph.sh/subnets/80)** `SN80` · [repo](https://github.com/dogelayer-ai/dogelayer)
+- **[dogelayer](https://metagraph.sh/subnets/80)** `SN80` · [repo](https://github.com/openroboto-ai/openroboto-subnet)
 - **[Grail](https://metagraph.sh/subnets/81)** `SN81` — `decentralized-training` · [docs](https://github.com/one-covenant/grail/tree/main/docs) · [repo](https://github.com/one-covenant/grail)
 - **[Compelle](https://metagraph.sh/subnets/82)** `SN82` · [site](https://compelle.com/) · [repo](https://github.com/compelle/compelle-validator)
 - **[CliqueAI](https://metagraph.sh/subnets/83)** `SN83` · [site](https://cliqueai.toptensor.ai/) · [repo](https://github.com/toptensor/CliqueAI)
@@ -96,7 +96,7 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[Subnet 86](https://metagraph.sh/subnets/86)** `SN86`
 - **[Luminar Network](https://metagraph.sh/subnets/87)** `SN87` — `video-intelligence` `vision` · [site](https://luminar.network/) · [docs](https://docs.luminar.network/) · [repo](https://github.com/Luminar-Network/luminar-sn)
 - **[Investing](https://metagraph.sh/subnets/88)** `SN88` — `data-artifact` `finance` · [site](https://investing88.ai/) · [repo](https://github.com/mobiusfund/investing)
-- **[InfiniteHash](https://metagraph.sh/subnets/89)** `SN89` · [site](https://infinitehash.xyz/) · [docs](https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md) · [repo](https://github.com/backend-developers-ltd/InfiniteHash)
+- **[InfiniteHash](https://metagraph.sh/subnets/89)** `SN89` · [site](https://infinitehash.xyz/) · [docs](https://github.com/backend-developers-ltd/InfiniteHash/blob/master/docs/subnet_auction_incentive_system.md) · [repo](https://github.com/DeltaCompute24/InfiniteQuant-Subnet)
 - **[DegenBrain](https://metagraph.sh/subnets/90)** `SN90` — `prediction-markets` `verification` · [site](https://subnet90.com/)
 - **[Bitstarter #1](https://metagraph.sh/subnets/91)** `SN91` · [site](https://www.bitstarter.ai/) · [repo](https://github.com/TensorLink-AI/cascade)
 - **[Tensorclaw](https://metagraph.sh/subnets/92)** `SN92` — `inference` `stale-source-restored` · [site](https://www.tensorclaw.ai/) · [repo](https://github.com/LumenLabs-io/enclave-subnet)
@@ -105,8 +105,8 @@ description: 128 curated subnets, generated from the registry overlays in regist
 - **[Actual](https://metagraph.sh/subnets/95)** `SN95` — `inference` `model-registry` · [site](https://actual.inc/)
 - **[Verathos](https://metagraph.sh/subnets/96)** `SN96` — `inference` `language-models` · [site](https://verathos.ai/) · [docs](https://verathos.ai/docs) · [repo](https://github.com/verathos-ai/verathos)
 - **[Albedo](https://metagraph.sh/subnets/97)** `SN97` · [site](https://albedo.tech) · [repo](https://github.com/unarbos/albedo)
-- **[ForeverMoney](https://metagraph.sh/subnets/98)** `SN98` — `finance` · [site](https://forevermoney.ai/) · [repo](https://github.com/SN98-ForeverMoney/forever-money)
-- **[Leoma](https://metagraph.sh/subnets/99)** `SN99` · [site](https://leoma.ai/) · [repo](https://github.com/RendixNetwork/leoma)
+- **[ForeverMoney](https://metagraph.sh/subnets/98)** `SN98` — `finance` · [site](https://forevermoney.ai/) · [repo](https://github.com/neverplayalone/neverplayalone_subnet)
+- **[Thirty Spokes](https://metagraph.sh/subnets/99)** `SN99` · [site](https://www.thirtyspokes.ai/)
 - **[Plaτform](https://metagraph.sh/subnets/100)** `SN100` — `ai-research` · [site](https://www.platform.network/) · [docs](https://www.platform.network/docs) · [repo](https://github.com/PlatformNetwork/platform)
 - **[eni](https://metagraph.sh/subnets/101)** `SN101` · [site](http://tag101.ai/) · [repo](https://github.com/tag101-ai/tag101)
 - **[ConnitoAI](https://metagraph.sh/subnets/102)** `SN102` · [site](https://connito.ai/) · [repo](https://github.com/Connito-AI/Connito)

--- a/apps/ui/scripts/generate-catalog-docs.ts
+++ b/apps/ui/scripts/generate-catalog-docs.ts
@@ -22,7 +22,15 @@ import {
 } from "../../../scripts/lib/readme-catalog.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const OUTPUT_PATH = path.join(__dirname, "../content/docs/catalog.mdx");
+
+// CATALOG_DOCS_OUTPUT redirects the write, the same override
+// generate-openapi-docs.ts takes as OPENAPI_DOCS_OUTPUT and for the same
+// reason: scripts/validate-ui-docs-drift.ts regenerates into a temp directory
+// and diffs, so a drift check can never leave a dirty working tree behind.
+const COMMITTED_PATH = path.join(__dirname, "../content/docs/catalog.mdx");
+const OUTPUT_PATH = process.env.CATALOG_DOCS_OUTPUT
+  ? path.resolve(process.env.CATALOG_DOCS_OUTPUT)
+  : COMMITTED_PATH;
 
 function frontmatter(curatedCount: number) {
   return [
@@ -52,13 +60,19 @@ async function main() {
   // re-run -- both expect, regardless of which one runs first.
   // prettier.format() does NOT read .prettierrc on its own (that's CLI-only
   // behavior) -- resolveConfig() is required to pick it up here.
-  const config = (await prettier.resolveConfig(OUTPUT_PATH)) ?? {};
+  // Resolve against COMMITTED_PATH, never OUTPUT_PATH: prettier looks the
+  // config up from the file's directory, and a CATALOG_DOCS_OUTPUT pointing at
+  // a temp dir would find none -- formatting the drift check's copy differently
+  // from the committed file and reporting drift that does not exist.
+  const config = (await prettier.resolveConfig(COMMITTED_PATH)) ?? {};
   const formatted = await prettier.format(raw, {
     ...config,
-    filepath: OUTPUT_PATH,
+    filepath: COMMITTED_PATH,
   });
   await writeFile(OUTPUT_PATH, formatted);
-  console.log(`Wrote content/docs/catalog.mdx: ${curatedCount} curated subnets.`);
+  console.log(
+    `Wrote ${OUTPUT_PATH === COMMITTED_PATH ? "content/docs/catalog.mdx" : OUTPUT_PATH}: ${curatedCount} curated subnets.`,
+  );
 }
 
 main();

--- a/registry/subnets/coldint.json
+++ b/registry/subnets/coldint.json
@@ -32,7 +32,7 @@
   },
   "schema_version": 1,
   "slug": "sn-29",
-  "source_repo": "https://github.com/coldint/hotfloat",
+  "source_repo": "https://github.com/coldint/coldint_validator",
   "status": "active",
   "surfaces": [
     {
@@ -61,8 +61,8 @@
       "authority": "official",
       "id": "sn-29-coldint-validator-source",
       "kind": "source-repo",
-      "name": "Coldint source repository",
-      "notes": "Official SN29 source repository. Chain-declared in SubnetIdentitiesV3 at block 8823651 and verified live 2026-08-13. Replaces coldint/coldint_validator, last pushed 2025-07-11.",
+      "name": "Coldint validator source repository",
+      "notes": "Official SN29 validator repository -- its README states \"Bittensor subnet 29 is focused on advancing collaborative, distributed model training\". Reverts #11086, which repointed this to coldint/hotfloat because SubnetIdentitiesV3 declares that repo for netuid 29. It is not SN29's: hotfloat's README is titled \"Cacheon (SN14)\", links tao.app/subnets/14 and cacheon.ai, and its validator/.env.example sets CACHEON_NETUID=14. The chain identity is operator-set and wrong here. Last pushed 2025-07-11; coldint/sn29 (the dynamic-configuration repository, also registered) names it as \"the validator code\".",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -71,8 +71,8 @@
       },
       "provider": "coldint",
       "public_safe": true,
-      "source_urls": ["https://github.com/coldint/hotfloat"],
-      "url": "https://github.com/coldint/hotfloat"
+      "source_urls": ["https://github.com/coldint/coldint_validator"],
+      "url": "https://github.com/coldint/coldint_validator"
     },
     {
       "auth_required": false,

--- a/scripts/validate-ui-docs-drift.ts
+++ b/scripts/validate-ui-docs-drift.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
 
-// Drift gate for apps/ui/content/docs/api-reference/** (#8917).
+// Drift gate for apps/ui/content/docs/api-reference/** (#8917) and
+// apps/ui/content/docs/catalog.mdx.
 //
 // Those pages are generated entirely from public/metagraph/openapi.json by
 // apps/ui/scripts/generate-openapi-docs.ts, so the thing that invalidates them
@@ -16,12 +17,25 @@ import { repoRoot } from "./lib.ts";
 // found out from a red `ui` job (observed on #8892, which added
 // /api/v1/chain/emission-pipeline).
 //
+// catalog.mdx has the identical shape one layer over: it is generated from the
+// curated overlays by apps/ui/scripts/generate-catalog-docs.ts, so a REGISTRY
+// PR invalidates it without touching apps/ui. That went unnoticed twice in one
+// day -- #11086 and #11090 each repointed source repos and each needed a
+// separate cleanup PR (#11104, #11106) once the `ui` job went red on somebody
+// else's branch. README.md is generated from the same renderer
+// (scripts/lib/readme-catalog.ts, "one source, two destinations") and IS gated,
+// by validate:readme-catalog; this closes the other destination.
+//
 // Generates into a TEMP directory via the generator's own
 // OPENAPI_DOCS_OUTPUT override rather than regenerating in place and diffing
 // the way the CI step does -- same never-mutate-the-tree convention as
 // validate-graphql-types-drift.ts, so running this can't leave a dirty
 // working tree behind on failure.
 const COMMITTED_DIR = path.join(repoRoot, "apps/ui/content/docs/api-reference");
+const COMMITTED_CATALOG = path.join(
+  repoRoot,
+  "apps/ui/content/docs/catalog.mdx",
+);
 const UI_DIR = path.join(repoRoot, "apps/ui");
 
 // The generator preserves one hand-written page it does not own; it is not
@@ -105,8 +119,47 @@ try {
     process.exit(1);
   }
 
+  // Same never-mutate-the-tree contract as above: the generator writes to a
+  // temp file via CATALOG_DOCS_OUTPUT and we diff, so a stale catalog cannot
+  // leave the working tree dirty on the way to reporting itself.
+  const catalogTemp = path.join(tempDir, "catalog.mdx");
+  try {
+    execFileSync("node", ["scripts/generate-catalog-docs.ts"], {
+      cwd: UI_DIR,
+      encoding: "utf8",
+      stdio: "pipe",
+      env: { ...process.env, CATALOG_DOCS_OUTPUT: catalogTemp },
+    });
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string };
+    console.error(
+      "Failed to run apps/ui/scripts/generate-catalog-docs.ts. The apps/ui " +
+        "workspace must be installed (root `npm ci` covers it).\n" +
+        `${e.stdout ?? ""}${e.stderr ?? ""}`,
+    );
+    process.exit(1);
+  }
+
+  const [expectedCatalog, committedCatalog] = await Promise.all([
+    fs.readFile(catalogTemp, "utf8"),
+    fs.readFile(COMMITTED_CATALOG, "utf8").catch(() => null),
+  ]);
+  if (committedCatalog !== expectedCatalog) {
+    console.error(
+      committedCatalog === null
+        ? "apps/ui/content/docs/catalog.mdx is missing."
+        : "apps/ui/content/docs/catalog.mdx is out of date with the registry overlays.",
+    );
+    console.error(
+      "\nRegenerate and commit:\n" +
+        "  cd apps/ui && node scripts/generate-catalog-docs.ts",
+    );
+    process.exit(1);
+  }
+
   console.log(
-    `API reference docs are current (${expected.size} generated page(s)).`,
+    `API reference docs are current (${expected.size} generated page(s)), ` +
+      "and so is the subnet catalog.",
   );
 } finally {
   await fs.rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
Three things that turned out to be one thing: **a repoint of mine that was wrong**, the generated catalog that has now gone stale twice behind registry changes, and **the missing gate that let both happen quietly**.

## SN29 was repointed to another subnet's repository

#11086 set netuid 29's `source_repo` to `coldint/hotfloat` because `SubnetIdentitiesV3` declares that repo for netuid 29. **It is not SN29's:**

- hotfloat's README is titled **`# Cacheon (SN14)`**
- it links `tao.app/subnets/14`, `cacheon.ai` and `@cacheon_ai`
- `validator/.env.example` sets **`CACHEON_NETUID=14`**

Reverted to `coldint/coldint_validator`, whose own README says *"Bittensor subnet 29 is focused on advancing collaborative, distributed model training"*. Stale (2025-07-11) but correct — and `coldint/sn29`, the dynamic-configuration repo also registered, names it as *"the validator code"*.

**The chain identity is operator-set and can be wrong.** #11086's other nine repoints each had a second, independent confirmation — the repository naming its own netuid, or a live check against a description that named the subnet. This one had only the chain. That was the gap, not the rule.

Found by a detector I wrote after netuid 36/99 turned out to be crossed: scan each harvested repo for the netuid it *declares* and compare it to the netuid it is registered under. Tested against the known 36/99 case first, so a zero would have meant something. It returned two real hits fleet-wide — 36/99, and this.

## The catalog, and why this is one PR

`apps/ui/content/docs/catalog.mdx` is generated from the curated overlays. It went stale after #11086 (cleaned up by [#11104](https://github.com/JSONbored/metagraphed/pull/11104)) and again after #11090 — and the SN29 revert would have made a third. The `ui` job catches it, but only later, on somebody else's branch.

| SN | change |
| --- | --- |
| **29** | `coldint/hotfloat` → `coldint/coldint_validator` **(this PR)** |
| 36 | Eirel → Leoma (`leoma.ai`, `RendixNetwork/leoma`) |
| 99 | Leoma → Thirty Spokes (`thirtyspokes.ai`, no public repo) |
| 66 | `ninja-subnet/ninja` → `conjectures-io/conjectures-validator` |
| 76 | `byzantiumaitao-arch/byzantium` → `praxi-labs/phylax-subnet` |
| 80 | `dogelayer-ai/dogelayer` → `openroboto-ai/openroboto-subnet` |
| 89 | `backend-developers-ltd/InfiniteHash` → `DeltaCompute24/InfiniteQuant-Subnet` |
| 98 | `SN98-ForeverMoney/forever-money` → `neverplayalone/neverplayalone_subnet` |

The header count moves **117 → 116 "with a public repo"**: Thirty Spokes has no repository we can point at, recorded as a gap note on the overlay.

## The gate

`validate-ui-docs-drift.ts` already exists for this exact failure shape — its header describes a contract PR that *"could not discover the staleness locally and only found out from a red `ui` job"*. **`catalog.mdx` is the same shape one layer over:** a *registry* PR invalidates it without touching `apps/ui`.

`README.md` comes off the same renderer (`scripts/lib/readme-catalog.ts` — *"one source, two destinations"*) and is already gated by `validate:readme-catalog`. This closes the other destination.

`generate-catalog-docs.ts` gains a `CATALOG_DOCS_OUTPUT` override, mirroring the `OPENAPI_DOCS_OUTPUT` the sibling generator takes, so the check regenerates into a temp file and diffs — never leaving a dirty tree behind.

**One trap worth its comment:** prettier resolves `.prettierrc` from the *output* file's directory, so a temp-dir output would format differently from the committed file and report drift that does not exist. Config and `filepath` resolve against the committed path in both modes; verified by generating to `/tmp` and diffing byte-for-byte.

**Proved the gate can fail:** appending one fake row to `catalog.mdx` makes it exit non-zero naming the file, and it passes again once reverted.

## Verification

`validate` · `validate:ui-docs-drift` · `validate:readme-catalog` · `validate:archive-policy` · `format:check` · `lint` · `typecheck` all pass on top of `6120dbcf8`, `npm run build` leaves the tree clean, and the affected suites pass (1,432 tests).