### PR TITLE
fix(tools): use the repo's own twox128, and drop the dependency I should not have added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,7 @@
         "typescript-eslint": "^8.65.0",
         "vite": "^7.3.6",
         "vitest": "^4.1.10",
-        "wrangler": "4.118.0",
-        "xxhash-wasm": "^1.1.0"
+        "wrangler": "4.118.0"
       },
       "engines": {
         "node": ">=22.23.1"
@@ -20477,13 +20476,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/xxhash-wasm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
-      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -233,8 +233,7 @@
     "typescript-eslint": "^8.65.0",
     "vite": "^7.3.6",
     "vitest": "^4.1.10",
-    "wrangler": "4.118.0",
-    "xxhash-wasm": "^1.1.0"
+    "wrangler": "4.118.0"
   },
   "overrides": {
     "esbuild": "^0.28.1",

--- a/scripts/measure-lane-populations.ts
+++ b/scripts/measure-lane-populations.ts
@@ -17,20 +17,27 @@
 // minutes per lane, and it would make CI depend on a third party being up. Run
 // it when a coverage alarm fires marginally, or before re-anchoring anything.
 //
-// ## THE SELF-CHECK IS NOT OPTIONAL
+// USES THE REPO'S OWN twox128. src/twox-storage-key.ts already implements
+// XXH64 and both prefix helpers, and its header states the convention plainly:
+// "XXH64 implemented directly rather than adding a new npm dependency". The
+// first cut of this script added `xxhash-wasm` and re-derived the same prefix
+// arithmetic, which was a dependency and a duplicate that both already had an
+// answer in the tree.
 //
-// Substrate's twox128 is xxhash64 with the digest LITTLE-endian, and getting
-// that wrong does not error -- it returns a prefix that matches no keys, so a
-// walk reports ZERO entries and reads exactly like an empty map. That happened
-// twice while writing this: once from big-endian digests, once from passing the
-// block hash into `state_getKeysPaged`'s startKey slot. Both produced confident,
-// wrong answers.
+// ## THE SELF-CHECK IS STILL NOT OPTIONAL
 //
-// So every run first hashes a known value and refuses to continue unless it
-// matches. `twox128("System") = 26aa394eea5630e07c48ae0c9558cef7` is published
-// in the Substrate docs and is not ours to get wrong.
+// Substrate's twox128 wants the digest LITTLE-endian, and getting that wrong
+// does not error -- it returns a prefix matching no keys, so a walk reports
+// ZERO entries and reads exactly like an empty map. That happened twice while
+// doing #11185: once from big-endian digests, once from passing the block hash
+// into `state_getKeysPaged`'s startKey slot. Both gave confident wrong answers.
+//
+// The shared helper is well tested, so this check now guards the WIRING rather
+// than the primitive -- that the prefix reaching the node is the one intended.
+// `twox128("System") = 26aa394eea5630e07c48ae0c9558cef7` is published by
+// Substrate and is not ours to get wrong.
 import { fileURLToPath } from "node:url";
-import xxhash from "xxhash-wasm";
+import { storageMapPrefix, twox128 } from "../src/twox-storage-key.ts";
 import { ACCOUNT_BALANCES_EXPECTED_ACCOUNTS } from "../src/account-balances-staleness-watchdog.ts";
 import { NEURONS_EXPECTED_NETUIDS } from "../src/neurons-staleness-watchdog.ts";
 import { NOMINATOR_POSITIONS_EXPECTED_COLDKEYS } from "../src/nominator-positions-staleness-watchdog.ts";
@@ -42,29 +49,22 @@ const PAGE = 1000;
 /** The published value for `twox128("System")`. */
 const SYSTEM_PREFIX = "26aa394eea5630e07c48ae0c9558cef7";
 
-type Hasher = (input: string) => Buffer;
+const hex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
 
-async function twox128Factory(): Promise<Hasher> {
-  const { h64Raw } = await xxhash();
-  const le = (value: bigint): Buffer => {
-    const b = Buffer.alloc(8);
-    b.writeBigUInt64LE(value);
-    return b;
-  };
-  const twox128: Hasher = (input) =>
-    Buffer.concat([
-      le(h64Raw(Buffer.from(input), 0n)),
-      le(h64Raw(Buffer.from(input), 1n)),
-    ]);
-  const check = twox128("System").toString("hex");
+/** The `0x`-prefixed storage prefix for one pallet item. */
+function prefixOf(pallet: string, item: string): string {
+  return `0x${hex(storageMapPrefix(pallet, item))}`;
+}
+
+function assertTwoxWiring(): void {
+  const check = hex(twox128("System"));
   if (check !== SYSTEM_PREFIX) {
     throw new Error(
       `twox128 self-check failed: got ${check}, expected ${SYSTEM_PREFIX}. ` +
-        `A wrong digest order returns a prefix matching no keys, so every walk ` +
-        `below would report ZERO and read as an empty map rather than as an error.`,
+        `A prefix that is wrong matches no keys, so every walk below would ` +
+        `report ZERO and read as an empty map rather than as an error.`,
     );
   }
-  return twox128;
 }
 
 async function rpc<T>(method: string, params: unknown[]): Promise<T> {
@@ -160,19 +160,14 @@ async function main(): Promise<void> {
   const only = process.argv.slice(2).filter((a) => !a.startsWith("-"));
   const wants = (lane: string) => only.length === 0 || only.includes(lane);
 
-  const twox128 = await twox128Factory();
+  assertTwoxWiring();
   const at = await rpc<string>("chain_getFinalizedHead", []);
   process.stdout.write(`node ${NODE}\nat   ${at}\n\n`);
 
   const rows: Measured[] = [];
 
   if (wants("neurons")) {
-    const key =
-      "0x" +
-      Buffer.concat([
-        twox128("SubtensorModule"),
-        twox128("TotalNetworks"),
-      ]).toString("hex");
+    const key = prefixOf("SubtensorModule", "TotalNetworks");
     const raw = await rpc<string | null>("state_getStorage", [key, at]);
     const total = raw ? Buffer.from(raw.slice(2), "hex").readUInt16LE(0) : 0;
     rows.push({
@@ -186,11 +181,7 @@ async function main(): Promise<void> {
   const needsAlpha =
     wants("validator-nominator-counts") || wants("nominator-positions");
   if (needsAlpha) {
-    const prefix =
-      "0x" +
-      Buffer.concat([twox128("SubtensorModule"), twox128("Alpha")]).toString(
-        "hex",
-      );
+    const prefix = prefixOf("SubtensorModule", "Alpha");
     process.stdout.write("walking SubtensorModule::Alpha ...\n");
     const { keys, finalPage } = await walkKeys(prefix, at, (n) => {
       if (n % 40_000 === 0) process.stdout.write(`  ...${n}\n`);
@@ -232,9 +223,7 @@ async function main(): Promise<void> {
     // out when attempted. So this reports the ceiling and says so rather than
     // printing a number that means something else.
     process.stdout.write("walking System::Account (slow) ...\n");
-    const prefix =
-      "0x" +
-      Buffer.concat([twox128("System"), twox128("Account")]).toString("hex");
+    const prefix = prefixOf("System", "Account");
     const { keys, finalPage } = await walkKeys(prefix, at, (n) => {
       if (n % 100_000 === 0) process.stdout.write(`  ...${n}\n`);
     });


### PR DESCRIPTION
Correcting #11208.

`src/twox-storage-key.ts` already exports `twox128` and `storageMapPrefix`, and its header states the convention outright:

> "XXH64 implemented directly rather than adding a new npm dependency, matching this codebase's existing 'implement the small crypto primitive by hand for Workers' convention"

#11208 added `xxhash-wasm` and re-derived the same prefix arithmetic anyway — **a dependency and a duplicate, both of which already had an answer in the tree.** The module is two directories from the script and I didn't look. #11206 was even filed arguing the dependency was necessary, on a premise I never checked.

## What changes

- `xxhash-wasm` removed from `package.json` and the lockfile
- the script's local `twox128Factory` deleted; it now calls `storageMapPrefix(pallet, item)` from the shared module
- the self-check stays, with its meaning **narrowed honestly**: the shared helper is well tested, so hashing `System` now guards the *wiring* — that the prefix reaching the node is the one intended — rather than the primitive. Still worth running, because a wrong prefix matches no keys and a walk then reports **zero**, which reads exactly like an empty map rather than an error.

Verified against production after the rewrite: `neurons  declared 129  chain 129  +0.0%`.

`tsc`, prettier, eslint clean; the decoder tests still pass.