### PR TITLE
fix(chain): parse the RPC envelope at the three remaining call sites

### DIFF
--- a/src/chain-burn.ts
+++ b/src/chain-burn.ts
@@ -22,6 +22,7 @@
 // "this value is unset chain-wide" rather than like a bug. The control that catches it
 // is reading a value you already know by another route: Tempo[64] must be 360.
 
+import { chainRpc } from "./chain-rpc.ts";
 import {
   type ChainNetworkId,
   networkKvKey,
@@ -112,14 +113,19 @@ async function rpcCall(
   method: string,
   params: unknown[],
 ): Promise<unknown> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    signal: AbortSignal.timeout(CHAIN_BURN_RPC_TIMEOUT_MS),
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-  });
-  if (!res?.ok) return null;
-  return ((await res.json()) as Row)?.result ?? null;
+  // NULL on any failure, which is this lane's contract and not the shared
+  // client's: chainRpc throws so a caller can tell why, and here every reason
+  // collapses to "no card". The envelope is parsed rather than cast on the way
+  // through (#11194).
+  try {
+    return (
+      (await chainRpc(url, method, params, {
+        timeoutMs: CHAIN_BURN_RPC_TIMEOUT_MS,
+      })) ?? null
+    );
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/chain-rpc.ts
+++ b/src/chain-rpc.ts
@@ -55,6 +55,15 @@ export interface ChainRpcOptions {
   /** Injected for tests and for callers that wrap fetch. */
   fetchImpl?: typeof fetch;
   /**
+   * The JSON-RPC request id.
+   *
+   * subtensor-pinned-storage increments one per call. Over HTTP with one
+   * request per response nothing correlates on it, so this changes no
+   * behaviour -- it is carried so that consolidating does not silently drop
+   * something a caller was deliberately doing.
+   */
+  id?: number;
+  /**
    * Abort after this long.
    *
    * Optional because two of the three callers had no timeout at all and adding
@@ -86,7 +95,12 @@ export async function chainRpc(
     ...(options.timeoutMs === undefined
       ? {}
       : { signal: AbortSignal.timeout(options.timeoutMs) }),
-    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: options.id ?? 1,
+      method,
+      params,
+    }),
   });
   if (!res.ok) throw new Error(`${method}: HTTP ${res.status}`);
 

--- a/src/subnet-conviction.ts
+++ b/src/subnet-conviction.ts
@@ -1,3 +1,4 @@
+import { chainRpc } from "./chain-rpc.ts";
 import type { FieldSources } from "./field-provenance.ts"; // Live subnet-ownership-contest ("conviction") leaderboard (#6638, part of
 // the conviction/ownership-contest tracker epic #4302) -- rolls each
 // captured subnet_locks row forward from its own last_update to "now" using
@@ -324,16 +325,14 @@ async function rpcCall(
   timeoutMs: number,
 ): Promise<{ ok: boolean; value: unknown }> {
   try {
-    const res = await fetch(rpcUrlForNetwork(), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: AbortSignal.timeout(timeoutMs),
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    // `ok` is this reader's contract: a ValueQuery item that is genuinely unset
+    // must be distinguishable from a read that failed, because the compiled
+    // default applies only to the first. chainRpc throws on both a bad
+    // transport and an error envelope, which is exactly the `ok: false` case.
+    const value = await chainRpc(rpcUrlForNetwork(), method, params, {
+      timeoutMs,
     });
-    if (!res.ok) return { ok: false, value: undefined };
-    const body = (await res.json()) as Row;
-    if (body?.error) return { ok: false, value: undefined };
-    return { ok: true, value: body?.result ?? null };
+    return { ok: true, value: value ?? null };
   } catch {
     return { ok: false, value: undefined };
   }

--- a/src/subtensor-pinned-storage.ts
+++ b/src/subtensor-pinned-storage.ts
@@ -19,6 +19,8 @@
 // how the two lanes would start disagreeing about which block they read, which
 // is the exact failure the pinning exists to prevent.
 
+import { chainRpc } from "./chain-rpc.ts";
+
 /** twox128("SubtensorModule") -- the pallet half of every key here. */
 const SUBTENSOR_PALLET_PREFIX = "658faa385070e074c85bf6b568cf0555";
 
@@ -92,21 +94,14 @@ export function createSubtensorPinnedStorage(
   let rpcId = 0;
 
   async function call<T>(method: string, params: unknown[]): Promise<T> {
-    const response = await doFetch(options.rpcUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: (rpcId += 1),
-        method,
-        params,
-      }),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!response.ok) throw new Error(`${method}: HTTP ${response.status}`);
-    const body = (await response.json()) as { result?: T; error?: unknown };
-    if (body.error) throw new Error(`${method}: ${JSON.stringify(body.error)}`);
-    return body.result as T;
+    // The incrementing id is carried through rather than dropped -- see
+    // ChainRpcOptions.id. Everything else here was the shared client already,
+    // including the throw-on-error this reader depends on (#11194).
+    return (await chainRpc(options.rpcUrl, method, params, {
+      fetchImpl: doFetch,
+      timeoutMs,
+      id: (rpcId += 1),
+    })) as T;
   }
 
   return {


### PR DESCRIPTION
Continues #11194 (after #11214). **Every chain RPC read in the repo now goes through the validated client** — no site hand-builds the envelope or casts the response.

## Three sites, three different contracts

This is why it isn't one rewrite repeated. Each was preserved exactly:

| site | contract |
|---|---|
| `subtensor-pinned-storage` | **throws**, and increments a request id per call |
| `chain-burn` | returns **null** on any failure, never throws |
| `subnet-conviction` | returns **`{ ok, value }`**, catching everything |

`chain-burn`'s null is deliberate — every failure reason collapses to "no card".

`subnet-conviction`'s `ok` is load-bearing in a subtler way: both items it reads are **ValueQuery**, so *genuinely unset* means the compiled default applies and *read failed* does not. The two must stay distinguishable, and its own module header says so.

Rewiring any of them to the shared client's throw-on-error would have changed behaviour at a live producer. Each keeps its contract and gains the parse.

## The `id` option

`chainRpc` hardcoded `id: 1`; `subtensor-pinned-storage` increments one per call. Over HTTP with one request per response nothing correlates on it, so carrying it changes nothing — it's carried anyway, because consolidating shouldn't silently drop something a caller was deliberately doing.

## Verification

124 tests across the five rewired modules, plus `emission-drift-check` (8) which consumes the pinned reader. Every schema gate green; unreferenced-exports holds at 731.

## What remains of #11194

The non-RPC upstreams, each needing its own schema in `schemas-src/`: GitHub API (`lane-alarm`), Unkey (`unkey-client`), Cloudflare AE (`analytics-engine-sql`), and `feature-flags`. `health-prober` reads arbitrary subnet API shapes and may not be schema-able at all. The internal ones — our own data-api via `mcp-server`, and the sync routes — are lower value since both ends are ours.