### PR TITLE
feat(fairness): the live lenses beside the windowed ones — the capture tripwire

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -2660,6 +2660,11 @@ type SubnetMinerFairness {
   concentration: SubnetMinerFairnessConcentration
 
   """
+  THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from \`concentration\`, trust these. Null when the current-metagraph store has no rows for this subnet.
+  """
+  live: SubnetMinerFairnessLive
+
+  """
   Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.
   """
   field_sources: JSON
@@ -2710,6 +2715,60 @@ type SubnetMinerFairnessConcentration {
   The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples.
   """
   uid: ConcentrationMetrics
+}
+
+type SubnetMinerFairnessLive {
+  """
+  Epoch-ms stamp of the newest current-metagraph row the lenses below were computed from -- read this against the window: these lenses are NOW, the ones under \`concentration\` are the whole window.
+  """
+  captured_at: Float
+  block_number: Int
+
+  """
+  The entity lens over the CURRENT per-UID incentive distribution (miners only). Incentive is the chain's live ranking and already a share, so \`total\` is the miners' summed incentive. Null when no miner carries any.
+  """
+  entity: SubnetMinerFairnessLiveEntity
+
+  """The per-UID lens over the same current incentive distribution."""
+  uid: SubnetMinerFairnessLiveUid
+}
+
+type SubnetMinerFairnessLiveEntity {
+  holders: Int!
+
+  """
+  The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit.
+  """
+  total: Float
+  gini: Float
+  hhi: Float
+  hhi_normalized: Float
+  nakamoto_coefficient: Int!
+  top_1pct_share: Float
+  top_5pct_share: Float
+  top_10pct_share: Float
+  top_20pct_share: Float
+  entropy: Float
+  entropy_normalized: Float
+}
+
+type SubnetMinerFairnessLiveUid {
+  holders: Int!
+
+  """
+  The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit.
+  """
+  total: Float
+  gini: Float
+  hhi: Float
+  hhi_normalized: Float
+  nakamoto_coefficient: Int!
+  top_1pct_share: Float
+  top_5pct_share: Float
+  top_10pct_share: Float
+  top_20pct_share: Float
+  entropy: Float
+  entropy_normalized: Float
 }
 
 """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6790,6 +6790,8 @@ export type SubnetMinerFairness = {
   entity_count: Scalars['Int']['output'];
   /** Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
   field_sources?: Maybe<Scalars['JSON']['output']>;
+  /** THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from `concentration`, trust these. Null when the current-metagraph store has no rows for this subnet. */
+  live?: Maybe<SubnetMinerFairnessLive>;
   /** Distinct non-validator UIDs seen anywhere in the window — the denominator for the persistence block. */
   miner_uid_count: Scalars['Int']['output'];
   netuid: Scalars['Int']['output'];
@@ -6809,6 +6811,51 @@ export type SubnetMinerFairnessConcentration = {
   entity?: Maybe<ConcentrationMetrics>;
   /** The same measures per UID, published beside the entity lens rather than instead of it. Where the two diverge, several UIDs share an operator. Same distribution and unit as the entity lens: window-summed daily per-tempo alpha samples. */
   uid?: Maybe<ConcentrationMetrics>;
+};
+
+export type SubnetMinerFairnessLive = {
+  __typename?: 'SubnetMinerFairnessLive';
+  block_number?: Maybe<Scalars['Int']['output']>;
+  /** Epoch-ms stamp of the newest current-metagraph row the lenses below were computed from -- read this against the window: these lenses are NOW, the ones under `concentration` are the whole window. */
+  captured_at?: Maybe<Scalars['Float']['output']>;
+  /** The entity lens over the CURRENT per-UID incentive distribution (miners only). Incentive is the chain's live ranking and already a share, so `total` is the miners' summed incentive. Null when no miner carries any. */
+  entity?: Maybe<SubnetMinerFairnessLiveEntity>;
+  /** The per-UID lens over the same current incentive distribution. */
+  uid?: Maybe<SubnetMinerFairnessLiveUid>;
+};
+
+export type SubnetMinerFairnessLiveEntity = {
+  __typename?: 'SubnetMinerFairnessLiveEntity';
+  entropy?: Maybe<Scalars['Float']['output']>;
+  entropy_normalized?: Maybe<Scalars['Float']['output']>;
+  gini?: Maybe<Scalars['Float']['output']>;
+  hhi?: Maybe<Scalars['Float']['output']>;
+  hhi_normalized?: Maybe<Scalars['Float']['output']>;
+  holders: Scalars['Int']['output'];
+  nakamoto_coefficient: Scalars['Int']['output'];
+  top_1pct_share?: Maybe<Scalars['Float']['output']>;
+  top_5pct_share?: Maybe<Scalars['Float']['output']>;
+  top_10pct_share?: Maybe<Scalars['Float']['output']>;
+  top_20pct_share?: Maybe<Scalars['Float']['output']>;
+  /** The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
+  total?: Maybe<Scalars['Float']['output']>;
+};
+
+export type SubnetMinerFairnessLiveUid = {
+  __typename?: 'SubnetMinerFairnessLiveUid';
+  entropy?: Maybe<Scalars['Float']['output']>;
+  entropy_normalized?: Maybe<Scalars['Float']['output']>;
+  gini?: Maybe<Scalars['Float']['output']>;
+  hhi?: Maybe<Scalars['Float']['output']>;
+  hhi_normalized?: Maybe<Scalars['Float']['output']>;
+  holders: Scalars['Int']['output'];
+  nakamoto_coefficient: Scalars['Int']['output'];
+  top_1pct_share?: Maybe<Scalars['Float']['output']>;
+  top_5pct_share?: Maybe<Scalars['Float']['output']>;
+  top_10pct_share?: Maybe<Scalars['Float']['output']>;
+  top_20pct_share?: Maybe<Scalars['Float']['output']>;
+  /** The sum of the distribution this lens was computed over, in that distribution's own unit and window -- the FIELD EMBEDDING this lens names both (window-summed per-tempo alpha samples on miner-fairness, incentive shares on performance, block counts on blocks-summary). Never comparable across routes: two lenses over different distributions share these measures, not a unit. */
+  total?: Maybe<Scalars['Float']['output']>;
 };
 
 export type SubnetMinerFairnessPersistence = {
@@ -8633,6 +8680,9 @@ export type ResolversTypes = ResolversObject<{
   SubnetList: ResolverTypeWrapper<SubnetList>;
   SubnetMinerFairness: ResolverTypeWrapper<SubnetMinerFairness>;
   SubnetMinerFairnessConcentration: ResolverTypeWrapper<SubnetMinerFairnessConcentration>;
+  SubnetMinerFairnessLive: ResolverTypeWrapper<SubnetMinerFairnessLive>;
+  SubnetMinerFairnessLiveEntity: ResolverTypeWrapper<SubnetMinerFairnessLiveEntity>;
+  SubnetMinerFairnessLiveUid: ResolverTypeWrapper<SubnetMinerFairnessLiveUid>;
   SubnetMinerFairnessPersistence: ResolverTypeWrapper<SubnetMinerFairnessPersistence>;
   SubnetMinerFairnessPoint: ResolverTypeWrapper<SubnetMinerFairnessPoint>;
   SubnetMover: ResolverTypeWrapper<SubnetMover>;
@@ -9096,6 +9146,9 @@ export type ResolversParentTypes = ResolversObject<{
   SubnetList: SubnetList;
   SubnetMinerFairness: SubnetMinerFairness;
   SubnetMinerFairnessConcentration: SubnetMinerFairnessConcentration;
+  SubnetMinerFairnessLive: SubnetMinerFairnessLive;
+  SubnetMinerFairnessLiveEntity: SubnetMinerFairnessLiveEntity;
+  SubnetMinerFairnessLiveUid: SubnetMinerFairnessLiveUid;
   SubnetMinerFairnessPersistence: SubnetMinerFairnessPersistence;
   SubnetMinerFairnessPoint: SubnetMinerFairnessPoint;
   SubnetMover: SubnetMover;
@@ -13248,6 +13301,7 @@ export type SubnetMinerFairnessResolvers<ContextType = GqlContext, ParentType ex
   days_covered?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   entity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  live?: Resolver<Maybe<ResolversTypes['SubnetMinerFairnessLive']>, ParentType, ContextType>;
   miner_uid_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   persistence?: Resolver<Maybe<ResolversTypes['SubnetMinerFairnessPersistence']>, ParentType, ContextType>;
@@ -13261,6 +13315,43 @@ export type SubnetMinerFairnessResolvers<ContextType = GqlContext, ParentType ex
 export type SubnetMinerFairnessConcentrationResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMinerFairnessConcentration'] = ResolversParentTypes['SubnetMinerFairnessConcentration']> = ResolversObject<{
   entity?: Resolver<Maybe<ResolversTypes['ConcentrationMetrics']>, ParentType, ContextType>;
   uid?: Resolver<Maybe<ResolversTypes['ConcentrationMetrics']>, ParentType, ContextType>;
+}>;
+
+export type SubnetMinerFairnessLiveResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMinerFairnessLive'] = ResolversParentTypes['SubnetMinerFairnessLive']> = ResolversObject<{
+  block_number?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  captured_at?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  entity?: Resolver<Maybe<ResolversTypes['SubnetMinerFairnessLiveEntity']>, ParentType, ContextType>;
+  uid?: Resolver<Maybe<ResolversTypes['SubnetMinerFairnessLiveUid']>, ParentType, ContextType>;
+}>;
+
+export type SubnetMinerFairnessLiveEntityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMinerFairnessLiveEntity'] = ResolversParentTypes['SubnetMinerFairnessLiveEntity']> = ResolversObject<{
+  entropy?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  entropy_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  gini?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hhi?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hhi_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  holders?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  nakamoto_coefficient?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  top_1pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_5pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_10pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_20pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type SubnetMinerFairnessLiveUidResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMinerFairnessLiveUid'] = ResolversParentTypes['SubnetMinerFairnessLiveUid']> = ResolversObject<{
+  entropy?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  entropy_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  gini?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hhi?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  hhi_normalized?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  holders?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  nakamoto_coefficient?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  top_1pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_5pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_10pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_20pct_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  total?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
 }>;
 
 export type SubnetMinerFairnessPersistenceResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMinerFairnessPersistence'] = ResolversParentTypes['SubnetMinerFairnessPersistence']> = ResolversObject<{
@@ -14701,6 +14792,9 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SubnetList?: SubnetListResolvers<ContextType>;
   SubnetMinerFairness?: SubnetMinerFairnessResolvers<ContextType>;
   SubnetMinerFairnessConcentration?: SubnetMinerFairnessConcentrationResolvers<ContextType>;
+  SubnetMinerFairnessLive?: SubnetMinerFairnessLiveResolvers<ContextType>;
+  SubnetMinerFairnessLiveEntity?: SubnetMinerFairnessLiveEntityResolvers<ContextType>;
+  SubnetMinerFairnessLiveUid?: SubnetMinerFairnessLiveUidResolvers<ContextType>;
   SubnetMinerFairnessPersistence?: SubnetMinerFairnessPersistenceResolvers<ContextType>;
   SubnetMinerFairnessPoint?: SubnetMinerFairnessPointResolvers<ContextType>;
   SubnetMover?: SubnetMoverResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11769,6 +11769,16 @@ export interface components {
                     storage: string | null;
                 };
             };
+            /** @description THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from `concentration`, trust these. Null when the current-metagraph store has no rows for this subnet. */
+            live?: {
+                block_number: number | null;
+                /** @description Epoch-ms stamp of the newest current-metagraph row the lenses below were computed from -- read this against the window: these lenses are NOW, the ones under `concentration` are the whole window. */
+                captured_at: number | null;
+                /** @description The entity lens over the CURRENT per-UID incentive distribution (miners only). Incentive is the chain's live ranking and already a share, so `total` is the miners' summed incentive. Null when no miner carries any. */
+                entity: components["schemas"]["ConcentrationMetrics"] | null;
+                /** @description The per-UID lens over the same current incentive distribution. */
+                uid: components["schemas"]["ConcentrationMetrics"] | null;
+            } | null;
             /** @description Distinct non-validator UIDs seen anywhere in the window — the denominator for the persistence block. */
             miner_uid_count: number;
             netuid: number;
@@ -44684,6 +44694,18 @@ export interface operations {
                      *           "example": {
                      *             "kind": "measured",
                      *             "storage": "example"
+                     *           }
+                     *         },
+                     *         "live": {
+                     *           "block_number": 5000000,
+                     *           "captured_at": 0.5,
+                     *           "entity": {
+                     *             "holders": 1,
+                     *             "nakamoto_coefficient": 1
+                     *           },
+                     *           "uid": {
+                     *             "holders": 1,
+                     *             "nakamoto_coefficient": 1
                      *           }
                      *         },
                      *         "miner_uid_count": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -10504,6 +10504,18 @@
                 "storage": "example"
               }
             },
+            "live": {
+              "block_number": 5000000,
+              "captured_at": 0.5,
+              "entity": {
+                "holders": 1,
+                "nakamoto_coefficient": 1
+              },
+              "uid": {
+                "holders": 1,
+                "nakamoto_coefficient": 1
+              }
+            },
             "miner_uid_count": 1,
             "netuid": 7,
             "persistence": {
@@ -51886,6 +51898,71 @@
               "type": "string"
             },
             "type": "object"
+          },
+          "live": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "block_number": {
+                    "anyOf": [
+                      {
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "captured_at": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "Epoch-ms stamp of the newest current-metagraph row the lenses below were computed from -- read this against the window: these lenses are NOW, the ones under `concentration` are the whole window."
+                  },
+                  "entity": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/ConcentrationMetrics"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "The entity lens over the CURRENT per-UID incentive distribution (miners only). Incentive is the chain's live ranking and already a share, so `total` is the miners' summed incentive. Null when no miner carries any."
+                  },
+                  "uid": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/ConcentrationMetrics"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "The per-UID lens over the same current incentive distribution."
+                  }
+                },
+                "required": [
+                  "captured_at",
+                  "block_number",
+                  "entity",
+                  "uid"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from `concentration`, trust these. Null when the current-metagraph store has no rows for this subnet."
           },
           "miner_uid_count": {
             "description": "Distinct non-validator UIDs seen anywhere in the window — the denominator for the persistence block.",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11769,6 +11769,16 @@ export interface components {
                     storage: string | null;
                 };
             };
+            /** @description THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from `concentration`, trust these. Null when the current-metagraph store has no rows for this subnet. */
+            live?: {
+                block_number: number | null;
+                /** @description Epoch-ms stamp of the newest current-metagraph row the lenses below were computed from -- read this against the window: these lenses are NOW, the ones under `concentration` are the whole window. */
+                captured_at: number | null;
+                /** @description The entity lens over the CURRENT per-UID incentive distribution (miners only). Incentive is the chain's live ranking and already a share, so `total` is the miners' summed incentive. Null when no miner carries any. */
+                entity: components["schemas"]["ConcentrationMetrics"] | null;
+                /** @description The per-UID lens over the same current incentive distribution. */
+                uid: components["schemas"]["ConcentrationMetrics"] | null;
+            } | null;
             /** @description Distinct non-validator UIDs seen anywhere in the window — the denominator for the persistence block. */
             miner_uid_count: number;
             netuid: number;
@@ -44684,6 +44694,18 @@ export interface operations {
                      *           "example": {
                      *             "kind": "measured",
                      *             "storage": "example"
+                     *           }
+                     *         },
+                     *         "live": {
+                     *           "block_number": 5000000,
+                     *           "captured_at": 0.5,
+                     *           "entity": {
+                     *             "holders": 1,
+                     *             "nakamoto_coefficient": 1
+                     *           },
+                     *           "uid": {
+                     *             "holders": 1,
+                     *             "nakamoto_coefficient": 1
                      *           }
                      *         },
                      *         "miner_uid_count": 1,

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -467,6 +467,10 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   SubnetMinerFairnessArtifactPoints: "SubnetMinerFairnessPoint",
   SubnetMinerFairnessArtifactPersistence: "SubnetMinerFairnessPersistence",
   SubnetMinerFairnessArtifactConcentration: "SubnetMinerFairnessConcentration",
+  // #11091: the live capture-tripwire block and its two lenses.
+  SubnetMinerFairnessArtifactLive: "SubnetMinerFairnessLive",
+  SubnetMinerFairnessArtifactLiveEntity: "SubnetMinerFairnessLiveEntity",
+  SubnetMinerFairnessArtifactLiveUid: "SubnetMinerFairnessLiveUid",
   // Both lenses collapse onto the ONE published component. The schema is
   // already shared in source (ConcentrationMetricsSchema); these entries are
   // what makes the reuse visible in the published contract rather than

--- a/schemas-src/routes/miner-fairness.ts
+++ b/schemas-src/routes/miner-fairness.ts
@@ -97,6 +97,28 @@ export const SubnetMinerFairnessArtifactSchema = subnetHistoryArtifactSchema(
         "Miner UIDs per controlling entity. 1.0 = every UID a distinct owner; higher = fewer operators each running many hotkeys. The network median is ~3.08 and the maximum ~21.3, so '256 miners' is routinely far fewer operators.",
     }),
     concentration: FairnessConcentrationSchema.optional(),
+    live: z
+      .object({
+        captured_at: z.number().nullable().meta({
+          description:
+            "Epoch-ms stamp of the newest current-metagraph row the lenses below were computed from -- read this against the window: these lenses are NOW, the ones under `concentration` are the whole window.",
+        }),
+        block_number: z.int().nullable(),
+        entity: ConcentrationMetricsSchema.nullable().meta({
+          description:
+            "The entity lens over the CURRENT per-UID incentive distribution (miners only). Incentive is the chain's live ranking and already a share, so `total` is the miners' summed incentive. Null when no miner carries any.",
+        }),
+        uid: ConcentrationMetricsSchema.nullable().meta({
+          description:
+            "The per-UID lens over the same current incentive distribution.",
+        }),
+      })
+      .nullable()
+      .optional()
+      .meta({
+        description:
+          "THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from `concentration`, trust these. Null when the current-metagraph store has no rows for this subnet.",
+      }),
     field_sources: FieldSourcesSchema.optional(),
   })
   .describe(

--- a/src/miner-fairness.ts
+++ b/src/miner-fairness.ts
@@ -73,6 +73,8 @@ export const SUBNET_MINER_FAIRNESS_FIELD_SOURCES = {
   },
   "concentration.entity": { kind: "measured", storage: "neuron_daily" },
   "concentration.uid": { kind: "measured", storage: "neuron_daily" },
+  "live.entity": { kind: "measured", storage: "neurons" },
+  "live.uid": { kind: "measured", storage: "neurons" },
   uids_per_entity: { kind: "measured", storage: "neuron_daily" },
 } as const;
 
@@ -164,10 +166,61 @@ function fairnessPoint(date: string, dayRows: Row[]): Row {
  * Null-safe: a cold or absent store yields `days_covered: 0` and null
  * distributions, never a throw and never a 404.
  */
+/**
+ * The live concentration block, from CURRENT `neurons` rows (#11091).
+ *
+ * The windowed lenses are this route's headline and they are doing their
+ * documented job -- persistence over a snapshot -- but a mid-window capture
+ * event is exactly what a window aggregate smooths away: SN75 reported a 30d
+ * uid gini of 0.77 while the live metagraph had ONE UID at incentive 0.990829
+ * and every other earner at 0.000107. This block is the same two lenses over
+ * the CURRENT per-UID incentive distribution, so the divergence is visible in
+ * one response instead of requiring a second call a caller does not know to
+ * make.
+ *
+ * Null when no current rows were supplied (a cold store is a real state) --
+ * never a fabricated smooth distribution.
+ */
+function liveConcentration(liveRows: Row[] | null | undefined): Row | null {
+  const list = Array.isArray(liveRows) ? liveRows : [];
+  const miners = list.filter((row) => !isValidator(row?.validator_permit));
+  if (miners.length === 0) return null;
+  const minerRows = miners.map((row) => ({
+    coldkey: row?.coldkey,
+    // The lens rides `incentive` rather than `emission_tao`: incentive IS the
+    // chain's current miner ranking (what the SN75 capture showed), and it is
+    // already a share -- no tempo or denomination question to answer.
+    emission_tao: nonNegativeCellOrNull(row?.incentive) ?? 0,
+  }));
+  const entities = groupByEntity(minerRows);
+  // Newest stamp across the rows: the store writes one capture per pass, but
+  // `max` stays honest if a pass ever lands mid-read.
+  let capturedAt: number | null = null;
+  let blockNumber: number | null = null;
+  for (const row of miners) {
+    const at = nonNegativeCellOrNull(row?.captured_at);
+    if (at !== null && (capturedAt === null || at > capturedAt))
+      capturedAt = at;
+    const block = nonNegativeCellOrNull(row?.block_number);
+    if (block !== null && (blockNumber === null || block > blockNumber))
+      blockNumber = block;
+  }
+  return {
+    captured_at: capturedAt,
+    block_number: blockNumber,
+    entity: computeConcentration(entities.emission),
+    uid: computeConcentration(minerRows.map((r) => r.emission_tao)),
+  };
+}
+
 export function buildSubnetMinerFairness(
   rows: Row[] | null | undefined,
   netuid: unknown,
-  { window, capped }: { window?: string; capped?: boolean } = {},
+  {
+    window,
+    capped,
+    liveRows,
+  }: { window?: string; capped?: boolean; liveRows?: Row[] | null } = {},
 ): Row {
   const list = Array.isArray(rows) ? rows : [];
 
@@ -264,6 +317,7 @@ export function buildSubnetMinerFairness(
       entity: entityLens as ConcentrationScorecard | null,
       uid: uidLens as ConcentrationScorecard | null,
     },
+    live: liveConcentration(liveRows),
     field_sources: SUBNET_MINER_FAIRNESS_FIELD_SOURCES,
   };
 }

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -1597,6 +1597,63 @@ test("GET /api/v1/subnets/:netuid/miner-fairness clusters by controlling entity"
   assert.ok((entityLens.gini as number) > (uidLens.gini as number));
 });
 
+// #11091: the live block rides the same response, from the CURRENT neurons
+// table -- the SN75 shape driven end-to-end through the real DDL: a smooth
+// window beside a live single-UID capture, plus a null-incentive row that must
+// read as zero rather than poison the lens.
+test("miner-fairness carries the live capture tripwire beside the window", async () => {
+  const date = dayAgo(1);
+  for (const uid of [0, 1]) {
+    await insertDaily({
+      uid,
+      coldkey: `5Even${uid}`,
+      validator_permit: 0,
+      emission_tao: 1,
+      snapshot_date: date,
+    });
+  }
+  await insertNeuron({
+    uid: 238,
+    coldkey: "5Captor",
+    validator_permit: 0,
+    incentive: 0.990829,
+  });
+  await insertNeuron({
+    uid: 1,
+    hotkey: "5Hot7-1",
+    coldkey: "5Crumb",
+    validator_permit: 0,
+    incentive: 0.000107,
+  });
+  await insertNeuron({
+    uid: 2,
+    hotkey: "5Hot7-2",
+    coldkey: "5Null",
+    validator_permit: 0,
+    incentive: null,
+  });
+  await insertNeuron({
+    uid: 3,
+    hotkey: "5Hot7-3",
+    coldkey: "5Vali",
+    validator_permit: 1,
+    incentive: 0.5,
+  });
+
+  const res = await call(req("/api/v1/subnets/7/miner-fairness"));
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Row;
+  const live = body.live as Row;
+  assert.ok(live, "the live block must ride the response");
+  const liveUid = live.uid as Row;
+  // One UID holds ~99.99% of live incentive: the tripwire the window hides.
+  assert.equal(liveUid.nakamoto_coefficient, 1);
+  // Three miners counted (the null-incentive one reads as zero, the validator
+  // is excluded), two of them positive holders.
+  assert.equal(liveUid.holders, 2);
+  assert.equal(live.captured_at, CAPTURED_AT);
+});
+
 test("miner-fairness counts a registered UID that earns nothing", async () => {
   // The headline fact: the population includes UIDs on zero, and a read that
   // dropped them would report 100% of miners earning on every subnet.

--- a/tests/miner-fairness.test.ts
+++ b/tests/miner-fairness.test.ts
@@ -387,6 +387,88 @@ describe("shaping", () => {
   });
 });
 
+describe("the live lens — the capture tripwire (#11091)", () => {
+  /** One CURRENT-metagraph row. Miner unless told otherwise. */
+  const liveRow = (over: Row = {}): Row => ({
+    uid: 0,
+    coldkey: "5A",
+    validator_permit: false,
+    incentive: 0,
+    captured_at: 1_700_000_000_000,
+    block_number: 8_000_000,
+    ...over,
+  });
+
+  test("AN ACTIVE CAPTURE IS VISIBLE LIVE WHILE THE WINDOW STAYS SMOOTH", () => {
+    // The SN75 shape: a month of evenly-earning days, then one UID holding
+    // 99% of live incentive. The windowed lens reports the month; the live
+    // lens must scream.
+    const windowRows = [
+      ...day("2026-08-12", 100, 100),
+      ...day("2026-08-11", 100, 100),
+    ];
+    const liveRows = [
+      liveRow({ uid: 238, coldkey: "5Captor", incentive: 0.990829 }),
+      ...Array.from({ length: 99 }, (_, i) =>
+        liveRow({ uid: i, coldkey: `5Miner${i}`, incentive: 0.000107 }),
+      ),
+    ];
+    const out = buildSubnetMinerFairness(windowRows, 75, {
+      window: "30d",
+      liveRows,
+    });
+    const live = out.live as Row;
+    const uidLens = live.uid as Row;
+    assert.equal(uidLens.nakamoto_coefficient, 1);
+    assert.ok((uidLens.top_1pct_share as number) > 0.9);
+    // The windowed lens over the smooth month must NOT scream -- the
+    // divergence between the two blocks is the signal, so both halves are
+    // asserted.
+    const windowUid = (out.concentration as Row).uid as Row;
+    assert.ok((windowUid.nakamoto_coefficient as number) > 1);
+    assert.equal(live.captured_at, 1_700_000_000_000);
+    assert.equal(live.block_number, 8_000_000);
+  });
+
+  test("validators are excluded from the live population too", () => {
+    const liveRows = [
+      liveRow({ uid: 0, incentive: 0.5 }),
+      liveRow({ uid: 1, coldkey: "5B", incentive: 0.5 }),
+      liveRow({
+        uid: 2,
+        coldkey: "5Val",
+        validator_permit: true,
+        incentive: 1,
+      }),
+    ];
+    const out = buildSubnetMinerFairness(day("2026-08-12", 2, 2), 7, {
+      liveRows,
+    });
+    const uidLens = (out.live as Row).uid as Row;
+    // Two equal miners: nakamoto 2. A counted validator would make it 1.
+    assert.equal(uidLens.nakamoto_coefficient, 2);
+    assert.equal(uidLens.holders, 2);
+  });
+
+  test("no current rows is a null block, never a fabricated distribution", () => {
+    const absent = buildSubnetMinerFairness(day("2026-08-12", 2, 2), 7, {});
+    assert.equal(absent.live, null);
+    const empty = buildSubnetMinerFairness(day("2026-08-12", 2, 2), 7, {
+      liveRows: [],
+    });
+    assert.equal(empty.live, null);
+  });
+
+  test("the payload with a live block still matches its own schema", () => {
+    const out = buildSubnetMinerFairness(day("2026-08-12", 3, 2), 7, {
+      window: "7d",
+      liveRows: [liveRow({ incentive: 0.4 })],
+    });
+    const parsed = SubnetMinerFairnessArtifactSchema.safeParse(out);
+    assert.ok(parsed.success, JSON.stringify(parsed.error?.issues));
+  });
+});
+
 describe("the window", () => {
   test("shares the emission-split vocabulary", () => {
     for (const label of ["7d", "30d", "90d"]) {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7506,6 +7506,24 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         WHERE nd.netuid = ${netuid} AND nd.snapshot_date >= ${cutoff}
         ORDER BY nd.snapshot_date DESC, nd.uid ASC
         LIMIT ${MINER_FAIRNESS_ROW_CAP}`;
+      // #11091: the CURRENT metagraph beside the window. A window aggregate
+      // smooths away a mid-window capture event (SN75: 30d uid gini 0.77
+      // while one UID held incentive 0.9908 live), so the builder publishes
+      // the same lenses over the live incentive distribution. One bounded
+      // read -- a subnet is at most 256 UIDs.
+      const liveRows = await sql<{
+        uid: Neurons["uid"];
+        coldkey: Neurons["coldkey"];
+        validator_permit: Neurons["validator_permit"];
+        incentive: Neurons["incentive"];
+        captured_at: Neurons["captured_at"];
+        block_number: Neurons["block_number"];
+      }>`
+        SELECT n.uid, n.coldkey, n.validator_permit, n.incentive,
+               n.captured_at, n.block_number
+        FROM neurons n
+        WHERE n.netuid = ${netuid}
+        ORDER BY n.uid ASC`;
       return json(
         buildSubnetMinerFairness(rows, netuid, {
           window: windowLabelFor(
@@ -7514,6 +7532,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
             DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
           ),
           capped: rows.length >= MINER_FAIRNESS_ROW_CAP,
+          liveRows,
         }),
       );
     };


### PR DESCRIPTION
## Summary

Field-report P0 (#11091), verified live before building: `/subnets/75/miner-fairness?window=30d` reports uid gini 0.771 while the live metagraph has UID 238 at incentive **0.990829** and every other earner at ≤0.000107 — a window aggregate doing its documented job and, in doing so, smoothing away an active capture event worth a >100x revenue mispricing.

The response now carries `live`: the same two lenses (entity + uid, shared `ConcentrationMetricsSchema`) over the **current** per-UID incentive distribution, miners only, with `captured_at`/`block_number` making the two blocks' instants explicit. One bounded `neurons` read in the same database the window rows come from. Incentive rather than `emission_tao` — it is the chain's live ranking and already a share, so no tempo/denomination question rides along. Null when the current store has no rows: a cold store is a real state, never a fabricated smooth distribution. `field_sources` marks both live lenses measured from `neurons`; the three new GraphQL types are registered in `PUBLISHED_TYPE_NAMES`.

## Testing / falsification

- Unit: the SN75 shape (live nakamoto 1 **beside** a smooth window — both halves asserted), validator exclusion, null block on absent/empty rows, schema round-trip. Falsified by neutering the live population: both capture tests fail.
- End-to-end through the real DDL (pglite): the live block rides the route response with a null-incentive row reading as zero and the validator excluded.
- Diff-intersection coverage: **17/17 lines, 17/17 branches**.
- Full suite: 903 files / 20,685 tests green.
- Post-merge: live-verify against SN75 (the live lens must show nakamoto 1 while the window stays smooth) + `conformance:tripwire`.

Closes #11091