### PR TITLE
feat(registry): the schema-parity ledger, per subnet (#11146 phase 4)

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -4440,6 +4440,35 @@ type GapsArtifactGaps {
   gaps: Gaps!
   gap_severity: String
   gap_priority: Int
+  schema_parity: GapsArtifactGapsSchemaParity
+}
+
+type GapsArtifactGapsSchemaParity {
+  """Captured machine-readable specs backing this measurement."""
+  captured_schema_count: Int!
+
+  """
+  Paths the subnet's captured spec(s) declare, summed across captured specs.
+  """
+  captured_path_count: Int!
+
+  """
+  Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero.
+  """
+  declared_non_get_count: Int
+
+  """
+  Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route).
+  """
+  registered_route_surface_count: Int!
+
+  """Registered surfaces declaring a non-GET method (#11146 phase 3)."""
+  registered_non_get_count: Int!
+
+  """
+  True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing.
+  """
+  flagged: Boolean!
 }
 
 type EvidenceList {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2745,7 +2745,24 @@ export type GapsArtifactGaps = {
   gaps: Gaps;
   name: Scalars['String']['output'];
   netuid: Scalars['Int']['output'];
+  schema_parity?: Maybe<GapsArtifactGapsSchemaParity>;
   slug: Scalars['String']['output'];
+};
+
+export type GapsArtifactGapsSchemaParity = {
+  __typename?: 'GapsArtifactGapsSchemaParity';
+  /** Paths the subnet's captured spec(s) declare, summed across captured specs. */
+  captured_path_count: Scalars['Int']['output'];
+  /** Captured machine-readable specs backing this measurement. */
+  captured_schema_count: Scalars['Int']['output'];
+  /** Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero. */
+  declared_non_get_count?: Maybe<Scalars['Int']['output']>;
+  /** True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing. */
+  flagged: Scalars['Boolean']['output'];
+  /** Registered surfaces declaring a non-GET method (#11146 phase 3). */
+  registered_non_get_count: Scalars['Int']['output'];
+  /** Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route). */
+  registered_route_surface_count: Scalars['Int']['output'];
 };
 
 /** Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps). */
@@ -8592,6 +8609,7 @@ export type ResolversTypes = ResolversObject<{
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   Gaps: ResolverTypeWrapper<Gaps>;
   GapsArtifactGaps: ResolverTypeWrapper<GapsArtifactGaps>;
+  GapsArtifactGapsSchemaParity: ResolverTypeWrapper<GapsArtifactGapsSchemaParity>;
   GapsList: ResolverTypeWrapper<GapsList>;
   GlobalHealth: ResolverTypeWrapper<GlobalHealth>;
   GlobalIncidentSurface: ResolverTypeWrapper<GlobalIncidentSurface>;
@@ -9061,6 +9079,7 @@ export type ResolversParentTypes = ResolversObject<{
   Float: Scalars['Float']['output'];
   Gaps: Gaps;
   GapsArtifactGaps: GapsArtifactGaps;
+  GapsArtifactGapsSchemaParity: GapsArtifactGapsSchemaParity;
   GapsList: GapsList;
   GlobalHealth: GlobalHealth;
   GlobalIncidentSurface: GlobalIncidentSurface;
@@ -11475,7 +11494,17 @@ export type GapsArtifactGapsResolvers<ContextType = GqlContext, ParentType exten
   gaps?: Resolver<ResolversTypes['Gaps'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  schema_parity?: Resolver<Maybe<ResolversTypes['GapsArtifactGapsSchemaParity']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type GapsArtifactGapsSchemaParityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GapsArtifactGapsSchemaParity'] = ResolversParentTypes['GapsArtifactGapsSchemaParity']> = ResolversObject<{
+  captured_path_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  captured_schema_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  declared_non_get_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  flagged?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  registered_non_get_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  registered_route_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type GapsListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GapsList'] = ResolversParentTypes['GapsList']> = ResolversObject<{
@@ -14748,6 +14777,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   FailureReasonsDay?: FailureReasonsDayResolvers<ContextType>;
   Gaps?: GapsResolvers<ContextType>;
   GapsArtifactGaps?: GapsArtifactGapsResolvers<ContextType>;
+  GapsArtifactGapsSchemaParity?: GapsArtifactGapsSchemaParityResolvers<ContextType>;
   GapsList?: GapsListResolvers<ContextType>;
   GlobalHealth?: GlobalHealthResolvers<ContextType>;
   GlobalIncidentSurface?: GlobalIncidentSurfaceResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8636,6 +8636,20 @@ export interface components {
                 gaps: components["schemas"]["Gaps"];
                 name: string;
                 netuid: number;
+                schema_parity?: {
+                    /** @description Paths the subnet's captured spec(s) declare, summed across captured specs. */
+                    captured_path_count: number;
+                    /** @description Captured machine-readable specs backing this measurement. */
+                    captured_schema_count: number;
+                    /** @description Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero. */
+                    declared_non_get_count: number | null;
+                    /** @description True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing. */
+                    flagged: boolean;
+                    /** @description Registered surfaces declaring a non-GET method (#11146 phase 3). */
+                    registered_non_get_count: number;
+                    /** @description Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route). */
+                    registered_route_surface_count: number;
+                };
                 slug: string;
             }[];
             generated_at: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -34250,6 +34250,61 @@
                   "minimum": 0,
                   "type": "integer"
                 },
+                "schema_parity": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "captured_path_count": {
+                      "description": "Paths the subnet's captured spec(s) declare, summed across captured specs.",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "captured_schema_count": {
+                      "description": "Captured machine-readable specs backing this measurement.",
+                      "maximum": 9007199254740991,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "declared_non_get_count": {
+                      "anyOf": [
+                        {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero."
+                    },
+                    "flagged": {
+                      "description": "True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing.",
+                      "type": "boolean"
+                    },
+                    "registered_non_get_count": {
+                      "description": "Registered surfaces declaring a non-GET method (#11146 phase 3).",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "registered_route_surface_count": {
+                      "description": "Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route).",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "captured_schema_count",
+                    "captured_path_count",
+                    "declared_non_get_count",
+                    "registered_route_surface_count",
+                    "registered_non_get_count",
+                    "flagged"
+                  ],
+                  "type": "object"
+                },
                 "slug": {
                   "type": "string"
                 }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8636,6 +8636,20 @@ export interface components {
                 gaps: components["schemas"]["Gaps"];
                 name: string;
                 netuid: number;
+                schema_parity?: {
+                    /** @description Paths the subnet's captured spec(s) declare, summed across captured specs. */
+                    captured_path_count: number;
+                    /** @description Captured machine-readable specs backing this measurement. */
+                    captured_schema_count: number;
+                    /** @description Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero. */
+                    declared_non_get_count: number | null;
+                    /** @description True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing. */
+                    flagged: boolean;
+                    /** @description Registered surfaces declaring a non-GET method (#11146 phase 3). */
+                    registered_non_get_count: number;
+                    /** @description Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route). */
+                    registered_route_surface_count: number;
+                };
                 slug: string;
             }[];
             generated_at: string;

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -47,6 +47,38 @@ export type CurationArtifact = z.infer<typeof CurationArtifactSchema>;
 
 export const GAPS_SORT_FIELDS = API_QUERY_COLLECTIONS.gaps.sort_fields;
 
+/** #11146 phase 4: captured spec vs registered catalogue, per subnet. Present
+ * only when the subnet has captured schema-index entries with stamped counts
+ * -- absence means "not measured", never "in parity". */
+export const SchemaParitySchema = z
+  .object({
+    captured_schema_count: z.int().min(1).meta({
+      description: "Captured machine-readable specs backing this measurement.",
+    }),
+    captured_path_count: z.int().min(0).meta({
+      description:
+        "Paths the subnet's captured spec(s) declare, summed across captured specs.",
+    }),
+    declared_non_get_count: z.int().min(0).nullable().meta({
+      description:
+        "Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero.",
+    }),
+    registered_route_surface_count: z.int().min(0).meta({
+      description:
+        "Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route).",
+    }),
+    registered_non_get_count: z.int().min(0).meta({
+      description:
+        "Registered surfaces declaring a non-GET method (#11146 phase 3).",
+    }),
+    flagged: z.boolean().meta({
+      description:
+        "True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing.",
+    }),
+  })
+  .strict();
+export type SchemaParity = z.infer<typeof SchemaParitySchema>;
+
 export const GapsEntrySchema = z
   .object({
     netuid: z.int().min(0),
@@ -61,6 +93,7 @@ export const GapsEntrySchema = z
     gaps: GapsSchema,
     gap_severity: z.enum(ENDPOINT_INCIDENT_SEVERITY_VALUES).optional(),
     gap_priority: z.int().min(0).optional(),
+    schema_parity: SchemaParitySchema.optional(),
   })
   .strict();
 

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -1121,8 +1121,75 @@ const curationIndex = mergedSubnets.map((subnet) => ({
   surface_count: subnet.surface_count,
 }));
 
+// #11146 phase 4: per-subnet schema parity -- captured spec vs registered
+// catalogue, the check the SN105 report asked for. Derived from schema INDEX
+// entries only, never the captured documents: documents exist solely in
+// credentialed builds, and this rollup must be a function of inputs every
+// build has (the reconciled index baseline + the registry). The counts ride
+// each captured entry's `snapshot` block, stamped at capture time.
+const capturedSchemaEntriesByNetuid = new Map<unknown, Row[]>();
+for (const entry of (schemaIndexArtifact.schemas as Row[]) || []) {
+  if (entry.status !== "captured") continue;
+  const list = capturedSchemaEntriesByNetuid.get(entry.netuid) || [];
+  list.push(entry);
+  capturedSchemaEntriesByNetuid.set(entry.netuid, list);
+}
+
+// The registered side of the ledger: concrete callable route surfaces
+// (subnet-api / sse / data-artifact). `openapi` is excluded on purpose -- the
+// spec document is how we KNOW the declared side, not a route of the API.
+const PARITY_ROUTE_KINDS = new Set(["subnet-api", "sse", "data-artifact"]);
+
+function schemaParityForSubnet(
+  netuid: unknown,
+  subnetSurfaces: Row[],
+): Row | null {
+  const captured = capturedSchemaEntriesByNetuid.get(netuid) || [];
+  if (captured.length === 0) return null;
+  const pathCounts = captured.map(
+    (entry) => (entry.snapshot as Row | undefined)?.path_count,
+  );
+  // An index entry predating the path_count stamp reports absence, not zero:
+  // a parity verdict built on a guessed denominator is the drift_status:
+  // "unchanged" mistake again.
+  if (!pathCounts.every((count) => Number.isInteger(count))) return null;
+  const capturedPathCount = pathCounts.reduce(
+    (sum: number, count) => sum + (count as number),
+    0,
+  );
+  const nonGetCounts = captured.map(
+    (entry) => (entry.snapshot as Row | undefined)?.non_get_operation_count,
+  );
+  const registeredRouteSurfaces = subnetSurfaces.filter((surface) =>
+    PARITY_ROUTE_KINDS.has(surface.kind as string),
+  );
+  return {
+    captured_schema_count: captured.length,
+    captured_path_count: capturedPathCount,
+    // Null until a capture stamped it (entries predate the stamp); the two
+    // sides of the mutation ledger only compare once both are measured.
+    declared_non_get_count: nonGetCounts.every((count) =>
+      Number.isInteger(count),
+    )
+      ? nonGetCounts.reduce((sum: number, count) => sum + (count as number), 0)
+      : null,
+    registered_route_surface_count: registeredRouteSurfaces.length,
+    registered_non_get_count: registeredRouteSurfaces.filter(
+      (surface) => surface.method && surface.method !== "GET",
+    ).length,
+    // The flag the issue asked for: the subnet declares more paths than the
+    // catalogue registers as routes. A caller reading only the registry
+    // cannot tell which routes those are -- that is the gap being named.
+    flagged: registeredRouteSurfaces.length < capturedPathCount,
+  };
+}
+
 const gapsIndex = mergedSubnets.map((subnet) => {
   const missingKinds = subnet.gaps.missing_kinds || [];
+  const schemaParity = schemaParityForSubnet(
+    subnet.netuid,
+    surfacesByNetuidForCounts.get(subnet.netuid) || [],
+  );
   return {
     coverage_level: subnet.coverage_level,
     curation_level: subnet.curation.level,
@@ -1148,6 +1215,10 @@ const gapsIndex = mergedSubnets.map((subnet) => {
     ),
     name: subnet.name,
     netuid: subnet.netuid,
+    // #11146 phase 4: present only when the subnet has captured schema entries
+    // whose counts are stamped -- absence means "not measured", never "in
+    // parity".
+    ...(schemaParity ? { schema_parity: schemaParity } : {}),
     slug: subnet.slug,
   };
 });

--- a/scripts/snapshot-openapi.ts
+++ b/scripts/snapshot-openapi.ts
@@ -201,6 +201,12 @@ async function snapshotSurface(surface: Row): Promise<Row> {
         normalized.paths && typeof normalized.paths === "object"
           ? Object.keys(normalized.paths).length
           : 0,
+      // #11146 phase 4: how many declared operations are mutations. Stamped
+      // here, where the document is in hand, because the parity rollup in the
+      // build must derive from index entries alone -- captured documents only
+      // exist in credentialed builds. Entries captured before this stamp have
+      // no value, and the rollup reports that as absence, never zero.
+      non_get_operation_count: countNonGetOperations(normalized),
       component_schema_count:
         normalized.components?.schemas &&
         typeof normalized.components.schemas === "object"
@@ -238,6 +244,26 @@ async function snapshotSurface(surface: Row): Promise<Row> {
     "not-found",
     "no machine-readable OpenAPI JSON found",
   );
+}
+
+// #11146 phase 4: the mutation half of the parity ledger. GET is what the
+// registry could always represent; everything else was invisible until the
+// method dimension (phase 3), and this count is what the gaps rollup compares
+// registered mutations against. `head`/`options`/`trace` are deliberately not
+// counted: they are not application operations a caller would register.
+const MUTATION_OPERATION_METHODS = ["post", "put", "patch", "delete"] as const;
+
+function countNonGetOperations(document: Row): number {
+  const paths = document?.paths;
+  if (!paths || typeof paths !== "object") return 0;
+  let count = 0;
+  for (const item of Object.values(paths as Record<string, unknown>)) {
+    if (!item || typeof item !== "object") continue;
+    for (const method of MUTATION_OPERATION_METHODS) {
+      if ((item as Row)[method]) count += 1;
+    }
+  }
+  return count;
 }
 
 function unavailable(

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1461,6 +1461,39 @@ test("public artifacts are internally consistent", () => {
   );
   assert.equal(curation.curation.length, native.subnets.length);
   assert.equal(gaps.gaps.length, native.subnets.length);
+  // #11146 phase 4: the schema-parity ledger. Present exactly on subnets with
+  // captured schema-index entries; every block internally consistent, and the
+  // flag is the arithmetic it claims to be. At least one subnet must be
+  // measured (the committed index seed carries 58 captured entries) and at
+  // least one flagged -- the whole point of the gate is that under-registration
+  // exists today, so a build where nothing is flagged means the ledger broke.
+  const parityRows = gaps.gaps.filter((row: Row) => row.schema_parity);
+  assert.equal(parityRows.length > 0, true, "no subnet measured for parity");
+  for (const row of parityRows) {
+    const parity = row.schema_parity as Row;
+    assert.equal((parity.captured_schema_count as number) >= 1, true);
+    assert.equal(
+      Number.isInteger(parity.captured_path_count) &&
+        (parity.captured_path_count as number) >= 0,
+      true,
+    );
+    assert.equal(
+      parity.declared_non_get_count === null ||
+        Number.isInteger(parity.declared_non_get_count),
+      true,
+    );
+    assert.equal(
+      parity.flagged,
+      (parity.registered_route_surface_count as number) <
+        (parity.captured_path_count as number),
+      `parity flag must be the arithmetic it claims (netuid ${row.netuid})`,
+    );
+  }
+  assert.equal(
+    parityRows.some((row: Row) => (row.schema_parity as Row).flagged),
+    true,
+    "no subnet flagged -- under-registration is measured to exist (#11146)",
+  );
   assert.equal(verification.candidate_count, verification.results.length);
   assert.equal(
     verification.results.length <= candidates.candidates.length,


### PR DESCRIPTION
## Summary

Phase 4 of #11146: the parity gate the SN105 report asked for. Every gaps row for a subnet with captured schema-index entries now carries a `schema_parity` block:

- `captured_path_count` — paths the subnet's captured spec(s) declare, from the `snapshot.path_count` the index entries already carried.
- `declared_non_get_count` — the mutation half of the ledger; the capture lane (`schemas:snapshot`) now stamps `non_get_operation_count` on each snapshot. Entries predating the stamp report **null — unmeasured, never zero** (the `drift_status: unchanged` lesson).
- `registered_route_surface_count` / `registered_non_get_count` — the catalogue side, countable since phase 3's `method` dimension.
- `flagged` — true when the subnet declares more paths than the catalogue registers as routes.

**Determinism**: derived from schema INDEX entries only, never captured documents (those exist solely in credentialed builds), so every build computes the same ledger from the same baseline.

**First measurement** (committed seed, 58 captured entries): 53 subnets measured, **27 flagged** — sn-3 registers 8 routes against 208 declared paths, sn-105 28 against 53; matching the epic's fleet measurement.

Served via `GapsEntrySchema` (REST /api/v1/gaps + MCP list_gaps/list_subnet_gaps derive from it); contract regen committed.

## Validation

- `npm run typecheck`, `lint`, `format:check`
- `npm run build` + `npm run validate`, `validate:api`, `validate:openapi`, `validate:contract-drift`, `validate:mcp`, `validate:schema-vocabularies` — all green
- Full suite: 20,909 passed. New assertions in `tests/artifacts.test.ts` pin the ledger's invariants and that the flag is the arithmetic it claims; no `src/**` lines changed (build lane + schema + capture lane only)

Part of #11146. Remaining on the epic after this: phases 1–2 (capture cadence/owner + drift-vs-upstream).