### PR TITLE
docs(mcp): record the two encodings measured against tools/list, and that the wire is already compressed

### DIFF
--- a/src/mcp-input-schema.ts
+++ b/src/mcp-input-schema.ts
@@ -145,6 +145,36 @@ export function inputJsonSchema(schema: z.ZodType) {
  * schemas -- and `$defs` cannot reach it, because each tool's schema has to be
  * self-contained. Shrinking that means the schemas carrying less, not being
  * encoded more cleverly (#9685, #9981).
+ *
+ * ## TWO MORE ENCODINGS, MEASURED 2026-08-14 AND ALSO NOT TAKEN (#11164)
+ *
+ * Asked again, so measured again -- on the live 240-tool payload, which
+ * serializes to 1.537 MB:
+ *
+ *   collapse `anyOf: [{type: X}, {type: "null"}]` -> `type: [X, "null"]`
+ *     3,231 occurrences, worth 2.95%
+ *   drop the per-schema `$schema` declaration
+ *     worth 1.78% (and unsafe beside `$defs`, which needs the dialect stated)
+ *   both together                                      4.72%
+ *
+ * Both are semantics-preserving and both fail the SAME test `$defs` failed:
+ * they change the emitted shape for every external caller to save single
+ * digits. A consumer reading `type` as a string, or keying on `$schema`, is
+ * broken by a saving smaller than the one already declined above.
+ *
+ * ## AND THE WIRE WAS NEVER THE PROBLEM
+ *
+ * The same payload, same endpoint, same session:
+ *
+ *   no Accept-Encoding      1,536,823 B   1.72 s
+ *   Accept-Encoding: gzip     189,028 B   0.27 s
+ *
+ * 8x, already, for every client that sends the header. What remains is MODEL
+ * CONTEXT for clients that load tool definitions into a prompt, and no
+ * encoding reaches that -- only carrying less does, which is the same
+ * conclusion #9685 and #9981 reached from the other direction. Brotli is not
+ * offered at the edge and is the one free win left; it is a zone setting, so
+ * it is tracked in metagraphed-infra#558 rather than here.
  */
 /**
  * The `degraded` block DISPATCH can stamp on any tool result (#10790).


### PR DESCRIPTION
## Why a comment and not a change

`src/mcp-input-schema.ts` already carries a measured, declined option for shrinking `tools/list` — Zod's `reused: "ref"` `$defs` extraction, 5.8%, rejected because it changes the emitted shape for external callers. The seam says *"MEASURED, so it does not have to be asked again."*

It was asked again (#11164). So this records the two remaining encodings, measured on the live 240-tool payload (1.537 MB serialized), and the wire numbers that reframe the whole question.

## What was measured

| transform | saving |
|---|---|
| `anyOf: [{type: X}, {type: "null"}]` → `type: [X, "null"]` (3,231 occurrences) | **2.95%** |
| drop the per-schema `$schema` | **1.78%** |
| both | 4.72% |
| (previously measured) `$defs` via `reused: "ref"` | 5.8% — declined |

Both new ones are semantics-preserving and both fail the test `$defs` already failed: they change the emitted shape for every external caller to save single digits. A consumer reading `type` as a string, or keying on `$schema`, is broken by a saving smaller than the one already declined.

## And the wire was never the cost

```
no Accept-Encoding      1,536,823 B   1.72 s
Accept-Encoding: gzip     189,028 B   0.27 s
```

8x already, for every client that sends the header — and repeat calls are a steady 0.21–0.24 s. What remains is **model context** for clients that load tool definitions into a prompt, which no encoding reaches. That is the same conclusion #9685 and #9981 arrived at from the other direction: *"shrinking that means the schemas carrying less, not being encoded more cleverly."*

Brotli and zstd are not offered at the edge at all (a `br`-only client gets the full uncompressed megabyte) — the one free win left, and a zone setting rather than a repo one, so it is tracked in metagraphed-infra#558.

Comment-only: no emitted schema changes, so no contract, artifact or generated output moves.

Refs #11164