### PR TITLE
feat(economics): what a miner here actually makes, at the percentiles

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -2551,6 +2551,11 @@ type SubnetEmissionSplitHistory {
   points: [SubnetEmissionSplitHistoryPoint!]!
 
   """
+  THE MINER INCOME DISTRIBUTION (#11096): what a miner here actually makes, per day, at p50/p75/p90 and the top earner, in alpha and USD -- shares measured from the window's per-UID emission (burn sink excluded), priced through the newest point's own legs. Null when the window holds no miner UIDs.
+  """
+  miner_earnings: SubnetEmissionSplitMinerEarnings
+
+  """
   Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5.
   """
   field_sources: JSON
@@ -2668,6 +2673,32 @@ type SubnetEmissionSplitHistoryPoint {
   \`total_alpha\` priced through \`alpha_price_tao\`. Reconstructed, and null whenever either input is.
   """
   total_tao: Float
+}
+
+type SubnetEmissionSplitMinerEarnings {
+  earning_miner_count: Int!
+
+  """
+  Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income.
+  """
+  zero_miner_count: Int!
+  p50_alpha_day: Float
+  p75_alpha_day: Float
+  p90_alpha_day: Float
+  top_alpha_day: Float
+
+  """
+  What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price).
+  """
+  p50_usd_day: Float
+  p75_usd_day: Float
+  p90_usd_day: Float
+  top_usd_day: Float
+
+  """
+  The point whose per-day legs priced these figures -- the newest in the window.
+  """
+  basis_date: String
 }
 
 """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6416,6 +6416,8 @@ export type SubnetEmissionSplitHistory = {
   __typename?: 'SubnetEmissionSplitHistory';
   /** Per-field { kind, storage } provenance map: every value is labelled measured (with the pallet-qualified storage item it was read from) or reconstructed (our arithmetic over measurements, storage null). ADR 0023 decision 5. */
   field_sources?: Maybe<Scalars['JSON']['output']>;
+  /** THE MINER INCOME DISTRIBUTION (#11096): what a miner here actually makes, per day, at p50/p75/p90 and the top earner, in alpha and USD -- shares measured from the window's per-UID emission (burn sink excluded), priced through the newest point's own legs. Null when the window holds no miner UIDs. */
+  miner_earnings?: Maybe<SubnetEmissionSplitMinerEarnings>;
   netuid: Scalars['Int']['output'];
   point_count: Scalars['Int']['output'];
   points: Array<SubnetEmissionSplitHistoryPoint>;
@@ -6476,6 +6478,24 @@ export type SubnetEmissionSplitHistoryPoint = {
   validator_share_of_uid?: Maybe<Scalars['Float']['output']>;
   /** The distributable day total x the MEASURED validator_share_of_uid, priced. Null when any input is. */
   validator_usd_day?: Maybe<Scalars['Float']['output']>;
+};
+
+export type SubnetEmissionSplitMinerEarnings = {
+  __typename?: 'SubnetEmissionSplitMinerEarnings';
+  /** The point whose per-day legs priced these figures -- the newest in the window. */
+  basis_date?: Maybe<Scalars['String']['output']>;
+  earning_miner_count: Scalars['Int']['output'];
+  p50_alpha_day?: Maybe<Scalars['Float']['output']>;
+  /** What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price). */
+  p50_usd_day?: Maybe<Scalars['Float']['output']>;
+  p75_alpha_day?: Maybe<Scalars['Float']['output']>;
+  p75_usd_day?: Maybe<Scalars['Float']['output']>;
+  p90_alpha_day?: Maybe<Scalars['Float']['output']>;
+  p90_usd_day?: Maybe<Scalars['Float']['output']>;
+  top_alpha_day?: Maybe<Scalars['Float']['output']>;
+  top_usd_day?: Maybe<Scalars['Float']['output']>;
+  /** Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income. */
+  zero_miner_count: Scalars['Int']['output'];
 };
 
 /** What the CHAIN charges to enter. Exact, measured, and the only hard numbers in this card. */
@@ -8675,6 +8695,7 @@ export type ResolversTypes = ResolversObject<{
   SubnetEmissionDecomposition: ResolverTypeWrapper<SubnetEmissionDecomposition>;
   SubnetEmissionSplitHistory: ResolverTypeWrapper<SubnetEmissionSplitHistory>;
   SubnetEmissionSplitHistoryPoint: ResolverTypeWrapper<SubnetEmissionSplitHistoryPoint>;
+  SubnetEmissionSplitMinerEarnings: ResolverTypeWrapper<SubnetEmissionSplitMinerEarnings>;
   SubnetEntryCost: ResolverTypeWrapper<SubnetEntryCost>;
   SubnetEventSummary: ResolverTypeWrapper<SubnetEventSummary>;
   SubnetEventSummaryArtifactCategories: ResolverTypeWrapper<SubnetEventSummaryArtifactCategories>;
@@ -9141,6 +9162,7 @@ export type ResolversParentTypes = ResolversObject<{
   SubnetEmissionDecomposition: SubnetEmissionDecomposition;
   SubnetEmissionSplitHistory: SubnetEmissionSplitHistory;
   SubnetEmissionSplitHistoryPoint: SubnetEmissionSplitHistoryPoint;
+  SubnetEmissionSplitMinerEarnings: SubnetEmissionSplitMinerEarnings;
   SubnetEntryCost: SubnetEntryCost;
   SubnetEventSummary: SubnetEventSummary;
   SubnetEventSummaryArtifactCategories: SubnetEventSummaryArtifactCategories;
@@ -13033,6 +13055,7 @@ export type SubnetEmissionDecompositionResolvers<ContextType = GqlContext, Paren
 
 export type SubnetEmissionSplitHistoryResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEmissionSplitHistory'] = ResolversParentTypes['SubnetEmissionSplitHistory']> = ResolversObject<{
   field_sources?: Resolver<Maybe<ResolversTypes['JSON']>, ParentType, ContextType>;
+  miner_earnings?: Resolver<Maybe<ResolversTypes['SubnetEmissionSplitMinerEarnings']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   point_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   points?: Resolver<Array<ResolversTypes['SubnetEmissionSplitHistoryPoint']>, ParentType, ContextType>;
@@ -13068,6 +13091,20 @@ export type SubnetEmissionSplitHistoryPointResolvers<ContextType = GqlContext, P
   validator_share?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validator_share_of_uid?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   validator_usd_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+}>;
+
+export type SubnetEmissionSplitMinerEarningsResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEmissionSplitMinerEarnings'] = ResolversParentTypes['SubnetEmissionSplitMinerEarnings']> = ResolversObject<{
+  basis_date?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  earning_miner_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  p50_alpha_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  p50_usd_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  p75_alpha_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  p75_usd_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  p90_alpha_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  p90_usd_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_alpha_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  top_usd_day?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  zero_miner_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type SubnetEntryCostResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetEntryCost'] = ResolversParentTypes['SubnetEntryCost']> = ResolversObject<{
@@ -14798,6 +14835,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   SubnetEmissionDecomposition?: SubnetEmissionDecompositionResolvers<ContextType>;
   SubnetEmissionSplitHistory?: SubnetEmissionSplitHistoryResolvers<ContextType>;
   SubnetEmissionSplitHistoryPoint?: SubnetEmissionSplitHistoryPointResolvers<ContextType>;
+  SubnetEmissionSplitMinerEarnings?: SubnetEmissionSplitMinerEarningsResolvers<ContextType>;
   SubnetEntryCost?: SubnetEntryCostResolvers<ContextType>;
   SubnetEventSummary?: SubnetEventSummaryResolvers<ContextType>;
   SubnetEventSummaryArtifactCategories?: SubnetEventSummaryArtifactCategoriesResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -11231,6 +11231,23 @@ export interface components {
                     storage: string | null;
                 };
             };
+            /** @description THE MINER INCOME DISTRIBUTION (#11096): what a miner here actually makes, per day, at p50/p75/p90 and the top earner, in alpha and USD -- shares measured from the window's per-UID emission (burn sink excluded), priced through the newest point's own legs. Null when the window holds no miner UIDs. */
+            miner_earnings?: {
+                /** @description The point whose per-day legs priced these figures -- the newest in the window. */
+                basis_date: string | null;
+                earning_miner_count: number;
+                p50_alpha_day: number | null;
+                /** @description What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price). */
+                p50_usd_day: number | null;
+                p75_alpha_day: number | null;
+                p75_usd_day: number | null;
+                p90_alpha_day: number | null;
+                p90_usd_day: number | null;
+                top_alpha_day: number | null;
+                top_usd_day: number | null;
+                /** @description Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income. */
+                zero_miner_count: number;
+            } | null;
             netuid: number;
             point_count: number;
             points: {
@@ -42031,6 +42048,19 @@ export interface operations {
                      *             "kind": "measured",
                      *             "storage": "example"
                      *           }
+                     *         },
+                     *         "miner_earnings": {
+                     *           "basis_date": "example",
+                     *           "earning_miner_count": 1,
+                     *           "p50_alpha_day": 0.5,
+                     *           "p50_usd_day": 0.5,
+                     *           "p75_alpha_day": 0.5,
+                     *           "p75_usd_day": 0.5,
+                     *           "p90_alpha_day": 0.5,
+                     *           "p90_usd_day": 0.5,
+                     *           "top_alpha_day": 0.5,
+                     *           "top_usd_day": 0.5,
+                     *           "zero_miner_count": 1
                      *         },
                      *         "netuid": 7,
                      *         "point_count": 1,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9605,6 +9605,19 @@
                 "storage": "example"
               }
             },
+            "miner_earnings": {
+              "basis_date": "example",
+              "earning_miner_count": 1,
+              "p50_alpha_day": 0.5,
+              "p50_usd_day": 0.5,
+              "p75_alpha_day": 0.5,
+              "p75_usd_day": 0.5,
+              "p90_alpha_day": 0.5,
+              "p90_usd_day": 0.5,
+              "top_alpha_day": 0.5,
+              "top_usd_day": 0.5,
+              "zero_miner_count": 1
+            },
             "netuid": 7,
             "point_count": 1,
             "points": [
@@ -48419,6 +48432,136 @@
               "type": "string"
             },
             "type": "object"
+          },
+          "miner_earnings": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "basis_date": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "The point whose per-day legs priced these figures -- the newest in the window."
+                  },
+                  "earning_miner_count": {
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "p50_alpha_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "p50_usd_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ],
+                    "description": "What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price)."
+                  },
+                  "p75_alpha_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "p75_usd_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "p90_alpha_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "p90_usd_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "top_alpha_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "top_usd_day": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "zero_miner_count": {
+                    "description": "Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income.",
+                    "maximum": 9007199254740991,
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "earning_miner_count",
+                  "zero_miner_count",
+                  "p50_alpha_day",
+                  "p75_alpha_day",
+                  "p90_alpha_day",
+                  "top_alpha_day",
+                  "p50_usd_day",
+                  "p75_usd_day",
+                  "p90_usd_day",
+                  "top_usd_day",
+                  "basis_date"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "THE MINER INCOME DISTRIBUTION (#11096): what a miner here actually makes, per day, at p50/p75/p90 and the top earner, in alpha and USD -- shares measured from the window's per-UID emission (burn sink excluded), priced through the newest point's own legs. Null when the window holds no miner UIDs."
           },
           "netuid": {
             "maximum": 9007199254740991,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -11231,6 +11231,23 @@ export interface components {
                     storage: string | null;
                 };
             };
+            /** @description THE MINER INCOME DISTRIBUTION (#11096): what a miner here actually makes, per day, at p50/p75/p90 and the top earner, in alpha and USD -- shares measured from the window's per-UID emission (burn sink excluded), priced through the newest point's own legs. Null when the window holds no miner UIDs. */
+            miner_earnings?: {
+                /** @description The point whose per-day legs priced these figures -- the newest in the window. */
+                basis_date: string | null;
+                earning_miner_count: number;
+                p50_alpha_day: number | null;
+                /** @description What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price). */
+                p50_usd_day: number | null;
+                p75_alpha_day: number | null;
+                p75_usd_day: number | null;
+                p90_alpha_day: number | null;
+                p90_usd_day: number | null;
+                top_alpha_day: number | null;
+                top_usd_day: number | null;
+                /** @description Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income. */
+                zero_miner_count: number;
+            } | null;
             netuid: number;
             point_count: number;
             points: {
@@ -42031,6 +42048,19 @@ export interface operations {
                      *             "kind": "measured",
                      *             "storage": "example"
                      *           }
+                     *         },
+                     *         "miner_earnings": {
+                     *           "basis_date": "example",
+                     *           "earning_miner_count": 1,
+                     *           "p50_alpha_day": 0.5,
+                     *           "p50_usd_day": 0.5,
+                     *           "p75_alpha_day": 0.5,
+                     *           "p75_usd_day": 0.5,
+                     *           "p90_alpha_day": 0.5,
+                     *           "p90_usd_day": 0.5,
+                     *           "top_alpha_day": 0.5,
+                     *           "top_usd_day": 0.5,
+                     *           "zero_miner_count": 1
                      *         },
                      *         "netuid": 7,
                      *         "point_count": 1,

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -463,6 +463,9 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   SubnetYieldArtifactNeurons: "SubnetYieldNeuron",
   SubnetEmissionSplitHistoryArtifact: "SubnetEmissionSplitHistory",
   SubnetEmissionSplitHistoryArtifactPoints: "SubnetEmissionSplitHistoryPoint",
+  // #11096: the per-UID miner income distribution block.
+  SubnetEmissionSplitHistoryArtifactMinerEarnings:
+    "SubnetEmissionSplitMinerEarnings",
   SubnetMinerFairnessArtifact: "SubnetMinerFairness",
   SubnetMinerFairnessArtifactPoints: "SubnetMinerFairnessPoint",
   SubnetMinerFairnessArtifactPersistence: "SubnetMinerFairnessPersistence",

--- a/schemas-src/routes/emission-split.ts
+++ b/schemas-src/routes/emission-split.ts
@@ -121,7 +121,39 @@ const SubnetEmissionSplitPointSchema = z
 
 export const SubnetEmissionSplitHistoryArtifactSchema =
   subnetHistoryArtifactSchema(SubnetEmissionSplitPointSchema)
-    .extend({ field_sources: FieldSourcesSchema.optional() })
+    .extend({
+      miner_earnings: z
+        .object({
+          earning_miner_count: z.int().min(0),
+          zero_miner_count: z.int().min(0).meta({
+            description:
+              "Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income.",
+          }),
+          p50_alpha_day: z.number().nullable(),
+          p75_alpha_day: z.number().nullable(),
+          p90_alpha_day: z.number().nullable(),
+          top_alpha_day: z.number().nullable(),
+          p50_usd_day: z.number().nullable().meta({
+            description:
+              "What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price).",
+          }),
+          p75_usd_day: z.number().nullable(),
+          p90_usd_day: z.number().nullable(),
+          top_usd_day: z.number().nullable(),
+          basis_date: z.string().nullable().meta({
+            description:
+              "The point whose per-day legs priced these figures -- the newest in the window.",
+          }),
+        })
+        .strict()
+        .nullable()
+        .optional()
+        .meta({
+          description:
+            "THE MINER INCOME DISTRIBUTION (#11096): what a miner here actually makes, per day, at p50/p75/p90 and the top earner, in alpha and USD -- shares measured from the window's per-UID emission (burn sink excluded), priced through the newest point's own legs. Null when the window holds no miner UIDs.",
+        }),
+      field_sources: FieldSourcesSchema.optional(),
+    })
     .describe(
       "Per-day split of one subnet's emission by recipient class — owner, validators, miners — over a 7d/30d/90d window, newest first. The validator/miner split is MEASURED from the per-UID neuron_daily rollup; the owner leg and every absolute figure are RECONSTRUCTED, because the owner's cut is paid outside the UID set and `SubnetOwnerCut` is unset on chain. A subnet with no daily rollup resolves to a schema-stable empty series (point_count 0), never null. Mirrors GET /api/v1/subnets/{netuid}/emission-split/history.",
     );

--- a/src/emission-split.ts
+++ b/src/emission-split.ts
@@ -153,6 +153,12 @@ export const SUBNET_EMISSION_SPLIT_FIELD_SOURCES = {
   "points.validator_usd_day": { kind: "reconstructed", storage: null },
   "points.miner_usd_day": { kind: "reconstructed", storage: null },
   "points.burned_usd_day": { kind: "reconstructed", storage: null },
+  "miner_earnings.earning_miner_count": {
+    kind: "measured",
+    storage: "neuron_daily",
+  },
+  "miner_earnings.p50_usd_day": { kind: "reconstructed", storage: null },
+  "miner_earnings.top_usd_day": { kind: "reconstructed", storage: null },
   "points.miner_alpha": {
     kind: "measured",
     storage: "neuron_daily.emission_tao",
@@ -327,6 +333,16 @@ function emissionSplitPoint(
  * Null-safe: a cold or absent store yields `point_count: 0`, never a throw and
  * never a 404. A subnet with no daily rollup is a real state.
  */
+/** A sorted array's p-quantile by nearest-rank, or null on empty. */
+function quantile(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null;
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(p * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
 export function buildSubnetEmissionSplitHistory(
   rows: Row[] | null | undefined,
   netuid: unknown,
@@ -372,12 +388,72 @@ export function buildSubnetEmissionSplitHistory(
       usdPerTaoByDay?.get(date) ?? null,
     ),
   );
+  // ── Per-UID miner earnings distribution (#11096) ─────────────────────────
+  // "What does a miner here make" -- the most common revenue question, derived
+  // wrong twice in a real research session before validation. Shares come from
+  // each MINER UID's window-summed emission samples (validators and the burn
+  // sink excluded); the money comes from the NEWEST point's own per-day legs,
+  // so the distribution and its pricing basis are one object.
+  const uidRao = new Map<number, bigint>();
+  const seenUids = new Set<number>();
+  for (const row of list) {
+    if (isValidator(row?.validator_permit)) continue;
+    if (burnHotkey != null && row?.hotkey === burnHotkey) continue;
+    const uid = nonNegativeCellOrNull(row?.uid);
+    if (uid === null) continue;
+    seenUids.add(uid);
+    const emission = nonNegativeCellOrNull(row?.emission_tao);
+    if (emission !== null && emission > 0) {
+      uidRao.set(uid, (uidRao.get(uid) ?? 0n) + toRaoBig(emission));
+    }
+  }
+  const masses = [...uidRao.values()].map(raoBigToTao).sort((a, b) => a - b);
+  const massTotal = masses.reduce((sum, v) => sum + v, 0);
+  const newest = points[0] as Row | undefined;
+  // miner_share is only ever a number when the point's `totals` object was
+  // built, and that object always writes total_alpha -- so one check suffices
+  // and a second would be an arm nothing can reach.
+  const minerAlphaDay =
+    newest && typeof newest.miner_share === "number"
+      ? (newest.total_alpha as number) * (newest.miner_share as number)
+      : null;
+  const minerUsdDay =
+    newest && typeof newest.miner_usd_day === "number"
+      ? (newest.miner_usd_day as number)
+      : null;
+  const legFor = (
+    share: number | null,
+    dayTotal: number | null,
+  ): number | null =>
+    share === null || dayTotal === null ? null : round9(share * dayTotal);
+  const shareAt = (p: number): number | null => {
+    const value = quantile(masses, p);
+    return value === null || massTotal <= 0 ? null : value / massTotal;
+  };
+  const minerEarnings =
+    seenUids.size === 0
+      ? null
+      : {
+          earning_miner_count: masses.length,
+          zero_miner_count: seenUids.size - masses.length,
+          p50_alpha_day: legFor(shareAt(0.5), minerAlphaDay),
+          p75_alpha_day: legFor(shareAt(0.75), minerAlphaDay),
+          p90_alpha_day: legFor(shareAt(0.9), minerAlphaDay),
+          top_alpha_day: legFor(shareAt(1), minerAlphaDay),
+          p50_usd_day: legFor(shareAt(0.5), minerUsdDay),
+          p75_usd_day: legFor(shareAt(0.75), minerUsdDay),
+          p90_usd_day: legFor(shareAt(0.9), minerUsdDay),
+          top_usd_day: legFor(shareAt(1), minerUsdDay),
+          basis_date: newest?.snapshot_date ?? null,
+        };
+
   return {
     schema_version: 1,
     netuid,
     window: window ?? null,
     point_count: points.length,
     points,
+    miner_earnings: minerEarnings,
     // Emitted by the BUILDER, not by each handler, so REST, MCP and GraphQL
     // publish byte-identical provenance. A per-surface copy is how one of them
     // ends up quietly claiming a reconstruction is a reading.

--- a/tests/emission-split.test.ts
+++ b/tests/emission-split.test.ts
@@ -530,3 +530,99 @@ describe("the USD legs (#11095)", () => {
     assert.equal(p.miner_usd_day, null);
   });
 });
+
+describe("the miner income distribution (#11096)", () => {
+  test("percentiles over per-UID shares, priced through the newest point", () => {
+    // Four earning miners at 1:1:2:4 of the window's miner mass, one on zero,
+    // plus the burn sink and a validator that must not enter.
+    const base = {
+      snapshot_date: "2026-08-12",
+      alpha_out_emission: 1,
+      alpha_price_tao: 0.01,
+      validator_permit: false,
+    };
+    const rows: Row[] = [
+      { ...base, uid: 0, hotkey: "5A", emission_tao: 1 },
+      { ...base, uid: 1, hotkey: "5B", emission_tao: 1 },
+      { ...base, uid: 2, hotkey: "5C", emission_tao: 2 },
+      { ...base, uid: 3, hotkey: "5D", emission_tao: 4 },
+      { ...base, uid: 4, hotkey: "5E", emission_tao: 0 },
+      { ...base, uid: 162, hotkey: "5OwnerHot", emission_tao: 100 },
+      {
+        ...base,
+        uid: 200,
+        hotkey: "5V",
+        validator_permit: true,
+        emission_tao: 50,
+      },
+    ];
+    const out = buildSubnetEmissionSplitHistory(rows, 13, {
+      burnHotkey: "5OwnerHot",
+      usdPerTaoByDay: new Map([["2026-08-12", 100]]),
+    });
+    const e = out.miner_earnings as Row;
+    assert.equal(e.earning_miner_count, 4);
+    assert.equal(e.zero_miner_count, 1);
+    const p = (out.points as Row[])[0];
+    const minerAlphaDay = (p.total_alpha as number) * (p.miner_share as number);
+    // Top earner holds 4/8 of miner mass.
+    assert.ok(
+      Math.abs((e.top_alpha_day as number) - minerAlphaDay * 0.5) < 1e-6,
+    );
+    // Median of [1,1,2,4] by nearest-rank is 1 -> 1/8 of the mass.
+    assert.ok(Math.abs((e.p50_alpha_day as number) - minerAlphaDay / 8) < 1e-6);
+    assert.ok((e.p50_usd_day as number) > 0);
+    assert.equal(e.basis_date, "2026-08-12");
+  });
+
+  test("an empty window is null, and an unpriced one nulls only the money", () => {
+    assert.equal(
+      buildSubnetEmissionSplitHistory([], 13, {}).miner_earnings,
+      null,
+    );
+    // sn74Day carries no uid column, so give each row one -- a row without a
+    // uid cannot enter a per-UID distribution.
+    const withUids: Row[] = sn74Day("2026-08-12").map((r, i) => ({
+      ...r,
+      uid: i,
+    }));
+    const out = buildSubnetEmissionSplitHistory(withUids, 74, {});
+    const e = out.miner_earnings as Row;
+    assert.ok((e.p50_alpha_day as number) > 0, "alpha needs no USD chain");
+    assert.equal(e.p50_usd_day, null);
+  });
+});
+
+describe("the distribution's degrade arms (#11096)", () => {
+  test("all miners on zero: counts present, every percentile null", () => {
+    const rows: Row[] = [0, 1, 2].map((uid) => ({
+      snapshot_date: "2026-08-12",
+      uid,
+      hotkey: `5Z${uid}`,
+      validator_permit: false,
+      emission_tao: 0,
+      alpha_out_emission: 1,
+    }));
+    const e = buildSubnetEmissionSplitHistory(rows, 7, {})
+      .miner_earnings as Row;
+    assert.equal(e.earning_miner_count, 0);
+    assert.equal(e.zero_miner_count, 3);
+    assert.equal(e.p50_alpha_day, null);
+    assert.equal(e.top_usd_day, null);
+  });
+
+  test("a window with UIDs but no dated points still answers, moneyless", () => {
+    // A row whose snapshot_date is unusable never becomes a point, so there is
+    // no basis to price against -- the shares exist, the money does not.
+    const rows: Row[] = [
+      { uid: 0, hotkey: "5A", validator_permit: false, emission_tao: 2 },
+      { uid: 1, hotkey: "5B", validator_permit: false, emission_tao: 1 },
+    ];
+    const e = buildSubnetEmissionSplitHistory(rows, 7, {})
+      .miner_earnings as Row;
+    assert.equal(e.earning_miner_count, 2);
+    assert.equal(e.basis_date, null);
+    assert.equal(e.p50_alpha_day, null, "no point, no day total");
+    assert.equal(e.p50_usd_day, null);
+  });
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7484,14 +7484,15 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
       );
       const rows = await sql<{
         snapshot_date: NeuronDaily["snapshot_date"];
+        uid: NeuronDaily["uid"];
         hotkey: NeuronDaily["hotkey"];
         validator_permit: NeuronDaily["validator_permit"];
         emission_tao: NeuronDaily["emission_tao"];
         alpha_out_emission: SubnetSnapshots["alpha_out_emission"];
         alpha_price_tao: SubnetSnapshots["alpha_price_tao"];
       }>`
-        SELECT nd.snapshot_date, nd.hotkey, nd.validator_permit, nd.emission_tao,
-               ss.alpha_out_emission, ss.alpha_price_tao
+        SELECT nd.snapshot_date, nd.uid, nd.hotkey, nd.validator_permit,
+               nd.emission_tao, ss.alpha_out_emission, ss.alpha_price_tao
         FROM neuron_daily nd
         LEFT JOIN subnet_snapshots ss
           ON ss.netuid = nd.netuid AND ss.snapshot_date = nd.snapshot_date


### PR DESCRIPTION
## Summary

Field-report P1 (#11096), the last data primitive of the report. `miner_earnings` on `/subnets/{netuid}/emission-split/history` — placed where every unit already lives rather than a new artifact, per the issue's own suggestion:

- **p50/p75/p90/top per day, in alpha and USD**, over each miner UID's share of the window's summed emission — validators and the **burn sink excluded** (#11094), priced through the **newest point's own per-day legs** (#11095), with `basis_date` naming the pricing day and `zero_miner_count` beside the percentiles (on the median subnet, most registered miners earn nothing — a distribution over earners alone would read as universal income).
- Degrade honestly: null block when the window holds no miner UIDs; alpha percentiles answer without the USD chain; only the money nulls on unpriced days. One structurally unreachable arm removed with its reasoning stated instead of ignored.
- New GraphQL type registered; docs regenerated.

## Testing

Exact-value pins (1:1:2:4 mass shape → top = ½ of the miner day-leg, nearest-rank median = ⅛), burn/validator exclusion, all-zero windows, dateless rows. Diff-intersection: 25/25 lines earlier + the two degrade tests closing the remaining arms (37/38 → the last removed as unreachable). Full suite 904 files / 20,722 green.

Closes #11096