### PR TITLE
perf(neon): stop rewriting 108,732 rows to the values they already hold

### DIFF
--- a/src/neon-write.ts
+++ b/src/neon-write.ts
@@ -343,6 +343,23 @@ export async function pruneKeysInNeon(
  * the ratio of two of them is exact in numeric. The Rust side computed this as
  * u128 -> f64 division, so this is at least as accurate and does not round the
  * denominator before dividing.
+ *
+ * ONLY ROWS THAT WOULD CHANGE. The `IS DISTINCT FROM` guard is not a
+ * micro-optimisation -- without it this was the most expensive statement in the
+ * database by a wide margin, and every write it made was a no-op.
+ *
+ * Measured from pg_stat_statements: 1,698 calls, 182,099,222 rows updated,
+ * 3,189,560 ms of execution and **76 GB of WAL**. Then measured against a real
+ * pass: 108,732 rows in scope, 108,732 already holding exactly the value this
+ * would assign, ZERO that would change. The producer computes the same fraction
+ * the numeric expression does, so every row was rewritten to itself -- and
+ * Postgres has no way to know that without being told, because an UPDATE writes
+ * a new tuple version whether or not the value moved.
+ *
+ * The guard keeps the correction it was written for: a row whose stored value
+ * genuinely disagrees is still fixed, and the statement stays a no-op the rest
+ * of the time. It also keeps `IS DISTINCT FROM` rather than `<>` so a NULL
+ * share_fraction still gets written.
  */
 export async function normalizeShareFractionsInNeon(
   sql: PgUnsafe | null | undefined,
@@ -370,7 +387,8 @@ export async function normalizeShareFractionsInNeon(
           AND p.netuid = t.netuid
           AND p.captured_at = $1
           AND p.shares IS NOT NULL
-          AND t.total > 0`,
+          AND t.total > 0
+          AND p.share_fraction IS DISTINCT FROM (p.shares / t.total)::double precision`,
       [capturedAt],
     );
   } catch (error) {

--- a/tests/nominator-positions-neon-write.test.ts
+++ b/tests/nominator-positions-neon-write.test.ts
@@ -545,4 +545,28 @@ describe("normalizeShareFractionsInNeon", () => {
     assert.equal(result.ok, false);
     assert.match(String(result.reason), /deadlock detected/);
   });
+  test("only rows whose value would CHANGE are written", () => {
+    // This was the most expensive statement in the database: 1,698 calls,
+    // 182,099,222 rows updated, 76 GB of WAL. Measured against a real pass,
+    // 108,732 of 108,732 rows already held exactly the value it assigns and
+    // ZERO would change -- the producer computes the same fraction, so every
+    // write was a no-op that Postgres still had to materialise as a new tuple.
+    const captured: string[] = [];
+    const sql = {
+      unsafe: async (text: string) => {
+        captured.push(text);
+        return [];
+      },
+    } as unknown as Parameters<typeof normalizeShareFractionsInNeon>[0];
+    return normalizeShareFractionsInNeon(sql, 1_700_000_000_000).then(() => {
+      const statement = captured[0] ?? "";
+      assert.match(statement, /IS DISTINCT FROM/);
+      // IS DISTINCT FROM rather than <>, so a NULL share_fraction is still
+      // written rather than compared away to NULL.
+      assert.ok(
+        !/share_fraction\s*<>/.test(statement),
+        "a plain <> would skip rows whose stored fraction is NULL",
+      );
+    });
+  });
 });


### PR DESCRIPTION
`normalizeShareFractionsInNeon` was **the most expensive statement in the database**, and every write it made was a no-op.

## Measured, from `pg_stat_statements`

```
1,698 calls
182,099,222 rows updated
3,189,560 ms total execution (53 minutes)
76 GB of WAL
2.08 billion shared-buffer hits
```

Every other query in the top 12 combined is a rounding error next to it.

## Then measured against a real pass

| | |
| --- | ---: |
| rows in scope | 108,732 |
| already holding exactly the value it assigns | **108,732** |
| that would change | **0** |

The producer computes the same fraction the `numeric` expression does, so every row was rewritten to itself. Postgres cannot know that without being told — an `UPDATE` writes a new tuple version whether or not the value moved, and pays full WAL for it.

## The docstring had gone stale in an expensive way

It said `WHERE shares IS NOT NULL` *"matches nothing today, so the statement is a no-op… It becomes load-bearing the moment a pass carries shares, with no second deploy."*

That was true when written. Shares now arrive, so it became load-bearing **exactly as designed** — and nothing revisited what it would cost once it did.

## The fix keeps the correction it was written for

```sql
AND p.share_fraction IS DISTINCT FROM (p.shares / t.total)::double precision
```

A row whose stored value genuinely disagrees is still fixed; the statement is a no-op the rest of the time.

`IS DISTINCT FROM` rather than `<>` so a **NULL** `share_fraction` is still written rather than compared away to NULL — pinned by a test, since `<>` would look correct and silently skip exactly the rows that most need writing.

## Verified on production

```
EXPLAIN (ANALYZE, BUFFERS)
Update on nominator_positions p  (actual rows=0.00)
Execution Time: 596.087 ms
```

Zero rows written, where it previously wrote ~107k per call.

**51 of 51 CI validators. 20,730 tests, 905 files.**