### PR TITLE
feat(chain): the bulk ranking answers the screening question whole

### DIFF
--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6673,6 +6673,8 @@ export interface components {
             sort: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
             subnet_count: number;
             subnets: {
+                /** @description How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version. */
+                earning_miner_count?: number;
                 entity_count: number;
                 entropy: number | null;
                 entropy_normalized: number | null;
@@ -6680,6 +6682,8 @@ export interface components {
                 hhi: number | null;
                 hhi_normalized: number | null;
                 holders: number | null;
+                /** @description Non-validator UIDs on this subnet's current metagraph, the burn sink excluded (#11094/#11098). The number every leaderboard calls 'miners'. */
+                miner_uid_count?: number;
                 nakamoto_coefficient: number | null;
                 netuid: number;
                 neuron_count: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22777,6 +22777,12 @@
             "items": {
               "additionalProperties": false,
               "properties": {
+                "earning_miner_count": {
+                  "description": "How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version.",
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
+                },
                 "entity_count": {
                   "maximum": 9007199254740991,
                   "minimum": 0,
@@ -22843,6 +22849,12 @@
                       "type": "null"
                     }
                   ]
+                },
+                "miner_uid_count": {
+                  "description": "Non-validator UIDs on this subnet's current metagraph, the burn sink excluded (#11094/#11098). The number every leaderboard calls 'miners'.",
+                  "maximum": 9007199254740991,
+                  "minimum": 0,
+                  "type": "integer"
                 },
                 "nakamoto_coefficient": {
                   "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6673,6 +6673,8 @@ export interface components {
             sort: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
             subnet_count: number;
             subnets: {
+                /** @description How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version. */
+                earning_miner_count?: number;
                 entity_count: number;
                 entropy: number | null;
                 entropy_normalized: number | null;
@@ -6680,6 +6682,8 @@ export interface components {
                 hhi: number | null;
                 hhi_normalized: number | null;
                 holders: number | null;
+                /** @description Non-validator UIDs on this subnet's current metagraph, the burn sink excluded (#11094/#11098). The number every leaderboard calls 'miners'. */
+                miner_uid_count?: number;
                 nakamoto_coefficient: number | null;
                 netuid: number;
                 neuron_count: number;

--- a/schemas-src/routes/chain-concentration-subnets.ts
+++ b/schemas-src/routes/chain-concentration-subnets.ts
@@ -24,6 +24,14 @@ export const SubnetConcentrationRowSchema = z
     neuron_count: z.int().min(0),
     entity_count: z.int().min(0),
     uids_per_entity: z.number().nullable(),
+    miner_uid_count: z.int().min(0).optional().meta({
+      description:
+        "Non-validator UIDs on this subnet's current metagraph, the burn sink excluded (#11094/#11098). The number every leaderboard calls 'miners'.",
+    }),
+    earning_miner_count: z.int().min(0).optional().meta({
+      description:
+        "How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version.",
+    }),
     holders: z.int().min(0).nullable(),
     total: z.number().nullable(),
     gini: z.number().nullable(),

--- a/src/concentration.ts
+++ b/src/concentration.ts
@@ -611,11 +611,14 @@ export function buildSubnetConcentrationRanking(
     sort = DEFAULT_CONCENTRATION_RANKING_SORT,
     order,
     limit,
+    burnHotkeyByNetuid,
   }: {
     lens?: ConcentrationLens;
     sort?: ConcentrationRankingSort;
     order?: "asc" | "desc" | null;
     limit: number;
+    /** netuid -> the subnet's burn hotkey, where MinerBurned > 0 (#11098). */
+    burnHotkeyByNetuid?: ReadonlyMap<number, string>;
   },
 ): SubnetConcentrationRankingResult {
   const list = Array.isArray(rows) ? rows : [];
@@ -639,9 +642,38 @@ export function buildSubnetConcentrationRanking(
     else byNetuid.set(netuid, [row]);
   }
 
-  const subnets = [...byNetuid.entries()].map(([netuid, group]) =>
-    rankingRow(buildConcentration(group, netuid), lens),
-  );
+  const subnets = [...byNetuid.entries()].map(([netuid, group]) => {
+    // #11098: the fairness scalars the screening question needs beside the
+    // lens, and #11094's burn discipline applied in bulk -- the burn sink is
+    // excluded from the EMISSION-reading lenses (its incentive is the chain's
+    // burn, not a holder's earnings) and from the miner counts; stake lenses
+    // keep it, since its stake is real.
+    const burnHotkey = burnHotkeyByNetuid?.get(netuid) ?? null;
+    const emissionLens = lens === "emission" || lens === "entity_emission";
+    const withoutBurn =
+      burnHotkey === null
+        ? group
+        : group.filter((row) => row?.hotkey !== burnHotkey);
+    let minerUidCount = 0;
+    let earningMinerCount = 0;
+    for (const row of withoutBurn) {
+      if (row?.validator_permit === true || Number(row?.validator_permit) === 1)
+        continue;
+      minerUidCount += 1;
+      const emission = Number(row?.emission_tao);
+      if (Number.isFinite(emission) && emission > 0) earningMinerCount += 1;
+    }
+    return Object.assign(
+      rankingRow(
+        buildConcentration(emissionLens ? withoutBurn : group, netuid),
+        lens,
+      ),
+      {
+        miner_uid_count: minerUidCount,
+        earning_miner_count: earningMinerCount,
+      },
+    );
+  });
 
   const direction = order ?? WIDEST_FIRST[sort];
   const factor = direction === "desc" ? -1 : 1;

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -2849,3 +2849,92 @@ test("emission-split serves the USD legs from the day's priced observation (#110
   // 7200 alpha day total x 0.01 alpha price x 350 usd.
   assert.ok(Math.abs((point.total_usd_day as number) - 25200) < 1e-3);
 });
+
+test("the bulk ranking excludes each subnet's burn sink and counts its miners (#11098)", async () => {
+  await seed(
+    `INSERT INTO subnet_ownership (netuid, owner_coldkey, owner_hotkey, captured_at)
+     VALUES (?, ?, ?, ?)`,
+    [7, "5OwnerCold", "5OwnerHot", CAPTURED_AT],
+  );
+  await seed(
+    `INSERT INTO subnet_snapshots (netuid, snapshot_date, miner_burned_fraction)
+     VALUES (?, ?, ?)`,
+    [7, dayAgo(0), 0.7],
+  );
+  await insertNeuron({
+    uid: 162,
+    hotkey: "5OwnerHot",
+    coldkey: "5OwnerCold",
+    validator_permit: 0,
+    emission_tao: 70,
+    incentive: 0.7,
+  });
+  await insertNeuron({
+    uid: 1,
+    hotkey: "5HotM1",
+    coldkey: "5ColdM1",
+    validator_permit: 0,
+    emission_tao: 10,
+    incentive: 0.1,
+  });
+  await insertNeuron({
+    uid: 2,
+    hotkey: "5HotM2",
+    coldkey: "5ColdM2",
+    validator_permit: 0,
+    emission_tao: 0,
+    incentive: 0,
+  });
+  await insertNeuron({
+    uid: 3,
+    hotkey: "5HotV",
+    coldkey: "5ColdV",
+    validator_permit: 1,
+    emission_tao: 20,
+    incentive: 0,
+  });
+
+  // A second subnet whose fraction is ZERO: its owner UID is an ordinary
+  // holder, and the map must not invent an exclusion for it.
+  await seed(
+    `INSERT INTO subnet_ownership (netuid, owner_coldkey, owner_hotkey, captured_at)
+     VALUES (?, ?, ?, ?)`,
+    [9, "5OC9", "5OH9", CAPTURED_AT],
+  );
+  await seed(
+    `INSERT INTO subnet_snapshots (netuid, snapshot_date, miner_burned_fraction)
+     VALUES (?, ?, ?)`,
+    [9, dayAgo(0), 0],
+  );
+  await insertNeuron({
+    netuid: 9,
+    uid: 0,
+    hotkey: "5OH9",
+    coldkey: "5OC9",
+    validator_permit: 0,
+    emission_tao: 5,
+  });
+  await insertNeuron({
+    netuid: 9,
+    uid: 1,
+    hotkey: "5H9b",
+    coldkey: "5C9b",
+    validator_permit: 0,
+    emission_tao: 5,
+  });
+
+  const res = await call(
+    req("/api/v1/chain/concentration/subnets?lens=emission&limit=200"),
+  );
+  assert.equal(res.status, 200);
+  const subnets = ((await res.json()) as Row).subnets as Row[];
+  const row = subnets.find((r) => r.netuid === 7) as Row;
+  assert.equal(row.miner_uid_count, 2, "sink and validator are not miners");
+  assert.equal(row.earning_miner_count, 1);
+  const zeroBurn = subnets.find((r) => r.netuid === 9) as Row;
+  assert.equal(zeroBurn.miner_uid_count, 2, "no exclusion invented");
+  assert.equal(zeroBurn.holders, 2);
+  // With the 70-emission sink excluded, the emission lens sees the validator's
+  // 20 and the miner's 10 -- two holders, not a 70% single-holder illusion.
+  assert.equal(row.holders, 2);
+});

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7388,13 +7388,48 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
         stake_tao: Neurons["stake_tao"];
         emission_tao: Neurons["emission_tao"];
         coldkey: Neurons["coldkey"];
+        hotkey: Neurons["hotkey"];
         validator_permit: Neurons["validator_permit"];
         netuid: Neurons["netuid"];
         captured_at: Neurons["captured_at"];
       }>`
-        SELECT stake_tao, emission_tao, coldkey, validator_permit, netuid, captured_at
+        SELECT stake_tao, emission_tao, coldkey, hotkey, validator_permit, netuid, captured_at
         FROM neurons`;
-      return json(buildSubnetConcentrationRanking(rows, query));
+      // #11098/#11094 in bulk: every subnet's burn hotkey in two grouped
+      // reads, so the emission lenses and the miner counts apply the same
+      // discipline the per-subnet routes do. A netuid missing from either
+      // half simply has no map entry -- no exclusion invented.
+      const owners = await sql<{ netuid: number; owner_hotkey: string | null }>`
+        SELECT DISTINCT ON (netuid) netuid, owner_hotkey
+        FROM subnet_ownership
+        ORDER BY netuid, captured_at DESC`;
+      const fractions = await sql<{
+        netuid: number;
+        miner_burned_fraction: number | null;
+      }>`
+        SELECT DISTINCT ON (netuid) netuid, miner_burned_fraction
+        FROM subnet_snapshots
+        ORDER BY netuid, snapshot_date DESC`;
+      const burnHotkeyByNetuid = new Map<number, string>();
+      const fractionByNetuid = new Map(
+        fractions.map((row) => [row.netuid, Number(row.miner_burned_fraction)]),
+      );
+      for (const row of owners) {
+        const fraction = fractionByNetuid.get(row.netuid);
+        if (
+          row.owner_hotkey &&
+          Number.isFinite(fraction) &&
+          (fraction as number) > 0
+        ) {
+          burnHotkeyByNetuid.set(row.netuid, row.owner_hotkey);
+        }
+      }
+      return json(
+        buildSubnetConcentrationRanking(rows, {
+          ...query,
+          burnHotkeyByNetuid,
+        }),
+      );
     };
   }
 


### PR DESCRIPTION
## Summary

Field-report P2 (#11098). Investigation showed the concentration half of "bulk fairness" was already served — `/chain/concentration/subnets` ranks every subnet in one call — so the delta is the fairness scalars and consistency, not a new route:

- Every ranked row gains `miner_uid_count` + `earning_miner_count` (live grain, described as such — the per-subnet miner-fairness route remains the windowed truth, cross-referenced).
- **#11094's burn discipline in bulk**: each subnet's burn sink, resolved for all subnets in two `DISTINCT ON` reads, is excluded from the miner counts and from the emission-reading lenses (`emission`, `entity_emission`); stake lenses keep it, since its stake is real. A netuid missing from either capture gets no exclusion.

## Testing

pglite end-to-end: a subnet with a 70%-emission sink serves `holders: 2` on the emission lens (no single-holder illusion), sink counted as neither miner nor earner. Existing ranking suite (18) untouched-green. Full suite 904 files / 20,723 green; contract-drift, published-names, docs gates green.

Closes #11098