### PR TITLE
fix(mcp): a projected tool result is validated as projected, like REST already does

### DIFF
--- a/src/mcp-response-tripwire.ts
+++ b/src/mcp-response-tripwire.ts
@@ -54,6 +54,7 @@
 // have been a contract agreeing with itself and proving nothing -- before the
 // flag was allowed to matter anywhere.
 import { outputSchemaSource } from "./mcp-input-schema.ts";
+import { isProjectedAway } from "./projection-signal.ts";
 
 /** The stable code an agent branches on, and telemetry groups by. */
 export const MCP_RESPONSE_DRIFT_CODE = "response_schema_drift";
@@ -163,6 +164,14 @@ export function validateMcpResponseTripwire(
   tool: string,
   published: unknown,
   structuredContent: unknown,
+  /**
+   * True when the CALLER asked for less -- `fields`, `sections`, or
+   * `include_points: false`. A projected result is shorter than the schema that
+   * describes it by design, so absence stops being a drift; see
+   * src/projection-signal.ts for what stays enforced, and why this had to be
+   * shared with REST rather than asked twice.
+   */
+  projected = false,
 ): void {
   let schema;
   try {
@@ -177,8 +186,18 @@ export function validateMcpResponseTripwire(
     );
     return;
   }
-  const result = schema.safeParse(asSentOverTheWire(structuredContent));
+  const wire = asSentOverTheWire(structuredContent);
+  const result = schema.safeParse(wire);
   if (!result.success) {
-    throw new McpResponseSchemaDriftError(tool, result.error);
+    const issues = projected
+      ? result.error.issues.filter(
+          (issue) => !isProjectedAway(wire, issue.path),
+        )
+      : result.error.issues;
+    // Every issue explained by the projection means the result is exactly what
+    // was asked for. Anything left is a real drift and still throws.
+    if (issues.length > 0) {
+      throw new McpResponseSchemaDriftError(tool, { ...result.error, issues });
+    }
   }
 }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -726,6 +726,7 @@ import {
   stripSentinelIntegerBounds,
 } from "./mcp-input-schema.ts";
 import { validateMcpResponseTripwire } from "./mcp-response-tripwire.ts";
+import { argsProject } from "./projection-signal.ts";
 import {
   buildSubnetValidatorEconomicsPayload,
   resolveEconomicsBlob,
@@ -16839,7 +16840,15 @@ async function dispatchTool(
       (ctx?.env as unknown as Row | undefined)?.METAGRAPH_VALIDATE_RESPONSES ===
       "true"
     ) {
-      validateMcpResponseTripwire(tool.name, outputSchema, payload);
+      // `argsProject` is the MCP half of the signal workers/api.ts derives
+      // from the URL -- one rule, one module, so a projection lever added to
+      // one surface cannot go missing on the other (#11142).
+      validateMcpResponseTripwire(
+        tool.name,
+        outputSchema,
+        payload,
+        argsProject(args),
+      );
     }
     return {
       content: toolResultContent(payload, outputSchema, ctx?.protocolVersion),

--- a/src/projection-signal.ts
+++ b/src/projection-signal.ts
@@ -1,0 +1,104 @@
+// "Did the caller ask for less?" — one answer, for both surfaces that validate
+// what they serve.
+//
+// ## WHY THIS IS SHARED RATHER THAN ASKED TWICE
+//
+// A projected response is SHORTER than the schema that describes it, on
+// purpose. `required` describes the unprojected document (#10960), so every
+// response tripwire has to know whether a projection happened before it can
+// call an absent key a drift.
+//
+// REST learned this in #10975: `?fields=name` returned 500 on six routes,
+// because the component describes the whole row and the caller had asked for
+// one column. #11079 added `include_points=false` to the same list for the same
+// reason. Both fixes landed in workers/api.ts as a URL-parameter check, and the
+// MCP dispatch — which accepts the SAME three levers as tool ARGUMENTS — never
+// got either. Measured 2026-08-14: `get_subnet(netuid=105,
+// sections="health,counts,curation,gaps")` failed with `response_schema_drift`
+// on `netuid`, a key the caller had deliberately not selected, on a response
+// that was exactly what was asked for. The REST route serving the same
+// projection answered 200.
+//
+// So the two seams disagreed about one contract, which is the thing the
+// zero-drift epic exists to stop. The vocabulary lives here, once, and both
+// callers derive from it: a fourth lever added tomorrow reaches both surfaces
+// or neither.
+//
+// ## WHAT A PROJECTION IS ALLOWED TO DO
+//
+// Remove keys. That is all. It cannot add one and it cannot change a type, so
+// `isProjectedAway` forgives ABSENCE and only at the issue's own path — an
+// unrecognized key or a present value of the wrong type still fails, on both
+// surfaces. Those are the two things a caller would actually be hurt by.
+
+/**
+ * The parameters that make a response smaller by request.
+ *
+ * `fields` picks columns out of the rows of a list; `sections` picks whole
+ * cards out of one composite document (#10600). They are different units of
+ * selection and deliberately different names, but they have the same
+ * consequence for a response validator.
+ */
+export const PROJECTION_PARAMETERS = ["fields", "sections"] as const;
+
+/**
+ * The third lever, which is not a parameter name but a value.
+ *
+ * `include_points=false` omits `data.points` BY REQUEST (#9720). It is spelled
+ * out rather than folded into the list above because only the literal `false`
+ * projects — any other value either defaults to true or is refused before a
+ * response exists to validate.
+ */
+export const PROJECTION_TOGGLE = "include_points" as const;
+
+/** REST's signal: the request URL carried a projecting parameter. */
+export function urlProjects(params: URLSearchParams): boolean {
+  return (
+    PROJECTION_PARAMETERS.some((name) => params.has(name)) ||
+    params.get(PROJECTION_TOGGLE) === "false"
+  );
+}
+
+/**
+ * MCP's signal: the tool call carried a projecting argument.
+ *
+ * An EMPTY string does not project — `fields: ""` selects nothing and the
+ * parsers refuse it upstream, so treating it as a projection here would forgive
+ * absence on a call that never narrowed anything. `include_points` arrives as a
+ * real boolean over MCP rather than the string REST parses.
+ */
+export function argsProject(args: unknown): boolean {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return false;
+  const record = args as Record<string, unknown>;
+  for (const name of PROJECTION_PARAMETERS) {
+    const value = record[name];
+    if (typeof value === "string" && value.length > 0) return true;
+  }
+  return record[PROJECTION_TOGGLE] === false;
+}
+
+/**
+ * Is this validation issue just a key the projection removed?
+ *
+ * Resolved by walking the path into the payload rather than matching on the
+ * issue's message, because a message is prose and this is a gate. `undefined`
+ * at the issue's own path means the value is genuinely absent; anything else
+ * present means the issue is about something the projection did not do.
+ *
+ * EXPORTED for its own test. The mid-path guard cannot be reached through a
+ * real Zod issue -- Zod reports at the level that failed and never emits a path
+ * descending THROUGH a scalar -- so the only way to prove it fires is to hand it
+ * such a path directly. Testing it beats suppressing it: this is the one place
+ * either tripwire can forgive a real drift, which it must never do.
+ */
+export function isProjectedAway(
+  payload: unknown,
+  path: readonly PropertyKey[],
+): boolean {
+  let node: unknown = payload;
+  for (const key of path) {
+    if (node == null || typeof node !== "object") return false;
+    node = (node as Record<PropertyKey, unknown>)[key];
+  }
+  return node === undefined;
+}

--- a/src/response-validation-tripwire.ts
+++ b/src/response-validation-tripwire.ts
@@ -35,6 +35,7 @@
 // parsed before it is sent, and a schema bug fails the route instead of
 // quietly shipping. That is the trade the flag exists to make.
 import { successEnvelopeSchema } from "../schemas-src/envelope.ts";
+import { isProjectedAway } from "./projection-signal.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import type { z } from "zod";
 
@@ -127,50 +128,11 @@ function asSentOverTheWire(payload: unknown): unknown {
   }
 }
 
-/**
- * Is this issue just a field the projection removed?
- *
- * ## WHY A PROJECTION NEEDS ITS OWN ANSWER
- *
- * `?fields=` returns FEWER keys on purpose, and the component describes the
- * whole row -- so every projected response failed, on every route that
- * advertises the parameter (#10975). Measured against production: `?fields=name`
- * returned 500 on gaps, curation, candidates, profiles, subnets and providers.
- * Selecting fewer fields is the entire point of the parameter and it was the
- * thing that broke it.
- *
- * ## WHAT IS STILL ENFORCED
- *
- * Only ABSENCE is forgiven, and only when the value at the issue's own path is
- * genuinely missing. A projection can remove a key; it cannot add one and it
- * cannot change a type. So an unrecognized key still fails, and a present value
- * of the wrong type still fails -- the two things a caller would actually be
- * hurt by.
- *
- * Resolved by walking the path into the payload rather than matching on the
- * issue's message, because a message is prose and this is a gate.
- *
- * EXPORTED for its own test. The mid-path guard below cannot be reached
- * through a real Zod issue -- Zod reports at the level that failed and never
- * emits a path descending THROUGH a scalar -- so the only way to prove it
- * fires is to hand it such a path directly.
- *
- * Testing it beats suppressing it twice over: a coverage-suppression comment
- * is counted by codecov/patch on a changed line anyway, and the guard is the
- * one place this function could forgive a real drift, which is exactly what
- * it must never do.
- */
-export function isProjectedAway(
-  payload: unknown,
-  path: readonly PropertyKey[],
-): boolean {
-  let node: unknown = payload;
-  for (const key of path) {
-    if (node == null || typeof node !== "object") return false;
-    node = (node as Record<PropertyKey, unknown>)[key];
-  }
-  return node === undefined;
-}
+// `isProjectedAway` moved to src/projection-signal.ts when the MCP tripwire
+// needed the same rule (#11142): the two seams validate one contract, so the
+// question "did the caller ask for less" is answered in one place for both.
+// Re-exported here because this module's own tests and callers named it.
+export { isProjectedAway } from "./projection-signal.ts";
 
 /**
  * Called ONLY when the caller has already confirmed

--- a/tests/parsed-query-reads.test.ts
+++ b/tests/parsed-query-reads.test.ts
@@ -51,13 +51,11 @@ const DECLARED: Record<string, number> = {
   // The two by-name generic readers, matched by their parameter variable.
   parameter: 1,
   name: 1,
-  // The audit seam's projection signal (#11079). auditResponse wraps the
-  // default fetch export, OUTSIDE the router's parse, and derives `projected`
-  // from the URL alone -- the same way it reads fields/sections via `.has()`,
-  // which this regex does not see. Not a second copy of a bound:
-  // parseBooleanParam is strict, so the literal "false" is the only value the
-  // read can act on, and any other value never reaches the seam as a 200.
-  include_points: 1,
+  // `include_points` was here for the audit seam's projection signal (#11079)
+  // and is GONE (#11142): the seam now calls `urlProjects` from
+  // src/projection-signal.ts, which owns all three levers for both this surface
+  // and the MCP dispatch. The ratchet falling is the point -- one raw read
+  // fewer, and the entry deleted rather than left to describe nothing.
 };
 
 function rawReads(file: string): string[] {

--- a/tests/projection-signal.test.ts
+++ b/tests/projection-signal.test.ts
@@ -1,0 +1,149 @@
+// #11142: the projection signal both response tripwires read.
+//
+// The bug this pins, reproduced against production 2026-08-14:
+//   get_subnet(netuid=105, sections="health,counts,curation,gaps")
+//     -> response_schema_drift on `netuid`
+//   GET /subnets/105/overview?sections=health,counts,curation,gaps
+//     -> 200
+// One contract, two seams, two answers. These tests hold them together.
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  argsProject,
+  isProjectedAway,
+  urlProjects,
+  PROJECTION_PARAMETERS,
+  PROJECTION_TOGGLE,
+} from "../src/projection-signal.ts";
+import { validateMcpResponseTripwire } from "../src/mcp-response-tripwire.ts";
+import { outputJsonSchema } from "../src/mcp-input-schema.ts";
+
+describe("urlProjects", () => {
+  const projects = (qs: string) => urlProjects(new URLSearchParams(qs));
+
+  it("sees each of the three levers", () => {
+    expect(projects("fields=netuid")).toBe(true);
+    expect(projects("sections=health")).toBe(true);
+    expect(projects("include_points=false")).toBe(true);
+  });
+
+  it("is false for a request that asked for everything", () => {
+    expect(projects("")).toBe(false);
+    expect(projects("limit=10&window=7d")).toBe(false);
+    // Only the literal `false` narrows the response; `true` is the default.
+    expect(projects("include_points=true")).toBe(false);
+  });
+});
+
+describe("argsProject", () => {
+  it("sees the same three levers as tool arguments", () => {
+    expect(argsProject({ fields: "netuid,name" })).toBe(true);
+    expect(argsProject({ sections: "health" })).toBe(true);
+    // A real boolean over MCP, not the string REST parses.
+    expect(argsProject({ include_points: false })).toBe(true);
+  });
+
+  it("does not treat an empty selection as a projection", () => {
+    // `fields: ""` selects nothing and is refused upstream. Calling it a
+    // projection here would forgive absence on a call that never narrowed.
+    expect(argsProject({ fields: "" })).toBe(false);
+    expect(argsProject({ sections: "" })).toBe(false);
+  });
+
+  it("is false for a call that asked for everything, and for a non-object", () => {
+    expect(argsProject({ netuid: 105 })).toBe(false);
+    expect(argsProject({ include_points: true })).toBe(false);
+    expect(argsProject(null)).toBe(false);
+    expect(argsProject(undefined)).toBe(false);
+    expect(argsProject(["fields"])).toBe(false);
+    expect(argsProject("fields=netuid")).toBe(false);
+  });
+
+  it("reads the levers from the exported vocabulary, not a private copy", () => {
+    for (const name of PROJECTION_PARAMETERS) {
+      expect(argsProject({ [name]: "x" })).toBe(true);
+    }
+    expect(argsProject({ [PROJECTION_TOGGLE]: false })).toBe(true);
+  });
+});
+
+describe("isProjectedAway", () => {
+  it("forgives a key the projection removed", () => {
+    expect(isProjectedAway({ health: {} }, ["netuid"])).toBe(true);
+  });
+
+  it("does not forgive a key that is present with the wrong value", () => {
+    expect(isProjectedAway({ netuid: "105" }, ["netuid"])).toBe(false);
+    expect(isProjectedAway({ netuid: null }, ["netuid"])).toBe(false);
+  });
+
+  it("does not descend through a scalar", () => {
+    // Unreachable through a real Zod issue -- Zod reports at the level that
+    // failed -- so it is proven by handing it such a path directly. This is the
+    // one place either tripwire could forgive a real drift.
+    expect(isProjectedAway({ netuid: 105 }, ["netuid", "inner"])).toBe(false);
+    expect(isProjectedAway(null, ["netuid"])).toBe(false);
+  });
+});
+
+describe("the MCP tripwire under a projection", () => {
+  // The shape of the tool the bug was reported against: a required scalar
+  // beside the sections a caller can select.
+  const schema = z
+    .object({
+      netuid: z.number(),
+      health: z.object({ status: z.string() }).optional(),
+      counts: z.object({ surfaces: z.number() }).optional(),
+    })
+    .strict();
+  const published = outputJsonSchema(schema);
+
+  it("throws on the projected result when the caller asked for everything", () => {
+    // The unprojected call is still fully enforced: this is a real drift.
+    expect(() =>
+      validateMcpResponseTripwire(
+        "get_subnet",
+        published,
+        { health: { status: "healthy" } },
+        false,
+      ),
+    ).toThrow(/netuid/);
+  });
+
+  it("accepts the same result when the caller selected sections", () => {
+    // The exact production failure: `netuid` is absent because it was not
+    // selected, and that is the answer the caller asked for.
+    expect(() =>
+      validateMcpResponseTripwire(
+        "get_subnet",
+        published,
+        { health: { status: "healthy" }, counts: { surfaces: 39 } },
+        true,
+      ),
+    ).not.toThrow();
+  });
+
+  it("still refuses a key the projection cannot explain", () => {
+    // A projection removes keys. It cannot ADD one, so an unrecognized key is
+    // a drift whether or not sections was supplied.
+    expect(() =>
+      validateMcpResponseTripwire(
+        "get_subnet",
+        published,
+        { health: { status: "healthy" }, surprise: 1 },
+        true,
+      ),
+    ).toThrow(/surprise/);
+  });
+
+  it("still refuses a present value of the wrong type", () => {
+    expect(() =>
+      validateMcpResponseTripwire(
+        "get_subnet",
+        published,
+        { netuid: "105" },
+        true,
+      ),
+    ).toThrow(/netuid/);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -599,6 +599,7 @@ import {
   ResponseSchemaDriftError,
   validateResponseTripwire,
 } from "../src/response-validation-tripwire.ts";
+import { urlProjects } from "../src/projection-signal.ts";
 import {
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
@@ -2070,17 +2071,10 @@ export async function auditResponse(
   const url = new URL(request.url);
   const matched = matchRoute(url.pathname);
   if (!matched?.artifactTemplate) return response;
-  const projected =
-    url.searchParams.has("fields") ||
-    url.searchParams.has("sections") ||
-    // #9720's "send me less" toggle is a projection lever like the other two:
-    // include_points=false omits data.points BY REQUEST, and the schema's
-    // `required` describes the unprojected response (#10960). parseBooleanParam
-    // is strict -- any value other than the literal "false" either defaults to
-    // true or 400s before this seam sees a 200 -- so string equality here is
-    // exactly the handler's own condition (#11079: every MCP get_tao_usd call
-    // was fingerprinted as drift for asking for less).
-    url.searchParams.get("include_points") === "false";
+  // The three levers are declared once, in src/projection-signal.ts, because
+  // the MCP dispatch answers the same question about the same contract and was
+  // answering it differently -- which is to say not at all (#11142).
+  const projected = urlProjects(url.searchParams);
   const run = async (body: unknown) => {
     await validateResponseTripwire(
       matched.id,


### PR DESCRIPTION
## The bug, reproduced against production

```
get_subnet(netuid=105, sections="health,counts,curation,gaps")   -> response_schema_drift on `netuid`
GET /subnets/105/overview?sections=health,counts,curation,gaps   -> 200
```

One contract, two seams, two answers. The tool's own parameter description tells clients that `required` describes the *unprojected* response and that they should skip validation — and then the server validated anyway and turned a correct answer into a tool error.

## Why

REST's `auditResponse` derives `projected` from the URL (`fields`, `sections`, `include_points=false`) and `validateResponseTripwire` forgives issues that are just projected-away keys (#10975, #11079). The MCP dispatch takes the same three levers as **arguments** and passed none of it: `validateMcpResponseTripwire(tool.name, outputSchema, payload)` had no projection parameter.

## The change

- `src/projection-signal.ts` — one declaration of the three levers, with `urlProjects` (REST) and `argsProject` (MCP) derived from it, plus the single `isProjectedAway` implementation both tripwires now import. The copy in `response-validation-tripwire.ts` is dissolved and the hardcoded triple in `workers/api.ts` reads the shared rule.
- The MCP tripwire gains `projected`, filtering exactly as REST does.
- The dispatch passes `argsProject(args)`.

**Still enforced on both surfaces:** a projection removes keys, so absence at the issue's own path is forgiven; an unrecognized key or a present value of the wrong type still throws. Tests pin both directions.

## Validation

13 new tests at 100% statement/branch coverage on the new module, plus `tests/response-validation-tripwire.test.ts`, `tests/mcp-tools.test.ts`, `tests/subnet-sections.test.ts` (98 total). `npm run build`, `validate:mcp`, `validate:api`, `validate:contract-drift`, `validate:schema-shape-duplicates`, `lint`, `format:check`, `typecheck`. No contract artifacts changed — the published schemas are unchanged, only what we do with them.

Closes #11144