### PR TITLE
fix(watchdog): the account-balances floor had gone slack as the population grew

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -120,16 +120,49 @@ export const ACCOUNT_BALANCES_STALENESS_THRESHOLD_MS = missedTicksMs(
 /**
  * How many accounts a COMPLETE pass is expected to write.
  *
- * The producer walks System::Account -- 542,618 entries at its own last live
- * measurement (2026-07-19), per tests/fixtures/sqlite-schema/0017_account_balances.sql -- and
- * SKIPS every account whose free and reserved are both zero, so a full pass
- * lands the nonzero-balance subset of that, ~306,000 accounts (2026-08-05).
+ * The producer walks System::Account and SKIPS every account whose free and
+ * reserved are both zero, so a full pass lands the nonzero-balance subset.
  *
- * Stated as the measurement rather than as a bound, because the floor below is
- * what the rule actually uses and is sized so that being wrong about this
- * number cannot make the alarm wrong in the dangerous direction.
+ * 366,700, re-measured 2026-08-14 from what a VERIFIED-COMPLETE pass actually
+ * wrote: 366,713 accounts stamped within the pass window, against 367,125 rows
+ * in the table, at an age of 3.8 h on a 6 h cadence. The 412-row difference is
+ * accounts that went to zero and kept their row -- this table never prunes, so
+ * its raw row count is history and is NOT the population (see
+ * src/lane-table-topology.ts).
+ *
+ * ## WHY THIS WAS 306,000, AND WHY DRIFT MATTERED HERE
+ *
+ * The old figure was measured 2026-08-05 and the population grew ~20% in nine
+ * days -- expected, because this is the one lane whose expectation only GROWS
+ * (it counts accounts that have ever held a balance).
+ *
+ * The previous comment argued that being wrong here "cannot make the alarm
+ * wrong in the dangerous direction", on the grounds that understating the
+ * expectation leaves the floor "merely slacker still, never tighter". The
+ * direction is right and the conclusion is not: slack IS the dangerous
+ * direction for a floor whose whole job is catching a truncated pass. At
+ * 306,000 the floor was 244,800 -- 67% of the live population -- so a pass
+ * could have lost a THIRD of all accounts and still reported ok. The blind spot
+ * the ratio's comment documents as "80% to 100%" had quietly become 67% to
+ * 100%. That is exactly the failure hotkey-alpha's own comment names: a floor
+ * that has grown too low to fire is invisible.
+ *
+ * ## HOW TO RE-MEASURE
+ *
+ * Ideally from chain: walk System::Account and count entries whose free and
+ * reserved are not both zero. That needs storage VALUES for ~543k keys, which
+ * is expensive and timed out when attempted here, so this is anchored instead
+ * on what a complete pass wrote -- sound because the producer writes exactly
+ * that subset, and because completeness was confirmed independently (99.9% of
+ * table rows refreshed, well inside cadence).
+ *
+ *   SELECT count(*) FILTER (WHERE captured_at >=
+ *            (SELECT max(captured_at) FROM account_balances) - <pass window>)
+ *     FROM account_balances;
+ *
+ * Do NOT anchor on `count(*)` alone: that is accumulated history.
  */
-export const ACCOUNT_BALANCES_EXPECTED_ACCOUNTS = 306_000;
+export const ACCOUNT_BALANCES_EXPECTED_ACCOUNTS = 366_700;
 
 /**
  * How much of that a single pass must cover before it counts as complete.

--- a/tests/account-balances-staleness-watchdog.test.ts
+++ b/tests/account-balances-staleness-watchdog.test.ts
@@ -203,6 +203,30 @@ describe("evaluateAccountBalancesStaleness", () => {
     assert.ok(verdict.age_ms < verdict.threshold_ms);
   });
 
+  test("the re-anchor tightened the guard: the OLD floor now alerts", () => {
+    // The finding behind #11185's account_balances entry. The expectation was
+    // 306,000, measured 2026-08-05, while the live population had grown to
+    // ~366,700 -- so the floor sat at 244,800, which is 67% of reality. A pass
+    // could lose a THIRD of all accounts and still report ok, and the blind
+    // spot the ratio documents as "80% to 100%" had quietly become 67% to 100%.
+    //
+    // Slack IS the dangerous direction for a floor whose job is catching a
+    // truncated pass, so this pins that the old floor is no longer acceptable.
+    const OLD_FLOOR = 244_800;
+    const verdict = evaluateAccountBalancesStaleness(
+      inputs({ coveredRows: OLD_FLOOR, totalRows: FULL }),
+    );
+    assert.equal(
+      verdict.reason,
+      "partial",
+      "a pass covering only the old floor must now be caught",
+    );
+    assert.ok(
+      ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS > OLD_FLOOR,
+      "the re-anchor must raise the floor, not lower it",
+    );
+  });
+
   test("a pass exactly at the floor is complete; one row under is not", () => {
     // Strictly-less, matching the threshold edge above, so a lane landing
     // exactly on the floor never flaps.


### PR DESCRIPTION
Completes #11185 (sub-issue of #11182). The last coverage rule with a population constant, and it had drifted the dangerous way.

## The finding

`ACCOUNT_BALANCES_EXPECTED_ACCOUNTS` was **306,000**, measured 2026-08-05. The live population is now **~366,700** — this is the one lane whose expectation only *grows*, since it counts accounts that have ever held a balance.

| | value |
|---|---|
| floor (306,000 × 0.8) | 244,800 |
| live population | ~366,700 |
| **floor as a fraction of reality** | **67%** |

A pass could have lost **a third of all accounts** and still reported `ok`. The blind spot the ratio's own comment documents as *"80% to 100%"* had quietly become **67% to 100%**.

## The previous comment argued this couldn't happen

> being wrong about this number cannot make the alarm wrong in the dangerous direction … if the true subset is nearer the raw 542,618, this floor is merely slacker still, never tighter

The *direction* is right and the *conclusion* isn't. **Slack is the dangerous direction** for a floor whose entire job is catching a truncated pass. It's the same failure `hotkey-alpha`'s comment names: a floor that has grown too low to fire is invisible.

## Re-measured from a verified-complete pass, not from the table

366,713 accounts stamped inside the pass window, against 367,125 rows, at 3.8 h on a 6 h cadence. The 412-row gap is accounts that went to zero and kept their row — **this table never prunes**, so its raw count is history, not population (per `src/lane-table-topology.ts`).

Chain would be the better anchor — walk `System::Account`, count entries whose `free` and `reserved` aren't both zero — but that needs storage **values** for ~543k keys and the walk timed out. The complete-pass figure is sound because the producer writes exactly that subset, and completeness was confirmed independently. The comment records the method *and* that limitation, and warns against anchoring on `count(*)`.

## Proven, not asserted

The test pins that the **old floor now alerts**, so the re-anchor demonstrably tightened the guard rather than moving a number. Verified it fails when reverted to 306,000.

`tsc`, prettier, eslint clean; 24 tests pass.

## #11185 summary

| watchdog | verdict |
|---|---|
| `neurons` | correct — verified 3 ways incl. chain (`TotalNetworks` = 129) |
| `subnet-burn-coverage` | latent `hotkey-alpha` asymmetry — fixed in #11195 |
| `account-balances` | **floor gone slack** — fixed here |
| others | no population constant; S1/S4 don't apply in this form |