### PR TITLE
feat(lakehouse): cover subnet_burn_history in the snapshot, Zod and the watchdog

### DIFF
--- a/generated/lakehouse/schema.json
+++ b/generated/lakehouse/schema.json
@@ -2903,5 +2903,26 @@
     "column": "reviewed_at",
     "type": "long",
     "required": false
+  },
+  {
+    "table": "subnet_burn_history",
+    "field_id": 1,
+    "column": "netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "subnet_burn_history",
+    "field_id": 2,
+    "column": "observed_at",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "subnet_burn_history",
+    "field_id": 3,
+    "column": "burn_tao",
+    "type": "double",
+    "required": false
   }
 ]

--- a/generated/lakehouse/types.ts
+++ b/generated/lakehouse/types.ts
@@ -1140,6 +1140,20 @@ export const TREASURY_READINGS_COLUMNS = [
   "reviewed_at",
 ] as const;
 
+/** `chain.subnet_burn_history` */
+export type SubnetBurnHistoryRow = {
+  netuid: number | null;
+  observed_at: number | null;
+  burn_tao: number | null;
+};
+
+/** `chain.subnet_burn_history` columns, in field-id order. */
+export const SUBNET_BURN_HISTORY_COLUMNS = [
+  "netuid",
+  "observed_at",
+  "burn_tao",
+] as const;
+
 /** Every Iceberg table this repo reads, by name. */
 export const LAKEHOUSE_TABLES = [
   "blocks",
@@ -1180,4 +1194,5 @@ export const LAKEHOUSE_TABLES = [
   "surface_uptime_daily",
   "tao_usd_index",
   "treasury_readings",
+  "subnet_burn_history",
 ] as const;

--- a/schemas-src/lakehouse.ts
+++ b/schemas-src/lakehouse.ts
@@ -955,6 +955,23 @@ export const TreasuryReadingsRowSchema = z
   .partial()
   .catchall(z.unknown());
 
+/**
+ * `chain.subnet_burn_history` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const SubnetBurnHistoryRowSchema = z
+  .object({
+    netuid: z.int().nullable(),
+    observed_at: z.int().nullable(),
+    burn_tao: z.number().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
 /** Every table's row schema, by table name. */
 export const LAKEHOUSE_ROW_SCHEMAS = {
   blocks: BlocksRowSchema,
@@ -995,4 +1012,5 @@ export const LAKEHOUSE_ROW_SCHEMAS = {
   surface_uptime_daily: SurfaceUptimeDailyRowSchema,
   tao_usd_index: TaoUsdIndexRowSchema,
   treasury_readings: TreasuryReadingsRowSchema,
+  subnet_burn_history: SubnetBurnHistoryRowSchema,
 } as const;

--- a/scripts/check-lakehouse-freshness.ts
+++ b/scripts/check-lakehouse-freshness.ts
@@ -206,6 +206,13 @@ export const EXPECTED: Readonly<Record<string, FreshnessRule>> = {
     reason:
       "state mirror, digest-gated: this changes only when a subnet's declaration does",
   },
+  // The only table mirrored on a COMPOSITE watermark: observed_at alone ties
+  // 94,208 times here, so (observed_at, netuid) is what identifies a row.
+  // Burn is re-read every poller pass, so this moves continuously.
+  subnet_burn_history: {
+    maxAgeMs: 2 * DAY,
+    reason: "state mirror, composite watermark on (observed_at, netuid)",
+  },
   subnet_identity: {
     maxAgeMs: 2 * DAY,
     reason: "state mirror, digest-gated: identity changes are rare",

--- a/scripts/refresh-lakehouse-schema.ts
+++ b/scripts/refresh-lakehouse-schema.ts
@@ -116,6 +116,9 @@ export const TABLES = [
   "surface_uptime_daily",
   "tao_usd_index",
   "treasury_readings",
+  // The last of the archive gap, created 2026-08-13 once a composite watermark
+  // made it mirrorable (metagraphed-infra#553).
+  "subnet_burn_history",
 ];
 
 // Guarded, so importing TABLES does not reach for the catalog. Before this the

--- a/tests/lakehouse-schema.test.ts
+++ b/tests/lakehouse-schema.test.ts
@@ -110,6 +110,7 @@ describe("the committed snapshot", () => {
         "surface_uptime_daily",
         "tao_usd_index",
         "treasury_readings",
+        "subnet_burn_history",
       ].sort(),
     );
     // The TS side mirrors the snapshot -- it is the READER's list.


### PR DESCRIPTION
Follow-up to #11107.

`subnet_burn_history` was created *after* the snapshot list was last extended, so it had an Iceberg table and a mirror entry but **no generated row schema, no parity coverage, and no declared cadence**.

That is precisely the gap the freshness watchdog's `EXPECTED` exists to make impossible. It only failed to catch this because the table was not in the snapshot it checks *against* — the same blind spot, one layer down. Worth noting rather than quietly fixing: a gate that validates a list can only be as complete as the list.

Now **39 tables / 418 columns** snapshotted, and `store-type-parity` compares **366** against Neon with **0 divergences**. It compared 186 this morning.

Classified at **2 days** rather than something wider: burn is re-read on every poller pass, so unlike the registry tables this one genuinely moves continuously, and a slack threshold would hide a stall.

## Verification

`store-type-parity` 0/366 · `archive-policy` 34 mirrored / 0 pending · `lakehouse-types-drift` clean · `schema-shape-duplicates` 4 pinned, 0 unpinned. **20,681 tests pass, 903 files.**

Deployed state confirms the lane: the mirror reported `30/30 ok=true` on its last tick, with container v44 (carrying the 31st table) deployed at 21:34.