### PR TITLE
fix(api): a declined extrinsics page is not an empty one

### DIFF
--- a/tests/degraded-answer-is-labelled.test.ts
+++ b/tests/degraded-answer-is-labelled.test.ts
@@ -24,6 +24,7 @@ import {
   labelDegradedResponse,
 } from "../workers/request-handlers/analytics.ts";
 import { currentR2SqlFailureGeneration } from "../src/r2-sql.ts";
+import { OFFSET_EMULATION_CAP } from "../src/r2-sql-blocks.ts";
 import { API_ROUTES, FEED_ROUTES } from "../src/contracts.ts";
 import { concretePath } from "./concrete-path.ts";
 
@@ -128,6 +129,80 @@ describe("the counterparties zero says it is a zero (#10270)", () => {
     assert.equal(body.data.counterparty_count, 1);
     assert.equal(body.data.transfers_scanned, 1);
     assert.equal(res.headers.get(DEGRADED_HEADER), null);
+  });
+});
+
+describe("a page declined BEFORE the query says so too (#11142)", () => {
+  /** Records every request, and refuses -- so "no query issued" is provable. */
+  function countingLakehouse(calls: string[]): typeof fetch {
+    return (async (input: unknown) => {
+      calls.push(String(input));
+      throw new Error("r2 sql unreachable");
+    }) as unknown as typeof fetch;
+  }
+
+  test("a depth past OFFSET_EMULATION_CAP is labelled, not served as end-of-feed", async () => {
+    // The sweep below cannot catch this one. It keys off the r2-sql failure
+    // generation, and this decline is taken before any query is issued, so no
+    // generation moves -- which is exactly how it reached production
+    // unlabelled. Asserting `calls` is empty is what proves the label came
+    // from the cap and not from a query that happened to fail.
+    const calls: string[] = [];
+    const res = (await withFetch(countingLakehouse(calls), () =>
+      handleRequest(
+        apiRequest(
+          `/api/v1/extrinsics?limit=5&offset=${OFFSET_EMULATION_CAP + 10}`,
+        ),
+        LAKEHOUSE_ENV,
+        {},
+      ),
+    )) as Response;
+    const body = (await res.json()) as {
+      data: { extrinsic_count: number; next_cursor: string | null };
+    };
+
+    assert.equal(calls.length, 0, "the cap must decline before querying");
+    assert.equal(res.status, 200);
+    // Still the schema-stable empty (#9146). What changes is that a caller can
+    // now tell it apart from a real end-of-feed, which this payload is
+    // otherwise byte-identical to.
+    assert.equal(body.data.extrinsic_count, 0);
+    assert.equal(body.data.next_cursor, null);
+    assert.equal(res.headers.get(DEGRADED_HEADER), "tier_unavailable");
+  });
+
+  test("a depth within the cap still asks the lakehouse", async () => {
+    // Non-vacuity for the assertion above: if the route short-circuited at
+    // every depth, `calls.length === 0` would prove nothing about the cap.
+    const calls: string[] = [];
+    await withFetch(countingLakehouse(calls), () =>
+      handleRequest(
+        apiRequest("/api/v1/extrinsics?limit=5&offset=0"),
+        LAKEHOUSE_ENV,
+        {},
+      ),
+    );
+    assert.ok(calls.length > 0, "a servable depth must reach the tier");
+  });
+
+  test("the call_hash arm is labelled too, having skipped the tier", async () => {
+    // A second, independent way into the same operand: call_hash has no column
+    // in the lakehouse table, so the read is skipped outright rather than
+    // declined. Unlabelled, that answered "no extrinsics match this hash" for
+    // a filter that was never evaluated.
+    const calls: string[] = [];
+    const res = (await withFetch(countingLakehouse(calls), () =>
+      handleRequest(
+        apiRequest(
+          `/api/v1/extrinsics?limit=5&call_module=SubtensorModule&call_hash=0x${"a".repeat(64)}`,
+        ),
+        LAKEHOUSE_ENV,
+        {},
+      ),
+    )) as Response;
+    assert.equal(calls.length, 0, "call_hash must skip the tier");
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get(DEGRADED_HEADER), "tier_unavailable");
   });
 });
 

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -296,7 +296,7 @@ registerModuleStateReset(
   },
 );
 
-function unmeasured<T>(stub: T): T {
+export function unmeasured<T>(stub: T): T {
   unmeasuredGeneration += 1;
   return stub;
 }

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -55,6 +55,7 @@ import {
   LIFECYCLE_CSV_COLUMNS,
   analyticsQueryError,
   markDataApiTierFallbackResponse,
+  unmeasured,
 } from "./analytics.ts";
 import {
   overlayAccountPositionHistoryColdTier,
@@ -7011,7 +7012,34 @@ export async function handleExtrinsics(
           },
           network,
         )
-      : null) ?? buildExtrinsicFeed([], { limit, offset, nextCursor: null });
+      : null) ??
+    // LABELLED, because an empty feed here is not an empty feed (#11142).
+    //
+    // Two different things reach this operand, and neither one means "no more
+    // extrinsics": the `call_hash` arm above skips the tier outright, and the
+    // cold tier returns null when it declines -- notably once `offset` passes
+    // OFFSET_EMULATION_CAP, which it checks BEFORE issuing any query.
+    //
+    // That last part is why the central label was not already covering this.
+    // `handleRequest` snapshots the r2-sql failure generation around every
+    // dispatch, so a query that fails (a `body_too_large` decline, a timeout)
+    // is labelled and barred from the cache without anyone remembering to. A
+    // decline taken before the query moves no generation at all, so the
+    // response went out as a bare 200.
+    //
+    // Measured against production 2026-08-14: `?offset=240` returned 5 rows
+    // and a cursor, `?offset=260` returned `extrinsic_count: 0` with
+    // `next_cursor: null` -- the exact end-of-feed signal -- with no
+    // `x-metagraph-degraded` header and `public, max-age=60,
+    // stale-while-revalidate=300`. Millions of rows sit behind that offset, so
+    // a client paginating the feed stopped early, dropped the tail, and the
+    // edge served that answer to everyone else for the next five minutes.
+    //
+    // `unmeasured` rather than the tier-fallback marker: these declines are
+    // STABLE, not transient. The same offset declines the same way for the
+    // whole TTL, so the answer stays cacheable and merely stops claiming to be
+    // measured -- which is the distinction degradedSince() draws.
+    unmeasured(buildExtrinsicFeed([], { limit, offset, nextCursor: null }));
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(
@@ -7073,7 +7101,8 @@ export async function handleSudo(request: Request, env: Env, url: URL) {
       blockEnd: query.block_end ?? null,
       from: query.from ?? null,
       to: query.to ?? null,
-    })) ?? buildExtrinsicFeed([], { limit, offset, nextCursor: null });
+    })) ??
+    unmeasured(buildExtrinsicFeed([], { limit, offset, nextCursor: null }));
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(
@@ -7138,7 +7167,8 @@ export async function handleGovernanceConfigChanges(
       blockEnd: query.block_end ?? null,
       from: query.from ?? null,
       to: query.to ?? null,
-    })) ?? buildExtrinsicFeed([], { limit, offset, nextCursor: null });
+    })) ??
+    unmeasured(buildExtrinsicFeed([], { limit, offset, nextCursor: null }));
   if (csvRequested(url, request)) {
     return csvResponse(
       extrinsicsToCsvRows(


### PR DESCRIPTION
## The defect, measured in production

`/api/v1/extrinsics` answered a **declined** read with `extrinsic_count: 0` and `next_cursor: null` — byte-identical to end-of-feed — as a bare `200` with `cache-control: public, max-age=60, stale-while-revalidate=300`.

```bash
for o in 240 260; do curl -s "https://api.metagraph.sh/api/v1/extrinsics?limit=5&offset=$o&block_end=8000000"; done
```

| offset | `extrinsic_count` | `next_cursor` | `x-metagraph-degraded` |
|---|---|---|---|
| 240 | 5 | `1776571356000.7999993.13` | — |
| **260** | **0** | **`null`** | **absent** |

Millions of rows sit behind offset 260. A client paginating this feed stopped early, silently dropped the tail, and the edge served that answer to everyone else for five minutes.

## Why it escaped the existing guard

Two different things reach the `?? buildExtrinsicFeed([], …)` operand, and neither means "no more extrinsics":

1. the `call_hash` arm **skips the tier outright** (no such column in the lakehouse), so that filter is never evaluated — verified: any `call_hash` query returns `count 0`;
2. the cold tier returns `null` when it declines — notably once `offset` passes `OFFSET_EMULATION_CAP`, checked **before issuing any query**.

`handleRequest` snapshots the r2-sql failure generation around every dispatch, so a query that *fails* (a `body_too_large` decline, a timeout) is labelled and barred from cache without anyone remembering to. A decline taken **before** the query moves no generation at all — so `tests/degraded-answer-is-labelled.test.ts`'s whole-route-table sweep, which keys off exactly that generation, could not see it.

This also got more reachable in #11143, which lowered the cap 1000 → 250 to stop the `body_too_large` declines. That was right on its own terms, but it moved this boundary forward, which is why it is fixed here.

## The fix

Wrap the operand in the existing `unmeasured` helper — whose own comment already describes this shape ("wrapping the final `?? build…()` operand is what makes it exact: `??` short-circuits, so it runs on precisely the requests that get an empty body and never on one carrying data"). No second mechanism, no new vocabulary.

`unmeasured` rather than the tier-fallback marker because these declines are **stable**: the same offset declines identically for the whole TTL, so the answer stays cacheable and merely stops claiming to be measured — the distinction `degradedSince()` already draws between transient and unmeasured.

The payload is unchanged and the header carries the signal. Labelling body-first was tried before and broke conditional requests, because the retry recomputes the ETag from an unlabelled body.

Applies to all three sites in the extrinsics family (feed, account, block).

## Tests

Three, in the file that owns this invariant. The load-bearing assertion is that **no query is issued** on the capped path — that is what proves the label comes from the cap rather than from a query that happened to fail. Plus non-vacuity that a servable depth still reaches the tier, and coverage of the `call_hash` arm.

Verified both labelling tests fail without the change (`2 failed | 9 passed`) and pass with it.

`tsc` clean; 275 tests pass across the touched surface (extrinsics, cold tier, cache profile, analytics handlers, edge cache, degraded labelling); prettier and eslint clean; unreferenced-exports holds at 731, the ceiling.

Closes #11142