### PR TITLE
fix(watchdog): re-anchor the nominator-counts expectation to chain, not to our table

### DIFF
--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -73,22 +73,57 @@ export const VALIDATOR_NOMINATOR_COUNTS_STALENESS_THRESHOLD_MS =
 /**
  * How many hotkeys a COMPLETE pass is expected to write.
  *
- * 112,245, read off production on 2026-08-05 as the row count at the newest
- * `captured_at`. The table is keyed on (hotkey) alone, so a row IS a hotkey --
- * every hotkey the SubtensorModule::Alpha scan found with at least one
- * nominator.
+ * 21,547, COUNTED ON CHAIN on 2026-08-14 rather than read off our own table:
+ *
+ *   prefix = twox128("SubtensorModule") ++ twox128("Alpha")
+ *   state_getKeysPaged(prefix, 1000, last, finalizedHead), walked to exhaustion
+ *   -> 120,253 entries over 121 pages, final page 253 (a SHORT page, so this is
+ *      end-of-iteration and not a truncated walk)
+ *   -> 21,547 distinct hotkeys, 24,605 distinct coldkeys
+ *
+ * ## WHY THIS WAS 112,245, AND WHY THAT NUMBER WAS THE BUG
+ *
+ * The old figure was "read off production on 2026-08-05 as the row count at the
+ * newest `captured_at`". That was true when written and became false without
+ * anything failing: the Alpha keyspace dropped ~84%, which the poller's own
+ * scan floor was re-anchored for on 2026-08-13 (762,577 -> 120,314 there, also
+ * by walking the map directly against two nodes). This constant was not
+ * re-anchored alongside it, so the two halves of the same lane disagreed about
+ * how big the network is.
+ *
+ * The result was an alarm that fired continuously on CORRECT data, saying
+ * `/validators` "serves a nominator_count that is silently a pass old" while
+ * the pass was in fact complete: it wrote 21,548 hotkeys against a chain that
+ * has 21,547. A stale constant does not fail loudly, it fails plausibly -- the
+ * same lesson the poller's floor comment records, one repo over.
+ *
+ * ## DO NOT RE-DERIVE THIS FROM THE TABLE
+ *
+ * `validator_nominator_counts` ACCUMULATES: it is keyed on (hotkey), and a
+ * hotkey that loses its last nominator keeps its row rather than being deleted.
+ * At the time of writing the table held 112,250 rows against those 21,547 live
+ * hotkeys, which is why reading the table's row count reproduces exactly the
+ * stale number this replaces. The expectation is a property of the CHAIN, so
+ * measure it there.
  */
-export const VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS = 112_245;
+export const VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS = 21_547;
 
 /**
  * How much of that a single pass must cover before it counts as complete.
  *
- * EIGHTY PERCENT, placed against the chunking rather than picked round: the
- * sync route caps a request at 25,000 rows, so a full pass is ~5 requests and a
- * death partway lands near 25k / 50k / 75k / 100k. This floor (~89,800) catches
- * every one of those but the last, which is the right trade -- tightening it
- * far enough to catch a 4-of-5 death would put the alarm inside the noise band
- * of ordinary population change.
+ * EIGHTY PERCENT. This was originally placed against the chunking -- the sync
+ * route caps a request at 25,000 rows, so at the old 112,245 expectation a full
+ * pass was ~5 requests and a death partway landed near 25k / 50k / 75k / 100k,
+ * which a ~89,800 floor caught in every case but the last.
+ *
+ * THAT REASONING NO LONGER APPLIES, and saying so matters more than keeping the
+ * number. At the measured 21,547 a full pass fits in ONE request, so there are
+ * no interior chunk boundaries for a death to land on: a pass either lands or
+ * it does not, and a partial one now means the SCAN died rather than the upload.
+ * 80% is kept because it still catches any shortfall over a fifth of the
+ * population while sitting outside the noise band of ordinary churn -- but it is
+ * now a plain tolerance, not a number derived from the chunk layout. If the
+ * population grows back past ~25,000 the original argument returns on its own.
  *
  * THE DRIFT DIRECTION IS DIFFERENT HERE than on account_balances, and worth
  * knowing before retuning. That lane's expectation only grows (it counts

--- a/tests/validator-nominator-counts-staleness-watchdog.test.ts
+++ b/tests/validator-nominator-counts-staleness-watchdog.test.ts
@@ -162,8 +162,11 @@ describe("evaluateValidatorNominatorCountsStaleness", () => {
     // The acceptance criterion. Both ticks carry an identically fresh
     // MAX(captured_at); the ONLY difference is how many hotkeys the pass
     // reached, which is exactly what a timestamp cannot express.
+    // A FRACTION of the expectation, not a literal: `54_000` was half of the
+    // old 112,245 and is above the whole measured population, so it would now
+    // read as a complete pass and assert nothing.
     const half = evaluateValidatorNominatorCountsStaleness(
-      inputs({ coveredRows: 54_000, totalRows: FULL }),
+      inputs({ coveredRows: Math.round(FULL / 2), totalRows: FULL }),
     );
     assert.equal(half.stale, true, "a half-covered pass must not read as ok");
     assert.equal(half.reason, "partial");
@@ -177,27 +180,56 @@ describe("evaluateValidatorNominatorCountsStaleness", () => {
     assert.equal(whole.age_ms, half.age_ms);
   });
 
-  test("a truncated pass is caught at every chunk boundary but the last", () => {
-    // The sync route caps a request at 25,000 rows, so a full pass is ~5
-    // requests and a death partway lands near these counts. The floor is placed
-    // against that grid rather than picked round.
-    for (const covered of [25_000, 50_000, 75_000]) {
+  test("a pass that died mid-scan is caught, wherever it died", () => {
+    // The chunk grid this used to assert (25k / 50k / 75k / 100k) is GONE. It
+    // followed from a 112,245-hotkey expectation across a 25,000-row sync cap,
+    // ~5 requests. Measured on chain 2026-08-14 the population is 21,547, so a
+    // full pass fits in ONE request and there are no interior boundaries left
+    // for a death to land on -- see the ratio's comment.
+    //
+    // What still has to hold is the property the grid was standing in for: a
+    // pass that covered materially less than the population must alert. These
+    // are fractions of the expectation rather than absolute counts, so the next
+    // re-anchor moves them automatically instead of silently re-encoding a
+    // population that has moved on.
+    for (const fraction of [0.25, 0.5, 0.75]) {
+      const covered = Math.round(
+        VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS * fraction,
+      );
       const verdict = evaluateValidatorNominatorCountsStaleness(
         inputs({ coveredRows: covered, totalRows: FULL }),
       );
       assert.equal(
         verdict.reason,
         "partial",
-        `a pass that died at ${covered} rows must alert`,
+        `a pass that reached only ${Math.round(fraction * 100)}% of the population must alert`,
       );
     }
-    // Documented gap, asserted so it is a decision rather than a surprise: a
-    // death in the final chunk clears the floor. Tightening far enough to catch
-    // it would put the alarm inside the noise band of population change.
-    const lastChunk = evaluateValidatorNominatorCountsStaleness(
-      inputs({ coveredRows: 100_000, totalRows: FULL }),
+    // The documented gap, still a decision rather than a surprise: a pass just
+    // inside the 80% tolerance clears, because tightening further would put the
+    // alarm inside the noise band of ordinary churn.
+    const nearlyWhole = evaluateValidatorNominatorCountsStaleness(
+      inputs({
+        coveredRows: Math.round(
+          VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS * 0.9,
+        ),
+        totalRows: FULL,
+      }),
     );
-    assert.equal(lastChunk.stale, false);
+    assert.equal(nearlyWhole.stale, false);
+  });
+
+  test("the real 2026-08-14 pass reads as COMPLETE, not partial", () => {
+    // The regression this re-anchor is for. Production reported 21,548 hotkeys
+    // covered and alarmed continuously that /validators served silently stale
+    // counts. Counted on chain the same day -- twox128 prefix walk of
+    // SubtensorModule::Alpha, 120,253 entries ending on a short page -- there
+    // are 21,547 distinct hotkeys. The pass was complete; the constant was not.
+    const verdict = evaluateValidatorNominatorCountsStaleness(
+      inputs({ coveredRows: 21_548, totalRows: 112_250 }),
+    );
+    assert.equal(verdict.stale, false);
+    assert.notEqual(verdict.reason, "partial");
   });
 
   test("the no-prune stragglers do not count against coverage", () => {
@@ -233,7 +265,10 @@ describe("evaluateValidatorNominatorCountsStaleness", () => {
     // If a whole pass has been missed, "the producer stopped" is the headline
     // and the coverage of its last attempt is a detail.
     const verdict = evaluateValidatorNominatorCountsStaleness(
-      inputs({ latestCapturedAtMs: NOW - 31 * HOUR, coveredRows: 54_000 }),
+      inputs({
+        latestCapturedAtMs: NOW - 31 * HOUR,
+        coveredRows: Math.round(FULL / 2),
+      }),
     );
     assert.equal(verdict.reason, "stale");
   });
@@ -340,7 +375,11 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
   });
 
   test("a recent but half-covered table alerts, naming both counts", async () => {
-    const { env } = fakeDb(NOW - HOUR, 54_000, 112_250);
+    // Half the measured population, expressed as a fraction so a re-anchor
+    // moves it: `54_000` was half of the old 112,245 expectation and now sits
+    // above the whole chain, which would make this assert nothing.
+    const HALF = Math.round(VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS / 2);
+    const { env } = fakeDb(NOW - HOUR, HALF, 112_250);
     const recorded: { error?: Error; route?: string; errorCode?: string }[] =
       [];
     const result = await runValidatorNominatorCountsStalenessWatchdog(env, {
@@ -352,13 +391,13 @@ describe("runValidatorNominatorCountsStalenessWatchdog", () => {
     });
     assert.equal(result.alerted, true);
     assert.equal(result.reason, "partial");
-    assert.equal(result.covered_rows, 54_000);
+    assert.equal(result.covered_rows, HALF);
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]!.errorCode, "stale_lane");
     const message = String(recorded[0]!.error?.message);
     // Distinct wording from the stalled case -- different place to go looking.
     assert.match(message, /truncated/);
-    assert.match(message, /54000 hotkeys/);
+    assert.match(message, new RegExp(`${HALF} hotkeys`));
     assert.match(message, /RECENT and PARTIAL/);
     assert.doesNotMatch(message, /nothing is refreshing/);
   });


### PR DESCRIPTION
## The alarm was right about everything except the number

> `validator-nominator-counts lane truncated: the newest pass reached only 21548 hotkeys against a floor of 89796 ... /validators serves a nominator_count that is silently a pass old`

Firing continuously, on **correct data**.

## Counted on chain, not inferred

```
prefix = twox128("SubtensorModule") ++ twox128("Alpha")
state_getKeysPaged(prefix, 1000, last, finalizedHead) to exhaustion
-> 120,253 entries over 121 pages, final page 253
   (SHORT page -> end-of-iteration, not a truncated walk)
-> 21,547 distinct hotkeys, 24,605 distinct coldkeys
```

The pass wrote **21,548** against a chain that has **21,547**. It was complete.

(The twox128 helper was validated against the known `twox128("System")` constant before any of these numbers were trusted — an earlier attempt returned 0 entries from a wrong byte order and a mis-ordered `state_getKeysPaged` param, and both would have produced a confident, wrong conclusion.)

## Why it went stale

`EXPECTED_HOTKEYS = 112_245` was *"read off production on 2026-08-05 as the row count at the newest `captured_at`"*. The Alpha keyspace then dropped ~84%. The poller's scan floor **was** re-anchored for that on 2026-08-13 (762,577 → 120,314, by the same kind of direct walk against two nodes); this constant was not, so the two halves of one lane disagreed about the size of the network.

## The trap this records

**Do not re-derive it from the table.** `validator_nominator_counts` accumulates — keyed on `(hotkey)`, and a hotkey that loses its last nominator keeps its row. The table holds 112,250 rows against 21,547 live hotkeys, which is precisely why reading the table reproduces the stale number. The expectation is a property of the chain, so it is measured there and the comment says so.

## The ratio's justification was stale too

80% came from the 25,000-row sync cap making a full pass ~5 requests, so a death landed near 25k/50k/75k/100k. At 21,547 a full pass fits in **one** request and those interior boundaries do not exist. The tolerance is kept; the derivation is retired explicitly rather than left standing as arithmetic that no longer holds.

## Tests

The chunk-boundary grid is replaced by **fractions of the expectation**, so the next re-anchor moves them instead of silently re-encoding a stale population. This mattered immediately: `54_000` as "half" was half of the old figure and now sits *above* the whole chain — it would have asserted nothing while looking fine.

Adds the real production reading (21,548 covered, 112,250 in table) as a case that must read **COMPLETE**.

24 tests pass; `tsc`, prettier, eslint clean.

Closes #11165