### PR TITLE
fix(ai-search): chunk the Vectorize delete, which rejects past 100 ids

### DIFF
--- a/src/ai-search.ts
+++ b/src/ai-search.ts
@@ -467,7 +467,20 @@ export async function runEmbeddingSync(
     embedded += valid.length;
   }
   if (removed.length && typeof env.VECTORIZE.deleteByIds === "function") {
-    await env.VECTORIZE.deleteByIds(removed);
+    // CHUNKED, like the upsert above. Vectorize caps deleteByIds at 100 ids and
+    // rejects the whole call past it -- observed in production as
+    // `VECTOR_DELETE_ERROR (code = 40007): too many ids in payload; max id
+    // count is 100, got 173`.
+    //
+    // The upsert was chunked from the start because embedding is batched
+    // anyway; the delete was not, because `removed` is usually small. It only
+    // fails on a large prune, which is exactly when it matters -- a rejected
+    // call leaves every stale vector in the index, so `semantic_search` keeps
+    // returning documents the registry no longer has, and the manifest is
+    // written as though the delete succeeded.
+    for (const ids of chunk(removed, EMBED_BATCH_SIZE)) {
+      await env.VECTORIZE.deleteByIds(ids);
+    }
   }
   if (env?.METAGRAPH_CONTROL?.put) {
     await env.METAGRAPH_CONTROL.put(EMBED_MANIFEST_KEY, JSON.stringify(next));

--- a/tests/ai-search.test.ts
+++ b/tests/ai-search.test.ts
@@ -1549,6 +1549,42 @@ describe("ai-search defensive branches", () => {
     assert.equal(r.ok, true);
   });
 
+  test("a large prune is deleted in chunks of 100, not one oversized call", async () => {
+    // Vectorize caps deleteByIds at 100 and rejects the WHOLE call past it.
+    // Seen in production as `VECTOR_DELETE_ERROR (code = 40007): too many ids
+    // in payload; max id count is 100, got 173`. A rejected delete leaves every
+    // stale vector in the index while the manifest is written as though it
+    // succeeded, so semantic_search keeps returning documents the registry no
+    // longer has.
+    const stale: Record<string, string> = {};
+    for (let i = 0; i < 173; i += 1) stale[`subnet:gone-${i}`] = `hash-${i}`;
+    const kv = memKv({ [EMBED_MANIFEST_KEY]: JSON.stringify(stale) });
+    const vectorize = stubVectorize();
+    const deletes: unknown[][] = [];
+    (vectorize as Row).deleteByIds = (ids: unknown[]) => {
+      deletes.push(ids);
+      return Promise.resolve({ count: ids.length });
+    };
+    const env = { AI: stubAi(), VECTORIZE: vectorize, METAGRAPH_CONTROL: kv };
+
+    await runEmbeddingSync(mockEnv(env), {
+      readArtifact: (() => Promise.resolve(oneDoc)) as unknown as ReadArtifact,
+    });
+
+    assert.ok(deletes.length >= 2, "173 ids must not go in one call");
+    for (const batch of deletes) {
+      assert.ok(
+        batch.length <= 100,
+        `a delete carried ${batch.length} ids, over the cap of 100`,
+      );
+    }
+    assert.equal(
+      deletes.flat().length,
+      173,
+      "every stale id must still be deleted",
+    );
+  });
+
   test("runEmbeddingSync skips deletion when VECTORIZE lacks deleteByIds", async () => {
     const kv = memKv({
       [EMBED_MANIFEST_KEY]: JSON.stringify({ "subnet:9": "stalehash" }),


### PR DESCRIPTION
Found in PostHog error tracking, first seen **2026-08-13T20:37Z**:

```
VECTOR_DELETE_ERROR (code = 40007): too many ids in payload; max id count is 100, got 173
```

`runEmbeddingSync` chunked its **upsert** from the start — embedding is batched anyway — and passed the whole `removed` array to `deleteByIds`. Vectorize caps that at 100 and rejects the **entire call** past it.

## Why it matters more than a failed delete

It only fails on a **large prune**, which is exactly when it matters most:

- a rejected delete leaves **every** stale vector in the index
- the manifest is still written as though the delete succeeded
- so `semantic_search` keeps returning documents the registry no longer has
- and the next run reads a manifest saying those ids are already gone — **the index never converges**

Chunked at `EMBED_BATCH_SIZE`, the constant the upsert already uses.

## The test

Builds 173 stale ids and asserts three things: more than one call, no call over 100, and **173 ids still deleted in total**. That last assertion is the one that matters — chunking that dropped the tail would satisfy the first two and still lose data.

Verified it fails against the unbatched version:

```
unbatched -> × a large prune is deleted in chunks of 100, not one oversized call
restored  -> ✓ passes
```

**51 of 51 CI validators. 20,738 tests, 906 files.**