### PR TITLE
feat(a2a): the registry answers other agents, and the card ships with the endpoint

### DIFF
--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -38,6 +38,7 @@ const SITE_ORIGIN = "https://metagraph.sh";
 const DISCOVERY_CONTENT_TYPES = {
   "/.well-known/api-catalog": ["application/linkset+json", "application/json"],
   "/.well-known/mcp/server-card.json": ["application/json"],
+  "/.well-known/agent-card.json": ["application/json"],
   "/.well-known/agent-skills/index.json": ["application/json"],
   "/.well-known/security.txt": ["text/plain"],
   "/llms.txt": ["text/plain"],

--- a/tests/a2a.test.ts
+++ b/tests/a2a.test.ts
@@ -1,0 +1,373 @@
+// #11175: the A2A surface -- the card, and the endpoint the card points at.
+//
+// The contract under test is honesty: every capability the card advertises
+// answers, and every method the server does not support answers the SPEC'S
+// code for that, not a router 404.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  agentCardResponse,
+  buildAgentCard,
+  handleA2ARequest,
+  A2A_CARD_PATH,
+  A2A_ENDPOINT_PATH,
+} from "../workers/request-handlers/a2a.ts";
+import { MCP_SERVER_VERSION } from "../src/mcp-server.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+import { handleRequest } from "../workers/api.ts";
+
+const CARD_URL = `https://api.metagraph.sh${A2A_CARD_PATH}`;
+const RPC_URL = `https://api.metagraph.sh${A2A_ENDPOINT_PATH}`;
+
+/** An env the AI gate accepts; the ask itself is injected per test. The gate
+ * needs the kill-switch AND the bindings (aiEnabled = flag && configured);
+ * the limiter binding stays absent, which fails open like every limiter. */
+const aiEnv = () =>
+  mockEnv({
+    METAGRAPH_ENABLE_AI: "true",
+    // aiConfigured demands a callable AI.run and a truthy VECTORIZE; the run
+    // itself is never reached because askQuestionImpl is injected.
+    AI: { run: async () => ({}) } as never,
+    VECTORIZE: {} as never,
+  });
+
+const askResult = {
+  question: "q",
+  answer: "SN64 serves inference [1].",
+  citations: [
+    {
+      ref: 1,
+      score: 0.91,
+      title: "Chutes",
+      netuid: 64,
+      slug: "sn-64",
+      url: "https://metagraph.sh/subnets/64",
+    },
+  ],
+  context_count: 1,
+  model: "test-model",
+};
+
+const rpc = (body: unknown, env = aiEnv(), deps = {}) =>
+  handleA2ARequest(
+    new Request(RPC_URL, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    }),
+    env,
+    { askQuestionImpl: async () => askResult, ...deps },
+  );
+
+describe("the agent card", () => {
+  test("advertises exactly what the endpoint implements", async () => {
+    const res = await agentCardResponse(new Request(CARD_URL));
+    assert.equal(res.status, 200);
+    const card = (await res.json()) as Row;
+    assert.equal(card.protocolVersion, "0.3.0");
+    assert.equal(card.url, `https://api.metagraph.sh${A2A_ENDPOINT_PATH}`);
+    assert.equal(card.preferredTransport, "JSONRPC");
+    assert.equal(card.version, MCP_SERVER_VERSION);
+    // ONE skill. The 240 MCP tools are tools; advertising each as an A2A
+    // skill would promise a delegation interface nobody built.
+    const skills = card.skills as Row[];
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].id, "ask");
+    // The card must not promise the lifecycles the endpoint refuses below.
+    assert.deepEqual(card.capabilities, {
+      streaming: false,
+      pushNotifications: false,
+      stateTransitionHistory: false,
+    });
+  });
+
+  test("card requests are conditional (etag round trip)", async () => {
+    const first = await agentCardResponse(new Request(CARD_URL));
+    const etag = first.headers.get("etag");
+    assert.ok(etag);
+    const second = await agentCardResponse(
+      new Request(CARD_URL, { headers: { "if-none-match": etag } }),
+    );
+    assert.equal(second.status, 304);
+    const head = await agentCardResponse(
+      new Request(CARD_URL, { method: "HEAD" }),
+    );
+    assert.equal(head.status, 200);
+    assert.equal(await head.text(), "");
+  });
+
+  test("buildAgentCard stamps the version it was handed", () => {
+    assert.equal(buildAgentCard("9.9.9").version, "9.9.9");
+  });
+});
+
+describe("message/send", () => {
+  test("answers a Message with the ask answer and structured citations", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "message/send",
+      params: {
+        message: {
+          role: "user",
+          parts: [{ kind: "text", text: "Which subnets serve inference?" }],
+          messageId: "m1",
+        },
+      },
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as Row;
+    assert.equal(body.id, 7);
+    const result = body.result as Row;
+    assert.equal(result.kind, "message");
+    assert.equal(result.role, "agent");
+    const parts = result.parts as Row[];
+    assert.equal(parts[0].kind, "text");
+    assert.equal(parts[0].text, askResult.answer);
+    assert.equal(parts[1].kind, "data");
+    assert.deepEqual((parts[1].data as Row).citations, askResult.citations);
+  });
+
+  test("joins multiple text parts into one question", async () => {
+    let seen = "";
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "message/send",
+        params: {
+          message: {
+            parts: [
+              { kind: "text", text: "Context: subnet 3." },
+              { kind: "text", text: "What is the burn?" },
+            ],
+          },
+        },
+      },
+      aiEnv(),
+      {
+        askQuestionImpl: async (_env: unknown, q: unknown) => {
+          seen = String(q);
+          return askResult;
+        },
+      },
+    );
+    assert.equal(res.status, 200);
+    assert.equal(seen, "Context: subnet 3.\nWhat is the burn?");
+  });
+
+  test("an empty message is invalid_params; a file-only one is the content-type code", async () => {
+    const empty = await rpc({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "message/send",
+      params: { message: { parts: [] } },
+    });
+    assert.equal(((await empty.json()) as Row).error?.["code"], -32602);
+
+    const fileOnly = await rpc({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "message/send",
+      params: {
+        message: { parts: [{ kind: "file", file: { uri: "x://y" } }] },
+      },
+    });
+    // -32005 ContentTypeNotSupportedError: the caller sent SOMETHING, in a
+    // mode this skill does not accept -- a different failure from sending
+    // nothing, and the spec has a code for each.
+    assert.equal(((await fileOnly.json()) as Row).error?.["code"], -32005);
+  });
+
+  test("a success with no request id answers id: null, per JSON-RPC", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      method: "message/send",
+      params: { message: { parts: [{ kind: "text", text: "q" }] } },
+    });
+    const body = (await res.json()) as Row;
+    assert.equal(body.id, null);
+    assert.equal((body.result as Row).kind, "message");
+  });
+
+  test("without an injected ask, the real askQuestion runs and its failure is contained", async () => {
+    // The stub env has a callable AI.run and an empty VECTORIZE, so the real
+    // pipeline fails inside retrieval -- proving the production arm of the
+    // dependency seam is wired and that its failure is a JSON-RPC error
+    // rather than an unhandled throw.
+    const res = await handleA2ARequest(
+      new Request(RPC_URL, {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 11,
+          method: "message/send",
+          params: { message: { parts: [{ kind: "text", text: "q" }] } },
+        }),
+      }),
+      aiEnv(),
+    );
+    assert.equal(((await res.json()) as Row).error?.["code"], -32603);
+  });
+
+  test("a message with no parts at all is invalid_params, not a crash", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "message/send",
+      params: {},
+    });
+    assert.equal(((await res.json()) as Row).error?.["code"], -32602);
+  });
+
+  test("a non-Error throw still answers a generic error, and id defaults to null", async () => {
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        method: "message/send",
+        params: { message: { parts: [{ kind: "text", text: "q" }] } },
+      },
+      aiEnv(),
+      {
+        askQuestionImpl: async () => {
+          throw "string failure";
+        },
+      },
+    );
+    const body = (await res.json()) as Row;
+    assert.equal((body.error as Row).code, -32603);
+    assert.equal((body.error as Row).message, "ask failed");
+    assert.equal(body.id, null);
+  });
+
+  test("an ask failure is a JSON-RPC error, not a thrown 500", async () => {
+    const res = await rpc(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        method: "message/send",
+        params: { message: { parts: [{ kind: "text", text: "q" }] } },
+      },
+      aiEnv(),
+      {
+        askQuestionImpl: async () => {
+          throw new Error("model unavailable");
+        },
+      },
+    );
+    const body = (await res.json()) as Row;
+    assert.equal((body.error as Row).code, -32603);
+    assert.match(String((body.error as Row).message), /model unavailable/);
+  });
+});
+
+describe("the methods this server refuses, with the spec's own codes", () => {
+  test("streaming methods answer UnsupportedOperationError (-32004)", async () => {
+    for (const method of ["message/stream", "tasks/resubscribe"]) {
+      const res = await rpc({ jsonrpc: "2.0", id: 5, method, params: {} });
+      assert.equal(((await res.json()) as Row).error?.["code"], -32004, method);
+    }
+  });
+
+  test("task methods answer TaskNotFoundError (-32001)", async () => {
+    // message/send returns a bare Message, so no task ever exists.
+    for (const method of ["tasks/get", "tasks/cancel"]) {
+      const res = await rpc({ jsonrpc: "2.0", id: 6, method, params: {} });
+      assert.equal(((await res.json()) as Row).error?.["code"], -32001, method);
+    }
+  });
+
+  test("an unknown method is -32601", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "agent/frobnicate",
+    });
+    assert.equal(((await res.json()) as Row).error?.["code"], -32601);
+    const missing = await rpc({ jsonrpc: "2.0", id: 9 });
+    const err = ((await missing.json()) as Row).error as Row;
+    assert.equal(err.code, -32601);
+    assert.match(String(err.message), /null/);
+  });
+});
+
+describe("transport guards", () => {
+  test("GET is refused with 405 and a pointer at the card", async () => {
+    const res = await handleA2ARequest(new Request(RPC_URL), aiEnv());
+    assert.equal(res.status, 405);
+    assert.match(
+      String(((await res.json()) as Row).error?.["message"]),
+      /agent-card\.json/,
+    );
+  });
+
+  test("a deployment without AI answers 503, not a fake answer", async () => {
+    const res = await handleA2ARequest(
+      new Request(RPC_URL, { method: "POST", body: "{}" }),
+      mockEnv(),
+    );
+    assert.equal(res.status, 503);
+  });
+
+  test("malformed JSON is a parse error", async () => {
+    const res = await handleA2ARequest(
+      new Request(RPC_URL, { method: "POST", body: "not json" }),
+      aiEnv(),
+      { askQuestionImpl: async () => askResult },
+    );
+    assert.equal(((await res.json()) as Row).error?.["code"], -32700);
+  });
+
+  test("a denied rate limit is a 429, before any body is read", async () => {
+    // The limiter binding present and saying no -- the same tiered config
+    // /api/v1/ask reads, exercised through the real applyTieredRateLimit.
+    const denied = aiEnv();
+    (denied as unknown as Row).AI_RATE_LIMITER = {
+      limit: async () => ({ success: false }),
+    };
+    const res = await handleA2ARequest(
+      new Request(RPC_URL, { method: "POST", body: "{}" }),
+      denied,
+    );
+    assert.equal(res.status, 429);
+  });
+
+  test("an oversized body is refused at the bound", async () => {
+    const res = await handleA2ARequest(
+      new Request(RPC_URL, {
+        method: "POST",
+        body: "x".repeat(70_000),
+        headers: { "content-length": "70000" },
+      }),
+      aiEnv(),
+    );
+    assert.equal(res.status, 413);
+  });
+});
+
+describe("router wiring", () => {
+  // Through the REAL router, not the handler directly: these are the lines
+  // workers/api.ts adds, and the thing they must prove is that the well-known
+  // path and the endpoint dispatch to this module at all.
+  test("the card and the endpoint are reachable through handleRequest", async () => {
+    const card = await handleRequest(
+      new Request(CARD_URL),
+      mockEnv(),
+      {} as never,
+    );
+    assert.equal(card.status, 200);
+    assert.equal(
+      ((await card.json()) as Row).url,
+      `https://api.metagraph.sh${A2A_ENDPOINT_PATH}`,
+    );
+
+    // No AI bindings on this env, so the endpoint answers its 503 -- which is
+    // exactly the proof the route reached the handler rather than a 404.
+    const rpcRes = await handleRequest(
+      new Request(RPC_URL, { method: "POST", body: "{}" }),
+      mockEnv(),
+      {} as never,
+    );
+    assert.equal(rpcRes.status, 503);
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -213,6 +213,7 @@ import {
   X_METAGRAPH_ARTIFACT_RESOLUTION_HEADER,
   X_METAGRAPH_ARTIFACT_SOURCE_HEADER,
   type CacheProfile,
+  readBoundedRequestText,
 } from "./http.ts";
 import {
   latestPointer,
@@ -229,6 +230,10 @@ import {
   envelopeResponse,
   publishedAt,
 } from "./responses.ts";
+import {
+  A2A_CARD_PATH,
+  A2A_ENDPOINT_PATH,
+} from "./request-handlers/a2a-paths.ts";
 import {
   BADGE_SVG_PATTERN,
   homepageResponse,
@@ -6136,6 +6141,16 @@ async function dispatchRequest(
     return handleGraphQLRequest(request, env, ctx);
   }
 
+  // A2A endpoint (#11175): a POST surface, so it must dispatch before the
+  // write-method gate below -- which 405s any method a matched read route
+  // does not take -- exactly as /mcp and /graphql do above. Deferred import
+  // for the same reason as both of those (#10424): the handler pulls in the
+  // AI stack, and the router stays cheap for requests that never touch it.
+  if (url.pathname === A2A_ENDPOINT_PATH) {
+    const { handleA2ARequest } = await import("./request-handlers/a2a.ts");
+    return handleA2ARequest(request, env);
+  }
+
   if (!["GET", "HEAD"].includes(request.method)) {
     // 405 says "this resource exists, but not with that method", so it is only true of
     // a path that exists. Every write route has already returned by here, so anything
@@ -6289,6 +6304,16 @@ async function dispatchRequest(
 
   if (url.pathname === "/.well-known/mcp/server-card.json") {
     return mcpServerCardResponse(request, env);
+  }
+
+  // A2A card (#11175): the card and the endpoint ship together, because a
+  // card advertising a capability with nothing behind it is the
+  // discovery-document version of a dead link. The card names one skill
+  // (ask); the ENDPOINT route lives above the write-method gate with the
+  // other POST surfaces.
+  if (url.pathname === A2A_CARD_PATH) {
+    const { agentCardResponse } = await import("./request-handlers/a2a.ts");
+    return agentCardResponse(request);
   }
 
   // Agent tool specs for non-MCP runtimes (OpenAI function calling / Anthropic
@@ -10410,42 +10435,6 @@ function aiRateLimitedResponse(rateLimit: TieredRateLimitResult) {
   );
 }
 
-async function readBoundedRequestText(request: Request, maxBytes: number) {
-  const contentLength = Number(request.headers.get("content-length") || 0);
-  if (contentLength > maxBytes) {
-    return { ok: false, text: "" };
-  }
-
-  if (!request.body) {
-    return { ok: true, text: "" };
-  }
-
-  const reader = request.body.getReader();
-  const decoder = new TextDecoder();
-  let bytes = 0;
-  let text = "";
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      const chunk =
-        typeof value === "string" ? new TextEncoder().encode(value) : value;
-      bytes += chunk.byteLength;
-      if (bytes > maxBytes) {
-        await reader.cancel();
-        return { ok: false, text: "" };
-      }
-      text += decoder.decode(chunk, { stream: true });
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  text += decoder.decode();
-  return { ok: true, text };
-}
-
 async function handleSemanticSearchRequest(
   request: Request,
   env: Env,
@@ -10766,7 +10755,9 @@ async function liveHealthOverlay(
 function allowedMethodsForPath(pathname: string): string {
   const url = { pathname };
   let methods = "GET, HEAD, OPTIONS";
-  if (url.pathname.startsWith("/rpc/")) {
+  if (url.pathname === A2A_ENDPOINT_PATH) {
+    methods = "POST, OPTIONS";
+  } else if (url.pathname.startsWith("/rpc/")) {
     methods = "POST, OPTIONS";
   } else if (url.pathname.startsWith("/api/v1/webhooks/")) {
     methods = "POST, GET, DELETE, OPTIONS";

--- a/workers/http.ts
+++ b/workers/http.ts
@@ -176,3 +176,49 @@ export function ifNoneMatchSatisfied(
     .map((candidate) => candidate.trim())
     .some((candidate) => candidate === "*" || opaqueTag(candidate) === current);
 }
+
+/**
+ * Read a request body up to `maxBytes`, refusing larger ones.
+ *
+ * Moved here from workers/api.ts when the A2A endpoint needed the same
+ * bounded read (#11175): the alternative was a copy, and a body bound that
+ * exists twice is a body bound that disagrees with itself eventually.
+ */
+export async function readBoundedRequestText(
+  request: Request,
+  maxBytes: number,
+) {
+  const contentLength = Number(request.headers.get("content-length") || 0);
+  if (contentLength > maxBytes) {
+    return { ok: false, text: "" };
+  }
+
+  if (!request.body) {
+    return { ok: true, text: "" };
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk =
+        typeof value === "string" ? new TextEncoder().encode(value) : value;
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) {
+        await reader.cancel();
+        return { ok: false, text: "" };
+      }
+      text += decoder.decode(chunk, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  text += decoder.decode();
+  return { ok: true, text };
+}

--- a/workers/request-handlers/a2a-paths.ts
+++ b/workers/request-handlers/a2a-paths.ts
@@ -1,0 +1,11 @@
+// The A2A paths, in a leaf module so the router can match them without
+// loading the handler -- workers/api.ts defers the a2a.ts import for the same
+// reason discovery.ts defers src/mcp-server.ts (#10424): the handler pulls in
+// the AI stack, and the router must stay cheap for the requests that never
+// touch it.
+
+/** The JSON-RPC endpoint the agent card advertises. Version-segmented like
+ * /api/v1, so a breaking A2A revision is a new path, not a new meaning. */
+export const A2A_ENDPOINT_PATH = "/a2a/v1";
+/** A2A 0.3's well-known card location. */
+export const A2A_CARD_PATH = "/.well-known/agent-card.json";

--- a/workers/request-handlers/a2a.ts
+++ b/workers/request-handlers/a2a.ts
@@ -1,0 +1,299 @@
+// A2A: the registry as an agent other agents can talk to (#11175).
+//
+// ## WHY THIS EXISTS, AND WHY IT IS THIS SMALL
+//
+// The agent-readiness scan asks for an A2A agent card, and the rule this repo
+// holds discovery documents to is that every advertised capability has a
+// working endpoint behind it -- a card pointing at nothing is the same
+// dishonesty as a registered mutation URL the prober GETs (#11146). So the
+// card ships WITH the endpoint, and the card advertises exactly one skill:
+// `ask`, the grounded Q&A the MCP surface already serves. One skill because we
+// have one capability that fits A2A's conversational shape; the 240 MCP tools
+// are tools, and pretending each is an agent "skill" would advertise a
+// delegation interface nobody built.
+//
+// ## ONE IMPLEMENTATION
+//
+// The message handler translates A2A text parts to a question, calls the SAME
+// `askQuestion` behind /api/v1/ask and the `ask` MCP tool, and translates the
+// answer back. No second retrieval path, no second prompt, no second rate
+// limit vocabulary: the tiered AI limit and the ai-enabled gate are the ones
+// every other AI surface reads. Improving ask improves all three surfaces.
+//
+// ## WHAT IS DELIBERATELY NOT IMPLEMENTED
+//
+// Tasks. A2A lets a server answer `message/send` with a bare Message instead
+// of a Task, which is the truthful shape for a stateless Q&A: there is nothing
+// to poll, cancel, or resubscribe to. The task methods therefore answer the
+// spec's own TaskNotFoundError / UnsupportedOperationError codes rather than
+// simulating a lifecycle this server does not have, and the card declares
+// streaming and push notifications unsupported so a conformant client never
+// tries.
+import {
+  aiEnabled,
+  askQuestion,
+  AI_TIERED_RATE_LIMIT,
+  type AskQuestionResult,
+} from "../../src/ai-search.ts";
+import { applyTieredRateLimit } from "../tiered-rate-limit.ts";
+import {
+  ifNoneMatchSatisfied,
+  readBoundedRequestText,
+  weakEtag,
+} from "../http.ts";
+import { discoveryHeaders } from "./discovery.ts";
+
+type Row = Record<string, unknown>;
+
+import { A2A_CARD_PATH, A2A_ENDPOINT_PATH } from "./a2a-paths.ts";
+export { A2A_CARD_PATH, A2A_ENDPOINT_PATH };
+
+/** Same ceiling as /api/v1/ask -- one question is one question, whichever
+ * protocol carried it. */
+const MAX_A2A_BODY_BYTES = 64 * 1024;
+
+// A2A's own JSON-RPC error codes (spec §8): the spec reserves -32001..-32006
+// for A2A-specific failures beside the standard JSON-RPC range.
+const RPC_PARSE_ERROR = -32700;
+const RPC_INVALID_REQUEST = -32600;
+const RPC_METHOD_NOT_FOUND = -32601;
+const RPC_INVALID_PARAMS = -32602;
+const RPC_INTERNAL = -32603;
+const A2A_TASK_NOT_FOUND = -32001;
+const A2A_UNSUPPORTED_OPERATION = -32004;
+const A2A_CONTENT_TYPE_NOT_SUPPORTED = -32005;
+
+export interface A2ADeps {
+  /** Injection seam for tests; production uses the real askQuestion. */
+  askQuestionImpl?: typeof askQuestion;
+}
+
+/**
+ * The agent card, worker-computed like the MCP server card so a version bump
+ * or skill change never needs a committed-artifact regen.
+ *
+ * `url` is absolute and points at the API host: the card is also proxied on
+ * the apex, and a relative url would advertise an endpoint on whichever host
+ * served the card.
+ */
+export function buildAgentCard(serverVersion: string): Row {
+  return {
+    protocolVersion: "0.3.0",
+    name: "metagraphed",
+    description:
+      "Live operational + integration registry for Bittensor subnets. " +
+      "Ask grounded questions about subnets, their APIs, health, and " +
+      "economics; answers carry bracketed citations into the registry. " +
+      "The full tool surface (240 tools) is MCP at https://api.metagraph.sh/mcp " +
+      "-- this A2A skill is the conversational front door, not the catalogue.",
+    url: `https://api.metagraph.sh${A2A_ENDPOINT_PATH}`,
+    preferredTransport: "JSONRPC",
+    provider: {
+      organization: "metagraphed",
+      url: "https://metagraph.sh",
+    },
+    version: serverVersion,
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+      stateTransitionHistory: false,
+    },
+    defaultInputModes: ["text/plain"],
+    defaultOutputModes: ["text/plain", "application/json"],
+    skills: [
+      {
+        id: "ask",
+        name: "Ask about the Bittensor subnet registry",
+        description:
+          "Natural-language Q&A grounded in the live registry (RAG over " +
+          "subnets, surfaces, health, and economics). Returns an answer with " +
+          "bracketed [n] citations, plus the citation records as a data part.",
+        tags: ["bittensor", "subnets", "registry", "search", "grounded-qa"],
+        examples: [
+          "Which subnets expose an inference API I can call today?",
+          "What does it cost to register a miner on subnet 3?",
+        ],
+        inputModes: ["text/plain"],
+        outputModes: ["text/plain", "application/json"],
+      },
+    ],
+    supportsAuthenticatedExtendedCard: false,
+  };
+}
+
+export async function agentCardResponse(request: Request): Promise<Response> {
+  // Deferred for the same reason discovery.ts defers it (#10424): the version
+  // constant lives with the MCP server, and a static import would drag the
+  // whole tool registry into every consumer of this module. One string does
+  // not justify that; card requests are rare and /mcp isolates have the module
+  // loaded already.
+  const { MCP_SERVER_VERSION } = await import("../../src/mcp-server.ts");
+  const body = `${JSON.stringify(buildAgentCard(MCP_SERVER_VERSION), null, 2)}\n`;
+  const headers = discoveryHeaders("application/json");
+  headers.set("etag", await weakEtag(body));
+  // etag was just set from a non-empty body; the fallback only satisfies the
+  // `string | null` of Headers.get, same as the sibling discovery handlers.
+  const etag = /* v8 ignore next */ headers.get("etag") || "";
+  if (ifNoneMatchSatisfied(request, etag)) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}
+
+function rpcError(
+  id: unknown,
+  code: number,
+  message: string,
+  status = 200,
+): Response {
+  // JSON-RPC errors ride a 200 by convention; only transport-level failures
+  // (rate limit, parse) carry an HTTP status, matching how /mcp answers.
+  return Response.json(
+    { jsonrpc: "2.0", id: id ?? null, error: { code, message } },
+    { status },
+  );
+}
+
+/** Every text part's text, joined -- the question as the caller composed it. */
+function questionFromMessage(message: Row | null | undefined): string {
+  const parts = Array.isArray(message?.parts) ? (message.parts as Row[]) : [];
+  return parts
+    .filter((part) => part?.kind === "text" && typeof part.text === "string")
+    .map((part) => (part.text as string).trim())
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function answerMessage(result: AskQuestionResult): Row {
+  return {
+    kind: "message",
+    role: "agent",
+    messageId: crypto.randomUUID(),
+    parts: [
+      { kind: "text", text: result.answer },
+      // The citations as structured data, so a consuming agent can follow
+      // them without re-parsing bracket references out of prose.
+      {
+        kind: "data",
+        data: { citations: result.citations, model: result.model },
+      },
+    ],
+  };
+}
+
+/**
+ * POST /a2a/v1 -- the JSON-RPC endpoint behind the card.
+ *
+ * Supported: `message/send` (blocking, answers a Message). Everything else
+ * answers the spec's own code for "this server does not do that", which is
+ * strictly more useful to a conformant client than a 404: the error names the
+ * contract instead of the router.
+ */
+export async function handleA2ARequest(
+  request: Request,
+  env: Env,
+  deps: A2ADeps = {},
+): Promise<Response> {
+  if (request.method !== "POST") {
+    return rpcError(
+      null,
+      RPC_INVALID_REQUEST,
+      `POST JSON-RPC to ${A2A_ENDPOINT_PATH}; see /.well-known/agent-card.json.`,
+      405,
+    );
+  }
+  if (!aiEnabled(env)) {
+    return rpcError(
+      null,
+      RPC_INTERNAL,
+      "The ask capability is not available on this deployment.",
+      503,
+    );
+  }
+  // The SAME tiered limit as /api/v1/ask and semantic search: one question is
+  // one AI call, whichever protocol carried it, and a separate budget here
+  // would be the loophole callers migrate to.
+  const rateLimit = await applyTieredRateLimit(
+    request,
+    env,
+    AI_TIERED_RATE_LIMIT,
+  );
+  if (!rateLimit.allowed) {
+    return rpcError(null, RPC_INTERNAL, "Rate limited. Retry later.", 429);
+  }
+  const bounded = await readBoundedRequestText(request, MAX_A2A_BODY_BYTES);
+  if (!bounded.ok) {
+    return rpcError(null, RPC_INVALID_REQUEST, "Request body too large.", 413);
+  }
+  let rpc: Row;
+  try {
+    rpc = JSON.parse(bounded.text) as Row;
+  } catch {
+    return rpcError(null, RPC_PARSE_ERROR, "Body must be valid JSON.");
+  }
+  const id = rpc?.id;
+  const method = rpc?.method;
+  const params = (rpc?.params ?? {}) as Row;
+
+  switch (method) {
+    case "message/send": {
+      const message = params.message as Row | undefined;
+      const question = questionFromMessage(message);
+      if (!question) {
+        const hasNonText = Array.isArray(message?.parts)
+          ? (message.parts as Row[]).some((part) => part?.kind !== "text")
+          : false;
+        // A file-only or data-only message is a content-type problem and gets
+        // the spec's code for it; an empty message is an invalid-params one.
+        return rpcError(
+          id,
+          hasNonText ? A2A_CONTENT_TYPE_NOT_SUPPORTED : RPC_INVALID_PARAMS,
+          hasNonText
+            ? "This skill accepts text parts only."
+            : "params.message.parts must include at least one non-empty text part.",
+        );
+      }
+      try {
+        const ask = deps.askQuestionImpl ?? askQuestion;
+        const result = await ask(env, question, {}, {});
+        return Response.json({
+          jsonrpc: "2.0",
+          id: id ?? null,
+          result: answerMessage(result),
+        });
+      } catch (error) {
+        return rpcError(
+          id,
+          RPC_INTERNAL,
+          error instanceof Error ? error.message : "ask failed",
+        );
+      }
+    }
+    case "message/stream":
+    case "tasks/resubscribe":
+      // The card says streaming: false; a conformant client never gets here.
+      return rpcError(
+        id,
+        A2A_UNSUPPORTED_OPERATION,
+        "Streaming is not supported; the agent card declares streaming: false.",
+      );
+    case "tasks/get":
+    case "tasks/cancel":
+      // message/send answers a bare Message, so no task ever exists to find.
+      return rpcError(
+        id,
+        A2A_TASK_NOT_FOUND,
+        "This agent answers message/send directly and never creates tasks.",
+      );
+    default:
+      return rpcError(
+        id,
+        RPC_METHOD_NOT_FOUND,
+        `Unknown method ${JSON.stringify(method ?? null)}.`,
+      );
+  }
+}

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -238,7 +238,7 @@ const HOMEPAGE_HTML = `<!doctype html>
 
 // Shared headers for the worker-owned discovery surfaces: open CORS so agents
 // can fetch cross-origin, the discovery Link header, and a public cache.
-function discoveryHeaders(contentType: string): Headers {
+export function discoveryHeaders(contentType: string): Headers {
   const headers = new Headers();
   headers.set("access-control-allow-origin", "*");
   headers.set("content-type", contentType);


### PR DESCRIPTION
## What this is

The A2A row of the agent-readiness scan, done honestly: `/.well-known/agent-card.json` ships **together with** the `POST /a2a/v1` endpoint it advertises, because a card pointing at nothing is the discovery-document version of a dead link — the same class of problem as the mutation-URL gap (#11146).

## Shape

- **One skill: `ask`.** The card advertises the grounded, cited Q&A the MCP tool and `/api/v1/ask` already serve — called through the **same `askQuestion`**, the same tiered AI rate limit (`AI_TIERED_RATE_LIMIT`), and the same `aiEnabled` gate. One implementation behind three protocols; improving ask improves all three. The 240 MCP tools stay tools — advertising each as an A2A skill would promise a delegation interface nobody built, and the card says where the full catalogue lives.
- **`message/send` answers a bare Message** (A2A permits this): the answer as a text part, the citations as a structured data part. Nothing exists to poll or cancel, so `tasks/get`/`tasks/cancel` answer the spec's own `TaskNotFoundError` (-32001), streaming methods answer `UnsupportedOperationError` (-32004), a file-only message answers `ContentTypeNotSupportedError` (-32005) — the spec's codes, not a router 404. The card declares `streaming: false` / `pushNotifications: false` so a conformant client never tries.
- **Worker-computed card** (like the MCP server card), version deferred-imported from the MCP server so `sync-mcp-version` keeps them in step with no committed artifact. Apex proxies the card, so the **scanned host** serves it.
- `readBoundedRequestText` moved `workers/api.ts` → `workers/http.ts` (exported): the endpoint needed the same bounded read, and a bound that exists twice eventually disagrees with itself. Router match uses a leaf `a2a-paths.ts` so the handler (and the AI stack behind it) stays deferred, per the #10424 discipline.

## Tests

19 tests, **100% statement and branch coverage** on the new module: card shape pinned against what the endpoint implements (capabilities the card denies are the methods the endpoint refuses), etag round trip, multi-part question joining, every error code arm, denied rate limit through the real `applyTieredRateLimit`, oversized body, non-Error throw, absent-id conventions, and the production arm of the ask seam (real `askQuestion` against the stub env fails **contained**, as a JSON-RPC error). Plus `validate:api`, `validate:mcp`, `validate:contract-drift`, discovery + api-coverage suites (352), both workspaces' lint/typecheck.

Closes #11175