### PR TITLE
fix(discovery): the Content Signal was outside its group, and 113 provider pages had no link

### DIFF
--- a/apps/ui/src/components/metagraphed/entity-index-directory.tsx
+++ b/apps/ui/src/components/metagraphed/entity-index-directory.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+
+/**
+ * The shell for a complete, crawlable index of an entity space.
+ *
+ * WHY THESE EXIST, and why they are not duplicates of the tables above them.
+ *
+ * The registry hub tables virtualize their bodies (#8248): every row is
+ * fetched, filtered and sorted, but only the rows in view are ever mounted as
+ * real DOM nodes. That is the right call for a long sortable table — and it
+ * means the SERVER-RENDERED HTML of a hub carries anchors for roughly one
+ * screenful. Measured against production on 2026-08-14:
+ *
+ *   /subnets         30 links   129 subnets
+ *   /apis/providers  25 links   138 providers
+ *
+ * So 99 subnet pages and 113 provider pages had no internal link anywhere on
+ * the site, reachable only from sitemap.xml. A URL whose only referrer is a
+ * sitemap is the classic profile for "Crawled – currently not indexed", the
+ * bucket 5,797 of our URLs sit in.
+ *
+ * Deliberately NOT a change to the virtualization: re-rendering every row live
+ * would trade a real interaction and rendering cost for links this gets free.
+ *
+ * Deliberately a collapsed `<details>`: the children of a closed `<details>`
+ * are in the DOM and in the server-rendered HTML, so a crawler follows every
+ * link, while a reader who came for the table sees one line rather than a wall
+ * of them. It is a jump list for them, not a doorway page for a crawler — the
+ * links carry each entity's real name and every target is a substantive page
+ * we already publish.
+ *
+ * The shell is shared so the two indexes cannot drift into different markup or
+ * different reasoning; only the per-entity link differs, and that has to stay
+ * with the caller because TanStack's `Link` is typed per route.
+ */
+export function EntityIndexDirectory({
+  label,
+  count,
+  children,
+}: {
+  /** Plural entity name, e.g. "subnets". Rendered as "All 129 subnets". */
+  label: string;
+  count: number;
+  /** One `<li>` per entity, each containing a real anchor. */
+  children: ReactNode;
+}) {
+  if (count === 0) return null;
+  return (
+    <details className="mt-8 rounded-xl border border-border bg-card p-4">
+      <summary className="cursor-pointer mg-type-label text-ink-muted hover:text-ink-strong">
+        All {count} {label}
+      </summary>
+      <nav aria-label={`All ${label}`} className="mt-3">
+        <ul className="columns-2 gap-x-6 sm:columns-3 lg:columns-4">{children}</ul>
+      </nav>
+    </details>
+  );
+}

--- a/apps/ui/src/components/metagraphed/provider-index-directory.tsx
+++ b/apps/ui/src/components/metagraphed/provider-index-directory.tsx
@@ -1,0 +1,43 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { providersQuery } from "@/lib/metagraphed/queries";
+import { EntityIndexDirectory } from "./entity-index-directory";
+
+/**
+ * A complete, crawlable index of every provider (#11204).
+ *
+ * The same defect the subnet index fixes, on the other hub: /apis/providers
+ * server-rendered 25 links for 138 providers, so 113 provider pages had no
+ * internal link anywhere on the site. See EntityIndexDirectory for the full
+ * reasoning.
+ */
+export function ProviderIndexDirectory() {
+  const { data } = useSuspenseQuery(providersQuery());
+  // Sorted by display name: unlike subnets, a provider has no numeric identity
+  // to order by, and a name is what a reader scans a directory for. The slug is
+  // the route key, so an entry without one cannot be linked and is dropped.
+  // `name` is optional on the type even though the list normalizer falls back
+  // to the slug — resolved here rather than asserted, so a future shape change
+  // surfaces as a type error instead of an empty anchor.
+  const providers = [...data.data]
+    .flatMap((provider) =>
+      provider.slug ? [{ slug: provider.slug, label: provider.name ?? provider.slug }] : [],
+    )
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return (
+    <EntityIndexDirectory label="providers" count={providers.length}>
+      {providers.map((provider) => (
+        <li key={provider.slug} className="break-inside-avoid py-0.5">
+          <Link
+            to="/providers/$slug"
+            params={{ slug: provider.slug }}
+            className="mg-type-caption text-ink-muted hover:text-accent"
+          >
+            {provider.label}
+          </Link>
+        </li>
+      ))}
+    </EntityIndexDirectory>
+  );
+}

--- a/apps/ui/src/components/metagraphed/subnet-index-directory.tsx
+++ b/apps/ui/src/components/metagraphed/subnet-index-directory.tsx
@@ -1,35 +1,13 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { SUBNETS_ALL_LIMIT, subnetsQuery } from "@/lib/metagraphed/queries";
+import { EntityIndexDirectory } from "./entity-index-directory";
 
 /**
- * A complete, crawlable index of every subnet.
+ * A complete, crawlable index of every subnet (#11204).
  *
- * WHY THIS EXISTS, and it is not a duplicate of the table above it.
- *
- * The registry table virtualizes its body (#8248): all 129 rows are fetched,
- * filtered and sorted, but only the rows in view are ever mounted as real DOM
- * nodes. That is the right call for a sortable 129-row table — and it means the
- * SERVER-RENDERED HTML of /subnets contains anchors for about 30 subnets.
- * Measured against production on 2026-08-14: 30 distinct `/subnets/{n}` hrefs
- * for 129 subnets.
- *
- * So 99 subnet pages had no internal link anywhere on the site and were
- * reachable only from sitemap.xml. A URL whose only referrer is a sitemap is
- * the classic profile for "Crawled – currently not indexed", which is the
- * bucket 5,797 of our URLs sit in — and per-subnet lookups are the demand
- * Search Console actually records, so those are the pages that most need to be
- * reachable.
- *
- * Deliberately NOT a change to the table's virtualization: that would trade a
- * real interaction and rendering cost for the same links this gets for free.
- *
- * Deliberately inside a collapsed `<details>`: the children of a closed
- * `<details>` are in the DOM and in the server-rendered HTML, so a crawler
- * follows every link, while a reader who came for the table sees one line
- * rather than a wall of 129 links. It is a jump list for them, not a doorway
- * page for a crawler — the links carry the subnet's real name, and every target
- * is a substantive page we already publish.
+ * See EntityIndexDirectory for why this exists and why it is not a duplicate of
+ * the virtualized table above it.
  */
 export function SubnetIndexDirectory() {
   // The same query the table issues, minus the reader's `q` filter — a
@@ -38,29 +16,21 @@ export function SubnetIndexDirectory() {
   // cache entry and costs no extra request.
   const { data } = useSuspenseQuery(subnetsQuery({ limit: SUBNETS_ALL_LIMIT }));
   const subnets = [...data.data].sort((a, b) => a.netuid - b.netuid);
-  if (subnets.length === 0) return null;
 
   return (
-    <details className="mt-8 rounded-xl border border-border bg-card p-4">
-      <summary className="cursor-pointer mg-type-label text-ink-muted hover:text-ink-strong">
-        All {subnets.length} subnets
-      </summary>
-      <nav aria-label="All subnets" className="mt-3">
-        <ul className="columns-2 gap-x-6 sm:columns-3 lg:columns-4">
-          {subnets.map((subnet) => (
-            <li key={subnet.netuid} className="break-inside-avoid py-0.5">
-              <Link
-                to="/subnets/$netuid"
-                params={{ netuid: subnet.netuid }}
-                className="mg-type-caption text-ink-muted hover:text-accent"
-              >
-                <span className="text-ink-strong">SN{subnet.netuid}</span>
-                {subnet.name ? ` · ${subnet.name}` : ""}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
-    </details>
+    <EntityIndexDirectory label="subnets" count={subnets.length}>
+      {subnets.map((subnet) => (
+        <li key={subnet.netuid} className="break-inside-avoid py-0.5">
+          <Link
+            to="/subnets/$netuid"
+            params={{ netuid: subnet.netuid }}
+            className="mg-type-caption text-ink-muted hover:text-accent"
+          >
+            <span className="text-ink-strong">SN{subnet.netuid}</span>
+            {subnet.name ? ` · ${subnet.name}` : ""}
+          </Link>
+        </li>
+      ))}
+    </EntityIndexDirectory>
   );
 }

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -4,11 +4,13 @@ import { useSuspenseQuery, useIsFetching } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Globe, Github, BookOpen, Radio, Layers, Network } from "lucide-react";
 import { ApiSourceFooter } from "@/components/metagraphed/api-source-footer";
+import { ProviderIndexDirectory } from "@/components/metagraphed/provider-index-directory";
 import { EmptyState, StaleBanner } from "@/components/metagraphed/states";
 import { Panel } from "@/components/metagraphed/primitives";
 import {
   AsyncPanel,
   FilterChipRow,
+  PanelSkeleton,
   FilterSheet,
   QueryBar,
   QueryProgress,
@@ -97,6 +99,17 @@ export function ProvidersPage() {
         ]}
       >
         <ProvidersGrid view={view} />
+      </AsyncPanel>
+      {/* #11204: the grid above renders one screenful into the server-rendered
+          HTML, so 113 of 138 provider pages had no internal link anywhere on
+          the site. This is the complete index — see the component for why it is
+          not a duplicate of the grid. */}
+      <AsyncPanel
+        context="provider index"
+        fallback={<PanelSkeleton height="sm" className="mt-8" />}
+        retryQueryKeys={[metagraphedQueryKey("providers")]}
+      >
+        <ProviderIndexDirectory />
       </AsyncPanel>
       <ApiSourceFooter
         paths={["/api/v1/providers", "/api/v1/source-health"]}

--- a/apps/ui/src/server.robots.test.ts
+++ b/apps/ui/src/server.robots.test.ts
@@ -120,9 +120,18 @@ describe("non-canonical hosts are withheld whole (#11002)", () => {
     expect(isCrawlable(robotsBody("metagraph.sh"), "/subnets")).toBe(true);
   });
 
-  it("the canonical host declares the Content Signals", () => {
+  it("the canonical host declares the Content Signals INSIDE the user-agent group", () => {
     const body = robotsBody("metagraph.sh");
     expect(body).toMatch(/^Content-Signal: search=yes, ai-input=yes, ai-train=yes$/m);
+    // Position is the property that makes it mean anything (#11174 shipped it
+    // above the first `User-agent` line, where it belongs to no group and RFC
+    // 9309 parsers ignore it). Asserting only that the line exists — which is
+    // all this test used to do — passes on a declaration nothing reads.
+    const lines = body.split("\n");
+    const group = lines.findIndex((line) => /^User-agent:/i.test(line));
+    const signal = lines.findIndex((line) => /^Content-Signal:/i.test(line));
+    expect(group, "a User-agent group must exist").toBeGreaterThanOrEqual(0);
+    expect(signal, "Content-Signal must come after the User-agent line").toBeGreaterThan(group);
     // And the non-canonical duplicate does not: it disallows everything, and a
     // usage signal on a host nobody may crawl is noise.
     expect(robotsBody("other.example")).not.toContain("Content-Signal");

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -257,8 +257,15 @@ export function robotsBody(host: string): string {
     // Content Signals (contentsignals.org): all three yes, deliberately —
     // public data that exists to be read and reasoned over by machines. The
     // API host carries the same declaration (scripts/build-artifacts.ts).
-    `Content-Signal: search=yes, ai-input=yes, ai-train=yes\n` +
+    //
+    // INSIDE the group, not above it. robots.txt is defined (RFC 9309) as
+    // groups introduced by a `User-agent` line, and Content Signals is a
+    // directive of the group it sits in — the spec's own example is
+    // `User-Agent: *` / `Content-Signal: ...` / `Allow: /`, in that order.
+    // Emitted above the first `User-agent` line it belongs to no group at all,
+    // which is how it shipped in #11174: present in the file, read by nothing.
     `User-agent: *\n` +
+    `Content-Signal: search=yes, ai-input=yes, ai-train=yes\n` +
     `Allow: /\n` +
     `# Unbounded per-entity detail: not in the sitemap, one uncached scan per URL.\n` +
     `# The hub indexes (/chain/blocks, /chain/extrinsics) stay crawlable, as does\n` +

--- a/apps/ui/tests/e2e/crawlable-subnet-index.spec.ts
+++ b/apps/ui/tests/e2e/crawlable-subnet-index.spec.ts
@@ -1,22 +1,33 @@
 import { test, expect } from "@playwright/test";
 
-// #11204: every subnet page must have a real internal link from /subnets.
+// #11204: every subnet and provider page must have a real internal link from
+// its hub.
 //
-// The registry table virtualizes its body (#8248), so the server-rendered HTML
-// only ever carried anchors for the rows in view. Measured against production
-// on 2026-08-14: 30 distinct `/subnets/{n}` hrefs for 129 subnets, which left
-// 99 subnet pages reachable only from sitemap.xml — the profile that lands a
+// The registry hubs virtualize their bodies (#8248), so the server-rendered
+// HTML only ever carried anchors for the rows in view. Measured against
+// production on 2026-08-14:
+//
+//   /subnets          30 links for 129 subnets   -> 99 pages unlinked
+//   /apis/providers   25 links for 138 providers -> 113 pages unlinked
+//
+// Those pages were reachable only from sitemap.xml — the profile that lands a
 // URL in "Crawled – currently not indexed", and per-subnet lookups are the
 // demand Search Console actually records.
 //
-// This asserts against the RAW HTTP RESPONSE rather than the hydrated DOM, via
+// These assert against the RAW HTTP RESPONSE rather than the hydrated DOM, via
 // the `request` fixture: a crawler does not run our JavaScript, so the property
-// only means something if it holds in the bytes the server sends. Asserting on
+// only means something in the bytes the server sends. Asserting on
 // `page.content()` would pass on links React added after hydration and prove
 // nothing about what Googlebot indexes.
 const API_STUB = "http://127.0.0.1:8081";
 
-test.describe("#11204 crawlable subnet index", () => {
+/** Distinct path segments linked under `prefix` in a raw HTML body. */
+function linkedUnder(html: string, prefix: string): Set<string> {
+  const pattern = new RegExp(`href="${prefix}([^"#?]+)"`, "g");
+  return new Set([...html.matchAll(pattern)].map((match) => match[1]));
+}
+
+test.describe("#11204 crawlable entity indexes", () => {
   test("the server-rendered /subnets links to EVERY subnet", async ({ request }) => {
     const listed = await request.get(`${API_STUB}/api/v1/subnets?limit=200`);
     expect(listed.ok(), "the stub must serve the subnet list this page reads").toBe(true);
@@ -32,15 +43,36 @@ test.describe("#11204 crawlable subnet index", () => {
 
     const page = await request.get("/subnets");
     expect(page.ok()).toBe(true);
-    const html = await page.text();
-
-    const linked = new Set(
-      [...html.matchAll(/href="\/subnets\/(\d+)"/g)].map((match) => Number(match[1])),
-    );
-    const missing = netuids.filter((netuid) => !linked.has(netuid));
+    const linked = linkedUnder(await page.text(), "/subnets/");
+    const missing = netuids.filter((netuid) => !linked.has(String(netuid)));
     expect(
       missing,
       `subnet pages with no internal link in the server-rendered HTML: ${missing.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  test("the server-rendered /apis/providers links to EVERY provider", async ({ request }) => {
+    const listed = await request.get(`${API_STUB}/api/v1/providers`);
+    expect(listed.ok(), "the stub must serve the provider list this page reads").toBe(true);
+    const slugs = (
+      ((await listed.json()) as { data?: { providers?: Array<{ slug?: string; id?: string }> } })
+        .data?.providers ?? []
+    )
+      // The list keys providers by `id`; the UI derives the route slug as
+      // `slug ?? id` (normalizeProviderListItem), so match that here.
+      .map((provider) => provider.slug || provider.id)
+      .filter((slug): slug is string => Boolean(slug));
+    expect(slugs.length).toBeGreaterThan(100);
+
+    const page = await request.get("/apis/providers");
+    expect(page.ok()).toBe(true);
+    const linked = linkedUnder(await page.text(), "/providers/");
+    const missing = slugs.filter(
+      (slug) => !linked.has(encodeURIComponent(slug)) && !linked.has(slug),
+    );
+    expect(
+      missing,
+      `provider pages with no internal link in the server-rendered HTML: ${missing.join(", ")}`,
     ).toEqual([]);
   });
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
-Content-Signal: search=yes, ai-input=yes, ai-train=yes
 User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 Allow: /
 # Unbounded per-entity detail: one uncached scan per URL, not in the sitemap.
 # The collection routes (/api/v1/blocks, /api/v1/extrinsics,

--- a/scripts/build-artifacts.ts
+++ b/scripts/build-artifacts.ts
@@ -2550,8 +2550,14 @@ await fs.writeFile(
   // to teach. Revisit alongside the paid tier if premium data ever needs a
   // different posture (it would need its own path-scoped block, not a flip
   // of this one).
-  `Content-Signal: search=yes, ai-input=yes, ai-train=yes\n` +
-    `User-agent: *\n` +
+  // INSIDE the group, not above it. robots.txt is defined (RFC 9309) as groups
+  // introduced by a `User-agent` line, and Content Signals is specified as a
+  // directive of the group it sits in -- contentsignals.org's own example is
+  // `User-Agent: *` / `Content-Signal: ...` / `Allow: /`, in that order. Emitted
+  // above the first `User-agent` line it belongs to no group at all, which is
+  // how it shipped in #11174: present in the file, and read by nothing.
+  `User-agent: *\n` +
+    `Content-Signal: search=yes, ai-input=yes, ai-train=yes\n` +
     `Allow: /\n` +
     `# Unbounded per-entity detail: one uncached scan per URL, not in the sitemap.\n` +
     `# The collection routes (/api/v1/blocks, /api/v1/extrinsics,\n` +

--- a/tests/discovery-artifacts.test.ts
+++ b/tests/discovery-artifacts.test.ts
@@ -258,14 +258,30 @@ describe("Discovery artifacts", () => {
   // /api/v1/blocks/{ref} URLs beneath the same prefix are not. Mirrors
   // apps/ui/src/server.robots.test.ts, which gates the apex's own copy — the two
   // hosts are one policy and a change to either alone reopens the walk.
-  test("robots.txt declares the Content Signals, before any group", async () => {
+  test("robots.txt declares the Content Signals INSIDE the user-agent group", async () => {
     // contentsignals.org: the declaration of HOW fetched content may be used.
     // All three yes is the deliberate posture of a public registry that exists
     // to be read by machines -- see the comment at the writer.
+    //
+    // The POSITION is what makes it mean anything. robots.txt is defined (RFC
+    // 9309) as groups introduced by a `User-agent` line, and Content Signals is
+    // a directive of its group -- the spec's example is `User-Agent: *` /
+    // `Content-Signal: ...` / `Allow: /`. #11174 emitted it ABOVE the first
+    // `User-agent` line, where it belongs to no group and parsers ignore it,
+    // and this test asserted only that the line existed, so it passed on a
+    // declaration nothing read. (Its name even said "before any group".)
     const txt = await fs.readFile(path.join(publicDir, "robots.txt"), "utf8");
     assert.match(
       txt,
       /^Content-Signal: search=yes, ai-input=yes, ai-train=yes$/m,
+    );
+    const lines = txt.split("\n");
+    const group = lines.findIndex((line) => /^User-agent:/i.test(line));
+    const signal = lines.findIndex((line) => /^Content-Signal:/i.test(line));
+    assert.ok(group >= 0, "a User-agent group must exist");
+    assert.ok(
+      signal > group,
+      "Content-Signal must come after the User-agent line",
     );
   });
 


### PR DESCRIPTION
Part of #11204. Two defects in the machine-readable surface — the one that matters for AI citations, and the second half of the crawlability gap #11231 opened.

## The Content Signal was outside its group, on both hosts

#11174 shipped the Content Signals declaration. It emits **above** the first `User-agent` line:

```
Content-Signal: search=yes, ai-input=yes, ai-train=yes   <- belongs to no group
User-agent: *
Allow: /
```

robots.txt is defined by **RFC 9309** as groups introduced by a `User-agent` line, and Content Signals is a directive *of the group it sits in*. contentsignals.org's own example, per Cloudflare's spec:

```
User-Agent: *
Content-Signal: search=yes, ai-train=no
Allow: /
```

Emitted above the first group, it belongs to none — present in the file, and read by nothing. Which means the declaration that says *"yes, AI may use this content"* has not been in effect since it shipped, on a registry whose entire pitch is being read and cited by machines.

Fixed on the **apex and the API host together**, since the two are one policy and a change to either alone reopens the gap.

### Why it survived review

Both tests asserted only that the line *existed*. The API-side test was even named `"robots.txt declares the Content Signals, before any group"` — the wrong behaviour written into the test name. Both now pin the **position**:

```ts
const group  = lines.findIndex((l) => /^User-agent:/i.test(l));
const signal = lines.findIndex((l) => /^Content-Signal:/i.test(l));
assert.ok(signal > group);
```

`public/robots.txt` is regenerated and committed with the change.

## 113 provider pages had no internal link

The same virtualization effect #11231 fixed on `/subnets`, on the other hub:

| hub | server-rendered links | entities | unlinked |
|---|---|---|---|
| `/subnets` | 129 | 129 | 0 *(fixed in #11231)* |
| `/apis/providers` | **25** | 138 | **113** |

Those 113 were reachable only from `sitemap.xml`. Same fix, and the shell both indexes share is now **one component** — they cannot drift into different markup or different reasoning. Only the per-entity link stays with the caller, because TanStack's `Link` is typed per route.

Providers sort by display name rather than a numeric identity, and `name` is optional on the type even though the list normalizer falls back to the slug — resolved in code rather than asserted, so a future shape change surfaces as a type error instead of an empty anchor.

## The test asserts the raw response

`crawlable-subnet-index.spec.ts` now covers both hubs, still via Playwright's `request` fixture over plain HTTP: a crawler does not run our JavaScript, so the property only means something in the bytes the server sends.

**Proved the new half fails.** With the provider index removed it names all 113 slugs:

```
Error: provider pages with no internal link in the server-rendered HTML:
byzantium, cacheon, chipforge, chutes, ... zipcode
```

## Checked and deliberately not changed

- **Sitemap**: 1,628 URLs, zero duplicates, zero wrong-host entries, and **zero blocked by robots.txt**. (My first pass flagged 59 — a substring false positive: `/docs/api-reference/accounts/…` does not *start with* `/accounts/`, and robots matching is path-prefix based. It is clean.)
- **AI discovery surface**: `llms.txt`, `agent.md`, `api-catalog`, `agent-card.json`, `mcp/server-card.json`, `security.txt`, `agent-skills/index.json` all serve 200 on **both** hosts. Only `/ai.txt` 404s, and that is a far less adopted proposal than `llms.txt`, which we already serve — not worth claiming a standard we do not follow.
- **GSC "Alternate page with proper canonical tag"** is the `?tab=` variants working as designed, and is an *info* item, not an error. No action, per #11204's own read.
- **`/validators`** still links 50 of 1,023 — deliberately, for the reasons in #11231: a thousand links on one hub reads as link-farming, validator pages are not the measured demand, and this site has already been burned once by indexing volume. That one needs the Search Console index report to decide, not a guess.

## Validation

Root: `typecheck`, `lint`, `format:check`, `validate` (exit 0), `tests/discovery-artifacts.test.ts` (13 passed).

`apps/ui`: `lint` (0 errors, 8 warnings, all pre-existing), `format:check`, `typecheck`, `test` (**257 files, 2130 tests**), `test:e2e` (**106 passed**, zero `[api-stub] MISS`), `build:worker:e2e`.

`npm run build` regenerated exactly one artifact (`public/robots.txt`); `r2-manifest.json` auto-reverted as designed.
