### PR TITLE
feat(registry): register SN105's orchestrator registration as the first declared mutation

### DIFF
--- a/registry/subnets/beam.json
+++ b/registry/subnets/beam.json
@@ -899,6 +899,27 @@
       "review": {
         "state": "maintainer-reviewed"
       }
+    },
+    {
+      "auth": {
+        "scheme": "custom",
+        "scopes_note": "The credential is the request body itself: registration requires the orchestrator's hotkey plus a wallet signature over the payload (verified against the live OpenAPI schema 2026-08-14). No header/apiKey applies; the spec declares no per-operation security."
+      },
+      "id": "sn-105-beam-orchestrators-register",
+      "name": "Beam POST orchestrators register",
+      "kind": "subnet-api",
+      "method": "POST",
+      "url": "https://beamcore.b1m.ai/orchestrators/register",
+      "provider": "beam",
+      "auth_required": true,
+      "authority": "community",
+      "public_safe": true,
+      "source_urls": ["https://beamcore.b1m.ai/openapi.json"],
+      "review": {
+        "state": "community-submitted",
+        "submitted_by": "jsonbored"
+      },
+      "notes": "Declared mutation (#11146 phase 3): POST /orchestrators/register on beamcore.b1m.ai, the mandatory registration step before an orchestrator can connect (the missing route named by the SN105 field report). Verified against the subnet's live OpenAPI schema 2026-08-14: POST-only, JSON body requiring `hotkey` with a wallet `signature` (the body IS the credential; the spec declares no per-operation security). Never probed -- the manifest schema forbids an enabled probe on a non-GET surface -- so it carries no probe-derived health; reach it through call_subnet_surface's schema-gated execution."
     }
   ],
   "website_url": "https://b1m.ai/"


### PR DESCRIPTION
## Summary

The first real user of #11146 phase 3's `method` dimension (shipped in #11210): SN105 Beam's `POST /orchestrators/register` — the **mandatory** registration step before an orchestrator can connect, and the exact missing route named by the SN105 field report that raised the epic. Its absence sends operators to debug ports instead of the documented front door.

One surface appended to `registry/subnets/beam.json` (now 36 surfaces), nothing else:
- `method: "POST"`, **no probe block** — the manifest schema forbids an enabled probe on a non-GET surface, so it carries no probe-derived health and the prober never touches it.
- `auth`: `scheme: "custom"` — the credential is the request body itself (hotkey + wallet signature over the payload); no header/apiKey applies and the spec declares no per-operation security.
- Discovery now names it (catalog row carries `method`, snippets correctly null); execution reaches it through `call_subnet_surface`'s schema-gated Phase 2 against the captured Beam schema.

## Verification

- Route re-verified against the live spec today: `GET https://beamcore.b1m.ai/openapi.json` declares `POST /orchestrators/register` (JSON body, `hotkey` required, `additionalProperties: false`). No test POST was made — it is a mutation.
- `npm run validate:surface -- registry/subnets/beam.json` (36 surfaces), `npm run scan:public-safety`, `npm run build` + `npm run validate` (129 subnets / 3,330 surfaces) all green; derived artifacts reproduced with no committed-artifact drift.

Part of #11146 (phase 4, the parity gate, remains).