### PR TITLE
fix(chain): parse the JSON-RPC envelope instead of casting it, in one place

### DIFF
--- a/schemas-src/chain-rpc-envelope.ts
+++ b/schemas-src/chain-rpc-envelope.ts
@@ -1,0 +1,42 @@
+// A Substrate node's JSON-RPC response envelope (#11194).
+//
+// LIVES HERE for the reason r2-sql-envelope.ts states: a schema outside
+// schemas-src is outside `no-passthrough`, `schema-shape-duplicates` and
+// `schema-opacity`, which is exactly where an unreasoned open object survives.
+// The first cut of this put it in `src/` beside its client and would have
+// escaped all three.
+import { z } from "zod";
+
+/**
+ * The JSON-RPC 2.0 envelope, PARSED rather than asserted.
+ *
+ * Every caller used to CAST this. `interface RpcResponse { result?: unknown;
+ * error?: { message?: string } }` was declared twice byte-identically, in
+ * head-poller.ts and raw-chain-capture.ts, with three more inline casts of the
+ * same shape elsewhere -- a shape this repo declared about somebody else's API
+ * and then never checked.
+ *
+ * A cast is not a check, and this is the most untrusted input the repo takes:
+ * a public archive nobody here operates, over a protocol where the result and
+ * the error share one envelope. A proxy answering 200 with an HTML error page
+ * satisfies the cast and reaches the caller as `undefined` fields.
+ *
+ * A PLAIN object, the same call r2-sql-envelope.ts makes. Zod strips unknown
+ * keys by default, so a node returning `jsonrpc` and `id` is accepted and those
+ * members are simply not carried forward -- the protocol working, not a fault
+ * here. `.passthrough()` was the first cut and `no-passthrough` rejected it,
+ * correctly: nothing reads those fields, so declaring the object open would
+ * have been openness without a reason.
+ *
+ * What it pins is that an OBJECT arrived carrying at most these two members, so
+ * a body that cannot answer them is a classified failure rather than a silent
+ * `undefined`.
+ *
+ * `error` is `unknown` rather than `{ message?: string }` because it is
+ * implementation-defined -- safe-mode-watchdog was already stringifying the
+ * whole thing precisely because the `.message` shape cannot be relied on.
+ */
+export const ChainRpcEnvelopeSchema = z.object({
+  result: z.unknown().optional(),
+  error: z.unknown().optional(),
+});

--- a/src/chain-rpc.ts
+++ b/src/chain-rpc.ts
@@ -1,0 +1,111 @@
+// One validated JSON-RPC call against a Substrate node (#11194).
+//
+// A chain RPC response is the most untrusted input this repo takes: it arrives
+// from a public archive nobody here operates, over a protocol where the error
+// and the result share one envelope. Every caller was CASTING it:
+//
+//   const body = (await res.json()) as RpcResponse;
+//
+// `interface RpcResponse { result?: unknown; error?: { message?: string } }`
+// was declared twice, byte-identical, in head-poller.ts and raw-chain-capture.ts,
+// and three more call sites cast the same shape inline. A cast at this boundary
+// is a promise the runtime never checks: a proxy returning an HTML error page
+// with a 200, or a node answering `{"result": null}` where a block was expected,
+// both satisfy the type and fail somewhere downstream instead.
+//
+// PARSED, not cast, and this is exactly where the #11189 line falls: Zod belongs
+// at boundaries where data arrives from outside the process, and NOT over
+// constants the compiler already owns. This is the former. The SCHEMA lives in
+// schemas-src/chain-rpc-envelope.ts so the schema gates cover it; only the call
+// lives here.
+//
+// ## WHAT IT DELIBERATELY DOES NOT DO
+//
+// It does not type `result`. The shape of a result depends on the method, and a
+// schema per method would be a second copy of the chain's own types -- which is
+// the drift #11207 catalogues. Callers decode their own result; what this
+// guarantees is that an ENVELOPE arrived at all, and that an `error` member is
+// raised as one rather than read past.
+import { ChainRpcEnvelopeSchema } from "../schemas-src/chain-rpc-envelope.ts";
+
+/**
+ * An RPC error rendered for a human, preferring `.message` when the node sent
+ * one.
+ *
+ * Both formats were in use -- `body.error.message` in head-poller and
+ * raw-chain-capture, `JSON.stringify(body.error)` in safe-mode-watchdog -- and
+ * neither is right alone: `.message` on a shapeless error yields `undefined`,
+ * and stringifying a well-formed one buries the message in braces. Preferring
+ * the message and falling back to JSON is strictly better than either and
+ * changes no existing message that was already useful.
+ */
+export function describeRpcError(error: unknown): string {
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof (error as { message?: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+  return JSON.stringify(error);
+}
+
+export interface ChainRpcOptions {
+  /** Injected for tests and for callers that wrap fetch. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Abort after this long.
+   *
+   * Optional because two of the three callers had no timeout at all and adding
+   * one would change their failure mode from "hangs until the platform kills
+   * it" to "throws" -- a better behaviour, but not one to introduce silently in
+   * the same change that consolidates them. safe-mode-watchdog passes its 20s.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Call `method` and return the raw `result`, or throw.
+ *
+ * Throws on a non-2xx, on a body that is not a JSON-RPC envelope, and on an
+ * envelope carrying `error`. Every message is prefixed with the method, because
+ * these run inside lanes that call several in sequence and "HTTP 500" alone
+ * does not say which read failed.
+ */
+export async function chainRpc(
+  url: string,
+  method: string,
+  params: unknown[],
+  options: ChainRpcOptions = {},
+): Promise<unknown> {
+  const doFetch = options.fetchImpl ?? fetch;
+  const res = await doFetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    ...(options.timeoutMs === undefined
+      ? {}
+      : { signal: AbortSignal.timeout(options.timeoutMs) }),
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  });
+  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
+
+  // safeParse over a cast: a proxy or captive portal answering 200 with HTML is
+  // the case a cast cannot see, and it reaches here as a JSON parse failure or
+  // as a non-object. Either way the caller learns the transport lied rather
+  // than reading `undefined` off a string.
+  let parsedBody: unknown;
+  try {
+    parsedBody = await res.json();
+  } catch (cause) {
+    throw new Error(`${method}: response body was not JSON`, { cause });
+  }
+  const envelope = ChainRpcEnvelopeSchema.safeParse(parsedBody);
+  if (!envelope.success) {
+    throw new Error(`${method}: response was not a JSON-RPC envelope`);
+  }
+  if (envelope.data.error !== undefined) {
+    throw new Error(`${method}: ${describeRpcError(envelope.data.error)}`);
+  }
+  return envelope.data.result;
+}

--- a/src/head-poller.ts
+++ b/src/head-poller.ts
@@ -24,28 +24,24 @@ import type { HeadBlock } from "../schemas-src/head-poller-wire.ts";
 export { HeadBlockSchema };
 export type { HeadBlock } from "../schemas-src/head-poller-wire.ts";
 import { bytesToHex, storageMapPrefix } from "./twox-storage-key.ts";
+import { chainRpc } from "./chain-rpc.ts";
 import { DEFAULT_SS58_PREFIX, encodeAccountId32 } from "./ss58.ts";
 
-interface RpcResponse {
-  result?: unknown;
-  error?: { message?: string };
-}
-
+/**
+ * The shared, VALIDATED client (#11194).
+ *
+ * This file used to carry its own copy of the envelope type and the call. Both
+ * were byte-identical to raw-chain-capture.ts's, and both CAST the response
+ * rather than parsing it -- see src/chain-rpc.ts for why that matters at a
+ * boundary served by a public archive nobody here operates.
+ */
 async function rpc(
   url: string,
   method: string,
   params: unknown[],
   fetchImpl: typeof fetch,
 ): Promise<unknown> {
-  const res = await fetchImpl(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-  });
-  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
-  const body = (await res.json()) as RpcResponse;
-  if (body.error) throw new Error(`${method}: ${body.error.message}`);
-  return body.result;
+  return chainRpc(url, method, params, { fetchImpl });
 }
 
 export function hexToNumber(hex: unknown): number {

--- a/src/raw-chain-capture.ts
+++ b/src/raw-chain-capture.ts
@@ -31,6 +31,7 @@
 // apart from the injected fetch and store, so the whole guarantee is testable
 // without a chain or a bucket.
 
+import { chainRpc } from "./chain-rpc.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 
 /** twox128("System") ++ twox128("Events") — the runtime storage key holding
@@ -56,26 +57,21 @@ export interface RawBlockCapture {
   captured_at: number;
 }
 
-interface RpcResponse {
-  result?: unknown;
-  error?: { message?: string };
-}
-
+/**
+ * The shared, VALIDATED client (#11194).
+ *
+ * This file used to carry its own copy of the envelope type and the call. Both
+ * were byte-identical to raw-chain-capture.ts's, and both CAST the response
+ * rather than parsing it -- see src/chain-rpc.ts for why that matters at a
+ * boundary served by a public archive nobody here operates.
+ */
 async function rpc(
   url: string,
   method: string,
   params: unknown[],
   fetchImpl: typeof fetch,
 ): Promise<unknown> {
-  const res = await fetchImpl(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-  });
-  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
-  const body = (await res.json()) as RpcResponse;
-  if (body.error) throw new Error(`${method}: ${body.error.message}`);
-  return body.result;
+  return chainRpc(url, method, params, { fetchImpl });
 }
 
 /**

--- a/src/safe-mode-watchdog.ts
+++ b/src/safe-mode-watchdog.ts
@@ -60,6 +60,7 @@
 //     the two halves now fail independently: history that cannot be read is
 //     reported as UNREAD (never as "no SafeMode activity"), and the pause
 //     verdict is still computed and still alerts.
+import { chainRpc } from "./chain-rpc.ts";
 import { bytesToHex, storageMapPrefix } from "../src/twox-storage-key.ts";
 import { loadExtrinsicFeedColdTier } from "./extrinsics-cold-tier.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
@@ -159,22 +160,20 @@ export function evaluateSafeMode({
 
 type Fetcher = typeof fetch;
 
+/** Its own timeout is the one thing this lane did differently, so it is the one
+ * thing passed through: everything else came from the shared client (#11194). */
+const RPC_TIMEOUT_MS = 20_000;
+
 async function rpc(
   url: string,
   method: string,
   params: unknown[],
   doFetch: Fetcher,
 ): Promise<unknown> {
-  const res = await doFetch(url, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    signal: AbortSignal.timeout(20_000),
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+  return chainRpc(url, method, params, {
+    fetchImpl: doFetch as typeof fetch,
+    timeoutMs: RPC_TIMEOUT_MS,
   });
-  if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
-  const body = (await res.json()) as { result?: unknown; error?: unknown };
-  if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
-  return body.result;
 }
 
 /** Reads the SafeMode extrinsic history, or null when the tier declined. */


### PR DESCRIPTION
Part of #11194 — the upstream-HTTP boundary, which is where that audit's real surface turned out to be.

## Where #11194 actually stands

Two of its four boundaries were **already closed**, and finding that out was half the work:

- **Lakehouse reads** — `catalogRowSchema` applies a Zod schema by default from `LAKEHOUSE_ROW_SCHEMAS` (40 tables), and `validate:lakehouse-readers` gates that every table read in SQL is snapshotted. The "only 4 of 79 calls pass a `rowSchema`" figure was misleading; the default covers them.
- **Store reads** — 4 casts left, and the coverage rules were fixed in #11198.

The open one was upstream HTTP: **17 `.json()` results cast vs 3 parsed**.

## The biggest cluster

`interface RpcResponse { result?: unknown; error?: { message?: string } }` declared **twice byte-identically** (`head-poller`, `raw-chain-capture`), three more inline casts of the same shape, and **four separate local `rpc()` helpers**.

A chain RPC response is the most untrusted input the repo takes — a public archive nobody here operates, over a protocol where result and error share one envelope. A cast is not a check: a proxy answering 200 with an HTML error page satisfies it and arrives as `undefined` fields.

## Compared before consolidating

The `toInt` lesson (#11207): identical-looking helpers often aren't. `head-poller` and `raw-chain-capture` were byte-identical. `safe-mode-watchdog` differed **deliberately** — a 20s `AbortSignal.timeout`, and `JSON.stringify(body.error)` where the others used `body.error.message`.

Both preserved. The timeout is a per-caller option, **defaulted off** because two callers had none and introducing one silently is a behaviour change in the same commit that consolidates them. `describeRpcError` prefers `.message` and falls back to JSON — strictly better than either, since `.message` on a shapeless error yields `"undefined"` and stringifying a well-formed one buries the message in braces.

## The schema lives in schemas-src, and the gates immediately earned it

My first cut put it in `src/` beside the client. That's outside `no-passthrough`, `schema-shape-duplicates` and `schema-opacity` — and `r2-sql-envelope.ts`'s header says exactly that, having been moved for the same reason.

Moved, and **`no-passthrough` rejected it within a minute**: `.passthrough()` is openness without a reason when nothing reads the extra fields. A plain `z.object` strips `jsonrpc` and `id` instead, which is the protocol working. A gate catching a real mistake as soon as the schema was in the right place.

85 tests pass across the three rewired modules; every schema gate green; unreferenced-exports holds at 731.