### PR TITLE
fix(ui): 99 of 129 subnet pages had no internal link anywhere on the site

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
       // peak.
       name: "interaction",
       testMatch:
-        /(evidence-deep-link|multisig-related-error|offline|sticky-table-header)\.spec\.ts$/,
+        /(crawlable-subnet-index|evidence-deep-link|multisig-related-error|offline|sticky-table-header)\.spec\.ts$/,
       dependencies: ["overflow"],
       // Serial within the phase costs a few seconds and removes the last
       // source of self-contention for exactly the tests that proved sensitive

--- a/apps/ui/src/components/metagraphed/subnet-index-directory.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-index-directory.tsx
@@ -1,0 +1,66 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { SUBNETS_ALL_LIMIT, subnetsQuery } from "@/lib/metagraphed/queries";
+
+/**
+ * A complete, crawlable index of every subnet.
+ *
+ * WHY THIS EXISTS, and it is not a duplicate of the table above it.
+ *
+ * The registry table virtualizes its body (#8248): all 129 rows are fetched,
+ * filtered and sorted, but only the rows in view are ever mounted as real DOM
+ * nodes. That is the right call for a sortable 129-row table — and it means the
+ * SERVER-RENDERED HTML of /subnets contains anchors for about 30 subnets.
+ * Measured against production on 2026-08-14: 30 distinct `/subnets/{n}` hrefs
+ * for 129 subnets.
+ *
+ * So 99 subnet pages had no internal link anywhere on the site and were
+ * reachable only from sitemap.xml. A URL whose only referrer is a sitemap is
+ * the classic profile for "Crawled – currently not indexed", which is the
+ * bucket 5,797 of our URLs sit in — and per-subnet lookups are the demand
+ * Search Console actually records, so those are the pages that most need to be
+ * reachable.
+ *
+ * Deliberately NOT a change to the table's virtualization: that would trade a
+ * real interaction and rendering cost for the same links this gets for free.
+ *
+ * Deliberately inside a collapsed `<details>`: the children of a closed
+ * `<details>` are in the DOM and in the server-rendered HTML, so a crawler
+ * follows every link, while a reader who came for the table sees one line
+ * rather than a wall of 129 links. It is a jump list for them, not a doorway
+ * page for a crawler — the links carry the subnet's real name, and every target
+ * is a substantive page we already publish.
+ */
+export function SubnetIndexDirectory() {
+  // The same query the table issues, minus the reader's `q` filter — a
+  // directory that shrinks when someone types a search is not an index. On the
+  // first (and crawled) render there is no `q`, so this shares the table's
+  // cache entry and costs no extra request.
+  const { data } = useSuspenseQuery(subnetsQuery({ limit: SUBNETS_ALL_LIMIT }));
+  const subnets = [...data.data].sort((a, b) => a.netuid - b.netuid);
+  if (subnets.length === 0) return null;
+
+  return (
+    <details className="mt-8 rounded-xl border border-border bg-card p-4">
+      <summary className="cursor-pointer mg-type-label text-ink-muted hover:text-ink-strong">
+        All {subnets.length} subnets
+      </summary>
+      <nav aria-label="All subnets" className="mt-3">
+        <ul className="columns-2 gap-x-6 sm:columns-3 lg:columns-4">
+          {subnets.map((subnet) => (
+            <li key={subnet.netuid} className="break-inside-avoid py-0.5">
+              <Link
+                to="/subnets/$netuid"
+                params={{ netuid: subnet.netuid }}
+                className="mg-type-caption text-ink-muted hover:text-accent"
+              >
+                <span className="text-ink-strong">SN{subnet.netuid}</span>
+                {subnet.name ? ` · ${subnet.name}` : ""}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </details>
+  );
+}

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -1792,6 +1792,16 @@ export function normalizeSubnet(raw: unknown): Subnet {
   } as Subnet;
 }
 
+/**
+ * One-shot ceiling for "every active subnet" reads (#8248).
+ *
+ * /api/v1/subnets has no server-side sort and the registry is ~129 subnets, so
+ * the page fetches the whole set once and works over it client-side. Shared so
+ * the registry table and the crawlable index cannot drift onto two different
+ * limits and disagree about what "every subnet" means.
+ */
+export const SUBNETS_ALL_LIMIT = 200;
+
 export const subnetsQuery = (params?: QueryParams) =>
   queryOptions({
     queryKey: k("subnets", params ?? {}),

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -70,6 +70,7 @@ import {
   CompareToggle,
 } from "@/components/metagraphed/subnets-compare-drawer";
 import {
+  SUBNETS_ALL_LIMIT,
   subnetsQuery,
   coverageQuery,
   healthQuery,
@@ -94,6 +95,7 @@ import { API_BASE } from "@/lib/metagraphed/config";
 import { useWatchlist } from "@/lib/metagraphed/watchlist";
 import { LeaderboardsSection, LeaderboardsCsvExportMenu } from "./-leaderboards-page";
 import { DomainsRollup } from "@/components/metagraphed/domains-rollup";
+import { SubnetIndexDirectory } from "@/components/metagraphed/subnet-index-directory";
 import type { AgentCatalogSummary, Subnet, SubnetEconomics } from "@/lib/metagraphed/types";
 import { useMeasuredRowHeight } from "@/hooks/use-measured-row-height";
 
@@ -102,7 +104,6 @@ import { useMeasuredRowHeight } from "@/hooks/use-measured-row-height";
 // "Load more" tier anymore. 200 comfortably exceeds the live subnet count
 // (verified: GET /api/v1/subnets?limit=200 already returns all 129 with
 // next_cursor: null) with headroom for registry growth.
-const ALL_ROWS_LIMIT = 200;
 
 // #8362: the mobile card branch (unlike the desktop table) isn't virtualized
 // -- it's a plain map over every filtered/sorted row, so all 129 cards
@@ -232,7 +233,7 @@ export function SubnetsPage() {
       replace: true,
       resetScroll: false,
     });
-  const subnetsCsvUrl = buildUrl("/api/v1/subnets", { limit: ALL_ROWS_LIMIT });
+  const subnetsCsvUrl = buildUrl("/api/v1/subnets", { limit: SUBNETS_ALL_LIMIT });
   return (
     <AppShell>
       <PageMasthead
@@ -317,6 +318,16 @@ export function SubnetsPage() {
             <h2 className="mb-2 mg-type-label text-ink-muted">Registration churn</h2>
             <NetworkSubnetLifecycle />
           </section>
+          {/* #11204: the table above virtualizes, so its server-rendered HTML
+              carries anchors for ~30 of 129 subnets and the other 99 pages had
+              no internal link anywhere on the site. This is the complete index
+              — see the component for why it is not a duplicate of the table. */}
+          <AsyncPanel
+            context="subnet index"
+            fallback={<PanelSkeleton height="sm" className="mt-8" />}
+          >
+            <SubnetIndexDirectory />
+          </AsyncPanel>
         </>
       )}
       <ApiSourceFooter
@@ -517,7 +528,7 @@ function SubnetsTable({ view, density = "comfortable" }: { view: ViewMode; densi
   // returns HTTP 400, `curation`/`health` are ignored) -- everything else is
   // applied client-side over this one page.
   const { data, isFetching } = useSuspenseQuery(
-    subnetsQuery({ q: search.q || undefined, limit: ALL_ROWS_LIMIT }),
+    subnetsQuery({ q: search.q || undefined, limit: SUBNETS_ALL_LIMIT }),
   );
 
   const watchlist = useWatchlist("subnet");

--- a/apps/ui/tests/e2e/crawlable-subnet-index.spec.ts
+++ b/apps/ui/tests/e2e/crawlable-subnet-index.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+// #11204: every subnet page must have a real internal link from /subnets.
+//
+// The registry table virtualizes its body (#8248), so the server-rendered HTML
+// only ever carried anchors for the rows in view. Measured against production
+// on 2026-08-14: 30 distinct `/subnets/{n}` hrefs for 129 subnets, which left
+// 99 subnet pages reachable only from sitemap.xml — the profile that lands a
+// URL in "Crawled – currently not indexed", and per-subnet lookups are the
+// demand Search Console actually records.
+//
+// This asserts against the RAW HTTP RESPONSE rather than the hydrated DOM, via
+// the `request` fixture: a crawler does not run our JavaScript, so the property
+// only means something if it holds in the bytes the server sends. Asserting on
+// `page.content()` would pass on links React added after hydration and prove
+// nothing about what Googlebot indexes.
+const API_STUB = "http://127.0.0.1:8081";
+
+test.describe("#11204 crawlable subnet index", () => {
+  test("the server-rendered /subnets links to EVERY subnet", async ({ request }) => {
+    const listed = await request.get(`${API_STUB}/api/v1/subnets?limit=200`);
+    expect(listed.ok(), "the stub must serve the subnet list this page reads").toBe(true);
+    const netuids = (
+      ((await listed.json()) as { data?: { subnets?: Array<{ netuid?: number }> } }).data
+        ?.subnets ?? []
+    )
+      .map((subnet) => subnet.netuid)
+      .filter((netuid): netuid is number => Number.isInteger(netuid));
+    // Guard the guard: if the fixture ever served an empty list this test would
+    // otherwise assert nothing and pass.
+    expect(netuids.length).toBeGreaterThan(100);
+
+    const page = await request.get("/subnets");
+    expect(page.ok()).toBe(true);
+    const html = await page.text();
+
+    const linked = new Set(
+      [...html.matchAll(/href="\/subnets\/(\d+)"/g)].map((match) => Number(match[1])),
+    );
+    const missing = netuids.filter((netuid) => !linked.has(netuid));
+    expect(
+      missing,
+      `subnet pages with no internal link in the server-rendered HTML: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Part of #11204. Found while scoping item 7 ("new rankable surfaces") — and it turns out the problem was never a shortage of pages. **Three quarters of the pages we already have were invisible to a crawler.**

## Measured

`/subnets` server-renders **30** distinct `/subnets/{n}` links. The registry holds **129** subnets.

```
distinct /subnets/N links in production HTML:   30
subnets in the registry:                       129
```

So **99 subnet pages had no internal link anywhere on the site** — no hub link, no lateral link, nothing. Their only referrer was `sitemap.xml`.

That is the textbook profile for **"Crawled – currently not indexed"**, which is the bucket **5,797** of our URLs sit in. And #11204's own finding is that the demand Search Console records is *per-subnet lookups* — pasted repo URLs, `subnet-95`, bare project names. Those are exactly the pages that most needed to be reachable, and three quarters of them were not.

The same shape exists on `/validators`: 50 links for 1,023 validators (see below — deliberately not "fixed" here).

## Cause

Not a bug. The registry table virtualizes its body (#8248): all 129 rows are fetched, filtered and sorted, but only rows in view are ever mounted as real `<tr>`s. That is the right call for a sortable 129-row table — the SEO consequence simply was not part of that trade.

## Fix

A complete index rendered alongside the table, **not** a change to the virtualization — re-rendering 129 live rows would trade real interaction and rendering cost for links this gets for free.

It sits inside a collapsed `<details>`. The children of a closed `<details>` are in the DOM and in the server-rendered HTML, so a crawler follows every link while a reader who came for the table sees one line rather than a wall of 129. It is a jump list for them, not a doorway page: the links carry each subnet's real name, and every target is a substantive page we already publish.

| | before | after |
|---|---|---|
| distinct crawlable `/subnets/{n}` links | 30 | **129** |
| `/subnets` document size | 497,579 B | 503,577 B (**+1.2%**) |

Verified against the **real Worker build** (`serve-e2e.ts` + the API stub), not `vite dev`.

## The test asserts the raw response, not the DOM

`crawlable-subnet-index.spec.ts` uses Playwright's `request` fixture to fetch `/subnets` over plain HTTP and diff the netuids in the API list against the `href`s in the body. A crawler does not run our JavaScript, so the property only means something in the bytes the server sends — asserting on `page.content()` would pass on links React added after hydration and prove nothing about what Googlebot sees.

It also guards itself: if the fixture ever served an empty subnet list, the test would otherwise assert nothing and pass, so it requires >100 netuids before comparing.

**Proved it can fail.** With the index removed, it fails naming all 99 missing netuids:

```
Error: subnet pages with no internal link in the server-rendered HTML:
30, 31, 32, ... 126, 127, 128
```

Registered in `playwright.config.ts`'s `interaction` project — that file warns that a spec matching neither project silently never runs.

## Validators: deliberately NOT given the same treatment

`/validators` links 50 of 1,023. I did not add a 1,023-link block, and that is a judgement call rather than an oversight:

- 129 links is a normal directory; 1,023 on one hub reads as link-farming and dilutes what each link passes.
- Validator pages are auto-generated entity pages, and the measured demand is subnet lookups — not validators.
- This site has already been burned once by volume: indexed count ballooned 2,542 → 4,099 with thin pages, Google reassessed, and impressions fell from ~600/day to single digits. Adding a thousand links to chase indexation is the same bet that lost last time.

The right question is whether those 1,023 URLs are indexed, sitting in the not-indexed bucket, or better removed from the sitemap entirely to stop spending crawl budget — and that needs the Search Console data, not a guess from here. Worth checking that report before touching it.

## Duplication

`/api/v1/subnets?limit=200`'s ceiling was written twice — once in the page, once in the new component. It now has one home (`SUBNETS_ALL_LIMIT`) next to the query it bounds, so the table and the index cannot drift onto different definitions of "every subnet".

## Validation

`apps/ui`, all green: `lint` (0 errors, 8 warnings — all pre-existing), `format:check`, `typecheck`, `test` (**257 files, 2130 tests**), `test:e2e` (**105 passed**, zero `[api-stub] MISS`), `build:worker:e2e`.

The responsive-overflow sweep passes on `/subnets` at all four viewports, which is the check that matters for a new multi-column list at 375px.
