### PR TITLE
fix(registry): probe SN105's public UID-range route, and say what its notes could not

### DIFF
--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -10,7 +10,7 @@
     "subtensor-wss"
   ],
   "schema_version": 1,
-  "surface_count": 606,
+  "surface_count": 607,
   "surfaces": [
     {
       "auth_required": false,
@@ -12395,6 +12395,26 @@
       "surface_id": "sn-105-beam-routing-orchestrators",
       "surface_key": "srf-dc7e0b51c0d1384d",
       "url": "https://beamcore.b1m.ai/routing/orchestrators"
+    },
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "data-artifact",
+      "netuid": 105,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "beam",
+      "public_safe": true,
+      "revenue": null,
+      "schema_source": null,
+      "subnet_name": "Beam",
+      "subnet_slug": "sn-105",
+      "surface_id": "sn-105-beam-uid-ranges",
+      "surface_key": "srf-9efb169daf6cd0a7",
+      "url": "https://beamcore.b1m.ai/config/uid-ranges"
     },
     {
       "auth_required": false,

--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -9,11 +9,13 @@
   "curation": {
     "gap_notes": [
       "No verified SSE/event stream yet -- /logs/stream/{source} exists but is path-parameterized, not a bare no-param route.",
-      "The BeamCore OpenAPI schema declares no security on all 53 paths, but most are actually auth-gated in practice (401): auth/me, auth/keys, clients, destinations, transfers, orchestrators/pending-transfers, orchestrators/workers, Validator/epoch-summary/latest-epoch, jobs, internal/routing/live. Only validators/orchestrators and status/orchestrator-relays are genuinely public -- both added as new surfaces."
+      "The BeamCore OpenAPI schema declares no security on any path, but most are auth-gated in practice (401): auth/me, auth/keys, clients, destinations, transfers, orchestrators/pending-transfers, orchestrators/workers, Validator/epoch-summary/latest-epoch, jobs, internal/routing/live. Those surfaces carry auth_required:true with probes disabled; verified 2026-08-14, when every one of them still answered 401 anonymously.",
+      "MUTATIONS ARE NOT REGISTERED, AND CANNOT BE. The spec declares 56 paths / 60 operations, of which 22 are POST/PATCH/PUT/DELETE; a registered surface is a URL with no method dimension (see metagraphed#11146), so registering one would publish a route the prober calls with GET and an agent reads as fetchable. Their absence here is a limit of the registry, NOT evidence that the subnet has no such route. The operationally load-bearing one is POST /orchestrators/register, which must be called before an orchestrator can connect -- skipping it yields orchestrator_not_routable, an error whose name sends operators to debug ports instead.",
+      "/orchestrators/prism-scores/{orch_uid} is the subnet's scoring surface and is registered but not callable: it is auth_required and path-parameterized, so it needs both a stored credential and Phase 2 path-param execution (call_subnet_surface with an explicit path+method against the captured schema)."
     ],
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
-    "reviewed_at": "2026-07-16T00:00:00.000Z",
+    "reviewed_at": "2026-08-14T00:00:00.000Z",
     "source_count": 5,
     "verified_at": "2026-07-16T00:00:00.000Z"
   },
@@ -99,7 +101,13 @@
         "submitted_by": "philluiz2323"
       },
       "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
-      "url": "https://beamcore.b1m.ai/config/uid-ranges"
+      "url": "https://beamcore.b1m.ai/config/uid-ranges",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      }
     },
     {
       "auth_required": false,


### PR DESCRIPTION
## Summary

Three corrections to `registry/subnets/beam.json`, each verified against the live API on 2026-08-14.

**The probe.** `/config/uid-ranges` carried no `probe` block at all — the only beamcore surface without one. I checked every probe-disabled beamcore surface anonymously: it is the **only** one that answers `200 application/json`; the other eleven answer `401` and correctly declare `auth_required: true`. So the fix is one surface, not the six originally suspected — `/health`, `/routing/orchestrators`, `/routing/worker-capacity`, `/validators/orchestrators` and `/status/orchestrator-relays` are already probed and healthy (`surface_count: 5`, all `ok`). The rebuild carries it into `operational-surfaces.json` (606 → 607).

**The stale count.** The notes asserted "all 53 paths"; the spec declares 56 paths / 60 operations today. Rather than update a number that drifts, the note no longer restates one.

**What the notes could not say.** 22 of the 60 declared operations are POST/PATCH/PUT/DELETE, and a registered surface is a URL with no method dimension (#11146) — so they cannot be registered, and their absence reads as "this API has no such route". The notes now say that explicitly and name `POST /orchestrators/register`, which is mandatory before an orchestrator can connect (skipping it yields `orchestrator_not_routable`, an error whose name sends operators to debug ports). A fourth note says what `/orchestrators/prism-scores/{orch_uid}` needs to become callable: a stored credential plus Phase 2 path-param execution.

`curation.reviewed_at` moves to today, for the review that produced these.

## Not in scope

Registering the mutations (#11146 phase 3) and the 11-day-stale capture behind `get_api_schema` (#11147, PR #11148) are tracked separately — registering a mutation as a bare URL today would publish a route the prober calls with GET.

## Validation

`validate:surface`, `scan:public-safety`, `npm run validate` (129 subnets, 3,325 surfaces), `npm run build`, `format:check`.

Closes #11150