### PR TITLE
fix(watchdog): re-measure the positions expectation against chain

### DIFF
--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -92,11 +92,39 @@ export const NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS = missedTicksMs(
 /**
  * How many coldkeys a COMPLETE pass is expected to cover.
  *
- * 23,668, read off production on 2026-08-05 as `COUNT(DISTINCT coldkey)` at
- * the newest `captured_at` -- every coldkey the SubtensorModule::Alpha scan
- * found holding at least one position.
+ * 21,263, COUNTED ON CHAIN on 2026-08-14 rather than read off our own table:
+ *
+ *   prefix = twox128("SubtensorModule") ++ twox128("Alpha")
+ *   state_getKeysPaged(prefix, 1000, last, finalizedHead), walked to exhaustion
+ *   -> 120,253 entries over 121 pages, final page 253 (a SHORT page, so this is
+ *      end-of-iteration and not a truncated walk)
+ *   -> 108,671 with netuid != 0, of which ZERO carry shares == 0
+ *   -> 21,263 distinct coldkeys
+ *
+ * This lane's sink stores netuid != 0 with shares > 0, so that last figure is
+ * the population a complete pass covers, measured against the source rather
+ * than inferred from the sink.
+ *
+ * ## THIS ONE DRIFTED, IT DID NOT ROT
+ *
+ * The previous 23,668 was "read off production on 2026-08-05 as
+ * `COUNT(DISTINCT coldkey)` at the newest `captured_at`" -- correctly scoped to
+ * ONE pass, so it never had the accumulation bug its siblings did (#11165,
+ * #11167 both re-anchored constants that had been read over a whole table that
+ * never prunes). It simply fell ~10% behind the network in nine days, which is
+ * the shrink direction the ratio's comment below already anticipates.
+ *
+ * Re-measuring is therefore routine maintenance here, not a defect fix, and the
+ * rule it feeds did its job in the meantime: the pass that prompted this covered
+ * 9,254 coldkeys, far below the floor rather than marginally under it, and was
+ * correctly read as a truncated pass rather than as drift.
+ *
+ * Measure it on CHAIN when re-anchoring. `nominator_positions` accumulates --
+ * `COUNT(DISTINCT coldkey)` over the whole table read 28,650 at the time of
+ * writing against those 21,263 live coldkeys, and that figure is the one the
+ * alarm text reports as context.
  */
-export const NOMINATOR_POSITIONS_EXPECTED_COLDKEYS = 23_668;
+export const NOMINATOR_POSITIONS_EXPECTED_COLDKEYS = 21_263;
 
 /**
  * How much of that a single pass must cover before it counts as complete.


### PR DESCRIPTION
## Counted on chain

```
twox128("SubtensorModule") ++ twox128("Alpha")
state_getKeysPaged walked to exhaustion
  -> 120,253 entries, 121 pages, final page 253 (short page = clean end)
  -> 108,671 with netuid != 0, of which ZERO carry shares == 0
  -> 21,263 distinct coldkeys
```

`23_668` → `21_263`.

## This one drifted rather than rotted

Worth keeping the distinction. The old figure was read at the newest `captured_at` — **correctly scoped to one pass** — so it never had the accumulation bug that #11165 and #11167 fixed, where a constant had been read over a table that never prunes. It just fell ~10% behind the network in nine days, which is the shrink direction its own comment already anticipates ("delegators unstake... re-measure and lower this").

So this is routine maintenance, and the rule kept working throughout: the pass that prompted it covered **9,254** coldkeys — far below the floor rather than marginally under — and was correctly read as a truncated pass rather than as drift.

## The truncation is real and is NOT fixed here

`nominator_positions` newest stamp is a pass that died mid-upload: 33,719 rows, 9,254 coldkeys, **no row in `nominator_positions_passes` at all**, 3.2 h old and no retry for ~21 h. The completion marker behaved correctly — it did not mark that pass complete.

That is a producer fault, filed as metagraphed-infra#559, and deliberately **not** addressed by lowering a floor to match a truncated pass.

## Records where to measure

`COUNT(DISTINCT coldkey)` over the whole table reads **28,650** against 21,263 live coldkeys — that inflated figure is what the alarm reports as context, and is exactly the trap the sibling lanes fell into.

22 tests pass; `tsc`, prettier clean.