### PR TITLE
docs(contract): say which grain each miner-earnings figure is measured at

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -2686,23 +2686,54 @@ type SubnetEmissionSplitHistoryPoint {
 }
 
 type SubnetEmissionSplitMinerEarnings {
+  """
+  Miner UIDs that recorded emission on ANY day of the window. A WINDOW count, deliberately not a live one: /chain/concentration/subnets publishes an \`earning_miner_count\` of its own read off the current snapshot, so the two differ by the miners that earned earlier in the window and do not right now -- and the smaller live number is the one that describes today.
+  """
   earning_miner_count: Int!
 
   """
   Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income.
   """
   zero_miner_count: Int!
+
+  """
+  The MEDIAN earning miner's alpha per day: their share of the window's summed miner emission (validators and the burn sink excluded) x the basis point's miner_alpha_day. Nearest-rank, so it is a real miner's figure and not an interpolation.
+  """
   p50_alpha_day: Float
+
+  """
+  The 75th-percentile earning miner's alpha per day, same derivation as p50.
+  """
   p75_alpha_day: Float
+
+  """
+  The 90th-percentile earning miner's alpha per day, same derivation as p50.
+  """
   p90_alpha_day: Float
+
+  """
+  The single largest earning miner's alpha per day. A ceiling, never a typical figure -- on a concentrated subnet it is multiples of p90.
+  """
   top_alpha_day: Float
 
   """
   What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price).
   """
   p50_usd_day: Float
+
+  """
+  The 75th-percentile earning miner's USD per day, same derivation as p50_usd_day.
+  """
   p75_usd_day: Float
+
+  """
+  The 90th-percentile earning miner's USD per day, same derivation as p50_usd_day.
+  """
   p90_usd_day: Float
+
+  """
+  The single largest earning miner's USD per day. A ceiling, never a typical figure.
+  """
   top_usd_day: Float
 
   """

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6487,15 +6487,23 @@ export type SubnetEmissionSplitMinerEarnings = {
   __typename?: 'SubnetEmissionSplitMinerEarnings';
   /** The point whose per-day legs priced these figures -- the newest in the window. */
   basis_date?: Maybe<Scalars['String']['output']>;
+  /** Miner UIDs that recorded emission on ANY day of the window. A WINDOW count, deliberately not a live one: /chain/concentration/subnets publishes an `earning_miner_count` of its own read off the current snapshot, so the two differ by the miners that earned earlier in the window and do not right now -- and the smaller live number is the one that describes today. */
   earning_miner_count: Scalars['Int']['output'];
+  /** The MEDIAN earning miner's alpha per day: their share of the window's summed miner emission (validators and the burn sink excluded) x the basis point's miner_alpha_day. Nearest-rank, so it is a real miner's figure and not an interpolation. */
   p50_alpha_day?: Maybe<Scalars['Float']['output']>;
   /** What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price). */
   p50_usd_day?: Maybe<Scalars['Float']['output']>;
+  /** The 75th-percentile earning miner's alpha per day, same derivation as p50. */
   p75_alpha_day?: Maybe<Scalars['Float']['output']>;
+  /** The 75th-percentile earning miner's USD per day, same derivation as p50_usd_day. */
   p75_usd_day?: Maybe<Scalars['Float']['output']>;
+  /** The 90th-percentile earning miner's alpha per day, same derivation as p50. */
   p90_alpha_day?: Maybe<Scalars['Float']['output']>;
+  /** The 90th-percentile earning miner's USD per day, same derivation as p50_usd_day. */
   p90_usd_day?: Maybe<Scalars['Float']['output']>;
+  /** The single largest earning miner's alpha per day. A ceiling, never a typical figure -- on a concentrated subnet it is multiples of p90. */
   top_alpha_day?: Maybe<Scalars['Float']['output']>;
+  /** The single largest earning miner's USD per day. A ceiling, never a typical figure. */
   top_usd_day?: Maybe<Scalars['Float']['output']>;
   /** Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income. */
   zero_miner_count: Scalars['Int']['output'];

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -6673,7 +6673,7 @@ export interface components {
             sort: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
             subnet_count: number;
             subnets: {
-                /** @description How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version. */
+                /** @description How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain, read off the current snapshot. The windowed answer is /subnets/{netuid}/emission-split/history -- per day on each point, and over the whole window in `miner_earnings.earning_miner_count` -- and it is the larger number, because it counts miners that earned earlier in the window and do not now. */
                 earning_miner_count?: number;
                 entity_count: number;
                 entropy: number | null;
@@ -11239,15 +11239,23 @@ export interface components {
             miner_earnings?: {
                 /** @description The point whose per-day legs priced these figures -- the newest in the window. */
                 basis_date: string | null;
+                /** @description Miner UIDs that recorded emission on ANY day of the window. A WINDOW count, deliberately not a live one: /chain/concentration/subnets publishes an `earning_miner_count` of its own read off the current snapshot, so the two differ by the miners that earned earlier in the window and do not right now -- and the smaller live number is the one that describes today. */
                 earning_miner_count: number;
+                /** @description The MEDIAN earning miner's alpha per day: their share of the window's summed miner emission (validators and the burn sink excluded) x the basis point's miner_alpha_day. Nearest-rank, so it is a real miner's figure and not an interpolation. */
                 p50_alpha_day: number | null;
                 /** @description What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price). */
                 p50_usd_day: number | null;
+                /** @description The 75th-percentile earning miner's alpha per day, same derivation as p50. */
                 p75_alpha_day: number | null;
+                /** @description The 75th-percentile earning miner's USD per day, same derivation as p50_usd_day. */
                 p75_usd_day: number | null;
+                /** @description The 90th-percentile earning miner's alpha per day, same derivation as p50. */
                 p90_alpha_day: number | null;
+                /** @description The 90th-percentile earning miner's USD per day, same derivation as p50_usd_day. */
                 p90_usd_day: number | null;
+                /** @description The single largest earning miner's alpha per day. A ceiling, never a typical figure -- on a concentrated subnet it is multiples of p90. */
                 top_alpha_day: number | null;
+                /** @description The single largest earning miner's USD per day. A ceiling, never a typical figure. */
                 top_usd_day: number | null;
                 /** @description Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income. */
                 zero_miner_count: number;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -22803,7 +22803,7 @@
               "additionalProperties": false,
               "properties": {
                 "earning_miner_count": {
-                  "description": "How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version.",
+                  "description": "How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain, read off the current snapshot. The windowed answer is /subnets/{netuid}/emission-split/history -- per day on each point, and over the whole window in `miner_earnings.earning_miner_count` -- and it is the larger number, because it counts miners that earned earlier in the window and do not now.",
                   "maximum": 9007199254740991,
                   "minimum": 0,
                   "type": "integer"
@@ -48487,6 +48487,7 @@
                     "description": "The point whose per-day legs priced these figures -- the newest in the window."
                   },
                   "earning_miner_count": {
+                    "description": "Miner UIDs that recorded emission on ANY day of the window. A WINDOW count, deliberately not a live one: /chain/concentration/subnets publishes an `earning_miner_count` of its own read off the current snapshot, so the two differ by the miners that earned earlier in the window and do not right now -- and the smaller live number is the one that describes today.",
                     "maximum": 9007199254740991,
                     "minimum": 0,
                     "type": "integer"
@@ -48499,7 +48500,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The MEDIAN earning miner's alpha per day: their share of the window's summed miner emission (validators and the burn sink excluded) x the basis point's miner_alpha_day. Nearest-rank, so it is a real miner's figure and not an interpolation."
                   },
                   "p50_usd_day": {
                     "anyOf": [
@@ -48520,7 +48522,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The 75th-percentile earning miner's alpha per day, same derivation as p50."
                   },
                   "p75_usd_day": {
                     "anyOf": [
@@ -48530,7 +48533,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The 75th-percentile earning miner's USD per day, same derivation as p50_usd_day."
                   },
                   "p90_alpha_day": {
                     "anyOf": [
@@ -48540,7 +48544,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The 90th-percentile earning miner's alpha per day, same derivation as p50."
                   },
                   "p90_usd_day": {
                     "anyOf": [
@@ -48550,7 +48555,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The 90th-percentile earning miner's USD per day, same derivation as p50_usd_day."
                   },
                   "top_alpha_day": {
                     "anyOf": [
@@ -48560,7 +48566,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The single largest earning miner's alpha per day. A ceiling, never a typical figure -- on a concentrated subnet it is multiples of p90."
                   },
                   "top_usd_day": {
                     "anyOf": [
@@ -48570,7 +48577,8 @@
                       {
                         "type": "null"
                       }
-                    ]
+                    ],
+                    "description": "The single largest earning miner's USD per day. A ceiling, never a typical figure."
                   },
                   "zero_miner_count": {
                     "description": "Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income.",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -6673,7 +6673,7 @@ export interface components {
             sort: "nakamoto_coefficient" | "gini" | "holders" | "top_1pct_share" | "total" | "netuid";
             subnet_count: number;
             subnets: {
-                /** @description How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version. */
+                /** @description How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain, read off the current snapshot. The windowed answer is /subnets/{netuid}/emission-split/history -- per day on each point, and over the whole window in `miner_earnings.earning_miner_count` -- and it is the larger number, because it counts miners that earned earlier in the window and do not now. */
                 earning_miner_count?: number;
                 entity_count: number;
                 entropy: number | null;
@@ -11239,15 +11239,23 @@ export interface components {
             miner_earnings?: {
                 /** @description The point whose per-day legs priced these figures -- the newest in the window. */
                 basis_date: string | null;
+                /** @description Miner UIDs that recorded emission on ANY day of the window. A WINDOW count, deliberately not a live one: /chain/concentration/subnets publishes an `earning_miner_count` of its own read off the current snapshot, so the two differ by the miners that earned earlier in the window and do not right now -- and the smaller live number is the one that describes today. */
                 earning_miner_count: number;
+                /** @description The MEDIAN earning miner's alpha per day: their share of the window's summed miner emission (validators and the burn sink excluded) x the basis point's miner_alpha_day. Nearest-rank, so it is a real miner's figure and not an interpolation. */
                 p50_alpha_day: number | null;
                 /** @description What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price). */
                 p50_usd_day: number | null;
+                /** @description The 75th-percentile earning miner's alpha per day, same derivation as p50. */
                 p75_alpha_day: number | null;
+                /** @description The 75th-percentile earning miner's USD per day, same derivation as p50_usd_day. */
                 p75_usd_day: number | null;
+                /** @description The 90th-percentile earning miner's alpha per day, same derivation as p50. */
                 p90_alpha_day: number | null;
+                /** @description The 90th-percentile earning miner's USD per day, same derivation as p50_usd_day. */
                 p90_usd_day: number | null;
+                /** @description The single largest earning miner's alpha per day. A ceiling, never a typical figure -- on a concentrated subnet it is multiples of p90. */
                 top_alpha_day: number | null;
+                /** @description The single largest earning miner's USD per day. A ceiling, never a typical figure. */
                 top_usd_day: number | null;
                 /** @description Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income. */
                 zero_miner_count: number;

--- a/schemas-src/routes/chain-concentration-subnets.ts
+++ b/schemas-src/routes/chain-concentration-subnets.ts
@@ -30,7 +30,7 @@ export const SubnetConcentrationRowSchema = z
     }),
     earning_miner_count: z.int().min(0).optional().meta({
       description:
-        "How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain; the per-subnet miner-fairness route answers it over a window, which is the durable version.",
+        "How many of them carry emission right now. Against miner_uid_count this is the screening fact a count alone hides -- and this bulk row is the LIVE grain, read off the current snapshot. The windowed answer is /subnets/{netuid}/emission-split/history -- per day on each point, and over the whole window in `miner_earnings.earning_miner_count` -- and it is the larger number, because it counts miners that earned earlier in the window and do not now.",
     }),
     holders: z.int().min(0).nullable(),
     total: z.number().nullable(),

--- a/schemas-src/routes/emission-split.ts
+++ b/schemas-src/routes/emission-split.ts
@@ -124,22 +124,46 @@ export const SubnetEmissionSplitHistoryArtifactSchema =
     .extend({
       miner_earnings: z
         .object({
-          earning_miner_count: z.int().min(0),
+          earning_miner_count: z.int().min(0).meta({
+            description:
+              "Miner UIDs that recorded emission on ANY day of the window. A WINDOW count, deliberately not a live one: /chain/concentration/subnets publishes an `earning_miner_count` of its own read off the current snapshot, so the two differ by the miners that earned earlier in the window and do not right now -- and the smaller live number is the one that describes today.",
+          }),
           zero_miner_count: z.int().min(0).meta({
             description:
               "Miner UIDs seen in the window that never recorded emission -- published beside the percentiles because on the median subnet this is most of them, and a distribution over earners alone reads as universal income.",
           }),
-          p50_alpha_day: z.number().nullable(),
-          p75_alpha_day: z.number().nullable(),
-          p90_alpha_day: z.number().nullable(),
-          top_alpha_day: z.number().nullable(),
+          p50_alpha_day: z.number().nullable().meta({
+            description:
+              "The MEDIAN earning miner's alpha per day: their share of the window's summed miner emission (validators and the burn sink excluded) x the basis point's miner_alpha_day. Nearest-rank, so it is a real miner's figure and not an interpolation.",
+          }),
+          p75_alpha_day: z.number().nullable().meta({
+            description:
+              "The 75th-percentile earning miner's alpha per day, same derivation as p50.",
+          }),
+          p90_alpha_day: z.number().nullable().meta({
+            description:
+              "The 90th-percentile earning miner's alpha per day, same derivation as p50.",
+          }),
+          top_alpha_day: z.number().nullable().meta({
+            description:
+              "The single largest earning miner's alpha per day. A ceiling, never a typical figure -- on a concentrated subnet it is multiples of p90.",
+          }),
           p50_usd_day: z.number().nullable().meta({
             description:
               "What the MEDIAN earning miner makes per day in USD -- each UID's share of the window's summed miner emission (validators and the burn sink excluded) x the newest point's miner_usd_day. Null when that point's USD chain is (no priced tao-usd day, unknown alpha price).",
           }),
-          p75_usd_day: z.number().nullable(),
-          p90_usd_day: z.number().nullable(),
-          top_usd_day: z.number().nullable(),
+          p75_usd_day: z.number().nullable().meta({
+            description:
+              "The 75th-percentile earning miner's USD per day, same derivation as p50_usd_day.",
+          }),
+          p90_usd_day: z.number().nullable().meta({
+            description:
+              "The 90th-percentile earning miner's USD per day, same derivation as p50_usd_day.",
+          }),
+          top_usd_day: z.number().nullable().meta({
+            description:
+              "The single largest earning miner's USD per day. A ceiling, never a typical figure.",
+          }),
           basis_date: z.string().nullable().meta({
             description:
               "The point whose per-day legs priced these figures -- the newest in the window.",


### PR DESCRIPTION
## Summary

`earning_miner_count` is published by two surfaces at two grains, and until now with one description between them:

| surface | grain | SN13 today |
|---|---|---|
| `/chain/concentration/subnets` bulk row | miners carrying emission in the CURRENT snapshot | 238 |
| `emission-split/history` → `miner_earnings` | miners that earned on ANY day of the window | 246 |

Both declarations now state their own grain and name the other, so the eight-miner gap reads as two questions rather than a contradiction.

The seven percentile figures beside the count (`p50/p75/p90/top` in alpha and USD) had no description at all — nothing said they are nearest-rank over per-UID window sums rather than averages, or that `top_*` is a ceiling. They do now.

The concentration row also pointed readers at miner-fairness for the windowed version; that route publishes no such count. Corrected to `emission-split/history`.

Contract-only: descriptions plus the regenerated OpenAPI, GraphQL SDL and types. No behaviour, no field added or removed.

## Validation

`npm run build`, `validate:contract-drift`, `validate:api`, `lint`, `format:check`, `typecheck`, api-reference docs regenerated, and `tests/emission-split.test.ts` + `tests/zod-schemas.test.ts` + `tests/field-provenance.test.ts` (452 tests).

Closes #11138