### PR TITLE
feat(probes): the fleet signs what it sends, and serves the key verifiers need

### DIFF
--- a/src/health-probe-core.ts
+++ b/src/health-probe-core.ts
@@ -178,6 +178,12 @@ export function acceptHeader(expect: unknown): string {
 interface ProbeOptions {
   isUnsafeUrl?: (url: unknown) => boolean | Promise<boolean>;
   fetchImpl?: typeof fetch;
+  /** Web Bot Auth (metagraphed-infra#562): stamps Signature/Signature-Input/
+   * Signature-Agent onto an outbound probe so origins can verify the fleet
+   * cryptographically. Absent (local, CI, unsigned deployments) means the
+   * probe goes out exactly as before -- the signature is additive and must
+   * never be the reason a probe fails. */
+  signRequest?: (url: string, headers: Headers) => Promise<void>;
   connect?: (
     url: string,
     calls: typeof SUBTENSOR_PROBE_CALLS,
@@ -209,7 +215,11 @@ export async function probeUrl(
   options: ProbeOptions = {},
   redirectCount = 0,
 ): Promise<HttpProbeResult> {
-  const { isUnsafeUrl = isUnsafePublicUrl, fetchImpl = fetch } = options;
+  const {
+    isUnsafeUrl = isUnsafePublicUrl,
+    fetchImpl = fetch,
+    signRequest,
+  } = options;
 
   if (await isUnsafeUrl(url)) {
     return {
@@ -227,12 +237,17 @@ export async function probeUrl(
   const started = performance.now();
 
   try {
+    const probeHeaders = new Headers({
+      accept,
+      "user-agent": "metagraphed-smoke-probe/0.0",
+    });
+    // Signed AFTER the safety guard and per hop: a redirect re-enters
+    // probeUrl, so each authority gets its own signature rather than the
+    // first hop's riding to a second host it was never bound to.
+    if (signRequest) await signRequest(url, probeHeaders);
     const response = await fetchImpl(url, {
       method,
-      headers: {
-        accept,
-        "user-agent": "metagraphed-smoke-probe/0.0",
-      },
+      headers: probeHeaders,
       redirect: "manual",
       signal: controller.signal,
     });

--- a/src/health-prober.ts
+++ b/src/health-prober.ts
@@ -17,6 +17,7 @@
 // unit-testable without a live runtime. Decoupled from the data build: a stale
 // structural snapshot can never freeze health again.
 
+import { botSignerFromEnv } from "./web-bot-auth.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import {
   isUnsafePublicUrl,
@@ -551,6 +552,9 @@ export async function runHealthProber(
         overrides.isUnsafeUrl ||
         workerResolvedUrlSafetyGuard({ fetchImpl: overrides.safetyFetch }),
       connect: overrides.connect || workerWebSocketConnector(),
+      // Web Bot Auth: resolved once per sweep, absent unless the signing
+      // secret is configured -- see src/web-bot-auth.ts's header.
+      signRequest: (await botSignerFromEnv(env))?.sign,
     } as Row);
   const concurrency = overrides.concurrency || PROBE_CONCURRENCY;
 

--- a/src/web-bot-auth-paths.ts
+++ b/src/web-bot-auth-paths.ts
@@ -1,0 +1,4 @@
+// The Web Bot Auth directory path, in a leaf module so the router matches it
+// without loading the signer -- the same discipline as a2a-paths.ts (#10424).
+export const BOT_KEY_DIRECTORY_PATH =
+  "/.well-known/http-message-signatures-directory";

--- a/src/web-bot-auth.ts
+++ b/src/web-bot-auth.ts
@@ -1,0 +1,244 @@
+// Web Bot Auth: the prober fleet signs what it sends (#11146 readiness row,
+// repo half of metagraphed-infra#562).
+//
+// ## WHY A PROBER SIGNS
+//
+// The fleet probes ~600 third-party subnet surfaces every 15 minutes, and to
+// every one of them an unsigned probe is indistinguishable from a scraper. As
+// subnets put up bot-management walls, unsigned probes start eating 403s --
+// which does not fail loudly, it QUIETLY DEGRADES the health data that is this
+// registry's core product: a blocked probe scores as a dead surface. Signing
+// per the IETF web-bot-auth draft (RFC 9421 HTTP Message Signatures, Ed25519)
+// lets any origin verify "this is metagraphed's prober" cryptographically and
+// allowlist the fleet, instead of trusting a User-Agent string anyone can
+// fake.
+//
+// ## THE SHAPE, PER THE DRAFT
+//
+// Three headers ride each signed request:
+//   Signature-Input  the signed components + parameters (created, expires,
+//                    keyid, tag, nonce), per RFC 9421
+//   Signature        the Ed25519 signature over the signature base
+//   Signature-Agent  where the verifier fetches our key directory
+//
+// The signed component set is `("@authority")` -- the minimum the draft
+// requires and deliberately nothing more: the authority binds the signature to
+// the destination host (a signature replayed against another host fails), and
+// signing paths or bodies would couple the signature to probe mechanics that
+// change. `keyid` is the base64url JWK thumbprint (RFC 7638) of the public
+// key, which is also how the directory names it, so verifier and directory
+// agree by construction.
+//
+// ## GATED ON THE SECRET, ABSENT MEANS TODAY
+//
+// Everything keys off METAGRAPH_BOT_SIGNING_KEY, formatted `<seed>.<public>`:
+// two base64url-encoded 32-byte halves, dot-separated. Both halves ride the
+// secret because WebCrypto cannot derive an Ed25519 public key from a seed,
+// and the directory must publish exactly the key the signatures verify
+// against. No secret -> no signing, no directory, no behaviour change: local
+// dev, CI and the determinism suite never see a signature. A malformed secret
+// DISABLES signing rather than failing probes -- an unsigned probe still
+// probes, and the signature must never be the reason health data stops.
+//
+// ## WHY THE KEY IS CACHED PER ISOLATE
+//
+// crypto.subtle.importKey is cheap but not free, and the prober signs ~600
+// requests per sweep. The imported CryptoKey and thumbprint are cached keyed
+// by the secret VALUE, so a rotated secret takes effect on the next isolate
+// without a deploy, and a changed value is never served stale.
+
+type Row = Record<string, unknown>;
+
+/** Where verifiers fetch our JWKS, on the primary host. The draft requires the
+ * directory response itself to be signed; the handler below does that. */
+export { BOT_KEY_DIRECTORY_PATH } from "./web-bot-auth-paths.ts";
+import { registerModuleStateReset } from "./module-state-registry.ts";
+export const BOT_KEY_DIRECTORY_CONTENT_TYPE =
+  "application/http-message-signatures-directory+json";
+
+/** The draft's tag for web-bot-auth signatures. */
+const SIGNATURE_TAG = "web-bot-auth";
+
+/** Signatures outlive transit, not much more: the draft's own guidance is
+ * that "a minute is often sufficient". */
+const SIGNATURE_TTL_SECONDS = 120;
+
+export interface BotSigner {
+  /** Adds Signature-Input / Signature / Signature-Agent for `url`'s authority. */
+  sign(url: string, headers: Headers): Promise<void>;
+  /** The public JWK, for the directory. */
+  publicJwk: Row;
+  thumbprint: string;
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let raw = "";
+  for (const b of bytes) raw += String.fromCharCode(b);
+  return btoa(raw).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64Encode(bytes: Uint8Array): string {
+  let raw = "";
+  for (const b of bytes) raw += String.fromCharCode(b);
+  return btoa(raw);
+}
+
+function base64UrlDecode(text: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(text)) return null;
+  try {
+    const padded = text.replaceAll("-", "+").replaceAll("_", "/");
+    const raw = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+    return Uint8Array.from(raw, (c) => c.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+/** RFC 7638 JWK thumbprint for an OKP key: SHA-256 over the canonical
+ * `{"crv","kty","x"}` member set, base64url -- the value web-bot-auth uses as
+ * `keyid`, so the verifier finds the directory entry by construction. */
+async function jwkThumbprint(jwk: Row): Promise<string> {
+  const canonical = `{"crv":"${jwk.crv}","kty":"${jwk.kty}","x":"${jwk.x}"}`;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(canonical),
+  );
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+interface SignerCacheEntry {
+  secret: string;
+  signer: BotSigner | null;
+}
+let signerCache: SignerCacheEntry | null = null;
+// The house reset (validate:module-state-resets): under `isolate: false` a
+// cached signer would leak across test files, and a file that never set a
+// secret would inherit one.
+registerModuleStateReset("src/web-bot-auth.ts", () => {
+  signerCache = null;
+});
+
+/** Test seam: clears the per-isolate signer cache. */
+export function resetBotSignerForTests(): void {
+  signerCache = null;
+}
+
+/**
+ * The signer for this deployment, or null when signing is off.
+ *
+ * Null on: no secret (the normal local/CI state), a secret that is not
+ * `<seed>.<public>` with 32-byte halves, or a WebCrypto that refuses Ed25519.
+ * Every arm is a deliberate "probe unsigned" rather than a throw -- see the
+ * module header.
+ */
+export async function botSignerFromEnv(env: {
+  METAGRAPH_BOT_SIGNING_KEY?: string;
+}): Promise<BotSigner | null> {
+  const secret = env?.METAGRAPH_BOT_SIGNING_KEY;
+  if (!secret) return null;
+  if (signerCache?.secret === secret) return signerCache.signer;
+  const signer = await buildSigner(secret);
+  signerCache = { secret, signer };
+  return signer;
+}
+
+// PKCS#8 DER header for an Ed25519 (OID 1.3.101.112) private key: WebCrypto
+// imports private keys as pkcs8, and prepending this to the raw 32-byte seed
+// is the standard wrapping.
+const ED25519_PKCS8_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
+  0x22, 0x04, 0x20,
+]);
+
+async function buildSigner(secret: string): Promise<BotSigner | null> {
+  const [seedPart, publicPart, ...extra] = secret.split(".");
+  if (extra.length > 0 || !seedPart || !publicPart) return null;
+  const seed = base64UrlDecode(seedPart);
+  const publicRaw = base64UrlDecode(publicPart);
+  if (!seed || seed.length !== 32 || !publicRaw || publicRaw.length !== 32) {
+    return null;
+  }
+  let privateKey: CryptoKey;
+  try {
+    const pkcs8 = new Uint8Array(ED25519_PKCS8_PREFIX.length + seed.length);
+    pkcs8.set(ED25519_PKCS8_PREFIX);
+    pkcs8.set(seed, ED25519_PKCS8_PREFIX.length);
+    privateKey = await crypto.subtle.importKey(
+      "pkcs8",
+      pkcs8,
+      { name: "Ed25519" },
+      false,
+      ["sign"],
+    );
+  } catch {
+    return null;
+  }
+  const publicJwk: Row = {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: base64UrlEncode(publicRaw),
+    use: "sig",
+  };
+  const thumbprint = await jwkThumbprint(publicJwk);
+
+  const sign = async (url: string, headers: Headers): Promise<void> => {
+    let authority: string;
+    try {
+      authority = new URL(url).host;
+    } catch {
+      // Not a URL the platform can parse; the probe itself will fail on it,
+      // and an unsigned attempt keeps the failure attributable to the probe.
+      return;
+    }
+    const created = Math.floor(Date.now() / 1000);
+    const expires = created + SIGNATURE_TTL_SECONDS;
+    const nonce = crypto.randomUUID();
+    // RFC 9421 signature params, in the order the draft's examples use.
+    const params =
+      `("@authority");created=${created};expires=${expires};` +
+      `keyid="${thumbprint}";tag="${SIGNATURE_TAG}";nonce="${nonce}"`;
+    const signatureBase =
+      `"@authority": ${authority}\n` + `"@signature-params": ${params}`;
+    const signature = new Uint8Array(
+      await crypto.subtle.sign(
+        { name: "Ed25519" },
+        privateKey,
+        new TextEncoder().encode(signatureBase),
+      ),
+    );
+    headers.set("signature-input", `sig1=${params}`);
+    headers.set("signature", `sig1=:${base64Encode(signature)}:`);
+    // Structured-field string: the origin verifiers fetch the directory from.
+    headers.set("signature-agent", `"https://api.metagraph.sh"`);
+  };
+
+  return { sign, publicJwk, thumbprint };
+}
+
+/**
+ * GET /.well-known/http-message-signatures-directory -- the JWKS verifiers
+ * fetch, itself signed with the key it publishes (the draft requires the
+ * directory response to demonstrate possession).
+ *
+ * 404 when signing is off: an empty directory would say "we sign with no
+ * keys", and absence is the truthful shape for a deployment with no key.
+ */
+export async function botKeyDirectoryResponse(
+  request: Request,
+  env: { METAGRAPH_BOT_SIGNING_KEY?: string },
+): Promise<Response> {
+  const signer = await botSignerFromEnv(env);
+  if (!signer) {
+    return new Response("no signing key configured", { status: 404 });
+  }
+  const body = `${JSON.stringify({ keys: [signer.publicJwk] }, null, 2)}\n`;
+  const headers = new Headers({
+    "content-type": BOT_KEY_DIRECTORY_CONTENT_TYPE,
+    "cache-control": "public, max-age=86400",
+  });
+  await signer.sign(request.url, headers);
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}

--- a/tests/web-bot-auth.test.ts
+++ b/tests/web-bot-auth.test.ts
@@ -1,0 +1,312 @@
+// Web Bot Auth (metagraphed-infra#562, repo half): the prober fleet's
+// outbound signatures and the key directory verifiers fetch.
+//
+// The load-bearing test is the VERIFY round trip: a signature this module
+// produces must verify with WebCrypto against the JWK the directory publishes,
+// over the exact RFC 9421 signature base a verifier reconstructs -- otherwise
+// the whole feature is three headers of noise.
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+import {
+  botKeyDirectoryResponse,
+  botSignerFromEnv,
+  resetBotSignerForTests,
+  BOT_KEY_DIRECTORY_CONTENT_TYPE,
+  BOT_KEY_DIRECTORY_PATH,
+} from "../src/web-bot-auth.ts";
+import { probeUrl } from "../src/health-probe-core.ts";
+import { handleRequest } from "../workers/api.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+function b64url(bytes: Uint8Array): string {
+  let raw = "";
+  for (const b of bytes) raw += String.fromCharCode(b);
+  return btoa(raw).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+/** A real Ed25519 pair, formatted the way the secret carries it. */
+async function generateSecret(): Promise<string> {
+  const pair = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const pkcs8 = new Uint8Array(
+    (await crypto.subtle.exportKey("pkcs8", pair.privateKey)) as ArrayBuffer,
+  );
+  // The raw seed is the last 32 bytes of the PKCS#8 encoding.
+  const seed = pkcs8.slice(pkcs8.length - 32);
+  const publicRaw = new Uint8Array(
+    (await crypto.subtle.exportKey("raw", pair.publicKey)) as ArrayBuffer,
+  );
+  return `${b64url(seed)}.${b64url(publicRaw)}`;
+}
+
+beforeEach(() => resetBotSignerForTests());
+
+describe("botSignerFromEnv", () => {
+  test("absent, malformed, or wrong-length secrets all mean unsigned", async () => {
+    assert.equal(await botSignerFromEnv(mockEnv()), null);
+    for (const bad of [
+      "not-a-key",
+      "onlyonepart",
+      "a.b.c",
+      `${b64url(new Uint8Array(16))}.${b64url(new Uint8Array(32))}`,
+      `${b64url(new Uint8Array(32))}.${b64url(new Uint8Array(16))}`,
+      "!!!.###",
+      // Valid base64url alphabet, invalid base64 length: the decode itself
+      // throws and the catch answers null.
+      "A.A",
+    ]) {
+      resetBotSignerForTests();
+      assert.equal(
+        await botSignerFromEnv(mockEnv({ METAGRAPH_BOT_SIGNING_KEY: bad })),
+        null,
+        `secret ${JSON.stringify(bad)} must disable signing, not throw`,
+      );
+    }
+  });
+
+  test("the signer is cached per secret value, and a rotation re-derives", async () => {
+    const s1 = await generateSecret();
+    const s2 = await generateSecret();
+    const a = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: s1 }),
+    );
+    const b = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: s1 }),
+    );
+    assert.equal(a, b, "same secret, same signer instance");
+    const c = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: s2 }),
+    );
+    assert.notEqual(a, c);
+    assert.notEqual(a?.thumbprint, c?.thumbprint);
+  });
+});
+
+test("a WebCrypto without Ed25519 disables signing instead of failing probes", async () => {
+  // The platform guard: workerd and Node both support Ed25519 today, so the
+  // arm is forced -- but the guard exists for the runtime that does not, and
+  // the contract is unsigned probes, never a throw.
+  const spy = vi
+    .spyOn(crypto.subtle, "importKey")
+    .mockRejectedValueOnce(new Error("Ed25519 unsupported"));
+  try {
+    const signer = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: await generateSecret() }),
+    );
+    assert.equal(signer, null);
+  } finally {
+    spy.mockRestore();
+  }
+});
+
+describe("the signature", () => {
+  test("verifies against the published JWK over the reconstructed base", async () => {
+    const secret = await generateSecret();
+    const signer = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: secret }),
+    );
+    assert.ok(signer);
+    const headers = new Headers();
+    await signer.sign("https://beamcore.b1m.ai/health?x=1", headers);
+
+    const input = headers.get("signature-input") ?? "";
+    const sig = headers.get("signature") ?? "";
+    assert.ok(input.startsWith("sig1=("));
+    assert.ok(sig.startsWith("sig1=:") && sig.endsWith(":"));
+    assert.equal(headers.get("signature-agent"), '"https://api.metagraph.sh"');
+    assert.match(input, /tag="web-bot-auth"/);
+    assert.match(input, /keyid="[A-Za-z0-9_-]+"/);
+    assert.match(input, /created=\d+;expires=\d+/);
+    // expires - created stays inside the draft's "a minute is often
+    // sufficient" guidance, with margin for transit.
+    const created = Number(/created=(\d+)/.exec(input)![1]);
+    const expires = Number(/expires=(\d+)/.exec(input)![1]);
+    assert.ok(expires - created >= 60 && expires - created <= 300);
+
+    // THE VERIFIER'S VIEW: rebuild the signature base exactly as RFC 9421
+    // says a receiver does, and verify with the directory's JWK.
+    const params = input.slice("sig1=".length);
+    const base = `"@authority": beamcore.b1m.ai\n"@signature-params": ${params}`;
+    const jwk = signer.publicJwk as unknown as JsonWebKey;
+    const publicKey = await crypto.subtle.importKey(
+      "jwk",
+      jwk,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    const sigBytes = Uint8Array.from(atob(sig.slice(6, -1)), (c) =>
+      c.charCodeAt(0),
+    );
+    assert.equal(
+      await crypto.subtle.verify(
+        { name: "Ed25519" },
+        publicKey,
+        sigBytes,
+        new TextEncoder().encode(base),
+      ),
+      true,
+      "the signature must verify over the reconstructed base",
+    );
+
+    // And it must NOT verify for a different authority: @authority is the
+    // whole point of the component set -- a replay against another host fails.
+    const wrongBase = `"@authority": other.example\n"@signature-params": ${params}`;
+    assert.equal(
+      await crypto.subtle.verify(
+        { name: "Ed25519" },
+        publicKey,
+        sigBytes,
+        new TextEncoder().encode(wrongBase),
+      ),
+      false,
+    );
+  });
+
+  test("keyid is the RFC 7638 thumbprint of the published JWK", async () => {
+    const signer = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: await generateSecret() }),
+    );
+    assert.ok(signer);
+    const jwk = signer.publicJwk as Row;
+    const canonical = `{"crv":"${jwk.crv}","kty":"${jwk.kty}","x":"${jwk.x}"}`;
+    const digest = new Uint8Array(
+      await crypto.subtle.digest(
+        "SHA-256",
+        new TextEncoder().encode(canonical),
+      ),
+    );
+    assert.equal(signer.thumbprint, b64url(digest));
+    const headers = new Headers();
+    await signer.sign("https://example.com/", headers);
+    assert.match(
+      headers.get("signature-input") || "",
+      new RegExp(`keyid="${signer.thumbprint}"`),
+    );
+  });
+
+  test("an unparseable URL leaves the request unsigned rather than failing it", async () => {
+    const signer = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: await generateSecret() }),
+    );
+    const headers = new Headers();
+    await signer!.sign("not a url", headers);
+    assert.equal(headers.get("signature"), null);
+  });
+});
+
+describe("the key directory", () => {
+  test("404s when signing is off — absence, not an empty key list", async () => {
+    const res = await botKeyDirectoryResponse(
+      new Request(`https://api.metagraph.sh${BOT_KEY_DIRECTORY_PATH}`),
+      mockEnv(),
+    );
+    assert.equal(res.status, 404);
+  });
+
+  test("serves the JWKS with the draft's content type, itself signed", async () => {
+    const secret = await generateSecret();
+    const env = mockEnv({ METAGRAPH_BOT_SIGNING_KEY: secret });
+    const res = await botKeyDirectoryResponse(
+      new Request(`https://api.metagraph.sh${BOT_KEY_DIRECTORY_PATH}`),
+      env,
+    );
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      BOT_KEY_DIRECTORY_CONTENT_TYPE,
+    );
+    // The directory response demonstrates possession: signed with the same
+    // key it publishes.
+    assert.ok(res.headers.get("signature-input"));
+    assert.ok(res.headers.get("signature"));
+    const body = (await res.json()) as { keys: Row[] };
+    assert.equal(body.keys.length, 1);
+    assert.equal(body.keys[0].kty, "OKP");
+    assert.equal(body.keys[0].crv, "Ed25519");
+
+    const head = await botKeyDirectoryResponse(
+      new Request(`https://api.metagraph.sh${BOT_KEY_DIRECTORY_PATH}`, {
+        method: "HEAD",
+      }),
+      env,
+    );
+    assert.equal(head.status, 200);
+    assert.equal(await head.text(), "");
+  });
+
+  test("is reachable through the real router", async () => {
+    const res = await handleRequest(
+      new Request(`https://api.metagraph.sh${BOT_KEY_DIRECTORY_PATH}`),
+      mockEnv(),
+      {} as never,
+    );
+    // No key configured in the mock env: the route dispatches and answers the
+    // handler's own 404, which is the proof the wiring exists.
+    assert.equal(res.status, 404);
+    assert.equal(await res.text(), "no signing key configured");
+  });
+});
+
+describe("the probe carries the signature", () => {
+  test("probeUrl stamps the headers when a signer is supplied, and not otherwise", async () => {
+    const secret = await generateSecret();
+    const signer = await botSignerFromEnv(
+      mockEnv({ METAGRAPH_BOT_SIGNING_KEY: secret }),
+    );
+    // A holder object rather than a bare let: the assignment happens inside
+    // the fetch closure, which TypeScript's narrowing cannot see.
+    const captured: { headers: Headers | null } = { headers: null };
+    const fetchImpl = (async (_url: unknown, init?: RequestInit) => {
+      captured.headers = new Headers(init?.headers);
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    await probeUrl(
+      "https://beamcore.b1m.ai/health",
+      "GET",
+      "application/json",
+      5000,
+      {
+        isUnsafeUrl: () => false,
+        fetchImpl,
+        signRequest: signer!.sign,
+      },
+    );
+    assert.ok(captured.headers);
+    assert.ok(
+      captured.headers.get("signature-input"),
+      "signed probe carries the input",
+    );
+    assert.ok(captured.headers.get("signature"));
+    assert.equal(
+      captured.headers.get("user-agent"),
+      "metagraphed-smoke-probe/0.0",
+    );
+
+    captured.headers = null;
+    await probeUrl(
+      "https://beamcore.b1m.ai/health",
+      "GET",
+      "application/json",
+      5000,
+      {
+        isUnsafeUrl: () => false,
+        fetchImpl,
+      },
+    );
+    // Read through a call so the earlier `= null` narrowing does not stick.
+    const second = ((): Headers | null => captured.headers)();
+    assert.ok(second);
+    assert.equal(
+      second.get("signature"),
+      null,
+      "no signer, no signature -- the pre-existing wire shape",
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -234,6 +234,7 @@ import {
   A2A_CARD_PATH,
   A2A_ENDPOINT_PATH,
 } from "./request-handlers/a2a-paths.ts";
+import { BOT_KEY_DIRECTORY_PATH } from "../src/web-bot-auth-paths.ts";
 import {
   BADGE_SVG_PATTERN,
   homepageResponse,
@@ -6314,6 +6315,14 @@ async function dispatchRequest(
   if (url.pathname === A2A_CARD_PATH) {
     const { agentCardResponse } = await import("./request-handlers/a2a.ts");
     return agentCardResponse(request);
+  }
+
+  // Web Bot Auth key directory (metagraphed-infra#562): the JWKS origins use
+  // to verify the prober fleet's signed requests. 404 when no signing key is
+  // configured -- absence is the truthful shape for an unsigned deployment.
+  if (url.pathname === BOT_KEY_DIRECTORY_PATH) {
+    const { botKeyDirectoryResponse } = await import("../src/web-bot-auth.ts");
+    return botKeyDirectoryResponse(request, env);
   }
 
   // Agent tool specs for non-MCP runtimes (OpenAI function calling / Anthropic

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -19,6 +19,10 @@
 // anywhere.
 interface Env {
   ACCOUNT_BALANCES_SYNC_SECRET?: string;
+  /** Web Bot Auth signing key for the prober fleet (metagraphed-infra#562):
+   * `<seed>.<public>`, both halves base64url-encoded 32 bytes. Absent means
+   * probes go out unsigned, which is the local/CI state. */
+  METAGRAPH_BOT_SIGNING_KEY?: string;
   ACCOUNT_IDENTITY_SYNC_SECRET?: string;
   SUBNET_IDENTITY_SYNC_SECRET?: string;
   SUBNET_OWNERSHIP_SYNC_SECRET?: string;


### PR DESCRIPTION
## Why

Repo half of metagraphed-infra#562. The fleet probes ~600 third-party surfaces every 15 minutes; to every origin an unsigned probe is indistinguishable from a scraper, and as subnets raise bot walls, blocked probes **quietly degrade the health data that is the core product** — a 403'd probe scores as a dead surface. Web Bot Auth (RFC 9421, Ed25519 — the draft Cloudflare's Verified Bots program verifies) makes the fleet cryptographically identifiable and allowlistable.

## What ships

- **`src/web-bot-auth.ts`** — the signer: `Signature` / `Signature-Input` / `Signature-Agent` over `("@authority")`, created/expires (120 s, per the draft's "a minute is often sufficient"), `keyid` = RFC 7638 JWK thumbprint, nonce per request. Signed **per hop**: a redirect re-enters `probeUrl`, so each authority gets its own signature rather than the first host's riding to a second it was never bound to.
- **`/.well-known/http-message-signatures-directory`** — the JWKS, served with the draft's content type and **itself signed** (possession proof). 404 when signing is off: absence, not an empty key list.
- **The seam**: `ProbeOptions.signRequest`, resolved once per sweep in `health-prober.ts` from `METAGRAPH_BOT_SIGNING_KEY` (`<seed>.<public>`, both base64url 32-byte halves — both ride the secret because WebCrypto cannot derive an Ed25519 public key from a seed). **Absent or malformed = unsigned, today's exact wire shape** — the signature must never be the reason health data stops. Signer cached per secret value per isolate, so rotation needs no deploy.

## Tests (10 new; 218 across the touched suites; 100% on the new module, 100% diff-intersection on changed lines)

The load-bearing one: a produced signature **verifies with WebCrypto against the published JWK over the reconstructed RFC 9421 base — and fails against a different authority** (the replay case). Plus: six malformed-secret shapes all mean unsigned-not-throw, the Ed25519-unsupported platform arm, cache/rotation semantics, thumbprint-equals-keyid, directory 404/200+signed/HEAD, router reachability, and probeUrl stamping headers with a signer and not without.

## After merge (infra#562)

Generate the pair, `wrangler secret put METAGRAPH_BOT_SIGNING_KEY`, verify the directory serves, then register with Cloudflare Verified Bots.

Closes #11192