### PR TITLE
feat(watchdog): declare each lane table's topology, so a rule stops guessing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -443,6 +443,7 @@ jobs:
           source .github/scripts/run-step.sh
           run_step npm run validate:contract-drift
           run_step npm run validate:db-types-drift
+          run_step npm run validate:lane-topology
           run_step npm run validate:lakehouse-types-drift
           run_step npm run validate:lakehouse-readers
           run_step npm run validate:store-type-parity

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "validate:types": "node scripts/validate-types.ts",
     "validate:contract-drift": "node scripts/validate-contract-drift.ts",
     "validate:db-types-drift": "node scripts/validate-db-types-drift.ts",
+    "validate:lane-topology": "node scripts/validate-lane-topology.ts",
     "validate:lakehouse-types-drift": "node scripts/validate-lakehouse-types-drift.ts",
     "validate:operational-surface-parity": "node scripts/validate-operational-surface-parity.ts",
     "validate:schema-enums": "node scripts/validate-schema-enums.ts",

--- a/scripts/validate-lane-topology.ts
+++ b/scripts/validate-lane-topology.ts
@@ -1,0 +1,124 @@
+// The lane topology declaration must describe tables that actually exist
+// (#11183).
+//
+// `src/lane-table-topology.ts` states things Postgres cannot know -- that a
+// producer prunes only its own rows, that a partial pass is partial in
+// coldkeys. Those are declarations and stay declarations. What this gates is
+// the half that IS checkable: every column the declaration names must exist in
+// `generated/db/schema.json`, the snapshot introspected from live Neon.
+//
+// WHY THAT MATTERS MORE THAN IT SOUNDS. The declaration is consumed by coverage
+// rules to scope their queries. A column renamed upstream would not fail those
+// rules loudly -- `WHERE source = $1` against a dropped column errors, but a
+// coverageUnit pointing at a column that moved would quietly count the wrong
+// thing, which is precisely the class of failure #11166/#11170/#11180 were.
+//
+// The consistency rules below are the other half: they refuse declarations that
+// are internally impossible, so a table cannot claim two producers without
+// saying how to tell them apart.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { repoRoot } from "./lib.ts";
+import {
+  COVERAGE_UNIT_ROWS,
+  LANE_TABLE_TOPOLOGY,
+  type LaneTableTopology,
+} from "../src/lane-table-topology.ts";
+
+const SNAPSHOT_PATH = "generated/db/schema.json";
+
+interface ColumnRow {
+  table: string;
+  column: string;
+}
+
+/** table -> its columns, from the introspected snapshot. */
+export function columnsByTable(raw: string): Map<string, Set<string>> {
+  const parsed = JSON.parse(raw) as ColumnRow[] | { columns: ColumnRow[] };
+  const rows = Array.isArray(parsed) ? parsed : parsed.columns;
+  const out = new Map<string, Set<string>>();
+  for (const row of rows) {
+    if (!out.has(row.table)) out.set(row.table, new Set());
+    out.get(row.table)!.add(row.column);
+  }
+  return out;
+}
+
+export function problemsFor(
+  topology: Readonly<Record<string, LaneTableTopology>>,
+  columns: Map<string, Set<string>>,
+): string[] {
+  const problems: string[] = [];
+  for (const [table, t] of Object.entries(topology)) {
+    const cols = columns.get(table);
+    if (!cols) {
+      problems.push(
+        `${table}: declared here but absent from ${SNAPSHOT_PATH} -- either the table was dropped or the snapshot is stale`,
+      );
+      continue;
+    }
+
+    const needsColumn: [string, string | null][] = [
+      ["producers.column", t.producers.column],
+      [
+        "coverageUnit",
+        t.coverageUnit === COVERAGE_UNIT_ROWS ? null : t.coverageUnit,
+      ],
+      ["prunes.perKey", t.prunes === false ? null : t.prunes.perKey],
+    ];
+    for (const [field, column] of needsColumn) {
+      if (column && !cols.has(column)) {
+        problems.push(
+          `${table}.${field} names "${column}", which is not a column of ${table} (${[...cols].sort().join(", ")})`,
+        );
+      }
+    }
+
+    // A table cannot claim several producer lanes without a way to tell them
+    // apart: that is exactly the state nominator_positions was read in (#11180).
+    if (t.producers.lanes.length > 1 && !t.producers.column) {
+      problems.push(
+        `${table}: declares ${t.producers.lanes.length} producer lanes but no column to tell them apart, so a coverage rule cannot scope to one`,
+      );
+    }
+    if (t.producers.lanes.length > 1 && !t.producers.fullScanValue) {
+      problems.push(
+        `${table}: declares several producer lanes but names no fullScanValue, so a rule cannot know whose completeness it is judging`,
+      );
+    }
+    if (t.producers.lanes.length === 1 && t.producers.column) {
+      problems.push(
+        `${table}: declares one producer lane but also a discriminator column -- one of the two is wrong, and a rule scoping on it would filter to a subset of a single writer's rows`,
+      );
+    }
+    if (t.producers.fullScanValue && !t.producers.column) {
+      problems.push(
+        `${table}: names a fullScanValue but no column to match it against, so the value can never be applied`,
+      );
+    }
+  }
+  return problems;
+}
+
+function main(): void {
+  const columns = columnsByTable(
+    readFileSync(path.join(repoRoot, SNAPSHOT_PATH), "utf8"),
+  );
+  const problems = problemsFor(LANE_TABLE_TOPOLOGY, columns);
+  if (problems.length) {
+    process.stderr.write(
+      `lane-topology: ${problems.length} problem(s):\n` +
+        problems.map((p) => `  ${p}`).join("\n") +
+        `\n  -> src/lane-table-topology.ts describes what a coverage rule needs to\n` +
+        `     scope correctly. A declaration that disagrees with the schema does not\n` +
+        `     fail the rule loudly; it makes it count the wrong thing.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    `lane-topology: ${Object.keys(LANE_TABLE_TOPOLOGY).length} lane table(s) declared, every named column present.\n`,
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/src/lane-table-topology.ts
+++ b/src/lane-table-topology.ts
@@ -1,0 +1,216 @@
+// What a coverage rule has to know about a table before it can be written
+// correctly (#11183).
+//
+// Three properties decide the shape of a correct coverage query, and until now
+// NONE of them was declared anywhere. Every watchdog re-derived them by reading
+// its writer, and on 2026-08-13/14 three of the four got it wrong -- each
+// alarming for hours on data that was correct:
+//
+//   * DOES IT PRUNE. `validator_nominator_counts` is keyed on (hotkey) and
+//     never deletes, so a hotkey that loses its last nominator keeps its row.
+//     Its expectation had been "read off production as the row count at the
+//     newest captured_at" -- 112,245 accumulated rows against 21,547 hotkeys
+//     actually on chain, a floor no correct pass could ever meet (#11166).
+//
+//   * HOW MANY PRODUCERS. `nominator_positions` has two, which is why it has a
+//     `source` column at all. Unscoped, `MAX(captured_at)` is whichever ran
+//     last, so a HEALTHY targeted `self-stake` run made the full `alpha` scan
+//     look truncated (#11180).
+//
+//   * ROWS OR KEYS. Coldkeys hold wildly different numbers of positions, so a
+//     scan that died after the largest delegators can show high ROW coverage
+//     having missed most accounts. Coverage has to be counted in the unit the
+//     pass is partial IN.
+//
+// NOT INTROSPECTABLE, which is why this is declared rather than snapshotted.
+// Postgres knows the columns; it cannot know that one producer prunes only its
+// own rows, or that a partial pass is partial in coldkeys. What IS checkable is
+// that the declaration matches the schema, and scripts/validate-lane-topology.ts
+// does exactly that against `generated/db/schema.json` -- so a column renamed
+// upstream fails CI here instead of silently un-scoping a rule.
+import { POSITION_SOURCE_ALPHA } from "./nominator-positions-neon-write.ts";
+import { type ProducerLane } from "./producer-cadence.ts";
+
+/** Coverage counted over whole rows rather than distinct keys. */
+export const COVERAGE_UNIT_ROWS = "rows";
+
+/**
+ * One table's topology.
+ *
+ * A plain interface with `satisfies` below, matching producer-cadence.ts --
+ * the sibling that owns the other half of this metadata and carries no Zod at
+ * all. `schemas-src/` is for PUBLISHED contract components; a Zod schema here
+ * would parse a compile-time constant against itself, which proves nothing the
+ * type does not already. The check that has teeth is the declaration against
+ * `generated/db/schema.json`, and that is schema-vs-schema, the house pattern.
+ */
+export interface LaneTableTopology {
+  /**
+   * Whether the writer deletes rows a pass did not refresh, and at what grain.
+   *
+   * `false` means the table ACCUMULATES: its row count is history, not
+   * population, and must never be used as an expectation. `{ perKey }` means
+   * the prune is scoped to the keys a batch contains -- which is why a partial
+   * pass leaves mixed freshness rather than corruption.
+   */
+  readonly prunes: false | { readonly perKey: string };
+  readonly producers: {
+    /**
+     * Which producer lanes write this table.
+     *
+     * `ProducerLane` from producer-cadence.ts, which already owns this
+     * vocabulary and pairs each lane with its cadence. Naming lanes freshly
+     * here would be a third spelling of a fact that already has two.
+     */
+    readonly lanes: readonly ProducerLane[];
+    /** The column telling them apart IN THE TABLE; null when there is one. */
+    readonly column: string | null;
+    /**
+     * The value the full-scan producer STAMPS in that column.
+     *
+     * Deliberately separate from `lanes`: the lane is `validator_nominators`
+     * and the value it writes is `alpha`. Those are two vocabularies for one
+     * producer and both already exist, so this records the pairing rather than
+     * inventing a name that collapses them.
+     */
+    readonly fullScanValue: string | null;
+  };
+  /** The column whose DISTINCT count is coverage, or COVERAGE_UNIT_ROWS. */
+  readonly coverageUnit: string;
+  /** Where a correct expectation is measured. Prose, deliberately. */
+  readonly populationSource: string;
+}
+
+/**
+ * Every Neon table a staleness watchdog counts coverage over.
+ *
+ * `populationSource` says CHAIN wherever the answer is a property of the
+ * network, because that is the rule the four bugs above all broke: an
+ * expectation read off our own sink reproduces whatever that sink accumulated.
+ */
+export const LANE_TABLE_TOPOLOGY = {
+  nominator_positions: {
+    // Scoped to the coldkeys a batch contains: an unstaked position genuinely
+    // stops existing, so that delete is correct, and a coldkey absent from the
+    // pass is left untouched rather than emptied.
+    prunes: { perKey: "coldkey" },
+    producers: {
+      lanes: ["validator_nominators", "self_stake"],
+      column: "source",
+      // The writer's own constant, imported rather than restated -- a second
+      // copy here would be free to drift from the value actually stamped.
+      fullScanValue: POSITION_SOURCE_ALPHA,
+    },
+    coverageUnit: "coldkey",
+    populationSource:
+      "chain: distinct coldkeys in SubtensorModule::Alpha with netuid != 0 and shares > 0 (21,263 on 2026-08-14)",
+  },
+  validator_nominator_counts: {
+    prunes: false,
+    // The same poller pass writes this and nominator_positions' alpha rows.
+    producers: {
+      lanes: ["validator_nominators"],
+      column: null,
+      fullScanValue: null,
+    },
+    coverageUnit: "hotkey",
+    populationSource:
+      "chain: distinct hotkeys in SubtensorModule::Alpha (21,547 on 2026-08-14)",
+  },
+  hotkey_alpha: {
+    prunes: false,
+    producers: { lanes: ["hotkey_alpha"], column: null, fullScanValue: null },
+    coverageUnit: COVERAGE_UNIT_ROWS,
+    populationSource:
+      "nominator_positions: distinct (hotkey, netuid) the NEWEST pass references -- the sink stores only pools a position names, so the expectation moves with that ledger (17,292 live on chain 2026-08-14 against 35,073 accumulated in the table)",
+  },
+  account_balances: {
+    prunes: false,
+    producers: {
+      lanes: ["account_balances"],
+      column: null,
+      fullScanValue: null,
+    },
+    coverageUnit: "ss58",
+    // The one lane whose expectation only GROWS, and the reason a ratio copied
+    // from its siblings would be wrong here.
+    populationSource:
+      "chain: accounts that have ever held a balance -- monotonic, unlike every other lane here",
+  },
+  neurons: {
+    prunes: false,
+    producers: { lanes: ["metagraph"], column: null, fullScanValue: null },
+    coverageUnit: "netuid",
+    populationSource: "chain: registered subnets and their UID counts",
+  },
+  // chain_detail_blocks is deliberately ABSENT. Its watchdog is a ticker
+  // against an advancing block frontier, not a coverage rule over a population,
+  // and `chain_detail` is not a ProducerLane -- it has no declared cadence.
+  // Forcing a lane name in to satisfy this shape would invent the vocabulary
+  // this module exists to avoid inventing. If it ever grows a coverage rule, it
+  // needs a cadence declaration first.
+} as const satisfies Record<string, LaneTableTopology>;
+
+export type LaneTableName = keyof typeof LANE_TABLE_TOPOLOGY;
+
+/**
+ * One table's topology, or a throw.
+ *
+ * Throws rather than returning undefined because every caller is a rule that
+ * would otherwise silently fall back to an unscoped query -- which is the
+ * defect this module exists to remove.
+ */
+export function laneTableTopology(table: LaneTableName): LaneTableTopology {
+  const topology = LANE_TABLE_TOPOLOGY[table];
+  if (!topology) throw new Error(`no declared topology for ${table}`);
+  return topology;
+}
+
+/**
+ * The producer whose completeness a coverage rule over `table` judges.
+ *
+ * THROWS on a table that declares several producers and names no full scan,
+ * rather than returning null for the caller to handle. A rule that received
+ * null would have to choose between scoping to nothing and scoping to
+ * everything, and "everything" is the unscoped read that made a healthy
+ * self-stake run look like a truncated alpha scan (#11180). Failing here is
+ * loud; that fallback was not.
+ */
+export function resolveFullScan(
+  topology: LaneTableTopology,
+  label: string,
+): string | null {
+  const { producers } = topology;
+  if (producers.fullScanValue) return producers.fullScanValue;
+  // One producer writes everything, so there is nothing to scope on and null is
+  // the honest answer -- unlike the several-producer case below, where null
+  // would mean "scope to everything" and reintroduce #11180.
+  if (producers.lanes.length === 1) return null;
+  throw new Error(
+    `${label} declares ${producers.lanes.length} producer lanes and no fullScanValue, so a coverage rule cannot know whose pass it is judging`,
+  );
+}
+
+export function fullScanProducer(table: LaneTableName): string | null {
+  return resolveFullScan(laneTableTopology(table), table);
+}
+
+/**
+ * The value a SCOPED coverage read must match, for a table that has a
+ * discriminator.
+ *
+ * Separate from `fullScanProducer` because null means two different things
+ * there: "nothing to scope on" for a single-producer table, and "I cannot tell"
+ * for an ambiguous one. A caller building `WHERE source = ?` can use neither --
+ * binding null matches no rows at all, so the rule would report zero coverage
+ * forever, which looks exactly like the truncated pass this all started with.
+ */
+export function requireFullScanValue(table: LaneTableName): string {
+  const value = fullScanProducer(table);
+  if (!value) {
+    throw new Error(
+      `${table} declares no discriminated full-scan producer, so a scoped coverage read cannot be built for it`,
+    );
+  }
+  return value;
+}

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -57,7 +57,7 @@ import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 import { readStore } from "./read-store.ts";
-import { POSITION_SOURCE_ALPHA } from "./nominator-positions-neon-write.ts";
+import { requireFullScanValue } from "./lane-table-topology.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -197,10 +197,16 @@ export const NOMINATOR_POSITIONS_PASS_WINDOW_MS = passWindowMs(
  * reported /accounts/{ss58}/positions as serving silently-partial data for
  * hours, on a lane where BOTH producers had succeeded.
  */
-// The writer's own constant, imported rather than restated: the column exists
-// so two producers can share the table, and a second copy of that vocabulary
-// here would be free to drift from the value actually being stamped.
-export const NOMINATOR_POSITIONS_SCAN_SOURCE = POSITION_SOURCE_ALPHA;
+// DERIVED from the table's declared topology (#11183), not restated here.
+//
+// `src/lane-table-topology.ts` is where "this table has two producers and
+// `alpha` is the full scan" is stated once, checked against the introspected
+// schema by validate:lane-topology, and read by every rule that needs it. The
+// value still originates in the WRITER's own constant, so there remains exactly
+// one definition of what gets stamped.
+export const NOMINATOR_POSITIONS_SCAN_SOURCE = requireFullScanValue(
+  "nominator_positions",
+);
 
 /**
  * Coverage, scoped to the full-scan producer.

--- a/tests/lane-table-topology.test.ts
+++ b/tests/lane-table-topology.test.ts
@@ -1,0 +1,237 @@
+// The lane topology declaration, and the gate that keeps it honest (#11183).
+//
+// The declaration exists because three coverage rules were written without
+// knowing three things Postgres cannot tell them, and all three were wrong
+// (#11166, #11170, #11180). A declaration nobody reads would be documentation,
+// so what is asserted here is that it is LOAD-BEARING: the nominator-positions
+// rule takes its scoping from it, and a declaration that disagrees with the
+// schema fails CI rather than quietly making a rule count the wrong thing.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, test } from "vitest";
+import {
+  COVERAGE_UNIT_ROWS,
+  LANE_TABLE_TOPOLOGY,
+  type LaneTableTopology,
+  fullScanProducer,
+  laneTableTopology,
+  requireFullScanValue,
+  resolveFullScan,
+} from "../src/lane-table-topology.ts";
+import { POSITION_SOURCE_ALPHA } from "../src/nominator-positions-neon-write.ts";
+import { NOMINATOR_POSITIONS_SCAN_SOURCE } from "../src/nominator-positions-staleness-watchdog.ts";
+import {
+  columnsByTable,
+  problemsFor,
+} from "../scripts/validate-lane-topology.ts";
+import { repoRoot } from "../scripts/lib.ts";
+
+/** The real snapshot, so the declaration is checked against real columns. */
+const COLUMNS = columnsByTable(
+  readFileSync(path.join(repoRoot, "generated/db/schema.json"), "utf8"),
+);
+
+/** A valid single-producer declaration, cloned per case so edits stay local. */
+function valid(): LaneTableTopology {
+  return {
+    prunes: false as const,
+    producers: { lanes: ["metagraph"], column: null, fullScanValue: null },
+    coverageUnit: COVERAGE_UNIT_ROWS,
+    populationSource: "chain: something",
+  };
+}
+
+describe("the committed declaration", () => {
+  test("it agrees with the introspected schema", () => {
+    assert.deepEqual(problemsFor(LANE_TABLE_TOPOLOGY, COLUMNS), []);
+  });
+
+  test("nominator_positions is declared with two producers and a discriminator", () => {
+    // The specific fact #11180 turned on. Asserted by name rather than by
+    // count, so a future producer added to the list cannot quietly satisfy it.
+    const t = laneTableTopology("nominator_positions");
+    assert.equal(t.producers.column, "source");
+    assert.deepEqual([...t.producers.lanes].sort(), [
+      "self_stake",
+      "validator_nominators",
+    ]);
+    assert.equal(t.producers.fullScanValue, POSITION_SOURCE_ALPHA);
+  });
+
+  test("the accumulating tables say so, because their row counts are history", () => {
+    // Each of these had (or fed) an expectation read off its own row count.
+    // `prunes: false` is the property that makes that read invalid.
+    for (const table of [
+      "validator_nominator_counts",
+      "hotkey_alpha",
+      "account_balances",
+    ] as const) {
+      assert.equal(
+        laneTableTopology(table).prunes,
+        false,
+        `${table} accumulates; declaring otherwise would license reading its population off itself`,
+      );
+    }
+  });
+});
+
+describe("the declaration is load-bearing, not decorative", () => {
+  test("the nominator-positions rule takes its scoping from it", () => {
+    // If this were a coincidence rather than a derivation, changing the
+    // declaration would leave the rule scoping to a stale literal -- which is
+    // the shape of the bug the declaration exists to prevent.
+    assert.equal(
+      NOMINATOR_POSITIONS_SCAN_SOURCE,
+      LANE_TABLE_TOPOLOGY.nominator_positions.producers.fullScanValue,
+    );
+  });
+
+  test("an ambiguous declaration throws rather than defaulting", () => {
+    // Returning null here would hand the caller a choice between scoping to
+    // nothing and scoping to everything, and "everything" is the unscoped read
+    // that made a healthy self-stake run look like a truncated alpha scan.
+    const two: LaneTableTopology = {
+      ...valid(),
+      producers: {
+        lanes: ["validator_nominators", "self_stake"],
+        column: "source",
+        fullScanValue: null,
+      },
+    };
+    const ambiguous = { two } as unknown as Readonly<
+      Record<string, LaneTableTopology>
+    >;
+    assert.throws(
+      () => resolveFullScan(two, "two"),
+      /cannot know whose pass/,
+      "an ambiguous topology must fail loudly",
+    );
+    // And the gate refuses it too, so it cannot reach a rule at all.
+    assert.ok(
+      problemsFor(ambiguous, new Map([["two", new Set(["source"])]])).some(
+        (p) => /names no fullScanValue/.test(p),
+      ),
+    );
+  });
+
+  test("requireFullScanValue refuses a table with nothing to scope on", () => {
+    // The guard a caller building `WHERE source = ?` depends on. Binding null
+    // there matches no rows at all, so the rule would report zero coverage
+    // forever -- indistinguishable from the truncated pass this began with.
+    assert.throws(
+      () => requireFullScanValue("validator_nominator_counts"),
+      /no discriminated full-scan producer/,
+    );
+    // And it returns the value where there IS one.
+    assert.equal(
+      requireFullScanValue("nominator_positions"),
+      POSITION_SOURCE_ALPHA,
+    );
+  });
+
+  test("a single-producer table resolves without a fullScan", () => {
+    // NULL, not a value: one producer writes everything, so there is nothing to
+    // scope on. That is different from the several-producer case, where null
+    // would mean "scope to everything" and reintroduce #11180.
+    assert.equal(fullScanProducer("validator_nominator_counts"), null);
+  });
+});
+
+describe("the gate refuses declarations that would misdirect a rule", () => {
+  const cols = new Map([["t", new Set(["captured_at", "coldkey", "source"])]]);
+
+  test("a column that does not exist is caught", () => {
+    const bad = {
+      t: { ...valid(), coverageUnit: "ghost" },
+    } as unknown as Readonly<Record<string, LaneTableTopology>>;
+    assert.match(
+      problemsFor(bad, cols).join("\n"),
+      /coverageUnit names "ghost"/,
+      "a coverageUnit pointing at a moved column counts the wrong thing silently",
+    );
+  });
+
+  test("a prune key that does not exist is caught", () => {
+    const bad = {
+      t: { ...valid(), prunes: { perKey: "ghost" } },
+    } as unknown as Readonly<Record<string, LaneTableTopology>>;
+    assert.match(
+      problemsFor(bad, cols).join("\n"),
+      /prunes\.perKey names "ghost"/,
+    );
+  });
+
+  test("several producers with no discriminator is caught", () => {
+    const bad = {
+      t: {
+        ...valid(),
+        producers: {
+          lanes: ["validator_nominators", "self_stake"],
+          column: null,
+          fullScanValue: "alpha",
+        },
+      },
+    } as unknown as Readonly<Record<string, LaneTableTopology>>;
+    assert.match(
+      problemsFor(bad, cols).join("\n"),
+      /no column to tell them apart/,
+    );
+  });
+
+  test("a fullScanValue with no column to match it against is caught", () => {
+    // Replaces an earlier check that fullScan had to be one of the producers.
+    // That check stopped meaning anything once `lanes` and `fullScanValue`
+    // became the two different vocabularies they actually are: the lane is
+    // `validator_nominators` and the value it stamps is `alpha`. What is still
+    // checkable is that a value can be applied at all.
+    const bad = {
+      t: {
+        ...valid(),
+        producers: {
+          lanes: ["validator_nominators"],
+          column: null,
+          fullScanValue: "alpha",
+        },
+      },
+    } as unknown as Readonly<Record<string, LaneTableTopology>>;
+    assert.match(
+      problemsFor(bad, cols).join("\n"),
+      /no column to match it against/,
+    );
+  });
+
+  test("one producer plus a discriminator is caught as contradictory", () => {
+    // Scoping on it would filter to a subset of a single writer's own rows,
+    // which reads as a truncated pass forever.
+    const bad = {
+      t: {
+        ...valid(),
+        producers: {
+          lanes: ["metagraph"],
+          column: "source",
+          fullScanValue: null,
+        },
+      },
+    } as unknown as Readonly<Record<string, LaneTableTopology>>;
+    assert.match(
+      problemsFor(bad, cols).join("\n"),
+      /declares one producer lane but also a discriminator/,
+    );
+  });
+
+  test("a table absent from the snapshot is caught, not skipped", () => {
+    const bad = { gone: valid() } as unknown as Readonly<
+      Record<string, LaneTableTopology>
+    >;
+    assert.match(
+      problemsFor(bad, cols).join("\n"),
+      /absent from generated\/db\/schema\.json/,
+    );
+  });
+
+  test("the real declaration is non-vacuous: the gate can fail", () => {
+    // Proves the empty result above is a verdict rather than an empty sweep.
+    assert.ok(problemsFor({ gone: valid() }, cols).length > 0);
+  });
+});


### PR DESCRIPTION
Closes #11183 (sub-issue of #11182).

## What was missing

Three properties decide the shape of a correct coverage query, and **none was declared anywhere**. Every watchdog re-derived them by reading its writer, and three of four got it wrong:

| property | what it cost |
|---|---|
| **does it prune?** | `validator_nominator_counts` never deletes — expectation read off 112,245 accumulated rows against 21,547 hotkeys on chain (#11166) |
| **how many producers?** | `nominator_positions` has two — a **healthy** `self-stake` run made the full alpha scan look truncated (#11180) |
| **rows or keys?** | coldkeys hold 1–N positions, so row coverage can look high having missed most accounts |

## Reuses the vocabularies that already exist

This is the part I got wrong first and corrected: `lanes` is **`ProducerLane`** from `producer-cadence.ts`, which already pairs each lane with its cadence. `fullScanValue` is the writer's own **`POSITION_SOURCE_ALPHA`**.

Those are two namings of one producer — the lane is `validator_nominators`, the value it *stamps* is `alpha` — so the declaration records the pairing rather than collapsing them into a third name. My first draft used `POSITION_SOURCE_ALPHA` as the producer for tables that have **no `source` column**, which asserted a relationship that doesn't exist just because the strings matched.

## No Zod, deliberately

Matching `producer-cadence.ts`, the sibling that owns the other half of this metadata and carries none. `schemas-src/` is for **published contract components** (`register()`ed in `openapi-registry.ts`); a schema here would `safeParse` a compile-time constant against itself and prove nothing the type doesn't.

Typing `lanes` as `ProducerLane` is strictly **stronger** than the Zod enum it replaced: a bad lane name is now a compile error rather than a runtime one.

## The check with teeth

`validate:lane-topology` compares every column the declaration names against `generated/db/schema.json` — the snapshot introspected from live Neon. Schema-vs-schema, the house pattern. A column renamed upstream fails CI instead of quietly making a rule count the wrong thing.

Registered in `package.json` and `validate.yml` beside the other drift gates, so it actually runs.

Verified it fails on both a non-existent column and a dropped discriminator:

```
nominator_positions.coverageUnit names "ghost_column", which is not a column of nominator_positions
nominator_positions: declares 2 producer lanes but no column to tell them apart
```

## Load-bearing, not decorative

The nominator-positions rule takes its scoping from the declaration via `requireFullScanValue`, which **throws** rather than returning null — binding null into `WHERE source = ?` matches no rows, so the rule would report zero coverage forever, indistinguishable from the truncated pass this began with.

`chain_detail_blocks` is deliberately **absent**: its watchdog is a ticker against an advancing frontier, and `chain_detail` isn't a `ProducerLane`. Forcing a lane name in to satisfy the shape would invent the vocabulary this module exists to avoid inventing.

120 tests pass across the lane suites; `tsc`, prettier, eslint clean; unreferenced-exports holds at 731; **patch coverage by diff intersection: 0 uncovered changed lines**.