### PR TITLE
fix(lakehouse): the offset over-fetch is a row count standing in for a byte budget

### DIFF
--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -49,8 +49,38 @@ const BLOCK_COLUMNS = BLOCKS_COLUMNS.join(", ");
  * reasonable trade and the loader declines, so the caller degrades to its
  * schema-stable empty rather than serving a page that is quietly wrong or
  * spending seconds scanning for a page nobody paginated to by hand.
+ *
+ * ## WHY 250 AND NOT 1000 (#11140)
+ *
+ * This is a ROW count standing in for a BYTE budget, and the two came apart on
+ * `chain.extrinsics`. R2 SQL has no OFFSET, so a deep page is emulated by
+ * over-fetching `limit + offset` rows and slicing -- at the old 1000, with a
+ * limit ceiling of 100, one page pulled up to 1,100 rows. Every row carries
+ * `call_args`, whose width is not bounded by anything.
+ *
+ * Measured 2026-08-14 on `chain_detail_extrinsics` (120,373 rows): avg
+ * `call_args` 1,425 B, p99 4,894 B, max 67,657 B -- a 45x spread. A typical
+ * 1,100-row page is ~1.5 MB and fine. But a FILTERED read concentrates the wide
+ * rows: `MevShield.submit_encrypted` averages 4,821 B and `Proxy.proxy` reaches
+ * 67,657 B, so `WHERE signer = ...` for an account that batches heavily returns
+ * a page of uniformly large rows.
+ *
+ * That is not hypothetical. Production declined four of these with
+ * `body_too_large`, and the received counts say the cap is not the variable:
+ * three tripped an 8 MB cap and the fourth tripped a **12 MB** one, after the
+ * cap had already been raised. Raising it again is the experiment that already
+ * failed -- and buffering >12 MB inside an isolate to serve one page is the
+ * wrong trade regardless.
+ *
+ * 250 caps the over-fetch at 350 rows, which is ~4 MB at the density that blew
+ * past 12 MB -- back under budget with room, by shrinking the fetch rather than
+ * growing the buffer. Depth beyond this is NOT lost: a cursor page sets `paged`
+ * to 0 and never over-fetches, so keyset pagination still walks the whole feed.
+ * A row count cannot bound bytes when row width varies 45x, so this is a
+ * measured margin, not a proof -- see the issue for the typed decline that
+ * replaces the silent empty page when it is exceeded anyway.
  */
-export const OFFSET_EMULATION_CAP = 1000;
+export const OFFSET_EMULATION_CAP = 250;
 
 export interface BlockFeedQuery {
   limit: number;

--- a/tests/r2-sql-blocks.test.ts
+++ b/tests/r2-sql-blocks.test.ts
@@ -13,6 +13,7 @@ import {
   safeAuthorLiteral,
 } from "../src/r2-sql-blocks.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
+import { CHAIN_EVENTS_LIMIT_MAX } from "../src/route-limits.ts";
 import { mockEnv } from "./row-type.ts";
 
 const TOKEN = { [R2_SQL_TOKEN_ENV]: "cfut_test" };
@@ -87,6 +88,39 @@ describe("loadBlockFeedFromR2Sql", () => {
     assert.ok(!/OFFSET/i.test(queries[0]!), "never emits an OFFSET clause");
     assert.equal(data!.blocks[0]!.block_number, 8);
     assert.equal(data!.blocks.length, 2);
+  });
+
+  test("the offset cap keeps the worst measured page under the body cap (#11140)", () => {
+    // NOT `OFFSET_EMULATION_CAP === 250` -- that asserts the code's own
+    // assumption and passes at any value. This pins the ARITHMETIC the constant
+    // exists to satisfy, so raising it back fails here with the reason.
+    //
+    // The over-fetch is `limit + offset` rows (R2 SQL has no OFFSET), each
+    // carrying an unbounded `call_args`. Measured 2026-08-14 on
+    // chain_detail_extrinsics: a filtered read concentrates the wide rows, and
+    // the density that actually declined in production implies ~11.4 KB/row --
+    // that page tripped a 12 MB cap, so the cap is not the free variable.
+    // Imported, not retyped: raising the limit ceiling widens the same
+    // over-fetch, so this must fail then too rather than pass on a stale 100.
+    const MAX_PAGE_LIMIT = CHAIN_EVENTS_LIMIT_MAX;
+    const OBSERVED_WIDE_ROW_BYTES = 11_400;
+    const PRODUCTION_BODY_CAP = 8 * 1024 * 1024;
+
+    const worstFetch = OFFSET_EMULATION_CAP + MAX_PAGE_LIMIT;
+    const worstBytes = worstFetch * OBSERVED_WIDE_ROW_BYTES;
+    assert.ok(
+      worstBytes < PRODUCTION_BODY_CAP,
+      `an emulated-offset page may fetch ${worstFetch} rows, which is ` +
+        `${worstBytes} bytes at the observed wide-row density and exceeds the ` +
+        `${PRODUCTION_BODY_CAP}-byte cap. Lower OFFSET_EMULATION_CAP; do not ` +
+        `raise the body cap -- 8 MB was already raised to 12 MB and still declined.`,
+    );
+    // And the margin is real, not a hair under: at least 2x headroom, so an
+    // era with denser payloads than the one measured does not reintroduce it.
+    assert.ok(
+      worstBytes * 2 < PRODUCTION_BODY_CAP,
+      "the offset cap should leave at least 2x headroom against the body cap",
+    );
   });
 
   test("declines a too-deep offset rather than scanning for it", async () => {


### PR DESCRIPTION
## What

Lowers `OFFSET_EMULATION_CAP` 1000 → 250, and pins the arithmetic that number has to satisfy.

## Why

R2 SQL has no `OFFSET`, so a deep cold-tier page is emulated by fetching `limit + offset` rows and slicing. At 1000, with a limit ceiling of 100, one page pulled **up to 1,100 rows** — each carrying an unbounded `call_args`. Production declined four such reads with `body_too_large`.

The received counts say the body cap was never the free variable: three tripped an **8 MB** cap and the fourth tripped a **12 MB** one, *after* the cap had already been raised. Growing the buffer is the experiment that already failed, and buffering >12 MB inside an isolate to serve one page is the wrong trade regardless.

Measured on `chain_detail_extrinsics` (120,373 rows): avg `call_args` 1,425 B, p99 4,894 B, max 67,657 B — a 45× spread. A typical 1,100-row page is ~1.5 MB and fine. But a **filtered** read concentrates the wide rows (`MevShield.submit_encrypted` averages 4,821 B; `Proxy.proxy` reaches 67,657 B), so `WHERE signer = ...` for an account that batches heavily returns a page of uniformly large rows. The density that actually declined implies ~11.4 KB/row.

250 caps the over-fetch at 350 rows — ~4 MB at that density — by shrinking the fetch instead of growing the buffer.

## Depth is not lost

A cursor page sets `paged` to 0 and never over-fetches, so keyset pagination still walks the entire feed. Only emulated-offset depth past 250 declines, and those are precisely the pages that were producing multi-MB responses and sometimes failing outright.

## Test

Pins the **arithmetic**, not the constant — `OFFSET_EMULATION_CAP === 250` would assert the code's own assumption and pass at any value. It imports `CHAIN_EVENTS_LIMIT_MAX` so raising the limit ceiling widens the same over-fetch and fails here too.

Verified it can fail: at the old 1000 it reports `12540000 bytes`, which matches the >12,582,912 production actually saw.

`tsc` clean; 1,217 tests pass across the touched cold-tier and graphql suites; prettier and eslint clean; `validate-r2-sql-scan-bounds` green.

## Follow-up

The residual — that exceeding the budget still degrades to a silent empty page indistinguishable from end-of-feed — is #11142.

Closes #11140