### PR TITLE
feat(ui): mcp setup docs, nav item and hero install one-liner

### DIFF
--- a/apps/ui/content/docs/index.mdx
+++ b/apps/ui/content/docs/index.mdx
@@ -78,6 +78,11 @@ public REST API surface by domain, with a full auto-generated reference for ever
     href="/docs/graphql"
   />
   <Card
+    title="MCP"
+    description="Bittensor in a box — the registry as Model Context Protocol tools, with per-client setup for Claude Code, Cursor, VS Code, and any streamable-HTTP client."
+    href="/docs/mcp"
+  />
+  <Card
     title="Webhooks"
     description="Subscribe to the registry's publish change feed with HMAC-signed, at-least-once delivery."
     href="/docs/webhooks"

--- a/apps/ui/content/docs/mcp.mdx
+++ b/apps/ui/content/docs/mcp.mdx
@@ -1,0 +1,101 @@
+---
+title: MCP
+description: Bittensor in a box — the whole registry as Model Context Protocol tools over one streamable-HTTP endpoint, with a curated 23-tool core profile for context-limited agents. No API key required.
+---
+
+Point any MCP client at the registry and it gets metagraphed as callable tools: subnet discovery and comparison, per-subnet health and economics, OpenAPI schemas for every registered subnet API (callable through the registry itself), chain blocks/extrinsics/events, account lookup, and grounded question-answering — the same data every REST route serves, shaped for agents. Bittensor in a box: one connect, no key, no account, no local install.
+
+```
+https://api.metagraph.sh/mcp        streamable HTTP — full catalog, 240 tools
+https://api.metagraph.sh/mcp/core   streamable HTTP — core profile, 23 tools
+```
+
+## Which endpoint
+
+**Default to `/mcp/core`.** The full `/mcp` tool list serializes to ~406K tokens of tool schemas — more than most model context windows — and a client that holds tool definitions in context pays that on every session. `/mcp/core` lists the curated golden path (discover → verify → integrate → call → screen economically) at ~43K tokens.
+
+|                      | `/mcp`                                        | `/mcp/core`                            |
+| -------------------- | --------------------------------------------- | -------------------------------------- |
+| Tools listed         | 240                                           | 23 (the curated golden path)           |
+| `tools/list` context | ~406K tokens                                  | ~43K tokens                            |
+| Tools callable       | all 240                                       | all 240 — listing filters, calls don't |
+| Pick it when         | context is cheap (subagents, offline tooling) | context is model context — most agents |
+
+<Callout title="A context diet, not an authorization boundary">
+  A session connected to `/mcp/core` can still `tools/call` every one of the 240 tools. When a thin
+  session needs more, `get_more_tools` pages additional tool definitions in on demand, and `ask`
+  answers whole questions without any further tools at all — a core session is never stranded.
+</Callout>
+
+## Authentication
+
+Optional. Anonymous access works on both endpoints at 100 requests/60s per client IP. Clients that support MCP authorization prompt an OAuth sign-in (GitHub) on first connect; an `Authorization: Bearer mg_…` [API key](/settings) header works too. Authenticating raises rate limits (500 requests/60s per account, higher on paid tiers) — it does not unlock additional tools or surfaces.
+
+## Connect a client
+
+### Claude Code
+
+One CLI command, no config file to hand-edit:
+
+```bash
+claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core
+```
+
+### Claude Desktop & claude.ai
+
+Both take the endpoint as a custom connector: **Settings → Connectors → Add custom connector**, then paste `https://api.metagraph.sh/mcp/core`. Claude Desktop also accepts a config-file entry:
+
+```json title="claude_desktop_config.json"
+{
+  "mcpServers": {
+    "metagraphed": {
+      "transport": { "type": "http", "url": "https://api.metagraph.sh/mcp/core" }
+    }
+  }
+}
+```
+
+### Cursor
+
+```json title=".cursor/mcp.json"
+{
+  "mcpServers": {
+    "metagraphed": { "url": "https://api.metagraph.sh/mcp/core" }
+  }
+}
+```
+
+### VS Code
+
+```json title=".vscode/mcp.json"
+{
+  "servers": {
+    "metagraphed": { "type": "http", "url": "https://api.metagraph.sh/mcp/core" }
+  }
+}
+```
+
+### Any other client
+
+Any client that speaks streamable-HTTP MCP connects directly — no install, no key:
+
+```json title="Generic streamable-HTTP entry"
+{
+  "type": "streamable-http",
+  "url": "https://api.metagraph.sh/mcp/core"
+}
+```
+
+## First calls to try
+
+All three are in the core profile:
+
+| Tool                  | Try                                                      | What it shows                                                                    |
+| --------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `search_subnets`      | `{"query": "inference"}`                                 | Keyword discovery across every subnet's curated profile.                         |
+| `ask`                 | `{"question": "which subnets expose an inference API?"}` | A grounded natural-language answer with citations — the whole-question shortcut. |
+| `call_subnet_surface` | a surface id from `list_subnet_apis`                     | Calling a subnet's own registered API through the registry, schema-checked.      |
+
+Every tool mirrors a documented REST route — the [API reference](/docs/api-reference) covers the request/response shapes behind them, and [For agents](/agents) has the rest of the machine surface: playbooks, `llms.txt`, the served skill, and prompt-ready links.
+
+<ApiSourceFooter paths={["/mcp", "/mcp/core"]} />

--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -533,6 +533,7 @@ function SiteFooter() {
           <FooterLink to="/docs/search-ai">Search & AI</FooterLink>
           <FooterLink to="/docs/feeds">Feeds</FooterLink>
           <FooterLink to="/docs/graphql">GraphQL</FooterLink>
+          <FooterLink to="/docs/mcp">MCP</FooterLink>
           <FooterLink to="/docs/rpc">RPC</FooterLink>
         </FooterCol>
       </div>

--- a/apps/ui/src/components/metagraphed/command-palette-body.tsx
+++ b/apps/ui/src/components/metagraphed/command-palette-body.tsx
@@ -31,6 +31,7 @@ import {
   Layers,
   Loader2,
   Network,
+  Plug,
   RotateCcw,
   Rss,
   Search,
@@ -105,6 +106,7 @@ interface RouteEntry {
 // docsRoutes below), it just renders with the default icon.
 const DOCS_ICON_OVERRIDES: Record<string, typeof Compass> = {
   "/docs/graphql": Braces,
+  "/docs/mcp": Plug,
   "/docs/rpc": Zap,
   "/docs/feeds": Rss,
   "/docs/chain-events": History,

--- a/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu-content.tsx
@@ -1,6 +1,6 @@
 import { Link, useRouterState } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUpRight, Boxes, RefreshCw, Search } from "lucide-react";
+import { ArrowUpRight, Boxes, Plug, RefreshCw, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { classNames } from "@/lib/metagraphed/format";
@@ -575,6 +575,26 @@ export function MobileMegaMenuBody({ onNavigate }: { onNavigate?: () => void }) 
           );
         })}
       </Accordion>
+      {/* MCP mirrors the desktop nav's plain top-level link — one setup page,
+          nothing to accordion. Styled like an accordion trigger row so it
+          reads as a sibling of the five panels above. */}
+      <Link
+        to="/docs/$"
+        params={{ _splat: "mcp" }}
+        onClick={onNavigate}
+        className="flex items-center gap-2 px-2 py-2.5 text-sm"
+        preload="intent"
+      >
+        <Plug
+          className={classNames(
+            "size-3.5",
+            pathname === "/docs/mcp" ? "text-accent" : "text-ink-muted",
+          )}
+        />
+        <span className={pathname === "/docs/mcp" ? "text-ink-strong font-medium" : "text-ink"}>
+          MCP
+        </span>
+      </Link>
     </div>
   );
 }

--- a/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
+++ b/apps/ui/src/components/metagraphed/nav-mega-menu.tsx
@@ -1,4 +1,5 @@
 import { Link, useRouterState } from "@tanstack/react-router";
+import { Plug } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { lazy, Suspense } from "react";
 import {
@@ -276,6 +277,41 @@ export function NavMegaMenu({ onNavigate }: NavMegaMenuProps) {
           </div>
         );
       })}
+      {/* MCP is a plain top-level link, not a panel — one setup page, nothing
+          to browse. Hover-intent closes any open panel so moving from a panel
+          trigger onto this link doesn't strand the panel open behind it. */}
+      <div onMouseEnter={scheduleClose}>
+        <Link
+          to="/docs/$"
+          params={{ _splat: "mcp" }}
+          aria-current={pathname === "/docs/mcp" ? "page" : undefined}
+          className={classNames(
+            "relative inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 h-9 text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40",
+            pathname === "/docs/mcp"
+              ? "text-ink-strong font-medium"
+              : "text-ink-muted hover:text-ink-strong",
+          )}
+          onClick={() => {
+            setOpenKey(null);
+            onNavigate?.();
+          }}
+          preload="intent"
+        >
+          <Plug
+            className={classNames(
+              "size-3.5",
+              pathname === "/docs/mcp" ? "text-accent" : "opacity-70",
+            )}
+          />
+          <span>MCP</span>
+          {pathname === "/docs/mcp" ? (
+            <span
+              aria-hidden
+              className="pointer-events-none absolute left-3 right-3 -bottom-1 h-[1.5px] rounded-full bg-accent mg-fade-in"
+            />
+          ) : null}
+        </Link>
+      </div>
       {activePanel ? (
         <>
           <div aria-hidden className="mg-mega-scrim" onClick={() => setOpenKey(null)} />

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -396,6 +396,14 @@ function openCommandPalette() {
   );
 }
 
+// The hero's MCP connect one-liner. Static rather than agentResourcesQuery()'s
+// `mcp.install` (which HomeForAgentsModule below renders) on purpose: the hero
+// renders pre-hydration with no query dependency, and this recommends
+// /mcp/core — the 23-tool context-diet profile (#11164) — where `mcp.install`
+// teaches the full 240-tool /mcp catalog. Per-client setup lives at /docs/mcp.
+const MCP_CORE_INSTALL =
+  "claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core";
+
 function HomeHero() {
   const hydrated = useHydrated();
   const { data: subnetsData } = useQuery({
@@ -484,6 +492,16 @@ function HomeHero() {
           >
             Read the API
           </Link>
+        </div>
+        {/* inline-flex, not flex: this is a control shell (a copyable command
+            row), not a content panel — same distinction the card-shell lint
+            rule draws for segmented controls. */}
+        <div className="mg-fade-in mg-fade-in-delay-3 mt-6 inline-flex w-full max-w-xl items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+          <Terminal className="size-3.5 shrink-0 text-accent" aria-hidden />
+          <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-left font-mono mg-type-caption-lg text-ink-muted">
+            {MCP_CORE_INSTALL}
+          </code>
+          <CopyButton value={MCP_CORE_INSTALL} label="MCP install command" />
         </div>
         <ChainHeadTip />
       </div>


### PR DESCRIPTION
## Summary

The MCP promotion pair: now that /mcp/core exists (#11164, closed — this is the docs/nav/hero promotion for what shipped there), the site actually tells people how to connect.

- **`content/docs/mcp.mdx`** — client-by-client MCP setup page: what the server is (Bittensor in a box), /mcp vs /mcp/core with /mcp/core recommended as the default for context-limited agents (23 tools, ~43K vs ~406K tokens; a context diet, not an authorization boundary — `get_more_tools` pages the rest in), auth (anonymous works at 100 req/60s, OAuth on first connect, `mg_` API keys), copy-paste config for Claude Code, Claude Desktop / claude.ai custom connectors, Cursor, VS Code, and a generic streamable-HTTP block, then first calls to try (`search_subnets`, `ask`, `call_subnet_surface`) with links to the API reference and /agents. Registers itself automatically: the ⌘K palette and Fumadocs sidebar derive from docsSource (docs-nav.functions.ts), so wiring is the same as graphql.mdx — a palette icon override, a footer link, and a docs-index card.
- **Header nav** — a plain top-level "MCP" link (→ /docs/mcp) after the five mega-panels in NavMegaMenu, matching the panel triggers' style, plus the mirrored row in the mobile sheet.
- **Hero** — a slim copy-pasteable `claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp/core` row between the CTA buttons and the chain-head tip. Static on purpose: the hero renders pre-hydration with no query dependency, and it recommends /mcp/core where the API-served `mcp.install` (rendered by the For-agents module below) teaches the full catalog.

Scoped to `apps/ui/**` only. Visual change — expected to be held for manual review.

## Validation

- `npm run lint --workspace apps/ui` — 0 errors (9 pre-existing react-refresh warnings in untouched files)
- `npm run format:check --workspace apps/ui` — clean
- `npm run typecheck --workspace apps/ui` — clean (workspace packages built first)
- `npm run test --workspace apps/ui` — 254 files, 2097 tests, all passing
- `npm run build:worker --workspace apps/ui` — builds clean
- `cd apps/ui && npx prettier --write content/docs/mcp.mdx` — formatted with the workspace's own prettier config
- Rebased onto current main (c77afdcb4) before push; new main commits touch no `apps/ui` path