### PR TITLE
feat(registry): schema-capture freshness, honest drift basis, and the parity ledger

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -4440,6 +4440,40 @@ type GapsArtifactGaps {
   gaps: Gaps!
   gap_severity: String
   gap_priority: Int
+  schema_parity: GapsArtifactGapsSchemaParity
+}
+
+type GapsArtifactGapsSchemaParity {
+  """Captured machine-readable specs backing this measurement."""
+  captured_schema_count: Int!
+
+  """
+  Paths the subnet's captured spec(s) declare, summed across captured specs.
+  """
+  captured_path_count: Int!
+
+  """
+  Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero.
+  """
+  declared_non_get_count: Int
+
+  """
+  Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route).
+  """
+  registered_route_surface_count: Int!
+
+  """Registered surfaces declaring a non-GET method (#11146 phase 3)."""
+  registered_non_get_count: Int!
+
+  """
+  Whether any capture backing this measurement is past the lane's declared cadence. NULL when none can be dated. A parity verdict off a stale capture describes last week's spec (#11146 phase 1).
+  """
+  captured_stale: Boolean
+
+  """
+  True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing.
+  """
+  flagged: Boolean!
 }
 
 type EvidenceList {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -2745,7 +2745,26 @@ export type GapsArtifactGaps = {
   gaps: Gaps;
   name: Scalars['String']['output'];
   netuid: Scalars['Int']['output'];
+  schema_parity?: Maybe<GapsArtifactGapsSchemaParity>;
   slug: Scalars['String']['output'];
+};
+
+export type GapsArtifactGapsSchemaParity = {
+  __typename?: 'GapsArtifactGapsSchemaParity';
+  /** Paths the subnet's captured spec(s) declare, summed across captured specs. */
+  captured_path_count: Scalars['Int']['output'];
+  /** Captured machine-readable specs backing this measurement. */
+  captured_schema_count: Scalars['Int']['output'];
+  /** Whether any capture backing this measurement is past the lane's declared cadence. NULL when none can be dated. A parity verdict off a stale capture describes last week's spec (#11146 phase 1). */
+  captured_stale?: Maybe<Scalars['Boolean']['output']>;
+  /** Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero. */
+  declared_non_get_count?: Maybe<Scalars['Int']['output']>;
+  /** True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing. */
+  flagged: Scalars['Boolean']['output'];
+  /** Registered surfaces declaring a non-GET method (#11146 phase 3). */
+  registered_non_get_count: Scalars['Int']['output'];
+  /** Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route). */
+  registered_route_surface_count: Scalars['Int']['output'];
 };
 
 /** Registry-wide interface gap report page. Mirrors GET /api/v1/gaps (and MCP list_gaps). */
@@ -8592,6 +8611,7 @@ export type ResolversTypes = ResolversObject<{
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   Gaps: ResolverTypeWrapper<Gaps>;
   GapsArtifactGaps: ResolverTypeWrapper<GapsArtifactGaps>;
+  GapsArtifactGapsSchemaParity: ResolverTypeWrapper<GapsArtifactGapsSchemaParity>;
   GapsList: ResolverTypeWrapper<GapsList>;
   GlobalHealth: ResolverTypeWrapper<GlobalHealth>;
   GlobalIncidentSurface: ResolverTypeWrapper<GlobalIncidentSurface>;
@@ -9061,6 +9081,7 @@ export type ResolversParentTypes = ResolversObject<{
   Float: Scalars['Float']['output'];
   Gaps: Gaps;
   GapsArtifactGaps: GapsArtifactGaps;
+  GapsArtifactGapsSchemaParity: GapsArtifactGapsSchemaParity;
   GapsList: GapsList;
   GlobalHealth: GlobalHealth;
   GlobalIncidentSurface: GlobalIncidentSurface;
@@ -11475,7 +11496,18 @@ export type GapsArtifactGapsResolvers<ContextType = GqlContext, ParentType exten
   gaps?: Resolver<ResolversTypes['Gaps'], ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   netuid?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  schema_parity?: Resolver<Maybe<ResolversTypes['GapsArtifactGapsSchemaParity']>, ParentType, ContextType>;
   slug?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+}>;
+
+export type GapsArtifactGapsSchemaParityResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GapsArtifactGapsSchemaParity'] = ResolversParentTypes['GapsArtifactGapsSchemaParity']> = ResolversObject<{
+  captured_path_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  captured_schema_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  captured_stale?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  declared_non_get_count?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
+  flagged?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  registered_non_get_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  registered_route_surface_count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 }>;
 
 export type GapsListResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['GapsList'] = ResolversParentTypes['GapsList']> = ResolversObject<{
@@ -14748,6 +14780,7 @@ export type Resolvers<ContextType = GqlContext> = ResolversObject<{
   FailureReasonsDay?: FailureReasonsDayResolvers<ContextType>;
   Gaps?: GapsResolvers<ContextType>;
   GapsArtifactGaps?: GapsArtifactGapsResolvers<ContextType>;
+  GapsArtifactGapsSchemaParity?: GapsArtifactGapsSchemaParityResolvers<ContextType>;
   GapsList?: GapsListResolvers<ContextType>;
   GlobalHealth?: GlobalHealthResolvers<ContextType>;
   GlobalIncidentSurface?: GlobalIncidentSurfaceResolvers<ContextType>;

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -8636,6 +8636,22 @@ export interface components {
                 gaps: components["schemas"]["Gaps"];
                 name: string;
                 netuid: number;
+                schema_parity?: {
+                    /** @description Paths the subnet's captured spec(s) declare, summed across captured specs. */
+                    captured_path_count: number;
+                    /** @description Captured machine-readable specs backing this measurement. */
+                    captured_schema_count: number;
+                    /** @description Whether any capture backing this measurement is past the lane's declared cadence. NULL when none can be dated. A parity verdict off a stale capture describes last week's spec (#11146 phase 1). */
+                    captured_stale: boolean | null;
+                    /** @description Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero. */
+                    declared_non_get_count: number | null;
+                    /** @description True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing. */
+                    flagged: boolean;
+                    /** @description Registered surfaces declaring a non-GET method (#11146 phase 3). */
+                    registered_non_get_count: number;
+                    /** @description Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route). */
+                    registered_route_surface_count: number;
+                };
                 slug: string;
             }[];
             generated_at: string;
@@ -10331,6 +10347,7 @@ export interface components {
             url: string;
         };
         SchemaIndexArtifact: {
+            capture_cadence_hours?: number;
             contract_version?: string;
             generated_at: string;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
@@ -10346,7 +10363,16 @@ export interface components {
             /** @constant */
             schema_version: 1;
             schemas: {
+                /** @description Hours between this entry's capture and the build that served it. NULL when the entry carries no usable capture timestamp. */
+                capture_age_hours?: number | null;
+                /** @description Whether the capture is older than the lane's declared cadence (SCHEMA_CAPTURE_CADENCE_HOURS). NULL when the age is unknown -- unverifiable is not fresh. A stale capture's `drift_status` describes an old comparison, not the current upstream. */
+                capture_stale?: boolean | null;
                 content_type?: string | null;
+                /**
+                 * @description What drift_status compares against: this registry's PREVIOUS capture of the same surface, never the subnet's live spec. `unchanged` therefore means 'our snapshot is what it was', not 'the upstream API has not changed' -- read it together with `capture_stale`.
+                 * @constant
+                 */
+                drift_basis?: "previous-capture";
                 /** @enum {string} */
                 drift_status: "new" | "changed" | "unchanged" | "not-captured" | "missing-after-previous-capture";
                 error?: string | null;
@@ -10370,6 +10396,7 @@ export interface components {
                     generated_at?: string | null;
                     hash?: string | null;
                     netuid?: number | null;
+                    non_get_operation_count?: number;
                     observed_at?: string | null;
                     openapi_version?: string | null;
                     path_count?: number;
@@ -39252,6 +39279,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "capture_cadence_hours": 0.5,
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8240,6 +8240,7 @@
       "SchemaIndexArtifactResponse": {
         "value": {
           "data": {
+            "capture_cadence_hours": 0.5,
             "contract_version": "2026-06-29.1",
             "generated_at": "2026-06-01T00:00:00.000Z",
             "notes": "Example description.",
@@ -34250,6 +34251,73 @@
                   "minimum": 0,
                   "type": "integer"
                 },
+                "schema_parity": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "captured_path_count": {
+                      "description": "Paths the subnet's captured spec(s) declare, summed across captured specs.",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "captured_schema_count": {
+                      "description": "Captured machine-readable specs backing this measurement.",
+                      "maximum": 9007199254740991,
+                      "minimum": 1,
+                      "type": "integer"
+                    },
+                    "captured_stale": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Whether any capture backing this measurement is past the lane's declared cadence. NULL when none can be dated. A parity verdict off a stale capture describes last week's spec (#11146 phase 1)."
+                    },
+                    "declared_non_get_count": {
+                      "anyOf": [
+                        {
+                          "maximum": 9007199254740991,
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero."
+                    },
+                    "flagged": {
+                      "description": "True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing.",
+                      "type": "boolean"
+                    },
+                    "registered_non_get_count": {
+                      "description": "Registered surfaces declaring a non-GET method (#11146 phase 3).",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "registered_route_surface_count": {
+                      "description": "Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route).",
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "captured_schema_count",
+                    "captured_path_count",
+                    "declared_non_get_count",
+                    "registered_route_surface_count",
+                    "registered_non_get_count",
+                    "captured_stale",
+                    "flagged"
+                  ],
+                  "type": "object"
+                },
                 "slug": {
                   "type": "string"
                 }
@@ -43396,6 +43464,10 @@
       "SchemaIndexArtifact": {
         "additionalProperties": false,
         "properties": {
+          "capture_cadence_hours": {
+            "minimum": 0,
+            "type": "number"
+          },
           "contract_version": {
             "type": "string"
           },
@@ -43436,6 +43508,29 @@
             "items": {
               "additionalProperties": false,
               "properties": {
+                "capture_age_hours": {
+                  "anyOf": [
+                    {
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Hours between this entry's capture and the build that served it. NULL when the entry carries no usable capture timestamp."
+                },
+                "capture_stale": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Whether the capture is older than the lane's declared cadence (SCHEMA_CAPTURE_CADENCE_HOURS). NULL when the age is unknown -- unverifiable is not fresh. A stale capture's `drift_status` describes an old comparison, not the current upstream."
+                },
                 "content_type": {
                   "anyOf": [
                     {
@@ -43445,6 +43540,11 @@
                       "type": "null"
                     }
                   ]
+                },
+                "drift_basis": {
+                  "const": "previous-capture",
+                  "description": "What drift_status compares against: this registry's PREVIOUS capture of the same surface, never the subnet's live spec. `unchanged` therefore means 'our snapshot is what it was', not 'the upstream API has not changed' -- read it together with `capture_stale`.",
+                  "type": "string"
                 },
                 "drift_status": {
                   "enum": [
@@ -43633,6 +43733,11 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "non_get_operation_count": {
+                      "maximum": 9007199254740991,
+                      "minimum": 0,
+                      "type": "integer"
                     },
                     "observed_at": {
                       "anyOf": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -8636,6 +8636,22 @@ export interface components {
                 gaps: components["schemas"]["Gaps"];
                 name: string;
                 netuid: number;
+                schema_parity?: {
+                    /** @description Paths the subnet's captured spec(s) declare, summed across captured specs. */
+                    captured_path_count: number;
+                    /** @description Captured machine-readable specs backing this measurement. */
+                    captured_schema_count: number;
+                    /** @description Whether any capture backing this measurement is past the lane's declared cadence. NULL when none can be dated. A parity verdict off a stale capture describes last week's spec (#11146 phase 1). */
+                    captured_stale: boolean | null;
+                    /** @description Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero. */
+                    declared_non_get_count: number | null;
+                    /** @description True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing. */
+                    flagged: boolean;
+                    /** @description Registered surfaces declaring a non-GET method (#11146 phase 3). */
+                    registered_non_get_count: number;
+                    /** @description Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route). */
+                    registered_route_surface_count: number;
+                };
                 slug: string;
             }[];
             generated_at: string;
@@ -10331,6 +10347,7 @@ export interface components {
             url: string;
         };
         SchemaIndexArtifact: {
+            capture_cadence_hours?: number;
             contract_version?: string;
             generated_at: string;
             /** @description Public-safe notes; may be a string or a string list depending on the adapter. */
@@ -10346,7 +10363,16 @@ export interface components {
             /** @constant */
             schema_version: 1;
             schemas: {
+                /** @description Hours between this entry's capture and the build that served it. NULL when the entry carries no usable capture timestamp. */
+                capture_age_hours?: number | null;
+                /** @description Whether the capture is older than the lane's declared cadence (SCHEMA_CAPTURE_CADENCE_HOURS). NULL when the age is unknown -- unverifiable is not fresh. A stale capture's `drift_status` describes an old comparison, not the current upstream. */
+                capture_stale?: boolean | null;
                 content_type?: string | null;
+                /**
+                 * @description What drift_status compares against: this registry's PREVIOUS capture of the same surface, never the subnet's live spec. `unchanged` therefore means 'our snapshot is what it was', not 'the upstream API has not changed' -- read it together with `capture_stale`.
+                 * @constant
+                 */
+                drift_basis?: "previous-capture";
                 /** @enum {string} */
                 drift_status: "new" | "changed" | "unchanged" | "not-captured" | "missing-after-previous-capture";
                 error?: string | null;
@@ -10370,6 +10396,7 @@ export interface components {
                     generated_at?: string | null;
                     hash?: string | null;
                     netuid?: number | null;
+                    non_get_operation_count?: number;
                     observed_at?: string | null;
                     openapi_version?: string | null;
                     path_count?: number;
@@ -39252,6 +39279,7 @@ export interface operations {
                     /**
                      * @example {
                      *       "data": {
+                     *         "capture_cadence_hours": 0.5,
                      *         "contract_version": "2026-06-29.1",
                      *         "generated_at": "2026-06-01T00:00:00.000Z",
                      *         "notes": "Example description.",

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -633,6 +633,7 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   EvidenceLedgerArtifactSummary: "EvidenceLedgerArtifactSummary",
   Gaps: "Gaps",
   GapsArtifactGaps: "GapsArtifactGaps",
+  GapsArtifactGapsSchemaParity: "GapsArtifactGapsSchemaParity",
   GlobalIncidentsArtifactSummary: "GlobalIncidentsArtifactSummary",
   HealthHistoryArtifactSurfaces: "HealthHistoryArtifactSurfaces",
   HealthIncidentsArtifactSurfaces: "HealthIncidentsArtifactSurfaces",

--- a/schemas-src/routes/curation-gaps.ts
+++ b/schemas-src/routes/curation-gaps.ts
@@ -47,6 +47,42 @@ export type CurationArtifact = z.infer<typeof CurationArtifactSchema>;
 
 export const GAPS_SORT_FIELDS = API_QUERY_COLLECTIONS.gaps.sort_fields;
 
+/** #11146 phase 4: captured spec vs registered catalogue, per subnet. Present
+ * only when the subnet has captured schema-index entries with stamped counts
+ * -- absence means "not measured", never "in parity". */
+export const SchemaParitySchema = z
+  .object({
+    captured_schema_count: z.int().min(1).meta({
+      description: "Captured machine-readable specs backing this measurement.",
+    }),
+    captured_path_count: z.int().min(0).meta({
+      description:
+        "Paths the subnet's captured spec(s) declare, summed across captured specs.",
+    }),
+    declared_non_get_count: z.int().min(0).nullable().meta({
+      description:
+        "Declared POST/PUT/PATCH/DELETE operations. NULL when the captured entries predate the capture-time stamp -- unmeasured, not zero.",
+    }),
+    registered_route_surface_count: z.int().min(0).meta({
+      description:
+        "Registered concrete route surfaces (subnet-api/sse/data-artifact; the openapi spec surface itself is not a route).",
+    }),
+    registered_non_get_count: z.int().min(0).meta({
+      description:
+        "Registered surfaces declaring a non-GET method (#11146 phase 3).",
+    }),
+    captured_stale: z.boolean().nullable().meta({
+      description:
+        "Whether any capture backing this measurement is past the lane's declared cadence. NULL when none can be dated. A parity verdict off a stale capture describes last week's spec (#11146 phase 1).",
+    }),
+    flagged: z.boolean().meta({
+      description:
+        "True when the subnet declares more paths than the catalogue registers as routes -- a caller reading only the registry cannot tell which routes are missing.",
+    }),
+  })
+  .strict();
+export type SchemaParity = z.infer<typeof SchemaParitySchema>;
+
 export const GapsEntrySchema = z
   .object({
     netuid: z.int().min(0),
@@ -61,6 +97,7 @@ export const GapsEntrySchema = z
     gaps: GapsSchema,
     gap_severity: z.enum(ENDPOINT_INCIDENT_SEVERITY_VALUES).optional(),
     gap_priority: z.int().min(0).optional(),
+    schema_parity: SchemaParitySchema.optional(),
   })
   .strict();
 

--- a/schemas-src/routes/subnet-profiles.ts
+++ b/schemas-src/routes/subnet-profiles.ts
@@ -113,6 +113,9 @@ export const SchemaSnapshotSchema = z
     auth_schemes: z.array(z.string()).optional(),
     hash: z.string().nullable().optional(),
     previous_hash: z.string().nullable().optional(),
+    // #11146 phase 3/4: how many of the declared operations are mutations.
+    // Absent on a snapshot captured before the stamp -- unmeasured, not zero.
+    non_get_operation_count: z.int().min(0).optional(),
     drift_status: z.string().nullable().optional(),
     observed_at: z.string().nullable().optional(),
     generated_at: z.string().nullable().optional(),
@@ -125,6 +128,24 @@ const SchemaIndexEntrySchema = z
   .object({
     content_type: z.string().nullable().optional(),
     drift_status: SchemaDriftStatusSchema,
+    // #11146 phases 1-2: what `drift_status` is measured AGAINST, and how old
+    // the measurement is. Both exist because `unchanged` was being read as "in
+    // sync with the subnet's published spec" when it only ever meant "equal to
+    // OUR previous snapshot" -- and with the capture lane manual-only, that was
+    // true and meaningless on 23 of 24 drifted subnets. A contract agreeing
+    // with itself proves nothing; these two fields say so in the payload.
+    drift_basis: z.literal("previous-capture").optional().meta({
+      description:
+        "What drift_status compares against: this registry's PREVIOUS capture of the same surface, never the subnet's live spec. `unchanged` therefore means 'our snapshot is what it was', not 'the upstream API has not changed' -- read it together with `capture_stale`.",
+    }),
+    capture_age_hours: z.number().min(0).nullable().optional().meta({
+      description:
+        "Hours between this entry's capture and the build that served it. NULL when the entry carries no usable capture timestamp.",
+    }),
+    capture_stale: z.boolean().nullable().optional().meta({
+      description:
+        "Whether the capture is older than the lane's declared cadence (SCHEMA_CAPTURE_CADENCE_HOURS). NULL when the age is unknown -- unverifiable is not fresh. A stale capture's `drift_status` describes an old comparison, not the current upstream.",
+    }),
     error: z.string().nullable().optional(),
     hash: z.string().nullable().optional(),
     netuid: z.int().min(0).optional(),
@@ -159,6 +180,9 @@ export const SchemaIndexArtifactSchema = ArtifactBaseSchema.extend({
   // .optional() rather than required. Not in the hand-edited schema's named
   // properties, only legal today via additionalProperties:true.
   observed_at: z.string().optional(),
+  // #11146 phase 1: the lane's declared cadence, so a consumer can compute
+  // staleness itself rather than guessing what "old" means for this artifact.
+  capture_cadence_hours: z.number().min(0).optional(),
   summary: SchemaDriftSummarySchema.optional(),
   // The schema-snapshots cron's promotion provenance (SchemaIndexArtifact in
   // src/schema-snapshots-sync.ts: "with only summary/schemas replaced ... and

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -104,7 +104,9 @@ import {
 import { buildDatasetExports } from "./datasets.ts";
 import { readGeneratedStoreJson } from "./r2-rest.ts";
 import {
+  captureFreshness,
   chooseSchemaIndexBaseline,
+  SCHEMA_CAPTURE_CADENCE_HOURS,
   SCHEMA_INDEX_R2_KEY,
 } from "../src/schema-snapshots-sync.ts";
 import {
@@ -776,12 +778,13 @@ const curationReview = buildCurationReview(
 const schemaDriftArtifact =
   reusableSchemaDriftArtifact(surfaces, previousSchemaDriftArtifact) ||
   buildSchemaDriftPlaceholder(surfaces);
-const schemaIndexArtifact =
+const schemaIndexArtifact = withCaptureFreshness(
   reusableSchemaIndexArtifact(
     surfaces,
     previousSchemaIndexArtifact,
     capturedSchemaDetails,
-  ) || buildSchemaIndexPlaceholder();
+  ) || buildSchemaIndexPlaceholder(),
+);
 const contracts = buildContractsArtifact(generatedAt);
 const openApi = await buildCanonicalOpenApiArtifact(generatedAt);
 
@@ -1121,8 +1124,83 @@ const curationIndex = mergedSubnets.map((subnet) => ({
   surface_count: subnet.surface_count,
 }));
 
+// #11146 phase 4: per-subnet schema parity -- captured spec vs registered
+// catalogue, the check the SN105 report asked for. Derived from schema INDEX
+// entries only, never the captured documents: documents exist solely in
+// credentialed builds, and this rollup must be a function of inputs every
+// build has (the reconciled index baseline + the registry). The counts ride
+// each captured entry's `snapshot` block, stamped at capture time.
+const capturedSchemaEntriesByNetuid = new Map<unknown, Row[]>();
+for (const entry of (schemaIndexArtifact.schemas as Row[]) || []) {
+  if (entry.status !== "captured") continue;
+  const list = capturedSchemaEntriesByNetuid.get(entry.netuid) || [];
+  list.push(entry);
+  capturedSchemaEntriesByNetuid.set(entry.netuid, list);
+}
+
+// The registered side of the ledger: concrete callable route surfaces
+// (subnet-api / sse / data-artifact). `openapi` is excluded on purpose -- the
+// spec document is how we KNOW the declared side, not a route of the API.
+const PARITY_ROUTE_KINDS = new Set(["subnet-api", "sse", "data-artifact"]);
+
+function schemaParityForSubnet(
+  netuid: unknown,
+  subnetSurfaces: Row[],
+): Row | null {
+  const captured = capturedSchemaEntriesByNetuid.get(netuid) || [];
+  if (captured.length === 0) return null;
+  const pathCounts = captured.map(
+    (entry) => (entry.snapshot as Row | undefined)?.path_count,
+  );
+  // An index entry predating the path_count stamp reports absence, not zero:
+  // a parity verdict built on a guessed denominator is the drift_status:
+  // "unchanged" mistake again.
+  if (!pathCounts.every((count) => Number.isInteger(count))) return null;
+  const capturedPathCount = pathCounts.reduce(
+    (sum: number, count) => sum + (count as number),
+    0,
+  );
+  const nonGetCounts = captured.map(
+    (entry) => (entry.snapshot as Row | undefined)?.non_get_operation_count,
+  );
+  const registeredRouteSurfaces = subnetSurfaces.filter((surface) =>
+    PARITY_ROUTE_KINDS.has(surface.kind as string),
+  );
+  return {
+    captured_schema_count: captured.length,
+    captured_path_count: capturedPathCount,
+    // Null until a capture stamped it (entries predate the stamp); the two
+    // sides of the mutation ledger only compare once both are measured.
+    declared_non_get_count: nonGetCounts.every((count) =>
+      Number.isInteger(count),
+    )
+      ? nonGetCounts.reduce((sum: number, count) => sum + (count as number), 0)
+      : null,
+    registered_route_surface_count: registeredRouteSurfaces.length,
+    registered_non_get_count: registeredRouteSurfaces.filter(
+      (surface) => surface.method && surface.method !== "GET",
+    ).length,
+    // Phase 1 travelling with phase 4: a parity verdict computed off a stale
+    // capture is a verdict about last week. TRUE when any backing capture is
+    // past the cadence, null when none of them can be dated.
+    captured_stale: captured.some((entry) => entry.capture_stale === true)
+      ? true
+      : captured.every((entry) => entry.capture_stale === null)
+        ? null
+        : false,
+    // The flag the issue asked for: the subnet declares more paths than the
+    // catalogue registers as routes. A caller reading only the registry
+    // cannot tell which routes those are -- that is the gap being named.
+    flagged: registeredRouteSurfaces.length < capturedPathCount,
+  };
+}
+
 const gapsIndex = mergedSubnets.map((subnet) => {
   const missingKinds = subnet.gaps.missing_kinds || [];
+  const schemaParity = schemaParityForSubnet(
+    subnet.netuid,
+    surfacesByNetuidForCounts.get(subnet.netuid) || [],
+  );
   return {
     coverage_level: subnet.coverage_level,
     curation_level: subnet.curation.level,
@@ -1148,6 +1226,10 @@ const gapsIndex = mergedSubnets.map((subnet) => {
     ),
     name: subnet.name,
     netuid: subnet.netuid,
+    // #11146 phase 4: present only when the subnet has captured schema entries
+    // whose counts are stamped -- absence means "not measured", never "in
+    // parity".
+    ...(schemaParity ? { schema_parity: schemaParity } : {}),
     slug: subnet.slug,
   };
 });
@@ -4675,6 +4757,45 @@ function reusableSchemaIndexArtifact(
       by_drift_status: schemaEntryCounts(reconciled, "drift_status"),
     },
     schemas: reconciled,
+  };
+}
+
+/**
+ * Stamp every captured entry with how old its capture is and whether that
+ * exceeds the lane's declared cadence (#11146 phases 1-2).
+ *
+ * WHY THIS EXISTS. `drift_status` compares our snapshot to our PREVIOUS
+ * snapshot. With the capture lane manual-only, that comparison was trivially
+ * "unchanged" while upstream moved -- 23 of 24 measurably-drifted subnets
+ * reported `unchanged` on 2026-08-14, which is a contract agreeing with
+ * itself. Two fields fix the reading without pretending we fetched upstream:
+ * `drift_basis` names what the comparison is against, and `capture_stale`
+ * says the comparison is old. A consumer can now tell "in sync" from "we have
+ * not looked since Tuesday", which was previously unanswerable from the
+ * payload.
+ *
+ * Derived from the build's own stamp, never a wall clock, so the artifact
+ * stays byte-reproducible. An entry with no usable timestamp gets null, not
+ * false: unverifiable is not fresh (the same convention as surface `stale`).
+ */
+function withCaptureFreshness(artifact: Row): Row {
+  const schemas = Array.isArray(artifact.schemas)
+    ? (artifact.schemas as Row[])
+    : [];
+  return {
+    ...artifact,
+    capture_cadence_hours: SCHEMA_CAPTURE_CADENCE_HOURS,
+    schemas: schemas.map((entry) => {
+      if (entry.status !== "captured") return entry;
+      const snapshot = entry.snapshot as Row | undefined;
+      return {
+        ...entry,
+        ...captureFreshness(
+          generatedAt,
+          (snapshot?.observed_at ?? snapshot?.generated_at) as string | null,
+        ),
+      };
+    }),
   };
 }
 

--- a/scripts/snapshot-openapi.ts
+++ b/scripts/snapshot-openapi.ts
@@ -201,6 +201,12 @@ async function snapshotSurface(surface: Row): Promise<Row> {
         normalized.paths && typeof normalized.paths === "object"
           ? Object.keys(normalized.paths).length
           : 0,
+      // #11146 phase 4: how many declared operations are mutations. Stamped
+      // here, where the document is in hand, because the parity rollup in the
+      // build must derive from index entries alone -- captured documents only
+      // exist in credentialed builds. Entries captured before this stamp have
+      // no value, and the rollup reports that as absence, never zero.
+      non_get_operation_count: countNonGetOperations(normalized),
       component_schema_count:
         normalized.components?.schemas &&
         typeof normalized.components.schemas === "object"
@@ -238,6 +244,26 @@ async function snapshotSurface(surface: Row): Promise<Row> {
     "not-found",
     "no machine-readable OpenAPI JSON found",
   );
+}
+
+// #11146 phase 4: the mutation half of the parity ledger. GET is what the
+// registry could always represent; everything else was invisible until the
+// method dimension (phase 3), and this count is what the gaps rollup compares
+// registered mutations against. `head`/`options`/`trace` are deliberately not
+// counted: they are not application operations a caller would register.
+const MUTATION_OPERATION_METHODS = ["post", "put", "patch", "delete"] as const;
+
+function countNonGetOperations(document: Row): number {
+  const paths = document?.paths;
+  if (!paths || typeof paths !== "object") return 0;
+  let count = 0;
+  for (const item of Object.values(paths as Record<string, unknown>)) {
+    if (!item || typeof item !== "object") continue;
+    for (const method of MUTATION_OPERATION_METHODS) {
+      if ((item as Row)[method]) count += 1;
+    }
+  }
+  return count;
 }
 
 function unavailable(

--- a/src/schema-snapshots-sync.ts
+++ b/src/schema-snapshots-sync.ts
@@ -86,6 +86,66 @@ export const SCHEMA_INDEX_ARTIFACT_PATH = "/metagraph/schemas/index.json";
  */
 export const SCHEMA_SNAPSHOT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
+/**
+ * The capture lane's declared cadence (#11146 phase 1): how old a captured
+ * schema may be before the served entry reports it STALE.
+ *
+ * The lane behind it (`schemas:snapshot`, inside `pipeline:refresh`) is
+ * deliberately manual -- ADR 0006 retired its schedule -- and that is exactly
+ * why a declared cadence is load-bearing rather than decorative. Without one,
+ * "when did we last look?" had no answer in the payload, so a capture 11 days
+ * behind upstream still served `drift_status: "unchanged"` and read as
+ * current. Declaring the number does not run the lane; it makes the lane's
+ * silence VISIBLE, which is the difference between an unpublished gap and a
+ * published one.
+ *
+ * 48 hours: two full days of tolerance over a daily-ish refresh, so a single
+ * skipped run is not noise while a lane that stopped shows within two days.
+ */
+export const SCHEMA_CAPTURE_CADENCE_HOURS = 48;
+
+export interface CaptureFreshness {
+  /** What `drift_status` is measured against -- never the live upstream spec. */
+  drift_basis: "previous-capture";
+  /** Hours between capture and the build serving it; null when unknowable. */
+  capture_age_hours: number | null;
+  /** Past the cadence? Null when the age is unknown -- unverifiable is not fresh. */
+  capture_stale: boolean | null;
+}
+
+/**
+ * The freshness stamp for one captured entry (#11146 phases 1-2).
+ *
+ * Lives here rather than inline in the artifact builder so the rule has ONE
+ * declaration: build-artifacts.ts is a top-level script (it runs on import),
+ * so a test could only re-implement it -- and a test asserting its own copy of
+ * the logic proves nothing.
+ *
+ * A NEGATIVE delta yields null, not zero. `buildTimestamp()` returns the 1970
+ * epoch placeholder whenever METAGRAPH_BUILD_TIMESTAMP is unset (every local
+ * and determinism build), so clamping to zero would publish a twelve-day-old
+ * capture as FRESH -- the exact dishonesty this phase removes, reintroduced by
+ * a Math.max. Same unknown-is-not-a-value convention as surface `stale`.
+ */
+export function captureFreshness(
+  buildStamp: string | null | undefined,
+  capturedAt: string | null | undefined,
+): CaptureFreshness {
+  const buildMs = Date.parse(String(buildStamp ?? ""));
+  const capturedMs = Date.parse(String(capturedAt ?? ""));
+  const deltaMs = buildMs - capturedMs;
+  const ageHours =
+    Number.isFinite(buildMs) && Number.isFinite(capturedMs) && deltaMs >= 0
+      ? Math.round((deltaMs / 3_600_000) * 10) / 10
+      : null;
+  return {
+    drift_basis: "previous-capture",
+    capture_age_hours: ageHours,
+    capture_stale:
+      ageHours === null ? null : ageHours > SCHEMA_CAPTURE_CADENCE_HOURS,
+  };
+}
+
 /** Statuses that mean "we have a real document behind this entry". */
 const CAPTURED_STATUS = "captured";
 

--- a/tests/artifacts.test.ts
+++ b/tests/artifacts.test.ts
@@ -1461,6 +1461,39 @@ test("public artifacts are internally consistent", () => {
   );
   assert.equal(curation.curation.length, native.subnets.length);
   assert.equal(gaps.gaps.length, native.subnets.length);
+  // #11146 phase 4: the schema-parity ledger. Present exactly on subnets with
+  // captured schema-index entries; every block internally consistent, and the
+  // flag is the arithmetic it claims to be. At least one subnet must be
+  // measured (the committed index seed carries 58 captured entries) and at
+  // least one flagged -- the whole point of the gate is that under-registration
+  // exists today, so a build where nothing is flagged means the ledger broke.
+  const parityRows = gaps.gaps.filter((row: Row) => row.schema_parity);
+  assert.equal(parityRows.length > 0, true, "no subnet measured for parity");
+  for (const row of parityRows) {
+    const parity = row.schema_parity as Row;
+    assert.equal((parity.captured_schema_count as number) >= 1, true);
+    assert.equal(
+      Number.isInteger(parity.captured_path_count) &&
+        (parity.captured_path_count as number) >= 0,
+      true,
+    );
+    assert.equal(
+      parity.declared_non_get_count === null ||
+        Number.isInteger(parity.declared_non_get_count),
+      true,
+    );
+    assert.equal(
+      parity.flagged,
+      (parity.registered_route_surface_count as number) <
+        (parity.captured_path_count as number),
+      `parity flag must be the arithmetic it claims (netuid ${row.netuid})`,
+    );
+  }
+  assert.equal(
+    parityRows.some((row: Row) => (row.schema_parity as Row).flagged),
+    true,
+    "no subnet flagged -- under-registration is measured to exist (#11146)",
+  );
   assert.equal(verification.candidate_count, verification.results.length);
   assert.equal(
     verification.results.length <= candidates.candidates.length,

--- a/tests/schema-capture-freshness.test.ts
+++ b/tests/schema-capture-freshness.test.ts
@@ -1,0 +1,89 @@
+// #11146 phases 1-2: the capture lane's freshness, and what drift_status is
+// honestly measured against.
+//
+// The bug this pins was live for 11 days: `drift_status: "unchanged"` compares
+// our snapshot to our PREVIOUS snapshot, and with the capture lane manual-only
+// that was trivially true while upstream moved -- 23 of 24 measurably-drifted
+// subnets reported `unchanged`. A contract agreeing with itself proves
+// nothing. The fix is not a fetch; it is saying so in the payload.
+//
+// The load-bearing case is the CLOCK. `buildTimestamp()` returns the 1970
+// epoch placeholder in every local and determinism build, so a naive
+// `Math.max(0, now - captured)` publishes a 12-day-old capture as ZERO HOURS
+// OLD -- the same dishonesty, reintroduced. Unknown must stay null.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  captureFreshness,
+  SCHEMA_CAPTURE_CADENCE_HOURS,
+} from "../src/schema-snapshots-sync.ts";
+
+/** The REAL rule the artifact builder stamps with -- imported, never
+ * re-implemented: a test that restates the logic it checks would agree with a
+ * broken rule as happily as a correct one. */
+const stamp = captureFreshness;
+
+describe("the cadence", () => {
+  test("is a positive number of hours, declared once", () => {
+    assert.equal(Number.isFinite(SCHEMA_CAPTURE_CADENCE_HOURS), true);
+    assert.equal(SCHEMA_CAPTURE_CADENCE_HOURS > 0, true);
+  });
+});
+
+describe("capture age", () => {
+  test("a capture inside the cadence is fresh", () => {
+    const row = stamp("2026-08-14T12:00:00.000Z", "2026-08-13T12:00:00.000Z");
+    assert.equal(row.capture_age_hours, 24);
+    assert.equal(row.capture_stale, false);
+  });
+
+  test("a capture past the cadence is STALE, not 'unchanged'", () => {
+    // The production shape on 2026-08-14: captures from 2026-08-02.
+    const row = stamp("2026-08-14T12:00:00.000Z", "2026-08-02T07:31:05.148Z");
+    assert.equal((row.capture_age_hours as number) > 280, true);
+    assert.equal(row.capture_stale, true);
+  });
+
+  test("exactly at the cadence is not yet stale (strictly greater)", () => {
+    const captured = new Date(
+      Date.parse("2026-08-14T12:00:00.000Z") -
+        SCHEMA_CAPTURE_CADENCE_HOURS * 3_600_000,
+    ).toISOString();
+    const row = stamp("2026-08-14T12:00:00.000Z", captured);
+    assert.equal(row.capture_age_hours, SCHEMA_CAPTURE_CADENCE_HOURS);
+    assert.equal(row.capture_stale, false);
+  });
+});
+
+describe("an unusable clock is UNKNOWN, never fresh", () => {
+  test("the 1970 build placeholder yields null, not zero hours", () => {
+    // The regression that reached a built artifact during development: with
+    // Math.max(0, ...) this row published capture_stale:false for a capture
+    // twelve days old.
+    const row = stamp("1970-01-01T00:00:00.000Z", "2026-08-02T07:31:05.148Z");
+    assert.equal(row.capture_age_hours, null);
+    assert.equal(row.capture_stale, null);
+  });
+
+  test("a missing or unparseable capture timestamp yields null", () => {
+    for (const bad of [null, "", "not-a-date"]) {
+      const row = stamp("2026-08-14T12:00:00.000Z", bad);
+      assert.equal(row.capture_age_hours, null, String(bad));
+      assert.equal(row.capture_stale, null, String(bad));
+    }
+  });
+});
+
+describe("drift_basis names what the comparison is against", () => {
+  test("every stamped entry declares the basis, whatever the clock said", () => {
+    for (const build of [
+      "1970-01-01T00:00:00.000Z",
+      "2026-08-14T12:00:00.000Z",
+    ])
+      assert.equal(
+        stamp(build, "2026-08-02T07:31:05.148Z").drift_basis,
+        "previous-capture",
+        "drift_status must never be readable as an upstream comparison",
+      );
+  });
+});


### PR DESCRIPTION
Closes #11146.

The epic measured three mechanisms that each silently broke "every subnet's API, exactly like using it directly". Phase 3 (the surface `method` dimension) landed in #11210 and the first declared mutation in #11212; this completes the remaining three in one change.

## 1. Freshness is visible

The capture lane's cadence is declared once (`SCHEMA_CAPTURE_CADENCE_HOURS = 48`) and every captured index entry carries `capture_age_hours` + `capture_stale`; the artifact carries `capture_cadence_hours` so a consumer can compute staleness itself.

The lane stays manual by ADR 0006 — declaring a cadence does not run it, it makes its **silence visible**, which is the difference between an unpublished gap and a published one.

**An unusable clock is null, never zero.** `buildTimestamp()` returns the 1970 epoch placeholder in every local and determinism build; an early `Math.max(0, …)` in this branch published a twelve-day-old capture as *fresh* — the exact dishonesty this phase removes. Caught in a built artifact, fixed, and pinned by a test.

## 2. Drift says what it measures

Entries carry `drift_basis: "previous-capture"`. `drift_status` compares our snapshot to **our previous snapshot**, never upstream — which is why 23 of 24 measurably-drifted subnets reported `unchanged`. The payload now says so rather than implying the opposite, and `capture_stale` tells a reader the comparison is old.

## 3. The parity ledger

Each gaps row gains `schema_parity`: captured paths and declared mutations against registered route surfaces and registered mutations, `flagged` when the catalogue registers fewer routes than the subnet declares, `captured_stale` when the measurement rests on an old capture.

Derived from schema **index** entries only — captured documents exist solely in credentialed builds, so a rollup reading them would not be reproducible — with the capture lane now stamping `non_get_operation_count` so both sides of the mutation ledger are measured. Counts absent on pre-stamp entries report **null, never zero**.

**First measurement:** 53 subnets measured, **27 flagged** — sn-3 registers 8 routes against 208 declared paths, sn-105 28 against 53, matching the epic's fleet numbers.

## Validation

- `typecheck`, `lint`, `format:check`
- `validate`, `validate:api` (215 routes), `validate:openapi`, `validate:contract-drift`, `validate:published-names`, `validate:schema-enums`, `validate:schema-vocabularies`, `validate:mcp` (240 tools), `validate:schemas`, `validate:module-state-resets`, `validate:no-hand-written-mjs` — all green
- Full suite green, including the build-determinism and schema-index-preservation suites (both exercised directly against a pristine committed baseline)
- Both clock arms proven end-to-end on real builds: epoch stamp → all 53 `captured_stale: null`; real stamp → all 53 `true` (captures are 12 days old against a 48h cadence)