### PR TITLE
feat(discovery): declare the Content Signals, and serve auth.md where scanners look

### DIFF
--- a/apps/ui/src/server.robots.test.ts
+++ b/apps/ui/src/server.robots.test.ts
@@ -119,4 +119,12 @@ describe("non-canonical hosts are withheld whole (#11002)", () => {
   it("still allows the apex itself — the guard is exact-host, not a prefix", () => {
     expect(isCrawlable(robotsBody("metagraph.sh"), "/subnets")).toBe(true);
   });
+
+  it("the canonical host declares the Content Signals", () => {
+    const body = robotsBody("metagraph.sh");
+    expect(body).toMatch(/^Content-Signal: search=yes, ai-input=yes, ai-train=yes$/m);
+    // And the non-canonical duplicate does not: it disallows everything, and a
+    // usage signal on a host nobody may crawl is noise.
+    expect(robotsBody("other.example")).not.toContain("Content-Signal");
+  });
 });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -215,6 +215,10 @@ export function robotsBody(host: string): string {
   return (
     `# metagraph.sh — public Bittensor subnet integration registry.\n` +
     `# AI agents welcome; the machine API + discovery live on api.metagraph.sh.\n` +
+    // Content Signals (contentsignals.org): all three yes, deliberately —
+    // public data that exists to be read and reasoned over by machines. The
+    // API host carries the same declaration (scripts/build-artifacts.ts).
+    `Content-Signal: search=yes, ai-input=yes, ai-train=yes\n` +
     `User-agent: *\n` +
     `Allow: /\n` +
     `# Unbounded per-entity detail: not in the sitemap, one uncached scan per URL.\n` +

--- a/public/.well-known/auth.md
+++ b/public/.well-known/auth.md
@@ -1,0 +1,51 @@
+# Authentication
+
+The metagraphed API at `api.metagraph.sh` is **public by default and
+read-only**. No authentication is _required_ for any endpoint — every tool and
+route is callable anonymously.
+
+Authentication is **optional and additive**: it raises rate limits. It does not
+currently unlock additional endpoints, tools, or data.
+
+- Auth scheme: none required; `Authorization: Bearer` accepted
+- Registration: not required, but self-serve keys are available
+- Protected resources: `POST /mcp` is an OAuth 2.1 protected resource that
+  permits anonymous access
+- OAuth / OIDC: supported for MCP clients (see below)
+
+## Optional credentials
+
+**API key.** A self-serve `mg_...` key sent as `Authorization: Bearer mg_...`
+raises the rate limits below. Keys are minted by wallet-signature login.
+
+**OAuth 2.1.** MCP clients that speak the spec can discover and complete
+authorization with no manual configuration:
+
+- Protected-resource metadata (RFC 9728):
+  https://api.metagraph.sh/.well-known/oauth-protected-resource/mcp
+- Authorization-server metadata:
+  https://api.metagraph.sh/.well-known/oauth-authorization-server
+
+A Bearer token that cannot be validated gets `401` with a
+`WWW-Authenticate` challenge pointing at the metadata above. **An anonymous
+request is not challenged** — it is served.
+
+## Rate limits
+
+Anonymous limits apply per client IP; a valid key raises them per account.
+Each entry below is anonymous → keyed.
+
+- REST + artifact reads: unmetered either way (cached at the edge)
+- RPC proxy (`/rpc/v1/*`): 100 / 60s → higher, per tier
+- MCP endpoint (`POST /mcp`): 100 / 60s → 500 / 60s, higher on paid tiers
+- AI routes (`/api/v1/ask`, `/api/v1/search/semantic`): 20 / 60s → higher, per tier
+
+Keyed accounts are also subject to a cost-weighted daily quota.
+
+## Discovery
+
+- Machine index: https://api.metagraph.sh/llms.txt
+- Agent workflows: https://api.metagraph.sh/agent-workflows.md
+- API catalog (RFC 9727): https://api.metagraph.sh/.well-known/api-catalog
+- OpenAPI 3.1: https://api.metagraph.sh/metagraph/openapi.json
+- MCP server card: https://api.metagraph.sh/.well-known/mcp/server-card.json

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 User-agent: *
 Allow: /
 # Unbounded per-entity detail: one uncached scan per URL, not in the sitemap.

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2408,7 +2408,16 @@ await fs.writeFile(
 // Changing one and not the other leaves the walk fully open.
 await fs.writeFile(
   path.join(repoRoot, "public/robots.txt"),
-  `User-agent: *\n` +
+  // Content Signals (contentsignals.org): a robots.txt-level declaration of
+  // HOW fetched content may be used, beside the existing WHERE rules. All
+  // three signals are yes ON PURPOSE -- this registry is public data whose
+  // entire pitch is being read, quoted and reasoned over by machines; saying
+  // ai-train=no here would ask the ecosystem not to learn the thing we exist
+  // to teach. Revisit alongside the paid tier if premium data ever needs a
+  // different posture (it would need its own path-scoped block, not a flip
+  // of this one).
+  `Content-Signal: search=yes, ai-input=yes, ai-train=yes\n` +
+    `User-agent: *\n` +
     `Allow: /\n` +
     `# Unbounded per-entity detail: one uncached scan per URL, not in the sitemap.\n` +
     `# The collection routes (/api/v1/blocks, /api/v1/extrinsics,\n` +
@@ -2491,6 +2500,15 @@ Keyed accounts are also subject to a cost-weighted daily quota.
 - MCP server card: ${llmsApiBase}/.well-known/mcp/server-card.json
 `;
 await fs.writeFile(path.join(repoRoot, "public/auth.md"), authMarkdown, "utf8");
+// The SAME document at /.well-known/auth.md: the agent-readiness scanners
+// (Cloudflare Diagnostics among them) probe the well-known path, and an agent
+// told "look in .well-known" should find the answer where it was told to look
+// rather than needing the root spelling we happened to pick first.
+await fs.writeFile(
+  path.join(repoRoot, "public/.well-known/auth.md"),
+  authMarkdown,
+  "utf8",
+);
 
 await writeJson(artifactFile("contracts.json"), contracts);
 await writeJson(

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -231,6 +231,28 @@ describe("Discovery artifacts", () => {
   // /api/v1/blocks/{ref} URLs beneath the same prefix are not. Mirrors
   // apps/ui/src/server.robots.test.ts, which gates the apex's own copy — the two
   // hosts are one policy and a change to either alone reopens the walk.
+  test("robots.txt declares the Content Signals, before any group", async () => {
+    // contentsignals.org: the declaration of HOW fetched content may be used.
+    // All three yes is the deliberate posture of a public registry that exists
+    // to be read by machines -- see the comment at the writer.
+    const txt = await fs.readFile(path.join(publicDir, "robots.txt"), "utf8");
+    assert.match(
+      txt,
+      /^Content-Signal: search=yes, ai-input=yes, ai-train=yes$/m,
+    );
+  });
+
+  test("auth.md is served at the well-known path the scanners probe", async () => {
+    const root = await fs.readFile(path.join(publicDir, "auth.md"), "utf8");
+    const wellKnown = await fs.readFile(
+      path.join(publicDir, ".well-known/auth.md"),
+      "utf8",
+    );
+    // The SAME document, byte for byte: two copies that can drift are two
+    // answers to "how do I authenticate", and only one of them gets updated.
+    assert.equal(wellKnown, root);
+  });
+
   test("robots.txt withholds the unbounded per-entity spaces, not the collections", async () => {
     const txt = await fs.readFile(path.join(publicDir, "robots.txt"), "utf8");
 


### PR DESCRIPTION
## Two scan rows, both passable today

**Content Signals.** Both hosts' robots.txt now open with

```
Content-Signal: search=yes, ai-input=yes, ai-train=yes
```

All three **yes** is the deliberate posture: this registry is public data whose entire pitch is being read, quoted and reasoned over by machines — `ai-train=no` would ask the ecosystem not to learn the thing we exist to teach. The comment at each writer says so, and notes that a future paid tier wanting a different posture for premium data gets a path-scoped block, not a flip of this line. The non-canonical apex duplicate (which disallows everything) deliberately does **not** carry the signal.

**Auth.md.** `/.well-known/auth.md` now serves the same bytes as `/auth.md` — the scanners probe the well-known path (it 404'd), and a test pins the two copies byte-identical so there are never two answers to "how do I authenticate".

## Where

- api host: `scripts/build-artifacts.ts` (robots writer + the auth.md writer emits both copies)
- apex: `robotsBody` in `apps/ui/src/server.ts` — server-side only, no visual output
- tests: `tests/discovery-artifacts.test.ts` (signal line + byte-identical alias), `apps/ui/src/server.robots.test.ts` (canonical host carries it, non-canonical does not)

## Validation

Root: `npm run validate`, `build`, `lint`, `format:check`, `typecheck`, discovery suite 13/13. apps/ui workspace: `lint`, `typecheck`, robots suite 9/9.

Closes #11173