### PR TITLE
fix(watchdog): bound the burn-coverage denominator to one pass, and record neurons' chain check

### DIFF
--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -104,11 +104,29 @@ export function neuronsStalenessThresholdMs(
 }
 
 /**
- * How many subnets a COMPLETE pass is expected to cover.
+ * How many netuids a COMPLETE pass is expected to cover.
  *
- * 129, read off production on 2026-08-05 as `COUNT(DISTINCT netuid)` at the
- * newest stamp, and matching the 129 native subnets `npm run validate` reports
- * from the registry -- two independent counts of the same thing.
+ * 129, and NETUIDS rather than subnets: that is 128 subnets plus root
+ * (netuid 0), max netuid 128. The distinction matters when re-measuring,
+ * because a source that counts "subnets" returns 128 and would look like an
+ * off-by-one against this.
+ *
+ * THREE independent counts now agree, one of them the chain itself:
+ *
+ *   production   COUNT(DISTINCT netuid) at the newest stamp   (2026-08-05)
+ *   registry     native subnets reported by `npm run validate`
+ *   CHAIN        SubtensorModule::TotalNetworks = 129, and
+ *                NetworksAdded walked to exhaustion = 129 entries (2026-08-14)
+ *
+ * The third is the one that matters and the one its siblings lacked. #11166 and
+ * #11167 both re-anchored constants that had been read off our own tables and
+ * had no chain check behind them; each was correct when written and became
+ * false without anything failing. Audited under #11185 and found CORRECT --
+ * recorded here so the next audit does not have to re-derive it.
+ *
+ * To re-measure:
+ *   key = twox128("SubtensorModule") ++ twox128("TotalNetworks")
+ *   state_getStorage(key, finalizedHead) -> u16 little-endian
  */
 export const NEURONS_EXPECTED_NETUIDS = 129;
 

--- a/src/subnet-burn-coverage-watchdog.ts
+++ b/src/subnet-burn-coverage-watchdog.ts
@@ -78,12 +78,30 @@ export const SUBNET_BURN_COVERAGE_FLOOR_RATIO = 0.95;
  * writer that wrote one netuid 129 times would otherwise pass a row count, and
  * that is close enough to the observed failure to be worth excluding.
  */
+// BOTH SIDES ARE ONE PASS (#11185). `expected` counted DISTINCT netuid over the
+// WHOLE of subnet_hyperparams while `covered` counted one stamp, which is the
+// asymmetry that made hotkey-alpha alarm on a complete pass for hours (#11170):
+// there, `referenced` spanned all of nominator_positions' history and no correct
+// pass could ever reach the floor.
+//
+// It has not fired here yet, and only because nothing has been removed.
+// Measured 2026-08-14: subnet_hyperparams holds 129 distinct netuids in total
+// AND 129 at its newest stamp -- identical, because no netuid has ever left.
+// Chain agrees: TotalNetworks = 129 and NetworksAdded = 129 entries, which is
+// 128 subnets plus root (netuid 0), max netuid 128.
+//
+// The first deregistration that leaves a stale row behind breaks that
+// coincidence: the denominator would exceed the live set and this alarm would
+// fire forever on complete passes. Windowing it to that table's own newest pass
+// makes the comparison structural rather than lucky.
 const SUBNET_BURN_COVERAGE_SQL =
   "SELECT (SELECT MAX(observed_at) FROM subnet_burn_history) AS latest," +
   " (SELECT COUNT(DISTINCT netuid) FROM subnet_burn_history" +
   " WHERE observed_at = (SELECT MAX(observed_at) FROM subnet_burn_history))" +
   " AS covered," +
-  " (SELECT COUNT(DISTINCT netuid) FROM subnet_hyperparams) AS expected";
+  " (SELECT COUNT(DISTINCT netuid) FROM subnet_hyperparams" +
+  " WHERE captured_at = (SELECT MAX(captured_at) FROM subnet_hyperparams))" +
+  " AS expected";
 
 /**
  * The single row that query returns.

--- a/tests/subnet-burn-coverage-watchdog.test.ts
+++ b/tests/subnet-burn-coverage-watchdog.test.ts
@@ -133,6 +133,38 @@ describe("the lane record", () => {
     };
   }
 
+  test("both counts span ONE pass, not one against all history", async () => {
+    // The hotkey-alpha shape (#11170): `covered` scoped to the newest stamp
+    // while `expected` counted a whole table that never prunes. It has not
+    // fired here only because no netuid has ever been removed -- measured
+    // 2026-08-14, subnet_hyperparams held 129 distinct netuids in total AND 129
+    // at its newest stamp, and chain agrees (TotalNetworks = 129: 128 subnets
+    // plus root). The first deregistration that leaves a stale row breaks that
+    // coincidence and the alarm fires forever on complete passes.
+    const seen: string[] = [];
+    pg.control.answers = [];
+    pg.control.rows = null;
+    pg.control.failNext = null;
+    pg.control.onQuery = (q: { text: string }) => seen.push(q.text);
+    pg.control.answers.push({
+      match: /FROM subnet_burn_history/,
+      rows: [{ latest: NOW - 60_000, covered: 129, expected: 129 }],
+    });
+    pg.control.answers.push({ match: /.*/, rows: [] });
+    await runSubnetBurnCoverageWatchdog(pgMockEnv() as unknown as Env, {
+      now: () => NOW,
+      recordVerdict: (async () => true) as never,
+    });
+    pg.control.onQuery = null;
+    const coverage = seen.find((q) => /FROM subnet_burn_history/.test(q));
+    assert.ok(coverage, "the coverage read must have been issued");
+    assert.match(
+      coverage,
+      /FROM subnet_hyperparams WHERE captured_at =[\s\S]*MAX\(captured_at\) FROM subnet_hyperparams/,
+      "the expected side must be bounded to that table's own newest pass",
+    );
+  });
+
   test("the detail carries the NUMBERS, not just the word", async () => {
     // "stale" alone sends an operator looking for a dead lane; "3 of 129
     // netuids (partial)" is the finding itself.


### PR DESCRIPTION
Part of #11185 (sub-issue of #11182). Auditing the remaining coverage rules against the four rules the last four broke.

## `subnet-burn-coverage` — the `hotkey-alpha` shape, latent

```sql
covered  = COUNT(DISTINCT netuid) WHERE observed_at = MAX(observed_at)   -- one pass
expected = COUNT(DISTINCT netuid) FROM subnet_hyperparams                -- ALL history
```

One pass measured against a whole table — exactly what made `hotkey-alpha` alarm on complete passes for hours (#11170).

**It has not fired here, and only by coincidence.** Measured 2026-08-14:

| | value |
|---|---|
| `subnet_hyperparams` distinct netuids, all time | 129 |
| `subnet_hyperparams` distinct netuids, newest stamp | 129 |
| chain: `TotalNetworks` / `NetworksAdded` | 129 / 129 |

Identical **because no netuid has ever been removed**. The first deregistration that leaves a stale row breaks the coincidence: the denominator exceeds the live set and this alarm fires forever on correct passes.

Windowing `expected` to that table's own newest pass makes the comparison structural rather than lucky. The test asserts it; verified it fails without the fix.

## `neurons` — audited, CORRECT, and now says why

`129` was *"read off production … and matching the registry"* — two counts, both **ours**. Verified against the network:

```
SubtensorModule::TotalNetworks = 129
NetworksAdded walked to exhaustion = 129 entries
```

Three independent sources now, one of them the chain. That third is what #11166 and #11167 lacked — both re-anchored constants read off our own tables, each correct when written and false later without anything failing.

Also corrected to say **netuids**, not subnets: 129 = **128 subnets + root (netuid 0)**, max netuid 128. A source counting "subnets" returns 128 and would read as an off-by-one. The comment now carries the re-measure command.

## What remains

`account_balances`' expectation is still being measured (a `System::Account` walk, ~543k keys, in progress). Its drift direction is the **safe** one — it counts accounts that have *ever* held a balance, so it only grows and a stale figure makes the floor more conservative, not less. Reported separately when the walk lands.

The other watchdogs carry no population constant, so S1/S4 don't apply to them in this form.

`tsc`, prettier, eslint clean; 60 tests pass across the three affected suites.