### PR TITLE
feat(chain): the burn sink is identified from chain state, not inferred

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -2225,6 +2225,11 @@ type NeuronState {
   Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture.
   """
   take: Float
+
+  """
+  True when this UID is the subnet's BURN SINK (#11094): the chain routes \`SubtensorModule.MinerBurned\` of miner incentive to the UID holding \`SubtensorModule.SubnetOwnerHotkey\`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.
+  """
+  is_burn_uid: Boolean
 }
 
 """
@@ -2570,8 +2575,15 @@ type SubnetEmissionSplitHistoryPoint {
   """
   validator_alpha: Float
 
-  """Emission to non-validator UIDs, alpha-denominated."""
+  """
+  Emission to non-validator UIDs, alpha-denominated -- the BURN SINK excluded (#11094): the SubnetOwnerHotkey UID carrying the MinerBurned fraction is its own \`burned_alpha\` leg, so this is what miners actually receive.
+  """
   miner_alpha: Float
+
+  """
+  Emission landing on the subnet's burn sink -- the UID holding \`SubtensorModule.SubnetOwnerHotkey\` while \`SubtensorModule.MinerBurned\` > 0. It rode the miner leg before #11094, overstating what miners receive by 1/(1-burn); 0 on a subnet that burns nothing.
+  """
+  burned_alpha: Float
 
   """
   Emission across the whole UID set. This is NOT the day's total emission: the subnet owner's cut is paid outside the UID set, so this is the distributable remainder — see \`total_alpha\`.
@@ -2582,6 +2594,11 @@ type SubnetEmissionSplitHistoryPoint {
   Validator share of the observed per-UID emission. MEASURED and parameter-free — a ratio of two sums this response also publishes. Null when the day emitted nothing, never 0, which would read as 'validators received none of it'.
   """
   validator_share_of_uid: Float
+
+  """
+  burned_alpha / uid_alpha. With \`validator_share_of_uid\` and \`miner_share_of_uid\` this sums to 1 over the UID set; null when the day emitted nothing.
+  """
+  burned_share_of_uid: Float
 
   """Miner share of the observed per-UID emission. Measured."""
   miner_share_of_uid: Float
@@ -2663,6 +2680,11 @@ type SubnetMinerFairness {
   THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from \`concentration\`, trust these. Null when the current-metagraph store has no rows for this subnet.
   """
   live: SubnetMinerFairnessLive
+
+  """
+  The UID excluded from every figure above as the subnet's BURN SINK (#11094): the chain routes \`SubtensorModule.MinerBurned\` of miner incentive to the \`SubtensorModule.SubnetOwnerHotkey\` UID, so it is not a miner and counting it would inflate each distribution by 1/(1-burn). Null when the subnet burns nothing -- no row was excluded.
+  """
+  burn_uid: Int
 
   """
   Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.
@@ -3914,6 +3936,11 @@ type NeuronHistoryPoint {
   Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture.
   """
   take: Float
+
+  """
+  True when this UID is the subnet's BURN SINK (#11094): the chain routes \`SubtensorModule.MinerBurned\` of miner incentive to the UID holding \`SubtensorModule.SubnetOwnerHotkey\`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.
+  """
+  is_burn_uid: Boolean
 }
 
 """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -3144,6 +3144,8 @@ export type NeuronHistoryPoint = {
   /** The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
   immunity_expires_at_block?: Maybe<Scalars['Int']['output']>;
   incentive?: Maybe<Scalars['Float']['output']>;
+  /** True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+  is_burn_uid?: Maybe<Scalars['Boolean']['output']>;
   is_immunity_period?: Maybe<Scalars['Boolean']['output']>;
   /** 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
   rank?: Maybe<Scalars['Float']['output']>;
@@ -3177,6 +3179,8 @@ export type NeuronState = {
   /** The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
   immunity_expires_at_block?: Maybe<Scalars['Int']['output']>;
   incentive?: Maybe<Scalars['Float']['output']>;
+  /** True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+  is_burn_uid?: Maybe<Scalars['Boolean']['output']>;
   is_immunity_period?: Maybe<Scalars['Boolean']['output']>;
   /** 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
   rank?: Maybe<Scalars['Float']['output']>;
@@ -6424,11 +6428,15 @@ export type SubnetEmissionSplitHistoryPoint = {
   __typename?: 'SubnetEmissionSplitHistoryPoint';
   /** The day's alpha price in TAO, from the same daily snapshot. This is `SubnetMovingPrice`, the chain's emission-weighting average — not a traded mark. */
   alpha_price_tao?: Maybe<Scalars['Float']['output']>;
+  /** Emission landing on the subnet's burn sink -- the UID holding `SubtensorModule.SubnetOwnerHotkey` while `SubtensorModule.MinerBurned` > 0. It rode the miner leg before #11094, overstating what miners receive by 1/(1-burn); 0 on a subnet that burns nothing. */
+  burned_alpha?: Maybe<Scalars['Float']['output']>;
+  /** burned_alpha / uid_alpha. With `validator_share_of_uid` and `miner_share_of_uid` this sums to 1 over the UID set; null when the day emitted nothing. */
+  burned_share_of_uid?: Maybe<Scalars['Float']['output']>;
   /** Non-validator UIDs that recorded emission above zero on this day. Against `miner_count` this is how many registered miners earned anything at all — the median subnet has almost none, and a miner count read alone overstates participation. */
   earning_miner_count?: Maybe<Scalars['Int']['output']>;
   /** Validator-permit UIDs that recorded emission above zero on this day. */
   earning_validator_count?: Maybe<Scalars['Int']['output']>;
-  /** Emission to non-validator UIDs, alpha-denominated. */
+  /** Emission to non-validator UIDs, alpha-denominated -- the BURN SINK excluded (#11094): the SubnetOwnerHotkey UID carrying the MinerBurned fraction is its own `burned_alpha` leg, so this is what miners actually receive. */
   miner_alpha?: Maybe<Scalars['Float']['output']>;
   miner_count?: Maybe<Scalars['Int']['output']>;
   /** Miner share of the whole day. Reconstructed. */
@@ -6784,6 +6792,8 @@ export type SubnetList = {
 /** Whether a subnet's registered miners actually earn, measured over a 7d/30d/90d window rather than from a snapshot. Reports the daily zero-emission rate, how many days each miner UID earned on (persistent-zero and occasionally-zero are different facts a snapshot collapses), and emission concentration across controlling entities as the headline lens with the per-UID lens beside it. DESCRIPTIVE ONLY — there is no fairness score and no grade: a high Gini on a subnet whose task genuinely has one best answer is not misconduct, and that context is not in this data. A subnet with no daily rollup resolves to a schema-stable empty series (days_covered 0), never null. Mirrors GET /api/v1/subnets/{netuid}/miner-fairness. */
 export type SubnetMinerFairness = {
   __typename?: 'SubnetMinerFairness';
+  /** The UID excluded from every figure above as the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the `SubtensorModule.SubnetOwnerHotkey` UID, so it is not a miner and counting it would inflate each distribution by 1/(1-burn). Null when the subnet burns nothing -- no row was excluded. */
+  burn_uid?: Maybe<Scalars['Int']['output']>;
   concentration?: Maybe<SubnetMinerFairnessConcentration>;
   /** How many days the series actually covers. Published beside every distribution figure: a distribution over 3 days and one over 31 are not the same claim, and `neuron_daily` is only ~27-33 days deep, so a 90d window is answered with the depth found rather than refused. */
   days_covered: Scalars['Int']['output'];
@@ -11743,6 +11753,7 @@ export type NeuronHistoryPointResolvers<ContextType = GqlContext, ParentType ext
   immunity_expires_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   immunity_expires_at_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   incentive?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  is_burn_uid?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   is_immunity_period?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   rank?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   registered_at_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -11767,6 +11778,7 @@ export type NeuronStateResolvers<ContextType = GqlContext, ParentType extends Re
   immunity_expires_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   immunity_expires_at_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   incentive?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  is_burn_uid?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   is_immunity_period?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   rank?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   registered_at_block?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -13018,6 +13030,8 @@ export type SubnetEmissionSplitHistoryResolvers<ContextType = GqlContext, Parent
 
 export type SubnetEmissionSplitHistoryPointResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEmissionSplitHistoryPoint'] = ResolversParentTypes['SubnetEmissionSplitHistoryPoint']> = ResolversObject<{
   alpha_price_tao?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  burned_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  burned_share_of_uid?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   earning_miner_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   earning_validator_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   miner_alpha?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
@@ -13298,6 +13312,7 @@ export type SubnetListResolvers<ContextType = GqlContext, ParentType extends Res
 }>;
 
 export type SubnetMinerFairnessResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetMinerFairness'] = ResolversParentTypes['SubnetMinerFairness']> = ResolversObject<{
+  burn_uid?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   concentration?: Resolver<Maybe<ResolversTypes['SubnetMinerFairnessConcentration']>, ParentType, ContextType>;
   days_covered?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   entity_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -9162,6 +9162,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -9202,6 +9204,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -11232,11 +11236,15 @@ export interface components {
             points: {
                 /** @description The day's alpha price in TAO, from the same daily snapshot. This is `SubnetMovingPrice`, the chain's emission-weighting average — not a traded mark. */
                 alpha_price_tao?: number | null;
+                /** @description Emission landing on the subnet's burn sink -- the UID holding `SubtensorModule.SubnetOwnerHotkey` while `SubtensorModule.MinerBurned` > 0. It rode the miner leg before #11094, overstating what miners receive by 1/(1-burn); 0 on a subnet that burns nothing. */
+                burned_alpha?: number | null;
+                /** @description burned_alpha / uid_alpha. With `validator_share_of_uid` and `miner_share_of_uid` this sums to 1 over the UID set; null when the day emitted nothing. */
+                burned_share_of_uid?: number | null;
                 /** @description Non-validator UIDs that recorded emission above zero on this day. Against `miner_count` this is how many registered miners earned anything at all — the median subnet has almost none, and a miner count read alone overstates participation. */
                 earning_miner_count?: number;
                 /** @description Validator-permit UIDs that recorded emission above zero on this day. */
                 earning_validator_count?: number;
-                /** @description Emission to non-validator UIDs, alpha-denominated. */
+                /** @description Emission to non-validator UIDs, alpha-denominated -- the BURN SINK excluded (#11094): the SubnetOwnerHotkey UID carrying the MinerBurned fraction is its own `burned_alpha` leg, so this is what miners actually receive. */
                 miner_alpha?: number | null;
                 miner_count?: number;
                 /** @description Miner share of the whole day. Reconstructed. */
@@ -11732,6 +11740,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -11749,6 +11759,8 @@ export interface components {
         };
         /** @description Whether a subnet's registered miners actually earn, measured over a 7d/30d/90d window rather than from a snapshot. Reports the daily zero-emission rate, how many days each miner UID earned on (persistent-zero and occasionally-zero are different facts a snapshot collapses), and emission concentration across controlling entities as the headline lens with the per-UID lens beside it. DESCRIPTIVE ONLY — there is no fairness score and no grade: a high Gini on a subnet whose task genuinely has one best answer is not misconduct, and that context is not in this data. A subnet with no daily rollup resolves to a schema-stable empty series (days_covered 0), never null. Mirrors GET /api/v1/subnets/{netuid}/miner-fairness. */
         SubnetMinerFairnessArtifact: {
+            /** @description The UID excluded from every figure above as the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the `SubtensorModule.SubnetOwnerHotkey` UID, so it is not a miner and counting it would inflate each distribution by 1/(1-burn). Null when the subnet burns nothing -- no row was excluded. */
+            burn_uid?: number | null;
             concentration?: {
                 /** @description THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO. */
                 entity?: components["schemas"]["ConcentrationMetrics"];
@@ -12769,6 +12781,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -44678,6 +44692,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "burn_uid": 1,
                      *         "concentration": {
                      *           "entity": {
                      *             "holders": 1,
@@ -44846,6 +44861,7 @@ export interface operations {
                      *           "immunity_expires_at": "2026-06-01T00:00:00.000Z",
                      *           "immunity_expires_at_block": 5000000,
                      *           "incentive": 0.5,
+                     *           "is_burn_uid": false,
                      *           "is_immunity_period": false,
                      *           "rank": 0.5,
                      *           "registered_at_block": 5000000,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6816,6 +6816,7 @@
               "immunity_expires_at": "2026-06-01T00:00:00.000Z",
               "immunity_expires_at_block": 5000000,
               "incentive": 0.5,
+              "is_burn_uid": false,
               "is_immunity_period": false,
               "rank": 0.5,
               "registered_at_block": 5000000,
@@ -10486,6 +10487,7 @@
       "SubnetMinerFairnessArtifactResponse": {
         "value": {
           "data": {
+            "burn_uid": 1,
             "concentration": {
               "entity": {
                 "holders": 1,
@@ -37333,6 +37335,10 @@
                       }
                     ]
                   },
+                  "is_burn_uid": {
+                    "description": "True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.",
+                    "type": "boolean"
+                  },
                   "is_immunity_period": {
                     "type": "boolean"
                   },
@@ -37598,6 +37604,10 @@
                       "type": "null"
                     }
                   ]
+                },
+                "is_burn_uid": {
+                  "description": "True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.",
+                  "type": "boolean"
                 },
                 "is_immunity_period": {
                   "type": "boolean"
@@ -48435,6 +48445,28 @@
                   ],
                   "description": "The day's alpha price in TAO, from the same daily snapshot. This is `SubnetMovingPrice`, the chain's emission-weighting average — not a traded mark."
                 },
+                "burned_alpha": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Emission landing on the subnet's burn sink -- the UID holding `SubtensorModule.SubnetOwnerHotkey` while `SubtensorModule.MinerBurned` > 0. It rode the miner leg before #11094, overstating what miners receive by 1/(1-burn); 0 on a subnet that burns nothing."
+                },
+                "burned_share_of_uid": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "burned_alpha / uid_alpha. With `validator_share_of_uid` and `miner_share_of_uid` this sums to 1 over the UID set; null when the day emitted nothing."
+                },
                 "earning_miner_count": {
                   "description": "Non-validator UIDs that recorded emission above zero on this day. Against `miner_count` this is how many registered miners earned anything at all — the median subnet has almost none, and a miner count read alone overstates participation.",
                   "maximum": 9007199254740991,
@@ -48456,7 +48488,7 @@
                       "type": "null"
                     }
                   ],
-                  "description": "Emission to non-validator UIDs, alpha-denominated."
+                  "description": "Emission to non-validator UIDs, alpha-denominated -- the BURN SINK excluded (#11094): the SubnetOwnerHotkey UID carrying the MinerBurned fraction is its own `burned_alpha` leg, so this is what miners actually receive."
                 },
                 "miner_count": {
                   "maximum": 9007199254740991,
@@ -51726,6 +51758,10 @@
                     }
                   ]
                 },
+                "is_burn_uid": {
+                  "description": "True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.",
+                  "type": "boolean"
+                },
                 "is_immunity_period": {
                   "type": "boolean"
                 },
@@ -51832,6 +51868,19 @@
         "additionalProperties": false,
         "description": "Whether a subnet's registered miners actually earn, measured over a 7d/30d/90d window rather than from a snapshot. Reports the daily zero-emission rate, how many days each miner UID earned on (persistent-zero and occasionally-zero are different facts a snapshot collapses), and emission concentration across controlling entities as the headline lens with the per-UID lens beside it. DESCRIPTIVE ONLY — there is no fairness score and no grade: a high Gini on a subnet whose task genuinely has one best answer is not misconduct, and that context is not in this data. A subnet with no daily rollup resolves to a schema-stable empty series (days_covered 0), never null. Mirrors GET /api/v1/subnets/{netuid}/miner-fairness.",
         "properties": {
+          "burn_uid": {
+            "anyOf": [
+              {
+                "maximum": 9007199254740991,
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The UID excluded from every figure above as the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the `SubtensorModule.SubnetOwnerHotkey` UID, so it is not a miner and counting it would inflate each distribution by 1/(1-burn). Null when the subnet burns nothing -- no row was excluded."
+          },
           "concentration": {
             "additionalProperties": false,
             "properties": {
@@ -57536,6 +57585,10 @@
                       "type": "null"
                     }
                   ]
+                },
+                "is_burn_uid": {
+                  "description": "True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.",
+                  "type": "boolean"
                 },
                 "is_immunity_period": {
                   "type": "boolean"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -9162,6 +9162,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -9202,6 +9204,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -11232,11 +11236,15 @@ export interface components {
             points: {
                 /** @description The day's alpha price in TAO, from the same daily snapshot. This is `SubnetMovingPrice`, the chain's emission-weighting average — not a traded mark. */
                 alpha_price_tao?: number | null;
+                /** @description Emission landing on the subnet's burn sink -- the UID holding `SubtensorModule.SubnetOwnerHotkey` while `SubtensorModule.MinerBurned` > 0. It rode the miner leg before #11094, overstating what miners receive by 1/(1-burn); 0 on a subnet that burns nothing. */
+                burned_alpha?: number | null;
+                /** @description burned_alpha / uid_alpha. With `validator_share_of_uid` and `miner_share_of_uid` this sums to 1 over the UID set; null when the day emitted nothing. */
+                burned_share_of_uid?: number | null;
                 /** @description Non-validator UIDs that recorded emission above zero on this day. Against `miner_count` this is how many registered miners earned anything at all — the median subnet has almost none, and a miner count read alone overstates participation. */
                 earning_miner_count?: number;
                 /** @description Validator-permit UIDs that recorded emission above zero on this day. */
                 earning_validator_count?: number;
-                /** @description Emission to non-validator UIDs, alpha-denominated. */
+                /** @description Emission to non-validator UIDs, alpha-denominated -- the BURN SINK excluded (#11094): the SubnetOwnerHotkey UID carrying the MinerBurned fraction is its own `burned_alpha` leg, so this is what miners actually receive. */
                 miner_alpha?: number | null;
                 miner_count?: number;
                 /** @description Miner share of the whole day. Reconstructed. */
@@ -11732,6 +11740,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -11749,6 +11759,8 @@ export interface components {
         };
         /** @description Whether a subnet's registered miners actually earn, measured over a 7d/30d/90d window rather than from a snapshot. Reports the daily zero-emission rate, how many days each miner UID earned on (persistent-zero and occasionally-zero are different facts a snapshot collapses), and emission concentration across controlling entities as the headline lens with the per-UID lens beside it. DESCRIPTIVE ONLY — there is no fairness score and no grade: a high Gini on a subnet whose task genuinely has one best answer is not misconduct, and that context is not in this data. A subnet with no daily rollup resolves to a schema-stable empty series (days_covered 0), never null. Mirrors GET /api/v1/subnets/{netuid}/miner-fairness. */
         SubnetMinerFairnessArtifact: {
+            /** @description The UID excluded from every figure above as the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the `SubtensorModule.SubnetOwnerHotkey` UID, so it is not a miner and counting it would inflate each distribution by 1/(1-burn). Null when the subnet burns nothing -- no row was excluded. */
+            burn_uid?: number | null;
             concentration?: {
                 /** @description THE HEADLINE LENS: emission concentration across controlling entities (coldkeys), with each entity's UIDs summed. A subnet with three operators behind 256 UIDs is not diverse, and the per-UID lens alone hides exactly that. The distribution is each entity's miner emission summed across the window's `days_covered` days, where each day contributes that day's captured PER-TEMPO alpha rate (the `emission_tao` convention) -- so `total` is a within-subnet ranking mass, not a window payout total, and never TAO. */
                 entity?: components["schemas"]["ConcentrationMetrics"];
@@ -12769,6 +12781,8 @@ export interface components {
                 /** @description The block immunity ends (registered_at_block + the subnet's live immunity_period); only present while is_immunity_period is true (#6640). */
                 immunity_expires_at_block?: number;
                 incentive?: number | null;
+                /** @description True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures. */
+                is_burn_uid?: boolean;
                 is_immunity_period?: boolean;
                 /** @description 1-based position by incentive, descending. dTAO has no chain rank storage, so this is DERIVED by the producer and assigned only to neurons with non-zero incentive -- null for the whole incentive == 0 population, which is most validators. Verified on netuid 64: non-null on exactly the 16 UIDs with incentive > 0. Null means unranked, not rank-last (#9541). */
                 rank?: number | null;
@@ -44678,6 +44692,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "burn_uid": 1,
                      *         "concentration": {
                      *           "entity": {
                      *             "holders": 1,
@@ -44846,6 +44861,7 @@ export interface operations {
                      *           "immunity_expires_at": "2026-06-01T00:00:00.000Z",
                      *           "immunity_expires_at_block": 5000000,
                      *           "incentive": 0.5,
+                     *           "is_burn_uid": false,
                      *           "is_immunity_period": false,
                      *           "rank": 0.5,
                      *           "registered_at_block": 5000000,

--- a/schemas-src/routes/emission-split.ts
+++ b/schemas-src/routes/emission-split.ts
@@ -40,7 +40,12 @@ const SubnetEmissionSplitPointSchema = z
         "Emission to validator-permit UIDs. ALPHA-denominated for every non-root subnet — safe to compare within one subnet, never across subnets without the price join.",
     }),
     miner_alpha: z.number().nullable().optional().meta({
-      description: "Emission to non-validator UIDs, alpha-denominated.",
+      description:
+        "Emission to non-validator UIDs, alpha-denominated -- the BURN SINK excluded (#11094): the SubnetOwnerHotkey UID carrying the MinerBurned fraction is its own `burned_alpha` leg, so this is what miners actually receive.",
+    }),
+    burned_alpha: z.number().nullable().optional().meta({
+      description:
+        "Emission landing on the subnet's burn sink -- the UID holding `SubtensorModule.SubnetOwnerHotkey` while `SubtensorModule.MinerBurned` > 0. It rode the miner leg before #11094, overstating what miners receive by 1/(1-burn); 0 on a subnet that burns nothing.",
     }),
     uid_alpha: z.number().nullable().optional().meta({
       description:
@@ -49,6 +54,10 @@ const SubnetEmissionSplitPointSchema = z
     validator_share_of_uid: z.number().nullable().optional().meta({
       description:
         "Validator share of the observed per-UID emission. MEASURED and parameter-free — a ratio of two sums this response also publishes. Null when the day emitted nothing, never 0, which would read as 'validators received none of it'.",
+    }),
+    burned_share_of_uid: z.number().nullable().optional().meta({
+      description:
+        "burned_alpha / uid_alpha. With `validator_share_of_uid` and `miner_share_of_uid` this sums to 1 over the UID set; null when the day emitted nothing.",
     }),
     miner_share_of_uid: z.number().nullable().optional().meta({
       description: "Miner share of the observed per-UID emission. Measured.",

--- a/schemas-src/routes/miner-fairness.ts
+++ b/schemas-src/routes/miner-fairness.ts
@@ -119,6 +119,10 @@ export const SubnetMinerFairnessArtifactSchema = subnetHistoryArtifactSchema(
         description:
           "THE CAPTURE TRIPWIRE: the same two lenses over the CURRENT metagraph, beside the windowed ones -- because a window aggregate smooths away a mid-window capture event. SN75 reported a 30d uid gini of 0.77 while one UID held incentive 0.9908 live; when these lenses diverge violently from `concentration`, trust these. Null when the current-metagraph store has no rows for this subnet.",
       }),
+    burn_uid: z.int().min(0).nullable().optional().meta({
+      description:
+        "The UID excluded from every figure above as the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the `SubtensorModule.SubnetOwnerHotkey` UID, so it is not a miner and counting it would inflate each distribution by 1/(1-burn). Null when the subnet burns nothing -- no row was excluded.",
+    }),
     field_sources: FieldSourcesSchema.optional(),
   })
   .describe(

--- a/schemas-src/routes/subnet-metagraph.ts
+++ b/schemas-src/routes/subnet-metagraph.ts
@@ -105,6 +105,12 @@ export const NeuronSchema = z
       .describe(
         "Validator take/commission (0..1) from SubtensorModule::Delegates; null when no Delegates entry at capture.",
       ),
+    is_burn_uid: z
+      .boolean()
+      .optional()
+      .describe(
+        "True when this UID is the subnet's BURN SINK (#11094): the chain routes `SubtensorModule.MinerBurned` of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey`, so its incentive is the burned fraction, not a miner's earnings. Exclude it before deriving any per-miner statistic -- including it inflates every figure by 1/(1-burn). False when the subnet burns nothing; absent when the serving tier did not resolve the two chain captures.",
+      ),
   })
   .strict()
   .describe(

--- a/src/emission-split.ts
+++ b/src/emission-split.ts
@@ -142,6 +142,11 @@ export const SUBNET_EMISSION_SPLIT_FIELD_SOURCES = {
     kind: "measured",
     storage: "neuron_daily.emission_tao",
   },
+  "points.burned_alpha": {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetOwnerHotkey",
+  },
+  "points.burned_share_of_uid": { kind: "reconstructed", storage: null },
   "points.miner_alpha": {
     kind: "measured",
     storage: "neuron_daily.emission_tao",
@@ -176,9 +181,11 @@ function emissionSplitPoint(
   date: string,
   dayRows: Row[],
   ownerCut: number,
+  burnHotkey?: string | null,
 ): Row {
   let validatorRao = 0n;
   let minerRao = 0n;
+  let burnedRao = 0n;
   let validatorCount = 0;
   let minerCount = 0;
   let earningValidatorCount = 0;
@@ -198,6 +205,14 @@ function emissionSplitPoint(
     // reads off this. Skipping it would shrink the denominator and overstate
     // how many UIDs earn.
     const rao = emission === null ? 0n : toRaoBig(emission);
+    // #11094: the burn sink is not a miner. The SubnetOwnerHotkey UID carries
+    // the MinerBurned fraction as incentive, so folding it into the miner leg
+    // overstated what miners receive by 1/(1-burn). Its own leg, beside the
+    // two real ones -- and it does not count toward either population.
+    if (burnHotkey != null && row?.hotkey === burnHotkey) {
+      burnedRao += rao;
+      continue;
+    }
     if (isValidator(row?.validator_permit)) {
       validatorCount += 1;
       validatorRao += rao;
@@ -211,7 +226,8 @@ function emissionSplitPoint(
 
   const validatorAlpha = raoBigToTao(validatorRao);
   const minerAlpha = raoBigToTao(minerRao);
-  const uidAlpha = raoBigToTao(validatorRao + minerRao);
+  const burnedAlpha = raoBigToTao(burnedRao);
+  const uidAlpha = raoBigToTao(validatorRao + minerRao + burnedRao);
 
   // Exact and parameter-free: the split of what was observed. Null rather than
   // 0/0 when the day emitted nothing -- a subnet the gate is emitting nothing
@@ -219,6 +235,7 @@ function emissionSplitPoint(
   const validatorShareOfUid =
     uidAlpha > 0 ? round9(validatorAlpha / uidAlpha) : null;
   const minerShareOfUid = uidAlpha > 0 ? round9(minerAlpha / uidAlpha) : null;
+  const burnedShareOfUid = uidAlpha > 0 ? round9(burnedAlpha / uidAlpha) : null;
 
   // The reconstructed half. `alpha_out_emission` is alpha per block; a day is
   // BLOCKS_PER_DAY of them, and the owner takes `ownerCut` of that. Computed as
@@ -242,9 +259,11 @@ function emissionSplitPoint(
     earning_miner_count: earningMinerCount,
     validator_alpha: round9(validatorAlpha),
     miner_alpha: round9(minerAlpha),
+    burned_alpha: round9(burnedAlpha),
     uid_alpha: round9(uidAlpha),
     validator_share_of_uid: validatorShareOfUid,
     miner_share_of_uid: minerShareOfUid,
+    burned_share_of_uid: burnedShareOfUid,
     owner_cut: round9(ownerCut),
     total_alpha: totals === null ? null : round9(totals.total),
     owner_alpha: totals === null ? null : round9(totals.owner),
@@ -284,7 +303,13 @@ export function buildSubnetEmissionSplitHistory(
     window,
     capped,
     ownerCut = OWNER_CUT,
-  }: { window?: string; capped?: boolean; ownerCut?: number } = {},
+    burnHotkey,
+  }: {
+    window?: string;
+    capped?: boolean;
+    ownerCut?: number;
+    burnHotkey?: string | null;
+  } = {},
 ): Row {
   const list = Array.isArray(rows) ? rows : [];
   // Rows arrive newest-first with same-date rows contiguous, so Map insertion
@@ -305,7 +330,7 @@ export function buildSubnetEmissionSplitHistory(
       ? ownerCut
       : OWNER_CUT;
   const points = days.map(([date, dayRows]) =>
-    emissionSplitPoint(date, dayRows, effectiveCut),
+    emissionSplitPoint(date, dayRows, effectiveCut, burnHotkey),
   );
   return {
     schema_version: 1,

--- a/src/metagraph-neurons.ts
+++ b/src/metagraph-neurons.ts
@@ -439,6 +439,7 @@ export function formatNeuron(
   row: Row | null | undefined,
   featuredHotkeys?: ReadonlySet<string>,
   immunityPeriod?: number | null,
+  burnHotkey?: string | null,
 ): Row | null {
   if (!row || typeof row !== "object") return null;
   const hotkey = row.hotkey ?? null;
@@ -476,6 +477,18 @@ export function formatNeuron(
   if (featuredHotkeys) {
     neuron.featured = Boolean(hotkey && featuredHotkeys.has(hotkey as string));
   }
+  // #11094: the burn sink, identified from chain state rather than inferred.
+  // A subnet with SubtensorModule.MinerBurned > 0 routes that fraction of
+  // miner incentive to the UID holding SubtensorModule.SubnetOwnerHotkey --
+  // verified against SN13 (uid 162 incentive 0.715557 vs MinerBurned
+  // 0.7155707) and the zero cases (SN53/SN75 owner UIDs at incentive 0).
+  // Emitted only when the caller resolved a burn hotkey (undefined otherwise,
+  // like `featured`), so builders without the join stay shape-stable.
+  if (burnHotkey !== undefined) {
+    neuron.is_burn_uid = Boolean(
+      burnHotkey !== null && hotkey && hotkey === burnHotkey,
+    );
+  }
   if (Number.isSafeInteger(immunityPeriod) && (immunityPeriod as number) >= 0) {
     Object.assign(
       neuron,
@@ -504,7 +517,10 @@ function snapshotStamp(rows: Row[]): {
 export function buildSubnetMetagraph(
   rows: Row[],
   netuid: unknown,
-  { immunityPeriod }: { immunityPeriod?: number | null } = {},
+  {
+    immunityPeriod,
+    burnHotkey,
+  }: { immunityPeriod?: number | null; burnHotkey?: string | null } = {},
 ): Row {
   const { captured_at, block_number } = snapshotStamp(rows);
   // Drop any malformed row (formatNeuron → null) so the array only holds real
@@ -513,7 +529,7 @@ export function buildSubnetMetagraph(
   // Wrapped (not a bare `rows.map(formatNeuron)`) so Array#map's index arg
   // never lands in formatNeuron's featuredHotkeys parameter.
   const neurons = rows
-    .map((row) => formatNeuron(row, undefined, immunityPeriod))
+    .map((row) => formatNeuron(row, undefined, immunityPeriod, burnHotkey))
     .filter((n): n is Row => Boolean(n));
   return {
     schema_version: 1,

--- a/src/miner-fairness.ts
+++ b/src/miner-fairness.ts
@@ -75,6 +75,10 @@ export const SUBNET_MINER_FAIRNESS_FIELD_SOURCES = {
   "concentration.uid": { kind: "measured", storage: "neuron_daily" },
   "live.entity": { kind: "measured", storage: "neurons" },
   "live.uid": { kind: "measured", storage: "neurons" },
+  burn_uid: {
+    kind: "measured",
+    storage: "SubtensorModule.SubnetOwnerHotkey",
+  },
   uids_per_entity: { kind: "measured", storage: "neuron_daily" },
 } as const;
 
@@ -220,9 +224,28 @@ export function buildSubnetMinerFairness(
     window,
     capped,
     liveRows,
-  }: { window?: string; capped?: boolean; liveRows?: Row[] | null } = {},
+    burnHotkey,
+  }: {
+    window?: string;
+    capped?: boolean;
+    liveRows?: Row[] | null;
+    burnHotkey?: string | null;
+  } = {},
 ): Row {
-  const list = Array.isArray(rows) ? rows : [];
+  const raw = Array.isArray(rows) ? rows : [];
+  // #11094: the burn sink is NOT a miner. A subnet with MinerBurned > 0
+  // routes that fraction of miner incentive to the SubnetOwnerHotkey UID, so
+  // counting it inflates every distribution figure by 1/(1-burn) -- SN13's
+  // uid lens read one "miner" holding 71.6% that was the chain's own burn.
+  // Excluded from the population and NAMED on the card, so a caller can see
+  // both the honest miner distribution and where the burn went.
+  const burnRows =
+    burnHotkey == null ? [] : raw.filter((row) => row?.hotkey === burnHotkey);
+  const list =
+    burnHotkey == null ? raw : raw.filter((row) => row?.hotkey !== burnHotkey);
+  const burnUidValue = burnRows.length
+    ? nonNegativeCellOrNull(burnRows[0]?.uid)
+    : null;
 
   const byDate = new Map<string, Row[]>();
   for (const row of list) {
@@ -317,7 +340,15 @@ export function buildSubnetMinerFairness(
       entity: entityLens as ConcentrationScorecard | null,
       uid: uidLens as ConcentrationScorecard | null,
     },
-    live: liveConcentration(liveRows),
+    live: liveConcentration(
+      burnHotkey == null
+        ? liveRows
+        : (liveRows ?? []).filter((row) => row?.hotkey !== burnHotkey),
+    ),
+    // Null carries two states apart on purpose: the subnet has no burn
+    // (burnHotkey null) OR the caller supplied no ownership join. Either way
+    // no row was excluded; a non-null uid says exactly which one was.
+    burn_uid: burnUidValue,
     field_sources: SUBNET_MINER_FAIRNESS_FIELD_SOURCES,
   };
 }

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -2692,3 +2692,100 @@ test("the consumer refuses a neurons message that does not claim key-completenes
   assert.deepEqual(acked, ["ack"], "unparseable is acked, not retried");
   assert.equal(await count("neurons"), 2, "nothing written, nothing pruned");
 });
+
+// #11094: the burn derivation end-to-end through the real DDL -- ownership +
+// snapshot rows resolve the burn hotkey, the metagraph flags the sink, and
+// the fairness card excludes it.
+test("the burn sink is flagged on the metagraph and excluded from fairness", async () => {
+  await seed(
+    `INSERT INTO subnet_ownership (netuid, owner_coldkey, owner_hotkey, captured_at)
+     VALUES (?, ?, ?, ?)`,
+    [7, "5OwnerCold", "5OwnerHot", CAPTURED_AT],
+  );
+  await seed(
+    `INSERT INTO subnet_snapshots (netuid, snapshot_date, miner_burned_fraction)
+     VALUES (?, ?, ?)`,
+    [7, dayAgo(0), 0.7156],
+  );
+  await insertNeuron({
+    uid: 162,
+    hotkey: "5OwnerHot",
+    coldkey: "5OwnerCold",
+    validator_permit: 0,
+    incentive: 0.7156,
+  });
+  await insertNeuron({
+    uid: 1,
+    hotkey: "5Hot7-m1",
+    coldkey: "5Cold7-m1",
+    validator_permit: 0,
+    incentive: 0.14,
+  });
+  await insertDaily({
+    uid: 162,
+    hotkey: "5OwnerHot",
+    coldkey: "5OwnerCold",
+    validator_permit: 0,
+    emission_tao: 7,
+    snapshot_date: dayAgo(1),
+  });
+  await insertDaily({
+    uid: 1,
+    hotkey: "5Hot7-m1",
+    coldkey: "5Cold7-m1",
+    validator_permit: 0,
+    emission_tao: 1,
+    snapshot_date: dayAgo(1),
+  });
+
+  const mg = await call(req("/api/v1/subnets/7/metagraph"));
+  assert.equal(mg.status, 200);
+  const neurons = ((await mg.json()) as Row).neurons as Row[];
+  const sink = neurons.find((n) => n.uid === 162);
+  assert.equal(sink?.is_burn_uid, true);
+
+  const fair = await call(req("/api/v1/subnets/7/miner-fairness"));
+  assert.equal(fair.status, 200);
+  const body = (await fair.json()) as Row;
+  assert.equal(body.burn_uid, 162);
+  assert.equal(body.miner_uid_count, 1, "only the real miner counts");
+});
+
+test("no snapshot row, or a zero fraction, resolves no burn -- nothing excluded", async () => {
+  // The two degrade arms: ownership without a snapshot (the ?? 0 arm), and a
+  // snapshot whose fraction is zero (the > 0 refusal). Both must resolve null
+  // -- a capture gap or a burn-free subnet never invents an exclusion.
+  await seed(
+    `INSERT INTO subnet_ownership (netuid, owner_coldkey, owner_hotkey, captured_at)
+     VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
+    [8, "5OC8", "5OH8", CAPTURED_AT, 9, "5OC9", "5OH9", CAPTURED_AT],
+  );
+  await seed(
+    `INSERT INTO subnet_snapshots (netuid, snapshot_date, miner_burned_fraction)
+     VALUES (?, ?, ?)`,
+    [9, dayAgo(0), 0],
+  );
+  await insertNeuron({
+    netuid: 8,
+    uid: 0,
+    hotkey: "5OH8",
+    coldkey: "5OC8",
+    validator_permit: 0,
+    incentive: 0.5,
+  });
+  await insertNeuron({
+    netuid: 9,
+    uid: 0,
+    hotkey: "5OH9",
+    coldkey: "5OC9",
+    validator_permit: 0,
+    incentive: 0.5,
+  });
+
+  for (const netuid of [8, 9]) {
+    const res = await call(req(`/api/v1/subnets/${netuid}/metagraph`));
+    assert.equal(res.status, 200);
+    const rows = ((await res.json()) as Row).neurons as Row[];
+    assert.equal(rows[0]?.is_burn_uid, false, `netuid ${netuid}`);
+  }
+});

--- a/tests/emission-split.test.ts
+++ b/tests/emission-split.test.ts
@@ -459,3 +459,43 @@ describe("the contract", () => {
     );
   });
 });
+
+describe("the burn leg (#11094)", () => {
+  test("the burn sink's emission is its own leg, not the miners'", () => {
+    const rows: Row[] = sn74Day("2026-08-12").map((r) => ({
+      ...r,
+      hotkey: "5M",
+    }));
+    rows.push({
+      snapshot_date: "2026-08-12",
+      alpha_out_emission: 1,
+      alpha_price_tao: 0.0135,
+      hotkey: "5OwnerHot",
+      validator_permit: false,
+      emission_tao: 200,
+    });
+    const out = buildSubnetEmissionSplitHistory(rows, 13, {
+      burnHotkey: "5OwnerHot",
+    });
+    const p = (out.points as Row[])[0];
+    assert.equal(p.burned_alpha, 200);
+    assert.ok(Math.abs((p.miner_alpha as number) - 34.5096) < 1e-6);
+    // The sink is in neither population.
+    assert.equal(p.miner_count, 6);
+    // The three shares of the UID set sum to 1.
+    const sum =
+      (p.validator_share_of_uid as number) +
+      (p.miner_share_of_uid as number) +
+      (p.burned_share_of_uid as number);
+    assert.ok(Math.abs(sum - 1) < 1e-6, String(sum));
+  });
+
+  test("no burn hotkey: burned_alpha is zero and nothing moves", () => {
+    const p = (
+      buildSubnetEmissionSplitHistory(sn74Day("2026-08-12"), 74, {})
+        .points as Row[]
+    )[0];
+    assert.equal(p.burned_alpha, 0);
+    assert.equal(p.burned_share_of_uid, 0);
+  });
+});

--- a/tests/featured-validators.test.ts
+++ b/tests/featured-validators.test.ts
@@ -13,7 +13,10 @@ import {
   FEATURED_HOTKEYS,
   FEATURED_HOTKEY_SET,
 } from "../generated/featured-validators.ts";
-import { buildSubnetValidators } from "../src/metagraph-neurons.ts";
+import {
+  buildSubnetMetagraph,
+  buildSubnetValidators,
+} from "../src/metagraph-neurons.ts";
 import { repoRoot } from "../scripts/lib.ts";
 import type { Row } from "./row-type.ts";
 
@@ -162,5 +165,34 @@ describe("the badge actually flips (#11080)", () => {
     const first = (out.validators as Row[])[0];
     assert.ok(first && "featured" in first);
     assert.equal(first.featured, false);
+  });
+});
+
+describe("the burn flag on metagraph rows (#11094)", () => {
+  const mgRow = (over: Row = {}): Row => ({
+    uid: 0,
+    hotkey: "5HotA",
+    coldkey: "5ColdA",
+    validator_permit: false,
+    incentive: 0.1,
+    ...over,
+  });
+
+  test("the owner-hotkey UID is flagged when a burn hotkey resolves", () => {
+    const out = buildSubnetMetagraph(
+      [mgRow({ uid: 162, hotkey: "5OwnerHot" }), mgRow({ uid: 1 })],
+      13,
+      { burnHotkey: "5OwnerHot" },
+    );
+    const byUid = new Map(
+      (out.neurons as Row[]).map((n) => [n.uid, n.is_burn_uid]),
+    );
+    assert.equal(byUid.get(162), true);
+    assert.equal(byUid.get(1), false);
+  });
+
+  test("without the resolution the key is absent, keeping older shapes intact", () => {
+    const out = buildSubnetMetagraph([mgRow()], 13, {});
+    assert.ok(!("is_burn_uid" in (out.neurons as Row[])[0]));
   });
 });

--- a/tests/miner-fairness.test.ts
+++ b/tests/miner-fairness.test.ts
@@ -469,6 +469,78 @@ describe("the live lens — the capture tripwire (#11091)", () => {
   });
 });
 
+describe("the burn sink (#11094)", () => {
+  // The SN13 shape: MinerBurned 0.7156 lands on the owner-hotkey UID as
+  // incentive, and before the exclusion it read as one "miner" holding 71.6%.
+  const rows = [
+    row({
+      uid: 162,
+      coldkey: "5OwnerCold",
+      hotkey: "5OwnerHot",
+      emission_tao: 7,
+    }),
+    row({ uid: 0, coldkey: "5A", hotkey: "5HotA", emission_tao: 1 }),
+    row({ uid: 1, coldkey: "5B", hotkey: "5HotB", emission_tao: 1 }),
+  ];
+
+  test("the burn UID is excluded from every population and NAMED on the card", () => {
+    const out = buildSubnetMinerFairness(rows, 13, { burnHotkey: "5OwnerHot" });
+    assert.equal(out.burn_uid, 162);
+    assert.equal(out.miner_uid_count, 2, "the sink is not a miner");
+    const p = (out.points as Row[])[0];
+    assert.equal(p.miner_count, 2);
+    const uidLens = (out.concentration as Row).uid as Row;
+    // Two equal miners once the sink is out: the lens must not see the 71.6%.
+    assert.equal(uidLens.holders, 2);
+    assert.ok((uidLens.gini as number) < 0.001, String(uidLens.gini));
+  });
+
+  test("no burn hotkey means no exclusion and a null burn_uid", () => {
+    const out = buildSubnetMinerFairness(rows, 13, {});
+    assert.equal(out.burn_uid, null);
+    assert.equal(out.miner_uid_count, 3);
+  });
+
+  test("the live lens excludes the sink too", () => {
+    const live = [
+      {
+        uid: 162,
+        coldkey: "5OwnerCold",
+        hotkey: "5OwnerHot",
+        validator_permit: false,
+        incentive: 0.7156,
+        captured_at: 1,
+        block_number: 1,
+      },
+      {
+        uid: 0,
+        coldkey: "5A",
+        hotkey: "5HotA",
+        validator_permit: false,
+        incentive: 0.14,
+        captured_at: 1,
+        block_number: 1,
+      },
+      {
+        uid: 1,
+        coldkey: "5B",
+        hotkey: "5HotB",
+        validator_permit: false,
+        incentive: 0.14,
+        captured_at: 1,
+        block_number: 1,
+      },
+    ];
+    const out = buildSubnetMinerFairness(rows, 13, {
+      burnHotkey: "5OwnerHot",
+      liveRows: live,
+    });
+    const liveUid = (out.live as Row).uid as Row;
+    assert.equal(liveUid.holders, 2, "the sink's 0.7156 must not enter");
+    assert.equal(liveUid.nakamoto_coefficient, 2);
+  });
+});
+
 describe("the window", () => {
   test("shares the emission-split vocabulary", () => {
     for (const label of ["7d", "30d", "90d"]) {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -6857,6 +6857,38 @@ export async function neuronDailyWindowBounds(
   };
 }
 
+/**
+ * The subnet's burn hotkey, or null when it burns nothing (#11094).
+ *
+ * A subnet with SubtensorModule.MinerBurned > 0 routes that fraction of miner
+ * incentive to the SubtensorModule.SubnetOwnerHotkey UID -- verified against
+ * SN13 (owner uid 162, incentive 0.715557 vs MinerBurned 0.7155707) and the
+ * zero cases (SN53/SN75, owner UIDs at incentive 0). Both halves are chain
+ * captures already in this database: the newest ownership row and the newest
+ * snapshot's burned fraction. Null -- no exclusion anywhere -- when either
+ * half is missing or the fraction is zero, so a subnet with no burn is
+ * untouched and a gap in the capture never invents one.
+ */
+async function resolveBurnHotkey(
+  sql: PgSql,
+  netuid: number,
+): Promise<string | null> {
+  const owner = await sql<{ owner_hotkey: string | null }>`
+    SELECT owner_hotkey FROM subnet_ownership
+    WHERE netuid = ${netuid}
+    ORDER BY captured_at DESC
+    LIMIT 1`;
+  const hotkey = owner[0]?.owner_hotkey;
+  if (!hotkey) return null;
+  const snapshot = await sql<{ miner_burned_fraction: number | null }>`
+    SELECT miner_burned_fraction FROM subnet_snapshots
+    WHERE netuid = ${netuid}
+    ORDER BY snapshot_date DESC
+    LIMIT 1`;
+  const fraction = Number(snapshot[0]?.miner_burned_fraction ?? 0);
+  return Number.isFinite(fraction) && fraction > 0 ? hotkey : null;
+}
+
 function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
   // GET /api/v1/subnets/:netuid/metagraph -- twin of the Postgres route of
   // the same name below. immunity_period comes from subnet_hyperparams,
@@ -6879,7 +6911,12 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
             `SELECT ${NEURON_COLUMNS} FROM neurons WHERE netuid = ? ORDER BY uid`,
             [netuid],
           );
-      return json(buildSubnetMetagraph(rows, netuid, { immunityPeriod: null }));
+      return json(
+        buildSubnetMetagraph(rows, netuid, {
+          immunityPeriod: null,
+          burnHotkey: await resolveBurnHotkey(sql, netuid),
+        }),
+      );
     };
   }
 
@@ -7447,12 +7484,13 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
       );
       const rows = await sql<{
         snapshot_date: NeuronDaily["snapshot_date"];
+        hotkey: NeuronDaily["hotkey"];
         validator_permit: NeuronDaily["validator_permit"];
         emission_tao: NeuronDaily["emission_tao"];
         alpha_out_emission: SubnetSnapshots["alpha_out_emission"];
         alpha_price_tao: SubnetSnapshots["alpha_price_tao"];
       }>`
-        SELECT nd.snapshot_date, nd.validator_permit, nd.emission_tao,
+        SELECT nd.snapshot_date, nd.hotkey, nd.validator_permit, nd.emission_tao,
                ss.alpha_out_emission, ss.alpha_price_tao
         FROM neuron_daily nd
         LEFT JOIN subnet_snapshots ss
@@ -7467,6 +7505,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
             DEFAULT_SUBNET_EMISSION_SPLIT_HISTORY_WINDOW,
           ),
           capped: rows.length >= EMISSION_SPLIT_HISTORY_ROW_CAP,
+          burnHotkey: await resolveBurnHotkey(sql, netuid),
         }),
       );
     };
@@ -7500,12 +7539,13 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         validator_permit: NeuronDaily["validator_permit"];
         emission_tao: NeuronDaily["emission_tao"];
       }>`
-        SELECT nd.snapshot_date, nd.uid, nd.coldkey, nd.validator_permit,
-               nd.emission_tao
+        SELECT nd.snapshot_date, nd.uid, nd.coldkey, nd.hotkey,
+               nd.validator_permit, nd.emission_tao
         FROM neuron_daily nd
         WHERE nd.netuid = ${netuid} AND nd.snapshot_date >= ${cutoff}
         ORDER BY nd.snapshot_date DESC, nd.uid ASC
         LIMIT ${MINER_FAIRNESS_ROW_CAP}`;
+      const burnHotkey = await resolveBurnHotkey(sql, netuid);
       // #11091: the CURRENT metagraph beside the window. A window aggregate
       // smooths away a mid-window capture event (SN75: 30d uid gini 0.77
       // while one UID held incentive 0.9908 live), so the builder publishes
@@ -7519,7 +7559,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         captured_at: Neurons["captured_at"];
         block_number: Neurons["block_number"];
       }>`
-        SELECT n.uid, n.coldkey, n.validator_permit, n.incentive,
+        SELECT n.uid, n.coldkey, n.hotkey, n.validator_permit, n.incentive,
                n.captured_at, n.block_number
         FROM neurons n
         WHERE n.netuid = ${netuid}
@@ -7533,6 +7573,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
           ),
           capped: rows.length >= MINER_FAIRNESS_ROW_CAP,
           liveRows,
+          burnHotkey,
         }),
       );
     };


### PR DESCRIPTION
## Summary

Field-report P1 (#11094). The mechanism, **chain-verified before building**: `SubtensorModule.MinerBurned > 0` routes that fraction of miner incentive to the UID holding `SubtensorModule.SubnetOwnerHotkey` — SN13's owner UID 162 carries incentive 0.715557 vs MinerBurned 0.7155707 (5dp), and the zero cases (SN53/SN75 owner UIDs at incentive 0) confirm both directions, also separating a burn from a genuine single-miner capture (SN75). The issue's incentive-matching heuristic is the *repro*, not the derivation.

- **Metagraph**: `is_burn_uid` on neuron rows (emitted only when the tier resolved both captures — shape-stable otherwise, like `featured`).
- **miner-fairness**: the sink is excluded from every population (points, persistence, windowed + live lenses) and **named** as `burn_uid` — per-miner figures stop being wrong by 1/(1−burn).
- **emission-split**: its own `burned_alpha`/`burned_share_of_uid` leg; the three UID-set shares sum to 1; `miner_alpha` is what miners actually receive.
- One data-api resolver joins the two captures already in the same database; null on any gap or zero fraction — a capture gap never invents an exclusion.

## Testing / falsification

Per-surface pins (SN13 shape: lens holders drop from 3→2 and gini →0 once the sink is out; the sink is in neither split population; flag absent without the resolution) + pglite end-to-end (ownership + snapshot rows → flagged metagraph + excluding fairness). Falsified by neutering the exclusion — the SN13-shape test fails. Full suite 904 files / 20,708 green; contract-drift, graphql parity, published-names, mcp, route-query parity green. Post-merge: live-verify SN13 (`burn_uid: 162`, lens excludes it) + `conformance:tripwire`.

Closes #11094