### PR TITLE
feat(ci): read the lane status objects nothing has ever read

### DIFF
--- a/.github/workflows/check-lane-status.yml
+++ b/.github/workflows/check-lane-status.yml
@@ -1,0 +1,45 @@
+# Did every lakehouse PRODUCER finish a pass recently enough?
+# (JSONbored/metagraphed-infra#571)
+#
+# check-lakehouse-freshness.yml watches the TABLES. This watches the LANES that
+# write them, which is not the same question: the account-summary projection
+# writes no Iceberg table at all, so when its producer was SIGKILLed on every
+# pass from 2026-08-14 15:07Z onward, nothing anywhere reported it. The route it
+# feeds silently returned to scanning 4,374 MB per request -- correct, ~30,000x
+# more expensive, and with no error to notice.
+#
+# SIX-HOURLY, not daily. The tightest bound here is six hours (the hourly decode
+# lanes), and the account-summary bound is deliberately set to fire a day before
+# the reader stops trusting the projection -- a daily sweep would spend most of
+# that warning.
+name: check-lane-status
+
+on:
+  schedule:
+    - cron: "43 */6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-lane-status
+  cancel-in-progress: false
+
+jobs:
+  lanes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 22
+      - name: Check every lakehouse lane's newest completed pass
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          LIVE_ALERT_WEBHOOK_URL: ${{ secrets.LIVE_ALERT_WEBHOOK_URL }}
+        # No `tee`: piping a report into tee discards the script's exit status,
+        # which is how a scheduled sweep in this repo came to be unable to fail.
+        run: npm run check:lane-status

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "validate:untyped-lakehouse-reads": "node scripts/validate-untyped-lakehouse-reads.ts",
     "validate:lakehouse-readers": "node scripts/validate-lakehouse-readers.ts",
     "check:lakehouse-freshness": "node scripts/check-lakehouse-freshness.ts",
+    "check:lane-status": "node scripts/check-lane-status.ts",
     "validate:store-type-parity": "node scripts/validate-store-type-parity.ts",
     "validate:featured-validators-drift": "node scripts/validate-featured-validators-drift.ts",
     "build:featured-validators": "node scripts/generate-featured-validators.ts",

--- a/scripts/check-lane-status.ts
+++ b/scripts/check-lane-status.ts
@@ -1,0 +1,447 @@
+// Did every lakehouse PRODUCER finish a pass recently enough?
+// (JSONbored/metagraphed-infra#571)
+//
+// ## What this is for
+//
+// `scripts/check-lakehouse-freshness.ts` watches lakehouse TABLES -- did a
+// snapshot arrive. This watches the LANES that write them, and the two are not
+// the same question: a lane can die while the tables it does not own stay
+// fresh, and a lane that writes no Iceberg table at all is invisible to the
+// other check entirely.
+//
+// The account-summary projection is the case that forced this. Its producer was
+// SIGKILLed on every pass from 2026-08-14 15:07Z onward, and nothing said so.
+// `/api/v1/accounts/{ss58}` silently returned to the lakehouse read it used
+// before the projection existed -- correct, and ~30,000x more expensive: 4,374
+// MB scanned per request instead of a ~36 KB GET. There is no error, no
+// degraded header and no failed check; the only symptom is one route's latency
+// drifting back to 5-18s, which is exactly the shape of thing that goes
+// unnoticed for weeks.
+//
+// Two sibling lanes had the same hole already: `account-events-rollup-status`
+// and `rpc-usage-export-status` have been written every hour for months with
+// nothing ever reading them. That is why this sweeps the status objects as a
+// FAMILY rather than adding an alarm for one lane.
+//
+// ## Why the STATUS OBJECT and not the data
+//
+// Each lane already publishes its own verdict, precisely because a container
+// lane's stderr reaches nobody. The object is the report; this is the reader it
+// never had. Asking the lane's OUTPUT instead ("is account_events_daily fresh")
+// answers a different question -- a lane can fail after its last successful
+// append and leave the table looking fine.
+//
+// ## A KILLED lane does not look like a lane that never ran
+//
+// This is the distinction the whole check turns on. `checked_at` is written
+// only on COMPLETION, and the mid-scan heartbeat overwrites the whole object.
+// So a SIGKILLed pass leaves `{phase: "scanning", started_at: ...}` with NO
+// `checked_at` at all -- not a stale timestamp, an absent one. Treating that as
+// "never ran, nothing to say" is how the outage above stayed quiet, so it is
+// reported as its own failure with the phase and start time it died at.
+//
+// ## Every status object must be CLASSIFIED
+//
+// The bucket is listed and any `*-status.json` missing from `EXPECTED_LANES`
+// FAILS, exactly as an unclassified table does on the lakehouse side. Absent
+// means nobody has thought about it; `maxAgeMs: null` with a reason means
+// somebody decided it cannot go stale. The two are different facts and only one
+// of them is safe -- and a new lane added in the private repo is precisely the
+// thing that would otherwise arrive here unwatched.
+import { fileURLToPath } from "node:url";
+
+import { r2ApiBaseUrl, r2ObjectUrl } from "./r2-rest.ts";
+
+const BUCKET = process.env.R2_ARTIFACTS_BUCKET ?? "metagraphed-artifacts";
+export const PREFIX = "metagraph/lakehouse/";
+
+/** The lane name a verdict line opens with, which every detail string starts with. */
+function laneOf(detail: string): string {
+  return detail.split(" ")[0] ?? "";
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+/**
+ * How a producer stamps its own verdict.
+ *
+ * Two shapes exist and neither is going to be talked into the other: the python
+ * lanes write `{checked_at, ok}` from a `finally`, while the decoder writes
+ * `{updated_at, status}` through `iceberg_r2.py`'s shared writer. Reading one
+ * shape's fields out of the other yields `undefined`, which would evaluate as
+ * "no completion recorded" and make every decode run look dead.
+ */
+export type LaneShape = "checked_at" | "updated_at";
+
+export interface LaneRule {
+  /** How old the newest COMPLETED pass may be, or null when staleness is meaningless. */
+  maxAgeMs: number | null;
+  /** Why this bound, in the producer's own terms. */
+  reason: string;
+  shape: LaneShape;
+}
+
+/**
+ * Every lane status object under `metagraph/lakehouse/`, and how stale each may be.
+ *
+ * BOUNDS ARE MISSED TICKS, not wall-clock guesses -- the reasoning
+ * `missedTicksMs` gives the Neon watchdogs and `check-lakehouse-freshness`
+ * gives the tables. A bound near one producer interval alerts on a lane that is
+ * merely working, and a watchdog people learn to ignore is worse than none.
+ *
+ * The decode container's cron is `17 * * * *`, and every lane in
+ * `entrypoint-decode-r2.sh` writes its status on EVERY tick -- including the
+ * ticks where it decides it has nothing to do, which is why a skip is not a
+ * silence here. Six hours is six missed ticks, matching the bound the lakehouse
+ * check already gives the decoder's own tables.
+ *
+ * `account-summary` is the exception, and deliberately: it is gated by a 20-hour
+ * floor and A SKIP DOES NOT REPUBLISH, so its `checked_at` advances about once a
+ * day rather than hourly.
+ */
+export const EXPECTED_LANES: Readonly<Record<string, LaneRule>> = {
+  "decode-run-status.json": {
+    maxAgeMs: 6 * HOUR,
+    shape: "updated_at",
+    reason: "the decoder itself, hourly on the :17 tick",
+  },
+  // TESTNET IS A SERVED NETWORK. `check-lakehouse-freshness` had to widen to
+  // `chain_testnet` for the same reason -- a stalled testnet decode would
+  // otherwise be invisible while the mainnet lane kept this green.
+  "testnet/decode-run-status.json": {
+    maxAgeMs: 6 * HOUR,
+    shape: "updated_at",
+    reason: "the testnet decoder, same hourly tick",
+  },
+  "state-mirror-status.json": {
+    maxAgeMs: 6 * HOUR,
+    shape: "checked_at",
+    reason: "state_mirror_r2.py, every decode tick",
+  },
+  "account-events-rollup-status.json": {
+    maxAgeMs: 6 * HOUR,
+    shape: "checked_at",
+    reason: "account_events_rollup_r2.py, every decode tick",
+  },
+  "daily-rollup-status.json": {
+    maxAgeMs: 6 * HOUR,
+    shape: "checked_at",
+    reason: "daily_rollup_r2.py export+reconcile, every decode tick",
+  },
+  "rpc-usage-export-status.json": {
+    maxAgeMs: 6 * HOUR,
+    shape: "checked_at",
+    reason: "rpc_usage_export_r2.py, every decode tick",
+  },
+  "account-summary-status.json": {
+    // TWO DAYS, and the number is chosen against the READER rather than the
+    // producer alone. `ACCOUNT_SUMMARY_MAX_AGE_MS` is three days: past it the
+    // route stops trusting the projection and silently pays the old 4,374 MB
+    // scan again. Alerting at two days means the lane is reported dead a full
+    // day BEFORE the surface it protects quietly regresses, which is the only
+    // bound that makes this check worth running.
+    maxAgeMs: 2 * DAY,
+    shape: "checked_at",
+    reason:
+      "account_summary_r2.py, 20h floor and a skip does not republish; " +
+      "fires one day before the reader's 3d trust bound expires",
+  },
+};
+
+/**
+ * Lanes known to be failing right now, so a NEW one still stands out.
+ *
+ * Same discipline as `KNOWN_FROZEN` on the lakehouse side: the entry records an
+ * outage that is already tracked, and the sweep reports a lane that LEAVES this
+ * set so the baseline has to shrink. A baseline that is only ever added to
+ * becomes a way of not looking.
+ */
+export const KNOWN_STALE: Readonly<Record<string, string>> = {
+  "account-summary-status.json":
+    "SIGKILLed inside window 20 of 21 on every pass since 2026-08-14 15:07Z; " +
+    "metagraphed-infra#570 moves it to its own sized container class",
+};
+
+export interface LaneReading {
+  lane: string;
+  /** The parsed status object, or null when it could not be read or parsed. */
+  body: Record<string, unknown> | null;
+  nowMs: number;
+}
+
+function parseStamp(value: unknown): number | null {
+  if (typeof value !== "string" || !value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function age(ms: number): string {
+  const hours = ms / HOUR;
+  return hours < 48 ? `${hours.toFixed(1)}h` : `${(ms / DAY).toFixed(1)}d`;
+}
+
+/**
+ * The verdict for one lane, as a pure function so the rule is testable without
+ * a bucket.
+ *
+ * `ok: false` is checked BEFORE staleness on purpose. A lane that ran on time
+ * and failed is a different fault from one that stopped running, and reporting
+ * the fresh timestamp first would describe a broken lane as healthy.
+ */
+export function evaluate(
+  reading: LaneReading,
+  rule: LaneRule | undefined,
+): { ok: boolean; detail: string } {
+  const { lane, body, nowMs } = reading;
+  if (!rule) {
+    return {
+      ok: false,
+      detail: `${lane} is not classified in EXPECTED_LANES -- add a bound, or an explicit null with a reason`,
+    };
+  }
+  if (rule.maxAgeMs === null) {
+    return { ok: true, detail: `${lane}: exempt (${rule.reason})` };
+  }
+  if (body === null) {
+    return {
+      ok: false,
+      detail: `${lane} could not be read or parsed (${rule.reason})`,
+    };
+  }
+
+  if (rule.shape === "updated_at") {
+    const status = body["status"];
+    const stamp = parseStamp(body["updated_at"]);
+    if (stamp === null) {
+      return {
+        ok: false,
+        detail: `${lane} has no usable updated_at (${rule.reason})`,
+      };
+    }
+    if (status !== "ok") {
+      return {
+        ok: false,
+        detail: `${lane} reports status=${JSON.stringify(status)} as of ${age(nowMs - stamp)} ago (${rule.reason})`,
+      };
+    }
+    if (nowMs - stamp > rule.maxAgeMs) {
+      return {
+        ok: false,
+        detail: `${lane} last updated ${age(nowMs - stamp)} ago, over its ${age(rule.maxAgeMs)} bound (${rule.reason})`,
+      };
+    }
+    return { ok: true, detail: `${lane}: ${age(nowMs - stamp)}` };
+  }
+
+  // A COMPLETED pass sets `ok`; a killed one leaves the heartbeat's `ok: null`
+  // behind. `=== false` rather than a truthiness test keeps those apart, so an
+  // interrupted run is reported as interrupted below rather than as a failure
+  // the lane actually recorded.
+  if (body["ok"] === false) {
+    const failures = body["failures"];
+    const why =
+      failures && typeof failures === "object"
+        ? ` -- ${JSON.stringify(failures).slice(0, 200)}`
+        : "";
+    return {
+      ok: false,
+      detail: `${lane} reported ok:false on its last pass${why} (${rule.reason})`,
+    };
+  }
+
+  const completed = parseStamp(body["checked_at"]);
+  if (completed === null) {
+    // THE KILLED CASE, and the reason this check exists. `checked_at` is
+    // written only on completion and the mid-scan heartbeat overwrites the
+    // whole object, so its absence means the last thing that happened was a
+    // start that never finished -- reported with what the lane managed to say
+    // before it died.
+    const started = parseStamp(body["started_at"]);
+    const phase = body["phase"];
+    const where =
+      typeof body["window"] === "string" ? `, window ${body["window"]}` : "";
+    if (started !== null) {
+      return {
+        ok: false,
+        detail:
+          `${lane} STARTED ${age(nowMs - started)} ago and never completed ` +
+          `(phase=${JSON.stringify(phase)}${where}) (${rule.reason})`,
+      };
+    }
+    return {
+      ok: false,
+      detail: `${lane} records no completed pass at all (${rule.reason})`,
+    };
+  }
+  if (nowMs - completed > rule.maxAgeMs) {
+    return {
+      ok: false,
+      detail: `${lane} last completed ${age(nowMs - completed)} ago, over its ${age(rule.maxAgeMs)} bound (${rule.reason})`,
+    };
+  }
+  return { ok: true, detail: `${lane}: ${age(nowMs - completed)}` };
+}
+
+/**
+ * Status object keys under the prefix, as lane names relative to it.
+ *
+ * Only `*-status.json`: the prefix also holds `decode-watermark.json` and
+ * `decode-gaps.json`, which are lane STATE rather than a verdict and have no
+ * freshness meaning of their own.
+ */
+export function laneNamesFrom(keys: readonly string[]): string[] {
+  return keys
+    .filter((k) => k.startsWith(PREFIX) && k.endsWith("-status.json"))
+    .map((k) => k.slice(PREFIX.length))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function listLaneKeys(
+  accountId: string,
+  apiToken: string,
+): Promise<string[]> {
+  const url =
+    `${r2ApiBaseUrl()}/accounts/${accountId}/r2/buckets/${BUCKET}/objects` +
+    `?prefix=${encodeURIComponent(PREFIX)}&per_page=1000`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiToken}` },
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    throw new Error(`listing ${BUCKET}/${PREFIX} failed: HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as {
+    success?: boolean;
+    result?: { key?: string }[];
+  };
+  if (!body.success)
+    throw new Error(`listing ${BUCKET}/${PREFIX} returned success:false`);
+  return (body.result ?? []).map((o) => o.key ?? "").filter(Boolean);
+}
+
+async function readLane(
+  accountId: string,
+  apiToken: string,
+  lane: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const res = await fetch(
+      r2ObjectUrl(accountId, BUCKET, `${PREFIX}${lane}`),
+      {
+        headers: { Authorization: `Bearer ${apiToken}` },
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    return body && typeof body === "object"
+      ? (body as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID ?? "";
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN ?? "";
+  if (!accountId || !apiToken) {
+    // Loud, not skipped: a watchdog that quietly passes without credentials is
+    // the "gate that cannot fail" this repo has been bitten by before.
+    process.stderr.write(
+      "CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN are required -- this reads live R2.\n",
+    );
+    process.exit(1);
+  }
+
+  const keys = await listLaneKeys(accountId, apiToken);
+  const lanes = laneNamesFrom(keys);
+  if (lanes.length === 0) {
+    // An empty listing is not "every lane is fine". Something is wrong with the
+    // prefix, the bucket or the token, and passing on it would be the same
+    // silent no-op this check exists to end.
+    process.stderr.write(
+      `lane-status: NO status objects found under ${PREFIX} -- wrong bucket, prefix or token?\n`,
+    );
+    process.exit(1);
+  }
+
+  // A DECLARED LANE THAT VANISHED is a failure too. The listing drives the
+  // sweep, so a lane whose object was deleted would otherwise simply stop being
+  // checked -- the quietest possible way for a producer to disappear.
+  const seen = new Set(lanes);
+  const missing = Object.keys(EXPECTED_LANES).filter((l) => !seen.has(l));
+
+  const nowMs = Date.now();
+  const failures: string[] = [];
+  const lines: string[] = [];
+  for (const lane of lanes) {
+    const rule = EXPECTED_LANES[lane];
+    const body = rule ? await readLane(accountId, apiToken, lane) : null;
+    const verdict = evaluate({ lane, body, nowMs }, rule);
+    lines.push(`${verdict.ok ? "ok   " : "STALE"} ${verdict.detail}`);
+    if (!verdict.ok) failures.push(verdict.detail);
+  }
+  for (const lane of missing) {
+    const detail = `${lane} is declared in EXPECTED_LANES but no longer exists in the bucket`;
+    lines.push(`STALE ${detail}`);
+    failures.push(detail);
+  }
+  process.stdout.write(lines.join("\n") + "\n");
+
+  const failed = new Set(failures.map(laneOf));
+  const baseline = Object.keys(KNOWN_STALE);
+  const recovered = baseline.filter((l) => seen.has(l) && !failed.has(l));
+  // PARENTHESISED, and it matters: `a ?? "" in KNOWN_STALE` parses as
+  // `a ?? ("" in KNOWN_STALE)` because `in` binds tighter than `??`, which
+  // yields the lane name, negates to false, and leaves `regressions` empty
+  // forever -- a watchdog that can only ever report "0 NEW".
+  const regressions = failures.filter(
+    (f) => !Object.hasOwn(KNOWN_STALE, laneOf(f)),
+  );
+
+  process.stdout.write(
+    `\nlane-status: ${failures.length} failing of ${lanes.length} -- ` +
+      `${failures.length - regressions.length} known (baseline ${baseline.length}), ` +
+      `${regressions.length} NEW, ${recovered.length} recovered.\n`,
+  );
+  if (recovered.length > 0) {
+    process.stderr.write(
+      "\nRECOVERED -- delete these from KNOWN_STALE so the baseline keeps shrinking:\n" +
+        recovered.map((l) => `  ${l}`).join("\n") +
+        "\n",
+    );
+  }
+  if (regressions.length === 0 && recovered.length === 0) return;
+
+  const webhook = process.env.LIVE_ALERT_WEBHOOK_URL;
+  if (webhook && regressions.length > 0) {
+    try {
+      await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: AbortSignal.timeout(15_000),
+        body: JSON.stringify({
+          content:
+            `⚠️ metagraphed: ${regressions.length} lakehouse lane(s) NEWLY dead or failing.\n` +
+            regressions
+              .slice(0, 10)
+              .map((f) => `• ${f}`)
+              .join("\n") +
+            `\nA dead lane throws no error -- the routes it feeds fall back and just get slower (infra#571).`,
+        }),
+      });
+    } catch (err) {
+      process.stderr.write(
+        `alert webhook failed: ${err instanceof Error ? err.message : err}\n`,
+      );
+    }
+  }
+  process.stderr.write(
+    `\nlane-status: ${failures.length} of ${lanes.length} lane(s) FAILING.\n`,
+  );
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) await main();

--- a/tests/lane-status.test.ts
+++ b/tests/lane-status.test.ts
@@ -1,0 +1,278 @@
+// The lane-status rule, tested without a bucket (JSONbored/metagraphed-infra#571).
+//
+// The claim worth pinning hardest is the KILLED case: `checked_at` is written
+// only on completion and the mid-scan heartbeat overwrites the whole object, so
+// a SIGKILLed pass leaves an ABSENT timestamp rather than an old one. Reading
+// that as "nothing to say" is precisely how the account-summary outage stayed
+// quiet for five and a half hours while the route it protects silently went
+// back to scanning 4,374 MB per request.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  EXPECTED_LANES,
+  KNOWN_STALE,
+  evaluate,
+  laneNamesFrom,
+  PREFIX,
+} from "../scripts/check-lane-status.ts";
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+const NOW = Date.parse("2026-08-14T21:00:00Z");
+
+function at(offsetMs: number): string {
+  return new Date(NOW - offsetMs).toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+const COMPLETED = "account-events-rollup-status.json";
+const DECODE = "decode-run-status.json";
+const SUMMARY = "account-summary-status.json";
+
+describe("lane status", () => {
+  test("an UNCLASSIFIED lane fails -- absent is not exempt", () => {
+    // The rule the lakehouse and Neon watchdogs already hold: absent means
+    // nobody thought about it, and a lane nobody classified is watched by
+    // nothing, forever. This is the one that catches a lane added in the
+    // PRIVATE repo, which is where every one of these producers lives.
+    const v = evaluate(
+      { lane: "brand-new-status.json", body: {}, nowMs: NOW },
+      undefined,
+    );
+    assert.equal(v.ok, false);
+    assert.match(v.detail, /not classified/);
+  });
+
+  test("a completed pass inside its bound passes", () => {
+    const v = evaluate(
+      {
+        lane: COMPLETED,
+        body: { ok: true, checked_at: at(40 * 60 * 1000) },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[COMPLETED],
+    );
+    assert.equal(v.ok, true);
+  });
+
+  test("a lane past its bound is STALE, and says by how much", () => {
+    const v = evaluate(
+      {
+        lane: COMPLETED,
+        body: { ok: true, checked_at: at(9 * HOUR) },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[COMPLETED],
+    );
+    assert.equal(v.ok, false);
+    assert.match(v.detail, /9\.0h/);
+    assert.match(v.detail, /over its 6\.0h bound/);
+  });
+
+  test("a KILLED pass is reported as started-and-never-completed", () => {
+    // THE CASE THIS WHOLE CHECK EXISTS FOR, and the exact body production was
+    // serving at 2026-08-14 21:00Z.
+    const v = evaluate(
+      {
+        lane: SUMMARY,
+        body: {
+          phase: "scanning",
+          started_at: at(35 * 60 * 1000),
+          ok: null,
+          window: "19/21",
+          rows_scanned: 246239473,
+        },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[SUMMARY],
+    );
+    assert.equal(v.ok, false);
+    assert.match(v.detail, /STARTED .* and never completed/);
+    // The phase and window travel with it, or the alert sends the reader back
+    // to inference -- which is what the mid-scan heartbeat was added to stop.
+    assert.match(v.detail, /phase="scanning"/);
+    assert.match(v.detail, /window 19\/21/);
+  });
+
+  test("a killed pass fails even when it died SECONDS ago", () => {
+    // Staleness cannot catch this: the object is fresh, it is the COMPLETION
+    // that is missing. A bound-only check would call a lane that dies on every
+    // pass perfectly healthy, forever.
+    const v = evaluate(
+      {
+        lane: SUMMARY,
+        body: { phase: "scanning", started_at: at(5_000), ok: null },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[SUMMARY],
+    );
+    assert.equal(v.ok, false);
+  });
+
+  test("ok:false is reported as a failed pass, not a stale one", () => {
+    // A lane that ran on time and FAILED is a different fault from one that
+    // stopped running. Reporting the fresh timestamp first would describe a
+    // broken lane as healthy.
+    const v = evaluate(
+      {
+        lane: COMPLETED,
+        body: {
+          ok: false,
+          checked_at: at(60_000),
+          failures: { _lane: "RuntimeError: boom" },
+        },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[COMPLETED],
+    );
+    assert.equal(v.ok, false);
+    assert.match(v.detail, /ok:false/);
+    assert.match(v.detail, /RuntimeError: boom/);
+  });
+
+  test("ok:null does not read as ok:false", () => {
+    // The heartbeat writes `ok: null` mid-scan. A truthiness test would call
+    // that a recorded failure and report the wrong fault for every killed run.
+    const v = evaluate(
+      { lane: SUMMARY, body: { ok: null, checked_at: at(60_000) }, nowMs: NOW },
+      EXPECTED_LANES[SUMMARY],
+    );
+    assert.equal(v.ok, true);
+  });
+
+  test("the decoder's OWN shape is read, not the python one", () => {
+    // Two shapes exist: `{checked_at, ok}` and `{updated_at, status}`. Reading
+    // one out of the other yields undefined, which would evaluate as "no
+    // completion recorded" and make every decode run look dead.
+    const v = evaluate(
+      {
+        lane: DECODE,
+        body: { status: "ok", updated_at: at(40 * 60 * 1000) },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[DECODE],
+    );
+    assert.equal(v.ok, true);
+  });
+
+  test("a decoder status other than ok fails", () => {
+    const v = evaluate(
+      {
+        lane: DECODE,
+        body: { status: "degraded", updated_at: at(60_000) },
+        nowMs: NOW,
+      },
+      EXPECTED_LANES[DECODE],
+    );
+    assert.equal(v.ok, false);
+    assert.match(v.detail, /status="degraded"/);
+  });
+
+  test("an unreadable object is a failure, not a pass", () => {
+    // R2 briefly unreachable must not read as "the lane is fine". The whole
+    // family of faults here is silent, so the default has to be loud.
+    const v = evaluate(
+      { lane: COMPLETED, body: null, nowMs: NOW },
+      EXPECTED_LANES[COMPLETED],
+    );
+    assert.equal(v.ok, false);
+    assert.match(v.detail, /could not be read/);
+  });
+
+  test("an unparseable timestamp fails rather than reading as epoch", () => {
+    for (const stamp of ["", "not a date", 1_760_000_000_000]) {
+      const v = evaluate(
+        { lane: COMPLETED, body: { ok: true, checked_at: stamp }, nowMs: NOW },
+        EXPECTED_LANES[COMPLETED],
+      );
+      assert.equal(v.ok, false, JSON.stringify(stamp));
+    }
+  });
+
+  test("account-summary fires BEFORE the reader stops trusting the projection", () => {
+    // The bound is chosen against the READER, not the producer alone.
+    // ACCOUNT_SUMMARY_MAX_AGE_MS is three days; past it /api/v1/accounts/{ss58}
+    // silently pays the 4,374 MB scan again. A bound at or past three days
+    // would alert only after the surface it protects had already regressed.
+    const bound = EXPECTED_LANES[SUMMARY]?.maxAgeMs;
+    assert.ok(bound !== null && bound !== undefined);
+    assert.ok(
+      bound < 3 * DAY,
+      `${bound} must fire inside the reader's 3d trust bound`,
+    );
+  });
+
+  test("every hourly lane is bounded in MISSED TICKS, not one interval", () => {
+    // A bound near one producer interval alerts on a lane that is merely
+    // working, and a watchdog people learn to ignore is worse than none.
+    for (const [lane, rule] of Object.entries(EXPECTED_LANES)) {
+      if (rule.maxAgeMs === null) continue;
+      assert.ok(rule.maxAgeMs >= 2 * HOUR, `${lane} is bounded too tightly`);
+      assert.ok(rule.reason.length > 0, `${lane} has no reason`);
+    }
+  });
+
+  test("the baseline names only lanes that are actually classified", () => {
+    // A baseline entry for a lane no rule covers would silence a lane the
+    // sweep never evaluates -- the quietest possible way to lose one.
+    const unclassified = Object.keys(KNOWN_STALE).filter(
+      (l) => !(l in EXPECTED_LANES),
+    );
+    assert.deepEqual(unclassified, []);
+  });
+
+  test("every baseline entry says WHY, with something to follow", () => {
+    for (const [lane, reason] of Object.entries(KNOWN_STALE)) {
+      assert.match(reason, /#\d+/, `${lane} must cite the issue tracking it`);
+    }
+  });
+});
+
+describe("which objects are swept", () => {
+  test("only *-status.json, so watermarks and gaps are not swept", () => {
+    // decode-watermark.json and decode-gaps.json are lane STATE, not a verdict.
+    // Sweeping them would demand a freshness rule for something that has no
+    // completion semantics at all.
+    const lanes = laneNamesFrom([
+      `${PREFIX}account-summary-status.json`,
+      `${PREFIX}decode-watermark.json`,
+      `${PREFIX}decode-gaps.json`,
+      `${PREFIX}decode-run-status.json`,
+    ]);
+    assert.deepEqual(lanes, [
+      "account-summary-status.json",
+      "decode-run-status.json",
+    ]);
+  });
+
+  test("the testnet subtree is swept too", () => {
+    // Testnet is a SERVED network -- check-lakehouse-freshness had to widen to
+    // chain_testnet for the same reason. A nested key must survive as a nested
+    // lane name, or it silently stops matching its rule.
+    const lanes = laneNamesFrom([`${PREFIX}testnet/decode-run-status.json`]);
+    assert.deepEqual(lanes, ["testnet/decode-run-status.json"]);
+    assert.ok("testnet/decode-run-status.json" in EXPECTED_LANES);
+  });
+
+  test("keys outside the prefix are ignored", () => {
+    assert.deepEqual(
+      laneNamesFrom(["metagraph/projections/x-status.json"]),
+      [],
+    );
+  });
+
+  test("all seven production lanes are classified", () => {
+    // The set observed in the bucket on 2026-08-14. A producer added without a
+    // rule fails the sweep at runtime; this fails it at review time.
+    for (const lane of [
+      "account-events-rollup-status.json",
+      "account-summary-status.json",
+      "daily-rollup-status.json",
+      "decode-run-status.json",
+      "rpc-usage-export-status.json",
+      "state-mirror-status.json",
+      "testnet/decode-run-status.json",
+    ]) {
+      assert.ok(lane in EXPECTED_LANES, `${lane} is not classified`);
+    }
+  });
+});


### PR DESCRIPTION
`check-lakehouse-freshness` watches the lakehouse **tables**. Nothing watched the **lanes** that write them, and the two are not the same question: a lane can die while the tables it does not own stay fresh, and a lane that writes no Iceberg table at all is invisible to that check entirely.

The account-summary projection is the case that forced this. Its producer has been SIGKILLed on every pass since **2026-08-14 15:07Z**, and nothing said so. `/api/v1/accounts/{ss58}` silently returned to the lakehouse read it used before the projection existed — correct, and ~30,000x more expensive: **4,374 MB scanned per request instead of a ~36 KB GET**. No error, no degraded header, no failed check. The only symptom is one route's latency drifting back to 5–18s, which is exactly the shape of thing that goes unnoticed for weeks.

Two sibling lanes had the same hole already: `account-events-rollup-status` and `rpc-usage-export-status` have been written every hour for months with nothing ever reading them. That is why this sweeps the family rather than adding an alarm for one lane.

## A killed lane does not look like one that never ran

This is the distinction the whole check turns on. `checked_at` is written only on completion, and the mid-scan heartbeat **overwrites the whole object** — so a SIGKILLed pass leaves an *absent* timestamp, not an old one.

Staleness cannot catch that: the object is fresh, it is the completion that is missing. A bound-only check would call a lane that dies on every single pass perfectly healthy, forever. It is reported with the phase and window it died at, so the alert does not send the reader back to inference.

## Bounds are missed ticks

Six hours is six missed ticks of the `:17` decode cron — the same bound the lakehouse check already gives the decoder's own tables. A bound near one producer interval alerts on a lane that is merely working, and a watchdog people learn to ignore is worse than none.

`account-summary` is the exception at two days, and the number is chosen against the **reader**: `ACCOUNT_SUMMARY_MAX_AGE_MS` is three days, past which the route stops trusting the projection and quietly pays the old scan again. Two days reports the lane dead a full day *before* the surface it protects regresses. A test pins that relationship rather than restating the constant.

## Everything must be classified, in both directions

- the bucket is **listed**, and any `*-status.json` missing from `EXPECTED_LANES` fails — which is what catches a lane added in the private repo, where all of these producers live;
- a **declared lane that vanished** fails too. The listing drives the sweep, so a deleted object would otherwise simply stop being checked — the quietest possible way for a producer to disappear;
- an **empty listing** fails rather than passing, and missing credentials exit 1 loudly. A watchdog that quietly passes is the "gate that cannot fail" this repo has been bitten by before.

`KNOWN_STALE` carries `account-summary` against metagraphed-infra#570 so a *new* death still stands out, with the same recovered-detection the lakehouse baseline has: a lane that leaves the set is reported so the baseline has to shrink.

## Run against production

```
ok    account-events-rollup-status.json: 0.8h
STALE account-summary-status.json STARTED 0.8h ago and never completed (phase="scanning", window 19/21) (...)
ok    daily-rollup-status.json: 0.9h
ok    decode-run-status.json: 0.9h
ok    rpc-usage-export-status.json: 0.7h
ok    state-mirror-status.json: 0.8h
ok    testnet/decode-run-status.json: 0.9h

lane-status: 1 failing of 7 -- 1 known (baseline 1), 0 NEW, 0 recovered.
```

Six healthy, and the seventh diagnosed exactly. **Verified it can fail:** with the baseline emptied, the same live data exits 1 with `1 NEW`.

The bucket listing also turned up a **testnet decode lane** the issue did not mention. It is classified here for the same reason `check-lakehouse-freshness` had to widen to `chain_testnet` — testnet is a served network, so a stalled testnet decode would otherwise stay invisible while the mainnet lane kept this green.

## One bug caught in review, worth naming

The first draft computed regressions as `!(laneOf(f) ?? "" in KNOWN_STALE)`. `in` binds tighter than `??`, so that parses as `laneOf(f) ?? ("" in KNOWN_STALE)` — the lane name, negated to `false`, leaving `regressions` empty forever. A watchdog that could only ever report "0 NEW". It is parenthesised via `Object.hasOwn` now, with a comment saying why, and the falsification run above is what proves it.

## Verification

| gate | result |
| --- | --- |
| `tests/lane-status.test.ts` | 19 passed |
| full `vitest run tests/` | green (the only failures were a missing `dist/metagraph-r2` manifest; `npm run r2:manifest` then green) |
| `validate:private-boundary`, `no-hand-written-mjs`, `workflows`, `docs`, `operations`, `lane-topology` | pass |
| `tsc --noEmit`, `eslint`, `prettier --check` | clean |
| meta-tests for CI wiring (pipeline parity, workflow observability, pipe-status, env-readers) | 143 passed |

No `src/**` or `workers/**` lines change, so `codecov/patch` has nothing to enforce here.

Closes JSONbored/metagraphed-infra#571 — cross-repo, so it will not autoclose; I'll close it by hand on merge.
