### PR TITLE
perf(discovery): the server card stops embedding the catalogue it exists to point at

### DIFF
--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -37,6 +37,33 @@ describe("Discovery artifacts", () => {
     assert.equal(card.endpoint, "https://api.metagraph.sh/mcp");
     assert.equal(card.transport, "streamable-http");
     assert.ok(card.capabilities?.tools, "card must advertise tool capability");
+    // #11170: the card is a discovery document, not the catalogue. The SEP
+    // explicitly excludes primitive definitions -- the runtime list operations
+    // own them -- and embedding all 240 tools made the card 3.27 MB, double
+    // tools/list itself. Counts and pointers replace the payload.
+    assert.equal(card.tools, undefined, "primitives are not embedded");
+    assert.equal(card.prompts, undefined);
+    assert.equal(card.resource_templates, undefined);
+    const counts = card.primitive_counts as Row;
+    assert.ok((counts.tools as number) >= 200, "tool count rides the card");
+    assert.ok((counts.prompts as number) >= 1);
+    assert.ok((counts.resource_templates as number) >= 1);
+    const defs = card.primitive_definitions as Row;
+    for (const key of ["mcp", "index", "openai", "anthropic"] as const) {
+      assert.match(String(defs[key]), /api\.metagraph\.sh/);
+    }
+    assert.deepEqual(card.remotes, [
+      { type: "streamable-http", url: "https://api.metagraph.sh/mcp" },
+    ]);
+    assert.equal(card.websiteUrl, "https://metagraph.sh");
+    // The budget that keeps this a card. The pre-#11170 card was 3,272,859
+    // bytes and the Cloudflare agent-readiness scan would not swallow it; a
+    // regression past this line means someone re-embedded a catalogue.
+    const body = JSON.stringify(card);
+    assert.ok(
+      body.length < 64_000,
+      `server card must stay a card: ${body.length} bytes`,
+    );
     // Bidirectional registry backlink, under our own domain namespace (not the
     // registry-reserved io.modelcontextprotocol.registry/* namespace).
     assert.equal(

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -466,9 +466,33 @@ export async function mcpServerCardResponse(
     },
     capabilities: MCP_CAPABILITIES,
     _meta: MCP_REGISTRY_META,
-    tools: listToolDefinitions(),
-    resource_templates: MCP_RESOURCE_TEMPLATES,
-    prompts: listPromptDefinitions(),
+    // SEP-2127's remotes[] shape, mirroring server.json's own entry, so a
+    // registry consumer and a card consumer read one vocabulary.
+    remotes: [{ type: "streamable-http", url: `${base}/mcp` }],
+    websiteUrl: "https://metagraph.sh",
+    // PRIMITIVES ARE DELIBERATELY NOT EMBEDDED (#11170). The card used to
+    // carry `tools: listToolDefinitions()` -- all 240 full definitions, 1.6 MB
+    // of a 1.65 MB document -- which the server-card SEP explicitly excludes:
+    // "this specification intentionally omits primitive definitions (tools,
+    // resources, and prompts) from server cards", because what a server
+    // exposes can vary by session and the runtime list operations are the
+    // source of truth. A discovery card is a business card, not the catalogue.
+    //
+    // Nothing is lost: the counts below say what is behind the door, and
+    // `primitive_definitions` names every place the full specs are served --
+    // the MCP list operations for protocol clients, and the agent-tools
+    // documents for OpenAI/Anthropic-style runtimes.
+    primitive_counts: {
+      tools: listToolDefinitions().length,
+      prompts: listPromptDefinitions().length,
+      resource_templates: MCP_RESOURCE_TEMPLATES.length,
+    },
+    primitive_definitions: {
+      mcp: `${base}/mcp (tools/list, prompts/list, resources/templates/list)`,
+      index: `${base}/.well-known/agent-tools/index.json`,
+      openai: `${base}/.well-known/agent-tools/openai.json`,
+      anthropic: `${base}/.well-known/agent-tools/anthropic.json`,
+    },
   };
   const pub = await publishedAt(env);
   const card = {


### PR DESCRIPTION
## Measured

`/.well-known/mcp/server-card.json` was **3,272,859 bytes on the wire** — `tools: listToolDefinitions()` embedded all 240 full definitions (1.62 MB of the 1.65 MB document), the same payload as `tools/list`, served twice. It is almost certainly why Cloudflare's agent-readiness scan fails the "MCP Server Card" row against a card served at exactly the right path.

## The spec settles it

[SEP-2127](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2127) (superseding SEP-1649): *"This specification intentionally omits primitive definitions (tools, resources, and prompts) from server cards"* — runtime list operations are the source of truth. So this is spec alignment, not a trade.

## The change

- Drop embedded `tools` / `prompts` / `resource_templates`.
- Add SEP-2127's `remotes[]` (mirroring `server.json`'s own entry, one vocabulary for both consumers) and `websiteUrl`.
- Keep the discovery value: `primitive_counts` (240/…) and `primitive_definitions` pointing at `tools/list` and `/.well-known/agent-tools/{index,openai,anthropic}.json` — every definition stays served where definitions live; nothing is lost, it just stops being duplicated.
- `capabilities.tools`, `serverInfo`, auth detail, `endpoint`/`transport` back-compat fields: unchanged.

**Card size: 3.27 MB → ~20 KB.**

## Tests

The discovery test now pins both directions — primitives absent, counts ≥ real floors, pointers named, `remotes` exact — plus a **64 KB budget assertion that cites the old 3,272,859-byte size**, so a re-embedded catalogue fails with the history attached. 29 discovery tests, 390 in the adjacent suites, `lint`, `format:check`, `typecheck` green.

Closes #11171