### PR TITLE
fix(accounts): decline the accounts whose two tiers would disagree

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -49,6 +49,8 @@
 // route faster, never wrong, and shipping it before the producer has backfilled
 // is safe by construction.
 
+import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "./account-events.ts";
+
 /** Objects the producer writes, one per shard. Contract with
  * metagraphed-infra's `services/indexer-rs/account_summary_r2.py`. */
 export const ACCOUNT_SUMMARY_PROJECTION_PREFIX =
@@ -206,5 +208,24 @@ export async function loadAccountSummaryProjection(
   // An account present with no usable groups is not an answer -- the caller
   // reads the lakehouse rather than publishing an empty card from a shard.
   if (!groups.length) return null;
+
+  // AN ACCOUNT OVER THE CAP IS NOT THIS TIER'S TO ANSWER.
+  //
+  // The projection aggregates an account's WHOLE history. The live path
+  // aggregates the newest ACCOUNT_EVENT_SUMMARY_SCAN_CAP events. Below the cap
+  // those are the same set, so the answers are identical -- above it they are
+  // not, and the difference is invisible in `event_count` (both clamp to CAP)
+  // while `event_kinds` and `subnet_count` silently widen to lifetime.
+  //
+  // Measured on 5Fv5t8frGG3MKt...: the live path reports 4 kinds across 2
+  // subnets, the projection 10 across 3. Same route, different answer depending
+  // on which tier served it, which is worse than either answer alone.
+  //
+  // So this declines above the cap and the lakehouse answers, exactly as it did
+  // before the projection existed. That is a small minority of accounts -- the
+  // cap is 5,000 lifetime events -- and it costs them nothing they were not
+  // already paying.
+  const scanned = groups.reduce((n, g) => n + Number(g.count), 0);
+  if (scanned > ACCOUNT_EVENT_SUMMARY_SCAN_CAP) return null;
   return groups;
 }

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -756,10 +756,15 @@ describe("the projection short-circuits the aggregate leg (#11131)", () => {
     assert.equal(buildAccountSummary(SS58, cold as never).event_count, 6);
   });
 
-  test("the cap keeps its meaning across both tiers", async () => {
-    // A route whose numbers depend on which tier served it is worse than
-    // either tier. The projection knows the true lifetime total; the published
-    // count stays clamped exactly as the live CTE's LIMIT CAP + 1 clamps it.
+  test("AN OVER-CAP ACCOUNT FALLS BACK -- the tiers must not disagree", async () => {
+    // I shipped this wrong and production caught it. The projection aggregates
+    // an account's WHOLE history; this leg aggregates the newest CAP events.
+    // `event_count` clamps to CAP either way, so the divergence hides there --
+    // but `event_kinds` and `subnet_count` widen to lifetime. Measured live:
+    // 4 kinds / 2 subnets from the lakehouse against 10 / 3 from the shard.
+    //
+    // So above the cap the projection declines and this leg runs, which is what
+    // keeps one route from having two answers.
     const engine = fakeEngine();
     const cold = await loadAccountSummaryColdTier(
       archive([
@@ -776,8 +781,12 @@ describe("the projection short-circuits the aggregate leg (#11131)", () => {
       SS58,
       { query: engine.query as never },
     );
+    assert.ok(
+      engine.seen.some((s) => s.includes("GROUP BY event_kind, netuid")),
+      "the lakehouse leg must answer for an account the shard cannot",
+    );
     const card = buildAccountSummary(SS58, cold as never);
-    assert.equal(card.event_count, ACCOUNT_EVENT_SUMMARY_SCAN_CAP);
-    assert.equal(card.event_scan_capped, true);
+    assert.equal(card.event_count, 6);
+    assert.equal(card.event_scan_capped, false);
   });
 });

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -7,6 +7,7 @@
 // payload it should have refused.
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
+import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "../src/account-events.ts";
 import {
   ACCOUNT_SUMMARY_MAX_AGE_MS,
   ACCOUNT_SUMMARY_POINTER_KEY,
@@ -319,6 +320,39 @@ describe("loadAccountSummaryProjection", () => {
         JSON.stringify(accounts),
       );
     }
+  });
+
+  test("AN ACCOUNT OVER THE CAP DECLINES -- the two tiers would disagree", async () => {
+    // The defect this exists for, caught in production before it was trusted.
+    // The projection aggregates an account's WHOLE history; the live path
+    // aggregates the newest CAP events. `event_count` clamps to CAP either way,
+    // so the difference hides there -- but `event_kinds` and `subnet_count`
+    // silently widen to lifetime.
+    //
+    // Measured on a real account: live reported 4 kinds across 2 subnets, the
+    // projection 10 across 3. Same route, different answer by tier.
+    const over = [
+      group({
+        kind: "AxonServed",
+        netuid: 7,
+        count: ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
+      }),
+      group({ kind: "Transfer", netuid: null, count: 1 }),
+    ];
+    const store = archive(published({ [HOT]: over }));
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+
+  test("an account EXACTLY at the cap is still answered", async () => {
+    // At the cap the two windows are the same set, so the answers agree -- an
+    // off-by-one here would drop the busiest accounts the tier CAN serve.
+    const atCap = [group({ count: ACCOUNT_EVENT_SUMMARY_SCAN_CAP })];
+    const store = archive(published({ [HOT]: atCap }));
+    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.equal(groups!.length, 1);
   });
 
   test("an account present with no usable groups declines", async () => {


### PR DESCRIPTION
I shipped a route that answered differently depending on which tier served it, and production caught it within minutes of the projection going live.

```
lakehouse : count=5000  kinds=4   subnets=2
projection: count=5000  kinds=10  subnets=3
```

The projection aggregates an account's **whole history**. The card's live leg aggregates the **newest `ACCOUNT_EVENT_SUMMARY_SCAN_CAP` events**. Below the cap those are the same set and the answers are identical. Above it they are not.

## What made it slip through

`event_count` clamps to CAP on **both** paths — so the one field I checked agreed. `event_kinds` and `subnet_count` have no such clamp and silently widened to lifetime. I wrote *"the cap keeps its meaning"* in the reader **and in a test**, and it was true of exactly the field I looked at.

## The fix

Below the cap the two windows are the same set, so serve only those: the reader sums the group counts it just read and declines above the cap, and the lakehouse answers exactly as it did before the projection existed. That's a small minority of accounts — 5,000 lifetime events — and it costs them nothing they weren't already paying.

**No new constant, deliberately.** The cap belongs to the card, which is defined here, so the *reader* applies it rather than the producer filtering on a number it would have to be told. The producer stays a plain "aggregate everything" pass with nothing to keep in sync across two repositories.

## Already rolled back

The pointer for the affected generation was deleted the moment the divergence was measured, so the route has been serving the lakehouse answer since. Rollback was **one small object** — which is exactly what generations (metagraphed-infra#569) were built to make possible, exercised here for real rather than in a test.

## Tests

- an account **over** the cap declines
- an account **exactly at** the cap is still answered — an off-by-one there would drop the busiest accounts this tier can legitimately serve
- the old test asserting the opposite is rewritten; it encoded the claim this disproves

52 CI validators, 20,898 tests, 914 files.