### PR TITLE
feat(registry): register SN105's operator dashboard

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -817,6 +817,29 @@
       },
       "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
       "url": "https://beamcore.b1m.ai/logs/stream/%7Bsource%7D"
+    },
+    {
+      "id": "sn-105-beam-dashboard",
+      "name": "Beam orchestrator dashboard",
+      "kind": "dashboard",
+      "url": "https://data.b1m.ai/",
+      "provider": "beam",
+      "authority": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Beam-Network/beam/blob/main/README.md"
+      ],
+      "notes": "The subnet's own operator dashboard, listed as \"Dashboard\" under Links in the Beam-Network/beam README. Serves the orchestrator view at /orchestrators; a Next.js app, not an API -- the callable API is beamcore.b1m.ai, which the same README names as CORE_SERVER_URL.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "review": {
+        "state": "maintainer-reviewed"
+      }
     }
   ],
   "website_url": "https://b1m.ai/"


### PR DESCRIPTION
## Summary

`https://data.b1m.ai/` — Beam's operator dashboard — was not registered. The subnet's own README lists it under **Links** as "Dashboard", which is the source_url for this entry.

Registered as `kind: dashboard`, probed for HTML like the other dashboards.

## It is an addition, not a correction

Checked side by side today:

| | data.b1m.ai | beamcore.b1m.ai |
|---|---|---|
| `/openapi.json` | 404 | 200 JSON |
| `/health` | 404 | 200 JSON |
| `/docs/json` | 404 | 200 JSON |
| `/` | 307 → /orchestrators, HTML | — |

Its only `/api/*` route is `/api/health`, reporting the Node process's uptime and memory — the app's health, not the subnet's. The same README names `CORE_SERVER_URL = https://beamcore.b1m.ai`, so the 29 registered beamcore surfaces point at the right host.

## Validation

`validate:surface` (32 surfaces), `scan:public-safety`, `npm run validate` (3,326 surfaces), `npm run build`, `format:check`.

Closes #11156