### PR TITLE
feat(mcp): get_subnet takes sections, mirroring the overview route it actually serves

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -428,7 +428,7 @@ type Query {
   """
   One subnet's composed overview card: the baked static subnet record overlaid with live probe-derived health, exactly as the REST route composes it. Null when no overview has been baked for that netuid (rather than a GraphQL error). Opaque JSON passed through verbatim, matching the get_subnet MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/overview.
   """
-  subnet_overview(netuid: Int!): JSON
+  subnet_overview(netuid: Int!, sections: String): JSON
 
   """
   One subnet's contributor-review profile: candidate surfaces, contract version, endpoints, and completeness/curation metadata. Null when no profile has been baked for that netuid (rather than a GraphQL error); a negative netuid is a BAD_USER_INPUT error. Opaque JSON passed through verbatim, matching the get_subnet_profile MCP/REST shape. Mirrors GET /api/v1/subnets/{netuid}/profile.

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -4987,6 +4987,7 @@ export type QuerySubnet_OhlcArgs = {
 
 export type QuerySubnet_OverviewArgs = {
   netuid: Scalars['Int']['input'];
+  sections?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -45189,7 +45189,10 @@ export interface operations {
     };
     subnetOverview: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `profile,health`. One of: counts, curation, gap_priorities, gaps, health, name, netuid, notes, profile, slug, status. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -3100,7 +3100,16 @@
       "public": true,
       "query_collection": null,
       "query_filter_names": [],
-      "query_parameters": []
+      "query_parameters": [
+        {
+          "description": "Comma-separated top-level sections to return, e.g. `profile,health`. One of: counts, curation, gap_priorities, gaps, health, name, netuid, notes, profile, slug, status. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+          "name": "sections",
+          "schema": {
+            "pattern": "^(?:counts|curation|gap_priorities|gaps|health|name|netuid|notes|profile|slug|status)(?:,(?:counts|curation|gap_priorities|gaps|health|name|netuid|notes|profile|slug|status))*$",
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/agent-catalog.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -98488,6 +98488,16 @@
               "minimum": 0,
               "type": "integer"
             }
+          },
+          {
+            "description": "Comma-separated top-level sections to return, e.g. `profile,health`. One of: counts, curation, gap_priorities, gaps, health, name, netuid, notes, profile, slug, status. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list.",
+            "in": "query",
+            "name": "sections",
+            "required": false,
+            "schema": {
+              "pattern": "^(?:counts|curation|gap_priorities|gaps|health|name|netuid|notes|profile|slug|status)(?:,(?:counts|curation|gap_priorities|gaps|health|name|netuid|notes|profile|slug|status))*$",
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -45189,7 +45189,10 @@ export interface operations {
     };
     subnetOverview: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Comma-separated top-level sections to return, e.g. `profile,health`. One of: counts, curation, gap_priorities, gaps, health, name, netuid, notes, profile, slug, status. Selecting sections never removes the response envelope (schema_version, contract_version, generated_at, operational_observed_at, health_source) -- a smaller document still has to say what it is. An unknown name is rejected rather than ignored. A projected document omits every non-selected section, including ones the document schema marks required: `required` describes the unprojected response (#10960), so a client validating responses should skip validation or treat sections as optional when it sends this parameter. NOT the same parameter as `fields`, which projects columns out of the rows of a list. */
+                sections?: string;
+            };
             header?: never;
             path: {
                 netuid: number;

--- a/schemas-src/mcp-tools/get-subnet.ts
+++ b/schemas-src/mcp-tools/get-subnet.ts
@@ -29,6 +29,8 @@
 // are modelled from what production actually serves, verified field by field
 // against a live get_subnet response.
 import { z } from "zod";
+import { sectionsSchema } from "../query-params.ts";
+import { SUBNET_OVERVIEW_SECTIONS } from "../routes/subnet-overview.ts";
 import { SubnetProfileArtifactSchema } from "../routes/subnet-profiles.ts";
 import { OverlaidSubnetHealthSchema } from "../routes/health.ts";
 import { netuidSchema } from "./shared.ts";
@@ -42,6 +44,16 @@ import { CurationMetadataSchema } from "../routes/subnet-detail.ts";
 export const GetSubnetInputSchema = z
   .object({
     netuid: netuidSchema(),
+    // #11100, the same argument get_subnet_detail carries for the same
+    // reason: the composed overview is the payload a research session
+    // measured as very large with heavy duplication, this tool is the one
+    // most likely to be an agent's first call, and an agent pays the
+    // unprojected bytes in context window. The bound comes FROM the route's
+    // vocabulary; validate:mcp-input-parity holds the two together.
+    sections: sectionsSchema(SUBNET_OVERVIEW_SECTIONS, [
+      "profile",
+      "health",
+    ]).optional(),
   })
   .strict();
 export type GetSubnetInput = z.infer<typeof GetSubnetInputSchema>;

--- a/schemas-src/route-queries.ts
+++ b/schemas-src/route-queries.ts
@@ -57,6 +57,7 @@
 // what 3/5 publishes either way.
 import { z } from "zod";
 import { SUBNET_DETAIL_SECTIONS } from "./routes/subnet-detail.ts";
+import { SUBNET_OVERVIEW_SECTIONS } from "./routes/subnet-overview.ts";
 import { SUBNET_PROFILE_SECTIONS } from "./routes/subnet-profiles.ts";
 import {
   ACCOUNTS_LIST_LIMIT_DEFAULT,
@@ -281,7 +282,6 @@ export const NO_QUERY_PARAMETERS: readonly string[] = [
   // null schema means the router validates nothing at all -- so the route
   // would silently ACCEPT any query string instead of rejecting it.
   "/api/v1/chain/deregistration-ranking",
-  "/api/v1/subnets/{netuid}/overview",
   "/api/v1/agent-catalog/{netuid}",
   "/api/v1/providers/{slug}",
   "/api/v1/coverage",
@@ -422,6 +422,16 @@ export const ROUTE_QUERY_SCHEMAS = {
     sections: sectionsSchema(SUBNET_PROFILE_SECTIONS, [
       "subnet",
       "profile",
+    ]).optional(),
+  }),
+  // #11100: the third composite subnet route. The overview is the payload the
+  // field report measured as very large with heavy duplication, and get_subnet
+  // -- the tool most likely to be an agent's first call -- serves it; an agent
+  // pays the unprojected bytes in context window.
+  "/api/v1/subnets/{netuid}/overview": z.object({
+    sections: sectionsSchema(SUBNET_OVERVIEW_SECTIONS, [
+      "profile",
+      "health",
     ]).optional(),
   }),
   "/api/v1/search/semantic": z.object({

--- a/schemas-src/routes/subnet-overview.ts
+++ b/schemas-src/routes/subnet-overview.ts
@@ -16,6 +16,7 @@
 // (.passthrough()) so this is a pure completeness gain, not a tightening.
 import { z } from "zod";
 import { ArtifactBaseSchema } from "../envelope.ts";
+import { sectionsOf } from "../artifact-sections.ts";
 import { OverlaidSubnetHealthSchema } from "./health.ts";
 import {
   CurationMetadataSchema,
@@ -53,3 +54,14 @@ export const SubnetOverviewArtifactSchema = ArtifactBaseSchema.extend({
 export type SubnetOverviewArtifact = z.infer<
   typeof SubnetOverviewArtifactSchema
 >;
+
+/**
+ * The overview's selectable sections (#11100), derived the same way the other
+ * two composite subnet routes derive theirs (#10600). The identity scalars
+ * (netuid/slug/name/status) ride the vocabulary by derivation -- selecting
+ * them is harmless, and excluding them by hand would be a second list to
+ * drift.
+ */
+export const SUBNET_OVERVIEW_SECTIONS = sectionsOf(
+  SubnetOverviewArtifactSchema,
+);

--- a/scripts/validate-mcp-input-parity.ts
+++ b/scripts/validate-mcp-input-parity.ts
@@ -77,22 +77,6 @@ const CURATED_VIEW =
 const RENAMED_ON_THE_MCP_SIDE =
   "a compatibility ALIAS the route does not publish; the tool also accepts the route's canonical name (#10018)";
 
-/**
- * The tool serves a DIFFERENT DOCUMENT from the route it is mapped to, so a
- * section name the route publishes does not exist in the tool's response.
- *
- * `get_subnet` is mapped to `/api/v1/subnets/{netuid}/profile` but reads
- * `/metagraph/overview/{netuid}.json` -- measured 2026-08-13, the overview
- * carries counts/curation/gap_priorities/health/name/netuid/slug/status where
- * the profile carries subnet/endpoints/surfaces/candidate_surfaces/notes.
- * Accepting `sections=subnet` there would advertise a card the document does
- * not have and answer with an almost-empty projection, which is worse than
- * refusing the parameter. `get_subnet_profile` reads the profile document
- * itself and DOES take it.
- */
-const DIFFERENT_DOCUMENT =
-  "this tool serves a different document from the route it mirrors; the section names the route publishes do not exist in its response (#10600)";
-
 /** A header on the route, an argument on the tool. */
 const REQUEST_HEADER =
   "the route takes this as a header; a tool has no headers, only arguments";
@@ -195,8 +179,6 @@ for (const [key, reason] of Object.entries({
   "list_review_gaps.review_state": MCP_NATIVE,
   "list_enrichment_targets.severity": MCP_NATIVE,
   "list_enrichment_targets.gap_code": MCP_NATIVE,
-  // --- a different document behind the same mapping (#10600) --------------
-  "get_subnet.sections": DIFFERENT_DOCUMENT,
   // --- curated views (#10008) ---------------------------------------------
   "find_subnet_opportunities.board": CURATED_VIEW,
   "search_subnets.type": CURATED_VIEW,

--- a/scripts/validate-mcp-route-map.ts
+++ b/scripts/validate-mcp-route-map.ts
@@ -34,8 +34,6 @@ const AGENT_UNREACHABLE: Record<string, string> = {
     "The contract document itself. get_api_schema serves a SUBNET's captured schema; this one is ours, and get_contracts describes it.",
   "/api/v1/search/resolve":
     "Identifier resolution (#9672). search_subnets and semantic_search are the agent-facing discovery paths; resolve is a UI affordance.",
-  "/api/v1/subnets/{netuid}/overview":
-    "The composed overview get_subnet already serves under its profile route.",
   "/api/v1/chain/stream":
     "The realtime firehose (#11045). A request/response tool cannot hold an " +
     "event stream open; MCP sessions subscribe through the hub's own " +

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -358,6 +358,7 @@ import {
 } from "./contracts.ts";
 import { projectToolSections } from "./section-projection.ts";
 import { SUBNET_DETAIL_SECTIONS } from "../schemas-src/routes/subnet-detail.ts";
+import { SUBNET_OVERVIEW_SECTIONS } from "../schemas-src/routes/subnet-overview.ts";
 import { SUBNET_PROFILE_SECTIONS } from "../schemas-src/routes/subnet-profiles.ts";
 import {
   GET_ECONOMICS_INSTRUCTIONS,
@@ -5825,7 +5826,15 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
         `/metagraph/overview/${netuid}.json`,
       );
       const live = await mcpLiveHealth(ctx);
-      return overlayOverviewHealth(overview, live, netuid) || overview;
+      // Projected LAST, after the health overlay, for the same reason
+      // get_subnet_detail projects after its economics overlay: `health` is
+      // itself a selectable section, so projecting first would drop the very
+      // card a caller asked for (#11100).
+      return projectToolSections(
+        overlayOverviewHealth(overview, live, netuid) || overview,
+        args,
+        SUBNET_OVERVIEW_SECTIONS,
+      );
     },
   },
   {

--- a/src/mcp-tool-exposures.ts
+++ b/src/mcp-tool-exposures.ts
@@ -60,7 +60,11 @@ export const MCP_EXPOSURES: Readonly<Record<string, McpExposure>> = {
   search_subnets: { operation: "search" },
   list_subnets: { operation: "subnets" },
   find_subnets_by_capability: { operation: "agent-catalog" },
-  get_subnet: { operation: "subnet-profile" },
+  // #11100: the overview route it actually serves. Mapped to subnet-profile
+  // while the overview route had no published lever; now that the route
+  // publishes `sections`, mirroring it directly is what lets input-parity
+  // hold the tool's vocabulary to the route's with no declared divergence.
+  get_subnet: { operation: "subnet-overview" },
   get_subnet_detail: { operation: "subnet-detail" },
   get_subnet_snapshot: {
     operation: null,

--- a/tests/subnet-sections.test.ts
+++ b/tests/subnet-sections.test.ts
@@ -33,6 +33,10 @@ import {
 } from "../schemas-src/routes/subnet-profiles.ts";
 import { ArtifactBaseSchema } from "../schemas-src/envelope.ts";
 import { LIVE_HEALTH_OVERLAY } from "../schemas-src/routes/subnet-detail.ts";
+import {
+  SUBNET_OVERVIEW_SECTIONS,
+  SubnetOverviewArtifactSchema,
+} from "../schemas-src/routes/subnet-overview.ts";
 
 const DETAIL = SUBNET_DETAIL_SECTIONS;
 const PROFILE = SUBNET_PROFILE_SECTIONS;
@@ -254,6 +258,24 @@ describe("GET /api/v1/subnets/{netuid}?sections=", () => {
     assert.match(String(error.message), /sections/);
   });
 
+  test("the overview route serves a selected section and sheds the rest (#11100)", async () => {
+    const { res, body } = await getRoute(
+      "/api/v1/subnets/1/overview?sections=profile",
+    );
+    assert.equal(res.status, 200);
+    const data = (body?.data ?? {}) as Row;
+    assert.ok("profile" in data, "the requested section is present");
+    for (const shed of ["health", "curation", "gaps", "counts"]) {
+      assert.ok(!(shed in data), `${shed} must be projected away`);
+    }
+    // Its own vocabulary: `economics` is a detail-route section the overview
+    // never carries, so it must be refused, not ignored.
+    const refused = await getRoute(
+      "/api/v1/subnets/1/overview?sections=economics",
+    );
+    assert.equal(refused.res.status, 400);
+  });
+
   test("the profile route refuses `economics`, which it cannot serve", async () => {
     // Its own vocabulary, not a shared one: accepting a name this document
     // never carries would promise a section that can never arrive.
@@ -290,6 +312,7 @@ describe("the lever is published, not just implemented", () => {
   it.each([
     ["/api/v1/subnets/{netuid}", SUBNET_DETAIL_SECTIONS],
     ["/api/v1/subnets/{netuid}/profile", SUBNET_PROFILE_SECTIONS],
+    ["/api/v1/subnets/{netuid}/overview", SUBNET_OVERVIEW_SECTIONS],
   ])("%s publishes sections with its own closed set", (route, vocabulary) => {
     const parameter = published(route).find((p) => p.name === "sections");
     expect(parameter, `${route} must publish sections`).toBeTruthy();
@@ -409,6 +432,23 @@ describe("the section vocabulary cannot drift from the document", () => {
         "surfaces",
       ],
     ],
+    [
+      "overview",
+      SUBNET_OVERVIEW_SECTIONS,
+      [
+        "counts",
+        "curation",
+        "gap_priorities",
+        "gaps",
+        "health",
+        "name",
+        "netuid",
+        "notes",
+        "profile",
+        "slug",
+        "status",
+      ],
+    ],
   ])("%s publishes exactly this vocabulary", (_name, vocab, expected) => {
     // Compared unsorted: `sectionsOf` sorts, so the published order is part of
     // what this pins.
@@ -422,6 +462,7 @@ describe("the section vocabulary cannot drift from the document", () => {
     for (const [schema, vocab] of [
       [SubnetDetailArtifactSchema, SUBNET_DETAIL_SECTIONS],
       [SubnetProfileArtifactSchema, SUBNET_PROFILE_SECTIONS],
+      [SubnetOverviewArtifactSchema, SUBNET_OVERVIEW_SECTIONS],
     ] as const) {
       for (const section of vocab) {
         assert.ok(

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -186,6 +186,7 @@ import {
   projectSections,
 } from "../src/section-projection.ts";
 import { SUBNET_DETAIL_SECTIONS } from "../schemas-src/routes/subnet-detail.ts";
+import { SUBNET_OVERVIEW_SECTIONS } from "../schemas-src/routes/subnet-overview.ts";
 import { SUBNET_PROFILE_SECTIONS } from "../schemas-src/routes/subnet-profiles.ts";
 
 /**
@@ -199,6 +200,7 @@ import { SUBNET_PROFILE_SECTIONS } from "../schemas-src/routes/subnet-profiles.t
 const SECTION_VOCABULARIES: Record<string, readonly string[] | undefined> = {
   "subnet-detail": SUBNET_DETAIL_SECTIONS,
   "subnet-profile": SUBNET_PROFILE_SECTIONS,
+  "subnet-overview": SUBNET_OVERVIEW_SECTIONS,
 };
 import { csvRequested, csvResponse } from "./csv.ts";
 import {


### PR DESCRIPTION
## Summary

Field-report P2 (#11100, premise corrected in implementation): the ask was a projection lever on `get_subnet`. Investigation showed the tool serves the composed **overview** document while being route-mapped to the **profile** route (a #10600-era approximation, excused by a `DIFFERENT_DOCUMENT` declared divergence), and the overview route published no lever at all.

- `/api/v1/subnets/{netuid}/overview` becomes the third composite subnet route with `sections=` (#10600 pattern exactly: vocabulary derived via `sectionsOf` from the artifact schema, published as a closed pattern, projected at the generic seam through `SECTION_VOCABULARIES`).
- `get_subnet` carries the argument, projected **after** the health overlay (same ordering reasoning as `get_subnet_detail`'s economics overlay).
- The route-map now states the truth: `get_subnet` mirrors the overview route. The `DIFFERENT_DOCUMENT` declared divergence and the overview's `AGENT_UNREACHABLE` entry are **deleted** — input-parity now holds the tool to its own route with zero declarations (228/228 aligned exactly).

## Testing

- Route: selected section served + rest shed, foreign section (`economics`) refused, envelope survives, lever published with the closed pattern, vocabulary pinned verbatim, every offered section is a declared artifact key.
- Full suite 903 files / 20,690 green; mcp-route-map, mcp-input-parity, route-query-parity, query-vocabulary, contract-drift, tool-route-divergence, validate:mcp all green.
- Post-merge: live-verify `?sections=profile` on production + `conformance:tripwire`.

Closes #11100