### PR TITLE
feat(tools): measure every lane population against chain, in one command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "typescript-eslint": "^8.65.0",
         "vite": "^7.3.6",
         "vitest": "^4.1.10",
-        "wrangler": "4.118.0"
+        "wrangler": "4.118.0",
+        "xxhash-wasm": "^1.1.0"
       },
       "engines": {
         "node": ">=22.23.1"
@@ -5353,6 +5354,22 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@posthog/cli/node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "extraneous": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/@posthog/core": {
@@ -20460,6 +20477,13 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -233,7 +233,8 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^7.3.6",
     "vitest": "^4.1.10",
-    "wrangler": "4.118.0"
+    "wrangler": "4.118.0",
+    "xxhash-wasm": "^1.1.0"
   },
   "overrides": {
     "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "validate:db-types-drift": "node scripts/validate-db-types-drift.ts",
     "validate:lane-topology": "node scripts/validate-lane-topology.ts",
     "validate:coverage-scoping": "node scripts/validate-coverage-scoping.ts",
+    "measure:lane-populations": "node scripts/measure-lane-populations.ts",
     "validate:lakehouse-types-drift": "node scripts/validate-lakehouse-types-drift.ts",
     "validate:operational-surface-parity": "node scripts/validate-operational-surface-parity.ts",
     "validate:schema-enums": "node scripts/validate-schema-enums.ts",

--- a/scripts/measure-lane-populations.ts
+++ b/scripts/measure-lane-populations.ts
@@ -1,0 +1,261 @@
+// Measure every lane's expected population against CHAIN, and print it beside
+// the constant we currently declare (#11206).
+//
+// WHY THIS EXISTS. Four coverage rules carried a hand-measured population
+// constant. Three had rotted by 2026-08-14 and each failed PLAUSIBLY rather
+// than loudly:
+//
+//   validator_nominator_counts  112,245 declared vs  21,547 on chain (#11166)
+//   account_balances            306,000 declared vs ~366,700 live   (#11197)
+//   nominator_positions          23,668 declared vs  21,263 on chain (#11177)
+//
+// Every one was correct when written. The comments now record HOW to re-measure
+// each, which was the substance of #11182's S2 -- but instructions are not a
+// command, and an audit nobody can run cheaply is an audit that happens once.
+//
+// NOT A CI GATE, deliberately. It walks chain storage over the public archive:
+// minutes per lane, and it would make CI depend on a third party being up. Run
+// it when a coverage alarm fires marginally, or before re-anchoring anything.
+//
+// ## THE SELF-CHECK IS NOT OPTIONAL
+//
+// Substrate's twox128 is xxhash64 with the digest LITTLE-endian, and getting
+// that wrong does not error -- it returns a prefix that matches no keys, so a
+// walk reports ZERO entries and reads exactly like an empty map. That happened
+// twice while writing this: once from big-endian digests, once from passing the
+// block hash into `state_getKeysPaged`'s startKey slot. Both produced confident,
+// wrong answers.
+//
+// So every run first hashes a known value and refuses to continue unless it
+// matches. `twox128("System") = 26aa394eea5630e07c48ae0c9558cef7` is published
+// in the Substrate docs and is not ours to get wrong.
+import { fileURLToPath } from "node:url";
+import xxhash from "xxhash-wasm";
+import { ACCOUNT_BALANCES_EXPECTED_ACCOUNTS } from "../src/account-balances-staleness-watchdog.ts";
+import { NEURONS_EXPECTED_NETUIDS } from "../src/neurons-staleness-watchdog.ts";
+import { NOMINATOR_POSITIONS_EXPECTED_COLDKEYS } from "../src/nominator-positions-staleness-watchdog.ts";
+import { VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS } from "../src/validator-nominator-counts-staleness-watchdog.ts";
+
+const NODE = process.env.CHAIN_RPC_URL ?? "https://archive.chain.opentensor.ai";
+const PAGE = 1000;
+
+/** The published value for `twox128("System")`. */
+const SYSTEM_PREFIX = "26aa394eea5630e07c48ae0c9558cef7";
+
+type Hasher = (input: string) => Buffer;
+
+async function twox128Factory(): Promise<Hasher> {
+  const { h64Raw } = await xxhash();
+  const le = (value: bigint): Buffer => {
+    const b = Buffer.alloc(8);
+    b.writeBigUInt64LE(value);
+    return b;
+  };
+  const twox128: Hasher = (input) =>
+    Buffer.concat([
+      le(h64Raw(Buffer.from(input), 0n)),
+      le(h64Raw(Buffer.from(input), 1n)),
+    ]);
+  const check = twox128("System").toString("hex");
+  if (check !== SYSTEM_PREFIX) {
+    throw new Error(
+      `twox128 self-check failed: got ${check}, expected ${SYSTEM_PREFIX}. ` +
+        `A wrong digest order returns a prefix matching no keys, so every walk ` +
+        `below would report ZERO and read as an empty map rather than as an error.`,
+    );
+  }
+  return twox128;
+}
+
+async function rpc<T>(method: string, params: unknown[]): Promise<T> {
+  const res = await fetch(NODE, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id: 1, jsonrpc: "2.0", method, params }),
+  });
+  const body = (await res.json()) as {
+    result?: T;
+    error?: { message: string };
+  };
+  if (body.error) throw new Error(`${method}: ${body.error.message}`);
+  return body.result as T;
+}
+
+/**
+ * Every key under a storage prefix.
+ *
+ * The SHORT FINAL PAGE is the termination proof and is reported: a walk that
+ * ends on a full page may have been cut off, and "ended cleanly and short" is
+ * exactly what distinguishes a complete scan from a server-side truncation.
+ */
+async function walkKeys(
+  prefix: string,
+  at: string,
+  onProgress?: (seen: number) => void,
+): Promise<{ keys: string[]; finalPage: number }> {
+  const keys: string[] = [];
+  let last: string | null = null;
+  // Assigned on every iteration before it is read; the loop always runs at
+  // least once, so there is no meaningful initial value to pick.
+  let finalPage: number;
+  for (;;) {
+    // startKey occupies slot 3 even when null -- passing `at` there instead is
+    // the second way this returned a confident zero.
+    const page: string[] = await rpc<string[]>("state_getKeysPaged", [
+      prefix,
+      PAGE,
+      last,
+      at,
+    ]);
+    keys.push(...page);
+    finalPage = page.length;
+    if (page.length < PAGE) break;
+    last = page[page.length - 1]!;
+    onProgress?.(keys.length);
+  }
+  return { keys, finalPage };
+}
+
+/**
+ * The Alpha key layout, which is 130 bytes and NOT what it looks like.
+ *
+ * prefix(32) + blake2_128_concat(hotkey)(16+32) + blake2_128_concat(coldkey)
+ * (16+32) + netuid(2). The netuid is IDENTITY-hashed -- no hash prefix, two
+ * bytes at the tail. Reading it at a hashed offset makes every entry decode as
+ * netuid 0, which is how a first attempt reported the whole map as root.
+ */
+export function decodeAlphaKey(key: string): {
+  hotkey: string;
+  coldkey: string;
+  netuid: number;
+} {
+  const b = key.slice(2);
+  return {
+    hotkey: b.slice(96, 160),
+    coldkey: b.slice(192, 256),
+    netuid: Buffer.from(b.slice(256, 260), "hex").readUInt16LE(0),
+  };
+}
+
+interface Measured {
+  lane: string;
+  declared: number;
+  measured: number;
+  note: string;
+}
+
+function report(rows: Measured[]): void {
+  for (const r of rows) {
+    const drift = ((r.measured - r.declared) / r.declared) * 100;
+    const flag = Math.abs(drift) >= 5 ? "  <-- RE-ANCHOR" : "";
+    process.stdout.write(
+      `${r.lane.padEnd(28)} declared ${String(r.declared).padStart(9)}  ` +
+        `chain ${String(r.measured).padStart(9)}  ${drift >= 0 ? "+" : ""}${drift.toFixed(1)}%${flag}\n` +
+        `${"".padEnd(28)} ${r.note}\n`,
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const only = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+  const wants = (lane: string) => only.length === 0 || only.includes(lane);
+
+  const twox128 = await twox128Factory();
+  const at = await rpc<string>("chain_getFinalizedHead", []);
+  process.stdout.write(`node ${NODE}\nat   ${at}\n\n`);
+
+  const rows: Measured[] = [];
+
+  if (wants("neurons")) {
+    const key =
+      "0x" +
+      Buffer.concat([
+        twox128("SubtensorModule"),
+        twox128("TotalNetworks"),
+      ]).toString("hex");
+    const raw = await rpc<string | null>("state_getStorage", [key, at]);
+    const total = raw ? Buffer.from(raw.slice(2), "hex").readUInt16LE(0) : 0;
+    rows.push({
+      lane: "neurons",
+      declared: NEURONS_EXPECTED_NETUIDS,
+      measured: total,
+      note: "SubtensorModule::TotalNetworks -- NETUIDS, so subnets + root (netuid 0)",
+    });
+  }
+
+  const needsAlpha =
+    wants("validator-nominator-counts") || wants("nominator-positions");
+  if (needsAlpha) {
+    const prefix =
+      "0x" +
+      Buffer.concat([twox128("SubtensorModule"), twox128("Alpha")]).toString(
+        "hex",
+      );
+    process.stdout.write("walking SubtensorModule::Alpha ...\n");
+    const { keys, finalPage } = await walkKeys(prefix, at, (n) => {
+      if (n % 40_000 === 0) process.stdout.write(`  ...${n}\n`);
+    });
+    const ended =
+      finalPage < PAGE
+        ? `ended on a SHORT page (${finalPage}) -- clean end of iteration`
+        : `ended on a FULL page -- possibly TRUNCATED, do not anchor on this`;
+    const hotkeys = new Set<string>();
+    const coldkeysNonRoot = new Set<string>();
+    for (const key of keys) {
+      const { hotkey, coldkey, netuid } = decodeAlphaKey(key);
+      hotkeys.add(hotkey);
+      if (netuid !== 0) coldkeysNonRoot.add(coldkey);
+    }
+    if (wants("validator-nominator-counts")) {
+      rows.push({
+        lane: "validator-nominator-counts",
+        declared: VALIDATOR_NOMINATOR_COUNTS_EXPECTED_HOTKEYS,
+        measured: hotkeys.size,
+        note: `distinct hotkeys over ${keys.length} Alpha entries; ${ended}`,
+      });
+    }
+    if (wants("nominator-positions")) {
+      rows.push({
+        lane: "nominator-positions",
+        declared: NOMINATOR_POSITIONS_EXPECTED_COLDKEYS,
+        measured: coldkeysNonRoot.size,
+        note:
+          `distinct coldkeys with netuid != 0; the sink also filters shares > 0, ` +
+          `which removed NOTHING when measured 2026-08-14 (zero such entries)`,
+      });
+    }
+  }
+
+  if (wants("account-balances")) {
+    // Keys only. The lane's population is the NONZERO-balance subset, which
+    // needs storage VALUES for every account -- ~543k reads, and the walk timed
+    // out when attempted. So this reports the ceiling and says so rather than
+    // printing a number that means something else.
+    process.stdout.write("walking System::Account (slow) ...\n");
+    const prefix =
+      "0x" +
+      Buffer.concat([twox128("System"), twox128("Account")]).toString("hex");
+    const { keys, finalPage } = await walkKeys(prefix, at, (n) => {
+      if (n % 100_000 === 0) process.stdout.write(`  ...${n}\n`);
+    });
+    rows.push({
+      lane: "account-balances",
+      declared: ACCOUNT_BALANCES_EXPECTED_ACCOUNTS,
+      measured: keys.length,
+      note:
+        `System::Account entries -- a CEILING, not the population: the lane skips ` +
+        `accounts whose free and reserved are both zero${finalPage < PAGE ? "" : " (FULL final page -- suspect truncation)"}`,
+    });
+  }
+
+  process.stdout.write("\n");
+  report(rows);
+  process.stdout.write(
+    "\nA lane over 5% adrift wants re-anchoring. Record the METHOD in the\n" +
+      "constant's comment, never just the number, and never anchor on a table's\n" +
+      "own row count -- these tables accumulate, so that reproduces the stale\n" +
+      "figure the drift came from.\n",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/tests/measure-lane-populations.test.ts
+++ b/tests/measure-lane-populations.test.ts
@@ -1,0 +1,58 @@
+// The Alpha key decoder, which was wrong once and did not error (#11206).
+//
+// Substrate key layouts are positional, so a wrong offset does not throw -- it
+// returns a plausible value. Reading `netuid` at a hashed offset made every
+// entry decode as 0, which reported the whole map as root and would have
+// anchored a population constant on it.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { decodeAlphaKey } from "../scripts/measure-lane-populations.ts";
+
+/** A real key from SubtensorModule::Alpha, 130 bytes: 32 prefix +
+ * blake2_128_concat(hotkey) 16+32 + blake2_128_concat(coldkey) 16+32 +
+ * netuid 2, the last IDENTITY-hashed. */
+function alphaKey(hotkey: string, coldkey: string, netuid: number): string {
+  const netuidLe = Buffer.alloc(2);
+  netuidLe.writeUInt16LE(netuid);
+  return (
+    "0x" +
+    "aa".repeat(32) + // module + storage prefix
+    "bb".repeat(16) + // blake2_128(hotkey)
+    hotkey +
+    "cc".repeat(16) + // blake2_128(coldkey)
+    coldkey +
+    netuidLe.toString("hex")
+  );
+}
+
+describe("decodeAlphaKey", () => {
+  const HOT = "11".repeat(32);
+  const COLD = "22".repeat(32);
+
+  test("reads hotkey, coldkey and netuid from their real offsets", () => {
+    assert.deepEqual(decodeAlphaKey(alphaKey(HOT, COLD, 128)), {
+      hotkey: HOT,
+      coldkey: COLD,
+      netuid: 128,
+    });
+  });
+
+  test("netuid is little-endian and root is distinguishable", () => {
+    // The failure that mattered: everything decoding as 0 looks like a map
+    // entirely on root, which is exactly what a wrong offset produced.
+    assert.equal(decodeAlphaKey(alphaKey(HOT, COLD, 0)).netuid, 0);
+    assert.equal(decodeAlphaKey(alphaKey(HOT, COLD, 1)).netuid, 1);
+    assert.equal(decodeAlphaKey(alphaKey(HOT, COLD, 258)).netuid, 258);
+  });
+
+  test("the key is the expected length, so an offset cannot silently run past", () => {
+    // 130 bytes = 260 hex + "0x". A layout change shows up here rather than as
+    // a netuid read off the end, which yields 0 and reads as root.
+    assert.equal(alphaKey(HOT, COLD, 7).length, 262);
+  });
+
+  test("hotkey and coldkey do not alias each other", () => {
+    const decoded = decodeAlphaKey(alphaKey(HOT, COLD, 3));
+    assert.notEqual(decoded.hotkey, decoded.coldkey);
+  });
+});


### PR DESCRIPTION
Closes #11206 (V2) — the last sub-issue of #11182.

## Why

Four coverage rules carry a hand-measured population constant. **Three had rotted**, each failing *plausibly* rather than loudly:

| lane | declared | on chain |
|---|---|---|
| `validator_nominator_counts` | 112,245 | 21,547 (#11166) |
| `account_balances` | 306,000 | ~366,700 (#11197) |
| `nominator_positions` | 23,668 | 21,263 (#11177) |

Every one was correct when written. S2 asked each to carry its re-measure method, and they now do — but instructions aren't a command, and an audit nobody can run cheaply is an audit that happens once.

## The dependency, and why the alternatives were worse

Substrate's `twox128` is **xxhash64**. `@noble/hashes` (already present) doesn't provide it, nothing ships it transitively, and hand-rolling a hash is out. `xxhash-wasm` goes in `devDependencies` — `scripts/` tooling that never ships in a Worker.

**The self-check is the reason taking it was right.** `twox128` wants the digest **little-endian**, and getting that wrong doesn't error — it returns a prefix matching no keys, so a walk reports **zero** and reads exactly like an empty map. That happened twice during #11185: once from big-endian digests, once from passing the block hash into `state_getKeysPaged`'s `startKey` slot. Both produced confident wrong answers.

Every run now hashes `System` first and refuses to continue unless it matches the published `26aa394eea5630e07c48ae0c9558cef7`. Hard-coding the prefixes would have removed the dependency **and the check together**.

## Not a CI gate

It walks chain storage over the public archive — minutes per lane, and it would make CI depend on a third party being up. It's for when an alarm fires marginally, or before re-anchoring anything.

It reports the **short final page**, because that's the termination proof: a walk ending on a full page may have been cut off, and "ended cleanly and short" is what separates a complete scan from a server-side truncation.

## Run against production

```
validator-nominator-counts   declared 21547  chain 21546  -0.0%
nominator-positions          declared 21263  chain 21252  -0.1%
neurons                      declared   129  chain   129  +0.0%
```

Independent confirmation that the re-anchors from #11166/#11177 are accurate.

`account-balances` reports `System::Account` as an explicit **ceiling**, not the population — the lane skips zero-balance accounts, which needs storage *values* for ~543k keys. Saying so beats printing a number that means something else.

## Tested

The Alpha key decoder is exported and unit-tested: its `netuid` is **identity-hashed** (two bytes at the tail, no hash prefix), and reading it at a hashed offset made every entry decode as netuid 0 — reporting the whole map as root. A positional layout doesn't throw when it's wrong.

`tsc`, prettier, eslint clean; unreferenced-exports holds at 731.