### PR TITLE
fix(watchdog): measure hotkey-alpha against the position ledger's newest pass

### DIFF
--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -128,8 +128,26 @@ const HOTKEY_ALPHA_COVERAGE_SQL =
   " (SELECT SUM(CASE WHEN captured_at >=" +
   " (SELECT MAX(captured_at) FROM hotkey_alpha) - ? THEN 1 ELSE 0 END)" +
   " FROM hotkey_alpha) AS covered," +
+  // THE NEWEST PASS ON BOTH SIDES (#11167). `covered` is already restricted to
+  // what this pass wrote; `referenced` counted DISTINCT pairs over the WHOLE of
+  // nominator_positions, which accumulates -- a (hotkey, netuid) whose stake is
+  // gone keeps its row. So a complete pass was measured against every pair the
+  // lane has ever seen and could not reach the floor by construction.
+  //
+  // Measured on chain 2026-08-14 (twox128 walk of SubtensorModule::Alpha,
+  // 120,253 entries): 17,292 live (hotkey, netuid) pairs with shares > 0. The
+  // table referenced 35,073, and the pass wrote 17,619 -- complete, and alarming
+  // against a floor of 28,058 derived from that 35,073.
+  //
+  // COUPLING, stated because it is load-bearing: this denominator now follows
+  // nominator_positions' newest pass, so a truncated positions pass shrinks this
+  // floor and can make hotkey_alpha look healthy on a short pass of its own.
+  // That is still strictly better than comparing against all history, but it is
+  // why nominator-positions' own truncation is tracked separately rather than
+  // being absorbed here.
   " (SELECT COUNT(*) FROM (SELECT DISTINCT hotkey, netuid" +
-  " FROM nominator_positions)) AS referenced";
+  " FROM nominator_positions WHERE captured_at >=" +
+  " (SELECT MAX(captured_at) FROM nominator_positions) - ?)) AS referenced";
 
 export type HotkeyAlphaStalenessReason = "no_rows" | "stale" | "partial" | null;
 
@@ -260,7 +278,13 @@ export async function runHotkeyAlphaStalenessWatchdog(
     HOTKEY_ALPHA_COVERAGE_FLOOR_RATIO;
 
   try {
-    const row = (await db.first(HOTKEY_ALPHA_COVERAGE_SQL, [passWindowMs])) as {
+    // Two binds now: the pass window applies to hotkey_alpha's `covered` and to
+    // nominator_positions' `referenced`, which must be measured over ITS newest
+    // pass rather than all history -- see the SQL.
+    const row = (await db.first(HOTKEY_ALPHA_COVERAGE_SQL, [
+      passWindowMs,
+      passWindowMs,
+    ])) as {
       latest: number | null;
       covered: number | null;
       total: number | null;

--- a/tests/hotkey-alpha-staleness-watchdog.test.ts
+++ b/tests/hotkey-alpha-staleness-watchdog.test.ts
@@ -265,7 +265,24 @@ describe("runHotkeyAlphaStalenessWatchdog", () => {
     // Both ledgers are read in the one statement — the floor is derived, not
     // fetched separately, so the two cannot be read at different moments.
     assert.match(reads[0], /FROM nominator_positions/);
-    assert.deepEqual(binds[0], [HOTKEY_ALPHA_PASS_WINDOW_MS]);
+    // And bounded to THAT ledger's newest pass. Without this the denominator is
+    // every (hotkey, netuid) nominator_positions has ever held -- it never
+    // prunes -- so a complete pass is measured against accumulated history and
+    // cannot clear the floor. Measured 2026-08-14: 35,073 pairs in the table
+    // against 17,292 live on chain, with the pass writing 17,619 (#11167).
+    assert.match(
+      reads[0],
+      /FROM nominator_positions WHERE captured_at >=[\s\S]*MAX\(captured_at\) FROM nominator_positions/,
+      "the referenced-pair floor must follow the position ledger's newest pass",
+    );
+    // TWICE: the pass window bounds `covered` on hotkey_alpha AND `referenced`
+    // on nominator_positions, so a complete pass is measured against the pairs
+    // that ledger's NEWEST pass names rather than every pair it has ever held
+    // (#11167).
+    assert.deepEqual(binds[0], [
+      HOTKEY_ALPHA_PASS_WINDOW_MS,
+      HOTKEY_ALPHA_PASS_WINDOW_MS,
+    ]);
   });
 
   test("an empty ledger alerts and names both affected surfaces", async () => {
@@ -359,7 +376,7 @@ describe("runHotkeyAlphaStalenessWatchdog", () => {
     );
     assert.equal(result.threshold_ms, 2 * HOUR);
     assert.equal(result.reason, "stale");
-    assert.deepEqual(binds[0], [90_000]);
+    assert.deepEqual(binds[0], [90_000, 90_000]);
   });
 
   test("a null SUM lands on 0 rather than NaN", async () => {


### PR DESCRIPTION
## The two halves were measured over different spans

The floor here is **derived, not declared** — correctly, because this sink stores only the pools some position *references*, so the expectation moves with the position ledger. But:

```sql
covered    -> rows stamped within the newest pass window
referenced -> COUNT(DISTINCT hotkey, netuid) over ALL of nominator_positions
```

`nominator_positions` never prunes: a pair whose stake is gone keeps its row. So `referenced` grows monotonically, and a complete pass is measured against every pair the lane has ever named — it cannot clear the floor by construction.

## Counted on chain, 2026-08-14

twox128 walk of `SubtensorModule::Alpha` to exhaustion (120,253 entries, 121 pages, ending on a short page), values read in batches:

| measure | value |
|---|---|
| live (hotkey, netuid) pairs, shares > 0 | **17,292** |
| pairs referenced by the table | 35,073 |
| pool totals the pass wrote | **17,619** |

The pass was **complete**, and alarmed against a floor of 28,058.

The module header already said a complete pass lands *"~17,902 distinct (hotkey, netuid) pairs"* — the design was right from the start; the table simply accumulated past it.

## The fix

Bound `referenced` to that ledger's newest pass, so both sides span the same window. The pass window is now bound twice, pinned by the read test, and the SQL restriction is asserted structurally (verified: removing it fails the test).

## Coupling, stated in the SQL because it is load-bearing

The denominator now follows `nominator_positions`' newest pass — so a *truncated* positions pass shrinks this floor and could make `hotkey_alpha` look healthy on a short pass of its own. Still strictly better than comparing against all history, and it is precisely why the positions lane's truncation is tracked separately rather than absorbed here.

## That truncation is real, and measured the same way

The newest positions pass covered **9,254 of 21,263** live coldkeys (43.5%). **Zero** netuid != 0 entries carry zero shares, so the `shares > 0` filter removes nothing and cannot explain the gap. That is a producer fault, filed as metagraphed-infra#559 — deliberately **not** fixed by lowering a floor to match it.

51 tests pass across both watchdog suites; `tsc`, prettier, eslint clean.

Closes #11167