### PR TITLE
feat(ui): the pages describe themselves — Dataset, breadcrumbs, and titles tuned to measured demand

### DIFF
--- a/apps/ui/src/components/metagraphed/agent-resource-grid.tsx
+++ b/apps/ui/src/components/metagraphed/agent-resource-grid.tsx
@@ -12,6 +12,7 @@ import { CopyButton, ExternalLink } from "@jsonbored/ui-kit";
 import { Panel } from "@/components/metagraphed/primitives";
 import { classNames } from "@/lib/metagraphed/format";
 import type { AgentResource } from "@/lib/metagraphed/types";
+import { API_ORIGIN } from "@/lib/metagraphed/identity";
 
 const KIND_META = {
   agent: { icon: Bot, tone: "text-accent" },
@@ -84,7 +85,7 @@ export function AgentResourceGrid({ resources }: { resources: AgentResource[] })
                   href={r.url}
                   className="mt-1.5 inline-flex mg-type-data text-ink-muted hover:text-ink-strong"
                 >
-                  {r.url.replace("https://api.metagraph.sh", "")}
+                  {r.url.replace(API_ORIGIN, "")}
                 </ExternalLink>
               </div>
               <CopyButton value={r.url} label={`${r.title} URL`} compact />

--- a/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
+++ b/apps/ui/src/components/metagraphed/endpoint-snippet.tsx
@@ -90,8 +90,12 @@ export function EndpointSnippet({ rows }: { rows: EndpointSnippetRow[] }) {
   const [lang, setLang] = useState<ApiSnippetLang>("url");
   return (
     <>
+      {/* Deliberately not <Panel>: this is a segmented language switcher
+          (role="tablist"), and Panel would impose card padding and semantics on
+          it. The no-restricted-syntax suppression that used to sit here went
+          dead — ESLint reports it as unused, so the rule no longer matches this
+          class list and the directive was only suppressing itself. */}
       <div
-        // eslint-disable-next-line no-restricted-syntax -- this is a segmented language switcher (role="tablist"), not a card shell; <Panel> would impose card padding/semantics. The rule's rounded+border+bg-card matcher is a false positive here
         className="mb-3 inline-flex rounded border border-border bg-card p-0.5"
         role="tablist"
         aria-label="Snippet language"

--- a/apps/ui/src/components/metagraphed/uptime-badge-embed.tsx
+++ b/apps/ui/src/components/metagraphed/uptime-badge-embed.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { CopyableCode, SectionAnchor } from "@jsonbored/ui-kit";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { classNames } from "@/lib/metagraphed/format";
+import { SITE_ORIGIN } from "@/lib/metagraphed/identity";
 
 // #8329: the subnet-team flywheel. A subnet that puts a live uptime badge in
 // its own README advertises the registry to exactly the audience we want, for
@@ -15,7 +16,6 @@ import { classNames } from "@/lib/metagraphed/format";
 // this is the production site rather than window.location.origin -- a snippet
 // copied from a preview deploy or localhost would otherwise carry that host
 // into someone else's repo.
-const SITE_ORIGIN = "https://metagraph.sh";
 
 const FORMATS = [
   { id: "markdown", label: "Markdown" },

--- a/apps/ui/src/lib/docs-layout-shared.tsx
+++ b/apps/ui/src/lib/docs-layout-shared.tsx
@@ -1,4 +1,5 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
+import { GITHUB_REPO_URL } from "@/lib/metagraphed/identity";
 
 export function baseOptions(): BaseLayoutProps {
   return {
@@ -7,7 +8,7 @@ export function baseOptions(): BaseLayoutProps {
     // network switcher. Fumadocs' own nav row would just be a second,
     // redundant header stacked directly under the real one.
     nav: { enabled: false },
-    githubUrl: "https://github.com/JSONbored/metagraphed",
+    githubUrl: GITHUB_REPO_URL,
     // The app already has its own theme toggle (SettingsPopover, synced to
     // the pre-hydration bootstrap script in lib/theme.ts) -- a second one in
     // the docs nav would be redundant and could drift out of sync with it.

--- a/apps/ui/src/lib/metagraphed/config.ts
+++ b/apps/ui/src/lib/metagraphed/config.ts
@@ -1,3 +1,5 @@
+import { API_ORIGIN, GITHUB_REPO_URL } from "./identity";
+
 // Metagraphed API client config.
 //
 // Two independent runtime dimensions, both persisted to localStorage:
@@ -17,7 +19,7 @@ const EVT = "metagraphed:api-base-changed";
 export const DEFAULT_API_BASE = (
   env?.VITE_METAGRAPH_API_BASE ||
   env?.VITE_METAGRAPHED_API_BASE ||
-  "https://api.metagraph.sh"
+  API_ORIGIN
 ).replace(/\/$/, "");
 
 let cached: string | null = null;
@@ -284,7 +286,7 @@ export function onNetworkChange(cb: (next: ChainNetwork) => void): () => void {
   return () => window.removeEventListener(NETWORK_EVT, handler);
 }
 
-export const DEFAULT_GITHUB_REPO = "https://github.com/JSONbored/metagraphed";
+export const DEFAULT_GITHUB_REPO = GITHUB_REPO_URL;
 export const GITHUB_REPO = env?.VITE_METAGRAPHED_REPO || DEFAULT_GITHUB_REPO;
 
 export const DEFAULT_DISCORD_URL = "https://discord.gg/nj9m9yVDnb";

--- a/apps/ui/src/lib/metagraphed/identity.ts
+++ b/apps/ui/src/lib/metagraphed/identity.ts
@@ -1,0 +1,42 @@
+/**
+ * Where this project lives publicly, in one place (#11204).
+ *
+ * Every value here was copy-pasted across several modules before — the two
+ * origins across six (server.ts, og-card.ts, uptime-badge-embed.tsx,
+ * agent-resource-grid.tsx, config.ts and the JSON-LD builders), the repo URL
+ * across three, the X handle across two. That is how one copy ends up stale
+ * after a domain or handle change and starts emitting canonical URLs, OG
+ * images, `sameAs` claims or card attribution pointing somewhere that no longer
+ * answers — and structured data that names the wrong account is an identity
+ * claim about someone else.
+ *
+ * Deliberately dependency-free: the Cloudflare Worker entry, a client-bundled
+ * route and React components all import this, so it must pull in nothing that
+ * exists on only one of those sides.
+ */
+
+/** The human-facing site (the apex). Canonical URLs and OG images live here. */
+export const SITE_ORIGIN = "https://metagraph.sh";
+
+/**
+ * The API + artifact host.
+ *
+ * NOT the same thing as the client's configured API base: `config.ts` lets a
+ * developer point the app at a local Worker, and this is the production default
+ * it falls back to. Anything that must name the canonical host regardless of
+ * that override — a redirect target, a discovery Link header — uses this.
+ */
+export const API_ORIGIN = "https://api.metagraph.sh";
+
+/** The public source repository. */
+export const GITHUB_REPO_URL = "https://github.com/JSONbored/metagraphed";
+
+/** The X account, as the handle a card attributes to. */
+export const X_HANDLE = "@metagraphed";
+
+/**
+ * The same account as a profile URL, derived rather than restated so the two
+ * forms cannot disagree — a `sameAs` pointing at one account while the card
+ * attributes another is exactly the drift this module exists to stop.
+ */
+export const X_PROFILE_URL = `https://x.com/${X_HANDLE.replace(/^@/, "")}`;

--- a/apps/ui/src/lib/metagraphed/json-ld.test.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { breadcrumbListJsonLd, stringifyJsonLd, subnetDatasetJsonLd } from "./json-ld";
+
+describe("stringifyJsonLd (#11204)", () => {
+  it("neutralizes a script break-out in any string it serializes", () => {
+    // The attack this exists for: a path segment or subnet name containing
+    // </script> would otherwise end the element and everything after it is
+    // markup, not data.
+    const out = stringifyJsonLd({ name: "</script><img src=x onerror=alert(1)>" });
+    expect(out).not.toContain("</script>");
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    expect(out).toContain("\\u003c");
+  });
+
+  it("escapes the JavaScript line terminators that are legal inside JSON", () => {
+    // U+2028/U+2029 parse fine as JSON but terminate a line inside a <script>,
+    // so an unescaped one is a syntax error in the page rather than in the data.
+    //
+    // Built from escapes rather than pasted: as raw characters these are
+    // invisible here, so a future edit could drop one and leave the assertions
+    // below passing against a string that no longer contains what they test.
+    const LINE_SEPARATOR = "\u2028";
+    const PARAGRAPH_SEPARATOR = "\u2029";
+    const out = stringifyJsonLd({ name: `a${LINE_SEPARATOR}b${PARAGRAPH_SEPARATOR}c` });
+    expect(out).toContain("\\u2028");
+    expect(out).toContain("\\u2029");
+    expect(out).not.toContain(LINE_SEPARATOR);
+    expect(out).not.toContain(PARAGRAPH_SEPARATOR);
+  });
+
+  it("still round-trips to the original value", () => {
+    // Escaping must not change what a consumer reads back.
+    const value = { name: "A & B <c>", nested: { list: [1, 2] } };
+    expect(JSON.parse(stringifyJsonLd(value))).toEqual(value);
+  });
+});
+
+describe("breadcrumbListJsonLd (#11204)", () => {
+  it("numbers positions from 1 in trail order", () => {
+    const crumbs = [
+      { name: "Home", item: "https://metagraph.sh/" },
+      { name: "Subnets", item: "https://metagraph.sh/subnets" },
+      { name: "Subnet 1", item: "https://metagraph.sh/subnets/1" },
+    ];
+    const out = breadcrumbListJsonLd(crumbs);
+    expect(out["@type"]).toBe("BreadcrumbList");
+    expect(out.itemListElement.map((entry) => entry.position)).toEqual([1, 2, 3]);
+    expect(out.itemListElement.map((entry) => entry.name)).toEqual(["Home", "Subnets", "Subnet 1"]);
+  });
+
+  it("emits an empty list rather than throwing on no crumbs", () => {
+    expect(breadcrumbListJsonLd([]).itemListElement).toEqual([]);
+  });
+});
+
+describe("subnetDatasetJsonLd (#11204)", () => {
+  const base = {
+    netuid: 1,
+    url: "https://metagraph.sh/subnets/1",
+    apiUrl: "https://api.metagraph.sh/api/v1/subnets/1",
+    artifactUrl: "https://api.metagraph.sh/metagraph/subnets/1.json",
+  };
+
+  it("names the subnet and keeps the netuid as the identifier", () => {
+    const out = subnetDatasetJsonLd({ ...base, name: "Apex" });
+    expect(out["@type"]).toBe("Dataset");
+    expect(out.name).toBe("Apex (Subnet 1)");
+    // The identifier must stay the netuid: it is the stable on-chain key, and
+    // the term a reader searches. A name can change; netuid 1 cannot.
+    expect(out.identifier).toBe("1");
+  });
+
+  it("still produces a valid node for a subnet with no name or description", () => {
+    const out = subnetDatasetJsonLd(base);
+    expect(out.name).toBe("Subnet 1");
+    expect(out.description).toContain("Bittensor subnet 1");
+  });
+
+  it("points distribution at both machine-readable representations", () => {
+    // This is what earns the markup — a Dataset with no distribution is just a
+    // description of a page.
+    const out = subnetDatasetJsonLd(base);
+    expect(out.distribution.map((d) => d.contentUrl)).toEqual([base.apiUrl, base.artifactUrl]);
+    for (const dist of out.distribution) {
+      expect(dist.encodingFormat).toBe("application/json");
+    }
+  });
+
+  it("omits sameAs entirely rather than asserting an empty identity", () => {
+    // An empty or wrong sameAs attaches this record to another project, which
+    // is worse than claiming nothing.
+    expect(subnetDatasetJsonLd(base)).not.toHaveProperty("sameAs");
+    expect(subnetDatasetJsonLd({ ...base, sameAs: null })).not.toHaveProperty("sameAs");
+    expect(subnetDatasetJsonLd({ ...base, sameAs: "https://example.com" })).toHaveProperty(
+      "sameAs",
+      ["https://example.com"],
+    );
+  });
+
+  it("prefers the subnet's own description but ignores a blank one", () => {
+    expect(subnetDatasetJsonLd({ ...base, description: "Open competitions." }).description).toBe(
+      "Open competitions.",
+    );
+    expect(subnetDatasetJsonLd({ ...base, description: "   " }).description).toContain(
+      "Registry record",
+    );
+  });
+});

--- a/apps/ui/src/lib/metagraphed/json-ld.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.ts
@@ -1,0 +1,124 @@
+import { SITE_ORIGIN } from "./identity";
+
+/**
+ * Pure schema.org JSON-LD builders (#11204 item 4).
+ *
+ * Split out of server.ts so a route's `head()` and the server-side <head>
+ * injection share ONE tested implementation instead of open-coding ListItem
+ * positions and `@type` strings twice. Every function here is pure — no fetch,
+ * no globals — which is what makes them testable without standing up a router.
+ *
+ * The rule these all ship under: **structured data may never claim something
+ * the page does not actually show.** A rich result is a promise about the page,
+ * and a broken promise costs more than a kept one earns, so each builder drops
+ * incomplete input rather than emitting a hollow node.
+ */
+
+/**
+ * Characters that must not survive into a `<script>` body verbatim.
+ *
+ * `<` alone stops the classic break-out (`</script>`), which is all server.ts
+ * escaped before. `>` and `&` are escaped too so the payload is inert in any
+ * parsing context, and U+2028/U+2029 because they are literal line terminators
+ * in JavaScript — legal inside a JSON string, fatal inside a script element.
+ * Spelled as escapes rather than pasted literally: as raw characters they are
+ * invisible in the source, so a later edit could drop one with nothing to see.
+ */
+const SCRIPT_JSON_ESCAPES: Record<string, string> = {
+  "<": "\\u003c",
+  ">": "\\u003e",
+  "&": "\\u0026",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
+/** Serialize JSON-LD safely for embedding in a `<script type="application/ld+json">`. */
+export function stringifyJsonLd(value: unknown): string {
+  return JSON.stringify(value).replace(
+    /[<>&\u2028\u2029]/g,
+    (character) => SCRIPT_JSON_ESCAPES[character] ?? character,
+  );
+}
+
+export interface BreadcrumbCrumb {
+  name: string;
+  /** Absolute URL — a crawler cannot resolve a relative `item`. */
+  item: string;
+}
+
+/** schema.org BreadcrumbList; positions are 1-based, in trail order. */
+export function breadcrumbListJsonLd(crumbs: BreadcrumbCrumb[]) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((crumb, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: crumb.name,
+      item: crumb.item,
+    })),
+  };
+}
+
+export interface SubnetDatasetInput {
+  netuid: number;
+  /** Registry / on-chain name, when we have one. */
+  name?: string | null;
+  description?: string | null;
+  /** Canonical page URL for this subnet. */
+  url: string;
+  /** Public API route serving this subnet's record. */
+  apiUrl: string;
+  /** Generated artifact for this subnet. */
+  artifactUrl: string;
+  /** The subnet's own site, when the registry has a verified one. */
+  sameAs?: string | null;
+}
+
+/**
+ * schema.org Dataset for one subnet's registry record.
+ *
+ * Dataset is the honest type, and a deliberate choice over
+ * SoftwareApplication/WebAPI: what this page publishes is OUR measured record
+ * of a subnet — its surfaces, endpoints, schemas, health and economics — not
+ * the subnet's software itself. Describing another team's API as an application
+ * we vouch for would be an over-claim, and not making that kind of claim is the
+ * registry's whole value.
+ *
+ * `distribution` is the part that earns the markup: it points at the two
+ * machine-readable representations the page already links, which is exactly
+ * what a dataset consumer wants and what Google's dataset index reads.
+ */
+export function subnetDatasetJsonLd(input: SubnetDatasetInput) {
+  const label = input.name ? `${input.name} (Subnet ${input.netuid})` : `Subnet ${input.netuid}`;
+  const description =
+    input.description?.trim() ||
+    `Registry record for Bittensor subnet ${input.netuid}: published interfaces, endpoints, schemas, health and economics.`;
+  return {
+    "@type": "Dataset",
+    name: label,
+    description,
+    url: input.url,
+    // The netuid is the subnet's stable on-chain identifier, and the term a
+    // reader is most likely to have searched to arrive here.
+    identifier: String(input.netuid),
+    isAccessibleForFree: true,
+    creator: { "@type": "Organization", name: "Metagraphed", url: SITE_ORIGIN },
+    distribution: [
+      {
+        "@type": "DataDownload",
+        encodingFormat: "application/json",
+        contentUrl: input.apiUrl,
+        name: "REST API",
+      },
+      {
+        "@type": "DataDownload",
+        encodingFormat: "application/json",
+        contentUrl: input.artifactUrl,
+        name: "Generated artifact",
+      },
+    ],
+    // Only assert an external identity we actually hold: an empty sameAs is
+    // worse than none, and a wrong one attaches this record to another project.
+    ...(input.sameAs ? { sameAs: [input.sameAs] } : {}),
+  };
+}

--- a/apps/ui/src/lib/metagraphed/og-card.ts
+++ b/apps/ui/src/lib/metagraphed/og-card.ts
@@ -1,3 +1,5 @@
+import { SITE_ORIGIN } from "./identity";
+
 // Builds the /og card URL a route puts in its own og:image (#8489).
 //
 // Deliberately a SEPARATE module from src/lib/og-image.ts (which renders the
@@ -18,8 +20,6 @@
 // routes emit their own og:image and server.ts skips those paths
 // (routeOwnsOgImage below is the single source of truth for which). That keeps
 // exactly one og:image tag on every page.
-
-const SITE_ORIGIN = "https://metagraph.sh";
 
 /** One "LABEL / value" cell in the card's stat rail. Max two are rendered. */
 export interface OgCardStat {

--- a/apps/ui/src/lib/metagraphed/seo-meta.test.ts
+++ b/apps/ui/src/lib/metagraphed/seo-meta.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { repoSlugFrom, SITE_ORIGIN } from "./seo-meta";
+
+describe("repoSlugFrom (#11204)", () => {
+  it("reduces a repo URL to the owner/name a searcher would paste", () => {
+    // Search Console shows queries that are literally a repo URL, so this slug
+    // is what a description has to contain to match one.
+    expect(repoSlugFrom("https://github.com/macrocosm-os/prompting")).toBe(
+      "macrocosm-os/prompting",
+    );
+  });
+
+  it("ignores everything below the repo root", () => {
+    expect(repoSlugFrom("https://github.com/owner/name/tree/main/docs")).toBe("owner/name");
+    expect(repoSlugFrom("https://github.com/owner/name.git")).toBe("owner/name");
+    expect(repoSlugFrom("https://www.github.com/owner/name")).toBe("owner/name");
+  });
+
+  it("returns null rather than guessing at a non-repo URL", () => {
+    // A wrong attribution in a search snippet is worse than an absent one --
+    // the same rule the registry publishes its own claims under.
+    for (const input of [
+      "https://github.com", // no owner or repo
+      "https://github.com/owner", // owner only
+      "https://gitlab.com/owner/name", // another forge
+      "https://example.com/owner/name", // not a forge at all
+      "not-a-url",
+      "",
+      null,
+      undefined,
+    ]) {
+      expect(repoSlugFrom(input), String(input)).toBeNull();
+    }
+  });
+
+  it("does not mistake GitHub's own routes for repositories", () => {
+    // `/orgs/x` and friends parse as owner/name but name no repo.
+    for (const input of [
+      "https://github.com/orgs/macrocosm-os",
+      "https://github.com/sponsors/someone",
+      "https://github.com/topics/bittensor",
+    ]) {
+      expect(repoSlugFrom(input), input).toBeNull();
+    }
+  });
+
+  it("re-exports the one canonical site origin", () => {
+    // Guards the consolidation: six modules used to hardcode this literal.
+    expect(SITE_ORIGIN).toBe("https://metagraph.sh");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/seo-meta.ts
+++ b/apps/ui/src/lib/metagraphed/seo-meta.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure helpers and constants for what a search result shows (#11204 item 5).
+ *
+ * Separate from json-ld.ts, which builds structured data: this is the prose a
+ * human reads in a result, and it is tuned to measured demand rather than to
+ * what reads nicely internally. Deliberately dependency-free, so the Worker
+ * entry and a route component can both import it.
+ */
+
+// The public identity constants live in their own dependency-free module
+// (identity.ts) because the Worker entry imports them too; re-exported here so
+// a caller shaping SEO text does not need to know that.
+export { SITE_ORIGIN } from "./identity";
+
+/**
+ * `https://github.com/owner/name` -> `owner/name`.
+ *
+ * Search Console shows the queries that already rank us are subnet lookups,
+ * several of them a repository URL pasted verbatim (`github.com/chronollm/sn38`).
+ * The slug is therefore worth carrying in a description, where it can match
+ * that query — but only when the registry actually holds a repo URL, and only
+ * when it parses to a real `owner/name` pair.
+ *
+ * Returns null for anything else (a bare host, a gist, a non-URL, a
+ * non-GitHub forge) rather than guessing: a wrong attribution in a snippet is
+ * worse than an absent one, which is the same rule the registry publishes
+ * under.
+ */
+export function repoSlugFrom(repo: string | null | undefined): string | null {
+  if (!repo) return null;
+  let url: URL;
+  try {
+    url = new URL(repo);
+  } catch {
+    return null;
+  }
+  if (!/(^|\.)github\.com$/i.test(url.hostname)) return null;
+  const segments = url.pathname.split("/").filter(Boolean);
+  if (segments.length < 2) return null;
+  const [owner, name] = segments;
+  // `/orgs/x`, `/sponsors/x` and friends are GitHub's own routes, not repos.
+  if (["orgs", "sponsors", "users", "settings", "topics"].includes(owner.toLowerCase())) {
+    return null;
+  }
+  return `${owner}/${name.replace(/\.git$/i, "")}`;
+}

--- a/apps/ui/src/routes/-design-primitives-page.tsx
+++ b/apps/ui/src/routes/-design-primitives-page.tsx
@@ -136,6 +136,7 @@ import {
   Wordmark,
   YieldPercentileStrip,
 } from "@jsonbored/ui-kit";
+import { GITHUB_REPO_URL } from "@/lib/metagraphed/identity";
 
 const COLUMNS: ColumnDef[] = [
   { id: "netuid", label: "Netuid", required: true },
@@ -712,7 +713,7 @@ function DataDisplaySection() {
               variant="filtered"
               title="No surfaces match this filter"
               hint="Widen the kind filter or clear the provider constraint to see more results."
-              evidenceHref="https://github.com/JSONbored/metagraphed"
+              evidenceHref={GITHUB_REPO_URL}
             />
           </Panel>
           <Panel

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -11,6 +11,9 @@ import {
 } from "@/lib/metagraphed/entity-not-found-meta";
 import { SubnetDetailPage } from "./-subnets-netuid-page";
 import { subnetFeedLinks } from "@/lib/metagraphed/feed-links";
+import { stringifyJsonLd, subnetDatasetJsonLd } from "@/lib/metagraphed/json-ld";
+import { repoSlugFrom, SITE_ORIGIN } from "@/lib/metagraphed/seo-meta";
+import { API_BASE } from "@/lib/metagraphed/config";
 
 export type SearchParams = {
   tab?: string;
@@ -63,10 +66,18 @@ export const Route = createFileRoute("/subnets/$netuid")({
       return {
         name: data.name ?? null,
         health: data.health ?? null,
+        // #11204: the subnet's own words, for the Dataset description and the
+        // meta description. Falls back inside the builder rather than here, so
+        // a subnet with no description still gets a valid, honest node.
+        description: data.description ?? null,
+        // The repo is what the measured demand actually pastes into search --
+        // GSC shows queries that are literally `github.com/<owner>/<repo>` --
+        // so it belongs in the description a searcher is matched against.
+        repo: data.repo ?? null,
         // #8489: whichever of these resolves first is the host the site's own
         // BrandIcon would use for this subnet.
         iconUrl: (data.icon_url ?? null) as string | { light?: string; dark?: string } | null,
-        website: (data.website ?? null) as string | null,
+        website: data.website ?? null,
         // The three facts the subnet masthead's own KPI band leads with
         // (#8247: price, emission share, total stake) -- the same ranking,
         // applied to the card that travels.
@@ -100,15 +111,28 @@ export const Route = createFileRoute("/subnets/$netuid")({
     if (!Number.isFinite(Number(params.netuid))) {
       return entityNotFoundMeta("Subnet", "This subnet identifier is not a valid netuid.");
     }
+    // #11204 item 5: the title is tuned to the demand Search Console actually
+    // records. The queries that already find us are subnet lookups — a pasted
+    // repo URL, `subnet-95`, a bare project name — so the netuid alias `SN<n>`
+    // leads (it matches both "sn38" and "subnet 38"), the project name follows,
+    // and the brand goes last where a truncation costs least. The old shape,
+    // "Apex (Subnet 1) — Metagraphed", buried the one token most likely to be
+    // typed inside parentheses.
+    const alias = `SN${params.netuid}`;
     const title = loaderData?.name
-      ? `${loaderData.name} (Subnet ${params.netuid}) — Metagraphed`
-      : `Subnet ${params.netuid} — Metagraphed`;
+      ? `${alias} · ${loaderData.name} — API, health & economics | Metagraphed`
+      : `${alias} — Bittensor subnet API, health & economics | Metagraphed`;
     const health = loaderData?.health && loaderData.health !== "unknown" ? loaderData.health : null;
+    // The repo slug (`owner/name`) is carried in the description because a
+    // pasted-repo-URL query is matched against it, and because it is the one
+    // fact that disambiguates two subnets with similar names. Appended only
+    // when the registry actually holds one.
+    const repoSlug = repoSlugFrom(loaderData?.repo);
     const description = loaderData?.name
-      ? `${loaderData.name}: Bittensor subnet ${params.netuid} — interfaces, endpoints, schemas${
+      ? `${loaderData.name} (${alias}): Bittensor subnet ${params.netuid} — interfaces, endpoints, schemas${
           health ? ` and live health (${health})` : ""
-        }, machine-readable on Metagraphed.`
-      : `Public-interface registry for Bittensor subnet ${params.netuid}: surfaces, endpoints, schemas, health.`;
+        }, machine-readable on Metagraphed.${repoSlug ? ` Source: ${repoSlug}.` : ""}`
+      : `Public-interface registry for Bittensor subnet ${params.netuid} (${alias}): surfaces, endpoints, schemas, health.`;
     return {
       meta: [
         { title },
@@ -155,6 +179,28 @@ export const Route = createFileRoute("/subnets/$netuid")({
       // advertising a feed for a netuid that is not a subnet would hand readers
       // a permanently empty subscription.
       links: subnetFeedLinks(params.netuid),
+      // #11204 item 4: the Dataset lives HERE rather than in server.ts's
+      // injected graph because it describes loader data -- the name and
+      // description -- that a path-only builder cannot see. Same reason the OG
+      // card moved to this route in #8489. server.ts still owns the
+      // Organization/WebSite/BreadcrumbList nodes on every page, so there is
+      // exactly one of each and no duplication between the two.
+      scripts: [
+        {
+          type: "application/ld+json",
+          children: stringifyJsonLd(
+            subnetDatasetJsonLd({
+              netuid: params.netuid,
+              name: loaderData?.name ?? null,
+              description: loaderData?.description ?? null,
+              url: `${SITE_ORIGIN}/subnets/${params.netuid}`,
+              apiUrl: `${API_BASE}/api/v1/subnets/${params.netuid}`,
+              artifactUrl: `${API_BASE}/metagraph/subnets/${params.netuid}.json`,
+              sameAs: loaderData?.website ?? null,
+            }),
+          ),
+        },
+      ],
     };
   },
   component: SubnetDetailPage,

--- a/apps/ui/src/server.seo.test.ts
+++ b/apps/ui/src/server.seo.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { buildOgImageUrl, routeOwnsOgImage } from "./lib/metagraphed/og-card";
-import { handleArtifactHostRedirect, SEO_DEFAULT_TAGS, sitemapLastmod } from "./server";
+import {
+  buildJsonLd,
+  handleArtifactHostRedirect,
+  SEO_DEFAULT_TAGS,
+  sitemapLastmod,
+} from "./server";
 
 // #8624. These are the SEO properties that were silently wrong in production and
 // that nothing was asserting: every /docs/* page shared one OG card, and the
@@ -55,6 +60,76 @@ describe("docs cards are OURS, not an entity's (#8624)", () => {
   it("still defaults to entity=1, so the entity routes are unaffected", () => {
     const url = new URL(buildOgImageUrl({ title: "Chutes", eyebrow: "Subnet" }));
     expect(url.searchParams.get("entity")).toBe("1");
+  });
+});
+
+describe("site-wide JSON-LD graph (#11204)", () => {
+  const graphOf = (pathname: string) =>
+    JSON.parse(buildJsonLd(pathname))["@graph"] as Array<Record<string, unknown>>;
+  const typesOn = (pathname: string) => graphOf(pathname).map((node) => node["@type"]);
+  const breadcrumbOn = (pathname: string) =>
+    graphOf(pathname).find((node) => node["@type"] === "BreadcrumbList") as
+      { itemListElement: Array<{ position: number; name: string; item: string }> } | undefined;
+
+  it("carries Organization and WebSite on every page", () => {
+    for (const path of ["/", "/subnets", "/docs/economics", "/validators/5Grwva"]) {
+      expect(typesOn(path), path).toEqual(expect.arrayContaining(["Organization", "WebSite"]));
+    }
+  });
+
+  it("claims only profiles this project controls via sameAs", () => {
+    // A sameAs is an identity assertion: a wrong one merges this entity with
+    // someone else's in a knowledge graph.
+    const org = graphOf("/").find((node) => node["@type"] === "Organization");
+    expect(org?.sameAs).toEqual([
+      "https://github.com/JSONbored/metagraphed",
+      "https://x.com/metagraphed",
+    ]);
+  });
+
+  it("breadcrumbs the validator pages, which are the biggest indexed set", () => {
+    // 1,023 validator URLs are in the sitemap and every one of them emitted no
+    // breadcrumb, which is most of why Search Console saw ONE valid item
+    // site-wide. The hotkey is truncated rather than shown in full.
+    const crumb = breadcrumbOn("/validators/5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY");
+    expect(crumb?.itemListElement.map((entry) => entry.name)).toEqual([
+      "Home",
+      "Validators",
+      "5Grwva…GKutQY",
+    ]);
+  });
+
+  it("breadcrumbs docs pages one level per path segment", () => {
+    const crumb = breadcrumbOn("/docs/api-reference/subnets");
+    expect(crumb?.itemListElement.map((entry) => entry.name)).toEqual([
+      "Home",
+      "Docs",
+      "API reference",
+      "Subnets",
+    ]);
+    // Every `item` must be absolute — a crawler cannot resolve a relative one.
+    for (const entry of crumb?.itemListElement ?? []) {
+      expect(() => new URL(entry.item)).not.toThrow();
+    }
+  });
+
+  it("still breadcrumbs subnets and providers", () => {
+    expect(breadcrumbOn("/subnets/64")?.itemListElement).toHaveLength(3);
+    expect(breadcrumbOn("/providers/chutes")?.itemListElement).toHaveLength(3);
+  });
+
+  it("emits no breadcrumb on pages that are not a detail view", () => {
+    // A one-item "trail" on a hub page is noise, and Google flags a breadcrumb
+    // that does not describe a real position in the hierarchy.
+    for (const path of ["/", "/subnets", "/validators", "/docs"]) {
+      expect(breadcrumbOn(path), path).toBeUndefined();
+    }
+  });
+
+  it("escapes a crafted path segment so it cannot break out of the script", () => {
+    const serialized = buildJsonLd("/subnets/</script><script>alert(1)</script>");
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).not.toContain("<");
   });
 });
 

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -4,6 +4,14 @@ import { consumeLastCapturedError } from "./lib/error-capture";
 import { renderErrorPage } from "./lib/error-page";
 import { handleOgImage } from "./lib/og-image";
 import { routeOwnsOgImage } from "./lib/metagraphed/og-card";
+import { breadcrumbListJsonLd, stringifyJsonLd } from "./lib/metagraphed/json-ld";
+import {
+  API_ORIGIN,
+  GITHUB_REPO_URL,
+  SITE_ORIGIN,
+  X_HANDLE,
+  X_PROFILE_URL,
+} from "./lib/metagraphed/identity";
 import { handleAnalyticsProxy, type PostHogAssetContext } from "./lib/analytics-proxy";
 
 type ServerEntry = {
@@ -29,8 +37,6 @@ declare const HTMLRewriter: {
 // PROXY the backend's resources (DRY + always current) and advertise them via a Link header on every
 // HTML page. Lives in the Worker entry (infra), never in Lovable's UI code, so it survives Lovable
 // regenerations.
-const API_ORIGIN = "https://api.metagraph.sh";
-const SITE_ORIGIN = "https://metagraph.sh";
 
 // Resources the backend serves canonically. The apex proxies them with a tight
 // response-header and media-type policy so API-origin cookies or active content
@@ -90,8 +96,8 @@ export const SEO_DEFAULT_TAGS =
   // X attributes the card to this account and shows it on the unfurl. `site`
   // and `creator` are the same handle because the site IS the author here --
   // there are no per-article bylines to differentiate.
-  `<meta name="twitter:site" content="@metagraphed">` +
-  `<meta name="twitter:creator" content="@metagraphed">`;
+  `<meta name="twitter:site" content="${X_HANDLE}">` +
+  `<meta name="twitter:creator" content="${X_HANDLE}">`;
 
 // Canonical human-facing pages for the sitemap (per-subnet pages are appended from the live list).
 const SITEMAP_STATIC_PATHS = [
@@ -438,6 +444,8 @@ function safeDecodePathSegment(segment: string): string {
 function buildBreadcrumb(pathname: string): unknown | null {
   const subnet = pathname.match(/^\/subnets\/([^/]+)\/?$/);
   const provider = pathname.match(/^\/providers\/([^/]+)\/?$/);
+  const validator = pathname.match(/^\/validators\/([^/]+)\/?$/);
+  const docs = pathname.match(/^\/docs\/(.+?)\/?$/);
   let trail: Array<{ name: string; path: string }> | null = null;
   if (subnet) {
     const name = safeDecodePathSegment(subnet[1]);
@@ -453,25 +461,54 @@ function buildBreadcrumb(pathname: string): unknown | null {
       { name: "Providers", path: "/apis/providers" },
       { name, path: `/providers/${provider[1]}` },
     ];
+  } else if (validator) {
+    // #11204: 1,023 validator pages are in the sitemap and every one of them
+    // was emitting no breadcrumb at all, which is most of why Search Console
+    // reported ONE valid breadcrumb item site-wide. The hotkey is truncated the
+    // way the page itself titles it -- a 48-character ss58 is not a crumb.
+    const hotkey = safeDecodePathSegment(validator[1]);
+    trail = [
+      { name: "Home", path: "/" },
+      { name: "Validators", path: "/validators" },
+      { name: shortKey(hotkey), path: `/validators/${validator[1]}` },
+    ];
+  } else if (docs) {
+    // 322 docs pages, likewise bare. The trail is derived from the path
+    // segments themselves, so a page added to content/docs/ is covered the
+    // moment it ships -- the same property that keeps it out of the sitemap's
+    // second list to forget.
+    const segments = docs[1].split("/").filter(Boolean);
+    trail = [
+      { name: "Home", path: "/" },
+      { name: "Docs", path: "/docs" },
+      ...segments.map((segment, index) => ({
+        name: titleCaseSlug(safeDecodePathSegment(segment)),
+        path: `/docs/${segments.slice(0, index + 1).join("/")}`,
+      })),
+    ];
   }
   if (!trail) return null;
-  return {
-    "@type": "BreadcrumbList",
-    itemListElement: trail.map((item, i) => ({
-      "@type": "ListItem",
-      position: i + 1,
-      name: item.name,
-      item: `${SITE_ORIGIN}${item.path}`,
-    })),
-  };
+  return breadcrumbListJsonLd(
+    trail.map((item) => ({ name: item.name, item: `${SITE_ORIGIN}${item.path}` })),
+  );
+}
+
+/** `api-reference` -> `API reference`; a URL slug is not a breadcrumb label. */
+function titleCaseSlug(slug: string): string {
+  const words = slug.replace(/[-_]+/g, " ").trim();
+  if (!words) return slug;
+  const cased = words.charAt(0).toUpperCase() + words.slice(1);
+  return cased.replace(/\bapi\b/gi, "API").replace(/\bmcp\b/gi, "MCP");
 }
 
 // schema.org JSON-LD: Organization + WebSite (with a sitelinks SearchAction over
 // /subnets?q=) on every page, plus a BreadcrumbList on the detail routes. The
-// serialized JSON escapes every "<" character so a crafted path segment can
-// never break out of the <script> element. ItemList on listings is intentionally
-// omitted (needs per-request data, rarely yields rich results).
-function buildJsonLd(pathname: string): string {
+// serialized JSON is escaped by stringifyJsonLd (see json-ld.ts) so a crafted
+// path segment can never break out of the <script> element. ItemList on
+// listings is intentionally omitted (needs per-request data, rarely yields rich
+// results); the per-subnet Dataset lives in the route's own head(), where the
+// loader data it describes is available.
+export function buildJsonLd(pathname: string): string {
   const graph: unknown[] = [
     {
       "@type": "Organization",
@@ -480,6 +517,11 @@ function buildJsonLd(pathname: string): string {
       url: SITE_ORIGIN,
       description:
         "The Bittensor subnet integration registry — what each subnet exposes (APIs, docs, schemas), whether it is healthy, and how to call it.",
+      // #11204: the profiles that let a search engine resolve "Metagraphed" to
+      // one entity rather than treating each surface as an unrelated site.
+      // Only accounts this project actually controls are listed — a sameAs is
+      // an identity claim, and a wrong one merges us with someone else.
+      sameAs: [GITHUB_REPO_URL, X_PROFILE_URL],
     },
     {
       "@type": "WebSite",
@@ -499,10 +541,10 @@ function buildJsonLd(pathname: string): string {
   ];
   const breadcrumb = buildBreadcrumb(pathname);
   if (breadcrumb) graph.push(breadcrumb);
-  return JSON.stringify({
+  return stringifyJsonLd({
     "@context": "https://schema.org",
     "@graph": graph,
-  }).replace(/</g, "\\u003c");
+  });
 }
 
 /**


### PR DESCRIPTION
Part of #11204 — items **4 (structured data)** and **5 (title/description templates)**, following #11225 which closed items 2 and 3.

Search Console records **8 clicks against ~8,000 impressions at average position 5.7**. We rank when we appear; the snippet is the weakness. Both causes are addressed here.

## Structured data was nearly absent

The breadcrumb builder covered exactly two route families — `/subnets/:n` and `/providers/:slug`. Our own sitemap lists **1,023 validator pages and 322 docs pages**, and every one of them emitted no breadcrumb at all, which is why the breadcrumbs report showed **one valid item site-wide**.

| Route | Before | After |
|---|---|---|
| `/subnets/1` | breadcrumb | breadcrumb **+ Dataset** |
| `/providers/chutes` | breadcrumb | breadcrumb |
| `/validators/{hotkey}` | *(none)* | `Home > Validators > 5Grwva…GKutQY` |
| `/docs/api-reference/subnets` | *(none)* | `Home > Docs > API reference > Subnets` |
| `/`, `/subnets`, `/docs` | *(none)* | *(none — a one-item trail on a hub is noise)* |

Docs breadcrumbs are derived from the path segments, so a page added to `content/docs/` is covered the moment it ships — the same property that keeps it out of a second list to forget.

Each subnet page now also emits a **Dataset** whose `distribution` points at the two machine-readable representations the page already links (the REST route and the generated artifact).

### What is deliberately NOT claimed

**Dataset, not SoftwareApplication/WebAPI.** What a subnet page publishes is *our measured record of* a subnet — its surfaces, endpoints, schemas, health and economics — not the subnet's software. Describing another team's API as an application we vouch for is exactly the claim this registry exists not to make.

**No FAQPage.** #11204 suggested one on docs. I checked all **483** `.mdx` files: not one carries an FAQ heading or a question-shaped heading. Marking up Q&A a page does not show is how a site earns a manual action instead of a rich result.

**`sameAs` only where we hold the identity.** A `sameAs` is an identity assertion; a wrong one merges this entity with someone else's in a knowledge graph. The Organization node lists only the repo and X account this project controls, and a subnet's Dataset carries `sameAs` only when the registry actually holds its site.

## Titles tuned to the demand we can measure

The queries that already rank us are subnet lookups — pasted repo URLs (`github.com/chronollm/sn38`), `actual-subnet-95`, bare project names. The old title buried the most-typed token inside parentheses:

```
before   Apex (Subnet 1) — Metagraphed
after    SN1 · Apex — API, health & economics | Metagraphed
```

`SN<n>` leads because it matches both "sn38" and "subnet 38"; the brand goes last, where truncation costs least. The **repo slug** rides in the description, where a pasted-repo query can match it — `repoSlugFrom` returns null for a non-repo URL, a bare host, another forge, or GitHub's own `/orgs/…` routes rather than guessing at an attribution.

```
Apex (SN1): Bittensor subnet 1 — interfaces, endpoints, schemas, machine-readable
on Metagraphed. Source: macrocosm-os/apex.
```

## Duplication removed along the way

The constants all of this depends on were scattered, which is how one copy goes stale after a domain change and starts emitting canonical URLs, OG cards and `sameAs` claims pointing at a host that no longer answers:

| Constant | Copies before | After |
|---|---|---|
| `https://metagraph.sh` | 3 (`server.ts`, `og-card.ts`, `uptime-badge-embed.tsx`) | 1 |
| `https://api.metagraph.sh` | 3 (`server.ts`, `config.ts`, `agent-resource-grid.tsx`) | 1 |
| repo URL | 3 (`server.ts`, `config.ts`, `docs-layout-shared.tsx`, +1 route) | 1 |
| `@metagraphed` | 2, in two different formats | 1 (profile URL derived from the handle) |

All now live in `lib/metagraphed/identity.ts`, deliberately dependency-free so the Worker entry, a client route and React components can all import it. A grep for the literals returns nothing outside that module.

Also folded in, rather than filed as separate work: three redundant `as string | null` assertions on fields the type already declares as `string?` (a cast there silences exactly the drift we want to catch), and a dead `eslint-disable` in `endpoint-snippet.tsx` that ESLint reported as unused — verified uncached that the rule genuinely does not fire without it. Lint warnings drop 9 → 8.

Escaping was hardened while the builders moved: `stringifyJsonLd` now escapes `>`, `&`, U+2028 and U+2029 as well as `<`. The last two are legal inside a JSON string but terminate a line inside a `<script>`.

## Validation

Run in `apps/ui`, all green:

- `lint` — 0 errors, **8** warnings (was 9; all remaining are pre-existing `react-refresh` ones in untouched files)
- `format:check`, `typecheck` — clean
- `test` — **257 files, 2130 tests** (was 2108; +22 covering the builders, the escaping, the extended breadcrumbs and the slug parser)
- `test:e2e` — **104 passed**, zero `[api-stub] MISS`
- `build` + `build:worker:e2e` — clean

Verified against the **real workerd build** (not `vite dev`, which skips the HTMLRewriter injection), so the server-injected graph and the route-emitted Dataset were both checked as actually rendered:

```
/subnets/1   2 ld+json blocks
             standalone: Dataset | Apex (Subnet 1)
             graph: Organization, WebSite, BreadcrumbList
             breadcrumb: Home > Subnets > Subnet 1
             sameAs: [".../JSONbored/metagraphed", "https://x.com/metagraphed"]
             title: SN1 · Apex — API, health & economics | Metagraphed
```

Every JSON-LD block was parsed, not eyeballed. Visual output is unchanged — this is `<head>` content plus one `<div>` comment.

## What remains on #11204

Item 6 (per-page OG cards) is #11075, gated behind the containers epic. Item 7 (new rankable surfaces — compare pages, a `gpu_required` facet, per-subnet economics summaries) is genuinely new page-building and is the only substantive item left; item 1 needs no code. Leaving #11204 open for item 7 rather than filing a new issue for it.
