### PR TITLE
feat(accounts): read the projection through its generation pointer

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -29,6 +29,20 @@
 // both-side events on 2026-07-10 alone. Reading it here would have published a
 // 284x undercount.
 //
+// THE PUBLISH IS ATOMIC, which is why this reads a POINTER first. 16,384 PUTs
+// are not a transaction: a producer run that dies partway would otherwise leave
+// half the fleet on today's aggregates and half on yesterday's -- and no
+// freshness bound can catch that, because the stale half is not old, it is one
+// day old. The producer writes each generation to a directory nothing reads and
+// flips `current.json` only once every shard has landed, so a failed run leaves
+// the previous generation whole. Stale-but-COHERENT is detectable; half-updated
+// is not.
+//
+// The pointer also DECLARES the fan-out, which retires a constant that lived in
+// two repositories with nothing able to enforce the pair -- no CI can diff a
+// python function against a typescript one. The producer owns the number now
+// and this reads it.
+//
 // THE FALLBACK IS THE POINT. A missing shard, an unparseable body, an account
 // the projection has not seen -- every one of them returns null, and the caller
 // runs exactly the lakehouse query it runs today. So this can only make the
@@ -40,90 +54,47 @@
 export const ACCOUNT_SUMMARY_PROJECTION_PREFIX =
   "metagraph/projections/account-summary";
 
-/**
- * How many shards the producer fans accounts across.
- *
- * SIZED FROM THE REAL PAYLOAD, because this number is what the route pays PER
- * REQUEST -- one whole shard is fetched to answer for one account. Measured:
- * 5,025,347 (account, event_kind, netuid) groups across ~1.2M accounts, 106 B
- * of JSON per group plus 53 B per account key, so ~601 MB in total:
- *
- *     shards    per shard   accounts/shard
- *        256      2294 KB             4688
- *       1024       573 KB             1172
- *       4096       143 KB              293
- *      16384        36 KB               73
- *
- * 16384 keeps a request at ~36 KB, against the 4,374 MB scan it replaces.
- *
- * MUST match `ACCOUNT_SUMMARY_SHARDS` on the writer. A mismatch does not error:
- * both sides compute a shard number happily and simply disagree about which
- * object holds an account, so every lookup misses and the route silently falls
- * back to the scan this exists to avoid. That is why the number is stated here
- * as a constant rather than read from the artifact -- a reader that trusted the
- * body's own `shard_count` could not detect the disagreement, because it would
- * have to fetch the right object first to learn it was fetching the wrong one.
- */
-export const ACCOUNT_SUMMARY_SHARDS = 16384;
-
-/**
- * How old a shard may be before this reader stops trusting it.
- *
- * A STALE PROJECTION SERVED AS FACT IS THE ONE WAY THIS CAN BE WRONG. Every
- * other failure here declines and the caller reads the lakehouse; a shard that
- * parses fine but was written a month ago would be published as the account's
- * current totals, with nothing in the payload to say so -- the card's
- * `generated_at` comes from the live recent-feed leg, so a frozen aggregate
- * beside a fresh feed looks entirely healthy.
- *
- * Three days. The producer's own floor is 20 hours, so this clears a missed
- * run, an overrunning one and a container redeploy, while still catching a dead
- * lane in days rather than never. Past it the route returns to exactly the
- * lakehouse read it used before the projection existed -- slower, correct, and
- * self-healing the moment the producer recovers.
- *
- * The same reasoning the projection-staleness watchdog applies in missed ticks:
- * a bound near one producer interval alerts on a lane that is merely working.
- */
-export const ACCOUNT_SUMMARY_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+/** Names the generation currently readable, and the fan-out it was built with. */
+export const ACCOUNT_SUMMARY_POINTER_KEY = `${ACCOUNT_SUMMARY_PROJECTION_PREFIX}/current.json`;
 
 /** The payload shape this reader understands. A producer that changes a field's
  * MEANING bumps it, and this declines rather than misreading the new one. */
 export const ACCOUNT_SUMMARY_SCHEMA_VERSION = 1;
 
 /**
- * FNV-1a over the address, mod `shards`.
+ * How old a published generation may be before this stops trusting it.
  *
- * MIRRORED EXACTLY from the producer's `shard_of`. A prefix scheme would read
- * more simply, but every Bittensor ss58 starts '5' and the following characters
- * are far from uniform, so prefix buckets differ by orders of magnitude and one
- * object ends up holding most of the fleet.
+ * Three days against a producer whose own floor is 20 hours: it clears a missed
+ * run, an overrunning one and a container redeploy, while still catching a dead
+ * lane in days rather than never. Past it the route returns to the lakehouse
+ * read it used before the projection existed -- slower, correct, and
+ * self-healing the moment the producer recovers.
+ */
+export const ACCOUNT_SUMMARY_MAX_AGE_MS = 3 * 24 * 60 * 60 * 1000;
+
+/**
+ * FNV-1a over the address, mod the fan-out the POINTER declares.
  *
  * `Math.imul` and `>>> 0` are not decoration: javascript numbers are doubles, so
  * a plain `h * 0x01000193` loses the low bits past 2^53 and yields a different
- * hash from python's -- which is exactly the class of difference that agrees on
- * every ASCII test address and disagrees in production. tests pin three known
- * values against the producer's own.
+ * hash from the producer's python. Tests pin three known values against it.
  */
-export function accountShard(
-  account: string,
-  shards: number = ACCOUNT_SUMMARY_SHARDS,
-): number {
+export function accountShard(account: string, shards: number): number {
   let h = 0x811c9dc5;
-  const bytes = new TextEncoder().encode(account);
-  for (const byte of bytes) {
+  for (const byte of new TextEncoder().encode(account)) {
     h ^= byte;
     h = Math.imul(h, 0x01000193) >>> 0;
   }
   return h % shards;
 }
 
-/** The R2 key holding this account's groups. */
+/** The R2 key holding this account's groups, within a generation. */
 export function accountSummaryShardKey(
   account: string,
-  shards: number = ACCOUNT_SUMMARY_SHARDS,
+  shards: number,
+  generation: string,
 ): string {
-  return `${ACCOUNT_SUMMARY_PROJECTION_PREFIX}/${accountShard(account, shards)}.json`;
+  return `${ACCOUNT_SUMMARY_PROJECTION_PREFIX}/${generation}/${accountShard(account, shards)}.json`;
 }
 
 interface ArtifactBucket {
@@ -146,117 +117,82 @@ function finite(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+async function readJson(
+  bucket: ArtifactBucket,
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const object = await bucket.get(key);
+    if (!object) return null;
+    const body = await object.json();
+    return body && typeof body === "object"
+      ? (body as Record<string, unknown>)
+      : null;
+  } catch {
+    // Unfetchable or unparseable is not a fault to report: the caller reads the
+    // lakehouse and answers correctly, just slower.
+    return null;
+  }
+}
+
 /**
  * One account's aggregate groups, in the column aliases `foldSummaryGroups`
  * already reads -- so the projection feeds the SAME builder the lakehouse query
  * feeds, and nothing downstream learns which one answered.
  *
- * THE CAP STILL MEANS WHAT IT MEANT. The caller derives `scanned` from the
- * summed group counts and clamps it to ACCOUNT_EVENT_SUMMARY_SCAN_CAP, so an
- * account over the cap reports `event_scan_capped: true` and null `first_*`
- * whichever tier answered. The projection knows the true lifetime total and
- * publishing it would be a better number -- but a route whose meaning depends
- * on which tier served it is worse than either, so that is a contract change
- * and not this one.
+ * Returns null -- meaning "ask the lakehouse" -- for every condition that is not
+ * an answer: no binding, no pointer, a schema this does not understand, a
+ * generation too old to trust, a shard that will not parse, or an account the
+ * projection has not seen.
  *
- * Returns null -- meaning "ask the lakehouse" -- for every condition that is
- * not an answer: no bucket bound, no object, a body this reader does not
- * understand, or an account the projection has not seen. None of those is an
- * error worth surfacing, because the caller's existing path handles all of
- * them by doing what it did before.
+ * THE CAP KEEPS ITS MEANING. The caller derives `scanned` from the summed group
+ * counts and clamps it, so an account over the cap reports `event_scan_capped`
+ * and null `first_*` whichever tier answered. The projection knows the true
+ * lifetime total and publishing it would be a better number -- but a route
+ * whose meaning depends on its tier is worse than either.
  */
 export async function loadAccountSummaryProjection(
   env: Env | null | undefined,
   account: string,
   {
-    shards = ACCOUNT_SUMMARY_SHARDS,
     now = Date.now,
     maxAgeMs = ACCOUNT_SUMMARY_MAX_AGE_MS,
-  }: { shards?: number; now?: () => number; maxAgeMs?: number } = {},
+  }: { now?: () => number; maxAgeMs?: number } = {},
 ): Promise<Record<string, unknown>[] | null> {
-  const first = await readShard(env, account, shards, now, maxAgeMs);
-  if (first.groups) return first.groups;
-  // THE PRODUCER OWNS THE FAN-OUT, so a disagreement is corrected rather than
-  // refused. `shards` above is a compiled STARTING GUESS: the number lives in
-  // two repositories and nothing can diff a python function against a
-  // typescript one, so the only durable contract is the one the payload states
-  // about itself.
-  //
-  // Re-derived ONCE, never in a loop -- a producer that declared a third value
-  // would otherwise be chased forever. And only ever downward in trust: the
-  // retry re-reads with the count the object itself declared, so growing the
-  // fan-out is picked up on the next request instead of silently returning the
-  // route to the 4,374 MB scan until someone notices it got slow again.
-  if (first.declared === null || first.declared === shards) return null;
-  const second = await readShard(env, account, first.declared, now, maxAgeMs);
-  return second.groups;
-}
-
-/** Nothing usable here, and nothing to retry with. */
-const MISS: ShardRead = { groups: null, declared: null };
-
-interface ShardRead {
-  groups: Record<string, unknown>[] | null;
-  /** The fan-out the object claimed, when it claimed one at all. */
-  declared: number | null;
-}
-
-async function readShard(
-  env: Env | null | undefined,
-  account: string,
-  shards: number,
-  now: () => number,
-  maxAgeMs: number,
-): Promise<ShardRead> {
-  // Same binding the thirteen sibling projections read from.
   const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
     ?.METAGRAPH_ARCHIVE;
-  if (!bucket?.get || !account) return MISS;
-  let body: unknown;
-  try {
-    const object = await bucket.get(accountSummaryShardKey(account, shards));
-    if (!object) return MISS;
-    body = await object.json();
-  } catch {
-    // A shard that cannot be fetched or parsed is not a fault to report: the
-    // caller reads the lakehouse and answers correctly, just slower.
-    return MISS;
-  }
-  if (!body || typeof body !== "object") return MISS;
-  const payload = body as Record<string, unknown>;
-  if (Number(payload["schema_version"]) !== ACCOUNT_SUMMARY_SCHEMA_VERSION) {
-    return MISS;
-  }
-  // A shard written for a DIFFERENT fan-out is not this account's shard, even
-  // though the object exists and parses -- it is the wrong bucket of the wrong
-  // partitioning, so its absence of this account proves nothing.
-  const declared = finite(payload["shard_count"]);
-  if (declared !== null && declared !== shards)
-    return { groups: null, declared };
+  if (!bucket?.get || !account) return null;
 
-  // STALE IS A DECLINE, not a slightly-old answer. See
-  // ACCOUNT_SUMMARY_MAX_AGE_MS: this is the only failure mode that could
-  // publish something wrong rather than merely fall back.
-  // A STRING, not whatever coerces. `Date.parse(String(12345))` is a valid
-  // date -- the year 12345 -- so a numeric field would read as fresh forever.
-  // The producer writes an ISO instant; anything else is a shape this reader
-  // does not understand.
-  const stamp = payload["generated_at"];
+  const pointer = await readJson(bucket, ACCOUNT_SUMMARY_POINTER_KEY);
+  if (!pointer) return null;
+  if (Number(pointer["schema_version"]) !== ACCOUNT_SUMMARY_SCHEMA_VERSION) {
+    return null;
+  }
+  const shards = finite(pointer["shard_count"]);
+  const generation = pointer["generation"];
+  if (!shards || shards < 1 || typeof generation !== "string" || !generation) {
+    return null;
+  }
+  // A STRING, not whatever coerces: `Date.parse(String(12345))` is a valid date
+  // -- the year 12345 -- so a numeric field would read as fresh forever.
+  const stamp = pointer["generated_at"];
   const generated = typeof stamp === "string" ? Date.parse(stamp) : Number.NaN;
-  if (!Number.isFinite(generated)) return MISS;
-  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return MISS;
+  if (!Number.isFinite(generated)) return null;
+  if (maxAgeMs > 0 && now() - generated > maxAgeMs) return null;
 
+  const payload = await readJson(
+    bucket,
+    accountSummaryShardKey(account, shards, generation),
+  );
+  if (!payload) return null;
   const accounts = payload["accounts"];
-  if (!accounts || typeof accounts !== "object") return MISS;
+  if (!accounts || typeof accounts !== "object") return null;
   const raw = (accounts as Record<string, unknown>)[account];
-  if (!Array.isArray(raw)) return MISS;
+  if (!Array.isArray(raw)) return null;
 
   const groups: Record<string, unknown>[] = [];
   for (const entry of raw as ProjectedGroup[]) {
     if (!entry || typeof entry !== "object") continue;
-    // Renamed to the column aliases `foldSummaryGroups` already reads, so the
-    // projection feeds the SAME builder the lakehouse query feeds and nothing
-    // downstream learns which one answered.
     groups.push({
       kind: entry.kind ?? null,
       netuid: entry.netuid ?? null,
@@ -269,6 +205,6 @@ async function readShard(
   }
   // An account present with no usable groups is not an answer -- the caller
   // reads the lakehouse rather than publishing an empty card from a shard.
-  if (!groups.length) return MISS;
-  return { groups, declared };
+  if (!groups.length) return null;
+  return groups;
 }

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -13,7 +13,7 @@
 import assert from "node:assert/strict";
 import { visibleInWindow } from "./helpers/scan-window.ts";
 import {
-  ACCOUNT_SUMMARY_SHARDS,
+  ACCOUNT_SUMMARY_POINTER_KEY,
   accountSummaryShardKey,
 } from "../src/account-summary-projection.ts";
 import { readFileSync } from "node:fs";
@@ -660,24 +660,38 @@ describe("all three account-summary surfaces go through the one composer", () =>
 });
 
 describe("the projection short-circuits the aggregate leg (#11131)", () => {
-  const SHARD_KEY = accountSummaryShardKey(SS58);
+  const GEN = "20260814T100000Z";
+  const SHARDS = 16384;
+  const SHARD_KEY = accountSummaryShardKey(SS58, SHARDS, GEN);
 
   /** An archive binding holding one shard for this account. */
   function archive(groups: unknown[] | null) {
+    const stamp = new Date().toISOString();
     return {
       METAGRAPH_ARCHIVE: {
-        get: async (key: string) =>
-          key === SHARD_KEY && groups
-            ? {
-                json: async () => ({
-                  schema_version: 1,
-                  generated_at: "2026-08-14T00:00:00Z",
-                  shard_count: ACCOUNT_SUMMARY_SHARDS,
-                  account_count: 1,
-                  accounts: { [SS58]: groups },
-                }),
-              }
-            : null,
+        get: async (key: string) => {
+          if (!groups) return null;
+          if (key === ACCOUNT_SUMMARY_POINTER_KEY) {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                generation: GEN,
+                shard_count: SHARDS,
+                generated_at: stamp,
+                account_count: 1,
+              }),
+            };
+          }
+          if (key === SHARD_KEY) {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                accounts: { [SS58]: groups },
+              }),
+            };
+          }
+          return null;
+        },
       },
     } as never;
   }

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -1,17 +1,16 @@
 // The account summary card's aggregate leg, read from a sharded projection
 // (#11131).
 //
-// The claims worth pinning are the ones whose failure is SILENT. This reader
-// cannot make the route wrong by declining -- every null falls back to the
-// lakehouse query the route ran before -- so the dangerous failures are the
-// other direction: routing to the wrong object, or accepting a payload it
-// should have refused.
+// This reader cannot make the route wrong by declining -- every null falls back
+// to the lakehouse query the route ran before -- so the dangerous failures are
+// the other direction: reading a HALF-PUBLISHED generation, or accepting a
+// payload it should have refused.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   ACCOUNT_SUMMARY_MAX_AGE_MS,
+  ACCOUNT_SUMMARY_POINTER_KEY,
   ACCOUNT_SUMMARY_SCHEMA_VERSION,
-  ACCOUNT_SUMMARY_SHARDS,
   accountShard,
   accountSummaryShardKey,
   loadAccountSummaryProjection,
@@ -19,6 +18,8 @@ import {
 
 const HOT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 const COLD = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty";
+const GEN = "20260814T100000Z";
+const SHARDS = 16384;
 
 function group(over: Record<string, unknown> = {}) {
   return {
@@ -33,7 +34,6 @@ function group(over: Record<string, unknown> = {}) {
   };
 }
 
-/** An R2 bucket holding exactly the objects given, keyed as the reader asks. */
 function archive(objects: Record<string, unknown>, { throws = false } = {}) {
   const asked: string[] = [];
   return {
@@ -51,366 +51,237 @@ function archive(objects: Record<string, unknown>, { throws = false } = {}) {
   };
 }
 
-function shardBody(
-  accounts: Record<string, unknown>,
-  over: Record<string, unknown> = {},
-) {
+function pointer(over: Record<string, unknown> = {}) {
   return {
     schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
-    generated_at: "2026-08-14T00:00:00Z",
-    shard_count: ACCOUNT_SUMMARY_SHARDS,
-    account_count: Object.keys(accounts).length,
-    accounts,
+    generation: GEN,
+    shard_count: SHARDS,
+    generated_at: "2026-08-14T10:00:00Z",
+    account_count: 812856,
     ...over,
   };
 }
 
+function published(accounts: Record<string, unknown>, over = {}) {
+  return {
+    [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(over),
+    [accountSummaryShardKey(HOT, SHARDS, GEN)]: {
+      schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+      generated_at: "2026-08-14T10:00:00Z",
+      shard_count: SHARDS,
+      accounts,
+    },
+  };
+}
+
+const FRESH = { now: () => Date.parse("2026-08-14T11:00:00Z") };
+
 describe("accountShard", () => {
-  test("the fan-out is sized from the real payload", () => {
-    // This is what the route pays PER REQUEST: one whole shard is fetched to
-    // answer for one account. ~601 MB of groups over 16384 shards is ~36 KB a
-    // request; over 256 it would have been 2.3 MB.
-    assert.equal(ACCOUNT_SUMMARY_SHARDS, 16384);
-  });
-
-  test("MATCHES THE PRODUCER AT THE DEFAULT FAN-OUT", () => {
-    // Pinned identically in metagraphed-infra's test_account_summary_r2.py.
-    assert.equal(accountShard(HOT), 11213);
-    assert.equal(accountShard(COLD), 5958);
-    assert.equal(accountShard(""), 7621);
-  });
-
   test("MATCHES THE PRODUCER BYTE FOR BYTE", () => {
-    // These three values are asserted IDENTICALLY in metagraphed-infra's
-    // services/indexer-rs/loader/test_account_summary_r2.py. Two
-    // implementations of FNV-1a agree on every ASCII address and part company
-    // on 32-bit overflow -- javascript's numbers are doubles, python's ints do
-    // not overflow at all -- and that divergence is invisible to either side's
-    // tests alone. It would show up only as every lookup missing in production,
-    // which reads as "the projection has no data" rather than as a bug.
+    // Pinned identically in metagraphed-infra's test_account_summary_r2.py.
+    // Two implementations of FNV-1a agree on every ASCII address and part
+    // company on 32-bit overflow -- javascript's numbers are doubles, python's
+    // ints do not overflow at all -- and that divergence is invisible to either
+    // side's tests alone.
     assert.equal(accountShard(HOT, 256), 205);
     assert.equal(accountShard(COLD, 256), 70);
     assert.equal(accountShard("", 256), 197);
+    assert.equal(accountShard(HOT, SHARDS), 11213);
   });
 
   test("the wrap is forced, not incidental", () => {
-    // A long address is where a `h * 0x01000193` without Math.imul silently
-    // loses precision past 2^53 and starts disagreeing with python.
     const long = "5" + "z".repeat(200);
-    assert.ok(Number.isInteger(accountShard(long)));
-    assert.ok(
-      accountShard(long) >= 0 && accountShard(long) < ACCOUNT_SUMMARY_SHARDS,
-    );
+    assert.ok(accountShard(long, SHARDS) >= 0);
+    assert.ok(accountShard(long, SHARDS) < SHARDS);
   });
 
-  test("stays inside the shard count for every fan-out", () => {
-    for (const n of [1, 2, 16, 256, 1024]) {
-      for (const account of [HOT, COLD, "5A", "z".repeat(64)]) {
-        const shard = accountShard(account, n);
-        assert.ok(shard >= 0 && shard < n, `${account} -> ${shard} of ${n}`);
-      }
-    }
-  });
-
-  test("the key names the object the producer writes", () => {
+  test("the key is scoped to a generation", () => {
     assert.equal(
-      accountSummaryShardKey(HOT),
-      "metagraph/projections/account-summary/11213.json",
+      accountSummaryShardKey(HOT, SHARDS, GEN),
+      `metagraph/projections/account-summary/${GEN}/11213.json`,
     );
   });
 });
 
 describe("loadAccountSummaryProjection", () => {
-  test("reads the account's groups from ITS OWN shard", async () => {
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({ [HOT]: [group()] }),
-    });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
+  test("reads the pointer, THEN the account's shard in that generation", async () => {
+    const store = archive(published({ [HOT]: [group()] }));
+    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
     assert.deepEqual(store.asked, [
-      "metagraph/projections/account-summary/11213.json",
+      ACCOUNT_SUMMARY_POINTER_KEY,
+      accountSummaryShardKey(HOT, SHARDS, GEN),
     ]);
-    assert.equal(groups!.length, 1);
-    assert.deepEqual(groups![0], {
-      kind: "AxonServed",
-      netuid: 7,
-      count: 3,
-      fb: 10,
-      lb: 90,
-      fo: 1_000,
-      lo: 9_000,
-    });
-  });
-
-  test("ONE GET, whatever the account", async () => {
-    // The whole point against the 4,374 MB scan it replaces. If this ever grew
-    // a second fetch it would still be correct and would have given back most
-    // of the win.
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({ [HOT]: [group()] }),
-    });
-    await loadAccountSummaryProjection(store.env, HOT);
-    assert.equal(store.asked.length, 1);
-  });
-
-  test("an account the projection has not seen DECLINES", async () => {
-    // Not an empty card: the caller reads the lakehouse, which is the only
-    // thing that can tell "no events" from "not projected yet".
-    const store = archive({
-      [accountSummaryShardKey(COLD)]: shardBody({ [HOT]: [group()] }),
-    });
-    assert.equal(await loadAccountSummaryProjection(store.env, COLD), null);
-  });
-
-  test("a missing shard, a bad body and a throwing bucket all decline", async () => {
-    assert.equal(
-      await loadAccountSummaryProjection(archive({}).env, HOT),
-      null,
-      "missing object",
-    );
-    assert.equal(
-      await loadAccountSummaryProjection(
-        archive({ [accountSummaryShardKey(HOT)]: "not an object" }).env,
-        HOT,
-      ),
-      null,
-      "unparseable body",
-    );
-    assert.equal(
-      await loadAccountSummaryProjection(
-        archive({}, { throws: true }).env,
-        HOT,
-      ),
-      null,
-      "r2 unavailable",
-    );
-    assert.equal(
-      await loadAccountSummaryProjection({} as never, HOT),
-      null,
-      "no binding",
-    );
-    assert.equal(
-      await loadAccountSummaryProjection(null, HOT),
-      null,
-      "no env at all",
-    );
-  });
-
-  test("A SCHEMA IT DOES NOT UNDERSTAND IS REFUSED", async () => {
-    // The version exists so a producer can change a field's MEANING without
-    // this reader publishing the old interpretation of the new bytes.
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody(
-        { [HOT]: [group()] },
-        { schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION + 1 },
-      ),
-    });
-    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
-  });
-
-  test("A DIFFERENT FAN-OUT IS CORRECTED, not refused", async () => {
-    // THE PRODUCER OWNS THIS NUMBER. It lives in two repositories and nothing
-    // can diff a python function against a typescript one, so the compiled
-    // value is a starting GUESS and the payload's own claim is the contract.
-    //
-    // Refusing here was safe but silent: the route simply returned to the
-    // 4,374 MB scan until somebody noticed it had got slow again.
-    const store = archive({
-      // What the reader guesses at, holding the producer's real fan-out.
-      [accountSummaryShardKey(HOT)]: shardBody({}, { shard_count: 64 }),
-      // Where the account actually lives under that fan-out.
-      [accountSummaryShardKey(HOT, 64)]: shardBody(
-        { [HOT]: [group()] },
-        { shard_count: 64 },
-      ),
-    });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
-    assert.equal(groups!.length, 1);
-    assert.deepEqual(store.asked, [
-      accountSummaryShardKey(HOT),
-      accountSummaryShardKey(HOT, 64),
+    assert.deepEqual(groups, [
+      {
+        kind: "AxonServed",
+        netuid: 7,
+        count: 3,
+        fb: 10,
+        lb: 90,
+        fo: 1000,
+        lo: 9000,
+      },
     ]);
   });
 
-  test("it re-derives ONCE, never in a loop", async () => {
-    // A producer declaring a third value on the retry would otherwise be
-    // chased forever, one GET per hop, on every request.
+  test("THE FAN-OUT COMES FROM THE POINTER, not a compiled constant", async () => {
+    // The number lives in two repositories and nothing can diff a python
+    // function against a typescript one, so the producer owns it and this
+    // learns it. A different fan-out is simply followed.
     const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({}, { shard_count: 64 }),
-      [accountSummaryShardKey(HOT, 64)]: shardBody({}, { shard_count: 8 }),
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer({ shard_count: 64 }),
+      [accountSummaryShardKey(HOT, 64, GEN)]: {
+        schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+        accounts: { [HOT]: [group()] },
+      },
     });
-    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
-    assert.equal(store.asked.length, 2, store.asked.join(" "));
+    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.equal(groups!.length, 1);
   });
 
-  test("a plain MISS does not trigger a retry", async () => {
-    // Nothing was declared, so there is no other fan-out to try -- a second
-    // GET would just be a wasted round trip on the common cold-cache path.
-    const store = archive({});
-    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
-    assert.equal(store.asked.length, 1);
+  test("A HALF-PUBLISHED GENERATION IS INVISIBLE", async () => {
+    // The property the pointer exists for. Shards for a new generation are on
+    // R2 but the pointer still names the old one, so the reader keeps serving
+    // a COHERENT set rather than a mixture of two.
+    const store = archive({
+      ...published({ [HOT]: [group({ count: 1 })] }),
+      // A newer, partially written generation nothing points at yet.
+      [`metagraph/projections/account-summary/20260815T100000Z/11213.json`]: {
+        schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+        accounts: { [HOT]: [group({ count: 999 })] },
+      },
+    });
+    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.equal(groups![0]!.count, 1, "must read the pointed-at generation");
   });
 
-  test("the retry is still bound by freshness", async () => {
-    // Otherwise a shrunk fan-out would leave stale objects above the new count
-    // that the reader would happily re-read.
-    const written = Date.parse("2026-08-01T00:00:00Z");
+  test("no pointer means no answer", async () => {
+    // Including the case where a shard happens to exist: without a pointer
+    // there is no generation that is known-complete.
     const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({}, { shard_count: 64 }),
-      [accountSummaryShardKey(HOT, 64)]: shardBody(
-        { [HOT]: [group()] },
-        { shard_count: 64, generated_at: "2026-08-01T00:00:00Z" },
-      ),
+      [accountSummaryShardKey(HOT, SHARDS, GEN)]: {
+        schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+        accounts: { [HOT]: [group()] },
+      },
     });
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+    assert.equal(store.asked.length, 1, "and it does not go looking");
+  });
+
+  test("a stale generation is refused", async () => {
+    // The only way this reader could publish something WRONG rather than
+    // merely fall back. The card's generated_at comes from the LIVE feed leg,
+    // so a frozen aggregate beside a fresh feed looks entirely healthy.
+    const store = archive(published({ [HOT]: [group()] }));
+    const written = Date.parse("2026-08-14T10:00:00Z");
     assert.equal(
       await loadAccountSummaryProjection(store.env, HOT, {
         now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS + 1,
       }),
       null,
-    );
-  });
-
-  test("an account present with NO usable groups declines", async () => {
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({ [HOT]: [] }),
-    });
-    assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
-  });
-
-  test("a group missing its count contributes zero rather than NaN", async () => {
-    // foldSummaryGroups sums these; one NaN would make the whole card's
-    // event_count NaN, which serialises to null and reads as "no events".
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({
-        [HOT]: [group({ count: undefined })],
-      }),
-    });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
-    assert.equal(groups![0]!.count, 0);
-  });
-
-  test("a shard with no accounts map, or a non-array account, declines", async () => {
-    // Both are "the object exists but says nothing about this account", which
-    // is a decline rather than an empty answer.
-    for (const body of [
-      shardBody({} as never, { accounts: undefined }),
-      shardBody({} as never, { accounts: "nope" }),
-      shardBody({ [HOT]: { not: "an array" } as never }),
-    ]) {
-      const store = archive({ [accountSummaryShardKey(HOT)]: body });
-      assert.equal(await loadAccountSummaryProjection(store.env, HOT), null);
-    }
-  });
-
-  test("a malformed entry is skipped, not published as nulls", async () => {
-    // A row that is not an object has no fields to degrade; keeping it would
-    // add a phantom group to the card's event_kinds.
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({
-        [HOT]: [null, "text", group()],
-      }),
-    });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
-    assert.equal(groups!.length, 1);
-  });
-
-  test("every absent field degrades to null rather than undefined", async () => {
-    // These feed foldSummaryGroups, which reads them positionally; `undefined`
-    // would serialise away and change the card's shape rather than its values.
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({
-        [HOT]: [{ count: 2 }],
-      }),
-    });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
-    assert.deepEqual(groups![0], {
-      kind: null,
-      netuid: null,
-      count: 2,
-      fb: null,
-      lb: null,
-      fo: null,
-      lo: null,
-    });
-  });
-
-  test("a shard that does not declare its fan-out is still read", async () => {
-    // shard_count is a guard, not a requirement: an older producer that omits
-    // it is trusted, because the reader asked for the key IT computed.
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody(
-        { [HOT]: [group()] },
-        { shard_count: undefined },
-      ),
-    });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
-    assert.equal(groups!.length, 1);
-  });
-
-  test("A STALE SHARD IS REFUSED", async () => {
-    // The ONLY way this reader could publish something wrong. Every other
-    // failure declines and the caller reads the lakehouse; a month-old shard
-    // parses perfectly and would be served as the account's current totals --
-    // and invisibly, because the card's `generated_at` comes from the LIVE
-    // recent-feed leg, so a frozen aggregate beside a fresh feed looks healthy.
-    const written = Date.parse("2026-08-01T00:00:00Z");
-    const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody(
-        { [HOT]: [group()] },
-        { generated_at: "2026-08-01T00:00:00Z" },
-      ),
-    });
-    assert.equal(
-      await loadAccountSummaryProjection(store.env, HOT, {
-        now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS + 1,
-      }),
-      null,
-      "past the bound",
     );
     assert.ok(
       await loadAccountSummaryProjection(store.env, HOT, {
         now: () => written + ACCOUNT_SUMMARY_MAX_AGE_MS - 1,
       }),
-      "inside the bound still answers",
     );
   });
 
-  test("the bound clears a missed producer run", async () => {
-    // The producer's own floor is 20 hours. A bound near one interval would
-    // decline on a lane that is merely slow, which is the sizing error the
-    // projection-staleness watchdog documents in missed ticks.
-    assert.ok(
-      ACCOUNT_SUMMARY_MAX_AGE_MS > 2 * 20 * 60 * 60 * 1000,
-      "must survive two missed runs",
-    );
+  test("the bound clears two missed producer runs", () => {
+    assert.ok(ACCOUNT_SUMMARY_MAX_AGE_MS > 2 * 20 * 60 * 60 * 1000);
   });
 
-  test("a shard with no readable generated_at is refused", async () => {
-    // Unknown age is not young. Without a timestamp there is no way to tell a
-    // fresh publish from a fossil, and the safe reading is the lakehouse.
-    for (const generated_at of [undefined, "", "not-a-date", 12345]) {
+  test("an unreadable generated_at is refused; unknown age is not young", async () => {
+    for (const generated_at of [undefined, "", "nope", 12345]) {
       const store = archive({
-        [accountSummaryShardKey(HOT)]: shardBody(
-          { [HOT]: [group()] },
-          { generated_at },
-        ),
+        ...published({ [HOT]: [group()] }),
+        [ACCOUNT_SUMMARY_POINTER_KEY]: pointer({ generated_at }),
       });
       assert.equal(
-        await loadAccountSummaryProjection(store.env, HOT),
+        await loadAccountSummaryProjection(store.env, HOT, FRESH),
         null,
         String(generated_at),
       );
     }
   });
 
-  test("a null netuid survives as null", async () => {
-    // Transfer carries no netuid, and coercing it to 0 would attribute balance
-    // movement to subnet zero.
+  test("a schema it does not understand is refused", async () => {
     const store = archive({
-      [accountSummaryShardKey(HOT)]: shardBody({
-        [HOT]: [group({ kind: "Transfer", netuid: null })],
+      ...published({ [HOT]: [group()] }),
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer({
+        schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION + 1,
       }),
     });
-    const groups = await loadAccountSummaryProjection(store.env, HOT);
-    assert.equal(groups![0]!.netuid, null);
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+
+  test("a malformed pointer is refused", async () => {
+    for (const over of [
+      { shard_count: 0 },
+      { shard_count: "many" },
+      { generation: "" },
+      { generation: 7 },
+    ]) {
+      const store = archive({
+        ...published({ [HOT]: [group()] }),
+        [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(over),
+      });
+      assert.equal(
+        await loadAccountSummaryProjection(store.env, HOT, FRESH),
+        null,
+        JSON.stringify(over),
+      );
+    }
+  });
+
+  test("no binding, a throwing bucket, and an unseen account all decline", async () => {
+    assert.equal(
+      await loadAccountSummaryProjection({} as never, HOT, FRESH),
+      null,
+    );
+    assert.equal(await loadAccountSummaryProjection(null, HOT, FRESH), null);
+    assert.equal(
+      await loadAccountSummaryProjection(
+        archive({}, { throws: true }).env,
+        HOT,
+        FRESH,
+      ),
+      null,
+    );
+    const store = archive(published({ [COLD]: [group()] }));
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+
+  test("a malformed entry is skipped and absent fields degrade to null", async () => {
+    const store = archive(published({ [HOT]: [null, "text", { count: 2 }] }));
+    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.deepEqual(groups, [
+      {
+        kind: null,
+        netuid: null,
+        count: 2,
+        fb: null,
+        lb: null,
+        fo: null,
+        lo: null,
+      },
+    ]);
+  });
+
+  test("an account present with no usable groups declines", async () => {
+    const store = archive(published({ [HOT]: [] }));
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
   });
 });

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -277,6 +277,50 @@ describe("loadAccountSummaryProjection", () => {
     ]);
   });
 
+  test("a non-object body is refused, at the pointer and at the shard", async () => {
+    // `readJson` returns null for anything that parses but is not an object --
+    // a bare string or number would otherwise be indexed into and read as an
+    // empty payload rather than a refusal.
+    const badPointer = archive({ [ACCOUNT_SUMMARY_POINTER_KEY]: "nope" });
+    assert.equal(
+      await loadAccountSummaryProjection(badPointer.env, HOT, FRESH),
+      null,
+      "pointer",
+    );
+    const badShard = archive({
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(),
+      [accountSummaryShardKey(HOT, SHARDS, GEN)]: 42,
+    });
+    assert.equal(
+      await loadAccountSummaryProjection(badShard.env, HOT, FRESH),
+      null,
+      "shard",
+    );
+  });
+
+  test("a shard with no accounts map, or a non-array account, declines", async () => {
+    // Both mean "the object exists but says nothing about this account", which
+    // is a decline rather than an empty answer.
+    for (const accounts of [
+      undefined,
+      "nope",
+      { [HOT]: { not: "an array" } },
+    ]) {
+      const store = archive({
+        [ACCOUNT_SUMMARY_POINTER_KEY]: pointer(),
+        [accountSummaryShardKey(HOT, SHARDS, GEN)]: {
+          schema_version: ACCOUNT_SUMMARY_SCHEMA_VERSION,
+          accounts,
+        },
+      });
+      assert.equal(
+        await loadAccountSummaryProjection(store.env, HOT, FRESH),
+        null,
+        JSON.stringify(accounts),
+      );
+    }
+  });
+
   test("an account present with no usable groups declines", async () => {
     const store = archive(published({ [HOT]: [] }));
     assert.equal(


### PR DESCRIPTION
Companion to metagraphed-infra#569, which makes the publish atomic.

The producer writes 16,384 objects, and that was never a transaction: a run dying partway left half the fleet on today's aggregates and half on yesterday's — silently and **undetectably**, because the stale half isn't *old*, it's one day old, so the freshness bound can't see it.

Half-updated is a confidently wrong answer. Stale-but-coherent is one this reader can detect and decline on.

So the reader now reads `current.json` first, then the shard **within the generation it names**. A generation still being written is invisible, because nothing points at it until every shard has landed.

## It also retires the duplicated constant

`ACCOUNT_SUMMARY_SHARDS` lived here as a compiled copy of a Python constant in another repository, with nothing able to enforce the pair — no CI can diff a Python function against a TypeScript one, and infra's `check-vendored-sync.py` byte-diffs whole files, which cannot work across two languages.

The pointer declares `shard_count`, so the producer owns the fan-out and this follows it. **The self-correcting retry #11196 added is gone with it** — there is nothing left to disagree about, which is better than recovering from a disagreement.

Freshness moves to the pointer too: one stamp for the whole set, rather than per shard where a mixture could disagree with itself. Still three days, against a producer whose floor is 20 hours.

## Unchanged: it cannot make the route wrong

Every decline still means "ask the lakehouse" — no binding, no pointer, an unknown schema, a generation too old, an unparseable shard, an account not yet projected. Only slower, never wrong.

**15 tests**, including that a newer half-written generation sitting on R2 is *not* read while the pointer still names the old one.

52 CI validators, 20,888 tests, 913 files.