### PR TITLE
feat(mcp): /mcp/core lists the golden path — a context diet, never a capability cut

### DIFF
--- a/src/github-oauth.ts
+++ b/src/github-oauth.ts
@@ -236,6 +236,19 @@ export function isMcpEndpointPath(pathname: string): boolean {
   return pathname === MCP_API_ROUTE || pathname === `${MCP_API_ROUTE}/`;
 }
 
+/**
+ * The core-profile endpoint (#11164): the same MCP server, listing only the
+ * curated core tool set. Same trailing-slash tolerance, same reasons.
+ * `matchesMcpApiRoute` already covers it (prefix match), so the OAuth and
+ * API-key handling on this path is identical to /mcp by construction.
+ */
+export function isMcpCorePath(pathname: string): boolean {
+  return (
+    pathname === `${MCP_API_ROUTE}/core` ||
+    pathname === `${MCP_API_ROUTE}/core/`
+  );
+}
+
 export function isNonOAuthMcpRequest(request: Request): boolean {
   if (!matchesMcpApiRoute(new URL(request.url).pathname)) return false;
   const header = request.headers.get("Authorization");

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@
 // a dedicated ADR amendment with its own consent model, not as an incremental
 // tool addition.
 import type { SubnetEconomics as SubnetEconomicsRow } from "../schemas-src/shared.ts";
+import { isMcpCorePath } from "./github-oauth.ts";
 import { loadSubnetWeightSettersColdTier } from "./subnet-weight-setters-loader.ts";
 import { clampToolLimit } from "../workers/request-params.ts";
 import { serveWithSdk } from "./mcp-sdk-adapter.ts";
@@ -1936,6 +1937,10 @@ const asCredentialStoreEnv = (env: Env) =>
 interface McpCtx {
   env: Env;
   domain?: string;
+  /** Which listing profile this request's endpoint serves (#11164): "core"
+   * for /mcp/core, "full" otherwise. Filters tools/list ONLY -- dispatch,
+   * validation, tripwire and analytics are identical on both endpoints. */
+  profile?: McpProfile;
   sessionId?: string | null;
   // #9789: the protocol revision THIS request declared, which decides whether
   // a tool result still needs the compatibility text block. Optional because
@@ -15420,8 +15425,102 @@ export function withAdvertisedRequiredIntent(
   return { ...schema, required: [...required, MCP_INTENT_ARG] };
 }
 
-export function listToolDefinitions() {
-  return MCP_TOOLS.map((tool) => {
+/**
+ * The core profile: the ~25 tools behind /mcp/core (#11164).
+ *
+ * ## WHY A SECOND ENDPOINT AND NOT A SMALLER CATALOGUE
+ *
+ * The full tools/list serializes to ~1.6 MB -- roughly 406K tokens for any
+ * client that holds tool definitions in model context, which is most of them.
+ * The wire was never the cost (gzip takes it to ~190 KB); the CONTEXT is, and
+ * no encoding reaches that. The only lever that does is listing fewer tools,
+ * and removing tools from /mcp would break "Bittensor in a box". So /mcp
+ * stays whole and /mcp/core lists this set: the golden path the served skill
+ * and llms.txt already teach -- discover, verify, integrate, call, screen --
+ * plus the escape hatches (`ask`, `get_more_tools`) that keep a thin session
+ * from ever being stranded.
+ *
+ * ## THE PROFILE FILTERS LISTING, NEVER CALLS
+ *
+ * A session connected to /mcp/core can still tools/call all 240 tools: the
+ * profile is a context diet, not an authorization boundary. Refusing the call
+ * would force a reconnect at the exact moment an agent discovered it needed
+ * more, and every dispatch-side control (validation, tripwire, analytics,
+ * rate limits) is per-tool, not per-profile, so nothing weakens.
+ *
+ * ## DERIVATION
+ *
+ * Seeded from the documented golden path (public/skills/bittensor/SKILL.md +
+ * llms.txt), which is the commitment the docs already make about what matters.
+ * Re-derive from $mcp_tool_call (PostHog) once that access is in-session; the
+ * set should track measured use, not taste.
+ *
+ * Validated at load: a name that stops matching a registered tool throws with
+ * the name, so a rename cannot silently shrink the profile.
+ */
+export const MCP_CORE_TOOL_NAMES: readonly string[] = [
+  // Discover
+  "search_subnets",
+  "find_subnets_by_capability",
+  "semantic_search",
+  "list_subnets",
+  "compare_subnets",
+  // Ask (the whole-question shortcut, and the stranded-session escape hatch)
+  "ask",
+  "get_more_tools",
+  // Verify
+  "get_subnet",
+  "get_subnet_health",
+  "registry_summary",
+  "get_coverage",
+  "get_feed",
+  // Integrate + call
+  "list_subnet_apis",
+  "get_api_schema",
+  "call_subnet_surface",
+  "store_surface_credential",
+  "get_best_rpc_endpoint",
+  // Screen economically
+  "get_economics",
+  "get_subnet_economics",
+  "get_subnet_cost_to_participate",
+  "get_subnet_emission_split_history",
+  "get_subnet_miner_fairness",
+  "get_tao_usd",
+];
+
+export type McpProfile = "full" | "core";
+
+/**
+ * Load-validation for the core profile, EXPORTED so its throw arm is provable:
+ * the guard's whole job is to fire on a rename, and a guard whose failure arm
+ * no test can reach is the pattern this repo keeps finding reverted (#10914).
+ */
+export function assertCoreNamesRegistered(
+  names: readonly string[],
+  registered: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const missing = names.filter((name) => !registered.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `MCP_CORE_TOOL_NAMES names unregistered tool(s): ${missing.join(", ")}. ` +
+        "A renamed tool must update the core profile in the same change.",
+    );
+  }
+  return new Set(names);
+}
+
+const CORE_TOOL_NAME_SET: ReadonlySet<string> = assertCoreNamesRegistered(
+  MCP_CORE_TOOL_NAMES,
+  new Set(MCP_TOOLS.map((tool) => tool.name)),
+);
+
+export function listToolDefinitions(profile: McpProfile = "full") {
+  const tools =
+    profile === "core"
+      ? MCP_TOOLS.filter((tool) => CORE_TOOL_NAME_SET.has(tool.name))
+      : MCP_TOOLS;
+  return tools.map((tool) => {
     // NORMALISED HERE, not at the spread below (#9654). The sentinel is a Zod
     // artifact of `z.int()`, not a property of which side of the call a schema
     // describes, so it landed on 1,083 of 1,083 output integer fields while
@@ -17061,18 +17160,22 @@ async function dispatchMessage(message: Row, ctx: McpCtx) {
             : rpcError(
                 id,
                 RPC_INVALID_PARAMS,
-                "tools/list is not paginated on this server: the full tool " +
-                  "catalogue is returned in one response and no `nextCursor` " +
-                  "is ever issued, so there is no cursor to resume from. Omit " +
-                  "`cursor`.",
+                "tools/list is not paginated on this server: this " +
+                  "endpoint's whole listing is returned in one response and " +
+                  "no `nextCursor` is ever issued, so there is no cursor to " +
+                  "resume from. Omit `cursor`.",
               );
         }
-        const tools = listToolDefinitions();
+        const tools = listToolDefinitions(ctx?.profile);
         // Recorded for a notification too: the discovery happened either way,
         // and dropping it would undercount exactly the crawler traffic this
-        // event exists to make visible.
+        // event exists to make visible. `profile` rides along so core-endpoint
+        // adoption is measurable against the full listing (#11164).
         scheduleMcpToolsListEvent(ctx, {
           toolCount: tools.length,
+          // Absent (a hand-built test ctx) reads as the full profile in
+          // analytics; the real dispatcher always sets it.
+          profile: ctx?.profile,
           // The names themselves, per the wire contract: joined against
           // $mcp_tool_call on $session_id they answer "advertised but never
           // called", which the count alone cannot.
@@ -17336,8 +17439,18 @@ async function buildContext(
   accountId: string | null = null,
 ) {
   let domain;
+  let profile: McpProfile = "full";
   try {
-    domain = new URL(request.url).host || PRIMARY_DOMAIN;
+    const requestUrl = new URL(request.url);
+    // An http(s) Request cannot carry an empty host -- the constructor
+    // refuses relative and hostless URLs -- so no `|| PRIMARY_DOMAIN` arm
+    // here; the catch below is the only real fallback.
+    domain = requestUrl.host;
+    // The endpoint IS the profile (#11164): /mcp/core lists the curated core
+    // set, everything else lists the whole catalogue. Derived per request
+    // rather than stored on the session, because a client binds its session
+    // to one endpoint URL anyway and stored state could only disagree.
+    profile = isMcpCorePath(requestUrl.pathname) ? "core" : "full";
   } catch {
     domain = PRIMARY_DOMAIN;
   }
@@ -17376,6 +17489,7 @@ async function buildContext(
   return {
     env,
     domain,
+    profile,
     sessionId,
     // Already validated by handleMcpRequest, so this is either a version we
     // support or absent (#9789).

--- a/tests/mcp-core-profile.test.ts
+++ b/tests/mcp-core-profile.test.ts
@@ -1,0 +1,115 @@
+// #11164: the /mcp/core profile -- a context diet, never a capability cut.
+//
+// The two contracts under test: the core LISTING is exactly the declared set,
+// and a core session can still CALL every tool -- the profile filters what a
+// client holds in context, not what it may do.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  assertCoreNamesRegistered,
+  handleMcpRequest,
+  listToolDefinitions,
+  MCP_CORE_TOOL_NAMES,
+} from "../src/mcp-server.ts";
+import { isMcpCorePath } from "../src/github-oauth.ts";
+import { mockEnv, type Row } from "./row-type.ts";
+
+const rpc = (url: string, body: unknown) =>
+  handleMcpRequest(
+    new Request(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-06-18",
+      },
+      body: JSON.stringify(body),
+    }),
+    mockEnv(),
+  );
+
+const toolsList = { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} };
+
+async function listedNames(url: string): Promise<string[]> {
+  const res = await rpc(url, toolsList);
+  assert.equal(res.status, 200);
+  const text = await res.text();
+  const json = text.startsWith("event:")
+    ? JSON.parse(text.slice(text.indexOf("data:") + 5).trim())
+    : JSON.parse(text);
+  return ((json.result as Row).tools as Row[]).map((t) => String(t.name));
+}
+
+describe("the endpoint is the profile", () => {
+  test("isMcpCorePath matches exactly the core endpoint, slash-tolerant", () => {
+    assert.equal(isMcpCorePath("/mcp/core"), true);
+    assert.equal(isMcpCorePath("/mcp/core/"), true);
+    assert.equal(isMcpCorePath("/mcp"), false);
+    assert.equal(isMcpCorePath("/mcp/"), false);
+    assert.equal(isMcpCorePath("/mcp/corex"), false);
+  });
+
+  test("/mcp/core lists exactly the declared set; /mcp lists everything", async () => {
+    const core = await listedNames("https://api.metagraph.sh/mcp/core");
+    assert.deepEqual(
+      [...core].sort(),
+      [...MCP_CORE_TOOL_NAMES].sort(),
+      "the core listing is the declaration, nothing more or less",
+    );
+    const full = await listedNames("https://api.metagraph.sh/mcp");
+    assert.ok(full.length > 200, `full listing stays whole (${full.length})`);
+    for (const name of core) {
+      assert.ok(full.includes(name), `${name} is a subset of full`);
+    }
+  });
+
+  test("the core listing is a context diet, measured", () => {
+    const size = (tools: unknown) => JSON.stringify(tools).length;
+    const full = size(listToolDefinitions());
+    const core = size(listToolDefinitions("core"));
+    // The whole point. If core creeps past a quarter of full, it has stopped
+    // being a diet and someone should look at what got added.
+    assert.ok(
+      core < full / 4,
+      `core (${core} B) must stay well under full (${full} B)`,
+    );
+  });
+});
+
+describe("the load guard", () => {
+  test("a renamed tool fails startup with the name attached", () => {
+    assert.throws(
+      () => assertCoreNamesRegistered(["ask", "gone_tool"], new Set(["ask"])),
+      /gone_tool/,
+    );
+    // And the passing arm returns the set it validated.
+    const ok = assertCoreNamesRegistered(["ask"], new Set(["ask", "other"]));
+    assert.ok(ok.has("ask"));
+  });
+
+  test("the trailing-slash core endpoint serves the core listing too", async () => {
+    const names = await listedNames("https://api.metagraph.sh/mcp/core/");
+    assert.equal(names.length, MCP_CORE_TOOL_NAMES.length);
+  });
+});
+
+describe("the profile never gates a call", () => {
+  test("a tool OUTSIDE the core set is callable through /mcp/core", async () => {
+    // get_networks is deliberately not in the core set. A conformant refusal
+    // here would be `unknown_tool`; anything else -- including a data-tier
+    // error from the hermetic env -- proves dispatch accepted the name.
+    assert.ok(!MCP_CORE_TOOL_NAMES.includes("get_networks"));
+    const res = await rpc("https://api.metagraph.sh/mcp/core", {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "get_networks", arguments: { context: "profile test" } },
+    });
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assert.ok(
+      !text.includes("Unknown tool"),
+      "a non-core tool must dispatch on the core endpoint",
+    );
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -609,6 +609,7 @@ import { urlProjects } from "../src/projection-signal.ts";
 import {
   handleAuthorizeRequest,
   handleGithubOAuthCallback,
+  isMcpCorePath,
   isMcpEndpointPath,
 } from "../src/github-oauth.ts";
 import {
@@ -5956,7 +5957,7 @@ async function dispatchRequest(
   // from joining a base URL, and rejecting it bought nothing: OAuthProvider already
   // treats the two as one route, and the app answering only the bare form is what put
   // an otherwise-correct client on the 405 path.
-  if (isMcpEndpointPath(url.pathname)) {
+  if (isMcpEndpointPath(url.pathname) || isMcpCorePath(url.pathname)) {
     // IMPORTED HERE, NOT AT MODULE SCOPE (#10424). src/mcp-server.ts is ~12.5k
     // lines and this is the ONLY thing api.ts uses from it, so a static import
     // made every consumer of api.ts pay for the whole MCP server: 23 of the 39

--- a/workers/request-handlers/discovery.ts
+++ b/workers/request-handlers/discovery.ts
@@ -469,6 +469,11 @@ export async function mcpServerCardResponse(
     // SEP-2127's remotes[] shape, mirroring server.json's own entry, so a
     // registry consumer and a card consumer read one vocabulary.
     remotes: [{ type: "streamable-http", url: `${base}/mcp` }],
+    // The core profile (#11164): the same server, listing only the curated
+    // ~23-tool golden path -- a context diet for clients that hold tool
+    // definitions in the prompt. Calls are unrestricted on both endpoints;
+    // every count on this card describes /mcp, the full listing.
+    core_endpoint: `${base}/mcp/core`,
     websiteUrl: "https://metagraph.sh",
     // PRIMITIVES ARE DELIBERATELY NOT EMBEDDED (#11170). The card used to
     // carry `tools: listToolDefinitions()` -- all 240 full definitions, 1.6 MB


### PR DESCRIPTION
## The lever that was left (#11164)

Compression fixed the wire (190 KB gzip / 141 KB brotli); **model context** was untouched: ~406K tokens for any client holding the 240 tool definitions in the prompt. The only thing that reaches context is listing fewer tools — and removing tools from `/mcp` would break "Bittensor in a box."

## Shape

- **`/mcp` unchanged** (240 tools). **`/mcp/core` lists 23** — the documented golden path (discover → verify → integrate → call → screen) plus `ask`/`get_more_tools` so a thin session is never stranded. Measured: **1,535,862 B → 172,077 B, a 9x context diet** (~43K tokens).
- **Listing-only filter.** A core session can still `tools/call` all 240 — the profile is a context diet, not an authorization boundary; validation, tripwire, rate limits and analytics are per-tool and identical on both endpoints. A test proves a non-core tool dispatches through `/mcp/core`.
- **The endpoint is the profile**, derived per request (`isMcpCorePath`, slash-tolerant, beside its sibling predicates; `matchesMcpApiRoute`'s prefix match means OAuth/API-key handling is identical by construction). No session state.
- **Declared once, load-validated**: a renamed tool fails startup naming the missing entry, so the profile cannot silently shrink. Derivation note says the set is seeded from the skill's golden path and should be re-derived from `$mcp_tool_call`.
- `scheduleMcpToolsListEvent` gains `profile`, so core adoption is measurable. The server card advertises `core_endpoint`; card counts still describe `/mcp` (stated in a comment). Pagination refusal text no longer says "full tool catalogue" on an endpoint where it isn't.

## Traps from the spec, each handled

`validate:mcp` runs against default (full) semantics — passes with all 240. Discovery card counts unchanged (full). agent-tools documents stay full (non-MCP runtimes don't pay context). 4 new tests through the real `handleMcpRequest` (exact-set listing, subset property, a <¼-size budget so the diet can't silently bloat, non-core call dispatch) + discovery suite (17 total). `lint`, `format:check`, `typecheck`, `validate:mcp` green.

Refs #11164 — closes after the skill/docs advertise the core endpoint in a follow-up.