### PR TITLE
fix(api): count the decline the labeller cannot see

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -101,7 +101,7 @@ import { storeAll } from "./analytics-live.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
-import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
 import { readStore } from "./read-store.ts";
@@ -178,7 +178,7 @@ export async function loadAccountTransfersColdTier(
   if (limit === null || offset === null || limit <= 0) return null;
   // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
   // reasonable trade and declining beats serving a page that is quietly wrong.
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   // An unusable address is a decline, not an unfiltered scan of every account.
   const addr = safeSs58Literal(ss58);
@@ -700,7 +700,7 @@ export async function loadValidatorNominatorsColdTier(
   const limit = safeBlockNumber(query.limit);
   const offset = safeBlockNumber(query.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const sort = query.sort ?? DEFAULT_NOMINATOR_SORT;
   // A sort this tier cannot express would otherwise silently serve the default

--- a/src/account-identity-cold-tier.ts
+++ b/src/account-identity-cold-tier.ts
@@ -13,7 +13,7 @@ import { buildAccountIdentity, IDENTITY_FIELDS } from "./account-identity.ts";
 import { buildAccountIdentityHistory } from "./account-identity-history.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
-import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 
 // Both SELECT lists are derived from the same exported field set data-api's
 // reads are built on: latest-only is account + the 7 identity fields +
@@ -64,7 +64,7 @@ export async function loadAccountIdentityHistoryColdTier(
     return null;
   // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
   // reasonable trade and declining beats serving a page that is quietly wrong.
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const where = [`account = '${addr}'`];
   const cursor = decodeCursor(query.cursor, CURSOR_ARITY);

--- a/src/events-cold-tier.ts
+++ b/src/events-cold-tier.ts
@@ -48,7 +48,7 @@ import {
   safeNameLiteral,
   safeSs58Literal,
 } from "./r2-sql.ts";
-import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { lakehouseHeadBlock } from "./blocks-cold-tier.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
@@ -204,7 +204,7 @@ export async function loadAccountEventsColdTier(
   const limit = safeBlockNumber(query.limit);
   const offset = safeBlockNumber(query.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   // An unusable address is a decline, not an unfiltered scan of every account.
   const addr = safeSs58Literal(ss58);
@@ -299,7 +299,7 @@ export async function loadSubnetEventsColdTier(
   const limit = safeBlockNumber(query.limit);
   const offset = safeBlockNumber(query.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   // An unusable netuid is a decline, not an unfiltered scan of every subnet.
   const subnet = safeBlockNumber(netuid);
@@ -365,7 +365,7 @@ export async function loadBlockEventsColdTier(
   const limit = safeBlockNumber(page.limit);
   const offset = safeBlockNumber(page.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const height = await resolveBlockHeight(env, ref, network);
   if (height === null) return null;

--- a/src/extrinsics-cold-tier.ts
+++ b/src/extrinsics-cold-tier.ts
@@ -47,7 +47,7 @@ import {
   safeNameLiteral,
   safeSs58Literal,
 } from "./r2-sql.ts";
-import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import {
   ACCOUNT_EVENTS_COLUMNS,
   EXTRINSICS_COLUMNS,
@@ -174,7 +174,7 @@ async function feedRows(
   if (limit === null || offset === null || limit <= 0) return null;
   // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
   // reasonable trade and declining beats serving a page that is quietly wrong.
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const base = feedPredicates(query);
   if (base === null) return null;

--- a/src/r2-sql-blocks.ts
+++ b/src/r2-sql-blocks.ts
@@ -24,6 +24,7 @@
 
 import { buildBlock, buildBlockFeed } from "./blocks.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
 import { type ChainNetworkId, chainTable } from "./chain-network.ts";
 import { BLOCKS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { BlocksRow } from "../generated/lakehouse/types.ts";
@@ -81,6 +82,51 @@ const BLOCK_COLUMNS = BLOCKS_COLUMNS.join(", ");
  * replaces the silent empty page when it is exceeded anyway.
  */
 export const OFFSET_EMULATION_CAP = 250;
+
+/**
+ * How many times a read has declined a too-deep offset, this isolate.
+ *
+ * Same contract as `currentR2SqlFailureGeneration`: a caller snapshots this
+ * before serving and compares after. It exists because that counter CANNOT see
+ * this decline -- the cap is checked before any SQL is built, so no query is
+ * issued, nothing fails, and no failure generation moves.
+ *
+ * That blindness shipped. `handleRequest` labels a degraded answer by comparing
+ * generations around the dispatch, so ten paginated routes answered a declined
+ * page as a bare, edge-cacheable 200 whose body was byte-identical to
+ * end-of-feed (#11142). `/api/v1/extrinsics?offset=260` reported
+ * `extrinsic_count: 0, next_cursor: null` with millions of rows behind it.
+ *
+ * UNMEASURED rather than transient, which is why it is a separate counter from
+ * the failure one rather than an increment of it: the same offset declines the
+ * same way for the whole TTL, so the answer stays cacheable and merely stops
+ * claiming to be measured. See `degradedSince` for that split.
+ */
+let offsetCapDeclineGeneration = 0;
+
+registerModuleStateReset("src/r2-sql-blocks.ts", () => {
+  offsetCapDeclineGeneration = 0;
+});
+
+export function currentOffsetCapDeclineGeneration(): number {
+  return offsetCapDeclineGeneration;
+}
+
+/**
+ * Whether `offset` is past the emulated-offset ceiling, RECORDING the decline.
+ *
+ * Every cold-tier reader asks through here rather than comparing against
+ * OFFSET_EMULATION_CAP itself. A bare comparison returns null silently, and the
+ * answer that reaches the caller is then indistinguishable from an empty feed
+ * -- which is the entire defect. Routing the check through one function is what
+ * makes a reader added tomorrow report the decline without its author having to
+ * know the labelling exists.
+ */
+export function offsetBeyondEmulationCap(offset: number): boolean {
+  if (offset <= OFFSET_EMULATION_CAP) return false;
+  offsetCapDeclineGeneration += 1;
+  return true;
+}
 
 export interface BlockFeedQuery {
   limit: number;
@@ -159,7 +205,7 @@ export async function fetchBlockRowsFromR2Sql(
   const offset = safeBlockNumber(query.offset ?? 0);
   if (limit === null || offset === null || limit <= 0) return null;
   // Refuse rather than mis-serve: see OFFSET_EMULATION_CAP.
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const where: string[] = [];
   const author = safeAuthorLiteral(query.author);

--- a/src/subnet-hyperparams-cold-tier.ts
+++ b/src/subnet-hyperparams-cold-tier.ts
@@ -12,7 +12,7 @@
 
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
-import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import {
   buildSubnetHyperparams,
   SUBNET_HYPERPARAMS_INSERT_COLUMNS,
@@ -75,7 +75,7 @@ export async function loadSubnetHyperparamsHistoryColdTier(
     return null;
   // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
   // reasonable trade and declining beats serving a page that is quietly wrong.
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const where = [`netuid = ${n}`];
   const cursor = decodeCursor(query.cursor, CURSOR_ARITY);

--- a/src/subnet-identity-cold-tier.ts
+++ b/src/subnet-identity-cold-tier.ts
@@ -11,7 +11,7 @@
 
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber } from "./r2-sql.ts";
-import { OFFSET_EMULATION_CAP } from "./r2-sql-blocks.ts";
+import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { buildSubnetIdentityHistory } from "./subnet-identity-history.ts";
 import {
   buildChainIdentityHistory,
@@ -47,7 +47,7 @@ export async function loadSubnetIdentityHistoryColdTier(
     return null;
   // R2 SQL has no OFFSET; past this depth the over-fetch stops being a
   // reasonable trade and declining beats serving a page that is quietly wrong.
-  if (offset > OFFSET_EMULATION_CAP) return null;
+  if (offsetBeyondEmulationCap(offset)) return null;
 
   const where = [`netuid = ${n}`];
   const cursor = decodeCursor(query.cursor, CURSOR_ARITY);

--- a/tests/degraded-answer-is-labelled.test.ts
+++ b/tests/degraded-answer-is-labelled.test.ts
@@ -277,6 +277,94 @@ describe("no registered route serves an unlabelled decline (#10270)", () => {
   });
 });
 
+describe("no paginated route declines a deep offset in silence (#11142)", () => {
+  /**
+   * The sweep above cannot see this class, by construction.
+   *
+   * Its discriminator is the r2-sql failure generation, so it only considers
+   * routes whose lakehouse read was ATTEMPTED and failed. A decline taken
+   * before the query -- `offset` past OFFSET_EMULATION_CAP is checked before
+   * any SQL is built -- moves no generation, issues no request, and therefore
+   * looks identical to a route that simply had nothing to say.
+   *
+   * That is exactly how `/api/v1/extrinsics` shipped answering
+   * `extrinsic_count: 0, next_cursor: null` -- byte-identical to end-of-feed --
+   * as a cacheable 200 with millions of rows behind the offset.
+   *
+   * DEPTH IS THE DISCRIMINATOR, not a list of routes to remember. Each route is
+   * driven twice: if it asks the lakehouse at a shallow offset but goes silent
+   * at a deep one, it declined without querying, and that answer must say so.
+   * A route that never pages the lakehouse is skipped by its own behaviour, so
+   * a route added tomorrow is covered without editing this file.
+   */
+  const EVERY_ROUTE = [...API_ROUTES, ...FEED_ROUTES];
+
+  /** Named so the sweep cannot go quietly green on a smaller surface. */
+  const PAGED_ANCHOR = "/api/v1/extrinsics";
+
+  test("a route that stops querying at depth must label the answer", async () => {
+    const calls: string[] = [];
+    const countingLakehouse = (async (input: unknown) => {
+      calls.push(String(input));
+      throw new Error("r2 sql unreachable");
+    }) as unknown as typeof fetch;
+
+    const paged: string[] = [];
+    const unlabelled: string[] = [];
+
+    await withFetch(countingLakehouse, async () => {
+      for (const route of EVERY_ROUTE) {
+        const path = concretePath(route.path);
+
+        // Shallow: does this route page the lakehouse at all? A route that
+        // does not (a baked artifact, or one that rejects `offset` outright
+        // with a 400) needs no exemption entry -- it simply never qualifies.
+        calls.length = 0;
+        try {
+          await handleRequest(
+            apiRequest(`${path}?offset=0`),
+            LAKEHOUSE_ENV,
+            {},
+          );
+        } catch {
+          continue;
+        }
+        if (calls.length === 0) continue;
+        paged.push(route.path);
+
+        // Deep: past the emulated-offset ceiling.
+        calls.length = 0;
+        let deep: Response;
+        try {
+          deep = (await handleRequest(
+            apiRequest(`${path}?offset=${OFFSET_EMULATION_CAP + 10}`),
+            LAKEHOUSE_ENV,
+            {},
+          )) as Response;
+        } catch {
+          continue;
+        }
+        // Still querying: the answer is whatever the tier said, and the
+        // generation-based sweep above already owns that case.
+        if (calls.length > 0) continue;
+        // A non-200 is already an honest refusal.
+        if (deep.status !== 200) continue;
+        if (!deep.headers.get(DEGRADED_HEADER)) unlabelled.push(route.path);
+      }
+    });
+
+    assert.deepEqual(
+      unlabelled,
+      [],
+      "these stopped querying at depth and answered 200 anyway, with nothing to say the page was declined rather than empty",
+    );
+    assert.ok(
+      paged.includes(PAGED_ANCHOR),
+      `${PAGED_ANCHOR} no longer pages the lakehouse -- this sweep is measuring less than it thinks`,
+    );
+  });
+});
+
 describe("what the router label refuses to touch", () => {
   // The four early returns, each stated once. Driving them through a route
   // would need a route that happens to be in each state, which is how a

--- a/tests/r2-sql-blocks.test.ts
+++ b/tests/r2-sql-blocks.test.ts
@@ -10,6 +10,8 @@ import {
   loadBlockFeedFromR2Sql,
   loadBlockFromR2Sql,
   OFFSET_EMULATION_CAP,
+  currentOffsetCapDeclineGeneration,
+  offsetBeyondEmulationCap,
   safeAuthorLiteral,
 } from "../src/r2-sql-blocks.ts";
 import { R2_SQL_TOKEN_ENV } from "../src/r2-sql.ts";
@@ -88,6 +90,35 @@ describe("loadBlockFeedFromR2Sql", () => {
     assert.ok(!/OFFSET/i.test(queries[0]!), "never emits an OFFSET clause");
     assert.equal(data!.blocks[0]!.block_number, 8);
     assert.equal(data!.blocks.length, 2);
+  });
+
+  test("the cap check RECORDS the decline it takes (#11142)", () => {
+    // The counter is the only way a declined page can be told from an empty
+    // one: the cap is checked before any SQL is built, so the r2-sql failure
+    // generation -- which is what handleRequest compares around a dispatch --
+    // never moves. A bare `offset > CAP` comparison is therefore invisible to
+    // the labeller, which is how ten routes shipped answering a declined page
+    // as end-of-feed.
+    const start = currentOffsetCapDeclineGeneration();
+
+    // At or below the ceiling: servable, and nothing to declare.
+    assert.equal(offsetBeyondEmulationCap(0), false);
+    assert.equal(offsetBeyondEmulationCap(OFFSET_EMULATION_CAP), false);
+    assert.equal(
+      currentOffsetCapDeclineGeneration(),
+      start,
+      "a servable depth must not report a decline, or the marker means nothing",
+    );
+
+    // Past it: declined, and said so.
+    assert.equal(offsetBeyondEmulationCap(OFFSET_EMULATION_CAP + 1), true);
+    assert.equal(currentOffsetCapDeclineGeneration(), start + 1);
+    assert.equal(offsetBeyondEmulationCap(OFFSET_EMULATION_CAP + 10_000), true);
+    assert.equal(
+      currentOffsetCapDeclineGeneration(),
+      start + 2,
+      "each decline counts, so concurrent reads on one isolate cannot mask one another",
+    );
   });
 
   test("the offset cap keeps the worst measured page under the body cap (#11140)", () => {

--- a/workers/request-handlers/analytics.ts
+++ b/workers/request-handlers/analytics.ts
@@ -58,6 +58,7 @@ import {
 } from "../responses.ts";
 import { currentDataApiTierFallbackGeneration } from "../data-api-tier.ts";
 import { currentR2SqlFailureGeneration } from "../../src/r2-sql.ts";
+import { currentOffsetCapDeclineGeneration } from "../../src/r2-sql-blocks.ts";
 import { loadBulkHealthTrends } from "../../src/bulk-health-trends.ts";
 import {} from "../../src/route-limits.ts";
 import { formatGlobalIncidents } from "../../src/health-serving.ts";
@@ -360,6 +361,20 @@ export interface DegradedSnapshot {
   postgresTier: number;
   r2Sql: number;
   unmeasured: number;
+  /**
+   * Reads that declined a too-deep offset WITHOUT issuing a query (#11142).
+   *
+   * A fourth counter because the other three cannot see this one. `r2Sql`
+   * moves when a query fails; the emulated-offset cap is checked before any SQL
+   * is built, so nothing is sent, nothing fails, and the answer went out as a
+   * bare 200 whose body was byte-identical to end-of-feed -- on ten paginated
+   * routes, edge-cached for the TTL.
+   *
+   * Counted at the single check in `offsetBeyondEmulationCap` rather than at
+   * each route's `?? build...([])`, because there are 92 of those and the whole
+   * design of this labelling is that no handler has to remember it.
+   */
+  offsetCapDeclined: number;
 }
 
 export function degradedSnapshot(): DegradedSnapshot {
@@ -367,6 +382,7 @@ export function degradedSnapshot(): DegradedSnapshot {
     postgresTier: currentDataApiTierFallbackGeneration(),
     r2Sql: currentR2SqlFailureGeneration(),
     unmeasured: unmeasuredGeneration,
+    offsetCapDeclined: currentOffsetCapDeclineGeneration(),
   };
 }
 
@@ -392,7 +408,13 @@ export function degradedSince(before: DegradedSnapshot): {
   return {
     transient:
       now.postgresTier !== before.postgresTier || now.r2Sql !== before.r2Sql,
-    unmeasured: now.unmeasured !== before.unmeasured,
+    // An offset-cap decline is UNMEASURED, not transient: the same offset
+    // declines identically for the whole TTL, so the answer stays cacheable and
+    // merely stops claiming to be measured. Barring it from the cache would
+    // re-run a refusal that cannot change.
+    unmeasured:
+      now.unmeasured !== before.unmeasured ||
+      now.offsetCapDeclined !== before.offsetCapDeclined,
   };
 }
 


### PR DESCRIPTION
## The defect, found by sweep rather than by guess

Ten paginated routes answered a **declined** page as a bare, edge-cacheable `200` whose body is byte-identical to end-of-feed (`count: 0`, `next_cursor: null`). A client paginating the feed stops there and silently drops the tail.

```
/api/v1/validators/{hotkey}/nominators      /api/v1/accounts/{ss58}/events
/api/v1/subnets/{netuid}/hyperparameters/history   /api/v1/accounts/{ss58}/extrinsics
/api/v1/subnets/{netuid}/events             /api/v1/accounts/{ss58}/transfers
/api/v1/subnets/{netuid}/identity-history   /api/v1/accounts/{ss58}/identity-history
/api/v1/blocks/{ref}/extrinsics             /api/v1/blocks/{ref}/events
```

Ten routes; exactly ten `if (offset > OFFSET_EMULATION_CAP) return null;` sites in the cold-tier readers. A 1:1 mapping.

## Why the existing guard could not see it

`handleRequest` labels degradation by snapshotting failure generations around the dispatch — deliberately from outside, so the label is "unforgettable rather than 40 more places to remember". A query that *fails* moves `currentR2SqlFailureGeneration()` and is labelled automatically.

The offset cap is checked **before any SQL is built**: nothing is sent, nothing fails, no generation moves. The existing whole-route-table sweep keys off those same generations, so it is structurally incapable of catching this class.

## Why not extend #11149's approach

#11149 wrapped the extrinsics feed's fallback in `unmeasured`. Right locally, wrong in shape — there are **92** `?? build…([])` operands in the handlers, and per-route wrapping is exactly what this architecture exists to avoid.

So this counts the decline **at the check**. `offsetBeyondEmulationCap(offset)` replaces the bare comparison at all ten reader sites and records it; `degradedSnapshot` carries a fourth counter and `degradedSince` folds it into **unmeasured** — not transient, because the same offset declines identically for the whole TTL, so the answer stays cacheable and merely stops claiming to be measured. A reader added later reports its decline without its author knowing the labelling exists.

#11149's wraps stay: they cover pre-query declines this counter cannot see — the `call_hash` arm that skips the tier outright, and a filter `feedPredicates` refuses to express.

## The durable part

A second sweep using **depth** as the discriminator: drive every registered route twice, and if it queries at a shallow offset but goes silent at a deep one, it declined without querying and must be labelled. No route list to maintain — a route that never pages the lakehouse is skipped by its own behaviour, so a route added tomorrow is covered without editing the file.

## Verification

- The new sweep **fails without the wiring**, naming all ten routes; passes with it.
- Direct unit test on the primitive: a servable depth must not report a decline (or the marker means nothing), and each decline counts.
- **Patch coverage by diff intersection: 0 uncovered changed lines** across all 8 source files.
- 388 tests pass across the affected surface (cold tier, blocks, extrinsics, events, edge cache, analytics handlers); `tsc`, prettier, eslint clean; unreferenced-exports holds at 731; `validate-r2-sql-scan-bounds` green.

Closes #11153