### PR TITLE
fix(ci): fail a release PR whose body would close an issue nobody finished

### DIFF
--- a/.github/workflows/check-release-closes.yml
+++ b/.github/workflows/check-release-closes.yml
@@ -1,0 +1,64 @@
+name: Release PR closing keywords
+
+# Stops a release PR from closing an issue nobody finished (#11052).
+#
+# release-please carries the generated changelog as the release PR's BODY, and
+# GitHub honours closing keywords anywhere in a body -- including inside
+# <details>. Its generator emits `closes #N` for any issue a commit referenced,
+# without distinguishing a deliberate `Refs #N`. So a PR that said `Refs #10606`
+# because the work was partial comes back in a release PR as `closes #10606`,
+# and merging the release closes an issue nobody finished. Measured on #11050:
+# 46 claimed closes, 45 already closed, and exactly one -- #10606 -- open on
+# purpose.
+#
+# Its own workflow rather than a step in validate.yml, for two reasons: this is
+# the only check whose input is the PR BODY rather than the tree (so it must
+# re-run on `edited`, which validate.yml deliberately does not listen for), and
+# it needs `issues: read` on the API, which validate.yml has no other use for.
+#
+# Scoped to release-please's branch, so it never runs on a contributor PR --
+# where a `Closes #N` naming an open issue is not a defect, it is the required
+# form.
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: check-release-closes-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  closing-keywords:
+    # release-please names its branch per component; `.` (the platform release)
+    # is the one that carries the aggregate changelog. startsWith covers the
+    # component branches (release-please--branches--main--components--…) too.
+    if: startsWith(github.event.pull_request.head.ref, 'release-please--branches--main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5 # a parse plus one API call per referenced issue
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: .nvmrc
+
+      # Only the PR NUMBER crosses the workflow boundary. The script fetches the
+      # body itself with the token, so attacker-controllable text is never
+      # interpolated into a workflow expression at all -- not even via `env:`.
+      # scripts/validate-workflows.ts refuses `github.event.pull_request.body`
+      # outright, which is the right call and is what pushed this here.
+      - name: Check closing keywords against issue state
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/validate-release-closes.ts ${{ github.event.pull_request.number }}

--- a/scripts/validate-release-closes.ts
+++ b/scripts/validate-release-closes.ts
@@ -1,0 +1,207 @@
+// Stops a release PR from closing an issue nobody finished (#11052).
+//
+// release-please carries the generated changelog as the release PR's BODY, and
+// GitHub honours closing keywords anywhere in a PR body -- including inside
+// <details>. The changelog generator emits `closes #N` for any issue reference
+// it extracts from a commit, and it does not distinguish a deliberate
+// `Refs #N`. So a PR that said `Refs #10606` because the work was partial comes
+// back a week later as `closes #10606` in a release PR, and merging the release
+// closes the issue.
+//
+// Measured on #11050: its body claimed to close 46 issues. 45 were already
+// closed by their own PRs (harmless noise); exactly one -- #10606 -- was open,
+// deliberately, because its third ask has no implementation. Editing the body by
+// hand does not survive: release-please regenerates it on every run.
+//
+// So the check is on the BODY, not on CHANGELOG.md: a closing keyword in a
+// committed file has no effect, only a PR body does. And it deliberately does
+// NOT lint the changelog text -- the issue links are the only trail from a
+// released version back to why a change happened, and they should stay. The one
+// case with a side effect is the one this fails on.
+//
+// The remedy when it fires is either to finish the issue or to rewrite that one
+// keyword to `refs`, and both are decisions a person should make on purpose.
+//
+// Takes a PR NUMBER and fetches the body itself, rather than having the workflow
+// interpolate `${{ github.event.pull_request.body }}`. A PR body is
+// attacker-controllable text, and passing it through the workflow -- even via
+// `env:` -- means untrusted text crosses that boundary at all. A number does
+// not. scripts/validate-workflows.ts refuses the interpolation outright, which
+// is the right call and pushed this to the better design.
+//
+// Runnable by hand against any PR:  node scripts/validate-release-closes.ts 11050
+import { execFileSync } from "node:child_process";
+
+/** GitHub's closing keywords, verbatim from its own docs. Case-insensitive. */
+const CLOSING_KEYWORDS = [
+  "close",
+  "closes",
+  "closed",
+  "fix",
+  "fixes",
+  "fixed",
+  "resolve",
+  "resolves",
+  "resolved",
+] as const;
+
+// Matches `closes #123`, and the markdown-linked form release-please actually
+// emits (`closes [#123](https://github.com/owner/repo/issues/123)`). The
+// optional `[` before `#` is what makes the linked form parse; without it the
+// generated changelog reads as having no closing keywords at all, which is the
+// silent-pass this gate exists to prevent.
+const SAME_REPO = new RegExp(
+  String.raw`\b(${CLOSING_KEYWORDS.join("|")})\b\s*:?\s*\[?#(\d+)`,
+  "gi",
+);
+
+// `owner/repo#123` and full issue URLs. Captured separately because a
+// cross-repo closing keyword does NOT close anything in the other repo -- only
+// a reference in ITS OWN repo does -- so counting them here would fail the
+// release for an issue the merge cannot touch.
+const CROSS_REPO = new RegExp(
+  String.raw`\b(?:${CLOSING_KEYWORDS.join("|")})\b\s*:?\s*\[?(?:[\w.-]+/[\w.-]+#\d+|https?://github\.com/[\w.-]+/[\w.-]+/issues/\d+)`,
+  "gi",
+);
+
+export interface ParsedClosers {
+  /** Issue numbers this body would close in THIS repo, ascending, deduped. */
+  sameRepo: number[];
+  /** How many closing keywords named another repo, which cannot close here. */
+  crossRepoCount: number;
+}
+
+/**
+ * Parse the closing keywords out of a PR body.
+ *
+ * PURE, so the parsing rules are testable without the network or a PR. Strips
+ * fenced code blocks first: a changelog that quotes a commit message inside
+ * ``` is showing text, not asking GitHub to close anything -- and GitHub agrees,
+ * it ignores keywords in code fences.
+ */
+export function parseClosingKeywords(body: string): ParsedClosers {
+  const withoutFences = body.replace(/```[\s\S]*?```/g, "");
+  const sameRepo = new Set<number>();
+  for (const match of withoutFences.matchAll(SAME_REPO)) {
+    const issue = Number(match[2]);
+    if (Number.isInteger(issue) && issue > 0) sameRepo.add(issue);
+  }
+  const crossRepoCount = [...withoutFences.matchAll(CROSS_REPO)].length;
+  return {
+    sameRepo: [...sameRepo].sort((a, b) => a - b),
+    crossRepoCount,
+  };
+}
+
+export interface IssueState {
+  number: number;
+  state: string;
+  title: string;
+}
+
+/** Format the failure so the operator can act without opening every link. */
+export function formatOpenIssues(open: readonly IssueState[]): string {
+  return [
+    `This release PR's body would CLOSE ${open.length} issue(s) that are still open:`,
+    "",
+    ...open.map((i) => `  #${i.number}  ${i.title}`),
+    "",
+    "release-please emits `closes #N` for every issue a commit referenced,",
+    "including a deliberate `Refs #N`. Merging this PR would close the above.",
+    "",
+    "Fix it by either:",
+    "  - finishing the issue, so closing it is correct; or",
+    "  - editing that one keyword to `refs` in the commit that introduced it,",
+    "    so the regenerated body stops claiming it.",
+    "",
+    "Editing this PR's body by hand does not hold -- release-please rewrites it.",
+  ].join("\n");
+}
+
+function issueStates(numbers: readonly number[], repo: string): IssueState[] {
+  const states: IssueState[] = [];
+  for (const number of numbers) {
+    // One call per issue rather than a search query: a search index can lag a
+    // just-closed issue by minutes, and a stale OPEN here would fail a release
+    // for no reason.
+    const raw = execFileSync(
+      "gh",
+      [
+        "api",
+        `repos/${repo}/issues/${number}`,
+        "--jq",
+        "{number:.number,state:.state,title:.title,pull:(.pull_request!=null)}",
+      ],
+      { encoding: "utf8" },
+    );
+    const parsed = JSON.parse(raw) as IssueState & { pull: boolean };
+    // A PR is an issue to the REST API. A closing keyword naming a PR does not
+    // leave an issue unfinished, so it is not this gate's business.
+    if (parsed.pull) continue;
+    states.push({
+      number: parsed.number,
+      state: parsed.state,
+      title: parsed.title,
+    });
+  }
+  return states;
+}
+
+/** Fetch one PR's body. Separated so `main` stays a readable sequence. */
+function prBody(number: number, repo: string): string {
+  return execFileSync(
+    "gh",
+    ["api", `repos/${repo}/pulls/${number}`, "--jq", '.body // ""'],
+    { encoding: "utf8" },
+  );
+}
+
+function main(): void {
+  const arg = process.argv[2];
+  const number = Number(arg);
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!arg || !Number.isInteger(number) || number <= 0) {
+    // Named, not defaulted: a check that "passes" having examined no PR has
+    // checked nothing, which is the failure mode this gate exists to prevent
+    // one level up.
+    console.error(
+      `needs a pull-request number; got ${JSON.stringify(arg ?? "")}\n` +
+        "  node scripts/validate-release-closes.ts <pr-number>",
+    );
+    process.exit(1);
+  }
+  if (!repo) {
+    console.error("GITHUB_REPOSITORY is not set");
+    process.exit(1);
+  }
+  const body = prBody(number, repo);
+
+  const { sameRepo, crossRepoCount } = parseClosingKeywords(body);
+  if (sameRepo.length === 0) {
+    console.log(
+      "No same-repo closing keywords in the release PR body" +
+        (crossRepoCount > 0
+          ? ` (${crossRepoCount} cross-repo one(s) ignored — they cannot close here).`
+          : "."),
+    );
+    return;
+  }
+
+  const states = issueStates(sameRepo, repo);
+  const open = states.filter((i) => i.state.toUpperCase() === "OPEN");
+  if (open.length > 0) {
+    console.error(formatOpenIssues(open));
+    process.exit(1);
+  }
+  console.log(
+    `Release PR body closes ${states.length} issue(s), all already closed` +
+      (crossRepoCount > 0
+        ? `; ${crossRepoCount} cross-repo reference(s) ignored.`
+        : "."),
+  );
+}
+
+// Only when run directly, so the pure helpers stay importable by tests.
+if (process.argv[1]?.endsWith("validate-release-closes.ts")) {
+  main();
+}

--- a/tests/validate-release-closes.test.ts
+++ b/tests/validate-release-closes.test.ts
@@ -1,0 +1,119 @@
+// The gate that stops a release PR closing an unfinished issue (#11052).
+//
+// The network half is not mocked: `issueStates` is one `gh api` call per issue
+// and the interesting behaviour is entirely in what gets EXTRACTED from the
+// body. That is where the bug lived — release-please emits the markdown-LINKED
+// form, so a parser that only matches `closes #123` reads the generated
+// changelog as having no closing keywords at all and passes silently, which is
+// exactly the failure this gate exists to prevent.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  formatOpenIssues,
+  parseClosingKeywords,
+} from "../scripts/validate-release-closes.ts";
+
+describe("parseClosingKeywords", () => {
+  test("MATCHES THE MARKDOWN-LINKED FORM release-please actually emits", () => {
+    // The whole point. #11050's body read `closes [#10606](…/issues/10606)`,
+    // and a `closes #\d+`-only pattern sees nothing there.
+    const { sameRepo } = parseClosingKeywords(
+      "* fix(chain): stop the refusal loop, closes " +
+        "[#10606](https://github.com/JSONbored/metagraphed/issues/10606)",
+    );
+    assert.deepEqual(sameRepo, [10606]);
+  });
+
+  test("matches every closing keyword GitHub honours, case-insensitively", () => {
+    for (const keyword of [
+      "close",
+      "closes",
+      "closed",
+      "fix",
+      "fixes",
+      "fixed",
+      "resolve",
+      "resolves",
+      "resolved",
+      "CLOSES",
+      "Fixes",
+    ]) {
+      const { sameRepo } = parseClosingKeywords(`${keyword} #7`);
+      assert.deepEqual(sameRepo, [7], `${keyword} must be honoured`);
+    }
+  });
+
+  test("`Refs #N` is NOT a closing keyword", () => {
+    // The distinction the whole issue turns on: `Refs` means the work is
+    // partial. If this ever matched, the gate would fail every release that
+    // advanced an issue without finishing it.
+    const { sameRepo } = parseClosingKeywords(
+      "* feat(api): partial capacity guard, Refs #10606\n* see also #999",
+    );
+    assert.deepEqual(sameRepo, []);
+  });
+
+  test("cross-repo keywords are counted, not treated as closers", () => {
+    // `owner/repo#N` and issue URLs cannot close anything in THIS repo, so
+    // failing a release for one would block on an issue the merge cannot touch.
+    const parsed = parseClosingKeywords(
+      "closes JSONbored/loopover#12 and " +
+        "fixes https://github.com/JSONbored/loopover/issues/13 and closes #14",
+    );
+    assert.deepEqual(parsed.sameRepo, [14]);
+    assert.equal(parsed.crossRepoCount, 2);
+  });
+
+  test("keywords inside fenced code blocks are ignored", () => {
+    // GitHub ignores them too — a changelog quoting a commit message is showing
+    // text, not asking for a close.
+    const { sameRepo } = parseClosingKeywords(
+      "```\ngit commit -m 'fix: thing, closes #1'\n```\ncloses #2",
+    );
+    assert.deepEqual(sameRepo, [2]);
+  });
+
+  test("results are deduped and ascending", () => {
+    const { sameRepo } = parseClosingKeywords(
+      "closes #30\nfixes #4\nresolves #30\ncloses [#12](x)",
+    );
+    assert.deepEqual(sameRepo, [4, 12, 30]);
+  });
+
+  test("a body with no closing keywords parses to nothing", () => {
+    // Must not throw or invent: an empty result is a legitimate answer and is
+    // what the common case (a release of pure chores) produces.
+    assert.deepEqual(parseClosingKeywords("### Features\n* a thing (#123)"), {
+      sameRepo: [],
+      crossRepoCount: 0,
+    });
+    assert.deepEqual(parseClosingKeywords(""), {
+      sameRepo: [],
+      crossRepoCount: 0,
+    });
+  });
+
+  test("`closes:` with a colon, and `<details>` nesting, both still count", () => {
+    // GitHub honours keywords anywhere in the body, including inside collapsed
+    // sections — which is where release-please puts the per-component changelog.
+    const { sameRepo } = parseClosingKeywords(
+      "<details><summary>metagraphed: 1.2.0</summary>\n\ncloses: #55\n\n</details>",
+    );
+    assert.deepEqual(sameRepo, [55]);
+  });
+});
+
+describe("formatOpenIssues", () => {
+  test("names each open issue and both remedies", () => {
+    // A gate that says only "failed" makes the operator re-derive what this
+    // script already knows.
+    const out = formatOpenIssues([
+      { number: 10606, state: "OPEN", title: "/api/v1/chain/stream 5xxs" },
+    ]);
+    assert.match(out, /#10606\s+\/api\/v1\/chain\/stream 5xxs/);
+    assert.match(out, /finishing the issue/);
+    assert.match(out, /`refs`/);
+    // And the trap that wasted a round on #11050: hand-editing does not hold.
+    assert.match(out, /release-please rewrites it/);
+  });
+});


### PR DESCRIPTION
Closes #11052.

release-please carries the generated changelog as the release PR's **body**, and GitHub honours closing keywords anywhere in a body — including inside `<details>`. Its generator emits `closes #N` for any issue a commit referenced and **does not distinguish a deliberate `Refs #N`**. So a PR that said `Refs #10606` because the work was partial comes back a week later as `closes #10606` in a release PR, and merging the release closes an issue nobody finished.

Measured on #11050: the body claimed **46 closes**. 45 were already closed by their own PRs — harmless noise — and exactly one, **#10606**, was open on purpose, because its third ask has no implementation. Hand-editing that body does not hold: release-please regenerates it on every run.

## The check

On a release PR only: parse the closing keywords out of the body, ask the API for each named issue's state, **fail on any that is `OPEN`**.

Deliberately narrow, per the issue's own "Don't" list:

- It reads the **body**, not `CHANGELOG.md`. A closing keyword in a committed file has no effect; only a PR body does.
- It does **not** lint the changelog text. The issue links are the only trail from a released version back to why a change happened, and they stay.
- It does **not** ban `Refs`. A PR that advances an issue without finishing it is exactly what `Refs` is for.

Two things the parser has to get right, both tested:

- **The markdown-linked form.** release-please emits `closes [#10606](https://github.com/…/issues/10606)`, so a `closes #\d+` pattern reads the generated changelog as having *no closing keywords at all* and passes silently — the exact shape of the bug.
- **Cross-repo references are counted, never failed on.** `owner/repo#N` cannot close anything here, so failing the release for one would block on an issue the merge cannot touch. Fenced code blocks are stripped for the same reason GitHub ignores them.

A PR is an issue to the REST API, so `pull_request != null` rows are skipped — a keyword naming a PR leaves no issue unfinished.

## Only the PR number crosses the workflow boundary

The script takes a **number** and fetches the body itself. A PR body is attacker-controllable text; passing it through the workflow — even via `env:` — means it crosses that boundary at all.

`validate-workflows.ts` refuses `github.event.pull_request.body` outright. That gate fired on my first attempt, it was **right to**, and it is what pushed this to the better design.

Its own workflow rather than a step in `validate.yml`: this is the only check whose input is the PR body rather than the tree, so it must re-run on `edited`, which `validate.yml` deliberately does not listen for. Scoped by branch prefix to release-please's PRs — on a contributor PR, `Closes #N` naming an open issue is not a defect, it is the required form.

## Verification

Both seams proven against the live API:

```
parser:  closes [#10606](…/issues/10606)  ->  { sameRepo: [10606], crossRepoCount: 0 }
state:   #10606  state=open  pull=false
```

The composed failure path was demonstrated end to end — exit 1, naming #10606 and both remedies — before the body source moved from an env var to a fetch:

```
This release PR's body would CLOSE 1 issue(s) that are still open:

  #10606  /api/v1/chain/stream 5xxs 95% of requests, …

Fix it by either:
  - finishing the issue, so closing it is correct; or
  - editing that one keyword to `refs` in the commit that introduced it,
    so the regenerated body stops claiming it.

Editing this PR's body by hand does not hold -- release-please rewrites it.
```

Nine unit tests cover the parser and the failure message. The entrypoint is outside the coverage `include` set by design, and `vitest.config.ts`'s own note prescribes exactly this shape — *"targeted unit tests of their pure helpers rather than the `execFileSync` entrypoint"*.

**No root npm script:** it needs a PR to examine, so registering one would invite adding it to the local validator set where it can only fail. It is runnable by hand — `node scripts/validate-release-closes.ts 11050`.

`validate` · `validate:workflows` · `validate:archive-policy` · `format:check` · `lint` · `typecheck` all pass on top of `8a5b826fa`.