### PR TITLE
feat(mcp): call_subnet_surface can send PATCH and DELETE

### DIFF
--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -165,6 +165,30 @@ export type VerifyIntegrationOutput = z.infer<
   typeof VerifyIntegrationOutputSchema
 >;
 
+/**
+ * The verbs this tool will send, and the subset that may carry a body.
+ *
+ * ONE DECLARATION because three places need it: the published input enum
+ * below, the dispatch guard that refuses anything else, and the request
+ * builder that decides whether a body is attached. They were three literals,
+ * and the enum was the one that silently bounded the tool -- 184 DELETE and 53
+ * PATCH operations declared across the fleet's captured specs were unreachable
+ * because a verb was missing from a list nothing pointed at (#11146).
+ *
+ * DELETE carries no body. HTTP permits one and most servers ignore it, and
+ * accepting it would mean validating against a requestBody the operation
+ * essentially never declares.
+ */
+export const CALL_SURFACE_METHODS = [
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+] as const;
+export const CALL_SURFACE_BODY_METHODS = ["POST", "PUT", "PATCH"] as const;
+
 export const CallSubnetSurfaceInputSchema = z
   .object({
     surface_id: surfaceIdSchema(),
@@ -188,9 +212,21 @@ export const CallSubnetSurfaceInputSchema = z
       // wrong assertion (#9659).
       .meta({ format: "uri-reference", examples: ["/v1/status"] }),
     method: z
-      .enum(["GET", "HEAD", "POST", "PUT"])
+      // PATCH and DELETE joined the four originals in #11146: across the
+      // fleet's captured specs, 184 DELETE and 53 PATCH operations were
+      // declared by subnets and unreachable through this tool purely because
+      // the verb was not in this enum. The gate is unchanged and does the real
+      // work -- the exact path+method must be declared in the surface's own
+      // captured schema, and an authenticated surface still needs the caller's
+      // own credential -- so widening the verb set grants no authority the
+      // caller did not already have calling the API directly.
+      .enum(CALL_SURFACE_METHODS)
       .optional()
-      .describe("HTTP method to use for the call.")
+      .describe(
+        "HTTP method to use for the call. A destructive verb (PATCH/DELETE) is " +
+          "accepted only when the surface's captured schema declares that exact " +
+          "path+method, and is sent with the caller's own credential.",
+      )
       .meta({ examples: ["GET"] }),
     // Branch order (object, then string) mirrors the hand-written original's
     // `type: ["object", "string"]`.

--- a/src/call-subnet-surface.ts
+++ b/src/call-subnet-surface.ts
@@ -280,9 +280,18 @@ export async function callSubnetSurface(
       : surface?.probe?.method === "HEAD"
         ? "HEAD"
         : "GET";
-  // GET/HEAD never carry a body even if one was somehow supplied -- only the
-  // tool handler's own POST/PUT validation path ever sets requestBody.
-  const canHaveBody = path && (method === "POST" || method === "PUT");
+  // A verb that does not carry a body never carries one even if one was somehow
+  // supplied -- only the tool handler's own validation path sets requestBody.
+  //
+  // Spelled out rather than imported from CALL_SURFACE_BODY_METHODS, which owns
+  // this vocabulary (schemas-src/mcp-tools/ai-integration.ts): this module has
+  // NO imports on purpose -- it is the outbound-fetch safety path, and pulling
+  // in the schema module would drag Zod and the whole tool registry into it.
+  // The tool handler validates the same rule from the shared list before ever
+  // calling here, so this is the defensive second check, not the decision.
+  const canHaveBody =
+    Boolean(path) &&
+    (method === "POST" || method === "PUT" || method === "PATCH");
   const timeoutMs = Number.isFinite(surface?.probe?.timeout_ms)
     ? (surface.probe?.timeout_ms as number)
     : 10_000;

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1107,6 +1107,8 @@ import {
   VerifyIntegrationInputSchema,
   VerifyIntegrationOutputSchema,
   CallSubnetSurfaceInputSchema,
+  CALL_SURFACE_METHODS,
+  CALL_SURFACE_BODY_METHODS,
   CallSubnetSurfaceOutputSchema,
   StoreSurfaceCredentialInputSchema,
   StoreSurfaceCredentialOutputSchema,
@@ -14419,7 +14421,7 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
     name: "call_subnet_surface",
     title: "Call a subnet's live API and return its response",
     description:
-      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). For POST/PUT, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, cookie, or merged into a POST/PUT JSON body (MCP execute Phase 3-4, #7686-#7688, #7701). Never obtains a credential on your behalf. Authenticated callers should register the credential once with store_surface_credential and OMIT the `credential` argument -- it is then resolved from the caller's own store and never travels through tool arguments, client logs, or the conversation transcript; passing it in-band still works but is deprecated for authenticated callers (#9009). Anonymous callers have no store to bind to and keep passing `credential` in-band, which is never retained past the single call.",
+      "Actually call a catalogued surface (by surface_id, stable surface_key, or deprecated surface_id alias) and return its real response body -- not just health/status metadata like verify_integration. The response is bounded: JSON is parsed and returned structured, other text is returned capped, and unexpected binary content-types are rejected. With no `path`/`method`, only the surface's own curated url is ever fetched, using its declared probe method (GET/HEAD) -- MCP execute Phase 1 (#7014). Supplying both `path` and `method` (GET/HEAD/POST/PUT/PATCH/DELETE) calls a different route on the SAME surface's host instead, but only when that exact path+method is declared in the surface's own captured schema (fetch it first with get_api_schema) -- an undeclared path, or a surface with no captured schema at all, is rejected outright, never guessed -- MCP execute Phase 2 (#7674, #7675). A concrete value substitutes into a templated path, so `/workers/abc` reaches a declared `/workers/{worker_id}`. PATCH and DELETE are reachable on the same terms as every other verb and grant no authority the caller lacks calling the API directly: the operation must be declared, and an authenticated surface still needs the caller's own credential. For POST/PUT/PATCH, `body` is validated against the matched operation's declared request body: rejected if the operation declares none, or if `content_type` isn't one of its declared media types (defaults to application/json when that's declared, or the operation's only declared media type). A surface with `auth_required:true` needs a `credential` argument to be callable at all -- see that argument's own description for which surfaces support it, including multi-value signature bundles (e.g. a Bittensor hotkey-signed request) that can be placed in a header, query param, cookie, or merged into a POST/PUT/PATCH JSON body (MCP execute Phase 3-4, #7686-#7688, #7701). Never obtains a credential on your behalf. Authenticated callers should register the credential once with store_surface_credential and OMIT the `credential` argument -- it is then resolved from the caller's own store and never travels through tool arguments, client logs, or the conversation transcript; passing it in-band still works but is deprecated for authenticated callers (#9009). Anonymous callers have no store to bind to and keep passing `credential` in-band, which is never retained past the single call.",
     inputSchema: inputJsonSchema(CallSubnetSurfaceInputSchema),
     async handler(
       args: z.infer<typeof CallSubnetSurfaceInputSchema>,
@@ -14468,19 +14470,29 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       if (hasMethod) {
         // hasMethod already proved args.method is a non-empty string.
         normalizedMethod = (args.method as string).toUpperCase();
-        if (!["GET", "HEAD", "POST", "PUT"].includes(normalizedMethod)) {
-          throw toolError(
-            "invalid_params",
-            "`method` must be GET, HEAD, POST, or PUT.",
-          );
-        }
         if (
-          hasBodyArg &&
-          (normalizedMethod === "GET" || normalizedMethod === "HEAD")
+          !(CALL_SURFACE_METHODS as readonly string[]).includes(
+            normalizedMethod,
+          )
         ) {
           throw toolError(
             "invalid_params",
-            "`body` is only valid with method POST or PUT.",
+            `\`method\` must be ${CALL_SURFACE_METHODS.join(", ")}.`,
+          );
+        }
+        // DELETE joins GET/HEAD here rather than with the body-carrying verbs:
+        // a request body on DELETE is permitted by HTTP and ignored by most
+        // servers, and accepting one would mean validating it against a
+        // requestBody the operation almost never declares.
+        if (
+          hasBodyArg &&
+          !(CALL_SURFACE_BODY_METHODS as readonly string[]).includes(
+            normalizedMethod,
+          )
+        ) {
+          throw toolError(
+            "invalid_params",
+            `\`body\` is only valid with method ${CALL_SURFACE_BODY_METHODS.join(", ")}.`,
           );
         }
       }

--- a/tests/call-subnet-surface-mcp.test.ts
+++ b/tests/call-subnet-surface-mcp.test.ts
@@ -591,14 +591,58 @@ describe("call_subnet_surface MCP tool (#7014)", () => {
       assert.match(result.content[0].text, /invalid_params/);
     });
 
-    test("a method outside GET/HEAD/POST/PUT is invalid_params", async () => {
+    test("a method outside the published enum is invalid_params", async () => {
+      // TRACE is not in CALL_SURFACE_METHODS and never will be. DELETE used to
+      // be this test's subject and is now a first-class verb (#11146) -- 184
+      // DELETE operations across the fleet's captured specs were unreachable
+      // for no reason but this list.
       const result = await callTool({
         surface_id: "x:api:4",
         path: "/users/123",
-        method: "DELETE",
+        method: "TRACE",
       });
       assert.equal(result.isError, true);
       assert.match(result.content[0].text, /invalid_params/);
+    });
+
+    test("DELETE and PATCH are refused when the schema does not declare them", async () => {
+      // The verb being callable does not make an undeclared operation callable:
+      // the gate is unchanged, and it is the gate that does the work.
+      for (const method of ["DELETE", "PATCH"]) {
+        const result = await callTool({
+          surface_id: "x:api:4",
+          path: "/users/123",
+          method,
+        });
+        assert.equal(result.isError, true, `${method} must be gated`);
+        assert.match(result.content[0].text, /path_not_declared/);
+      }
+    });
+
+    test("a body is refused on DELETE and accepted on PATCH", async () => {
+      // DELETE carries no body: HTTP permits one, most servers ignore it, and
+      // the operation essentially never declares a requestBody to validate it
+      // against. PATCH is a body verb like POST and PUT.
+      const withBody = await callTool({
+        surface_id: "x:api:4",
+        path: "/users/123",
+        method: "DELETE",
+        body: { name: "x" },
+      });
+      assert.equal(withBody.isError, true);
+      assert.match(withBody.content[0].text, /invalid_params/);
+      assert.match(withBody.content[0].text, /POST, PUT, PATCH/);
+
+      // PATCH gets past the body guard and is stopped by the schema gate
+      // instead, which is the correct refusal for this fixture.
+      const patch = await callTool({
+        surface_id: "x:api:4",
+        path: "/users/123",
+        method: "PATCH",
+        body: { name: "x" },
+      });
+      assert.equal(patch.isError, true);
+      assert.match(patch.content[0].text, /path_not_declared/);
     });
 
     test("a surface with no captured schema at all is rejected with no_schema", async () => {


### PR DESCRIPTION
## Measured

Across the 51 subnets whose registered spec is reachable and parseable:

| verb | declared operations |
|---|---|
| POST | 490 |
| **DELETE** | **184** |
| PUT | 137 |
| **PATCH** | **53** |

The tool's Zod enum was `["GET","HEAD","POST","PUT"]`, so **239 operations subnets publish were unreachable** — not refused with a reason, simply unrepresentable. On SN105 that is `PATCH /orchestrators/ready`, `PATCH /orchestrators/{id}/workers/{worker_id}`, and three DELETEs.

## The verb was never the control

Unchanged and still doing the work: the exact path+method must be declared in the surface's **captured** schema, an `auth_required` surface needs the **caller's own** credential (we never obtain one), and the resolved URL must stay on the surface's origin. A caller who can `POST /clients/register` through us can already `DELETE /destinations/{id}` directly against the same host with the same key.

## The change

- `CALL_SURFACE_METHODS` and `CALL_SURFACE_BODY_METHODS` are declared once in `schemas-src/mcp-tools/ai-integration.ts` and read by the published enum and the dispatch guard — they were three separate literals, and the enum was the one silently bounding the tool.
- PATCH carries a body, validated like POST/PUT. **DELETE carries none**: HTTP permits it, servers ignore it, and the operation essentially never declares a requestBody to validate against.
- OPTIONS stays out — a preflight verb, 2 instances fleet-wide.
- `src/call-subnet-surface.ts` keeps its check local and says why: that module has **no imports** by design (it is the outbound-fetch safety path), so importing the schema module would drag Zod and the tool registry into it. The handler validates from the shared list first; this is the defensive second check.

Verified in passing: templated paths already work — `path="/workers/abc"` matched the declared `/workers/{worker_id}` and returned the subnet's own 404 body.

## Tests

The old test asserted DELETE was invalid; it now asserts an unknown verb (TRACE) is, plus two new cases: DELETE/PATCH are still refused with `path_not_declared` when the schema does not declare them, and a body is refused on DELETE while accepted on PATCH. 102 tests in that file, 85 across the three sibling suites, **100% statement/branch coverage** on `src/call-subnet-surface.ts`.

`validate:mcp` (240 tools), `validate:api`, `validate:contract-drift`, `validate:published-names`, `lint`, `format:check`, `typecheck`.

Closes #11162