### PR TITLE
perf(accounts): serve the summary card's aggregate from a sharded projection

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -101,6 +101,7 @@ import { storeAll } from "./analytics-live.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
 import { r2SqlQuery, safeBlockNumber, safeSs58Literal } from "./r2-sql.ts";
 import { windowedFloorRead, windowedRowRead } from "./account-events-window.ts";
+import { loadAccountSummaryProjection } from "./account-summary-projection.ts";
 import type { R2SqlReader } from "./r2-sql.ts";
 import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
@@ -1054,30 +1055,39 @@ export async function loadAccountSummaryColdTier(
   // and `first_seen`. So it re-issues instead, keeping its own ORDER BY and
   // LIMIT inside the SQL, and stops as soon as the window holds CAP + 1 rows --
   // at which point the newest CAP + 1 within it are the newest overall.
+  // THE PROJECTION FIRST (#11131). The grouped leg is a LIFETIME aggregate over
+  // a scattered key, so no window bounds it -- measured 4,374 MB and ~14s per
+  // request, which is the read that aborts at the 15s ceiling. A sharded R2
+  // artifact answers the identical question in one GET, and a miss returns null
+  // so this arm simply does not run. It can make the route faster, never wrong.
+  const projected = await loadAccountSummaryProjection(env, ss58);
+
   const [groupRows, recentRows] = await Promise.all([
-    windowedFloorRead<Record<string, unknown>[]>(env, {
-      query,
-      attempt: (bound, run) =>
-        run(
-          env,
-          `WITH scan AS (${scan(bound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
-            `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
-            `min(observed_at) AS fo, max(observed_at) AS lo ` +
-            `FROM scan GROUP BY event_kind, netuid`,
-          { onError: track("summary-groups") },
-        ),
-      // `sum(count)` over the groups is the rows the CTE saw, which is exactly
-      // the number the retired cap probe returned.
-      //
-      // No `?? 0`: `count(*)` always yields a value, so the nullish half is a
-      // branch no test can reach -- the same reading the `scanned` line below
-      // already applies. An absent count would make the sum NaN, `NaN > CAP` is
-      // false, and the read falls back to the unbounded query it would have
-      // issued anyway, so nothing is lost by not guarding it.
-      satisfied: (rows) =>
-        rows.reduce((n, row) => n + Number(row.count), 0) >
-        ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
-    }),
+    projected
+      ? Promise.resolve(projected)
+      : windowedFloorRead<Record<string, unknown>[]>(env, {
+          query,
+          attempt: (bound, run) =>
+            run(
+              env,
+              `WITH scan AS (${scan(bound)}) SELECT event_kind AS kind, netuid AS netuid, ` +
+                `count(*) AS count, min(block_number) AS fb, max(block_number) AS lb, ` +
+                `min(observed_at) AS fo, max(observed_at) AS lo ` +
+                `FROM scan GROUP BY event_kind, netuid`,
+              { onError: track("summary-groups") },
+            ),
+          // `sum(count)` over the groups is the rows the CTE saw, which is exactly
+          // the number the retired cap probe returned.
+          //
+          // No `?? 0`: `count(*)` always yields a value, so the nullish half is a
+          // branch no test can reach -- the same reading the `scanned` line below
+          // already applies. An absent count would make the sum NaN, `NaN > CAP` is
+          // false, and the read falls back to the unbounded query it would have
+          // issued anyway, so nothing is lost by not guarding it.
+          satisfied: (rows) =>
+            rows.reduce((n, row) => n + Number(row.count), 0) >
+            ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+        }),
     windowedRowRead<AccountEventsRow>(env, {
       query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),
       table: "chain.account_events",

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -1,0 +1,189 @@
+// The account summary card's aggregate leg, served from a SHARDED PROJECTION
+// artifact instead of scanning the lakehouse per request (#11131).
+//
+// WHAT THIS REPLACES. `/api/v1/accounts/{ss58}` asks its aggregate leg for
+// per-(event_kind, netuid) totals over one account's whole history, which is
+// `(hotkey = X OR coldkey = X)` against 455M rows in 51 files. An account value
+// is scattered across every file, so statistics cannot prune it and the engine
+// opens all of them: measured against production 2026-08-14, 4,374 MB and ~14s
+// PER REQUEST, and it is the read that aborts at the 15s r2-sql ceiling.
+//
+// #11141 bounded every FEED on that table -- a page went 1,068.9 MB -> 3.0 MB --
+// but a lifetime aggregate has no window that answers it. Proving an account has
+// fewer than N events means reading its whole history, so the scan has to
+// happen; the only question is once per request or once per day. This is once
+// per day, in the infra container that already runs the sibling rollups
+// (metagraphed-infra#557).
+//
+// WHY SHARDED R2 AND NOT ANOTHER LAKEHOUSE TABLE. Because `account` would be a
+// scattered key there too -- a rollup keyed on it opens most of its own files
+// for a point lookup exactly as the source does, which shrinks the table ~5x and
+// cures nothing. #11133 measured that bucketing on a scattered key trades bytes
+// for R2 requests at a bad rate. This route is a POINT LOOKUP by a
+// high-cardinality key, and ~1.2M accounts over 256 objects is one GET.
+//
+// WHY NOT `chain.account_events_daily`, which already exists. Its rule is
+// `hotkey IS NOT NULL AND netuid IS NOT NULL`, deliberately, so Transfer and
+// Deposit (coldkey, no netuid) and WeightsSet (no hotkey) are absent. For
+// 5EYCAe5jLQhn6ofDSvqF... it holds no row on any day against 1,343,321
+// both-side events on 2026-07-10 alone. Reading it here would have published a
+// 284x undercount.
+//
+// THE FALLBACK IS THE POINT. A missing shard, an unparseable body, an account
+// the projection has not seen -- every one of them returns null, and the caller
+// runs exactly the lakehouse query it runs today. So this can only make the
+// route faster, never wrong, and shipping it before the producer has backfilled
+// is safe by construction.
+
+/** Objects the producer writes, one per shard. Contract with
+ * metagraphed-infra's `services/indexer-rs/account_summary_r2.py`. */
+export const ACCOUNT_SUMMARY_PROJECTION_PREFIX =
+  "metagraph/projections/account-summary";
+
+/**
+ * How many shards the producer fans accounts across.
+ *
+ * MUST match `ACCOUNT_SUMMARY_SHARDS` on the writer. A mismatch does not error:
+ * both sides compute a shard number happily and simply disagree about which
+ * object holds an account, so every lookup misses and the route silently falls
+ * back to the scan this exists to avoid. That is why the number is stated here
+ * as a constant rather than read from the artifact -- a reader that trusted the
+ * body's own `shard_count` could not detect the disagreement, because it would
+ * have to fetch the right object first to learn it was fetching the wrong one.
+ */
+export const ACCOUNT_SUMMARY_SHARDS = 256;
+
+/** The payload shape this reader understands. A producer that changes a field's
+ * MEANING bumps it, and this declines rather than misreading the new one. */
+export const ACCOUNT_SUMMARY_SCHEMA_VERSION = 1;
+
+/**
+ * FNV-1a over the address, mod `shards`.
+ *
+ * MIRRORED EXACTLY from the producer's `shard_of`. A prefix scheme would read
+ * more simply, but every Bittensor ss58 starts '5' and the following characters
+ * are far from uniform, so prefix buckets differ by orders of magnitude and one
+ * object ends up holding most of the fleet.
+ *
+ * `Math.imul` and `>>> 0` are not decoration: javascript numbers are doubles, so
+ * a plain `h * 0x01000193` loses the low bits past 2^53 and yields a different
+ * hash from python's -- which is exactly the class of difference that agrees on
+ * every ASCII test address and disagrees in production. tests pin three known
+ * values against the producer's own.
+ */
+export function accountShard(
+  account: string,
+  shards: number = ACCOUNT_SUMMARY_SHARDS,
+): number {
+  let h = 0x811c9dc5;
+  const bytes = new TextEncoder().encode(account);
+  for (const byte of bytes) {
+    h ^= byte;
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h % shards;
+}
+
+/** The R2 key holding this account's groups. */
+export function accountSummaryShardKey(
+  account: string,
+  shards: number = ACCOUNT_SUMMARY_SHARDS,
+): string {
+  return `${ACCOUNT_SUMMARY_PROJECTION_PREFIX}/${accountShard(account, shards)}.json`;
+}
+
+interface ArtifactBucket {
+  get(key: string): Promise<{ json(): Promise<unknown> } | null>;
+}
+
+/** One (event_kind, netuid) group, in the producer's field names. */
+interface ProjectedGroup {
+  kind: unknown;
+  netuid: unknown;
+  count: unknown;
+  fb: unknown;
+  lb: unknown;
+  fo: unknown;
+  lo: unknown;
+}
+
+function finite(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * One account's aggregate groups, in the column aliases `foldSummaryGroups`
+ * already reads -- so the projection feeds the SAME builder the lakehouse query
+ * feeds, and nothing downstream learns which one answered.
+ *
+ * THE CAP STILL MEANS WHAT IT MEANT. The caller derives `scanned` from the
+ * summed group counts and clamps it to ACCOUNT_EVENT_SUMMARY_SCAN_CAP, so an
+ * account over the cap reports `event_scan_capped: true` and null `first_*`
+ * whichever tier answered. The projection knows the true lifetime total and
+ * publishing it would be a better number -- but a route whose meaning depends
+ * on which tier served it is worse than either, so that is a contract change
+ * and not this one.
+ *
+ * Returns null -- meaning "ask the lakehouse" -- for every condition that is
+ * not an answer: no bucket bound, no object, a body this reader does not
+ * understand, or an account the projection has not seen. None of those is an
+ * error worth surfacing, because the caller's existing path handles all of
+ * them by doing what it did before.
+ */
+export async function loadAccountSummaryProjection(
+  env: Env | null | undefined,
+  account: string,
+  { shards = ACCOUNT_SUMMARY_SHARDS }: { shards?: number } = {},
+): Promise<Record<string, unknown>[] | null> {
+  // Same binding the thirteen sibling projections read from.
+  const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
+    ?.METAGRAPH_ARCHIVE;
+  if (!bucket?.get || !account) return null;
+  let body: unknown;
+  try {
+    const object = await bucket.get(accountSummaryShardKey(account, shards));
+    if (!object) return null;
+    body = await object.json();
+  } catch {
+    // A shard that cannot be fetched or parsed is not a fault to report: the
+    // caller reads the lakehouse and answers correctly, just slower.
+    return null;
+  }
+  if (!body || typeof body !== "object") return null;
+  const payload = body as Record<string, unknown>;
+  if (Number(payload["schema_version"]) !== ACCOUNT_SUMMARY_SCHEMA_VERSION) {
+    return null;
+  }
+  // A shard written for a DIFFERENT fan-out is not this account's shard, even
+  // though the object exists and parses -- it is the wrong bucket of the wrong
+  // partitioning, so its absence of this account proves nothing.
+  const declared = finite(payload["shard_count"]);
+  if (declared !== null && declared !== shards) return null;
+
+  const accounts = payload["accounts"];
+  if (!accounts || typeof accounts !== "object") return null;
+  const raw = (accounts as Record<string, unknown>)[account];
+  if (!Array.isArray(raw)) return null;
+
+  const groups: Record<string, unknown>[] = [];
+  for (const entry of raw as ProjectedGroup[]) {
+    if (!entry || typeof entry !== "object") continue;
+    // Renamed to the column aliases `foldSummaryGroups` already reads, so the
+    // projection feeds the SAME builder the lakehouse query feeds and nothing
+    // downstream learns which one answered.
+    groups.push({
+      kind: entry.kind ?? null,
+      netuid: entry.netuid ?? null,
+      count: finite(entry.count) ?? 0,
+      fb: entry.fb ?? null,
+      lb: entry.lb ?? null,
+      fo: entry.fo ?? null,
+      lo: entry.lo ?? null,
+    });
+  }
+  // An account present with no usable groups is not an answer -- the caller
+  // reads the lakehouse rather than publishing an empty card from a shard.
+  if (!groups.length) return null;
+  return groups;
+}

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -12,6 +12,7 @@
 // folded into the aggregate (it was the query that aborted -- see "two reads").
 import assert from "node:assert/strict";
 import { visibleInWindow } from "./helpers/scan-window.ts";
+import { accountSummaryShardKey } from "../src/account-summary-projection.ts";
 import { readFileSync } from "node:fs";
 import { describe, test } from "vitest";
 import {
@@ -652,5 +653,114 @@ describe("all three account-summary surfaces go through the one composer", () =>
       readFileSync("src/account-summary-card.ts", "utf8"),
       /loadAccountSummaryColdTier\(/,
     );
+  });
+});
+
+describe("the projection short-circuits the aggregate leg (#11131)", () => {
+  const SHARD_KEY = accountSummaryShardKey(SS58);
+
+  /** An archive binding holding one shard for this account. */
+  function archive(groups: unknown[] | null) {
+    return {
+      METAGRAPH_ARCHIVE: {
+        get: async (key: string) =>
+          key === SHARD_KEY && groups
+            ? {
+                json: async () => ({
+                  schema_version: 1,
+                  generated_at: "2026-08-14T00:00:00Z",
+                  shard_count: 256,
+                  account_count: 1,
+                  accounts: { [SS58]: groups },
+                }),
+              }
+            : null,
+      },
+    } as never;
+  }
+
+  test("THE 4,374 MB SCAN IS NOT ISSUED when the shard answers", async () => {
+    // The measured cost this whole change exists to remove. The grouped leg is
+    // a lifetime aggregate over a scattered key, so no window bounds it -- the
+    // only fix is to not run it per request.
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier(
+      archive([
+        {
+          kind: "AxonServed",
+          netuid: 55,
+          count: 4,
+          fb: 8_700_000,
+          lb: 8_750_000,
+          fo: AGG.fo,
+          lo: AGG.lo,
+        },
+        {
+          kind: "NeuronRegistered",
+          netuid: 7,
+          count: 2,
+          fb: 8_710_000,
+          lb: 8_760_000,
+          fo: AGG.fo,
+          lo: AGG.lo,
+        },
+      ]),
+      SS58,
+      { query: engine.query as never },
+    );
+
+    assert.equal(cold.declined, undefined);
+    for (const sql of engine.seen) {
+      assert.doesNotMatch(
+        sql,
+        /GROUP BY event_kind, netuid/,
+        `the grouped scan must not run: ${sql.slice(0, 120)}`,
+      );
+    }
+    // The card is still built from the SAME builder over the SAME shape.
+    const card = buildAccountSummary(SS58, cold as never);
+    assert.equal(card.event_count, 6);
+    assert.equal(card.subnet_count, 2);
+    assert.equal(card.event_kinds.length, 2);
+  });
+
+  test("a shard that cannot answer falls back to the scan, unchanged", async () => {
+    // The safety property: shipping the reader before the producer has
+    // backfilled must be indistinguishable from not shipping it.
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier(archive(null), SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(cold.declined, undefined);
+    assert.ok(
+      engine.seen.some((s) => s.includes("GROUP BY event_kind, netuid")),
+      "the lakehouse leg must still run",
+    );
+    assert.equal(buildAccountSummary(SS58, cold as never).event_count, 6);
+  });
+
+  test("the cap keeps its meaning across both tiers", async () => {
+    // A route whose numbers depend on which tier served it is worse than
+    // either tier. The projection knows the true lifetime total; the published
+    // count stays clamped exactly as the live CTE's LIMIT CAP + 1 clamps it.
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier(
+      archive([
+        {
+          kind: "AxonServed",
+          netuid: 55,
+          count: ACCOUNT_EVENT_SUMMARY_SCAN_CAP + 500,
+          fb: 1,
+          lb: 2,
+          fo: AGG.fo,
+          lo: AGG.lo,
+        },
+      ]),
+      SS58,
+      { query: engine.query as never },
+    );
+    const card = buildAccountSummary(SS58, cold as never);
+    assert.equal(card.event_count, ACCOUNT_EVENT_SUMMARY_SCAN_CAP);
+    assert.equal(card.event_scan_capped, true);
   });
 });

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -1,0 +1,295 @@
+// The account summary card's aggregate leg, read from a sharded projection
+// (#11131).
+//
+// The claims worth pinning are the ones whose failure is SILENT. This reader
+// cannot make the route wrong by declining -- every null falls back to the
+// lakehouse query the route ran before -- so the dangerous failures are the
+// other direction: routing to the wrong object, or accepting a payload it
+// should have refused.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  ACCOUNT_SUMMARY_SCHEMA_VERSION,
+  ACCOUNT_SUMMARY_SHARDS,
+  accountShard,
+  accountSummaryShardKey,
+  loadAccountSummaryProjection,
+} from "../src/account-summary-projection.ts";
+
+const HOT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
+const COLD = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+
+function group(over: Record<string, unknown> = {}) {
+  return {
+    kind: "AxonServed",
+    netuid: 7,
+    count: 3,
+    fb: 10,
+    lb: 90,
+    fo: 1_000,
+    lo: 9_000,
+    ...over,
+  };
+}
+
+/** An R2 bucket holding exactly the objects given, keyed as the reader asks. */
+function archive(objects: Record<string, unknown>, { throws = false } = {}) {
+  const asked: string[] = [];
+  return {
+    env: {
+      METAGRAPH_ARCHIVE: {
+        get: async (key: string) => {
+          asked.push(key);
+          if (throws) throw new Error("r2 down");
+          if (!(key in objects)) return null;
+          return { json: async () => objects[key] };
+        },
+      },
+    } as never,
+    asked,
+  };
+}
+
+function shardBody(
+  accounts: Record<string, unknown>,
+  over: Record<string, unknown> = {},
+) {
+  return {
+    schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+    generated_at: "2026-08-14T00:00:00Z",
+    shard_count: ACCOUNT_SUMMARY_SHARDS,
+    account_count: Object.keys(accounts).length,
+    accounts,
+    ...over,
+  };
+}
+
+describe("accountShard", () => {
+  test("MATCHES THE PRODUCER BYTE FOR BYTE", () => {
+    // These three values are asserted IDENTICALLY in metagraphed-infra's
+    // services/indexer-rs/loader/test_account_summary_r2.py. Two
+    // implementations of FNV-1a agree on every ASCII address and part company
+    // on 32-bit overflow -- javascript's numbers are doubles, python's ints do
+    // not overflow at all -- and that divergence is invisible to either side's
+    // tests alone. It would show up only as every lookup missing in production,
+    // which reads as "the projection has no data" rather than as a bug.
+    assert.equal(accountShard(HOT, 256), 205);
+    assert.equal(accountShard(COLD, 256), 70);
+    assert.equal(accountShard("", 256), 197);
+  });
+
+  test("the wrap is forced, not incidental", () => {
+    // A long address is where a `h * 0x01000193` without Math.imul silently
+    // loses precision past 2^53 and starts disagreeing with python.
+    const long = "5" + "z".repeat(200);
+    assert.ok(Number.isInteger(accountShard(long)));
+    assert.ok(accountShard(long) >= 0 && accountShard(long) < 256);
+  });
+
+  test("stays inside the shard count for every fan-out", () => {
+    for (const n of [1, 2, 16, 256, 1024]) {
+      for (const account of [HOT, COLD, "5A", "z".repeat(64)]) {
+        const shard = accountShard(account, n);
+        assert.ok(shard >= 0 && shard < n, `${account} -> ${shard} of ${n}`);
+      }
+    }
+  });
+
+  test("the key names the object the producer writes", () => {
+    assert.equal(
+      accountSummaryShardKey(HOT),
+      "metagraph/projections/account-summary/205.json",
+    );
+  });
+});
+
+describe("loadAccountSummaryProjection", () => {
+  test("reads the account's groups from ITS OWN shard", async () => {
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({ [HOT]: [group()] }),
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.deepEqual(store.asked, [
+      "metagraph/projections/account-summary/205.json",
+    ]);
+    assert.equal(groups!.length, 1);
+    assert.deepEqual(groups![0], {
+      kind: "AxonServed",
+      netuid: 7,
+      count: 3,
+      fb: 10,
+      lb: 90,
+      fo: 1_000,
+      lo: 9_000,
+    });
+  });
+
+  test("ONE GET, whatever the account", async () => {
+    // The whole point against the 4,374 MB scan it replaces. If this ever grew
+    // a second fetch it would still be correct and would have given back most
+    // of the win.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({ [HOT]: [group()] }),
+    });
+    await loadAccountSummaryProjection(store.env, HOT);
+    assert.equal(store.asked.length, 1);
+  });
+
+  test("an account the projection has not seen DECLINES", async () => {
+    // Not an empty card: the caller reads the lakehouse, which is the only
+    // thing that can tell "no events" from "not projected yet".
+    const store = archive({
+      [accountSummaryShardKey(COLD)]: shardBody({ [HOT]: [group()] }),
+    });
+    assert.equal(await loadAccountSummaryProjection(store.env, COLD), null);
+  });
+
+  test("a missing shard, a bad body and a throwing bucket all decline", async () => {
+    assert.equal(
+      await loadAccountSummaryProjection(archive({}).env, HOT),
+      null,
+      "missing object",
+    );
+    assert.equal(
+      await loadAccountSummaryProjection(
+        archive({ [accountSummaryShardKey(HOT)]: "not an object" }).env,
+        HOT,
+      ),
+      null,
+      "unparseable body",
+    );
+    assert.equal(
+      await loadAccountSummaryProjection(
+        archive({}, { throws: true }).env,
+        HOT,
+      ),
+      null,
+      "r2 unavailable",
+    );
+    assert.equal(
+      await loadAccountSummaryProjection({} as never, HOT),
+      null,
+      "no binding",
+    );
+    assert.equal(
+      await loadAccountSummaryProjection(null, HOT),
+      null,
+      "no env at all",
+    );
+  });
+
+  test("A SCHEMA IT DOES NOT UNDERSTAND IS REFUSED", async () => {
+    // The version exists so a producer can change a field's MEANING without
+    // this reader publishing the old interpretation of the new bytes.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody(
+        { [HOT]: [group()] },
+        { schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION + 1 },
+      ),
+    });
+    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
+  });
+
+  test("A SHARD WRITTEN FOR A DIFFERENT FAN-OUT IS REFUSED", async () => {
+    // The dangerous case, because it does not look like an error: both sides
+    // compute a shard number happily and disagree about which object holds an
+    // account. Without this the reader would read a real, parseable object,
+    // fail to find the account in it, and report "not projected" forever.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody(
+        { [HOT]: [group()] },
+        { shard_count: 64 },
+      ),
+    });
+    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
+  });
+
+  test("an account present with NO usable groups declines", async () => {
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({ [HOT]: [] }),
+    });
+    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
+  });
+
+  test("a group missing its count contributes zero rather than NaN", async () => {
+    // foldSummaryGroups sums these; one NaN would make the whole card's
+    // event_count NaN, which serialises to null and reads as "no events".
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({
+        [HOT]: [group({ count: undefined })],
+      }),
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.equal(groups![0]!.count, 0);
+  });
+
+  test("a shard with no accounts map, or a non-array account, declines", async () => {
+    // Both are "the object exists but says nothing about this account", which
+    // is a decline rather than an empty answer.
+    for (const body of [
+      shardBody({} as never, { accounts: undefined }),
+      shardBody({} as never, { accounts: "nope" }),
+      shardBody({ [HOT]: { not: "an array" } as never }),
+    ]) {
+      const store = archive({ [accountSummaryShardKey(HOT)]: body });
+      assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
+    }
+  });
+
+  test("a malformed entry is skipped, not published as nulls", async () => {
+    // A row that is not an object has no fields to degrade; keeping it would
+    // add a phantom group to the card's event_kinds.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({
+        [HOT]: [null, "text", group()],
+      }),
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.equal(groups!.length, 1);
+  });
+
+  test("every absent field degrades to null rather than undefined", async () => {
+    // These feed foldSummaryGroups, which reads them positionally; `undefined`
+    // would serialise away and change the card's shape rather than its values.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({
+        [HOT]: [{ count: 2 }],
+      }),
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.deepEqual(groups![0], {
+      kind: null,
+      netuid: null,
+      count: 2,
+      fb: null,
+      lb: null,
+      fo: null,
+      lo: null,
+    });
+  });
+
+  test("a shard that does not declare its fan-out is still read", async () => {
+    // shard_count is a guard, not a requirement: an older producer that omits
+    // it is trusted, because the reader asked for the key IT computed.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody(
+        { [HOT]: [group()] },
+        { shard_count: undefined },
+      ),
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.equal(groups!.length, 1);
+  });
+
+  test("a null netuid survives as null", async () => {
+    // Transfer carries no netuid, and coercing it to 0 would attribute balance
+    // movement to subnet zero.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({
+        [HOT]: [group({ kind: "Transfer", netuid: null })],
+      }),
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.equal(groups![0]!.netuid, null);
+  });
+});


### PR DESCRIPTION
Closes #11131. Companion to metagraphed-infra#557, which writes what this reads.

#11141 bounded every **feed** on `chain.account_events` — a page went 1,068.9 MB → 3.0 MB — and left one read still scanning gigabytes: the summary card's grouped leg. It asks for per-`(event_kind, netuid)` totals over one account's whole history, which is `(hotkey = X OR coldkey = X)` against 455M rows in 51 files. An account value is scattered across every file, so statistics cannot prune it. Measured against production: **4,374 MB and ~14s per request**, and it is the read that aborts at the 15s ceiling.

No window fixes that, and I measured the ways it could have:

| form | scanned |
| --- | ---: |
| CTE + `ORDER BY block_number DESC LIMIT 5001` (today) | 4,374 MB |
| CTE + `ORDER BY observed_at DESC` | 3,162 MB |
| CTE + `LIMIT`, no ORDER BY | 1,384 MB |
| plain `GROUP BY`, no cap | 4,650 MB |

The predicate is the cost. A lifetime aggregate has no smaller correct scan — proving an account has fewer than N events means reading its whole history. So the scan has to happen; the only question is once per *request* or once per *day*.

## Once per day, into R2

The producer aggregates both key sides and every event kind into one row per `(account, event_kind, netuid)`, fans ~1.2M accounts across 256 objects, and this reads exactly **one** with a single GET.

**Why not another lakehouse table.** `account` would be a scattered key there too, so a rollup keyed on it opens most of its own files for a point lookup exactly as the source does — ~5x smaller, still no pruning. #11133 measured that bucketing on a scattered key trades bytes for R2 requests at a bad rate. This route is a point lookup by a high-cardinality key, which is not what Iceberg is for.

**Why not `chain.account_events_daily`.** Its rule is `hotkey IS NOT NULL AND netuid IS NOT NULL`, deliberately — excluding Transfer/Deposit (coldkey, no netuid) and WeightsSet (no hotkey). For `5EYCAe5jLQhn6ofDSvqF…` it holds **no row on any day**, against **1,343,321** both-side events on 2026-07-10 alone. Reading it here would have published a 284x undercount. I nearly wired it up; testing it first is what stopped me.

## It cannot make the route wrong

Every failure returns null and the caller runs the query it runs today: no binding, no object, an unparseable body, a schema version it doesn't understand, an account not yet projected. **Shipping this before the producer has backfilled is indistinguishable from not shipping it**, which is why the two PRs need no ordering.

Rows are renamed to the aliases `foldSummaryGroups` already reads, so the projection feeds the **same** builder the lakehouse feeds and nothing downstream learns which answered. **The cap keeps its meaning**: the caller derives `scanned` from the summed group counts and clamps it, so an account over the cap reports `event_scan_capped: true` and null `first_*` whichever tier served it. The projection knows the true lifetime total and publishing it would be a better number — but a route whose meaning depends on its tier is worse than either, so that's a contract change and not this one.

## The shard function is the risk

FNV-1a with forced 32-bit wrap, implemented **twice** — once in Python, once here. Two implementations agree on every ASCII address and part company on overflow: JavaScript numbers are doubles, Python ints don't overflow at all. That divergence is invisible to either side's tests and would surface only as every lookup missing — which reads as "the projection has no data" rather than as a bug. **Both sides pin the same three addresses to 205, 70 and 197.**

A shard written for a different fan-out is refused for the same reason: the object exists and parses, and failing to find the account in it proves nothing.

## Verified

- 52 CI validators, **20,832 tests, 909 files**, rebased onto current main.
- **100% patch coverage, line and branch** (88/88 by diff intersection).
- A test asserts the grouped scan is **not issued** when the shard answers, and another that a shard which cannot answer falls back to it unchanged.