### PR TITLE
refactor(watchdog): read coverage rows through generated types, and stop copying two helpers

### DIFF
--- a/src/account-balances-staleness-watchdog.ts
+++ b/src/account-balances-staleness-watchdog.ts
@@ -90,7 +90,13 @@ import { laneHealthStore } from "./lane-health-store.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import {
+  countOrZero,
+  numberOrNull,
+  readStore,
+  type ReadStoreDb,
+} from "./read-store.ts";
+import type { AccountBalances } from "../generated/db/types.ts";
 
 /**
  * How old the ledger may get before this is a stall.
@@ -297,16 +303,20 @@ export function evaluateAccountBalancesStaleness(input: {
   return { ...base, stale: false, reason: null, age_ms: age };
 }
 
-/** D1 counts arrive as numbers, but a null SUM over no rows and a shim that
- * stringifies both have to land on 0 rather than NaN -- a NaN would compare
- * false against the floor and report the truncated table healthy. */
-function countOrZero(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
+/**
+ * The single row the coverage read returns.
+ *
+ * `latest` is typed through the GENERATED column type, so a stamp that changes
+ * type in Neon changes here rather than silently arriving as something else.
+ * The counts are `string | number` for the driver's reason, not the column's:
+ * COUNT() is BIGINT and node-postgres hands a bigint back as a string whenever
+ * it is not exactly representable. Every member is nullable because each
+ * subselect answers null on an empty table.
+ */
+interface AccountBalancesCoverageRow {
+  latest: AccountBalances["captured_at"] | null;
+  covered: string | number | null;
+  total: string | number | null;
 }
 
 export interface AccountBalancesStalenessDeps {
@@ -334,7 +344,7 @@ export async function runAccountBalancesStalenessWatchdog(
   // the frozen copy D1 left and would have alarmed permanently -- reporting the lane
   // stalled while the lane was fine.
   const db = readStore(env, ["account_balances"]) as unknown as
-    StatementClientLike | undefined;
+    ReadStoreDb | undefined;
   if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
@@ -348,15 +358,12 @@ export async function runAccountBalancesStalenessWatchdog(
     ACCOUNT_BALANCES_COVERAGE_FLOOR_ROWS;
 
   try {
-    const row = (await db.first(ACCOUNT_BALANCES_COVERAGE_SQL, [
-      passWindowMs,
-    ])) as {
-      latest: number | null;
-      covered: number | null;
-      total: number | null;
-    } | null;
+    const row = await db.first<AccountBalancesCoverageRow>(
+      ACCOUNT_BALANCES_COVERAGE_SQL,
+      [passWindowMs],
+    );
     const verdict = evaluateAccountBalancesStaleness({
-      latestCapturedAtMs: row?.latest ?? null,
+      latestCapturedAtMs: numberOrNull(row?.latest),
       coveredRows: countOrZero(row?.covered),
       totalRows: countOrZero(row?.total),
       nowMs: now(),

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -29,7 +29,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type ReadStoreDb } from "./read-store.ts";
 
 /**
  * How far behind the lane may fall before this is a stall.
@@ -91,10 +91,6 @@ export function evaluateChainDetailStaleness(input: {
   };
 }
 
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
-}
-
 /**
  * The live-follow lane's head, as one read.
  *
@@ -107,7 +103,7 @@ export async function readChainDetailHead(
   env: Record<string, unknown> | null | undefined,
 ): Promise<{ latestObservedAtMs: number | null; headBlock: number | null }> {
   const db = readStore(env, ["chain_detail_blocks"]) as unknown as
-    StatementClientLike | undefined;
+    ReadStoreDb | undefined;
   if (!db?.first) return { latestObservedAtMs: null, headBlock: null };
   const row = (await db.first(
     "SELECT MAX(observed_at) AS latest, MAX(block_number) AS head " +
@@ -150,7 +146,7 @@ export async function runChainDetailStalenessWatchdog(
   // the frozen copy D1 left and would have alarmed permanently -- reporting the lane
   // stalled while the lane was fine.
   const db = readStore(env, ["chain_detail_blocks"]) as unknown as
-    StatementClientLike | undefined;
+    ReadStoreDb | undefined;
   if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =

--- a/src/hotkey-alpha-staleness-watchdog.ts
+++ b/src/hotkey-alpha-staleness-watchdog.ts
@@ -64,7 +64,13 @@ import { laneHealthStore } from "./lane-health-store.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import {
+  countOrZero,
+  numberOrNull,
+  readStore,
+  type ReadStoreDb,
+} from "./read-store.ts";
+import type { HotkeyAlpha } from "../generated/db/types.ts";
 
 /**
  * How old the pool ledger may get before this is a stall.
@@ -226,16 +232,23 @@ export function evaluateHotkeyAlphaStaleness(input: {
   return { ...base, stale: false, reason: null, age_ms: age };
 }
 
-/** D1 counts arrive as numbers, but a null SUM over no rows and a shim that
- * stringifies both have to land on 0 rather than NaN -- a NaN would compare
- * false against the floor and report a truncated ledger healthy. */
-function countOrZero(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
+/**
+ * The single row the coverage read returns.
+ *
+ * `latest` is typed through the GENERATED column type, so a stamp that changes
+ * type in Neon changes here rather than silently arriving as something else.
+ * The counts are `string | number` for the driver's reason, not the column's:
+ * COUNT() is BIGINT and node-postgres hands a bigint back as a string whenever
+ * it is not exactly representable. Every member is nullable because each
+ * subselect answers null on an empty table.
+ */
+interface HotkeyAlphaCoverageRow {
+  latest: HotkeyAlpha["captured_at"] | null;
+  covered: string | number | null;
+  total: string | number | null;
+  /** Pairs the position ledger's NEWEST pass names -- the derived denominator
+   * (#11170), bounded to one pass on both sides. */
+  referenced: string | number | null;
 }
 
 export interface HotkeyAlphaStalenessDeps {
@@ -265,7 +278,7 @@ export async function runHotkeyAlphaStalenessWatchdog(
   const db = readStore(env, [
     "hotkey_alpha",
     "nominator_positions",
-  ]) as unknown as StatementClientLike | undefined;
+  ]) as unknown as ReadStoreDb | undefined;
   if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
@@ -281,17 +294,12 @@ export async function runHotkeyAlphaStalenessWatchdog(
     // Two binds now: the pass window applies to hotkey_alpha's `covered` and to
     // nominator_positions' `referenced`, which must be measured over ITS newest
     // pass rather than all history -- see the SQL.
-    const row = (await db.first(HOTKEY_ALPHA_COVERAGE_SQL, [
-      passWindowMs,
-      passWindowMs,
-    ])) as {
-      latest: number | null;
-      covered: number | null;
-      total: number | null;
-      referenced: number | null;
-    } | null;
+    const row = await db.first<HotkeyAlphaCoverageRow>(
+      HOTKEY_ALPHA_COVERAGE_SQL,
+      [passWindowMs, passWindowMs],
+    );
     const verdict = evaluateHotkeyAlphaStaleness({
-      latestCapturedAtMs: row?.latest ?? null,
+      latestCapturedAtMs: numberOrNull(row?.latest),
       coveredRows: countOrZero(row?.covered),
       totalRows: countOrZero(row?.total),
       referencedPairs: countOrZero(row?.referenced),

--- a/src/neurons-staleness-watchdog.ts
+++ b/src/neurons-staleness-watchdog.ts
@@ -50,7 +50,13 @@ import {
 } from "./neon-write-buffer.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import {
+  countOrZero,
+  numberOrNull,
+  readStore,
+  type ReadStoreDb,
+} from "./read-store.ts";
+import type { Neurons } from "../generated/db/types.ts";
 
 /** The buffer lane these rows are written on, when buffering is on. */
 export const NEURONS_BUFFER_LANE = "neurons";
@@ -244,16 +250,20 @@ export function evaluateNeuronsStaleness(input: {
   return { ...base, stale: false, reason: null, age_ms: age };
 }
 
-/** A null count over no rows, or a shim that stringifies, must land on 0 rather
- * than NaN -- a NaN compares false against the floor and would report a
- * half-scanned network healthy. */
-function countOrZero(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
+/**
+ * The single row the coverage read returns.
+ *
+ * `latest` is typed through the GENERATED column type, so a stamp that changes
+ * type in Neon changes here rather than silently arriving as something else.
+ * The counts are `string | number` for the driver's reason, not the column's:
+ * COUNT() is BIGINT and node-postgres hands a bigint back as a string whenever
+ * it is not exactly representable. Every member is nullable because each
+ * subselect answers null on an empty table.
+ */
+interface NeuronsCoverageRow {
+  latest: Neurons["captured_at"] | null;
+  covered: string | number | null;
+  total: string | number | null;
 }
 
 export interface NeuronsStalenessDeps {
@@ -280,8 +290,7 @@ export async function runNeuronsStalenessWatchdog(
   // laneHealthStore already; this read did not, so the watchdog was measuring
   // the frozen copy D1 left and would have alarmed permanently -- reporting the lane
   // stalled while the lane was fine.
-  const db = readStore(env, ["neurons"]) as unknown as
-    StatementClientLike | undefined;
+  const db = readStore(env, ["neurons"]) as unknown as ReadStoreDb | undefined;
   if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs = neuronsStalenessThresholdMs(env);
@@ -292,13 +301,11 @@ export async function runNeuronsStalenessWatchdog(
     NEURONS_COVERAGE_FLOOR_NETUIDS;
 
   try {
-    const row = (await db.first(NEURONS_COVERAGE_SQL, [passWindowMs])) as {
-      latest: number | null;
-      covered: number | null;
-      total: number | null;
-    } | null;
+    const row = await db.first<NeuronsCoverageRow>(NEURONS_COVERAGE_SQL, [
+      passWindowMs,
+    ]);
     const verdict = evaluateNeuronsStaleness({
-      latestCapturedAtMs: row?.latest ?? null,
+      latestCapturedAtMs: numberOrNull(row?.latest),
       coveredNetuids: countOrZero(row?.covered),
       totalNetuids: countOrZero(row?.total),
       nowMs: now(),

--- a/src/nominator-positions-staleness-watchdog.ts
+++ b/src/nominator-positions-staleness-watchdog.ts
@@ -56,7 +56,13 @@ import { laneHealthStore } from "./lane-health-store.ts";
 import { missedTicksMs, passWindowMs } from "./producer-cadence.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import {
+  countOrZero,
+  numberOrNull,
+  readStore,
+  type ReadStoreDb,
+} from "./read-store.ts";
+import type { NominatorPositions } from "../generated/db/types.ts";
 import { requireFullScanValue } from "./lane-table-topology.ts";
 
 /**
@@ -288,16 +294,20 @@ export function evaluateNominatorPositionsStaleness(input: {
   return { ...base, stale: false, reason: null, age_ms: age };
 }
 
-/** A null count over no rows, or a shim that stringifies, must land on 0 rather
- * than NaN -- a NaN compares false against the floor and would report a
- * half-scanned keyspace healthy. */
-function countOrZero(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
+/**
+ * The single row the coverage read returns.
+ *
+ * `latest` is typed through the GENERATED column type, so a stamp that changes
+ * type in Neon changes here rather than silently arriving as something else.
+ * The counts are `string | number` for the driver's reason, not the column's:
+ * COUNT() is BIGINT and node-postgres hands a bigint back as a string whenever
+ * it is not exactly representable. Every member is nullable because each
+ * subselect answers null on an empty table.
+ */
+interface NominatorPositionsCoverageRow {
+  latest: NominatorPositions["captured_at"] | null;
+  covered: string | number | null;
+  total: string | number | null;
 }
 
 export interface NominatorPositionsStalenessDeps {
@@ -325,7 +335,7 @@ export async function runNominatorPositionsStalenessWatchdog(
   // the frozen copy D1 left and would have alarmed permanently -- reporting the lane
   // stalled while the lane was fine.
   const db = readStore(env, ["nominator_positions"]) as unknown as
-    StatementClientLike | undefined;
+    ReadStoreDb | undefined;
   if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
@@ -343,17 +353,16 @@ export async function runNominatorPositionsStalenessWatchdog(
     // MAX(captured_at), the window itself, then the source scoping the outer
     // aggregate. See NOMINATOR_POSITIONS_SCAN_SOURCE for why an unscoped read
     // reports a healthy self-stake run as a truncated alpha scan.
-    const row = (await db.first(NOMINATOR_POSITIONS_COVERAGE_SQL, [
-      NOMINATOR_POSITIONS_SCAN_SOURCE,
-      passWindowMs,
-      NOMINATOR_POSITIONS_SCAN_SOURCE,
-    ])) as {
-      latest: number | null;
-      covered: number | null;
-      total: number | null;
-    } | null;
+    const row = await db.first<NominatorPositionsCoverageRow>(
+      NOMINATOR_POSITIONS_COVERAGE_SQL,
+      [
+        NOMINATOR_POSITIONS_SCAN_SOURCE,
+        passWindowMs,
+        NOMINATOR_POSITIONS_SCAN_SOURCE,
+      ],
+    );
     const verdict = evaluateNominatorPositionsStaleness({
-      latestCapturedAtMs: row?.latest ?? null,
+      latestCapturedAtMs: numberOrNull(row?.latest),
       coveredColdkeys: countOrZero(row?.covered),
       totalColdkeys: countOrZero(row?.total),
       nowMs: now(),

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -63,6 +63,48 @@ type Row = Record<string, unknown>;
  * every one of them. Loaders shared with the producer store (tao-usd,
  * pipeline-history, chain-concentration-history) consume the same verbs, so
  * one loader serves both providers with no adapter shape between them. */
+/**
+ * A `COUNT()`/`SUM()` result as a number, or 0.
+ *
+ * Lives here because the reason it exists is the DRIVER's: Postgres returns
+ * COUNT as BIGINT, and node-postgres hands a bigint back as a STRING whenever
+ * the value is not exactly representable (see src/pg-sql.ts's parser). So a
+ * coverage row's counts are honestly `string | number | null`, and every reader
+ * needs the same coercion.
+ *
+ * It was copy-pasted into five staleness watchdogs as `countOrZero` and into
+ * src/lane-alarm.ts as `toInt` -- six identical bodies under two names, which is
+ * how a coercion quietly diverges.
+ *
+ * Zero rather than NaN or a throw: every caller is a coverage rule, and a count
+ * it cannot read must be treated as "covered nothing" so the rule alerts. NaN
+ * compares false against a floor and would report healthy -- see
+ * "an uncountable coverage number reads as ZERO, never as covered".
+ */
+export function countOrZero(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * A BIGINT column as a number, preserving null.
+ *
+ * The sibling of `countOrZero` and for the same driver reason, but a stamp is
+ * not a count: an unreadable timestamp must stay NULL, because 0 is a real
+ * instant (1970) and would make a dead lane read as merely very stale rather
+ * than as never having reported.
+ *
+ * Epoch-ms values are exactly representable, so today the driver hands these
+ * back as numbers and this is a no-op. It exists because the GENERATED type
+ * says `number | string` and a reader that assumes `number` is the #9782 class
+ * of bug -- code and column disagreeing about a type, with nothing throwing.
+ */
+export function numberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
 export interface ReadStoreDb {
   query<T = Row>(text: string, values?: unknown[]): Promise<T[]>;
   first<T = Row>(text: string, values?: unknown[]): Promise<T | null>;

--- a/src/validator-nominator-counts-staleness-watchdog.ts
+++ b/src/validator-nominator-counts-staleness-watchdog.ts
@@ -45,7 +45,13 @@
 
 import { laneHealthStore } from "./lane-health-store.ts";
 import { passWindowMs } from "./producer-cadence.ts";
-import { readStore } from "./read-store.ts";
+import {
+  countOrZero,
+  numberOrNull,
+  readStore,
+  type ReadStoreDb,
+} from "./read-store.ts";
+import type { ValidatorNominatorCounts } from "../generated/db/types.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
 
@@ -241,16 +247,20 @@ export function evaluateValidatorNominatorCountsStaleness(input: {
   return { ...base, stale: false, reason: null, age_ms: age };
 }
 
-/** A null SUM over no rows, or a shim that stringifies, must land on 0 rather
- * than NaN -- a NaN compares false against the floor and would report a
- * truncated table healthy. */
-function countOrZero(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
+/**
+ * The single row the coverage read returns.
+ *
+ * `latest` is typed through the GENERATED column type, so a stamp that changes
+ * type in Neon changes here rather than silently arriving as something else.
+ * The counts are `string | number` for the driver's reason, not the column's:
+ * COUNT() is BIGINT and node-postgres hands a bigint back as a string whenever
+ * it is not exactly representable. Every member is nullable because each
+ * subselect answers null on an empty table.
+ */
+interface ValidatorNominatorCountsCoverageRow {
+  latest: ValidatorNominatorCounts["captured_at"] | null;
+  covered: string | number | null;
+  total: string | number | null;
 }
 
 export interface ValidatorNominatorCountsStalenessDeps {
@@ -292,7 +302,7 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
   // threaded in by hand. Each of those alone is silent -- the lane simply stops
   // reporting, and an absent verdict reads as health.
   const db = readStore(env, ["validator_nominator_counts"]) as unknown as
-    StatementClientLike | undefined;
+    ReadStoreDb | undefined;
   if (!db?.first) return { ok: false, reason: "no store bound" };
 
   const thresholdMs =
@@ -306,15 +316,12 @@ export async function runValidatorNominatorCountsStalenessWatchdog(
     VALIDATOR_NOMINATOR_COUNTS_COVERAGE_FLOOR_ROWS;
 
   try {
-    const row = (await db.first(VALIDATOR_NOMINATOR_COUNTS_COVERAGE_SQL, [
-      passWindowMs,
-    ])) as {
-      latest: number | null;
-      covered: number | null;
-      total: number | null;
-    } | null;
+    const row = await db.first<ValidatorNominatorCountsCoverageRow>(
+      VALIDATOR_NOMINATOR_COUNTS_COVERAGE_SQL,
+      [passWindowMs],
+    );
     const verdict = evaluateValidatorNominatorCountsStaleness({
-      latestCapturedAtMs: row?.latest ?? null,
+      latestCapturedAtMs: numberOrNull(row?.latest),
       coveredRows: countOrZero(row?.covered),
       totalRows: countOrZero(row?.total),
       nowMs: now(),


### PR DESCRIPTION
Closes #11198 (V4, sub-issue of #11182). The last one — the epic closes with it.

## The duplication, found by looking

| helper | copies | note |
|---|---|---|
| `countOrZero` | **6** | five watchdogs byte-identical, plus `lane-alarm.ts` under the name `toInt` |
| `interface StatementClientLike` | **6** | a *weaker* duplicate of a type these files already receive |

`StatementClientLike` is the interesting one: `ReadStoreDb` from `read-store.ts` already provides `first<T>` — **generic**, where the local copies were `Promise<unknown>`. `lane-alarm.ts` had already noticed its own copy and aliased it (`type StatementClientLike = LaneHealthDb`) — the same discovery made once and never propagated.

Both now come from `read-store.ts`. `countOrZero` belongs there because the reason it exists is the **driver's**: `COUNT()` is BIGINT, and node-postgres returns a bigint as a **string** whenever it isn't exactly representable.

## The casts the generic removes

```ts
const row = (await db.first(SQL, [...])) as {
  latest: number | null; covered: number | null; total: number | null;
} | null;
```

Three things wrong, and the generated types say so:

- **`latest` is `captured_at`, typed `number | string`** in `generated/db/types.ts`. The cast asserted `number`, so a stamp arriving as a string would flow into age arithmetic unchecked — the #9782 class, code and column disagreeing with nothing throwing.
- the counts are BIGINT for the same reason and were also asserted `number`.
- it's a **cast at a real boundary**, the pattern #11194 exists to sweep.

Each now declares a named row interface whose `latest` is `<Generated>["captured_at"] | null`, read through `db.first<Row>(…)` with **no assertion**. A column that changes type in Neon changes here.

## The one that was already right

`chain-detail-staleness-watchdog.ts` coerced its stamp (`toInt(row?.latest)`); the other five passed `row?.latest ?? null` straight through. They now use `numberOrNull`, which **preserves null** rather than collapsing to 0 — a stamp of 0 is a real instant (1970) and would make a dead lane read as merely very stale instead of as never having reported.

**No live bug:** epoch-ms values are exactly representable, so the driver hands them back as numbers today. The types were lying about a hazard that hasn't fired.

150 tests pass across the affected suites; both new gates green; unreferenced-exports holds at 731; `tsc`, prettier, eslint clean.