### PR TITLE
chore(registry): drop the pilot partnership blocks from the two overlays

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -40,10 +40,6 @@
     "outcome": "none-found",
     "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
   },
-  "partnership": {
-    "since": "2026-07-04",
-    "tier": "pilot"
-  },
   "schema_version": 1,
   "slug": "allways",
   "source_repo": "https://github.com/entrius/allways",

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -43,10 +43,6 @@
     "outcome": "none-found",
     "checked": ["website", "docs", "openapi", "dashboard", "source-repo"]
   },
-  "partnership": {
-    "since": "2026-07-04",
-    "tier": "pilot"
-  },
   "schema_version": 1,
   "slug": "gittensor",
   "social": {

--- a/tests/validate-error-messages.test.ts
+++ b/tests/validate-error-messages.test.ts
@@ -171,21 +171,16 @@ describe("validate-schemas.ts enum error messages", () => {
     const subnetFiles = await listJsonFiles(
       path.join(repoRoot, "registry/subnets"),
     );
-    let targetFile;
-    let targetDocument;
-    for (const file of subnetFiles) {
-      const document = await readJson(file);
-      if (document.partnership) {
-        targetFile = file;
-        targetDocument = document;
-        break;
-      }
-    }
-    assert.ok(targetFile, "at least one subnet file must have a partnership");
+    // INJECTED rather than found: the registry may legitimately hold zero
+    // partnership blocks (it does today), and this test is about the schema's
+    // enum error message, not about any subnet carrying the field.
+    const targetFile = subnetFiles[0];
+    assert.ok(targetFile, "the registry must hold at least one subnet file");
+    const targetDocument = await readJson(targetFile);
 
     mutatedFile = targetFile;
     originalContents = readFileSync(mutatedFile, "utf8");
-    targetDocument.partnership.tier = "sponsor";
+    targetDocument.partnership = { since: "2026-01-01", tier: "sponsor" };
     writeFileSync(mutatedFile, JSON.stringify(targetDocument, null, 2));
 
     const { status, output } = runNode(["scripts/validate-schemas.ts"]);

--- a/tests/validate-surface-reviewed-convention.test.ts
+++ b/tests/validate-surface-reviewed-convention.test.ts
@@ -153,10 +153,16 @@ describe("validate-surface.ts reviewed-tier convention (#5739)", () => {
     assert.doesNotMatch(output, /convention advisory/i);
   });
 
-  test("the three live exempt files are acknowledged, not flagged", () => {
+  test("root stays exempt; the two ex-pilot manifests are flagged like anyone else", () => {
     // Pin to the three named files rather than a no-args full-corpus scan:
     // other tests (validate-error-messages) mutate registry/subnets/*.json
     // in place under parallel vitest, which races a full-corpus run.
+    //
+    // The pilot exemption is gone from allways/gittensor, so their hand-seeded
+    // surfaces now draw the same NON-BLOCKING advisory any deviating
+    // adapter-backed entry draws -- deliberately: an ordinary subnet's gaps
+    // are visible, not exempted. Backfilling their source_urls/verified_at is
+    // what clears the advisory.
     const { status, output } = runNode([
       "scripts/validate-surface.ts",
       "registry/subnets/root.json",
@@ -166,8 +172,8 @@ describe("validate-surface.ts reviewed-tier convention (#5739)", () => {
     assert.equal(status, 0, output);
     assert.match(output, /acknowledged exemption/i);
     assert.match(output, /root\.json/);
+    assert.match(output, /convention advisory/i);
     assert.match(output, /gittensor\.json/);
     assert.match(output, /allways\.json/);
-    assert.doesNotMatch(output, /convention advisory/i);
   });
 });


### PR DESCRIPTION
Removes the `partnership` blocks from `allways.json` and `gittensor.json` — the field now serves null for every subnet and nothing keys on it (the homepage pilot section that read it is already gone in #11115). The reviewed-tier advisory this uncovers on allways (hand-seeded surfaces without `source_urls`) is non-blocking and now visible rather than exempted. Full `npm run validate` green after regeneration.