### PR TITLE
refactor(attribution): derive the surfaces artifact path from the contract that declares it

### DIFF
--- a/workers/api.ts
+++ b/workers/api.ts
@@ -3010,6 +3010,31 @@ export async function sweepableSubnets(
  * surface-less record would persist a `no-sources` finding built out of our own
  * outage. Same distinction `unreachable` keeps from `none-published`.
  */
+/**
+ * The declared template for one subnet's surfaces artifact, READ FROM THE
+ * CONTRACT rather than restated here.
+ *
+ * A literal `/metagraph/surfaces/${netuid}.json` would compile, pass every unit
+ * test, and silently stop resolving the day the contract moves the path -- which
+ * is the same failure mode as the bug this whole resolver exists to fix, one
+ * level up. `PUBLIC_ARTIFACTS` is the owner; this reads it.
+ *
+ * Throwing on a missing id is deliberate: the artifact is declared in
+ * `src/contracts.ts` and a build where it is not is a broken contract, not a
+ * condition to degrade through.
+ */
+const SURFACES_SUBNET_ARTIFACT_PATH = (() => {
+  const declared = PUBLIC_ARTIFACTS.find(
+    (entry) => entry.id === "surfaces-subnet",
+  )?.path;
+  if (!declared) {
+    throw new Error(
+      "contracts: PUBLIC_ARTIFACTS has no `surfaces-subnet` entry, which the attribution sweep resolves against",
+    );
+  }
+  return declared;
+})();
+
 export async function sweepRecordFor(
   env: Env,
   netuid: number,
@@ -3018,7 +3043,7 @@ export async function sweepRecordFor(
   if (!base) return null;
   const surfaces = await readArtifact(
     env,
-    `/metagraph/surfaces/${netuid}.json`,
+    artifactPathFromTemplate(SURFACES_SUBNET_ARTIFACT_PATH, { netuid }),
   );
   if (!surfaces.ok) {
     throw new Error(


### PR DESCRIPTION
refactor(attribution): derive the surfaces artifact path from the contract that declares it

#11228 landed with the path written out: `/metagraph/surfaces/${netuid}.json`.
That is the same shape of mistake the PR was fixing, one level up. A literal
compiles, passes every unit test, and silently stops resolving the day the
contract moves the path -- and the symptom would be `no-sources` on every
subnet, which is exactly the false finding #11228 exists to end.

`PUBLIC_ARTIFACTS` already owns it as the `surfaces-subnet` entry, and
`workers/api.ts` already imports both it and `artifactPathFromTemplate`, so this
costs no new dependency and no module-scope work beyond one `find`.

A missing entry THROWS rather than degrading. The artifact is declared in
`src/contracts.ts`; a build without it is a broken contract, not a condition to
serve around. Verified: renaming the id to one that does not exist fails the
suite at module load with the message naming the entry.

Full suite path unchanged -- 62 tests green, typecheck, eslint and prettier
clean.

Follows #11228. Related: #11194 (the boundaries that CAST where they should
parse -- the artifact BODY here is still read as `as Row`, which needs an
artifact-to-schema registry that does not exist yet).
