### PR TITLE
feat(lakehouse): catch a table R2 SQL cannot read, and stop counting it as stale

### DIFF
--- a/scripts/check-lakehouse-freshness.ts
+++ b/scripts/check-lakehouse-freshness.ts
@@ -36,6 +36,12 @@ const BASE =
 const WAREHOUSE =
   process.env.R2_WAREHOUSE ??
   "918f0f0e2eb26709d1cf4fb76085c8fb_metagraphed-lakehouse";
+// The R2 SQL door takes the BARE bucket name where the catalog takes the
+// account-prefixed warehouse. They are not interchangeable and each 404s on the
+// other's form -- iceberg_r2.py's catalog() carries the same warning.
+const WAREHOUSE_BUCKET = process.env.R2_SQL_BUCKET ?? "metagraphed-lakehouse";
+const ACCOUNT_ID =
+  process.env.R2_ACCOUNT_ID ?? "918f0f0e2eb26709d1cf4fb76085c8fb";
 
 const HOUR = 60 * 60 * 1000;
 const DAY = 24 * HOUR;
@@ -265,6 +271,15 @@ export const EXPECTED: Readonly<Record<string, FreshnessRule>> = {
  * claim: "this cannot go stale" rather than "this is stale and we know".
  */
 export const KNOWN_FROZEN: ReadonlySet<string> = new Set([
+  // Was eighteen, then three, now one. `account_events_daily` gained a producer
+  // (metagraphed-infra#544) and `rpc_proxy_events` gained the Analytics Engine
+  // export (#547); both are writing on the tick, so the baseline must stop
+  // claiming they are frozen or it overstates the outage.
+  //
+  // `featured_validators` is the last, and it is not waiting on a producer: the
+  // curation moved to registry/featured-validators.json (#11080), so the
+  // lakehouse copy is a fossil of the retired side table. It stays here until
+  // that is either fed from the registry or dropped -- a decision, not a lane.
   // Was eighteen. metagraphed-infra#536 ported the Neon -> Iceberg sink that
   // the 2026-08-02 host retirement took with it, and fifteen of these came
   // back on 2026-08-13 -- verified against the catalog, 11 -> 22 chain tables
@@ -278,9 +293,7 @@ export const KNOWN_FROZEN: ReadonlySet<string> = new Set([
   //                         published from this repo
   //   rpc_proxy_events      no such table in Neon; the RPC proxy Worker writes
   //                         it to D1
-  "account_events_daily",
   "featured_validators",
-  "rpc_proxy_events",
 ]);
 export interface TableAge {
   table: string;
@@ -317,6 +330,112 @@ export function evaluate(
   return { ok: true, detail: `${age.table}: ${days.toFixed(1)}d` };
 }
 
+interface SchemaField {
+  id?: number;
+  name?: string;
+  type?: unknown;
+}
+
+/**
+ * Columns whose TYPE changed between schema generations.
+ *
+ * R2 SQL tolerates schema AUGMENTATION -- adding a column -- and rejects a type
+ * change outright: "Query spans incompatible schemas". Iceberg permits the
+ * widening, so `int -> long` and `float -> double` look free and are not: every
+ * data file written under the old schema stays unreadable until it is rewritten.
+ *
+ * THIS IS THE THIRD TIME IT WAS FOUND BY HAND. `neuron_daily.take` broke reads
+ * for hours before anyone noticed (metagraphed-infra#542); `neurons.take` broke
+ * the moment it was widened; `nominator_positions.share_fraction` sat broken
+ * through several verification passes because the SMOKE TESTS DID NOT SPAN.
+ *
+ * METADATA ALONE IS NOT ENOUGH, and the first version of this got it wrong.
+ * Iceberg keeps every historical schema in `schemas[]` FOREVER, so a table that
+ * has been rewritten under its current schema still lists the old one -- this
+ * reported five tables I had just fixed. The list records that a type once
+ * changed, not that any data file still carries the old type.
+ *
+ * So metadata is the cheap FILTER and a probe is the authority. The probe is
+ * `count(<column>)`, which must project the column and read every file: it
+ * cannot be answered from statistics like `count(*)`, and cannot be satisfied
+ * by one file like `SELECT col LIMIT 1`. Those are precisely the two shapes
+ * that passed while `nominator_positions.share_fraction` was broken for its
+ * real cold-tier read.
+ */
+/** Ask R2 SQL whether a column is actually unreadable across generations. */
+async function columnSpansGenerations(
+  auth: Record<string, string>,
+  table: string,
+  column: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `https://api.sql.cloudflarestorage.com/api/v1/accounts/${ACCOUNT_ID}/r2-sql/query/${WAREHOUSE_BUCKET}`,
+      {
+        method: "POST",
+        headers: { ...auth, "content-type": "application/json" },
+        body: JSON.stringify({
+          warehouse: WAREHOUSE_BUCKET,
+          query: `SELECT count(${column}) AS n FROM chain.${table}`,
+        }),
+      },
+    );
+    const body = (await res.json()) as {
+      errors?: { message?: string }[];
+    };
+    return (body.errors ?? []).some((e) =>
+      (e.message ?? "").includes("spans incompatible schemas"),
+    );
+  } catch {
+    // A probe that cannot run must not silently clear the table.
+    return true;
+  }
+}
+
+export function typeChangedAcrossSchemas(
+  metadata:
+    | {
+        schemas?: { "schema-id"?: number; fields?: SchemaField[] }[];
+        "current-schema-id"?: number;
+      }
+    | undefined,
+): string[] {
+  const schemas = metadata?.schemas ?? [];
+  if (schemas.length < 2) return [];
+  const current =
+    schemas.find((s) => s["schema-id"] === metadata?.["current-schema-id"]) ??
+    schemas[schemas.length - 1];
+  const currentType = new Map<number, string>();
+  const currentName = new Map<number, string>();
+  for (const field of current?.fields ?? []) {
+    if (typeof field.id === "number") {
+      currentType.set(field.id, JSON.stringify(field.type));
+      currentName.set(field.id, String(field.name ?? field.id));
+    }
+  }
+  const changed = new Set<string>();
+  for (const schema of schemas) {
+    if (schema === current) continue;
+    for (const field of schema.fields ?? []) {
+      if (typeof field.id !== "number") continue;
+      const now = currentType.get(field.id);
+      // A field ABSENT from the current schema was dropped; one absent from an
+      // older schema was added. Both are augmentation, which R2 SQL reads fine.
+      // Only a field in both with a different type breaks it.
+      if (now === undefined) continue;
+      if (now !== JSON.stringify(field.type)) {
+        // The CURRENT name, not the one the old generation used. Iceberg
+        // identifies a column by id, so a rename keeps the id -- and the name
+        // that belongs in the error is the one someone would put in a query.
+        changed.add(
+          currentName.get(field.id) ?? String(field.name ?? field.id),
+        );
+      }
+    }
+  }
+  return [...changed].sort();
+}
+
 async function main(): Promise<void> {
   const token = process.env.R2_CATALOG_TOKEN ?? "";
   if (!token) {
@@ -348,13 +467,40 @@ async function main(): Promise<void> {
 
   const now = Date.now();
   const failures: string[] = [];
+  // Kept SEPARATE from `failures`: an unreadable column is not a staleness
+  // problem, and folding it in made the summary report "6 stale" when exactly
+  // one table was stale. A watchdog that miscounts its own findings is one
+  // people learn to discount.
+  const unreadable: string[] = [];
   const lines: string[] = [];
   for (const table of tables) {
     const meta = (await (
       await fetch(`${BASE}/v1/${prefix}/namespaces/chain/tables/${table}`, {
         headers: auth,
       })
-    ).json()) as { metadata?: { snapshots?: { "timestamp-ms"?: number }[] } };
+    ).json()) as {
+      metadata?: {
+        snapshots?: { "timestamp-ms"?: number }[];
+        schemas?: { "schema-id"?: number; fields?: SchemaField[] }[];
+        "current-schema-id"?: number;
+      };
+    };
+    // Candidates from metadata, confirmed by probe -- see the note above on why
+    // the metadata list alone reports tables that are already fine.
+    const candidates = typeChangedAcrossSchemas(meta.metadata);
+    const spanned: string[] = [];
+    for (const column of candidates) {
+      if (await columnSpansGenerations(auth, table, column)) {
+        spanned.push(column);
+      }
+    }
+    if (spanned.length) {
+      unreadable.push(
+        `${table}: R2 SQL cannot read ${spanned.join(", ")} -- the column's ` +
+          `TYPE changed across schema generations and data files still carry ` +
+          `the old one. Rewrite the table under its current schema.`,
+      );
+    }
     const snapshots = meta.metadata?.snapshots ?? [];
     const newestMs = snapshots.length
       ? Math.max(...snapshots.map((s) => s["timestamp-ms"] ?? 0))
@@ -377,6 +523,7 @@ async function main(): Promise<void> {
   const regressions = failures.filter(
     (f) => !KNOWN_FROZEN.has(f.split(" ")[0] ?? ""),
   );
+  reportUnreadable(unreadable);
   process.stdout.write(
     `\nlakehouse-freshness: ${failures.length} stale of ${tables.length} -- ` +
       `${failures.length - regressions.length} known (baseline ${KNOWN_FROZEN.size}), ` +
@@ -418,6 +565,26 @@ async function main(): Promise<void> {
     `\nlakehouse-freshness: ${failures.length} of ${tables.length} table(s) STALE.\n`,
   );
   process.exit(1);
+}
+
+/**
+ * Report unreadable columns and decide the exit code.
+ *
+ * Reported SEPARATELY from staleness because they are different faults with
+ * different fixes: a stale table needs its producer looked at, an unreadable
+ * column needs the table rewritten. Folding them together made the summary say
+ * "6 stale" when one table was stale, and a watchdog that miscounts its own
+ * findings is one people learn to discount.
+ */
+function reportUnreadable(unreadable: string[]): void {
+  if (!unreadable.length) return;
+  process.stdout.write(
+    `\nUNREADABLE -- ${unreadable.length} table(s) span incompatible schemas:\n  ` +
+      unreadable.join("\n  ") +
+      `\n  R2 SQL tolerates adding a column and rejects a type change. Rewrite\n` +
+      `  each table under its current schema; Iceberg keeps the old schema in\n` +
+      `  its metadata either way, so only a probe can tell you it is fixed.\n`,
+  );
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/tests/lakehouse-freshness.test.ts
+++ b/tests/lakehouse-freshness.test.ts
@@ -1,7 +1,11 @@
 // The lakehouse freshness rule, tested without a catalog (#11048).
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { EXPECTED, evaluate } from "../scripts/check-lakehouse-freshness.ts";
+import {
+  EXPECTED,
+  evaluate,
+  typeChangedAcrossSchemas,
+} from "../scripts/check-lakehouse-freshness.ts";
 import { TABLES } from "../scripts/refresh-lakehouse-schema.ts";
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -76,5 +80,84 @@ describe("lakehouse freshness", () => {
       const rule = EXPECTED[t]!;
       assert.ok(rule.maxAgeMs !== null && rule.maxAgeMs < 10.5 * DAY, t);
     }
+  });
+});
+
+describe("type changes across schema generations (metagraphed-infra#542)", () => {
+  const field = (id: number, name: string, type: string) => ({
+    id,
+    name,
+    type,
+  });
+
+  test("a widened column is a candidate", () => {
+    // float -> double is legal in Iceberg and unreadable in R2 SQL until the
+    // files are rewritten. This is the case that broke chain.neurons.
+    const changed = typeChangedAcrossSchemas({
+      "current-schema-id": 1,
+      schemas: [
+        { "schema-id": 0, fields: [field(22, "take", "float")] },
+        { "schema-id": 1, fields: [field(22, "take", "double")] },
+      ],
+    });
+    assert.deepEqual(changed, ["take"]);
+  });
+
+  test("ADDING a column is not a candidate", () => {
+    // R2 SQL tolerates augmentation, so observed_at appearing in a later
+    // generation must not be reported -- three registry tables gained exactly
+    // that column and none of them broke.
+    const changed = typeChangedAcrossSchemas({
+      "current-schema-id": 1,
+      schemas: [
+        { "schema-id": 0, fields: [field(1, "netuid", "int")] },
+        {
+          "schema-id": 1,
+          fields: [field(1, "netuid", "int"), field(2, "observed_at", "long")],
+        },
+      ],
+    });
+    assert.deepEqual(changed, []);
+  });
+
+  test("a DROPPED column is not a candidate", () => {
+    const changed = typeChangedAcrossSchemas({
+      "current-schema-id": 1,
+      schemas: [
+        {
+          "schema-id": 0,
+          fields: [field(1, "netuid", "int"), field(2, "gone", "string")],
+        },
+        { "schema-id": 1, fields: [field(1, "netuid", "int")] },
+      ],
+    });
+    assert.deepEqual(changed, []);
+  });
+
+  test("a single generation is never a candidate", () => {
+    assert.deepEqual(
+      typeChangedAcrossSchemas({
+        "current-schema-id": 0,
+        schemas: [{ "schema-id": 0, fields: [field(1, "a", "int")] }],
+      }),
+      [],
+    );
+  });
+
+  test("matching is by FIELD ID, not name", () => {
+    // Iceberg identifies a column by id; a rename with the same id is the same
+    // column, and two columns sharing a name across generations need not be.
+    const changed = typeChangedAcrossSchemas({
+      "current-schema-id": 1,
+      schemas: [
+        { "schema-id": 0, fields: [field(7, "old_name", "int")] },
+        { "schema-id": 1, fields: [field(7, "new_name", "long")] },
+      ],
+    });
+    assert.deepEqual(changed, ["new_name"]);
+  });
+
+  test("undefined metadata is not a crash", () => {
+    assert.deepEqual(typeChangedAcrossSchemas(undefined), []);
   });
 });


### PR DESCRIPTION
A widening breaks R2 SQL reads until the files are rewritten, and this has now been found **by hand three times**: `neuron_daily.take` broke reads for hours before anyone noticed (metagraphed-infra#542), `neurons.take` broke the moment I widened it, and `nominator_positions.share_fraction` sat broken through several of my own verification passes.

That third one is why this exists. **My smoke tests did not span:**

```
count(*)                       passes — projects no column
SELECT col LIMIT 1             passes — answered from one file
SELECT col WHERE <scattered>   FAILS  — projects it AND reads every file
```

Only the third is a real cold-tier read, and it is the one shape a casual health check does not use. I declared three tables healthy off `count(*)` while their filtered reads were broken.

## Metadata narrows, a probe decides

My first version checked metadata alone and reported **five tables I had just fixed**: Iceberg keeps every historical schema in `schemas[]` forever, so the list records that a type *once* changed, not that a file still carries the old one.

So metadata is the cheap filter and `count(<column>)` is the authority — it must project the column and read every file, which is exactly what the passing shapes above avoid. A probe that cannot run marks the table suspect rather than clearing it.

## It is not a staleness finding

Folding these into `failures` made the summary report **"6 stale" when exactly one table was stale**. A watchdog that miscounts its own findings is one people learn to discount, so unreadable columns report separately with their own fix: *stale* means look at the producer, *unreadable* means rewrite the table.

## Frozen baseline 3 → 1

`account_events_daily` has a producer now (metagraphed-infra#544) and `rpc_proxy_events` has the AE export (#547) — both write on the tick, so the baseline must stop calling them frozen or it overstates the outage. `featured_validators` is the last, and is not waiting on a lane: its curation moved to `registry/featured-validators.json` (#11080), so the lakehouse copy is a fossil pending a decision.

## Tests

Six new, covering the distinctions that matter:

- a widened column **is** a candidate
- **adding** a column is not (R2 SQL tolerates augmentation — three registry tables gained `observed_at` and none broke)
- **dropping** a column is not
- a single generation never is
- matching is by **field id**, reporting the **current** name (a rename keeps the id; the name in the error should be the one you would query)
- `undefined` metadata does not crash

## Verification

Live run: `1 stale of 42 — 1 known (baseline 1), 0 NEW, 0 recovered`, zero unreadable. **50 of 50 CI validators pass. 20,692 tests.**