### PR TITLE
fix(accounts): correct a fan-out disagreement instead of refusing it

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -174,30 +174,65 @@ export async function loadAccountSummaryProjection(
     maxAgeMs = ACCOUNT_SUMMARY_MAX_AGE_MS,
   }: { shards?: number; now?: () => number; maxAgeMs?: number } = {},
 ): Promise<Record<string, unknown>[] | null> {
+  const first = await readShard(env, account, shards, now, maxAgeMs);
+  if (first.groups) return first.groups;
+  // THE PRODUCER OWNS THE FAN-OUT, so a disagreement is corrected rather than
+  // refused. `shards` above is a compiled STARTING GUESS: the number lives in
+  // two repositories and nothing can diff a python function against a
+  // typescript one, so the only durable contract is the one the payload states
+  // about itself.
+  //
+  // Re-derived ONCE, never in a loop -- a producer that declared a third value
+  // would otherwise be chased forever. And only ever downward in trust: the
+  // retry re-reads with the count the object itself declared, so growing the
+  // fan-out is picked up on the next request instead of silently returning the
+  // route to the 4,374 MB scan until someone notices it got slow again.
+  if (first.declared === null || first.declared === shards) return null;
+  const second = await readShard(env, account, first.declared, now, maxAgeMs);
+  return second.groups;
+}
+
+/** Nothing usable here, and nothing to retry with. */
+const MISS: ShardRead = { groups: null, declared: null };
+
+interface ShardRead {
+  groups: Record<string, unknown>[] | null;
+  /** The fan-out the object claimed, when it claimed one at all. */
+  declared: number | null;
+}
+
+async function readShard(
+  env: Env | null | undefined,
+  account: string,
+  shards: number,
+  now: () => number,
+  maxAgeMs: number,
+): Promise<ShardRead> {
   // Same binding the thirteen sibling projections read from.
   const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
     ?.METAGRAPH_ARCHIVE;
-  if (!bucket?.get || !account) return null;
+  if (!bucket?.get || !account) return MISS;
   let body: unknown;
   try {
     const object = await bucket.get(accountSummaryShardKey(account, shards));
-    if (!object) return null;
+    if (!object) return MISS;
     body = await object.json();
   } catch {
     // A shard that cannot be fetched or parsed is not a fault to report: the
     // caller reads the lakehouse and answers correctly, just slower.
-    return null;
+    return MISS;
   }
-  if (!body || typeof body !== "object") return null;
+  if (!body || typeof body !== "object") return MISS;
   const payload = body as Record<string, unknown>;
   if (Number(payload["schema_version"]) !== ACCOUNT_SUMMARY_SCHEMA_VERSION) {
-    return null;
+    return MISS;
   }
   // A shard written for a DIFFERENT fan-out is not this account's shard, even
   // though the object exists and parses -- it is the wrong bucket of the wrong
   // partitioning, so its absence of this account proves nothing.
   const declared = finite(payload["shard_count"]);
-  if (declared !== null && declared !== shards) return null;
+  if (declared !== null && declared !== shards)
+    return { groups: null, declared };
 
   // STALE IS A DECLINE, not a slightly-old answer. See
   // ACCOUNT_SUMMARY_MAX_AGE_MS: this is the only failure mode that could
@@ -208,13 +243,13 @@ export async function loadAccountSummaryProjection(
   // does not understand.
   const stamp = payload["generated_at"];
   const generated = typeof stamp === "string" ? Date.parse(stamp) : Number.NaN;
-  if (!Number.isFinite(generated)) return null;
-  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return null;
+  if (!Number.isFinite(generated)) return MISS;
+  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return MISS;
 
   const accounts = payload["accounts"];
-  if (!accounts || typeof accounts !== "object") return null;
+  if (!accounts || typeof accounts !== "object") return MISS;
   const raw = (accounts as Record<string, unknown>)[account];
-  if (!Array.isArray(raw)) return null;
+  if (!Array.isArray(raw)) return MISS;
 
   const groups: Record<string, unknown>[] = [];
   for (const entry of raw as ProjectedGroup[]) {
@@ -234,6 +269,6 @@ export async function loadAccountSummaryProjection(
   }
   // An account present with no usable groups is not an answer -- the caller
   // reads the lakehouse rather than publishing an empty card from a shard.
-  if (!groups.length) return null;
-  return groups;
+  if (!groups.length) return MISS;
+  return { groups, declared };
 }

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -207,18 +207,66 @@ describe("loadAccountSummaryProjection", () => {
     assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
   });
 
-  test("A SHARD WRITTEN FOR A DIFFERENT FAN-OUT IS REFUSED", async () => {
-    // The dangerous case, because it does not look like an error: both sides
-    // compute a shard number happily and disagree about which object holds an
-    // account. Without this the reader would read a real, parseable object,
-    // fail to find the account in it, and report "not projected" forever.
+  test("A DIFFERENT FAN-OUT IS CORRECTED, not refused", async () => {
+    // THE PRODUCER OWNS THIS NUMBER. It lives in two repositories and nothing
+    // can diff a python function against a typescript one, so the compiled
+    // value is a starting GUESS and the payload's own claim is the contract.
+    //
+    // Refusing here was safe but silent: the route simply returned to the
+    // 4,374 MB scan until somebody noticed it had got slow again.
     const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody(
+      // What the reader guesses at, holding the producer's real fan-out.
+      [accountSummaryShardKey(HOT)]: shardBody({}, { shard_count: 64 }),
+      // Where the account actually lives under that fan-out.
+      [accountSummaryShardKey(HOT, 64)]: shardBody(
         { [HOT]: [group()] },
         { shard_count: 64 },
       ),
     });
+    const groups = await loadAccountSummaryProjection(store.env, HOT);
+    assert.equal(groups!.length, 1);
+    assert.deepEqual(store.asked, [
+      accountSummaryShardKey(HOT),
+      accountSummaryShardKey(HOT, 64),
+    ]);
+  });
+
+  test("it re-derives ONCE, never in a loop", async () => {
+    // A producer declaring a third value on the retry would otherwise be
+    // chased forever, one GET per hop, on every request.
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({}, { shard_count: 64 }),
+      [accountSummaryShardKey(HOT, 64)]: shardBody({}, { shard_count: 8 }),
+    });
     assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
+    assert.equal(store.asked.length, 2, store.asked.join(" "));
+  });
+
+  test("a plain MISS does not trigger a retry", async () => {
+    // Nothing was declared, so there is no other fan-out to try -- a second
+    // GET would just be a wasted round trip on the common cold-cache path.
+    const store = archive({});
+    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
+    assert.equal(store.asked.length, 1);
+  });
+
+  test("the retry is still bound by freshness", async () => {
+    // Otherwise a shrunk fan-out would leave stale objects above the new count
+    // that the reader would happily re-read.
+    const written = Date.parse("2026-08-01T00:00:00Z");
+    const store = archive({
+      [accountSummaryShardKey(HOT)]: shardBody({}, { shard_count: 64 }),
+      [accountSummaryShardKey(HOT, 64)]: shardBody(
+        { [HOT]: [group()] },
+        { shard_count: 64, generated_at: "2026-08-01T00:00:00Z" },
+      ),
+    });
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, {
+        now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS + 1,
+      }),
+      null,
+    );
   });
 
   test("an account present with NO usable groups declines", async () => {


### PR DESCRIPTION
The shard count lives in **two repositories** — a Python constant in the producer, a TypeScript one here — and nothing can enforce that pair. The existing cross-repo mechanism (metagraphed-infra's `check-vendored-sync.py`) byte-diffs whole files against their canonical copy upstream. That works for a Dockerfile. It cannot work for the same contract expressed in two languages.

Refusing a mismatch was **safe but silent**: the reader declined, the caller read the lakehouse, and the route quietly returned to the 4,374 MB scan until somebody noticed it had got slow again. Safe-but-invisible is the failure mode this whole issue was about.

## The producer owns the number

So the compiled value is demoted to a **starting guess**, and the payload's own `shard_count` becomes the contract. On a disagreement the key is re-derived with the count the object declared and read once more — so growing the fan-out is picked up on the next request rather than needing a synchronised deploy across two repos.

- **Re-derived once, never in a loop.** A producer declaring a third value on the retry would otherwise be chased forever, one GET per hop, on every request.
- **The retry is still bound by freshness**, which is what makes a *shrunk* fan-out safe: objects left above the new count are stale, and stale is already a decline (#11181).
- **A plain miss does not retry** — nothing was declared, so there's no other fan-out to try, and a second GET would just be a wasted round trip on the common cold-cache path.

Four tests, including that a third declaration costs exactly two GETs and no more.

52 CI validators, full suite green.