### PR TITLE
fix(watchdog): scope positions coverage to the full-scan producer

### DIFF
--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -57,6 +57,7 @@ import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
+import { POSITION_SOURCE_ALPHA } from "./nominator-positions-neon-write.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -177,11 +178,47 @@ export const NOMINATOR_POSITIONS_PASS_WINDOW_MS = passWindowMs(
  * rule. Read together the pair is the diagnosis: `covered` well under `total`
  * is a scan that died partway through the keyspace.
  */
+/**
+ * The producer this rule is about.
+ *
+ * `nominator_positions` has TWO writers and they are not interchangeable.
+ * `alpha` is the 24h SubtensorModule::Alpha full scan whose completeness this
+ * alarm exists to police. `self-stake` is a targeted top-up that fills the gap
+ * that scan cannot reach -- an owner's own self-stake -- and it writes a
+ * legitimate SUBSET with its own fresh `captured_at`, pruning only its own
+ * source.
+ *
+ * Unscoped, `MAX(captured_at)` is therefore whichever producer ran last, and a
+ * healthy self-stake run makes the full scan look truncated. Measured
+ * 2026-08-14: self-stake wrote 9,254 coldkeys at 05:42 and reported
+ * `ok -- 37542 scanned, 33719 written, 0 error(s)`, while the alpha scan's own
+ * newest pass held 19,870 coldkeys and was marked complete in
+ * `nominator_positions_passes`. The alarm read the 9,254 as the newest pass and
+ * reported /accounts/{ss58}/positions as serving silently-partial data for
+ * hours, on a lane where BOTH producers had succeeded.
+ */
+// The writer's own constant, imported rather than restated: the column exists
+// so two producers can share the table, and a second copy of that vocabulary
+// here would be free to drift from the value actually being stamped.
+export const NOMINATOR_POSITIONS_SCAN_SOURCE = POSITION_SOURCE_ALPHA;
+
+/**
+ * Coverage, scoped to the full-scan producer.
+ *
+ * Every clause carries the source filter, including the `MAX(captured_at)` the
+ * window is measured from -- scoping the count while leaving the anchor global
+ * would compare the alpha scan's coverage against self-stake's clock and read
+ * as zero coverage the moment the two producers' stamps diverged.
+ *
+ * `total` stays scoped too, so the number the alarm reports as context is the
+ * same population the rule is judging rather than a second, larger one.
+ */
 const NOMINATOR_POSITIONS_COVERAGE_SQL =
   "SELECT COUNT(DISTINCT coldkey) AS total, MAX(captured_at) AS latest, " +
   "COUNT(DISTINCT CASE WHEN captured_at >= " +
-  "(SELECT MAX(captured_at) FROM nominator_positions) - ? THEN coldkey END) " +
-  "AS covered FROM nominator_positions";
+  "(SELECT MAX(captured_at) FROM nominator_positions WHERE source = ?) - ? " +
+  "THEN coldkey END) " +
+  "AS covered FROM nominator_positions WHERE source = ?";
 
 export type NominatorPositionsStalenessReason =
   "no_rows" | "stale" | "partial" | null;
@@ -296,8 +333,14 @@ export async function runNominatorPositionsStalenessWatchdog(
     NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS;
 
   try {
+    // Three binds, in statement order: the source anchoring the window's
+    // MAX(captured_at), the window itself, then the source scoping the outer
+    // aggregate. See NOMINATOR_POSITIONS_SCAN_SOURCE for why an unscoped read
+    // reports a healthy self-stake run as a truncated alpha scan.
     const row = (await db.first(NOMINATOR_POSITIONS_COVERAGE_SQL, [
+      NOMINATOR_POSITIONS_SCAN_SOURCE,
       passWindowMs,
+      NOMINATOR_POSITIONS_SCAN_SOURCE,
     ])) as {
       latest: number | null;
       covered: number | null;

--- a/tests/nominator-positions-staleness-watchdog.test.ts
+++ b/tests/nominator-positions-staleness-watchdog.test.ts
@@ -6,6 +6,7 @@
 // lakehouse export, which is exactly the condition that ran unnoticed for
 // 34 hours and produced this issue.
 import assert from "node:assert/strict";
+import { POSITION_SOURCE_ALPHA } from "../src/nominator-positions-neon-write.ts";
 import { readFileSync } from "node:fs";
 import { describe, test, vi } from "vitest";
 import { pgMockEnv } from "./helpers/pg-mock.ts";
@@ -24,6 +25,7 @@ import {
   NOMINATOR_POSITIONS_COVERAGE_FLOOR_COLDKEYS,
   NOMINATOR_POSITIONS_EXPECTED_COLDKEYS,
   NOMINATOR_POSITIONS_PASS_WINDOW_MS,
+  NOMINATOR_POSITIONS_SCAN_SOURCE,
   NOMINATOR_POSITIONS_STALENESS_THRESHOLD_MS,
   evaluateNominatorPositionsStaleness,
   runNominatorPositionsStalenessWatchdog,
@@ -247,7 +249,27 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
       now: () => NOW,
       recordException: (async () => true) as never,
     }).then(() => {
-      assert.deepEqual(binds[0], [NOMINATOR_POSITIONS_PASS_WINDOW_MS]);
+      // Scoped to the full-scan producer on both ends: nominator_positions has
+      // two writers, and an unscoped MAX(captured_at) makes a healthy
+      // self-stake run look like a truncated alpha scan (#11167 follow-up).
+      assert.deepEqual(binds[0], [
+        NOMINATOR_POSITIONS_SCAN_SOURCE,
+        NOMINATOR_POSITIONS_PASS_WINDOW_MS,
+        NOMINATOR_POSITIONS_SCAN_SOURCE,
+      ]);
+      // `source =` without the placeholder: the pg layer rewrites `?` to `$n`.
+      assert.match(queries[0], /source = /);
+      // BOTH ends, which is the half-fix this guards against: scoping the outer
+      // aggregate while leaving the window's MAX(captured_at) global would
+      // measure the alpha scan's coverage against self-stake's clock and read
+      // as zero the moment the two producers' stamps diverged.
+      assert.equal(
+        queries[0].match(/source = \$\d/g)?.length,
+        2,
+        "the window anchor and the outer aggregate must both be scoped",
+      );
+      // The writer's vocabulary, not a copy of it.
+      assert.equal(NOMINATOR_POSITIONS_SCAN_SOURCE, POSITION_SOURCE_ALPHA);
       assert.ok(
         NOMINATOR_POSITIONS_PASS_WINDOW_MS < 24 * HOUR,
         "the window must stay under VALIDATOR_NOMINATORS_POLL_SECS (24h)",
@@ -261,7 +283,7 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
       // `?` reached Postgres unrewritten and matched nothing.
       assert.match(
         queries[0]!,
-        /captured_at >= \(SELECT MAX\(captured_at\) FROM nominator_positions\) - \$\d/,
+        /captured_at >= \(SELECT MAX\(captured_at\) FROM nominator_positions WHERE source = \$\d\) - \$\d/,
       );
     });
   });
@@ -303,7 +325,11 @@ describe("runNominatorPositionsStalenessWatchdog", () => {
     assert.equal(raised.alerted, true);
     assert.equal(raised.reason, "partial");
     assert.equal(raised.coverage_floor_coldkeys, 22_000);
-    assert.deepEqual(binds[0], [HOUR]);
+    assert.deepEqual(binds[0], [
+      NOMINATOR_POSITIONS_SCAN_SOURCE,
+      HOUR,
+      NOMINATOR_POSITIONS_SCAN_SOURCE,
+    ]);
 
     // Lowered under the same reading, the identical tick is quiet. This is the
     // documented remedy if the delegating population ever genuinely shrinks.


### PR DESCRIPTION
## Two writers, one table, and a rule that could not tell them apart

`nominator_positions` has **two** producers, and the `source` column exists precisely so they can share it:

- **`alpha`** — the 24h `SubtensorModule::Alpha` full scan this alarm exists to police.
- **`self-stake`** — a targeted top-up filling the gap that scan cannot reach (an owner's own self-stake). It writes a legitimate **subset** with its own fresh `captured_at`, and prunes only its own source.

Unscoped, `MAX(captured_at)` is whichever producer ran last. So a **healthy self-stake run made the full scan look truncated.**

## Measured in production, 2026-08-14

```
lane_health  self-stake  ok -- 37542 scanned, 33719 written, 0 error(s)
```

| source | rows | coldkeys | newest |
|---|---|---|---|
| `alpha` | 109,534 | 19,870 | 08-13 19:53 |
| `self-stake` | 33,719 | 9,254 | 08-14 05:42 |

**Both producers succeeded.** The alarm read self-stake's 9,254 as "the newest pass" and reported for hours that `/accounts/{ss58}/positions` was serving silently partial data. It was not — every coldkey's position set is coherent, and the alpha scan's own pass is marked complete in `nominator_positions_passes`.

That mistaken reading is also what **metagraphed-infra#559** was filed on. There is no producer truncation; I've corrected that issue.

## Both ends are scoped, and the test enforces it

The filter is on the outer aggregate **and** on the `MAX(captured_at)` the window is measured from. Scoping only the outer one would compare the alpha scan's coverage against self-stake's clock and read as zero the moment their stamps diverged — a plausible-looking half-fix, so the test counts the scoped clauses rather than trusting the shape. Verified: reverting either end fails it.

## No handroll

The source value is imported from the writer (`POSITION_SOURCE_ALPHA`), not restated, so the rule cannot drift from the value actually being stamped.

## Siblings checked rather than assumed

`validator_nominator_counts` and `hotkey_alpha` have no `source` column at all — one producer each — so neither needs this. This is genuinely specific to `nominator_positions`.

75 tests pass across the three watchdog suites; `tsc`, prettier, eslint clean; unreferenced-exports holds at 731.