### PR TITLE
feat(registry): declare the surface method dimension (#11146 phase 3)

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -1221,6 +1221,11 @@ type Surface {
   key: String
   kind: String!
   last_verified_at: String
+
+  """
+  HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution.
+  """
+  method: String
   name: String
   netuid: Int!
   notes: String

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -7908,6 +7908,8 @@ export type Surface = {
   key?: Maybe<Scalars['String']['output']>;
   kind: Scalars['String']['output'];
   last_verified_at?: Maybe<Scalars['String']['output']>;
+  /** HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution. */
+  method?: Maybe<Scalars['String']['output']>;
   name?: Maybe<Scalars['String']['output']>;
   netuid: Scalars['Int']['output'];
   notes?: Maybe<Scalars['String']['output']>;
@@ -14231,6 +14233,7 @@ export type SurfaceResolvers<ContextType = GqlContext, ParentType extends Resolv
   key?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   kind?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   last_verified_at?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  method?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   notes?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -5959,6 +5959,11 @@ export interface components {
                     status?: string;
                 };
                 kind: string;
+                /**
+                 * @description HTTP method this service is invoked with; absent means GET. A non-GET service is a declared mutation (#11146): it carries no GET snippets -- call it through call_subnet_surface with the captured schema.
+                 * @enum {string}
+                 */
+                method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
                 provider?: string | null;
                 schema_artifact?: string | null;
                 schema_source?: {
@@ -13103,6 +13108,11 @@ export interface components {
             key?: string;
             kind: components["schemas"]["SurfaceKind"];
             last_verified_at?: string | null;
+            /**
+             * @description HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution.
+             * @enum {string}
+             */
+            method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
             name?: string;
             netuid: number;
             notes?: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -18691,6 +18691,17 @@
                 "kind": {
                   "type": "string"
                 },
+                "method": {
+                  "description": "HTTP method this service is invoked with; absent means GET. A non-GET service is a declared mutation (#11146): it carries no GET snippets -- call it through call_subnet_surface with the captured schema.",
+                  "enum": [
+                    "GET",
+                    "POST",
+                    "PUT",
+                    "PATCH",
+                    "DELETE"
+                  ],
+                  "type": "string"
+                },
                 "provider": {
                   "anyOf": [
                     {
@@ -59463,6 +59474,17 @@
                 "type": "null"
               }
             ]
+          },
+          "method": {
+            "description": "HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution.",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "PATCH",
+              "DELETE"
+            ],
+            "type": "string"
           },
           "name": {
             "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5959,6 +5959,11 @@ export interface components {
                     status?: string;
                 };
                 kind: string;
+                /**
+                 * @description HTTP method this service is invoked with; absent means GET. A non-GET service is a declared mutation (#11146): it carries no GET snippets -- call it through call_subnet_surface with the captured schema.
+                 * @enum {string}
+                 */
+                method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
                 provider?: string | null;
                 schema_artifact?: string | null;
                 schema_source?: {
@@ -13103,6 +13108,11 @@ export interface components {
             key?: string;
             kind: components["schemas"]["SurfaceKind"];
             last_verified_at?: string | null;
+            /**
+             * @description HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution.
+             * @enum {string}
+             */
+            method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
             name?: string;
             netuid: number;
             notes?: string;

--- a/schemas-src/mcp-tools/ai-integration.ts
+++ b/schemas-src/mcp-tools/ai-integration.ts
@@ -50,14 +50,23 @@ const HowDoICallServiceSchema = z
     surface_id: z.string(),
     kind: z.string(),
     capability: z.string(),
+    method: z
+      .string()
+      .optional()
+      .describe(
+        "HTTP method this service is invoked with; absent means GET (#11146).",
+      ),
     base_url: z.string(),
     callable: z.boolean(),
     auth: z
       .object({ required: z.boolean(), schemes: z.array(z.string()) })
       .strict(),
+    // NULL for a declared non-GET service (#11146): the generator refuses to
+    // emit a GET snippet against a mutation, and the catalog row stored none.
     snippets: z
       .object({ curl: z.string(), python: z.string(), typescript: z.string() })
-      .strict(),
+      .strict()
+      .nullable(),
     // TWO BRANCHES, and only the unavailable one was declared (#10790). When a
     // schema or fixture EXISTS the producer adds the tool call that fetches it
     // -- which is the entire point of `how_do_i_call` -- and when it does not,

--- a/schemas-src/query-enums.ts
+++ b/schemas-src/query-enums.ts
@@ -143,6 +143,12 @@ export const QUERY_ENUMS = {
     "generic-openapi-or-custom",
     "stream-adapter",
   ],
+  // The HTTP method a registered surface is invoked with (#11146 phase 3).
+  // Not a query filter but owned here like responseEnvelopeField: the manifest
+  // schema, the served SurfaceSchema, and the callable-execution seam all need
+  // the same closed set, and validate:schema-enums pins the manifest copy to
+  // this one. Absent on a surface means GET.
+  surfaceMethod: ["GET", "POST", "PUT", "PATCH", "DELETE"],
   surfaceKind: [
     "archive",
     "dashboard",

--- a/schemas-src/routes/agent-catalog.ts
+++ b/schemas-src/routes/agent-catalog.ts
@@ -37,7 +37,11 @@ import {
 } from "../envelope.ts";
 import { IntegrationReadinessSchema } from "./subnet-profile.ts";
 import { AgentReadinessBlockerSchema } from "./coverage.ts";
-import { AuthSchema, LIVE_HEALTH_OVERLAY } from "./subnet-detail.ts";
+import {
+  AuthSchema,
+  LIVE_HEALTH_OVERLAY,
+  SurfaceMethodSchema,
+} from "./subnet-detail.ts";
 
 export const AgentReadinessStatusSchema = z
   .object({
@@ -212,6 +216,10 @@ export const AgentCatalogServiceSchema = z
     kind: z.string(),
     capability: z.string().optional(),
     description: z.string().nullable().optional(),
+    method: SurfaceMethodSchema.optional().meta({
+      description:
+        "HTTP method this service is invoked with; absent means GET. A non-GET service is a declared mutation (#11146): it carries no GET snippets -- call it through call_subnet_surface with the captured schema.",
+    }),
     base_url: z.string(),
     provider: z.string().nullable().optional(),
     authority: z.string().nullable().optional(),

--- a/schemas-src/routes/subnet-detail.ts
+++ b/schemas-src/routes/subnet-detail.ts
@@ -54,6 +54,13 @@ export const SURFACE_KIND_VALUES = QUERY_ENUMS.surfaceKind;
 export const SurfaceKindSchema = z.enum(SURFACE_KIND_VALUES);
 export type SurfaceKind = z.infer<typeof SurfaceKindSchema>;
 
+/** The HTTP method a surface is invoked with; absent means GET (#11146
+ * phase 3). The manifest schema's copy of this enum is pinned to the same
+ * QUERY_ENUMS declaration by validate:schema-enums. */
+export const SURFACE_METHOD_VALUES = QUERY_ENUMS.surfaceMethod;
+export const SurfaceMethodSchema = z.enum(SURFACE_METHOD_VALUES);
+export type SurfaceMethod = z.infer<typeof SurfaceMethodSchema>;
+
 export const SourceTierSchema = z.enum([
   "native-chain",
   "provider-claimed",
@@ -655,6 +662,10 @@ export const SurfaceSchema = z
     key: z.string().optional(),
     kind: SurfaceKindSchema,
     last_verified_at: z.string().nullable().optional(),
+    method: SurfaceMethodSchema.optional().meta({
+      description:
+        "HTTP method this surface is invoked with; absent means GET. A non-GET surface is a declared mutation (#11146): the prober never touches it (the manifest schema forbids an enabled probe on one), so it carries no probe-derived health -- reach it through call_subnet_surface's schema-gated execution.",
+    }),
     name: z.string().optional(),
     netuid: z.int().min(0),
     notes: z.string().optional(),

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -186,6 +186,10 @@
             "data-artifact"
           ]
         },
+        "method": {
+          "description": "HTTP method this surface is invoked with. ABSENT MEANS GET -- every pre-existing surface keeps its meaning unchanged. A non-GET surface is a declared mutation (metagraphed#11146): it may never enable a probe (the prober only speaks GET/HEAD, and probing a mutation with GET would publish a route that answers a method nobody declared), and callers reach it through call_subnet_surface's schema-gated execution, not by fetching the URL.",
+          "enum": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        },
         "url": {
           "type": "string",
           "format": "uri",
@@ -232,7 +236,7 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["state"],
-          "description": "Per-surface HUMAN review/governance state for the single-file contribution model: a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". Human-governance axis ONLY \u2014 machine verification + freshness (live or stale) is the separate probe-derived `verification` overlay (health, last_verified_at, incidents); subnet-level curation has its own `curation.review_state`.",
+          "description": "Per-surface HUMAN review/governance state for the single-file contribution model: a surface enters as \"community-submitted\"; a maintainer promotes it to \"maintainer-reviewed\" or marks it \"rejected\". Human-governance axis ONLY — machine verification + freshness (live or stale) is the separate probe-derived `verification` overlay (health, last_verified_at, incidents); subnet-level curation has its own `curation.review_state`.",
           "properties": {
             "state": {
               "enum": ["community-submitted", "maintainer-reviewed", "rejected"]
@@ -366,7 +370,30 @@
         "notes": {
           "type": "string"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "method": {
+                "enum": ["POST", "PUT", "PATCH", "DELETE"]
+              }
+            },
+            "required": ["method"]
+          },
+          "then": {
+            "properties": {
+              "probe": {
+                "properties": {
+                  "enabled": {
+                    "const": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     },
     "revenue": {
       "type": "object",

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -1842,6 +1842,10 @@ function buildSubnetServices(netuid: unknown): Row[] {
         kind: surface.kind,
         capability: surface.name || surface.notes || `${surface.kind} surface`,
         description: surface.notes || null,
+        // #11146 phase 3: absent means GET, so every pre-existing row is
+        // byte-identical. A non-GET service gets no snippets below (the
+        // generator refuses to GET a declared mutation).
+        ...(surface.method ? { method: surface.method } : {}),
         base_url: surface.url,
         provider: surface.provider || null,
         authority: surface.authority || null,
@@ -1855,6 +1859,7 @@ function buildSubnetServices(netuid: unknown): Row[] {
         // filled from the structured auth detail (issue #746, was #351 guess).
         snippets: generateServiceSnippets({
           base_url: surface.url,
+          method: surface.method,
           auth_required: authRequired,
           auth_schemes: authSchemes,
           auth: authDetail,

--- a/scripts/validate-schema-enums.ts
+++ b/scripts/validate-schema-enums.ts
@@ -95,6 +95,11 @@ compareSchemaEnum(
   subnetSchema.$defs.surface.properties.kind.enum,
   QUERY_ENUMS.surfaceKind,
 );
+compareSchemaEnum(
+  "subnet-manifest surface method",
+  subnetSchema.$defs.surface.properties.method.enum,
+  QUERY_ENUMS.surfaceMethod,
+);
 
 if (errors.length > 0) {
   console.error(

--- a/src/integration-snippets.ts
+++ b/src/integration-snippets.ts
@@ -114,6 +114,13 @@ export function generateServiceSnippets(
 ): ServiceSnippets | null {
   const url = service?.base_url;
   if (!isSnippetSafeUrl(url)) return null;
+  // A declared mutation (#11146): "GET the surface URL" stops being a valid
+  // entry point, and a wrong-verb snippet is worse than none. The service row
+  // carries `method` instead, and the agent reaches the surface through
+  // call_subnet_surface with the captured schema.
+  if (typeof service?.method === "string" && service.method !== "GET") {
+    return null;
+  }
   // Prefer the structured auth detail; fall back to the scheme-type guess only
   // when no structured detail is present at all. A structured detail is
   // authoritative — including an explicit scheme:"none" (→ no credential). Auth

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -14312,6 +14312,9 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
           surface_id: s.surface_id,
           kind: s.kind,
           capability: s.capability,
+          // #11146 phase 3: present only on a declared non-GET service row;
+          // absent means GET, so every pre-existing answer is unchanged.
+          ...(s.method ? { method: s.method } : {}),
           base_url: s.base_url,
           callable: rowOf(s.eligibility)?.callable === true,
           auth: {

--- a/tests/integration-snippets.test.ts
+++ b/tests/integration-snippets.test.ts
@@ -100,6 +100,23 @@ describe("generateServiceSnippets (#351)", () => {
       null,
     );
   });
+
+  test("refuses a declared mutation -- no GET snippet for a non-GET service (#11146)", () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      assert.equal(
+        generateServiceSnippets({ base_url: "https://x.io/api", method }),
+        null,
+        method,
+      );
+    }
+    // An explicit GET is the same as absent: snippets as before.
+    const out = generateServiceSnippets({
+      base_url: "https://x.io/api",
+      method: "GET",
+    });
+    assert.ok(out);
+    assert.match(out.curl, /^curl -sS 'https:\/\/x\.io\/api'$/);
+  });
 });
 
 describe("generateServiceSnippets structured auth (#746)", () => {

--- a/tests/mcp-server-branch-coverage.test.ts
+++ b/tests/mcp-server-branch-coverage.test.ts
@@ -1532,6 +1532,37 @@ describe("how_do_i_call — snippets fall through to null", () => {
     const res = await callTool("how_do_i_call", { netuid: 7 }, { deps });
     assert.equal(res.body.result.structuredContent.services[0].snippets, null);
   });
+
+  test("a declared non-GET service carries its method and snippets null (#11146)", async () => {
+    // The mutation arm: `...(s.method ? { method } : {})` true branch, and the
+    // regenerator's non-GET refusal (base_url present, still no snippets).
+    const deps = makeDeps({
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        name: "Data",
+        slug: "sn-7",
+        integration_readiness: 70,
+        services: [
+          {
+            surface_id: "sn-7-register",
+            kind: "subnet-api",
+            capability: "Registration API",
+            method: "POST",
+            base_url: "https://api.sn7.example/register",
+            auth_required: true,
+            auth_schemes: ["bearer"],
+            schema_artifact: null,
+            schema_url: null,
+            eligibility: { callable: true },
+          },
+        ],
+      },
+    });
+    const res = await callTool("how_do_i_call", { netuid: 7 }, { deps });
+    const svc = res.body.result.structuredContent.services[0];
+    assert.equal(svc.method, "POST");
+    assert.equal(svc.snippets, null);
+  });
 });
 
 // ── rankSubnetsForTask keyword docs fallback ───────────────────────────

--- a/tests/subnet-manifest-surface-method.test.ts
+++ b/tests/subnet-manifest-surface-method.test.ts
@@ -1,0 +1,130 @@
+// #11146 phase 3: the surface `method` dimension. The registry can now NAME a
+// declared mutation (POST/PUT/PATCH/DELETE) instead of only representing what
+// the prober can GET.
+//
+// Two contracts under test, and the second is the load-bearing one:
+//   1. absent means GET -- every pre-existing surface validates unchanged, and
+//      a surface may say `method: "GET"` explicitly with a probe.
+//   2. a non-GET surface may NEVER enable a probe. The prober only speaks
+//      GET/HEAD, and probing a mutation with GET would score a route nobody
+//      declared -- so the cross-field rule must REJECT, not merely warn.
+import assert from "node:assert/strict";
+import path from "node:path";
+import { describe, test } from "vitest";
+import { Ajv2020 } from "ajv/dist/2020.js";
+import addFormatsPlugin from "ajv-formats";
+import { readJson, repoRoot } from "../scripts/lib.ts";
+import { QUERY_ENUMS } from "../src/contracts.ts";
+
+const addFormats = addFormatsPlugin as unknown as (instance: Ajv2020) => void;
+const ajv = new Ajv2020({
+  strict: false,
+  validateFormats: true,
+  allErrors: true,
+});
+addFormats(ajv);
+const manifestSchema = await readJson(
+  path.join(repoRoot, "schemas/subnet-manifest.schema.json"),
+);
+const validate = ajv.compile(manifestSchema);
+
+type Json = Record<string, unknown>;
+
+function manifest(surfaceOverrides: Json): Json {
+  return {
+    schema_version: 1,
+    netuid: 105,
+    name: "Beam",
+    slug: "sn-105",
+    status: "active",
+    categories: ["compute"],
+    surfaces: [
+      {
+        id: "sn-105-beam-orchestrator-register",
+        name: "Beam orchestrator registration",
+        kind: "subnet-api",
+        url: "https://beamcore.b1m.ai/orchestrators/register",
+        provider: "beam",
+        auth_required: true,
+        authority: "community",
+        public_safe: true,
+        ...surfaceOverrides,
+      },
+    ],
+  };
+}
+
+function errorsFor(doc: Json): string[] {
+  validate(doc);
+  return (validate.errors || []).map(
+    (error) => `${error.instancePath} ${error.message}`,
+  );
+}
+
+describe("absent means GET", () => {
+  test("a surface with no method still validates (all 3,329 existing rows)", () => {
+    assert.deepEqual(errorsFor(manifest({})), []);
+  });
+
+  test("an explicit GET with an enabled probe validates", () => {
+    assert.deepEqual(
+      errorsFor(
+        manifest({
+          method: "GET",
+          probe: { enabled: true, method: "GET", expect: "json" },
+        }),
+      ),
+      [],
+    );
+  });
+
+  test("the schema's enum is the QUERY_ENUMS vocabulary, by value", () => {
+    // validate:schema-enums pins this in CI; the test pins it in the suite so
+    // a drift fails close to the declaration.
+    const surfaceDef = (manifestSchema.$defs as Json).surface as Json;
+    const methodProp = ((surfaceDef.properties as Json).method as Json)
+      .enum as string[];
+    assert.deepEqual(methodProp, [...QUERY_ENUMS.surfaceMethod]);
+  });
+});
+
+describe("a declared mutation", () => {
+  test("validates with no probe block at all", () => {
+    assert.deepEqual(errorsFor(manifest({ method: "POST" })), []);
+  });
+
+  test("validates with a probe explicitly disabled", () => {
+    assert.deepEqual(
+      errorsFor(
+        manifest({
+          method: "POST",
+          probe: { enabled: false, method: "GET", expect: "json" },
+        }),
+      ),
+      [],
+    );
+  });
+
+  test("is REJECTED with an enabled probe -- the prober never GETs a mutation", () => {
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      const errors = errorsFor(
+        manifest({
+          method,
+          probe: { enabled: true, method: "GET", expect: "json" },
+        }),
+      );
+      assert.ok(
+        errors.some((error) => error.includes("/probe/enabled")),
+        `${method} + enabled probe must fail on probe.enabled, got: ${errors.join("; ")}`,
+      );
+    }
+  });
+
+  test("an out-of-vocabulary method is rejected", () => {
+    const errors = errorsFor(manifest({ method: "OPTIONS" }));
+    assert.ok(
+      errors.some((error) => error.includes("/method")),
+      errors.join("; "),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of #11146: the catalogue can now NAME a declared mutation instead of only representing what the prober can GET.

- `schemas/subnet-manifest.schema.json`: optional `method` on `$defs.surface` (enum GET/POST/PUT/PATCH/DELETE). **Absent means GET** — all 3,329 existing surfaces validate unchanged.
- **Cross-field rule (the load-bearing part):** `method` ∈ {POST, PUT, PATCH, DELETE} ⇒ `probe.enabled` must be `false` (or the probe absent). The prober only speaks GET/HEAD; probing a mutation with GET would publish health for a route nobody declared. Proven to REJECT in `tests/subnet-manifest-surface-method.test.ts`.
- Vocabulary owned by `QUERY_ENUMS.surfaceMethod`; the manifest schema's copy is pinned by `validate:schema-enums`, and the served shapes derive from the same declaration.
- Served passthrough: `SurfaceSchema` (subnet detail, surfaces lists, endpoints-pools by derivation), `AgentCatalogServiceSchema`, and the `how_do_i_call` step (mirror widened: `snippets` nullable — see below) all declare optional `method`.
- `generateServiceSnippets` refuses a non-GET service: a wrong-verb GET snippet is worse than none; the row's `method` + `call_subnet_surface` with the captured schema is the honest path.
- Contract regen committed (openapi.json, types.d.ts, packages/contract, generated/graphql).

No registry data changes here: registering the first real mutation surface (SN105 `POST /orchestrators/register`) follows as its own PR, as does phase 4 (the captured-vs-registered path parity gate).

## Validation

- `npm run typecheck`, `lint`, `format:check`
- `npm run validate` (129 subnets / 3,329 surfaces), `validate:api` (215 routes), `validate:openapi`, `validate:schemas`, `validate:schema-enums`, `validate:schema-vocabularies`, `validate:contract-drift`, `validate:mcp` (240 tools), `validate:module-state-resets`, `validate:unreferenced-exports`
- `npm run test:coverage` unsharded; diff-intersection on changed `src/**` lines: 0 uncovered statements, 0 uncovered branch arms
- Negative fixture proven locally: a POST surface with an enabled probe fails `validate:surface` on `/probe/enabled must be equal to constant`

Part of #11146 (phase 4 follows, so the issue stays open).