### PR TITLE
fix(schemas): the build trusts the capture it just performed, and rejects one entry instead of all of them

### DIFF
--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -103,7 +103,10 @@ import {
 } from "../src/mcp-server.ts";
 import { buildDatasetExports } from "./datasets.ts";
 import { readGeneratedStoreJson } from "./r2-rest.ts";
-import { SCHEMA_INDEX_R2_KEY } from "../src/schema-snapshots-sync.ts";
+import {
+  chooseSchemaIndexBaseline,
+  SCHEMA_INDEX_R2_KEY,
+} from "../src/schema-snapshots-sync.ts";
 import {
   buildChangelog,
   type ArtifactEntry,
@@ -342,10 +345,21 @@ const previousSchemaDriftArtifact = await readOptionalJson(
 const previousSchemaIndexStore = await readGeneratedStoreJson(
   SCHEMA_INDEX_R2_KEY,
 ).catch(() => null);
-const previousSchemaIndexArtifact =
-  previousSchemaIndexStore && Array.isArray(previousSchemaIndexStore.schemas)
-    ? previousSchemaIndexStore
-    : await readOptionalJson(path.join(outputRoot, "schemas/index.json"));
+// #11147: the store no longer wins UNCONDITIONALLY. It used to, which meant a
+// publish validated the store against the detail documents `schemas-snapshot`
+// had just written -- so a subnet that changed its spec failed the hash check
+// and one failure discarded all 57 captured schemas, every publish, leaving the
+// fleet frozen 11 days behind. chooseSchemaIndexBaseline prefers whichever copy
+// was observed most recently and merges the store's last-good entries back in
+// through the cron's own retention, so a capture this build performed is
+// trusted without costing the drift history of a surface it could not reach.
+const previousSchemaIndexArtifact = chooseSchemaIndexBaseline(
+  await readOptionalJson(path.join(outputRoot, "schemas/index.json")),
+  previousSchemaIndexStore,
+  // The build's own stamp, not a wall clock: retention has to be a function of
+  // the build's inputs or the artifacts stop being byte-reproducible.
+  Date.parse(generatedAt) || 0,
+);
 
 // snapshot-openapi writes the sanitized OpenAPI `document` into per-surface
 // schema files (R2 staging); capture it before the wipe below so the schema
@@ -4519,20 +4533,40 @@ function reusableSchemaIndexArtifact(
     );
   }
   const currentSurfaces = openApiSurfacesById(surfaces);
-  // Forgery/staleness guard: a committed entry whose surface still exists but no
-  // longer matches it (tampered or drifted metadata) means the index can't be
-  // trusted — discard it wholesale and fall back to the build placeholder.
-  for (const entry of previous.schemas) {
+  // Forgery/staleness guard: an entry whose surface still exists but no longer
+  // matches it (tampered or drifted metadata) cannot be trusted.
+  //
+  // PER ENTRY, NOT WHOLESALE (#11147). Rejecting one entry used to discard the
+  // whole index -- every captured schema, for every subnet -- and in production
+  // that is what happened: one subnet changing its published spec cost the other
+  // 56 their captured schema, on every publish, for 11 days.
+  //
+  // Dropping only the offending entry is strictly safer than dropping all of
+  // them. A forged entry is still refused -- it is replaced by the not-captured
+  // placeholder its surface would get if it had never been captured -- and the
+  // honest entries beside it survive. The old behaviour handed an attacker who
+  // could tamper with ONE entry the power to blank the whole index, which is a
+  // denial of service the guard was never meant to grant.
+  const rejected: string[] = [];
+  const vetted: Row[] = (previous.schemas as Row[]).map((entry) => {
     const surface = currentSurfaces.get(entry.surface_id);
-    if (!surface) continue;
+    if (!surface) return entry;
     const mismatch = schemaIndexEntryMismatch(entry, surface, capturedDetails);
-    if (mismatch) {
-      return discardSchemaIndex(
-        `entry ${entry.surface_id} no longer matches its surface on ${mismatch}`,
-        previous,
-      );
-    }
+    if (!mismatch) return entry;
+    rejected.push(`${entry.surface_id} (${mismatch})`);
+    return notCapturedSchemaIndexEntry(surface);
+  });
+  if (rejected.length > 0) {
+    // Named and counted, because this used to be the moment the index vanished
+    // and the only evidence was a diff between two builds.
+    console.warn(
+      `schema index: dropped ${rejected.length} entr${rejected.length === 1 ? "y" : "ies"} ` +
+        `that no longer match their surface — ${rejected.slice(0, 5).join(", ")}` +
+        `${rejected.length > 5 ? `, +${rejected.length - 5} more` : ""}. ` +
+        "The surviving entries are unaffected; re-run the schema capture to restore these.",
+    );
   }
+
   // Reconcile incrementally with the current surface set instead of nuking the
   // whole index when it changes: keep every committed entry whose surface still
   // exists (captured snapshots survive), drop entries for removed surfaces, and
@@ -4540,10 +4574,8 @@ function reusableSchemaIndexArtifact(
   // openapi surface is now a routine single-file contribution, so it must never
   // wipe the captured schema index; a later `schemas:snapshot` upgrades the
   // placeholders to captured.
-  const previousIds = new Set(
-    previous.schemas.map((entry) => entry.surface_id),
-  );
-  const reconciled = previous.schemas.filter((entry) =>
+  const previousIds = new Set(vetted.map((entry) => entry.surface_id));
+  const reconciled = vetted.filter((entry) =>
     currentSurfaces.has(entry.surface_id),
   );
   for (const [surfaceId, surface] of currentSurfaces) {
@@ -4551,6 +4583,8 @@ function reusableSchemaIndexArtifact(
       reconciled.push(notCapturedSchemaIndexEntry(surface));
     }
   }
+  // Unchanged means unchanged INCLUDING the vetting: a run that rejected an
+  // entry always falls through to the rebuild below, never returns `previous`.
   if (stableStringify(reconciled) === stableStringify(previous.schemas)) {
     return previous;
   }

--- a/src/schema-snapshots-sync.ts
+++ b/src/schema-snapshots-sync.ts
@@ -169,6 +169,85 @@ export function retainLastGoodSchemas(
   return { schemas, retained_count: retained };
 }
 
+/**
+ * Which copy of the schema index the build should reconcile: the one this build
+ * CAPTURED, or the durable store.
+ *
+ * ## THE DEADLOCK THIS ENDS (#11147)
+ *
+ * The publish captures every registered spec live (`schemas-snapshot`), writes
+ * the index and the per-surface detail documents, and then
+ * `reusableSchemaIndexArtifact` validated the STORE against THIS BUILD'S detail
+ * documents -- because the store was preferred unconditionally. `detailMatches`
+ * compares document hashes, so a subnet that changed its spec since the store
+ * was written failed, and one failure discarded all 57 captured schemas.
+ *
+ * The fresher the capture, the more certain the discard. Measured 2026-08-14:
+ * every captured schema frozen at `observed_at: 2026-08-02`, 24 of 52 subnets'
+ * captured path count differing from their live spec, and 23 of those 24 still
+ * reporting `drift_status: "unchanged"` -- the store agreeing with itself.
+ *
+ * ## THE RULE
+ *
+ * Prefer whichever copy was OBSERVED most recently. Nothing needs to know
+ * whether a capture ran: a build that captured has a newer `observed_at` by
+ * construction, and a build that did not (local dev, the Validate lane, the
+ * determinism test) reads the committed seed whose stamp is unchanged, so the
+ * store still wins and those builds stay byte-reproducible.
+ *
+ * The store keeps its real job. When the fresh index wins, the store's
+ * last-good entries are merged back in through `retainLastGoodSchemas` -- the
+ * SAME retention the cron applies -- so a surface whose spec was unreachable
+ * during THIS capture keeps the entry it had, and only genuinely persistent
+ * failure ages it out. Preferring fresh therefore costs no drift history.
+ *
+ * `nowMs` is the build's own timestamp rather than a wall clock, so the merge
+ * is a function of its inputs and a rebuild produces the same bytes.
+ */
+export function chooseSchemaIndexBaseline(
+  captured: Row | null | undefined,
+  store: Row | null | undefined,
+  nowMs: number,
+): Row | null {
+  const storeUsable = store && Array.isArray(store.schemas) ? store : null;
+  const capturedUsable =
+    captured && Array.isArray(captured.schemas) ? captured : null;
+  if (!capturedUsable) return storeUsable ?? (captured as Row | null) ?? null;
+  if (!storeUsable) return capturedUsable;
+  const capturedAt = indexObservedAtMs(capturedUsable);
+  const storeAt = indexObservedAtMs(storeUsable);
+  // Not strictly newer -- including both unstamped, and including equal, which
+  // is what a build that did not capture sees -- leaves the store in charge.
+  if (capturedAt == null || (storeAt != null && capturedAt <= storeAt)) {
+    return storeUsable;
+  }
+  const merged = retainLastGoodSchemas(
+    capturedUsable.schemas as Row[],
+    schemaEntriesById(storeUsable),
+    nowMs,
+  );
+  return {
+    ...capturedUsable,
+    summary: summarizeSchemaEntries(merged.schemas),
+    schemas: merged.schemas,
+  };
+}
+
+/**
+ * When the index as a whole was observed. Reads the index stamp rather than any
+ * entry's, because this answers "which capture run is newer", not "how old is
+ * this surface" -- `entryObservedAtMs` answers that one.
+ */
+export function indexObservedAtMs(doc: Row | null | undefined): number | null {
+  const observedAt = doc?.observed_at ?? doc?.generated_at;
+  if (typeof observedAt !== "string" || !observedAt) return null;
+  // The build placeholder is not a time. A stamp of 1970 means "this build had
+  // no clock", which must never read as older-or-newer than a real capture.
+  if (observedAt === "1970-01-01T00:00:00.000Z") return null;
+  const ms = Date.parse(observedAt);
+  return Number.isFinite(ms) ? ms : null;
+}
+
 /** Recount the index summary over whatever survived retention. */
 export function summarizeSchemaEntries(schemas: Row[]): Row {
   const countBy = (key: string): Record<string, number> => {

--- a/tests/artifacts-build-schema-index.test.ts
+++ b/tests/artifacts-build-schema-index.test.ts
@@ -174,7 +174,7 @@ test("a renamed subnet does not wholesale-discard the committed schema index", (
   }
 }, 120_000);
 
-test("a schema-index discard is named, counted, and recorded for CI", () => {
+test("one tampered entry is dropped, and only that entry (#11147)", () => {
   const schemaIndexPath = harness.artifactFilePath("schemas/index.json");
   const summaryPath = harness.artifactFilePath("build-summary.json");
   const originalSchemaIndex = readFileSync(schemaIndexPath, "utf8");
@@ -189,11 +189,12 @@ test("a schema-index discard is named, counted, and recorded for CI", () => {
     (schema: Row) => schema.status === "captured",
   ).length;
 
-  // #9909: the discard itself is correct and stays -- an index that cannot be
-  // trusted must not be reused. What was wrong is that it was SILENT: captured
-  // schemas vanished from the agent catalog and operational-surfaces'
-  // schema_source with nothing in the build log, and the cause had to be found
-  // by diffing a pristine build against a changed one.
+  // #9909 made the discard loud; #11147 made it PROPORTIONATE. Refusing a
+  // tampered entry is still correct and still happens -- what changed is that it
+  // no longer takes every other subnet's captured schema with it. In production
+  // one subnet changing its published spec cost the other 56 their schema on
+  // every publish for 11 days, which is a denial of service the guard was never
+  // meant to grant.
   (target.snapshot ??= {}).hash = "forged-by-this-test";
 
   try {
@@ -209,14 +210,67 @@ test("a schema-index discard is named, counted, and recorded for CI", () => {
       stdio: "pipe",
     });
 
+    const rebuilt = JSON.parse(readFileSync(schemaIndexPath, "utf8"));
+    const entry = rebuilt.schemas.find(
+      (schema: Row) => schema.surface_id === target.surface_id,
+    );
+    // The tampered entry loses its captured claim -- the forgery is refused.
+    assert(entry, "the surface must still be listed");
+    assert.equal(entry.status, "not-captured");
+    assert.equal(entry.hash, null);
+    // ...and nothing else does. This is the whole point: the index survives.
+    const capturedAfter = rebuilt.schemas.filter(
+      (schema: Row) => schema.status === "captured",
+    ).length;
+    assert.equal(capturedAfter, capturedBefore - 1);
+    assert.equal(rebuilt.source, "openapi-snapshot");
+    // A proportionate rejection is not a wholesale discard, so the CI gate --
+    // which fails on ANY dropped_captured -- must not fire for it.
+    assert.equal(
+      JSON.parse(readFileSync(summaryPath, "utf8")).schema_index_discard,
+      null,
+    );
+  } finally {
+    writeFileSync(schemaIndexPath, originalSchemaIndex);
+    writeFileSync(summaryPath, originalSummary);
+    execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
+      cwd: harness.scriptCwd,
+      encoding: "utf8",
+      env: harness.env,
+      stdio: "pipe",
+    });
+    harness.restoreSupportArtifacts(supportArtifacts);
+  }
+}, 120_000);
+
+test("a structurally unusable index is still discarded wholesale, and recorded for CI", () => {
+  // The wholesale path stays, and validate.ts still gates on it: an index that
+  // is not a schema snapshot at all cannot be vetted entry by entry, because
+  // there is nothing to trust about its shape.
+  const schemaIndexPath = harness.artifactFilePath("schemas/index.json");
+  const summaryPath = harness.artifactFilePath("build-summary.json");
+  const originalSchemaIndex = readFileSync(schemaIndexPath, "utf8");
+  const originalSummary = readFileSync(summaryPath, "utf8");
+  const supportArtifacts = harness.snapshotSupportArtifacts();
+  const schemaIndex = JSON.parse(originalSchemaIndex);
+  const capturedBefore = schemaIndex.schemas.filter(
+    (schema: Row) => schema.status === "captured",
+  ).length;
+  schemaIndex.source = "not-an-openapi-snapshot";
+
+  try {
+    writeFileSync(schemaIndexPath, `${JSON.stringify(schemaIndex, null, 2)}\n`);
+    execFileSync(process.execPath, ["scripts/build-artifacts.ts"], {
+      cwd: harness.scriptCwd,
+      encoding: "utf8",
+      env: harness.env,
+      stdio: "pipe",
+    });
     const discard = JSON.parse(readFileSync(summaryPath, "utf8"))
       .schema_index_discard as Row;
     assert(discard, "the discard must be recorded on the build summary");
     assert.equal(discard.dropped_captured, capturedBefore);
-    // The reason names the entry AND the field, which is the difference between
-    // a one-line diagnosis and an isolation run.
-    assert.match(String(discard.reason), new RegExp(target.surface_id));
-    assert.match(String(discard.reason), /snapshot\.hash/);
+    assert.match(String(discard.reason), /no reusable committed index/);
   } finally {
     writeFileSync(schemaIndexPath, originalSchemaIndex);
     writeFileSync(summaryPath, originalSummary);

--- a/tests/artifacts-build-schema.test.ts
+++ b/tests/artifacts-build-schema.test.ts
@@ -79,12 +79,29 @@ test("artifact build does not preserve forged schema snapshot metadata", () => {
       ? readFileSync(schemaDriftPath, "utf8")
       : "";
     const rebuiltSchemaIndex = readFileSync(schemaIndexPath, "utf8");
+    // THE SECURITY PROPERTY, unchanged: forged metadata never survives a build.
     assert.equal(rebuiltSchemaDrift.includes(forgedMarker), false);
     assert.equal(rebuiltSchemaIndex.includes(forgedMarker), false);
     if (rebuiltSchemaDrift) {
       assert.equal(JSON.parse(rebuiltSchemaDrift).source, "artifact-build");
     }
-    assert.equal(JSON.parse(rebuiltSchemaIndex).source, "artifact-build");
+    // WHAT CHANGED (#11147): the BLAST RADIUS, not the refusal. The tampered
+    // entry loses its captured claim; the index and every honest entry beside
+    // it survive. Collapsing to the `artifact-build` placeholder -- which is
+    // what this asserted before -- let anyone who could tamper with one entry
+    // blank all 57, and in production a subnet legitimately changing its spec
+    // did exactly that on every publish for 11 days.
+    const rebuilt = JSON.parse(rebuiltSchemaIndex);
+    assert.equal(rebuilt.source, "openapi-snapshot");
+    const rebuiltTarget = rebuilt.schemas.find(
+      (schema: Row) => schema.surface_id === indexTarget.surface_id,
+    );
+    assert.equal(rebuiltTarget.status, "not-captured");
+    assert.equal(rebuiltTarget.hash, null);
+    assert(
+      rebuilt.schemas.some((schema: Row) => schema.status === "captured"),
+      "honest captured entries must survive one forged neighbour",
+    );
   } finally {
     if (originalSchemaDrift) {
       writeFileSync(schemaDriftPath, originalSchemaDrift);

--- a/tests/schema-snapshots-sync.test.ts
+++ b/tests/schema-snapshots-sync.test.ts
@@ -22,6 +22,8 @@ import {
   SCHEMA_INDEX_ARTIFACT_PATH,
   SCHEMA_INDEX_R2_KEY,
   SCHEMA_SNAPSHOT_RETENTION_MS,
+  chooseSchemaIndexBaseline,
+  indexObservedAtMs,
 } from "../src/schema-snapshots-sync.ts";
 import { mockEnv, type AnyFn, type Row } from "./row-type.ts";
 
@@ -543,5 +545,155 @@ describe("runSchemaSnapshotsSync", () => {
       raw.includes(`"${SCHEMA_SNAPSHOTS_SYNC_CRON}"`),
       `wrangler.jsonc has no trigger for ${SCHEMA_SNAPSHOTS_SYNC_CRON}`,
     );
+  });
+});
+
+describe("chooseSchemaIndexBaseline (#11147)", () => {
+  const index = (observedAt: string | null, schemas: Row[]): Row => ({
+    source: "openapi-snapshot",
+    observed_at: observedAt,
+    schemas,
+  });
+  const captured = (id: string, observedAt: string, hash: string): Row => ({
+    surface_id: id,
+    status: "captured",
+    hash,
+    snapshot: { observed_at: observedAt },
+  });
+  const notCaptured = (id: string): Row => ({
+    surface_id: id,
+    status: "not-captured",
+    hash: null,
+  });
+  const now = Date.parse("2026-08-14T06:00:00.000Z");
+
+  test("this build's capture wins when it is newer than the store", () => {
+    // The production deadlock: the store was preferred unconditionally, so the
+    // build validated an 11-day-old copy against detail documents it had just
+    // captured, and one changed spec discarded all of them.
+    const store = index("2026-08-02T07:31:05.148Z", [
+      captured("sn-105", "2026-08-02T07:31:05.148Z", "old"),
+    ]);
+    const fresh = index("2026-08-14T05:30:00.000Z", [
+      captured("sn-105", "2026-08-14T05:30:00.000Z", "new"),
+    ]);
+    const chosen = chooseSchemaIndexBaseline(fresh, store, now);
+    assert.equal((chosen?.schemas as Row[])[0].hash, "new");
+  });
+
+  test("the store stays in charge when the capture did not run", () => {
+    // A build that did not capture reads the committed seed, whose stamp is
+    // unchanged -- equal is not newer, which is what keeps local and CI builds
+    // byte-reproducible.
+    const stamp = "2026-08-02T07:31:05.148Z";
+    const store = index(stamp, [captured("sn-105", stamp, "store")]);
+    const seed = index(stamp, [captured("sn-105", stamp, "seed")]);
+    assert.equal(
+      (chooseSchemaIndexBaseline(seed, store, now)?.schemas as Row[])[0].hash,
+      "store",
+    );
+  });
+
+  test("a surface the fresh capture could not reach keeps its last-good entry", () => {
+    // Preferring fresh must not cost the drift history the retention exists to
+    // protect: a spec that 502'd during THIS capture is not a spec that changed.
+    const store = index("2026-08-13T00:00:00.000Z", [
+      captured("sn-1", "2026-08-13T00:00:00.000Z", "lastgood"),
+      captured("sn-105", "2026-08-13T00:00:00.000Z", "old"),
+    ]);
+    const fresh = index("2026-08-14T05:30:00.000Z", [
+      notCaptured("sn-1"),
+      captured("sn-105", "2026-08-14T05:30:00.000Z", "new"),
+    ]);
+    const chosen = chooseSchemaIndexBaseline(fresh, store, now);
+    const byId = new Map(
+      (chosen?.schemas as Row[]).map((row) => [row.surface_id, row]),
+    );
+    assert.equal(byId.get("sn-1")?.status, "captured");
+    assert.equal(byId.get("sn-1")?.hash, "lastgood");
+    assert.equal(byId.get("sn-105")?.hash, "new");
+    // The summary is recounted over what actually survived.
+    assert.equal((chosen?.summary as Row)?.schema_count, 2);
+  });
+
+  test("a last-good entry older than the retention window is not resurrected", () => {
+    const store = index("2026-06-01T00:00:00.000Z", [
+      captured("sn-1", "2026-06-01T00:00:00.000Z", "ancient"),
+    ]);
+    const fresh = index("2026-08-14T05:30:00.000Z", [notCaptured("sn-1")]);
+    const chosen = chooseSchemaIndexBaseline(fresh, store, now);
+    assert.equal((chosen?.schemas as Row[])[0].status, "not-captured");
+  });
+
+  test("either copy missing or shapeless falls back to the other", () => {
+    const store = index("2026-08-02T00:00:00.000Z", [
+      captured("sn-105", "2026-08-02T00:00:00.000Z", "store"),
+    ]);
+    const fresh = index("2026-08-14T00:00:00.000Z", [
+      captured("sn-105", "2026-08-14T00:00:00.000Z", "fresh"),
+    ]);
+    assert.equal(chooseSchemaIndexBaseline(null, store, now), store);
+    assert.equal(chooseSchemaIndexBaseline(fresh, null, now), fresh);
+    assert.equal(chooseSchemaIndexBaseline(null, null, now), null);
+    // A body with no schemas array is not an index; it must not win by having a
+    // newer stamp.
+    const shapeless = {
+      source: "openapi-snapshot",
+      observed_at: "2027-01-01T00:00:00.000Z",
+    } as Row;
+    assert.equal(chooseSchemaIndexBaseline(shapeless, store, now), store);
+    assert.equal(chooseSchemaIndexBaseline(fresh, shapeless, now), fresh);
+    // Neither usable: the caller still gets whatever it handed in, not a throw.
+    assert.equal(chooseSchemaIndexBaseline(shapeless, null, now), shapeless);
+  });
+
+  test("an unstamped or placeholder capture never outranks a stamped store", () => {
+    const store = index("2026-08-02T00:00:00.000Z", [
+      captured("sn-105", "2026-08-02T00:00:00.000Z", "store"),
+    ]);
+    for (const stamp of [null, "1970-01-01T00:00:00.000Z", "not-a-date"]) {
+      const fresh = index(stamp, [
+        captured("sn-105", "2026-08-14T00:00:00.000Z", "fresh"),
+      ]);
+      assert.equal(
+        (chooseSchemaIndexBaseline(fresh, store, now)?.schemas as Row[])[0]
+          .hash,
+        "store",
+        `stamp ${String(stamp)} must not win`,
+      );
+    }
+    // ...but a stamped capture beats an UNSTAMPED store, which is the cold-start
+    // case: a store written before stamps existed must not freeze the fleet.
+    const unstampedStore = index(null, [
+      captured("sn-105", "2026-08-02T00:00:00.000Z", "store"),
+    ]);
+    const fresh = index("2026-08-14T00:00:00.000Z", [
+      captured("sn-105", "2026-08-14T00:00:00.000Z", "fresh"),
+    ]);
+    assert.equal(
+      (
+        chooseSchemaIndexBaseline(fresh, unstampedStore, now)?.schemas as Row[]
+      )[0].hash,
+      "fresh",
+    );
+  });
+
+  test("indexObservedAtMs reads the index stamp, refusing the build placeholder", () => {
+    assert.equal(
+      indexObservedAtMs({ observed_at: "2026-08-14T00:00:00.000Z" } as Row),
+      Date.parse("2026-08-14T00:00:00.000Z"),
+    );
+    // generated_at is the fallback when a copy carries no observed_at.
+    assert.equal(
+      indexObservedAtMs({ generated_at: "2026-08-14T00:00:00.000Z" } as Row),
+      Date.parse("2026-08-14T00:00:00.000Z"),
+    );
+    assert.equal(indexObservedAtMs({} as Row), null);
+    assert.equal(indexObservedAtMs(null), null);
+    assert.equal(
+      indexObservedAtMs({ observed_at: "1970-01-01T00:00:00.000Z" } as Row),
+      null,
+    );
+    assert.equal(indexObservedAtMs({ observed_at: "nope" } as Row), null);
   });
 });


### PR DESCRIPTION
## The deadlock

`schemas-snapshot` captures every registered spec live on each publish, writes the index and the per-surface detail documents — and then `reusableSchemaIndexArtifact` validated the **durable store** against **those fresh documents**, because the store was preferred unconditionally at [build-artifacts.ts:345](scripts/build-artifacts.ts:345). `detailMatches` compares document hashes, so a subnet that changed its spec since the store was written failed the check, and one failure discarded all 57 captured schemas.

**The fresher the capture, the more certain the discard.** Today's publish printed it:

```
schema index discarded (entry sn-1-apex-orchestrator-openapi no longer matches its surface
on schema detail document) — dropping 57 captured schema(s).
```

sn-1's five identity fields all still match; only the document hash moved. Apex changed its spec, which is the event this system exists to detect.

## What it cost

Production was frozen at `observed_at: 2026-08-02` for 11 days. Of 52 subnets whose captured schema can be compared against their live spec, **24 have a different path count and 23 of those still report `drift_status: "unchanged"`** — the store agreeing with itself. `call_subnet_surface` Phase 2 gates on the captured schema, so anything a subnet published in those 11 days was unreachable through the MCP.

## The change

**`chooseSchemaIndexBaseline`** (in `src/schema-snapshots-sync.ts`, beside the retention it reuses) prefers whichever copy was **observed most recently**, and merges the store's last-good entries back through `retainLastGoodSchemas` — the same retention the cron applies. So a surface whose spec was unreachable during this capture keeps its entry, and only persistent failure ages it out; preferring fresh costs no drift history.

Nothing needs to know whether a capture ran: a build that captured has a newer stamp by construction, and a build that did not reads the committed seed whose stamp is unchanged — equal is not newer, so local, CI and the determinism test are byte-identical (verified: `tests/artifacts-build-determinism.test.ts` passes).

**The forgery guard now rejects per entry.** A tampered entry still loses its captured claim and becomes the not-captured placeholder its surface would otherwise carry — it just no longer takes 56 honest neighbours with it. The old behaviour handed anyone who could tamper with one entry the power to blank the whole index, which is a denial of service the guard was never meant to grant. The wholesale path stays for a structurally unusable index, and `validate.ts` still gates on it.

### Two security-test expectations changed, deliberately

- `artifact build does not preserve forged schema snapshot metadata` — still asserts the forged marker never survives (the actual security property). It now also asserts the index does **not** collapse to the `artifact-build` placeholder, that the tampered entry is `not-captured` with a null hash, and that honest captured entries survive.
- `a schema-index discard is named, counted, and recorded for CI` → **`one tampered entry is dropped, and only that entry`**, asserting `capturedAfter === capturedBefore - 1`. A new test, `a structurally unusable index is still discarded wholesale, and recorded for CI`, keeps the CI control covered.

## Validation

37 tests in `schema-snapshots-sync` (7 new) at **100% statement/branch coverage** on the changed module, both artifact-build schema suites (7 tests, ~60s of real builds), `artifacts-build-determinism`, `npm run validate`, `validate:contract-drift`, `validate:api`, `validate:mcp`, `lint`, `format:check`, `typecheck`.

## Post-merge verification

`get_api_schema(sn-105-beam-openapi)` should report `path_count: 56` (live) rather than 53, with `observed_at` inside a day, once a publish runs with this change.

Closes #11147