### PR TITLE
feat(lakehouse): close the Zod gap — cover what we write, and prove testnet still matches

### DIFF
--- a/generated/lakehouse/schema.json
+++ b/generated/lakehouse/schema.json
@@ -2924,5 +2924,61 @@
     "column": "burn_tao",
     "type": "double",
     "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 1,
+    "column": "hotkey",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 2,
+    "column": "netuid",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 3,
+    "column": "day",
+    "type": "date",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 4,
+    "column": "event_count",
+    "type": "int",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 5,
+    "column": "event_kinds",
+    "type": "string",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 6,
+    "column": "first_block",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 7,
+    "column": "last_block",
+    "type": "long",
+    "required": false
+  },
+  {
+    "table": "account_events_daily",
+    "field_id": 8,
+    "column": "updated_at",
+    "type": "long",
+    "required": false
   }
 ]

--- a/generated/lakehouse/types.ts
+++ b/generated/lakehouse/types.ts
@@ -1154,6 +1154,30 @@ export const SUBNET_BURN_HISTORY_COLUMNS = [
   "burn_tao",
 ] as const;
 
+/** `chain.account_events_daily` */
+export type AccountEventsDailyRow = {
+  hotkey: string | null;
+  netuid: number | null;
+  day: string | null;
+  event_count: number | null;
+  event_kinds: string | null;
+  first_block: number | null;
+  last_block: number | null;
+  updated_at: number | null;
+};
+
+/** `chain.account_events_daily` columns, in field-id order. */
+export const ACCOUNT_EVENTS_DAILY_COLUMNS = [
+  "hotkey",
+  "netuid",
+  "day",
+  "event_count",
+  "event_kinds",
+  "first_block",
+  "last_block",
+  "updated_at",
+] as const;
+
 /** Every Iceberg table this repo reads, by name. */
 export const LAKEHOUSE_TABLES = [
   "blocks",
@@ -1195,4 +1219,5 @@ export const LAKEHOUSE_TABLES = [
   "tao_usd_index",
   "treasury_readings",
   "subnet_burn_history",
+  "account_events_daily",
 ] as const;

--- a/schemas-src/lakehouse.ts
+++ b/schemas-src/lakehouse.ts
@@ -987,6 +987,28 @@ export const SubnetBurnHistoryRowSchema = z
   .partial()
   .catchall(z.unknown());
 
+/**
+ * `chain.account_events_daily` as the catalog declares it.
+ *
+ * OPEN (`.catchall`) on purpose: a read selects a projection, and often
+ * an aggregate alias that is not a column at all. Closed would delete it.
+ * PARTIAL on purpose: a projection carries a subset of the columns.
+ * What stays pinned is the TYPE of any declared column that IS present.
+ */
+export const AccountEventsDailyRowSchema = z
+  .object({
+    hotkey: z.string().nullable(),
+    netuid: z.int().nullable(),
+    day: z.iso.date().nullable(),
+    event_count: z.int().nullable(),
+    event_kinds: z.string().nullable(),
+    first_block: z.int().nullable(),
+    last_block: z.int().nullable(),
+    updated_at: z.int().nullable(),
+  })
+  .partial()
+  .catchall(z.unknown());
+
 /** Every table's row schema, by table name. */
 export const LAKEHOUSE_ROW_SCHEMAS = {
   blocks: BlocksRowSchema,
@@ -1028,4 +1050,5 @@ export const LAKEHOUSE_ROW_SCHEMAS = {
   tao_usd_index: TaoUsdIndexRowSchema,
   treasury_readings: TreasuryReadingsRowSchema,
   subnet_burn_history: SubnetBurnHistoryRowSchema,
+  account_events_daily: AccountEventsDailyRowSchema,
 } as const;

--- a/scripts/refresh-lakehouse-schema.ts
+++ b/scripts/refresh-lakehouse-schema.ts
@@ -19,6 +19,7 @@ import path from "node:path";
 import { repoRoot } from "./lib.ts";
 type Row = Record<string, unknown>;
 
+import { CHAIN_FIREHOSE_TOPICS } from "../src/chain-firehose-topics.ts";
 import {
   SNAPSHOT_PATH,
   type LakehouseColumn,
@@ -239,7 +240,12 @@ async function main(): Promise<void> {
   // describes them -- silently, because the row schema would still parse the
   // fields it recognises. So the claim is asserted here, where the catalog is
   // already in hand, rather than left in a comment.
-  const DECODED = ["blocks", "extrinsics", "chain_events", "account_events"];
+  // CHAIN_FIREHOSE_TOPICS, not a fifth copy of the same four names. The
+  // vocabulary gate caught the restatement immediately, which is the gate doing
+  // exactly its job: src/chain-firehose-topics.ts already owns this set, and
+  // the decoder's tables, the GraphQL enum and the published `topics` parameter
+  // all derive from it.
+  const DECODED: readonly string[] = CHAIN_FIREHOSE_TOPICS;
   const divergent: string[] = [];
   for (const table of DECODED) {
     const [main, test] = await Promise.all([

--- a/scripts/refresh-lakehouse-schema.ts
+++ b/scripts/refresh-lakehouse-schema.ts
@@ -17,6 +17,8 @@ import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { repoRoot } from "./lib.ts";
+type Row = Record<string, unknown>;
+
 import {
   SNAPSHOT_PATH,
   type LakehouseColumn,
@@ -119,6 +121,12 @@ export const TABLES = [
   // The last of the archive gap, created 2026-08-13 once a composite watermark
   // made it mirrorable (metagraphed-infra#553).
   "subnet_burn_history",
+  // DERIVED HERE, not mirrored: account_events_daily is rolled up from
+  // chain.account_events by metagraphed-infra#544. The old comment below said
+  // it was "queried by nothing", which was true when nothing produced it -- we
+  // now WRITE it every tick, so its shape is load-bearing and it belongs under
+  // the same drift and parity coverage as everything else we write.
+  "account_events_daily",
 ];
 
 // Guarded, so importing TABLES does not reach for the catalog. Before this the
@@ -148,6 +156,31 @@ async function main(): Promise<void> {
   if (!prefix) {
     process.stderr.write("catalog /v1/config returned no prefix\n");
     process.exit(1);
+  }
+
+  async function tableFields(
+    namespace: string,
+    table: string,
+  ): Promise<[string, string, boolean][]> {
+    const res = await fetch(
+      `${BASE}/v1/${prefix}/namespaces/${namespace}/tables/${table}`,
+      { headers: auth },
+    );
+    if (!res.ok) {
+      process.stderr.write(`${namespace}.${table}: HTTP ${res.status}\n`);
+      process.exit(1);
+    }
+    const body = (await res.json()) as Row;
+    const meta = body.metadata as Row;
+    const schemas = (meta?.schemas ?? []) as Row[];
+    const current =
+      schemas.find((s) => s["schema-id"] === meta?.["current-schema-id"]) ??
+      schemas[schemas.length - 1];
+    return ((current?.fields ?? []) as Row[]).map((f) => [
+      String(f.name),
+      typeof f.type === "string" ? f.type : JSON.stringify(f.type),
+      Boolean(f.required),
+    ]);
   }
 
   const columns: LakehouseColumn[] = [];
@@ -192,6 +225,40 @@ async function main(): Promise<void> {
       });
     }
   }
+
+  // TESTNET IS NOT SNAPSHOTTED SEPARATELY, AND THIS IS WHY THAT IS SAFE.
+  //
+  // `chain_testnet` holds the same four decoded tables under the same NAMES, so
+  // a flat snapshot keyed by table name cannot hold both. They are excluded on
+  // the grounds that one decoder writes both namespaces, so the shapes are
+  // identical and the mainnet Zod schema describes a testnet row exactly.
+  //
+  // That was an assumption until it was checked. Measured 2026-08-13: all four
+  // agree on every field id, name, type and nullability. If the decoder ever
+  // diverges, testnet rows would be validated against a schema that no longer
+  // describes them -- silently, because the row schema would still parse the
+  // fields it recognises. So the claim is asserted here, where the catalog is
+  // already in hand, rather than left in a comment.
+  const DECODED = ["blocks", "extrinsics", "chain_events", "account_events"];
+  const divergent: string[] = [];
+  for (const table of DECODED) {
+    const [main, test] = await Promise.all([
+      tableFields("chain", table),
+      tableFields("chain_testnet", table),
+    ]);
+    if (JSON.stringify(main) !== JSON.stringify(test)) divergent.push(table);
+  }
+  if (divergent.length) {
+    process.stderr.write(
+      `chain_testnet has diverged from chain for: ${divergent.join(", ")}.\n` +
+        `  The mainnet Zod schemas no longer describe a testnet row. Either\n` +
+        `  restore the decoder's symmetry or give testnet its own snapshot.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    `chain_testnet matches chain on all ${DECODED.length} decoded tables\n`,
+  );
 
   writeFileSync(
     path.join(repoRoot, SNAPSHOT_PATH),

--- a/tests/lakehouse-schema.test.ts
+++ b/tests/lakehouse-schema.test.ts
@@ -48,10 +48,11 @@ describe("the committed snapshot", () => {
     // decision is recorded. The cost is that adding a table is two edits; that
     // cost IS the check.
     //
-    // account_events_daily is NOT here on purpose: it is named in four
-    // comments and a route description and queried by nothing, because
-    // src/account-history-cold-tier.ts computes its own day bucket from
-    // account_events instead.
+    // account_events_daily WAS excluded on the grounds that it is "queried by
+    // nothing" -- src/account-history-cold-tier.ts computes its own day bucket
+    // from account_events instead. That held while nothing produced it. It has
+    // a producer now (metagraphed-infra#544, backfilling 1,241 days), and a
+    // table we WRITE needs drift coverage whether or not a route reads it.
     assert.deepEqual(
       [...new Set(snapshot.map((c) => c.table))].sort(),
       [
@@ -111,6 +112,11 @@ describe("the committed snapshot", () => {
         "tao_usd_index",
         "treasury_readings",
         "subnet_burn_history",
+        // Derived here rather than mirrored: rolled up from chain.account_events
+        // by metagraphed-infra#544. The list once excluded it as "queried by
+        // nothing", which was true only while nothing produced it -- we write it
+        // every tick now, so it belongs under the same drift coverage.
+        "account_events_daily",
       ].sort(),
     );
     // The TS side mirrors the snapshot -- it is the READER's list.


### PR DESCRIPTION
Asked whether the lakehouse had full Zod coverage, I measured rather than answered — and it did not. **8 of 47 tables had no row schema.** Two of those were real gaps.

## `account_events_daily`: we write it and did not validate it

Excluded on the rule that it is *"named in four comments and a route description and queried by nothing."* That was true **while nothing produced it**. It has a producer now (metagraphed-infra#544, backfilling 1,241 days), so we write it every tick with no drift coverage on the shape we write.

The rule this file states became wrong when the lakehouse became the archive: it is **"what we read OR write"**, not "what a route queries". Both the script header and the test comment asserting the old reason are corrected rather than left contradicting the list beside them.

## `chain_testnet`: not a missing schema, an unverified assumption

The four decoded tables exist in both namespaces under the **same names**, so a flat snapshot keyed by table name cannot hold both. They are excluded because one decoder writes both, so the mainnet schema describes a testnet row exactly.

That was an assumption. Measured — all four agree on every field id, name, type and nullability:

```
blocks           chain=8 cols   testnet=8 cols   identical=True
extrinsics       chain=11 cols  testnet=11 cols  identical=True
chain_events     chain=8 cols   testnet=8 cols   identical=True
account_events   chain=11 cols  testnet=11 cols  identical=True
```

Now **asserted in the refresh**, where the catalog is already in hand. A divergence fails it instead of silently validating testnet rows against a schema that stopped describing them — and the row schema would still parse the fields it recognised, which is what makes that the quiet kind of wrong.

## What stays uncovered, deliberately

`chain.featured_validators` (fossil of the retired side table), `chain.rehearsal` and `spike.dedup_test` (exodus scratch). **Nothing writes any of them**, and all are declared in the freshness watchdog as deliberately frozen — which is the statement that matters.

## Verification

40 tables, 426 columns snapshotted. `store-type-parity` unchanged at **366 columns, 0 divergences** — `account_events_daily` is derived *in* the lakehouse so it has no Neon counterpart to compare, which is correct rather than a gap.

`lakehouse-types-drift` clean · unreferenced exports 731 at ceiling · **20,681 tests pass, 903 files.**