### PR TITLE
fix(ci): the catalog check fails the PR that causes the drift

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1231,18 +1231,11 @@ jobs:
 
       # Same drift-check shape as the API reference docs step just above
       # (#6634, the #1652 acceptance line that was never actually built):
-      # content/docs/catalog.mdx is entirely generated from the curated
-      # registry/subnets/ overlays via scripts/lib/readme-catalog.ts (the
-      # same renderer README.md's own catalog section uses) -- an enriched
-      # subnet that never regenerates this page silently drifts otherwise.
-      - name: Build subnet catalog docs (drift check)
-        working-directory: apps/ui
-        run: |
-          node scripts/generate-catalog-docs.ts
-          if ! git diff --exit-code -- content/docs/catalog.mdx; then
-            echo "::error::apps/ui/content/docs/catalog.mdx is stale -- run 'node scripts/generate-catalog-docs.ts' (from apps/ui) and commit the result."
-            exit 1
-          fi
+      # content/docs/catalog.mdx's drift check moved to validate:readme-catalog
+      # (#11109): the drift is CAUSED by registry changes, and registry-only
+      # PRs skip this path-filtered job -- so the check here failed every PR
+      # except the one that introduced the drift. The always-running validate
+      # job now holds both catalog destinations against the shared renderer.
 
       # Same drift-check shape again, and here it IS the acceptance criterion:
       # #8610 asks that "every enforced limit on the page matches tier config as

--- a/apps/ui/scripts/generate-catalog-docs.ts
+++ b/apps/ui/scripts/generate-catalog-docs.ts
@@ -1,77 +1,39 @@
 // Generates content/docs/catalog.mdx from the curated subnet overlays
-// (#6634, follow-on from #1652's "catalog / resources sections generated
-// from registry artifacts" acceptance line, never actually built). Reuses
-// the exact same rendering helpers scripts/generate-registry-readme-section.ts
-// already uses for the README's own catalog section (scripts/lib/readme-catalog.ts)
-// so the two never drift apart on what counts as "curated" or how a subnet
-// entry renders -- one source, two destinations (README + this docs page).
+// (#6634). A THIN WRAPPER since #11109: the rendering -- frontmatter, the
+// shared catalog body, and the workspace-config Prettier pass -- lives in
+// scripts/lib/readme-catalog.ts (renderCatalogDocsMdx), where the
+// always-running readme-catalog check holds this page beside README.md's
+// section. One renderer, two destinations, one check.
 //
-// Committed generated output, same convention as content/docs/api-reference/**
-// (scripts/generate-openapi-docs.ts) -- re-run this after a registry overlay
-// changes:
+// Committed generated output, same convention as content/docs/api-reference/**:
 //
 //   node scripts/generate-catalog-docs.ts
+//
+// (or `npm run readme:catalog` at the repo root, which writes both
+// destinations.)
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import prettier from "prettier";
 import {
+  CATALOG_DOCS_COMMITTED_PATH,
   curatedSubnetOverlays,
   loadOverlays,
-  renderCatalog,
+  renderCatalogDocsMdx,
 } from "../../../scripts/lib/readme-catalog.ts";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // CATALOG_DOCS_OUTPUT redirects the write, the same override
 // generate-openapi-docs.ts takes as OPENAPI_DOCS_OUTPUT and for the same
 // reason: scripts/validate-ui-docs-drift.ts regenerates into a temp directory
 // and diffs, so a drift check can never leave a dirty working tree behind.
-const COMMITTED_PATH = path.join(__dirname, "../content/docs/catalog.mdx");
 const OUTPUT_PATH = process.env.CATALOG_DOCS_OUTPUT
   ? path.resolve(process.env.CATALOG_DOCS_OUTPUT)
-  : COMMITTED_PATH;
-
-function frontmatter(curatedCount: number) {
-  return [
-    "---",
-    "title: Subnet catalog",
-    `description: ${curatedCount} curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.`,
-    "---",
-    "",
-    "",
-  ].join("\n");
-}
+  : CATALOG_DOCS_COMMITTED_PATH;
 
 async function main() {
   const overlays = loadOverlays();
-  // metagraphed#8352: this used to pass the raw overlays.length (includes
-  // root/SN0) straight into the frontmatter description, silently
-  // disagreeing with renderCatalog's own body text below it, which
-  // (correctly) excludes root from "curated subnets" -- one number, computed
-  // one way, used in both places.
-  const curatedCount = curatedSubnetOverlays(overlays).length;
-  const catalog = renderCatalog(overlays);
-  const raw = `${frontmatter(curatedCount)}${catalog}\n`;
-  // Run through this workspace's own Prettier config (MDX treats <sub> as
-  // JSX, which reflows differently than the plain-markdown formatting the
-  // shared renderer's output otherwise matches) so the committed file is
-  // always byte-identical to what `format:check` -- and this generator
-  // re-run -- both expect, regardless of which one runs first.
-  // prettier.format() does NOT read .prettierrc on its own (that's CLI-only
-  // behavior) -- resolveConfig() is required to pick it up here.
-  // Resolve against COMMITTED_PATH, never OUTPUT_PATH: prettier looks the
-  // config up from the file's directory, and a CATALOG_DOCS_OUTPUT pointing at
-  // a temp dir would find none -- formatting the drift check's copy differently
-  // from the committed file and reporting drift that does not exist.
-  const config = (await prettier.resolveConfig(COMMITTED_PATH)) ?? {};
-  const formatted = await prettier.format(raw, {
-    ...config,
-    filepath: COMMITTED_PATH,
-  });
+  const formatted = await renderCatalogDocsMdx(overlays);
   await writeFile(OUTPUT_PATH, formatted);
   console.log(
-    `Wrote ${OUTPUT_PATH === COMMITTED_PATH ? "content/docs/catalog.mdx" : OUTPUT_PATH}: ${curatedCount} curated subnets.`,
+    `Wrote ${OUTPUT_PATH === CATALOG_DOCS_COMMITTED_PATH ? "content/docs/catalog.mdx" : OUTPUT_PATH}: ${curatedSubnetOverlays(overlays).length} curated subnets.`,
   );
 }
 

--- a/scripts/generate-registry-readme-section.ts
+++ b/scripts/generate-registry-readme-section.ts
@@ -17,23 +17,33 @@
 //   node scripts/generate-registry-readme-section.ts           # write README.md
 //   node scripts/generate-registry-readme-section.ts --check    # verify up-to-date
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
 import {
+  CATALOG_DOCS_COMMITTED_PATH,
   injectedReadme,
   loadOverlays,
   renderCatalog,
+  renderCatalogDocsMdx,
 } from "./lib/readme-catalog.ts";
 
 const README_PATH = path.join(repoRoot, "README.md");
 
-function main(): void {
+async function main(): Promise<void> {
   const check = process.argv.includes("--check");
   const overlays = loadOverlays();
   const catalog = renderCatalog(overlays);
   const current = readFileSync(README_PATH, "utf8");
   const next = injectedReadme(current, catalog);
+  // ONE RENDERER, TWO DESTINATIONS, ONE CHECK (#11109). catalog.mdx's drift
+  // check used to live only in the path-filtered ui job, which registry-only
+  // PRs skip -- so the PR that caused a drift passed and every unrelated PR
+  // after it failed. Held here because this command runs on every PR. A
+  // checkout without apps/ui (the pipeline sandbox copies data dirs only) is
+  // not this check's problem to report.
+  const docsPresent = existsSync(path.dirname(CATALOG_DOCS_COMMITTED_PATH));
+  const docsNext = docsPresent ? await renderCatalogDocsMdx(overlays) : null;
 
   if (check) {
     if (next !== current) {
@@ -42,16 +52,29 @@ function main(): void {
       );
       process.exit(1);
     }
+    if (
+      docsNext !== null &&
+      (!existsSync(CATALOG_DOCS_COMMITTED_PATH) ||
+        readFileSync(CATALOG_DOCS_COMMITTED_PATH, "utf8") !== docsNext)
+    ) {
+      console.error(
+        "apps/ui/content/docs/catalog.mdx is stale. Run `npm run readme:catalog` and commit it -- a registry overlay change regenerates BOTH catalog destinations.",
+      );
+      process.exit(1);
+    }
     console.log(
-      `README catalog up to date (${overlays.length} curated overlays, incl. root).`,
+      `README catalog up to date (${overlays.length} curated overlays, incl. root)` +
+        (docsNext !== null ? "; docs catalog page matches." : "."),
     );
     return;
   }
 
   writeFileSync(README_PATH, next);
+  if (docsNext !== null) writeFileSync(CATALOG_DOCS_COMMITTED_PATH, docsNext);
   console.log(
-    `Wrote README catalog: ${overlays.length} curated overlays injected (incl. root).`,
+    `Wrote README catalog: ${overlays.length} curated overlays injected (incl. root)` +
+      (docsNext !== null ? "; docs catalog page regenerated." : "."),
   );
 }
 
-main();
+await main();

--- a/scripts/lib/readme-catalog.ts
+++ b/scripts/lib/readme-catalog.ts
@@ -119,6 +119,53 @@ export function renderCatalog(overlays: Row[]): string {
   ].join("\n");
 }
 
+/**
+ * The docs page destination (#11109). One renderer, two committed outputs --
+ * README.md's catalog section and this MDX page -- and until #11109 only the
+ * first was checked where registry PRs actually run: catalog.mdx's drift check
+ * lived in the path-filtered ui job, which registry-only changes skip, so the
+ * PR that CAUSED the drift passed and every unrelated PR after it failed
+ * (twice in one day: #11104, #11108). The rendering lives here so the
+ * always-running readme-catalog check can hold both destinations, and the
+ * apps/ui generator stays a thin wrapper.
+ */
+export const CATALOG_DOCS_COMMITTED_PATH = path.join(
+  repoRoot,
+  "apps/ui/content/docs/catalog.mdx",
+);
+
+function catalogDocsFrontmatter(curatedCount: number): string {
+  return [
+    "---",
+    "title: Subnet catalog",
+    `description: ${curatedCount} curated subnets, generated from the registry overlays in registry/subnets/ -- focus areas, links, and coverage at a glance.`,
+    "---",
+    "",
+    "",
+  ].join("\n");
+}
+
+/**
+ * The exact bytes content/docs/catalog.mdx must hold for these overlays.
+ *
+ * Formatted through the apps/ui workspace's own Prettier config (MDX treats
+ * `<sub>` as JSX, which reflows differently than plain markdown), resolved
+ * against the COMMITTED path so a temp-dir output cannot pick up a different
+ * config and report drift that does not exist. prettier.format() does not read
+ * .prettierrc on its own -- resolveConfig() is the CLI-only lookup, done here.
+ */
+export async function renderCatalogDocsMdx(overlays: Row[]): Promise<string> {
+  const curatedCount = curatedSubnetOverlays(overlays).length;
+  const raw = `${catalogDocsFrontmatter(curatedCount)}${renderCatalog(overlays)}\n`;
+  const prettier = await import("prettier");
+  const config =
+    (await prettier.resolveConfig(CATALOG_DOCS_COMMITTED_PATH)) ?? {};
+  return prettier.format(raw, {
+    ...config,
+    filepath: CATALOG_DOCS_COMMITTED_PATH,
+  });
+}
+
 export function injectedReadme(readme: string, catalog: string): string {
   const beginAt = readme.indexOf(BEGIN);
   const endAt = readme.indexOf(END);


### PR DESCRIPTION
## Summary

Closes #11109 — the gate-placement fix for today's twice-repeated failure class: registry-only merges (#11086, #11090) left `catalog.mdx` stale, every unrelated PR failed the path-filtered `ui` job's drift check on its merge ref, and the causing PRs never saw it. #11104/#11108 were the hand-refreshes this cost.

- The MDX rendering (frontmatter + shared catalog body + apps/ui-config prettier pass) moves into the shared renderer `scripts/lib/readme-catalog.ts` — one renderer, two destinations.
- `validate:readme-catalog` (always-running `validate` job) now checks **both** destinations; its remediation message tells the registry author to run `npm run readme:catalog`, which now writes both.
- `apps/ui/scripts/generate-catalog-docs.ts` becomes a thin wrapper over the same function — **byte-identical output verified** against the committed file, and the `CATALOG_DOCS_OUTPUT` temp-dir override `validate:ui-docs-drift` depends on still works.
- The `ui` job's misplaced drift step is deleted (a comment records where it went and why).
- A checkout without `apps/ui` (the pipeline sandbox copies data dirs only) skips the second destination rather than failing.

## Falsification

Perturbed `catalog.mdx` → the moved check fails naming both destinations; restored → green. `validate:workflows`, `validate:ui-docs-drift`, readme-catalog + pipeline-parity tests, lint/format all green.

Closes #11109