### PR TITLE
fix(conformance): the cross-surface sweep compared declined answers and different questions

### DIFF
--- a/scripts/check-cross-surface-values.ts
+++ b/scripts/check-cross-surface-values.ts
@@ -134,15 +134,25 @@ async function withTimeout<T>(run: (signal: AbortSignal) => Promise<T>) {
  * surfaces agree about the data, one of them just could not read it this time.
  * So a labelled response counts as "did not answer" and lands in the incomplete
  * bucket, where a declining surface belongs.
+ *
+ * ALL THREE SURFACES SET IT, and until now only REST was asked. Measured
+ * 2026-08-14 against production, forcing the r2-sql timeout on
+ * /accounts/{ss58}/transfers: REST, the GraphQL POST and the MCP POST each
+ * answered the 15s abort with `x-metagraph-degraded: tier_unavailable`. Reading
+ * it on one surface only is what produced this sweep's three-day red streak --
+ * `get_account_transfers transfer_count: rest 100, graphql 0` was GraphQL
+ * declining, correctly labelled, and scored as a disagreement because nothing
+ * looked at the label.
  */
+function degradedHeader(res: Response): string | null {
+  return res.headers.get("x-metagraph-degraded");
+}
+
 async function restBody(path: string): Promise<Row | null> {
   try {
     const answer = await withTimeout(async (signal) => {
       const res = await fetch(`${REST_ORIGIN}${path}`, { signal });
-      return {
-        degraded: res.headers.get("x-metagraph-degraded"),
-        body: (await res.json()) as Row,
-      };
+      return { degraded: degradedHeader(res), body: (await res.json()) as Row };
     });
     if (answer.degraded) return null;
     const data = at(answer.body, "data");
@@ -156,16 +166,17 @@ async function restBody(path: string): Promise<Row | null> {
 
 async function graphqlField(plan: FieldPlan): Promise<Row | null> {
   try {
-    const body = await withTimeout(async (signal) => {
+    const answer = await withTimeout(async (signal) => {
       const res = await fetch(GRAPHQL_ENDPOINT, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ query: plan.query }),
         signal,
       });
-      return (await res.json()) as Row;
+      return { degraded: degradedHeader(res), body: (await res.json()) as Row };
     });
-    const value = at(body, "data", plan.field);
+    if (answer.degraded) return null;
+    const value = at(answer.body, "data", plan.field);
     return value && typeof value === "object" && !Array.isArray(value)
       ? (value as Row)
       : null;
@@ -174,10 +185,43 @@ async function graphqlField(plan: FieldPlan): Promise<Row | null> {
   }
 }
 
+/**
+ * The first path-parameter value REST is asked about that the GraphQL query
+ * does not mention, or null when they agree.
+ *
+ * Compares VALUES rather than names because that is what actually has to match:
+ * the two sweeps fill their arguments from separate tables, and a comparison
+ * across surfaces is only meaningful when both were handed the same subject.
+ *
+ * Only path parameters are checked. A query-string default that differs is a
+ * real divergence to report -- two surfaces answering the same subject with
+ * different defaults is exactly what this sweep exists to find.
+ */
+function mismatchedSubject(
+  template: string,
+  path: string,
+  query: string,
+): string | null {
+  const names = [...template.matchAll(/\{([^}]+)\}/g)].map((m) => m[1]!);
+  if (names.length === 0) return null;
+  const templateParts = template.split("/");
+  const pathParts = path.split("?")[0]!.split("/");
+  for (const [index, part] of templateParts.entries()) {
+    if (!part.startsWith("{") || !part.endsWith("}")) continue;
+    const value = pathParts[index];
+    if (!value) continue;
+    const decoded = decodeURIComponent(value);
+    if (!query.includes(decoded)) {
+      return `${part} rest=${decoded}`;
+    }
+  }
+  return null;
+}
+
 let rpcId = 0;
 async function mcpTool(name: string, args: Row): Promise<Row | null> {
   try {
-    const body = await withTimeout(async (signal) => {
+    const answer = await withTimeout(async (signal) => {
       const res = await fetch(MCP_ENDPOINT, {
         method: "POST",
         headers: {
@@ -192,8 +236,10 @@ async function mcpTool(name: string, args: Row): Promise<Row | null> {
         }),
         signal,
       });
-      return (await res.json()) as Row;
+      return { degraded: degradedHeader(res), body: (await res.json()) as Row };
     });
+    if (answer.degraded) return null;
+    const body = answer.body;
     if (at(body, "error") || at(body, "result", "isError")) return null;
     const structured = at(body, "result", "structuredContent");
     return structured && typeof structured === "object"
@@ -286,6 +332,24 @@ export async function run(): Promise<CrossSurfaceReport> {
     if (!plan || !path) {
       report.unpaired.push(
         `${tool} (${template}) -- ${!plan ? "no GraphQL field mirrors it" : "a path parameter has no fixture"}`,
+      );
+      continue;
+    }
+    // The three surfaces must be asked the SAME question before their answers
+    // mean anything together. They are subjected independently -- REST from
+    // conformance-subjects.ts's SUBJECTS, GraphQL from
+    // check-graphql-conformance.ts's own ARGUMENT_FIXTURES -- and the two tables
+    // have drifted: `h160` is 0x1212..12 in one and 0xaaaa..aa in the other. The
+    // sweep duly reported that /evm/address/{h160} "diverges", when it had asked
+    // the two surfaces about two different addresses.
+    //
+    // The plan bakes its arguments into `query`, so the check is whether every
+    // subject value in the concrete REST path appears there. Cheap, and general
+    // over any future drift rather than over the one key that drifted.
+    const subject = mismatchedSubject(template, path, plan.query);
+    if (subject) {
+      report.unpaired.push(
+        `${tool} (${template}) -- surfaces asked different subjects (${subject})`,
       );
       continue;
     }


### PR DESCRIPTION
`check-cross-surface-values` has failed every scheduled run since **2026-08-11**. Both causes are in the sweep, not in the surfaces it compares.

## 1. The degraded header was read on one surface of three

The function that reads it states the rule plainly:

> *"A DEGRADED answer is not a disagreement, and the header is the only way to tell… a labelled response counts as 'did not answer' and lands in the incomplete bucket."*

`restBody` implements it. **`graphqlField` and `mcpTool` never looked.**

All three surfaces set it. Measured against production 2026-08-14, forcing the r2-sql timeout on `/accounts/{ss58}/transfers`:

| surface | on the 15s abort |
| --- | --- |
| REST | `x-metagraph-degraded: tier_unavailable` |
| GraphQL POST | `x-metagraph-degraded: tier_unavailable` |
| MCP POST | `x-metagraph-degraded: tier_unavailable` |

So `get_account_transfers transfer_count: rest 100, graphql 0` — reported three days running — was **GraphQL declining, correctly labelling it, and being scored as a disagreement because nothing read the label.** Hoisted into one `degradedHeader(res)` and applied on all three paths.

## 2. The three surfaces were asked different questions

REST is subjected from `conformance-subjects.ts`'s `SUBJECTS`; GraphQL from `check-graphql-conformance.ts`'s own `ARGUMENT_FIXTURES`. The two tables have drifted on **four** keys:

| parameter | REST asks | GraphQL asks |
| --- | --- | --- |
| `{h160}` | `0x1212…12` | `0xaaaa…aa` |
| `{hash}` | a real decoded extrinsic | `0xaaaa…` |
| `{tag}` | `agents` | `inference` |
| `{slug}` | `academia` | `opentensor-foundation` |

`/evm/address/{h160}` was reported as diverging on both `h160` and `ss58`. **It was not** — the sweep asked the two surfaces about two different addresses and reported that the answers differed.

Fixed generally rather than by aligning one key: the plan bakes its arguments into `query`, so the sweep now checks that every path-parameter value in the concrete REST path appears there, and marks the triple **unpaired — naming the subject** — when it does not. That catches all four and any future drift, and touches only this sweep; `check-graphql-conformance`'s fixtures are its own gate's business.

Deliberately **path** parameters only. A query-string default that differs between surfaces is a real divergence, and finding those is what this sweep is for.

## Measured, against production

| | divergences | incomplete | unpaired |
| --- | ---: | ---: | ---: |
| before (CI 2026-08-13) | **7** | 11 | 23 |
| after fix 1 | 4 | 27 | 19 |
| after both | **5** | 16 | 24 |

The account-transfers pair leaves the divergence bucket for *incomplete*; the four drifted subjects leave it for *unpaired*, each named.

## What is left, and why it is not fixed here

All five remaining divergences are **live counters sampled seconds apart**:

```
weight_sets          rest 212781,    graphql 212764
last_stored_round    rest 31292428,  mcp/graphql 31292431
oldest_stored_round  rest 31076429,  mcp/graphql 31076432
```

drand rounds advance every 3 seconds, and **both randomness fields are off by exactly 3 against both other surfaces** — the sweep's own `CALL_SPACING_MS` between calls, read back as a disagreement. That is structural: this gate cannot go green while it compares monotonic counters sampled at different instants.

Fixing it means deciding what a counter comparison should assert — equality within a tolerance, or simply that it never goes backwards — and **a tolerance is exactly the kind of thing that hides a real regression.** That is a judgement for the owner of #10312, not something to pick unilaterally inside a bug fix.

## Verification

`validate` · `typecheck` · `lint` · `format:check` · `validate:workflows` · `validate:archive-policy` all pass on top of `6814b56d6`, and the sweep was run end-to-end against production three times to produce the table above.