### PR TITLE
feat(lakehouse): the frozen baseline is empty — featured_validators is a decision, not debt

### DIFF
--- a/scripts/check-lakehouse-freshness.ts
+++ b/scripts/check-lakehouse-freshness.ts
@@ -110,8 +110,24 @@ export const EXPECTED: Readonly<Record<string, FreshnessRule>> = {
     reason: "identity poller, restore pending",
   },
   featured_validators: {
-    maxAgeMs: 7 * DAY,
-    reason: "registry projection, restore pending",
+    // EXEMPT, and this is a decision rather than an unpaid debt.
+    //
+    // The curation moved to registry/featured-validators.json (#11080), where
+    // git holds it with authorship, review and full history -- a better archive
+    // for a commercial arrangement than Iceberg, which has none of those.
+    //
+    // The roster was then emptied (#11116): no validator currently carries an
+    // arrangement, so the badge serves false everywhere, correctly. The two
+    // rows still in this table are the materialised record of an arrangement
+    // that has ENDED.
+    //
+    // Feeding it from the registry would therefore write zero rows or overwrite
+    // those two -- destroying the only thing the table holds. Doing nothing is
+    // the option that preserves the record, so it is frozen ON PURPOSE and no
+    // longer counted against the frozen baseline.
+    maxAgeMs: null,
+    reason:
+      "a past arrangement, kept as-is: the roster is empty and git is the archive for the curation",
   },
   neurons: { maxAgeMs: 2 * DAY, reason: "metagraph poller, restore pending" },
   nominator_positions: {
@@ -293,7 +309,6 @@ export const KNOWN_FROZEN: ReadonlySet<string> = new Set([
   //                         published from this repo
   //   rpc_proxy_events      no such table in Neon; the RPC proxy Worker writes
   //                         it to D1
-  "featured_validators",
 ]);
 export interface TableAge {
   table: string;


### PR DESCRIPTION
The last table from the 2026-08-02 outage, and it closes as a **written decision** rather than a producer.

## Why feeding it would be wrong

The curation moved to `registry/featured-validators.json` (#11080), where **git** holds it with authorship, review and full history — a better archive for a commercial arrangement than Iceberg, which has none of those.

The roster was then **emptied** (#11116): no validator currently carries an arrangement, so the badge serves `false` everywhere — correctly, and for a *reason* rather than structurally. Confirmed live: all 17 validators on subnet 64 carry the field, none is featured.

That makes mirroring this table actively harmful. The registry holds **zero** entries, so a mirror would write nothing or overwrite the two rows still there — and those two rows are the materialised record of an arrangement that has **ended**. Doing nothing is the option that preserves the record.

So it is exempt with that reasoning attached, rather than left counting against a baseline it can never leave.

## The baseline is now empty

```
KNOWN_FROZEN: 18 → 3 → 1 → 0
lakehouse-freshness: 0 stale of 46 -- 0 known (baseline 0), 0 NEW, 0 recovered
```

The set that described the outage no longer describes anything, which is the correct end state for a shrinking baseline.

**It does not go vacuous:** an unclassified table still fails outright, and three tables remain explicitly exempt with stated reasons (`rehearsal` — exodus fixture; `spike.dedup_test` — scratch; this one). The gate still has teeth; it simply has nothing left to report.

## Verification

`0 stale of 46` across both namespaces · **50 of 50 CI validators** · **20,706 tests, 904 files**.