### PR TITLE
feat(mcp): the served title carries the product's own tagline

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.JSONbored/metagraphed",
-  "title": "metagraphed — Bittensor subnet operational registry",
-  "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
+  "title": "metagraphed — Bittensor in a box",
+  "description": "Bittensor in a box: the live operational + integration registry for every subnet — discover, verify, call, and screen subnet APIs, schemas, health, and economics through one MCP server.",
   "version": "1.78.19",
   "websiteUrl": "https://metagraph.sh",
   "repository": {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -2189,7 +2189,13 @@ const ACCOUNT_TRANSFERS_DIRECTIONS = ["all", "sent", "received"];
 
 export const MCP_SERVER_INFO = {
   name: "metagraphed",
-  title: "metagraphed — Bittensor subnet operational registry",
+  // "Bittensor in a box" is the product's own tagline -- it has been the
+  // served skill's H1 since the skill existed, and it is the phrase users
+  // repeat back. The NAME stays `metagraphed`: the registry identity
+  // (io.github.JSONbored/metagraphed), the npm/PyPI packages, and every
+  // `claude mcp add` in the wild key on it, and a tagline is not worth
+  // breaking an address for.
+  title: "metagraphed — Bittensor in a box",
   // Implementation.description (added in MCP 2025-11-25): a short human-readable
   // line surfaced during initialization.
   description:


### PR DESCRIPTION
## Summary

Two strings, one identity decision.

- `MCP_SERVER_INFO.title`: `metagraphed — Bittensor subnet operational registry` → **`metagraphed — Bittensor in a box`**. The phrase has been the served skill's H1 all along and is what users repeat back; the title clients display now matches.
- `server.json` (the MCP Registry listing): same title, and the description now leads with the tagline and names the four verbs the server actually offers — discover, verify, **call**, screen.

**The name stays `metagraphed`**, deliberately: the registry identity (`io.github.JSONbored/metagraphed`), npm/PyPI, mcp.so, and every `claude mcp add metagraphed` in the wild key on it. The comment at the constant records that reasoning so a future rename debate starts from it.

No version bump — `sync-mcp-version` owns that post-merge.

## Validation

`validate:mcp` (240 tools, title flows into serverInfo + the worker-computed server card), `validate:contract-drift`, discovery + mcp-server suites (1,386 tests), `lint`, `format:check`, `typecheck`, `npm run build`.