### PR TITLE
feat(archive): the debt is zero, and pending cannot become a parking space

### DIFF
--- a/scripts/validate-archive-policy.ts
+++ b/scripts/validate-archive-policy.ts
@@ -79,18 +79,19 @@ export const POLICY: Readonly<Record<string, Policy>> = {
   surfaces: "mirrored",
   validator_nominator_counts: "mirrored",
 
-  // -- pending: the one table still owed an archive copy --------------------
+  // -- formerly the archive debt, now empty ---------------------------------
   //
-  // `subnet_burn_history` is not waiting on effort, it is waiting on a
-  // DECISION. It has no `id`, and its timestamps do not identify a row:
-  // 95,060 rows across 852 distinct `observed_at` values -- 94,208 ties. A
-  // `> since` watermark would skip nearly every row, and `versioned` would
-  // re-append all 95,060 on every change. It needs a composite watermark the
-  // mirror does not support, and a lane that silently drops rows is worse than
-  // a table that is honestly still missing.
+  // `subnet_burn_history` was the last entry, and it closed on a MEASUREMENT
+  // rather than more effort. It has no `id`, and `observed_at` alone ties
+  // 94,208 times across 852 distinct values, so a `> since` watermark would
+  // have skipped nearly every row. `(observed_at, netuid)` is unique -- 95,447
+  // rows, 95,447 distinct pairs, zero ties -- and metagraphed-infra#553 taught
+  // the mirror to compare row values in one predicate.
   //
-  // The other fifteen that were here are mirrored as of 2026-08-13
-  // (metagraphed-infra#552).
+  // PENDING_CEILING is 0 and only falls, so a table filed as `pending` from
+  // here fails the gate outright. Deliberate: `pending` was a debt list being
+  // paid down, and it must not become a parking space for anything nobody
+  // wants to classify.
   //
   // NOT only chain data. The first cut of this map filed anything that was not
   // chain-derived under `serving`, which was too fast: `surface_uptime_daily`,
@@ -110,7 +111,7 @@ export const POLICY: Readonly<Record<string, Policy>> = {
   emission_flow_watch: "mirrored",
   emission_gate_param_history: "mirrored",
   hotkey_alpha: "mirrored",
-  subnet_burn_history: "pending",
+  subnet_burn_history: "mirrored",
   subnet_deregistration_daily: "mirrored",
   subnet_emission_enabled_history: "mirrored",
   subnet_identity: "mirrored",
@@ -169,7 +170,7 @@ export const POLICY: Readonly<Record<string, Policy>> = {
 };
 
 /** How many `pending` tables we accept. ONLY FALLS. */
-export const PENDING_CEILING = 1;
+export const PENDING_CEILING = 0;
 
 interface Column {
   table: string;

--- a/tests/archive-policy.test.ts
+++ b/tests/archive-policy.test.ts
@@ -24,13 +24,16 @@ describe("archive policy", () => {
     assert.ok(stale.length > 0);
   });
 
-  test("pending is the debt list, and it is currently non-empty", () => {
-    // A vacuous pass would be the failure mode here: if this ever reads zero
-    // because the map emptied rather than because the debt was paid, the
-    // ceiling test below stops proving anything.
-    const pending = Object.entries(POLICY).filter(([, p]) => p === "pending");
-    assert.ok(pending.length > 0, "pending must not be silently emptied");
+  test("pending matches the ceiling, and the ceiling is zero", () => {
+    // This asserted pending was NON-empty, guarding against the map emptying
+    // and making the ceiling vacuous. The debt is now genuinely paid, so the
+    // guard inverts -- and the non-vacuity that matters moves to `mirrored`,
+    // which must stay large or this gate is measuring nothing.
+    const pending = Object.values(POLICY).filter((p) => p === "pending");
     assert.equal(pending.length, PENDING_CEILING);
+    assert.equal(PENDING_CEILING, 0);
+    const mirrored = Object.values(POLICY).filter((p) => p === "mirrored");
+    assert.ok(mirrored.length > 30, `mirrored collapsed to ${mirrored.length}`);
   });
 
   test("subnet_identity is mirrored alongside its own history", () => {
@@ -42,12 +45,11 @@ describe("archive policy", () => {
     assert.equal(POLICY.subnet_identity_history, "mirrored");
   });
 
-  test("the one remaining debt is subnet_burn_history, and it is a decision", () => {
-    // Not waiting on effort: 95,060 rows across 852 distinct observed_at
-    // values means a `> since` watermark skips nearly everything, and
-    // `versioned` would re-append all 95,060 on every change.
-    assert.equal(POLICY.subnet_burn_history, "pending");
-    assert.equal(PENDING_CEILING, 1);
+  test("subnet_burn_history is mirrored via a composite watermark", () => {
+    // The last debt, and it closed on a measurement rather than effort:
+    // observed_at alone ties 94,208 times across 852 distinct values,
+    // (observed_at, netuid) is unique across all 95,447 rows.
+    assert.equal(POLICY.subnet_burn_history, "mirrored");
   });
 
   test("credentials and personal data are never archived", () => {


### PR DESCRIPTION
Closes #11089.

Every Neon table with a time dimension now has a lakehouse copy. `PENDING_CEILING` falls **1 → 0**.

```
64 Neon tables: 34 mirrored, 0 pending, 7 sensitive, 17 serving, 5 transient, 1 meta
```

## The last one closed on a measurement, not effort

`subnet_burn_history` was recorded as blocked on a decision. It has no `id`, and `observed_at` alone **ties 94,208 times across 852 distinct values** — a `> since` watermark would have skipped nearly every row.

`(observed_at, netuid)` is unique: **95,447 rows, 95,447 distinct pairs, zero ties**. So metagraphed-infra#553 taught the mirror to compare row values in one predicate. Verified end to end — first run appended 95,447 rows, re-run reported `no rows above [1786655811684, 128]`, and the lakehouse holds exactly Neon's count.

## Two guards inverted rather than deleted

`pending is the debt list, and it is currently non-empty` existed so an emptied map could not make the ceiling vacuous. The debt is now genuinely paid, so that guard would fail for the right reason and the wrong outcome.

It becomes *"pending matches the ceiling, and the ceiling is zero"* — and the non-vacuity it was protecting **moves to `mirrored`**, which must stay above 30 or this gate is measuring nothing.

The ceiling at 0 is stricter than a ratchet that merely fell: a table filed as `pending` from here **fails outright**. That is the point — `pending` was a debt list being paid down, and it must not quietly become the answer for anything nobody wants to classify.

## Where this leaves the model

| tier | job | store |
| --- | --- | --- |
| hot | serve queries | Neon |
| cold / permanent record | everything with a time dimension | lakehouse — **complete** |
| disaster recovery | restore the hot tier | Neon PITR, **not** the lakehouse |
| credentials & PII | must remain deletable | Neon only — 7 tables, asserted by test |

## Verification

`archive-policy` 34/0/7/17/5/1 · `schema-shape-duplicates` 4 pinned, 0 unpinned · unreferenced exports **731 at ceiling** · `npm run lint` clean. **20,681 tests pass, 903 files.**