### PR TITLE
fix(accounts): refuse a stale projection instead of serving it as fact

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -66,6 +66,27 @@ export const ACCOUNT_SUMMARY_PROJECTION_PREFIX =
  */
 export const ACCOUNT_SUMMARY_SHARDS = 16384;
 
+/**
+ * How old a shard may be before this reader stops trusting it.
+ *
+ * A STALE PROJECTION SERVED AS FACT IS THE ONE WAY THIS CAN BE WRONG. Every
+ * other failure here declines and the caller reads the lakehouse; a shard that
+ * parses fine but was written a month ago would be published as the account's
+ * current totals, with nothing in the payload to say so -- the card's
+ * `generated_at` comes from the live recent-feed leg, so a frozen aggregate
+ * beside a fresh feed looks entirely healthy.
+ *
+ * Three days. The producer's own floor is 20 hours, so this clears a missed
+ * run, an overrunning one and a container redeploy, while still catching a dead
+ * lane in days rather than never. Past it the route returns to exactly the
+ * lakehouse read it used before the projection existed -- slower, correct, and
+ * self-healing the moment the producer recovers.
+ *
+ * The same reasoning the projection-staleness watchdog applies in missed ticks:
+ * a bound near one producer interval alerts on a lane that is merely working.
+ */
+export const ACCOUNT_SUMMARY_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+
 /** The payload shape this reader understands. A producer that changes a field's
  * MEANING bumps it, and this declines rather than misreading the new one. */
 export const ACCOUNT_SUMMARY_SCHEMA_VERSION = 1;
@@ -147,7 +168,11 @@ function finite(value: unknown): number | null {
 export async function loadAccountSummaryProjection(
   env: Env | null | undefined,
   account: string,
-  { shards = ACCOUNT_SUMMARY_SHARDS }: { shards?: number } = {},
+  {
+    shards = ACCOUNT_SUMMARY_SHARDS,
+    now = Date.now,
+    maxAgeMs = ACCOUNT_SUMMARY_MAX_AGE_MS,
+  }: { shards?: number; now?: () => number; maxAgeMs?: number } = {},
 ): Promise<Record<string, unknown>[] | null> {
   // Same binding the thirteen sibling projections read from.
   const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
@@ -173,6 +198,18 @@ export async function loadAccountSummaryProjection(
   // partitioning, so its absence of this account proves nothing.
   const declared = finite(payload["shard_count"]);
   if (declared !== null && declared !== shards) return null;
+
+  // STALE IS A DECLINE, not a slightly-old answer. See
+  // ACCOUNT_SUMMARY_MAX_AGE_MS: this is the only failure mode that could
+  // publish something wrong rather than merely fall back.
+  // A STRING, not whatever coerces. `Date.parse(String(12345))` is a valid
+  // date -- the year 12345 -- so a numeric field would read as fresh forever.
+  // The producer writes an ISO instant; anything else is a shape this reader
+  // does not understand.
+  const stamp = payload["generated_at"];
+  const generated = typeof stamp === "string" ? Date.parse(stamp) : Number.NaN;
+  if (!Number.isFinite(generated)) return null;
+  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return null;
 
   const accounts = payload["accounts"];
   if (!accounts || typeof accounts !== "object") return null;

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  ACCOUNT_SUMMARY_MAX_AGE_MS,
   ACCOUNT_SUMMARY_SCHEMA_VERSION,
   ACCOUNT_SUMMARY_SHARDS,
   accountShard,
@@ -295,6 +296,62 @@ describe("loadAccountSummaryProjection", () => {
     });
     const groups = await loadAccountSummaryProjection(store.env, HOT);
     assert.equal(groups!.length, 1);
+  });
+
+  test("A STALE SHARD IS REFUSED", async () => {
+    // The ONLY way this reader could publish something wrong. Every other
+    // failure declines and the caller reads the lakehouse; a month-old shard
+    // parses perfectly and would be served as the account's current totals --
+    // and invisibly, because the card's `generated_at` comes from the LIVE
+    // recent-feed leg, so a frozen aggregate beside a fresh feed looks healthy.
+    const written = Date.parse("2026-08-01T00:00:00Z");
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody(
+        { [HOT]: [group()] },
+        { generated_at: "2026-08-01T00:00:00Z" },
+      ),
+    });
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, {
+        now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS + 1,
+      }),
+      null,
+      "past the bound",
+    );
+    assert.ok(
+      await loadAccountSummaryProjection(store.env, HOT, {
+        now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS - 1,
+      }),
+      "inside the bound still answers",
+    );
+  });
+
+  test("the bound clears a missed producer run", async () => {
+    // The producer's own floor is 20 hours. A bound near one interval would
+    // decline on a lane that is merely slow, which is the sizing error the
+    // projection-staleness watchdog documents in missed ticks.
+    assert.ok(
+      ACCOUNT_SUMMARY_MAX_AGE_MS > 2 * 20 * 60 * 60 * 1000,
+      "must survive two missed runs",
+    );
+  });
+
+  test("a shard with no readable generated_at is refused", async () => {
+    // Unknown age is not young. Without a timestamp there is no way to tell a
+    // fresh publish from a fossil, and the safe reading is the lakehouse.
+    for (const generated_at of [undefined, "", "not-a-date", 12345]) {
+      const store = archive({
+        [accountSummaryShardKey(HOT)]: shardBody(
+          { [HOT]: [group()] },
+          { generated_at },
+        ),
+      });
+      assert.equal(
+        await loadAccountSummaryProjection(store.env, HOT),
+        null,
+        String(generated_at),
+      );
+    }
   });
 
   test("a null netuid survives as null", async () => {


### PR DESCRIPTION
The projection reader declines on every failure it can see — no binding, no object, a bad body, an unknown schema version, a wrong fan-out, an account it hasn't projected — and the caller reads the lakehouse. One case slipped through: **a shard that parses fine but was written a month ago.**

That is the only way this reader could publish something *wrong* rather than merely fall back, and it would do it invisibly. The card's `generated_at` comes from the **live** recent-feed leg, so a frozen aggregate sitting beside a fresh feed looks entirely healthy — the exact shape of a confident zero.

## Nothing else covers it

`projection-staleness-watchdog` iterates `PROJECTION_LANES` and derives its bound from `PROJECTION_LANES_CRON`. This artifact has neither, because its producer is the infra container rather than the Worker lane runner. There is no sweep over infra-written artifacts at all — the sibling rollup's own status object has no watcher either.

So the bound lives where the decision is made.

## Three days

The producer's own floor is 20 hours, so this clears a missed run, an overrunning one, and a container redeploy — while still catching a dead lane in days rather than never. Past it the route returns to exactly the read it used before the projection existed: slower, correct, and **self-healing** the moment the producer recovers.

Same reasoning the staleness watchdog applies in missed ticks: a bound near one producer interval alerts on a lane that is merely working.

## An unreadable timestamp is also a decline

Unknown age is not young. And it must be a **string** — `Date.parse(String(12345))` is a valid date, the year 12345, so a numeric field would have read as fresh forever. Caught by a test, not by reading.

52 CI validators, 20,839 tests, 909 files.