### PR TITLE
fix(docs): the 25 API-reference group paths every page links were 404s

### DIFF
--- a/apps/ui/content/docs/api-reference/accounts/index.mdx
+++ b/apps/ui/content/docs/api-reference/accounts/index.mdx
@@ -1,0 +1,87 @@
+---
+title: Accounts
+description: Every Accounts endpoint in the metagraphed API, with its method and path.
+---
+
+40 endpoints.
+
+- [Account Axon Removals](/docs/api-reference/accounts/account-axon-removals) — `GET /api/v1/accounts/{ss58}/axon-removals`  
+  Fetch one account's axon-removal footprint per subnet over a recent window (7d/30d/90d): each subnet's AxonInfoRemoved count with the first and last removal timestamps, plus account totals, an HHI concentration of where its teardown activity is focused, and the dominant subnet — read from the account_events AxonInfoRemoved stream, which the runtime has never populated; an empty footprint is marked `degraded` rather than published as a measured zero.
+- [Account Balance](/docs/api-reference/accounts/account-balance) — `GET /api/v1/accounts/{ss58}/balance`  
+  Fetch the live TAO balance (free + reserved, in TAO) for one account, queried from the finney RPC at request time with 60s KV cache.
+- [Account Balance By Network](/docs/api-reference/accounts/account-balance-by-network) — `GET /api/v1/{network}/accounts/{ss58}/balance`  
+  Network-addressed form of the route above.
+- [Account Children](/docs/api-reference/accounts/account-children) — `GET /api/v1/accounts/{ss58}/children`  
+  Fetch the live child-hotkey delegation graph for one account (#6723, part of the child-hotkey delegation epic #6721) — every child hotkey this account currently delegates stake-weight to, per subnet, queried from the chain's own ChildKeys storage map at request time with 120s KV cache.
+- [Account Children By Network](/docs/api-reference/accounts/account-children-by-network) — `GET /api/v1/{network}/accounts/{ss58}/children`  
+  Network-addressed form of the route above.
+- [Account Counterparties](/docs/api-reference/accounts/account-counterparties) — `GET /api/v1/accounts/{ss58}/counterparties`  
+  Fetch the per-counterparty fund-flow rollup for one account — or, with ?counterparty=\<ss58>, pair-level native-TAO transfer evidence for one relationship — computed live from the account_events store.
+- [Account Deregistrations](/docs/api-reference/accounts/account-deregistrations) — `GET /api/v1/accounts/{ss58}/deregistrations`  
+  Fetch one account's neuron-deregistration footprint per subnet over a recent window (7d/30d/90d): each subnet's NeuronDeregistered eviction count with the first and last eviction timestamps, plus account totals, an HHI concentration of where its deregistration activity is focused, and the dominant subnet — DERIVED from UID reuse (the slots where this account was the PREVIOUS holder); NeuronDeregistered has never been emitted by the runtime, the payload's `derivation` block states the lower bound, and `degraded` marks an answer nothing derived.
+- [Account Entities](/docs/api-reference/accounts/account-entities) — `GET /api/v1/accounts/{ss58}/entities`  
+  Fetch one address's community-contributed entity labels plus every subnet-ownership tie it has via the chain_events SubnetOwnerChanged stream (#6737-#6740) — either side of an automatic conviction-contest transfer.
+- [Account Events](/docs/api-reference/accounts/account-events) — `GET /api/v1/accounts/{ss58}/events`  
+  Fetch the paginated first-party chain-event history for one account (hotkey or coldkey), newest first.
+- [Account Extrinsics](/docs/api-reference/accounts/account-extrinsics) — `GET /api/v1/accounts/{ss58}/extrinsics`  
+  Fetch the extrinsics this account signed (matched by signer), newest first, computed live from the extrinsics tier.
+- [Account History](/docs/api-reference/accounts/account-history) — `GET /api/v1/accounts/{ss58}/history`  
+  Fetch the durable per-day activity series for one account, newest day first, from the hotkey-keyed account_events_daily rollup (#1854).
+- [Account Identity](/docs/api-reference/accounts/account-identity) — `GET /api/v1/accounts/{ss58}/identity`  
+  Fetch the latest-only personal chain identity for one account (epic #4301/5.4), computed live from the account_identity tier.
+- [Account Identity History](/docs/api-reference/accounts/account-identity-history) — `GET /api/v1/accounts/{ss58}/identity-history`  
+  Fetch the append-only diff-tracking timeline for one account's personal chain identity (epic #4301/5.2): each entry is a snapshot recorded when any tracked field changed.
+- [Account Parents](/docs/api-reference/accounts/account-parents) — `GET /api/v1/accounts/{ss58}/parents`  
+  Fetch the live parent-hotkey delegation graph for one account (#6723, part of epic #6721) — every hotkey currently delegating stake-weight to this account, per subnet, queried from the chain's own ParentKeys storage map at request time with 120s KV cache.
+- [Account Parents By Network](/docs/api-reference/accounts/account-parents-by-network) — `GET /api/v1/{network}/accounts/{ss58}/parents`  
+  Network-addressed form of the route above.
+- [Account Portfolio](/docs/api-reference/accounts/account-portfolio) — `GET /api/v1/accounts/{ss58}/portfolio`  
+  Fetch a wallet's cross-subnet neuron portfolio: each position's economics (stake, emission, rank, trust, incentive, dividends, role) and yield, plus aggregates (totals, subnet/validator counts, overall return, stake concentration).
+- [Account Positions](/docs/api-reference/accounts/account-positions) — `GET /api/v1/accounts/{ss58}/positions`  
+  Fetch this account's reconstructed nominator-side positions: what it holds delegated across every hotkey/subnet, distinct from /portfolio's hotkey-scoped view.
+- [Account Prometheus](/docs/api-reference/accounts/account-prometheus) — `GET /api/v1/accounts/{ss58}/prometheus`  
+  Fetch one account's Prometheus-endpoint serving footprint per subnet over a recent window (7d/30d/90d): each subnet's PrometheusServed announcement count with the first and last announcement timestamps, plus account totals, an HHI concentration of where its telemetry activity is focused, and the dominant subnet — read from the account_events PrometheusServed stream, which carries 0 of the 18,041 PrometheusServed events the chain emitted; an empty footprint is marked `degraded` rather than published as a measured zero.
+- [Account Registrations](/docs/api-reference/accounts/account-registrations) — `GET /api/v1/accounts/{ss58}/registrations`  
+  Fetch one account's neuron-registration footprint per subnet over a recent window (7d/30d/90d): each subnet's NeuronRegistered count with the first and last registration timestamps, plus account totals, an HHI concentration of where its registration activity is focused, and the dominant subnet — summed live from the account_events store.
+- [Account Root Claim](/docs/api-reference/accounts/account-root-claim) — `GET /api/v1/accounts/{ss58}/root-claim`  
+  Fetch the live root-claim current state for one Finney ss58 account (#7229) — RootClaimType setting, per-hotkey RootClaimable rates, RootClaimed cumulative watermarks, and RootClaimableThreshold — queried from the finney RPC at request time with 120s KV cache.
+- [Account Root Claim By Network](/docs/api-reference/accounts/account-root-claim-by-network) — `GET /api/v1/{network}/accounts/{ss58}/root-claim`  
+  Network-addressed form of the route above.
+- [Account Serving](/docs/api-reference/accounts/account-serving) — `GET /api/v1/accounts/{ss58}/serving`  
+  Fetch one account's axon-serving footprint per subnet over a recent window (7d/30d/90d): each subnet's AxonServed announcement count with the first and last announcement timestamps, plus account totals, an HHI concentration of where its serving activity is focused, and the dominant subnet — summed live from the account_events store.
+- [Account Stake Flow](/docs/api-reference/accounts/account-stake-flow) — `GET /api/v1/accounts/{ss58}/stake-flow`  
+  Fetch one account's StakeAdded vs StakeRemoved flow per subnet over a recent window (7d/30d/90d): per-subnet net and gross flow with a direction label (accumulating/exiting/churning/idle), plus account totals, an HHI concentration of where the flow is focused, and the dominant subnet — summed live from the account_events store.
+- [Account Stake Moves](/docs/api-reference/accounts/account-stake-moves) — `GET /api/v1/accounts/{ss58}/stake-moves`  
+  Fetch one account's stake-movement (re-delegation) footprint per subnet over a recent window (7d/30d/90d): each subnet's StakeMoved count with the first and last movement timestamps and the alpha price on the day of the most recent move (from the daily subnet_snapshots rollup), plus account totals, an HHI concentration of where its re-delegation churn is focused, and the dominant subnet — summed live from the account_events store.
+- [Account Subnet Position History](/docs/api-reference/accounts/account-subnet-position-history) — `GET /api/v1/accounts/{ss58}/subnets/{netuid}/history`  
+  Fetch one wallet's position on one subnet over time (the 'Alpha Holdings chart'): one point per snapshot_date with the position's economics (stake, emission, rank, trust, incentive, dividends, coldkey, role) and yield, computed live from the account_position_daily rollup tier.
+- [Account Subnets](/docs/api-reference/accounts/account-subnets) — `GET /api/v1/accounts/{ss58}/subnets`  
+  Fetch the subnets where an account's hotkey is currently registered (its cross-subnet footprint), computed live from the neurons store.
+- [Account Summary](/docs/api-reference/accounts/account-summary) — `GET /api/v1/accounts/{ss58}`  
+  Fetch a cross-subnet activity summary for one account (hotkey or coldkey): chain-event aggregates joined to its current subnet registrations + stake.
+- [Account Transfers](/docs/api-reference/accounts/account-transfers) — `GET /api/v1/accounts/{ss58}/transfers`  
+  Fetch the native-TAO Balances.Transfer feed for one account, newest first, computed live from the account_events store.
+- [Account Weight Setters](/docs/api-reference/accounts/account-weight-setters) — `GET /api/v1/accounts/{ss58}/weight-setters`  
+  Fetch one account's (validator's) weight-setting footprint per subnet over a recent window (7d/30d): each subnet's WeightsSet count with the first and last set timestamps, plus account totals, an HHI concentration of where its weight-setting activity is focused, and the dominant subnet — summed live from the account_events store.
+- [Accounts List](/docs/api-reference/accounts/accounts-list) — `GET /api/v1/accounts`  
+  Fetch the site-wide accounts leaderboard: every currently-registered hotkey (miners included, not just validator_permit=1 ones) grouped across all current subnet memberships, with cross-subnet stake/emission totals, stake dominance, a validator/miner UID breakdown, and top membership rows.
+- [Evm Address Mapping](/docs/api-reference/accounts/evm-address-mapping) — `GET /api/v1/evm/address/{h160}`  
+  Fetch the live H160 -> SS58 address mapping for one EVM address (#6725/#6728), via the AddressMapping EVM precompile's addressMapping(address), queried from the finney RPC at request time with 1h KV cache.
+- [Evm Address Mapping By Network](/docs/api-reference/accounts/evm-address-mapping-by-network) — `GET /api/v1/{network}/evm/address/{h160}`  
+  Network-addressed form of the route above.
+- [Network Parameters](/docs/api-reference/accounts/network-parameters) — `GET /api/v1/network/parameters`  
+  Fetch live global Subtensor protocol/governance parameters (#6343) — TaoWeight, StakeThreshold, PendingChildKeyCooldown — queried from the finney RPC at request time with 300s KV cache.
+- [Network Parameters By Network](/docs/api-reference/accounts/network-parameters-by-network) — `GET /api/v1/{network}/network/parameters`  
+  Network-addressed form of the route above.
+- [Randomness](/docs/api-reference/accounts/randomness) — `GET /api/v1/network/randomness`  
+  Fetch the live drand randomness-beacon status (#6730/#6731) — LastStoredRound, OldestStoredRound — queried from the finney RPC at request time with 30s KV cache.
+- [Randomness By Network](/docs/api-reference/accounts/randomness-by-network) — `GET /api/v1/{network}/network/randomness`  
+  Network-addressed form of the route above.
+- [Sudo Key](/docs/api-reference/accounts/sudo-key) — `GET /api/v1/sudo/key`  
+  Fetch the current Sudo::Key holder, queried from the finney RPC at request time with 1h KV cache (re-scoped from the original Senate/Council membership framing — subtensor has no such pallet, #4310).
+- [Sudo Key By Network](/docs/api-reference/accounts/sudo-key-by-network) — `GET /api/v1/{network}/sudo/key`  
+  Network-addressed form of the route above.
+- [TAO Usd](/docs/api-reference/accounts/tao-usd) — `GET /api/v1/network/tao-usd`  
+  Fetch the TAO/USD index.
+- [Top Holders](/docs/api-reference/accounts/top-holders) — `GET /api/v1/accounts/top-holders`  
+  Fetch the balance-based top-holder leaderboard: every account (coldkey) with a nonzero free balance and/or delegated stake position, with free/delegated/total TAO columns matching the taostats-style Account/Free/Delegated/Total benchmark /api/v1/accounts explicitly cannot derive.

--- a/apps/ui/content/docs/api-reference/accounts/meta.json
+++ b/apps/ui/content/docs/api-reference/accounts/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Accounts",
   "pages": [
+    "index",
     "account-axon-removals",
     "account-balance",
     "account-balance-by-network",

--- a/apps/ui/content/docs/api-reference/adapters/index.mdx
+++ b/apps/ui/content/docs/api-reference/adapters/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Adapters
+description: Every Adapters endpoint in the metagraphed API, with its method and path.
+---
+
+2 endpoints.
+
+- [Adapter](/docs/api-reference/adapters/adapter) — `GET /api/v1/adapters/{slug}`  
+  Fetch adapter-backed public metrics.
+- [Review Adapter Candidates](/docs/api-reference/adapters/review-adapter-candidates) — `GET /api/v1/review/adapter-candidates`  
+  Fetch subnets worth deeper adapter work.

--- a/apps/ui/content/docs/api-reference/adapters/meta.json
+++ b/apps/ui/content/docs/api-reference/adapters/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Adapters",
   "pages": [
+    "index",
     "adapter",
     "review-adapter-candidates"
   ]

--- a/apps/ui/content/docs/api-reference/agents/index.mdx
+++ b/apps/ui/content/docs/api-reference/agents/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Agents
+description: Every Agents endpoint in the metagraphed API, with its method and path.
+---
+
+2 endpoints.
+
+- [Agent Catalog](/docs/api-reference/agents/agent-catalog) — `GET /api/v1/agent-catalog`  
+  List subnets exposing callable services for AI agents (compact capability index).
+- [Agent Catalog Subnet](/docs/api-reference/agents/agent-catalog-subnet) — `GET /api/v1/agent-catalog/{netuid}`  
+  Fetch the callable-services catalog for one subnet (each service with its schema + health).

--- a/apps/ui/content/docs/api-reference/agents/meta.json
+++ b/apps/ui/content/docs/api-reference/agents/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Agents",
   "pages": [
+    "index",
     "agent-catalog",
     "agent-catalog-subnet"
   ]

--- a/apps/ui/content/docs/api-reference/alerts/index.mdx
+++ b/apps/ui/content/docs/api-reference/alerts/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Alerts
+description: Every Alerts endpoint in the metagraphed API, with its method and path.
+---
+
+1 endpoint.
+
+- [Alert Trigger](/docs/api-reference/alerts/alert-trigger) — `GET /api/v1/alerts/triggers/{id}`  
+  Read back one alert trigger: what it watches (`table_filter` plus the four narrowing fields `netuid`, `event_kind`, `account`, `min_amount_tao` -- all nullable, so a trigger that sets none of them matches every event on its table), where it delivers (`channel`, `destination`), whether it is `active`, and its firing record.

--- a/apps/ui/content/docs/api-reference/alerts/meta.json
+++ b/apps/ui/content/docs/api-reference/alerts/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Alerts",
   "pages": [
+    "index",
     "alert-trigger"
   ]
 }

--- a/apps/ui/content/docs/api-reference/api-dx/index.mdx
+++ b/apps/ui/content/docs/api-reference/api-dx/index.mdx
@@ -1,0 +1,9 @@
+---
+title: API DX
+description: Every API DX endpoint in the metagraphed API, with its method and path.
+---
+
+1 endpoint.
+
+- [Agent Resources](/docs/api-reference/api-dx/agent-resources) — `GET /api/v1/agent-resources`  
+  Fetch the AI-resources index: the copyable agent (/agent.md), the MCP server + its tools, the skill, llms.txt, OpenAPI, and the agent-facing APIs.

--- a/apps/ui/content/docs/api-reference/api-dx/meta.json
+++ b/apps/ui/content/docs/api-reference/api-dx/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "API DX",
   "pages": [
+    "index",
     "agent-resources"
   ]
 }

--- a/apps/ui/content/docs/api-reference/blocks/index.mdx
+++ b/apps/ui/content/docs/api-reference/blocks/index.mdx
@@ -1,0 +1,33 @@
+---
+title: Blocks
+description: Every Blocks endpoint in the metagraphed API, with its method and path.
+---
+
+13 endpoints.
+
+- [Block Chain Events](/docs/api-reference/blocks/block-chain-events) — `GET /api/v1/blocks/{ref}/chain-events`  
+  Fetch EVERY raw pallet-level event in one block (by numeric block_number; event_index ascending), served live from the live-follow hot tier above the decode seam and the chain_events lakehouse at or below it (no static file).
+- [Block Chain Events By Network](/docs/api-reference/blocks/block-chain-events-by-network) — `GET /api/v1/{network}/blocks/{ref}/chain-events`  
+  Network-addressed form of the route above.
+- [Block Detail](/docs/api-reference/blocks/block-detail) — `GET /api/v1/blocks/{ref}`  
+  Fetch per-block detail by numeric block_number or 0x block_hash.
+- [Block Detail By Network](/docs/api-reference/blocks/block-detail-by-network) — `GET /api/v1/{network}/blocks/{ref}`  
+  Network-addressed form of the route above.
+- [Block Events](/docs/api-reference/blocks/block-events) — `GET /api/v1/blocks/{ref}/events`  
+  Fetch the ACCOUNT-ATTRIBUTED events in one block (by numeric block_number or 0x block_hash), in natural order; ?limit (\<=1000) / ?offset.
+- [Block Events By Network](/docs/api-reference/blocks/block-events-by-network) — `GET /api/v1/{network}/blocks/{ref}/events`  
+  Network-addressed form of the route above.
+- [Block Extrinsics](/docs/api-reference/blocks/block-extrinsics) — `GET /api/v1/blocks/{ref}/extrinsics`  
+  Fetch the extrinsics in one block (by numeric block_number or 0x block_hash), in natural order; ?limit (\<=100) / ?offset.
+- [Block Extrinsics By Network](/docs/api-reference/blocks/block-extrinsics-by-network) — `GET /api/v1/{network}/blocks/{ref}/extrinsics`  
+  Network-addressed form of the route above.
+- [Blocks Feed](/docs/api-reference/blocks/blocks-feed) — `GET /api/v1/blocks`  
+  Fetch the recent-block feed (newest first) for the block explorer; ?limit (\<=100) / ?offset, or ?cursor= for stable keyset paging under head-of-chain inserts (#1851).
+- [Blocks Feed By Network](/docs/api-reference/blocks/blocks-feed-by-network) — `GET /api/v1/{network}/blocks`  
+  Network-addressed form of the route above.
+- [Blocks Summary](/docs/api-reference/blocks/blocks-summary) — `GET /api/v1/blocks/summary`  
+  Fetch block-production analytics over recent blocks: inter-block time distribution, extrinsic/event throughput, block-author decentralization (concentration over each author's block count), and the spec-version spread.
+- [Blocks Summary By Network](/docs/api-reference/blocks/blocks-summary-by-network) — `GET /api/v1/{network}/blocks/summary`  
+  Network-addressed form of the route above.
+- [Runtime Versions](/docs/api-reference/blocks/runtime-versions) — `GET /api/v1/runtime`  
+  Fetch the spec-version transition timeline — the earliest known block at each distinct runtime spec_version, ascending by block_number.

--- a/apps/ui/content/docs/api-reference/blocks/meta.json
+++ b/apps/ui/content/docs/api-reference/blocks/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Blocks",
   "pages": [
+    "index",
     "block-chain-events",
     "block-chain-events-by-network",
     "block-detail",

--- a/apps/ui/content/docs/api-reference/candidates/index.mdx
+++ b/apps/ui/content/docs/api-reference/candidates/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Candidates
+description: Every Candidates endpoint in the metagraphed API, with its method and path.
+---
+
+2 endpoints.
+
+- [Candidates](/docs/api-reference/candidates/candidates) — `GET /api/v1/candidates`  
+  List unpromoted candidate surfaces.
+- [Subnet Candidates](/docs/api-reference/candidates/subnet-candidates) — `GET /api/v1/subnets/{netuid}/candidates`  
+  List unpromoted candidate surfaces for one subnet.

--- a/apps/ui/content/docs/api-reference/candidates/meta.json
+++ b/apps/ui/content/docs/api-reference/candidates/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Candidates",
   "pages": [
+    "index",
     "candidates",
     "subnet-candidates"
   ]

--- a/apps/ui/content/docs/api-reference/chain/index.mdx
+++ b/apps/ui/content/docs/api-reference/chain/index.mdx
@@ -1,0 +1,113 @@
+---
+title: Chain
+description: Every Chain endpoint in the metagraphed API, with its method and path.
+---
+
+53 endpoints.
+
+- [Chain Activity](/docs/api-reference/chain/chain-activity) — `GET /api/v1/chain/activity`  
+  Fetch daily network-activity aggregates (extrinsic/event/block counts, success rate, unique signers) over a 7d or 30d window, newest day first.
+- [Chain Activity By Network](/docs/api-reference/chain/chain-activity-by-network) — `GET /api/v1/{network}/chain/activity`  
+  Network-addressed form of the route above.
+- [Chain Alpha Volume](/docs/api-reference/chain/chain-alpha-volume) — `GET /api/v1/chain/alpha-volume`  
+  Fetch the network-wide rolling 24h buy/sell alpha-volume leaderboard: every subnet that had StakeAdded (buy) or StakeRemoved (sell) volume in the last 24h (subnets with no volume are excluded) ranked by total_volume_tao (biggest market activity first, ?limit \<=100), each with the same buy/sell/total volume + sentiment scorecard as GET /api/v1/subnets/\{netuid}/volume, plus a network rollup (with its own net/gross sentiment reading) and a distribution (count, mean, min, p25, median, p75, p90, max) of the per-subnet total volume.
+- [Chain Alpha Volume By Network](/docs/api-reference/chain/chain-alpha-volume-by-network) — `GET /api/v1/{network}/chain/alpha-volume`  
+  Network-addressed form of the route above.
+- [Chain Axon Removals](/docs/api-reference/chain/chain-axon-removals) — `GET /api/v1/chain/axon-removals`  
+  Fetch network-wide axon-removal activity over a 7d or 30d window across the subnets with observed removal activity (subnets with no AxonInfoRemoved events are absent): a per-subnet leaderboard (AxonInfoRemoved event count, distinct removers, and average removals per remover) ranked by total removals, a network rollup with the true distinct remover count (a hotkey removing an axon on several subnets counts once) and total removals, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-teardown intensity.
+- [Chain Burn](/docs/api-reference/chain/chain-burn) — `GET /api/v1/chain/burn`  
+  Fetch every subnet's live registration/burn cost in one response, ranked cheapest-first (#9399).
+- [Chain Burn By Network](/docs/api-reference/chain/chain-burn-by-network) — `GET /api/v1/{network}/chain/burn`  
+  Network-addressed form of the route above.
+- [Chain Calls](/docs/api-reference/chain/chain-calls) — `GET /api/v1/chain/calls`  
+  Fetch the extrinsic call-mix breakdown (count + share per call_module, or call_module/call_function with group_by=module_function) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=.
+- [Chain Calls By Network](/docs/api-reference/chain/chain-calls-by-network) — `GET /api/v1/{network}/chain/calls`  
+  Network-addressed form of the route above.
+- [Chain Concentration](/docs/api-reference/chain/chain-concentration) — `GET /api/v1/chain/concentration`  
+  Fetch network-wide stake and emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) aggregated across all subnets' neurons over three lenses (per-UID, per-entity with coldkeys collapsed across subnets into the network control distribution, and validator-only consensus power), computed live from the neurons store; schema-stable nulls when cold.
+- [Chain Concentration History](/docs/api-reference/chain/chain-concentration-history) — `GET /api/v1/chain/concentration/history`  
+  Fetch the network-wide concentration series.
+- [Chain Concentration Subnets](/docs/api-reference/chain/chain-concentration-subnets) — `GET /api/v1/chain/concentration/subnets`  
+  Fetch every subnet ranked by distribution spread.
+- [Chain Deregistrations](/docs/api-reference/chain/chain-deregistrations) — `GET /api/v1/chain/deregistrations`  
+  Fetch network-wide neuron-deregistration activity over a 7d or 30d window across the subnets with observed deregistration activity (subnets with no NeuronDeregistered events are absent): a per-subnet leaderboard (NeuronDeregistered event count, distinct deregistered hotkeys, and average deregistrations per hotkey) ranked by total deregistrations, a network rollup with the true distinct hotkey count (a hotkey deregistered on several subnets counts once) and total deregistrations, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-deregistration intensity.
+- [Chain Deregistrations By Network](/docs/api-reference/chain/chain-deregistrations-by-network) — `GET /api/v1/{network}/chain/deregistrations`  
+  Network-addressed form of the route above.
+- [Chain Events Feed](/docs/api-reference/chain/chain-events-feed) — `GET /api/v1/chain-events`  
+  Fetch the recent all-events feed (newest first) from the chain_events lakehouse table — every raw pallet.method event, distinct from the curated account-attributed stream.
+- [Chain Events Feed By Network](/docs/api-reference/chain/chain-events-feed-by-network) — `GET /api/v1/{network}/chain-events`  
+  Network-addressed form of the route above.
+- [Chain Events Stats](/docs/api-reference/chain/chain-events-stats) — `GET /api/v1/chain-events/stats`  
+  Fetch the chain-activity aggregate — the pallet.method event distribution over the most recent N blocks the decode lane has published — from the chain_events lakehouse table.
+- [Chain Events Stats By Network](/docs/api-reference/chain/chain-events-stats-by-network) — `GET /api/v1/{network}/chain-events/stats`  
+  Network-addressed form of the route above.
+- [Chain Fees](/docs/api-reference/chain/chain-fees) — `GET /api/v1/chain/fees`  
+  Fetch fee/tip market analytics — a per-UTC-day fee series (totals, plus averages and exact ordered-offset medians computed over signed extrinsics only) plus a windowed top-fee-payer list — over a 7d or 30d window, optionally scoped to one pallet with ?call_module=.
+- [Chain Fees By Network](/docs/api-reference/chain/chain-fees-by-network) — `GET /api/v1/{network}/chain/fees`  
+  Network-addressed form of the route above.
+- [Chain Holders](/docs/api-reference/chain/chain-holders) — `GET /api/v1/chain/holders`  
+  Fetch every subnet ranked by alpha-ownership concentration.
+- [Chain Identity History](/docs/api-reference/chain/chain-identity-history) — `GET /api/v1/chain/identity-history`  
+  Fetch the network-wide recent subnet-identity-change feed (newest first) aggregated across all subnets: the most-recent SubnetIdentitiesV3 changes, each carrying the netuid it belongs to plus the same tracked identity fields as the per-subnet identity-history route, capped to ?limit (default 50, max 200) and reporting the distinct subnet_count the feed spans, computed from the frozen lakehouse export of subnet_identity_history; schema-stable empty feed when cold.
+- [Chain Idle Stake](/docs/api-reference/chain/chain-idle-stake) — `GET /api/v1/chain/idle-stake`  
+  Fetch the network-wide idle-stake rollup: every subnet's own idle-stake scorecard (stake delegated to a currently-zero-dividends hotkey) ranked by idle_stake_alpha descending, plus the network total, computed live from the neurons store; schema-stable empty ranking when cold.
+- [Chain Performance](/docs/api-reference/chain/chain-performance) — `GET /api/v1/chain/performance`  
+  Fetch network-wide reward-distribution & score-spread metrics aggregated across all subnets' neurons: reward concentration (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for incentive across all neurons and dividends across validators, plus the p10–p90 spread of the 0–1 trust, consensus, and validator_trust scores, computed live from the neurons store; schema-stable nulls when cold.
+- [Chain Prometheus](/docs/api-reference/chain/chain-prometheus) — `GET /api/v1/chain/prometheus`  
+  Fetch network-wide Prometheus-endpoint serving activity over a 7d or 30d window across the subnets with observed telemetry activity (subnets with no PrometheusServed events are absent): a per-subnet leaderboard (PrometheusServed event count, distinct exporters, and average announcements per exporter) ranked by total announcements, a network rollup with the true distinct exporter count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity.
+- [Chain Registrations](/docs/api-reference/chain/chain-registrations) — `GET /api/v1/chain/registrations`  
+  Fetch network-wide neuron-registration activity over a 7d or 30d window across the subnets with observed registration activity (subnets with no NeuronRegistered events are absent): a per-subnet leaderboard (NeuronRegistered event count, distinct registrants, and average registrations per registrant) ranked by total registrations, a network rollup with the true distinct registrant count (a hotkey registering on several subnets counts once) and total registrations, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-registration intensity.
+- [Chain Registrations By Network](/docs/api-reference/chain/chain-registrations-by-network) — `GET /api/v1/{network}/chain/registrations`  
+  Network-addressed form of the route above.
+- [Chain Revenue Coverage](/docs/api-reference/chain/chain-revenue-coverage) — `GET /api/v1/chain/revenue-coverage`  
+  Fetch every subnet's revenue coverage in one response.
+- [Chain Serving](/docs/api-reference/chain/chain-serving) — `GET /api/v1/chain/serving`  
+  Fetch network-wide axon-serving announcement activity over a 7d or 30d window across the subnets with observed serving activity (subnets with no AxonServed events are absent): a per-subnet leaderboard (AxonServed event count, distinct servers, and average announcements per server) ranked by total announcements, a network rollup with the true distinct server count (a hotkey announcing on several subnets counts once) and total announcements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-announcement intensity.
+- [Chain Signers](/docs/api-reference/chain/chain-signers) — `GET /api/v1/chain/signers`  
+  Fetch the windowed most-active-account leaderboard (signers ranked by ?sort=tx_count or ?sort=total_fee_tao, with total fees/tips + newest signed block) over a 7d or 30d window, optionally scoped to one pallet with ?call_module=.
+- [Chain Signers By Network](/docs/api-reference/chain/chain-signers-by-network) — `GET /api/v1/{network}/chain/signers`  
+  Network-addressed form of the route above.
+- [Chain Stake Flow](/docs/api-reference/chain/chain-stake-flow) — `GET /api/v1/chain/stake-flow`  
+  Fetch network-wide cross-subnet capital flow over a 7d or 30d window: every subnet that moved stake in the window ranked by net StakeAdded minus StakeRemoved TAO (subnets with no stake events in the window are excluded) (biggest net inflow first, ?limit \<=100), with per-subnet staked/unstaked/net/gross totals and a direction label, a network rollup, and a distribution (count, mean, min, p25, median, p75, p90, max) of the per-subnet net flow.
+- [Chain Stake Flow By Network](/docs/api-reference/chain/chain-stake-flow-by-network) — `GET /api/v1/{network}/chain/stake-flow`  
+  Network-addressed form of the route above.
+- [Chain Stake Moves](/docs/api-reference/chain/chain-stake-moves) — `GET /api/v1/chain/stake-moves`  
+  Fetch network-wide stake-movement (re-delegation) activity over a 7d or 30d window across the subnets with observed movement activity (subnets with no StakeMoved events are absent): a per-subnet leaderboard (StakeMoved event count, distinct movers, and average movements per mover) ranked by total movements, a network rollup with the true distinct mover count (an account moving stake out of several subnets counts once) and total movements, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet re-move intensity.
+- [Chain Stake Moves By Network](/docs/api-reference/chain/chain-stake-moves-by-network) — `GET /api/v1/{network}/chain/stake-moves`  
+  Network-addressed form of the route above.
+- [Chain Stake Transfers](/docs/api-reference/chain/chain-stake-transfers) — `GET /api/v1/chain/stake-transfers`  
+  Fetch network-wide stake-transfer activity over a 7d or 30d window across the subnets with observed transfer activity (subnets with no StakeTransferred events are absent): a per-subnet leaderboard (StakeTransferred event count, distinct senders, and average transfers per sender) ranked by total transfers, a network rollup with the true distinct sender count (an account transferring stake out of several subnets counts once) and total transfers, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet transfer intensity.
+- [Chain Stake Transfers By Network](/docs/api-reference/chain/chain-stake-transfers-by-network) — `GET /api/v1/{network}/chain/stake-transfers`  
+  Network-addressed form of the route above.
+- [Chain Stream](/docs/api-reference/chain/chain-stream) — `GET /api/v1/chain/stream`  
+  Subscribe to decoded chain activity as it is captured (#4982, ADR 0015).
+- [Chain Subnet Lifecycle](/docs/api-reference/chain/chain-subnet-lifecycle) — `GET /api/v1/chain/subnet-lifecycle`  
+  Fetch every subnet's registrations and deregistrations across the network (#10263), newest first, from the subnet_lifecycle Neon table.
+- [Chain Transfer Pairs](/docs/api-reference/chain/chain-transfer-pairs) — `GET /api/v1/chain/transfer-pairs`  
+  Fetch network-wide directed native-TAO transfer-pair analytics over a 7d or 30d window: total pairable Balances.Transfer volume + count, unique sender/receiver pairs, returned pair count, top-pair share, and top sender -> receiver pairs ranked by ?sort=volume or ?sort=count (?limit, \<=100).
+- [Chain Transfer Pairs By Network](/docs/api-reference/chain/chain-transfer-pairs-by-network) — `GET /api/v1/{network}/chain/transfer-pairs`  
+  Network-addressed form of the route above.
+- [Chain Transfers](/docs/api-reference/chain/chain-transfers) — `GET /api/v1/chain/transfers`  
+  Fetch network-wide native-TAO transfer analytics over a 7d or 30d window: total Balances.Transfer volume + count, distinct senders/receivers, the top senders and receivers ranked by volume (?limit, \<=100), and the top senders' share of total volume.
+- [Chain Transfers By Network](/docs/api-reference/chain/chain-transfers-by-network) — `GET /api/v1/{network}/chain/transfers`  
+  Network-addressed form of the route above.
+- [Chain Turnover](/docs/api-reference/chain/chain-turnover) — `GET /api/v1/chain/turnover`  
+  Fetch network-wide validator-set turnover across all subnets between the window's start and end neuron_daily snapshots: a per-subnet leaderboard (validators entered, exited, Jaccard retention, and a 0-100 stability score) ranked by gross churn, a network rollup over the union of every subnet's validator hotkeys, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet stability scores.
+- [Chain Weight Setters](/docs/api-reference/chain/chain-weight-setters) — `GET /api/v1/chain/weights/setters`  
+  Fetch the network-wide weight-setter leaderboard over a 7d or 30d window: the individual validators driving consensus across every subnet ranked by activity, each with its total WeightsSet count (summed across every subnet it operates on), its share of the network total, and its first/last set time.
+- [Chain Weights](/docs/api-reference/chain/chain-weights) — `GET /api/v1/chain/weights`  
+  Fetch network-wide validator weight-setting activity over a 7d or 30d window across the subnets with observed weight-setting activity (subnets with no WeightsSet events are absent): a per-subnet leaderboard (distinct weight-setting validators, WeightsSet event count, and average updates per validator) ranked by total events, a network rollup with the true distinct setter count (a validator setting weights on several subnets counts once) and total events, and a distribution summary (count, mean, min, p25, median, p75, p90, max) of the per-subnet update intensity.
+- [Chain Yield](/docs/api-reference/chain/chain-yield) — `GET /api/v1/chain/yield`  
+  Fetch network-wide emission-yield (return rate) aggregated across all subnets' neurons: the aggregate network return (total emission / total stake), the same split by validator vs miner role, and the count/mean/median/min/max plus p10–p90 spread of the per-neuron emission/stake return, computed live from the neurons store; schema-stable nulls when cold.
+- [Crowdloan Detail](/docs/api-reference/chain/crowdloan-detail) — `GET /api/v1/crowdloans/{crowdloan_id}`  
+  Fetch one crowdloan's live state (#8696) from the Crowdloan pallet's Crowdloans storage map at request time with 120s KV cache.
+- [Crowdloan Detail By Network](/docs/api-reference/chain/crowdloan-detail-by-network) — `GET /api/v1/{network}/crowdloans/{crowdloan_id}`  
+  Network-addressed form of the route above.
+- [Crowdloans](/docs/api-reference/chain/crowdloans) — `GET /api/v1/crowdloans`  
+  List every crowdloan the chain has ever opened (#8696), with its terms and how much it raised, queried from the Crowdloan pallet's own NextCrowdloanId/Crowdloans storage at request time with 120s KV cache.
+- [Crowdloans By Network](/docs/api-reference/chain/crowdloans-by-network) — `GET /api/v1/{network}/crowdloans`  
+  Network-addressed form of the route above.
+- [Emission Gate Changes](/docs/api-reference/chain/emission-gate-changes) — `GET /api/v1/chain/governance/emission-changes`  
+  Fetch the emission-gate change log.
+- [Indexer Lag](/docs/api-reference/chain/indexer-lag) — `GET /api/v1/chain/indexer-lag`  
+  Fetch the block-indexing latency card.

--- a/apps/ui/content/docs/api-reference/chain/meta.json
+++ b/apps/ui/content/docs/api-reference/chain/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Chain",
   "pages": [
+    "index",
     "chain-activity",
     "chain-activity-by-network",
     "chain-alpha-volume",

--- a/apps/ui/content/docs/api-reference/contracts/index.mdx
+++ b/apps/ui/content/docs/api-reference/contracts/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Contracts
+description: Every Contracts endpoint in the metagraphed API, with its method and path.
+---
+
+3 endpoints.
+
+- [API Index](/docs/api-reference/contracts/api-index) — `GET /api/v1`  
+  List backend API routes and response envelope metadata.
+- [Contracts](/docs/api-reference/contracts/contracts) — `GET /api/v1/contracts`  
+  Fetch artifact contract metadata.
+- [OpenAPI](/docs/api-reference/contracts/openapi) — `GET /api/v1/openapi.json`  
+  Fetch OpenAPI 3.1 contract.

--- a/apps/ui/content/docs/api-reference/contracts/meta.json
+++ b/apps/ui/content/docs/api-reference/contracts/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Contracts",
   "pages": [
+    "index",
     "api-index",
     "contracts",
     "openapi"

--- a/apps/ui/content/docs/api-reference/endpoints/index.mdx
+++ b/apps/ui/content/docs/api-reference/endpoints/index.mdx
@@ -1,0 +1,15 @@
+---
+title: Endpoints
+description: Every Endpoints endpoint in the metagraphed API, with its method and path.
+---
+
+4 endpoints.
+
+- [Endpoint Incidents](/docs/api-reference/endpoints/endpoint-incidents) — `GET /api/v1/endpoint-incidents`  
+  Fetch probe-derived endpoint incidents.
+- [Endpoint Pools](/docs/api-reference/endpoints/endpoint-pools) — `GET /api/v1/endpoint-pools`  
+  Fetch generalized endpoint pool scores.
+- [Endpoints](/docs/api-reference/endpoints/endpoints) — `GET /api/v1/endpoints`  
+  List generalized endpoint resources and monitored public surfaces.
+- [Subnet Endpoints](/docs/api-reference/endpoints/subnet-endpoints) — `GET /api/v1/subnets/{netuid}/endpoints`  
+  List generalized endpoint resources for one subnet.

--- a/apps/ui/content/docs/api-reference/endpoints/meta.json
+++ b/apps/ui/content/docs/api-reference/endpoints/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Endpoints",
   "pages": [
+    "index",
     "endpoint-incidents",
     "endpoint-pools",
     "endpoints",

--- a/apps/ui/content/docs/api-reference/evidence/index.mdx
+++ b/apps/ui/content/docs/api-reference/evidence/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Evidence
+description: Every Evidence endpoint in the metagraphed API, with its method and path.
+---
+
+2 endpoints.
+
+- [Evidence](/docs/api-reference/evidence/evidence) — `GET /api/v1/evidence`  
+  Fetch public evidence ledger.
+- [Subnet Evidence](/docs/api-reference/evidence/subnet-evidence) — `GET /api/v1/subnets/{netuid}/evidence`  
+  Fetch public evidence ledger claims for one subnet.

--- a/apps/ui/content/docs/api-reference/evidence/meta.json
+++ b/apps/ui/content/docs/api-reference/evidence/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Evidence",
   "pages": [
+    "index",
     "evidence",
     "subnet-evidence"
   ]

--- a/apps/ui/content/docs/api-reference/extrinsics/index.mdx
+++ b/apps/ui/content/docs/api-reference/extrinsics/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Extrinsics
+description: Every Extrinsics endpoint in the metagraphed API, with its method and path.
+---
+
+6 endpoints.
+
+- [Extrinsic Detail](/docs/api-reference/extrinsics/extrinsic-detail) — `GET /api/v1/extrinsics/{hash}`  
+  Fetch per-extrinsic detail by 0x extrinsic_hash OR the composite \<block_number>-\<extrinsic_index> id (the guaranteed-present identifier, since the hash is best-effort/nullable).
+- [Extrinsic Detail By Network](/docs/api-reference/extrinsics/extrinsic-detail-by-network) — `GET /api/v1/{network}/extrinsics/{hash}`  
+  Network-addressed form of the route above.
+- [Extrinsics Feed](/docs/api-reference/extrinsics/extrinsics-feed) — `GET /api/v1/extrinsics`  
+  Fetch the recent-extrinsic feed (newest first) for the block explorer; ?limit (\<=100) / ?offset (or ?cursor= for stable keyset paging, #1851) and a conjunctive filter set (#1846): ?block=\<n>, ?signer=, ?call_module=, ?call_function=, ?call_hash= (0x-prefixed 64-hex-char decoded call hash, requires ?call_module= to keep the JSON scan scoped — matches a Multisig approval chain's linked calls, #4322), ?success=true|false, ?block_start/?block_end (block range), ?from/?to (observed_at epoch-ms range).
+- [Extrinsics Feed By Network](/docs/api-reference/extrinsics/extrinsics-feed-by-network) — `GET /api/v1/{network}/extrinsics`  
+  Network-addressed form of the route above.
+- [Governance Config Changes](/docs/api-reference/extrinsics/governance-config-changes) — `GET /api/v1/governance/config-changes`  
+  Fetch subtensor's own root-origin hyperparameter/network-config change feed, newest first — the extrinsics feed hardcoded to call_module='AdminUtils' (re-scoped from the original Council/Senate framing; subtensor has no such pallet).
+- [Sudo Calls](/docs/api-reference/extrinsics/sudo-calls) — `GET /api/v1/sudo`  
+  Fetch the root-origin (Sudo pallet) call table, newest first — subtensor has no Council/Senate, so this is the extrinsics feed hardcoded to call_module='Sudo'.

--- a/apps/ui/content/docs/api-reference/extrinsics/meta.json
+++ b/apps/ui/content/docs/api-reference/extrinsics/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Extrinsics",
   "pages": [
+    "index",
     "extrinsic-detail",
     "extrinsic-detail-by-network",
     "extrinsics-feed",

--- a/apps/ui/content/docs/api-reference/feeds/index.mdx
+++ b/apps/ui/content/docs/api-reference/feeds/index.mdx
@@ -1,0 +1,71 @@
+---
+title: Feeds
+description: Every Feeds endpoint in the metagraphed API, with its method and path.
+---
+
+32 endpoints.
+
+- [Feed Gaps](/docs/api-reference/feeds/feed-gaps) — `GET /api/v1/feeds/gaps`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Gaps Atom](/docs/api-reference/feeds/feed-gaps-atom) — `GET /api/v1/feeds/gaps.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Gaps JSON](/docs/api-reference/feeds/feed-gaps-json) — `GET /api/v1/feeds/gaps.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Gaps Rss](/docs/api-reference/feeds/feed-gaps-rss) — `GET /api/v1/feeds/gaps.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Incidents](/docs/api-reference/feeds/feed-incidents) — `GET /api/v1/feeds/incidents`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Incidents Atom](/docs/api-reference/feeds/feed-incidents-atom) — `GET /api/v1/feeds/incidents.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Incidents JSON](/docs/api-reference/feeds/feed-incidents-json) — `GET /api/v1/feeds/incidents.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Incidents Rss](/docs/api-reference/feeds/feed-incidents-rss) — `GET /api/v1/feeds/incidents.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Registry](/docs/api-reference/feeds/feed-registry) — `GET /api/v1/feeds/registry`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Registry Atom](/docs/api-reference/feeds/feed-registry-atom) — `GET /api/v1/feeds/registry.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Registry JSON](/docs/api-reference/feeds/feed-registry-json) — `GET /api/v1/feeds/registry.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Registry Rss](/docs/api-reference/feeds/feed-registry-rss) — `GET /api/v1/feeds/registry.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Revenue](/docs/api-reference/feeds/feed-revenue) — `GET /api/v1/feeds/revenue`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Revenue Atom](/docs/api-reference/feeds/feed-revenue-atom) — `GET /api/v1/feeds/revenue.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Revenue JSON](/docs/api-reference/feeds/feed-revenue-json) — `GET /api/v1/feeds/revenue.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Revenue Rss](/docs/api-reference/feeds/feed-revenue-rss) — `GET /api/v1/feeds/revenue.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Subnet](/docs/api-reference/feeds/feed-subnet) — `GET /api/v1/feeds/subnets/{netuid}`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Subnet Atom](/docs/api-reference/feeds/feed-subnet-atom) — `GET /api/v1/feeds/subnets/{netuid}.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Subnet JSON](/docs/api-reference/feeds/feed-subnet-json) — `GET /api/v1/feeds/subnets/{netuid}.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Subnet Rss](/docs/api-reference/feeds/feed-subnet-rss) — `GET /api/v1/feeds/subnets/{netuid}.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Upgrades](/docs/api-reference/feeds/feed-upgrades) — `GET /api/v1/feeds/upgrades`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Upgrades Atom](/docs/api-reference/feeds/feed-upgrades-atom) — `GET /api/v1/feeds/upgrades.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Upgrades JSON](/docs/api-reference/feeds/feed-upgrades-json) — `GET /api/v1/feeds/upgrades.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Upgrades Rss](/docs/api-reference/feeds/feed-upgrades-rss) — `GET /api/v1/feeds/upgrades.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Wallets](/docs/api-reference/feeds/feed-wallets) — `GET /api/v1/feeds/wallets`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Wallets Atom](/docs/api-reference/feeds/feed-wallets-atom) — `GET /api/v1/feeds/wallets.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Wallets JSON](/docs/api-reference/feeds/feed-wallets-json) — `GET /api/v1/feeds/wallets.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Wallets Rss](/docs/api-reference/feeds/feed-wallets-rss) — `GET /api/v1/feeds/wallets.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.
+- [Feed Watch](/docs/api-reference/feeds/feed-watch) — `GET /api/v1/feeds/watch`  
+  Content-negotiated: send `Accept: application/rss+xml`, `application/atom+xml`, or `application/feed+json`.
+- [Feed Watch Atom](/docs/api-reference/feeds/feed-watch-atom) — `GET /api/v1/feeds/watch.atom`  
+  Always returns `application/atom+xml`, regardless of `Accept`.
+- [Feed Watch JSON](/docs/api-reference/feeds/feed-watch-json) — `GET /api/v1/feeds/watch.json`  
+  Always returns `application/feed+json`, regardless of `Accept`.
+- [Feed Watch Rss](/docs/api-reference/feeds/feed-watch-rss) — `GET /api/v1/feeds/watch.rss`  
+  Always returns `application/rss+xml`, regardless of `Accept`.

--- a/apps/ui/content/docs/api-reference/feeds/meta.json
+++ b/apps/ui/content/docs/api-reference/feeds/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Feeds",
   "pages": [
+    "index",
     "feed-gaps",
     "feed-gaps-atom",
     "feed-gaps-json",

--- a/apps/ui/content/docs/api-reference/health/index.mdx
+++ b/apps/ui/content/docs/api-reference/health/index.mdx
@@ -1,0 +1,29 @@
+---
+title: Health
+description: Every Health endpoint in the metagraphed API, with its method and path.
+---
+
+11 endpoints.
+
+- [Failure Reasons](/docs/api-reference/health/failure-reasons) — `GET /api/v1/health/failure-reasons`  
+  Fetch the probe failure-reason mix.
+- [Health](/docs/api-reference/health/health) — `GET /api/v1/health`  
+  Fetch global health summary.
+- [Health History](/docs/api-reference/health/health-history) — `GET /api/v1/health/history/{date}`  
+  Fetch compact daily health history.
+- [Health Trends Bulk](/docs/api-reference/health/health-trends-bulk) — `GET /api/v1/health/trends`  
+  Fetch compact 7d/30d daily uptime and latency trends for all subnets (computed live from the store).
+- [Incidents](/docs/api-reference/health/incidents) — `GET /api/v1/incidents`  
+  Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from the store).
+- [Self Health](/docs/api-reference/health/self-health) — `GET /api/v1/self-health`  
+  metagraphed's OWN uptime: a verdict scoped strictly to our own components (api / site / publish) plus each one's trailing-90-day daily uptime ratios and latest probe state, served from the self_health_daily lakehouse rollup at /api/v1/self-health (no static file).
+- [Subnet Health](/docs/api-reference/health/subnet-health) — `GET /api/v1/subnets/{netuid}/health`  
+  Fetch health detail for one subnet.
+- [Subnet Health Incidents](/docs/api-reference/health/subnet-health-incidents) — `GET /api/v1/subnets/{netuid}/health/incidents`  
+  Fetch SLA (uptime ratio) and reconstructed downtime incidents per operational surface for one subnet over a 7d or 30d window (computed live from the store).
+- [Subnet Health Percentiles](/docs/api-reference/health/subnet-health-percentiles) — `GET /api/v1/subnets/{netuid}/health/percentiles`  
+  Fetch latency percentiles (p50/p95/p99) per operational surface for one subnet over a 7d or 30d window (computed live from the store).
+- [Subnet Health Trends](/docs/api-reference/health/subnet-health-trends) — `GET /api/v1/subnets/{netuid}/health/trends`  
+  Fetch 7d/30d uptime and success-only latency trends (mean + p50/p95/p99 tail + healthy-sample count) per operational surface for one subnet (computed live from the store).
+- [Subnet Uptime](/docs/api-reference/health/subnet-uptime) — `GET /api/v1/subnets/{netuid}/uptime`  
+  Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily rollup).

--- a/apps/ui/content/docs/api-reference/health/meta.json
+++ b/apps/ui/content/docs/api-reference/health/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Health",
   "pages": [
+    "index",
     "failure-reasons",
     "health",
     "health-history",

--- a/apps/ui/content/docs/api-reference/operations/index.mdx
+++ b/apps/ui/content/docs/api-reference/operations/index.mdx
@@ -1,0 +1,21 @@
+---
+title: Operations
+description: Every Operations endpoint in the metagraphed API, with its method and path.
+---
+
+7 endpoints.
+
+- [Build](/docs/api-reference/operations/build) — `GET /api/v1/build`  
+  Fetch generated build summary.
+- [Changelog](/docs/api-reference/operations/changelog) — `GET /api/v1/changelog`  
+  Fetch latest generated change summary.
+- [Freshness](/docs/api-reference/operations/freshness) — `GET /api/v1/freshness`  
+  Fetch freshness and staleness state.
+- [Network Capabilities](/docs/api-reference/operations/network-capabilities) — `GET /api/v1/networks`  
+  List every addressable network and what it actually serves.
+- [Network Capabilities By Network](/docs/api-reference/operations/network-capabilities-by-network) — `GET /api/v1/{network}/networks`  
+  Network-addressed form of the route above.
+- [Source Health](/docs/api-reference/operations/source-health) — `GET /api/v1/source-health`  
+  Fetch upstream source health.
+- [Source Snapshots](/docs/api-reference/operations/source-snapshots) — `GET /api/v1/source-snapshots`  
+  Fetch source input hashes and counts.

--- a/apps/ui/content/docs/api-reference/operations/meta.json
+++ b/apps/ui/content/docs/api-reference/operations/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Operations",
   "pages": [
+    "index",
     "build",
     "changelog",
     "freshness",

--- a/apps/ui/content/docs/api-reference/profiles/index.mdx
+++ b/apps/ui/content/docs/api-reference/profiles/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Profiles
+description: Every Profiles endpoint in the metagraphed API, with its method and path.
+---
+
+2 endpoints.
+
+- [Profiles](/docs/api-reference/profiles/profiles) — `GET /api/v1/profiles`  
+  List public-safe subnet profiles and completeness scores.
+- [Subnet Profile](/docs/api-reference/profiles/subnet-profile) — `GET /api/v1/subnets/{netuid}/profile`  
+  Fetch public-safe profile detail for one subnet.

--- a/apps/ui/content/docs/api-reference/profiles/meta.json
+++ b/apps/ui/content/docs/api-reference/profiles/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Profiles",
   "pages": [
+    "index",
     "profiles",
     "subnet-profile"
   ]

--- a/apps/ui/content/docs/api-reference/providers/index.mdx
+++ b/apps/ui/content/docs/api-reference/providers/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Providers
+description: Every Providers endpoint in the metagraphed API, with its method and path.
+---
+
+3 endpoints.
+
+- [Provider Detail](/docs/api-reference/providers/provider-detail) — `GET /api/v1/providers/{slug}`  
+  Fetch per-provider detail.
+- [Provider Endpoints](/docs/api-reference/providers/provider-endpoints) — `GET /api/v1/providers/{slug}/endpoints`  
+  List endpoint resources for one provider or operator.
+- [Providers](/docs/api-reference/providers/providers) — `GET /api/v1/providers`  
+  List providers and sources.

--- a/apps/ui/content/docs/api-reference/providers/meta.json
+++ b/apps/ui/content/docs/api-reference/providers/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Providers",
   "pages": [
+    "index",
     "provider-detail",
     "provider-endpoints",
     "providers"

--- a/apps/ui/content/docs/api-reference/registry/index.mdx
+++ b/apps/ui/content/docs/api-reference/registry/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Registry
+description: Every Registry endpoint in the metagraphed API, with its method and path.
+---
+
+17 endpoints.
+
+- [Compare](/docs/api-reference/registry/compare) — `GET /api/v1/compare`  
+  Compare several subnets side by side across the registry structure (completeness + surface counts), the live economics tier, and the live per-subnet health rollup — one call, requested order.
+- [Coverage](/docs/api-reference/registry/coverage) — `GET /api/v1/coverage`  
+  Fetch registry coverage summary.
+- [Coverage By Network](/docs/api-reference/registry/coverage-by-network) — `GET /api/v1/{network}/coverage`  
+  Network-addressed form of the route above.
+- [Coverage Depth](/docs/api-reference/registry/coverage-depth) — `GET /api/v1/coverage-depth`  
+  Fetch the machine-usable coverage depth scorecard and ranked enrichment queue.
+- [Curation](/docs/api-reference/registry/curation) — `GET /api/v1/curation`  
+  Fetch curation states by subnet.
+- [Fixture Detail](/docs/api-reference/registry/fixture-detail) — `GET /api/v1/fixtures/{surface_id}`  
+  Fetch one captured, sanitized live request/response fixture by surface id.
+- [Fixtures](/docs/api-reference/registry/fixtures) — `GET /api/v1/fixtures`  
+  Fetch the index of captured live request/response fixtures (which surfaces carry a sanitized sample).
+- [Gaps](/docs/api-reference/registry/gaps) — `GET /api/v1/gaps`  
+  Fetch interface gap report.
+- [Lineage](/docs/api-reference/registry/lineage) — `GET /api/v1/lineage`  
+  Fetch maintainer-approved cross-network subnet lineage (graduated subnets + the deploying-soon testnet pipeline).
+- [Registry Leaderboards](/docs/api-reference/registry/registry-leaderboards) — `GET /api/v1/registry/leaderboards`  
+  Fetch registry leaderboards computed live from the store + registry projections + the economics tier.
+- [Registry Summary](/docs/api-reference/registry/registry-summary) — `GET /api/v1/registry/summary`  
+  Fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
+- [Review Enrichment Evidence](/docs/api-reference/registry/review-enrichment-evidence) — `GET /api/v1/review/enrichment-evidence`  
+  Fetch detailed candidate evidence behind the enrichment queue.
+- [Review Enrichment Queue](/docs/api-reference/registry/review-enrichment-queue) — `GET /api/v1/review/enrichment-queue`  
+  Fetch the prioritized all-subnet enrichment queue.
+- [Review Enrichment Targets](/docs/api-reference/registry/review-enrichment-targets) — `GET /api/v1/review/enrichment-targets`  
+  Fetch contributor-ready enrichment targets grouped by missing surface kind and review route.
+- [Review Gaps](/docs/api-reference/registry/review-gaps) — `GET /api/v1/review/gaps`  
+  Fetch contributor-targeted subnet gap priorities.
+- [Review Profile Completeness](/docs/api-reference/registry/review-profile-completeness) — `GET /api/v1/review/profile-completeness`  
+  Fetch profile completeness gaps for contributor targeting.
+- [Subnet Gaps](/docs/api-reference/registry/subnet-gaps) — `GET /api/v1/subnets/{netuid}/gaps`  
+  Fetch interface gap priorities and enrichment queue for one subnet.

--- a/apps/ui/content/docs/api-reference/registry/meta.json
+++ b/apps/ui/content/docs/api-reference/registry/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Registry",
   "pages": [
+    "index",
     "compare",
     "coverage",
     "coverage-by-network",

--- a/apps/ui/content/docs/api-reference/rpc/index.mdx
+++ b/apps/ui/content/docs/api-reference/rpc/index.mdx
@@ -1,0 +1,13 @@
+---
+title: RPC
+description: Every RPC endpoint in the metagraphed API, with its method and path.
+---
+
+3 endpoints.
+
+- [RPC Endpoints](/docs/api-reference/rpc/rpc-endpoints) — `GET /api/v1/rpc/endpoints`  
+  Fetch Bittensor RPC endpoint status.
+- [RPC Pools](/docs/api-reference/rpc/rpc-pools) — `GET /api/v1/rpc/pools`  
+  Fetch endpoint pool scores.
+- [RPC Usage](/docs/api-reference/rpc/rpc-usage) — `GET /api/v1/rpc/usage`  
+  Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution, and bounded time buckets for heatmaps — over a 7d or 30d window (computed live from the store telemetry).

--- a/apps/ui/content/docs/api-reference/rpc/meta.json
+++ b/apps/ui/content/docs/api-reference/rpc/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "RPC",
   "pages": [
+    "index",
     "rpc-endpoints",
     "rpc-pools",
     "rpc-usage"

--- a/apps/ui/content/docs/api-reference/schemas/index.mdx
+++ b/apps/ui/content/docs/api-reference/schemas/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Schemas
+description: Every Schemas endpoint in the metagraphed API, with its method and path.
+---
+
+1 endpoint.
+
+- [Schemas](/docs/api-reference/schemas/schemas) — `GET /api/v1/schemas`  
+  Fetch captured schema index.

--- a/apps/ui/content/docs/api-reference/schemas/meta.json
+++ b/apps/ui/content/docs/api-reference/schemas/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Schemas",
   "pages": [
+    "index",
     "schemas"
   ]
 }

--- a/apps/ui/content/docs/api-reference/search/index.mdx
+++ b/apps/ui/content/docs/api-reference/search/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Search
+description: Every Search endpoint in the metagraphed API, with its method and path.
+---
+
+6 endpoints.
+
+- [Ask](/docs/api-reference/search/ask) — `POST /api/v1/ask`  
+  Ask a natural-language question about the registry and get a grounded answer with citations.
+- [Search](/docs/api-reference/search/search) — `GET /api/v1/search`  
+  Fetch compact search index.
+- [Search Index](/docs/api-reference/search/search-index) — `GET /api/v1/search-index`  
+  Fetch the slim search index — the same documents as /search without the per-document token blobs, for fast browser typeahead and listing.
+- [Search Resolve](/docs/api-reference/search/search-resolve) — `GET /api/v1/search/resolve`  
+  Resolve a pasted query to the chain entities it could name (metagraphed-infra#362).
+- [Search Resolve By Network](/docs/api-reference/search/search-resolve-by-network) — `GET /api/v1/{network}/search/resolve`  
+  Network-addressed form of the route above.
+- [Search Semantic](/docs/api-reference/search/search-semantic) — `GET /api/v1/search/semantic`  
+  Search the registry by MEANING rather than by keyword: ?q= is embedded and ranked by cosine similarity, so it finds surfaces whose text never contains your terms.

--- a/apps/ui/content/docs/api-reference/search/meta.json
+++ b/apps/ui/content/docs/api-reference/search/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Search",
   "pages": [
+    "index",
     "ask",
     "search",
     "search-index",

--- a/apps/ui/content/docs/api-reference/subnets/index.mdx
+++ b/apps/ui/content/docs/api-reference/subnets/index.mdx
@@ -1,0 +1,145 @@
+---
+title: Subnets
+description: Every Subnets endpoint in the metagraphed API, with its method and path.
+---
+
+69 endpoints.
+
+- [Deregistration Ranking](/docs/api-reference/subnets/deregistration-ranking) — `GET /api/v1/chain/deregistration-ranking`  
+  Fetch the order in which the chain would deregister subnets to make room for a new registration (#10285) — 'how close is this subnet to being pruned', answered with the pallet's own rule rather than a proxy for it.
+- [Domain Summary](/docs/api-reference/subnets/domain-summary) — `GET /api/v1/domains/{tag}/summary`  
+  Fetch one domain/capability tag's own rollup: member subnet count, total stake, total emission share (the sum of the stage-1 price shares, not TAO received), and within-domain emission concentration.
+- [Domains](/docs/api-reference/subnets/domains) — `GET /api/v1/domains`  
+  Fetch the per-domain rollup overview: every domain/capability tag in the existing 14-tag taxonomy, each with its member subnet count, total stake, total emission share (the sum of the stage-1 price shares, not TAO received), and within-domain emission concentration.
+- [Economics](/docs/api-reference/subnets/economics) — `GET /api/v1/economics`  
+  List per-subnet validator and economic metrics (counts, stake, registration cost, alpha price, alpha market-cap proxy, alpha FDV proxy, emission share, and registration block height).
+- [Economics By Network](/docs/api-reference/subnets/economics-by-network) — `GET /api/v1/{network}/economics`  
+  Network-addressed form of the route above.
+- [Economics Trends](/docs/api-reference/subnets/economics-trends) — `GET /api/v1/economics/trends`  
+  Fetch the network-wide economics time series (#1307): per UTC day across all subnets — total stake, stake-weighted + median alpha price, total validator/miner counts, and mean emission share — aggregated live from the daily subnet_snapshots rollup.
+- [Emission Pipeline](/docs/api-reference/subnets/emission-pipeline) — `GET /api/v1/chain/emission-pipeline`  
+  Fetch the v440 emission pipeline decomposed per subnet (#8744): stage 1's price share, MinerBurned, the post-burn weighted share, the post-Hill-gate share, SubnetEmissionEnabled, the final share of block emission actually received, the gate's give-or-take (`gate_delta`), `distance_to_bar` measured against the WEIGHTED share (theta is computed over the post-burn distribution, so comparing stage 1 to it answers a question the gate does not ask), and the TAO split -- `tao_in_emission` (pool liquidity injection) vs `excess_tao` (chain buys), their `tao_total`, and `liquidity_fraction`.
+- [Subnet Alpha Volume](/docs/api-reference/subnets/subnet-alpha-volume) — `GET /api/v1/subnets/{netuid}/volume`  
+  Fetch the rolling 24h buy/sell alpha volume for one subnet: unsigned totals (never netted) in both alpha and TAO for StakeAdded (buy) vs StakeRemoved (sell), plus event counts, summed live from the same account_events stream as GET /api/v1/subnets/\{netuid}/stake-flow.
+- [Subnet Axon Removals](/docs/api-reference/subnets/subnet-axon-removals) — `GET /api/v1/subnets/{netuid}/axon-removals`  
+  Fetch axon-removal activity for one subnet over a 7d or 30d window: the distinct removers (hotkeys), the AxonInfoRemoved event count, and the average removals per remover, read from the account_events AxonInfoRemoved stream, which the runtime has never populated — an empty card is marked `degraded` rather than published as a measured zero.
+- [Subnet Burn](/docs/api-reference/subnets/subnet-burn) — `GET /api/v1/subnets/{netuid}/burn`  
+  Fetch the live current registration/burn cost for one subnet (#6321) — the dynamic price between the static min_burn_tao/max_burn_tao bounds already in /subnets/\{netuid}/hyperparameters, queried from the chain's own Burn storage map at request time with 120s KV cache.
+- [Subnet Burn By Network](/docs/api-reference/subnets/subnet-burn-by-network) — `GET /api/v1/{network}/subnets/{netuid}/burn`  
+  Network-addressed form of the route above.
+- [Subnet Burn History](/docs/api-reference/subnets/subnet-burn-history) — `GET /api/v1/subnets/{netuid}/burn/history`  
+  Fetch one subnet's registration-cost series.
+- [Subnet Concentration](/docs/api-reference/subnets/subnet-concentration) — `GET /api/v1/subnets/{netuid}/concentration`  
+  Fetch stake & emission concentration metrics (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for one subnet across per-UID, per-entity (coldkeys collapsed), and validator-only consensus-power lenses (computed live from the neurons store).
+- [Subnet Concentration History](/docs/api-reference/subnets/subnet-concentration-history) — `GET /api/v1/subnets/{netuid}/concentration/history`  
+  Fetch the per-day stake & emission concentration trend (Gini, Nakamoto coefficient, top-10% share) for one subnet over a 7d/30d/90d window (computed live from the neuron_daily rollup).
+- [Subnet Conviction](/docs/api-reference/subnets/subnet-conviction) — `GET /api/v1/subnets/{netuid}/conviction`  
+  Fetch the live per-subnet conviction leaderboard (#6638, part of the conviction/ownership-contest tracker epic #4302) — who currently holds the most rolled conviction, i.e.
+- [Subnet Cost To Participate](/docs/api-reference/subnets/subnet-cost-to-participate) — `GET /api/v1/subnets/{netuid}/cost-to-participate`  
+  Read what one subnet says it takes to participate there, beside what the chain exactly charges to enter.
+- [Subnet Deregistrations](/docs/api-reference/subnets/subnet-deregistrations) — `GET /api/v1/subnets/{netuid}/deregistrations`  
+  Fetch neuron-deregistration activity for one subnet over a 7d or 30d window: the distinct deregistered hotkeys, the NeuronDeregistered event count, and the average deregistrations per hotkey, DERIVED from UID reuse in the NeuronRegistered stream (NeuronDeregistered has never been emitted by the runtime).
+- [Subnet Detail](/docs/api-reference/subnets/subnet-detail) — `GET /api/v1/subnets/{netuid}`  
+  Fetch per-subnet detail.
+- [Subnet Detail By Network](/docs/api-reference/subnets/subnet-detail-by-network) — `GET /api/v1/{network}/subnets/{netuid}`  
+  Network-addressed form of the route above.
+- [Subnet Emission Pipeline History](/docs/api-reference/subnets/subnet-emission-pipeline-history) — `GET /api/v1/subnets/{netuid}/emission-pipeline/history`  
+  Fetch one subnet's emission-pipeline series.
+- [Subnet Emission Split History](/docs/api-reference/subnets/subnet-emission-split-history) — `GET /api/v1/subnets/{netuid}/emission-split/history`  
+  Fetch the per-day split of one subnet's emission by recipient class over a 7d/30d/90d window: how much went to the owner, to validators, and to miners, one point per day (computed live from the neuron_daily rollup).
+- [Subnet Event Summary](/docs/api-reference/subnets/subnet-event-summary) — `GET /api/v1/subnets/{netuid}/event-summary`  
+  Fetch a windowed event summary for one subnet: account_events counts by kind and coarse category, distinct hotkey/coldkey counts, TAO/alpha sums where applicable, first/last evidence bounds, plus a newest-first evidence slice.
+- [Subnet Events](/docs/api-reference/subnets/subnet-events) — `GET /api/v1/subnets/{netuid}/events`  
+  Fetch the first-party chain-event stream for one subnet (registrations, stake, weights, axon, delegation, lifecycle, transfers), newest first, from the account_events store filtered by netuid.
+- [Subnet History](/docs/api-reference/subnets/subnet-history) — `GET /api/v1/subnets/{netuid}/history`  
+  Fetch a subnet's per-day aggregate history (neuron/validator counts + stake/emission totals) for sparklines, computed live from the neuron_daily rollup tier.
+- [Subnet Holders](/docs/api-reference/subnets/subnet-holders) — `GET /api/v1/subnets/{netuid}/holders`  
+  Fetch who owns one subnet's alpha (#9557) — the top coldkeys by alpha held on that netuid, with each holder's share of the subnet total, how many hotkeys they hold it through, and whole-subnet aggregates (distinct holder count, total measured alpha, top5/top10/top20 concentration).
+- [Subnet Hyperparameters](/docs/api-reference/subnets/subnet-hyperparameters) — `GET /api/v1/subnets/{netuid}/hyperparameters`  
+  Fetch one subnet's consensus, economic, and governance hyperparameters (kappa, weight/activity settings, burn cost, liquid alpha, commit-reveal, yuma version, and more), refreshed daily and computed live from the subnet_hyperparams tier.
+- [Subnet Hyperparameters History](/docs/api-reference/subnets/subnet-hyperparameters-history) — `GET /api/v1/subnets/{netuid}/hyperparameters/history`  
+  Fetch the append-only hyperparameter-change timeline for one subnet (#4309): each entry is a subnet_hyperparams snapshot recorded when any hyperparameter changed.
+- [Subnet Identity History](/docs/api-reference/subnets/subnet-identity-history) — `GET /api/v1/subnets/{netuid}/identity-history`  
+  Fetch the append-only on-chain identity timeline for one subnet (#1647): each entry is a SubnetIdentitiesV3 snapshot recorded when any tracked field changed.
+- [Subnet Idle Stake](/docs/api-reference/subnets/subnet-idle-stake) — `GET /api/v1/subnets/{netuid}/idle-stake`  
+  Fetch stake delegated to a hotkey currently earning zero dividends for one subnet — dividends are the only stream delegated stake ever receives in dTAO, so this covers both no-permit and zero-weight-output hotkeys alike (computed live from the neurons store).
+- [Subnet Lease](/docs/api-reference/subnets/subnet-lease) — `GET /api/v1/subnets/{netuid}/lease`  
+  Fetch the live subnet-lease state (#6719, part of the subnet-leasing/crowdloan-tracking epic #6717) — whether a subnet is currently under a lease and, if so, its terms + accumulated-but-undistributed alpha dividends, queried from the chain's own SubnetUidToLeaseId/SubnetLeases/AccumulatedLeaseDividends storage maps at request time with 120s KV cache.
+- [Subnet Lease By Network](/docs/api-reference/subnets/subnet-lease-by-network) — `GET /api/v1/{network}/subnets/{netuid}/lease`  
+  Network-addressed form of the route above.
+- [Subnet Lease History](/docs/api-reference/subnets/subnet-lease-history) — `GET /api/v1/subnets/{netuid}/lease/history`  
+  Fetch every SubnetLeaseCreated/SubnetLeaseTerminated event one subnet has had (#6719, part of epic #6717), decoded from the account_events stream #6718 started capturing.
+- [Subnet Lifecycle](/docs/api-reference/subnets/subnet-lifecycle) — `GET /api/v1/subnets/{netuid}/lifecycle`  
+  Fetch when one subnet was registered or deregistered (#10263): an append-only timeline, newest first, from the subnet_lifecycle Neon table.
+- [Subnet Metagraph](/docs/api-reference/subnets/subnet-metagraph) — `GET /api/v1/subnets/{netuid}/metagraph`  
+  Fetch the per-UID metagraph (stake, trust, consensus, incentive, dividends, emission, validator_permit, rank, axon) for one subnet, computed live from the neurons store.
+- [Subnet Miner Fairness](/docs/api-reference/subnets/subnet-miner-fairness) — `GET /api/v1/subnets/{netuid}/miner-fairness`  
+  Measure whether a subnet's registered miners actually earn, over a 7d/30d/90d window rather than from a snapshot.
+- [Subnet Movers](/docs/api-reference/subnets/subnet-movers) — `GET /api/v1/subnets/movers`  
+  Fetch the cross-subnet momentum leaderboard: every subnet ranked by its change in stake, emission, validator, and neuron count between the window's start and end neuron_daily snapshots, with start/end values, deltas, percentage changes, and each subnet's share of network stake/emission at the end.
+- [Subnet Neuron](/docs/api-reference/subnets/subnet-neuron) — `GET /api/v1/subnets/{netuid}/neurons/{uid}`  
+  Fetch a single neuron's metagraph state by UID, computed live from the neurons store.
+- [Subnet Neuron History](/docs/api-reference/subnets/subnet-neuron-history) — `GET /api/v1/subnets/{netuid}/neurons/{uid}/history`  
+  Fetch a UID's per-day metagraph history (stake, trust, consensus, incentive, dividends, emission, rank over time), computed live from the neuron_daily rollup tier.
+- [Subnet OHLC](/docs/api-reference/subnets/subnet-ohlc) — `GET /api/v1/subnets/{netuid}/ohlc`  
+  Fetch open/high/low/close/volume candles for one subnet's alpha price, bucketed by ?interval= (1h or 1d, default 1h) from the same account_events StakeAdded/StakeRemoved stream as GET /api/v1/subnets/\{netuid}/volume — each row is one executed trade, price = amount_tao / alpha_amount.
+- [Subnet Overview](/docs/api-reference/subnets/subnet-overview) — `GET /api/v1/subnets/{netuid}/overview`  
+  Fetch a composed overview (profile + health + curation + gaps + counts) for one subnet.
+- [Subnet Owner Capture](/docs/api-reference/subnets/subnet-owner-capture) — `GET /api/v1/subnets/{netuid}/owner-capture`  
+  Measure how much of one subnet's emission reaches its owner, per day over a 7d/30d/90d window.
+- [Subnet Owner Cut](/docs/api-reference/subnets/subnet-owner-cut) — `GET /api/v1/subnets/{netuid}/owner-cut`  
+  Fetch one subnet's owner-cut accrual and its disposition.
+- [Subnet Ownership History](/docs/api-reference/subnets/subnet-ownership-history) — `GET /api/v1/subnets/{netuid}/ownership-history`  
+  Fetch every ownership transfer one subnet has undergone (#6637, part of the conviction/ownership-contest tracker epic #4302) — see docs/conviction-lock-mechanism.md for the on-chain mechanism: a permissionless, conviction-weighted contest that runs continuously for every subnet, where ownership transfers automatically once a challenger's rolled conviction overtakes the incumbent owner's (no vote, no owner cooperation required).
+- [Subnet Performance](/docs/api-reference/subnets/subnet-performance) — `GET /api/v1/subnets/{netuid}/performance`  
+  Fetch reward-distribution & score-spread metrics for one subnet: reward concentration (Gini, HHI, Nakamoto coefficient, top-percentile shares, entropy) for incentive across all neurons and dividends across validators, plus the p10–p90 spread of the 0–1 trust, consensus, and validator_trust scores (computed live from the neurons store).
+- [Subnet Performance History](/docs/api-reference/subnets/subnet-performance-history) — `GET /api/v1/subnets/{netuid}/performance/history`  
+  Fetch the per-day reward-flow & trust trend for one subnet over a 7d/30d/90d window: the incentive/dividends reward concentration (Gini, Nakamoto coefficient, top-10% share) plus the mean & median of the 0–1 trust, consensus, and validator_trust scores (computed live from the neuron_daily rollup).
+- [Subnet Prometheus](/docs/api-reference/subnets/subnet-prometheus) — `GET /api/v1/subnets/{netuid}/prometheus`  
+  Fetch Prometheus-endpoint serving activity for one subnet over a 7d or 30d window: the distinct exporters (hotkeys), the PrometheusServed event count, and the average announcements per exporter, read from the account_events PrometheusServed stream, which carries 0 of the 18,041 PrometheusServed events the chain emitted — an empty card is marked `degraded` rather than published as a measured zero.
+- [Subnet Recycled](/docs/api-reference/subnets/subnet-recycled) — `GET /api/v1/subnets/{netuid}/recycled`  
+  Fetch the live cumulative TAO recycled for registration on one subnet, queried from the chain's own RAORecycledForRegistration storage map at request time with 600s KV cache.
+- [Subnet Recycled By Network](/docs/api-reference/subnets/subnet-recycled-by-network) — `GET /api/v1/{network}/subnets/{netuid}/recycled`  
+  Network-addressed form of the route above.
+- [Subnet Registrations](/docs/api-reference/subnets/subnet-registrations) — `GET /api/v1/subnets/{netuid}/registrations`  
+  Fetch neuron-registration activity for one subnet over a 7d or 30d window: the distinct registrants (hotkeys), the NeuronRegistered event count, and the average registrations per registrant, computed live from the account_events NeuronRegistered stream.
+- [Subnet Revenue](/docs/api-reference/subnets/subnet-revenue) — `GET /api/v1/subnets/{netuid}/revenue`  
+  Fetch one subnet's external revenue against the TAO the network emits to it: the measured tao_total denominator with its alternates, the observed revenue, and the two ratios.
+- [Subnet Serving](/docs/api-reference/subnets/subnet-serving) — `GET /api/v1/subnets/{netuid}/serving`  
+  Fetch axon-serving announcement activity for one subnet over a 7d or 30d window: the distinct servers (hotkeys), the AxonServed event count, and the average announcements per server, computed live from the account_events AxonServed stream.
+- [Subnet Stake Flow](/docs/api-reference/subnets/subnet-stake-flow) — `GET /api/v1/subnets/{netuid}/stake-flow`  
+  Fetch net stake flow for one subnet over a recent window: total TAO staked (StakeAdded) vs unstaked (StakeRemoved), the net flow, and the stake/unstake event counts, summed live from the account_events stream.
+- [Subnet Stake Moves](/docs/api-reference/subnets/subnet-stake-moves) — `GET /api/v1/subnets/{netuid}/stake-moves`  
+  Fetch stake-movement (re-delegation) activity for one subnet over a 7d or 30d window: the distinct movers (accounts), the StakeMoved event count, and the average movements per mover, computed live from the account_events StakeMoved stream.
+- [Subnet Stake Quote](/docs/api-reference/subnets/subnet-stake-quote) — `GET /api/v1/subnets/{netuid}/stake-quote`  
+  Fetch a read-only constant-product stake/unstake slippage quote for one subnet: the expected alpha/TAO out, spot vs effective price (TAO per alpha), and price-impact percent for a swap of ?amount= in ?direction=stake|unstake (default stake), computed live from the subnet's economics-tier AMM pool reserves (tao_in_pool_tao, alpha_in_pool).
+- [Subnet Stake Transfers](/docs/api-reference/subnets/subnet-stake-transfers) — `GET /api/v1/subnets/{netuid}/stake-transfers`  
+  Fetch stake-transfer activity for one subnet over a 7d or 30d window: the distinct senders (accounts), the StakeTransferred event count, and the average transfers per sender, computed live from the account_events StakeTransferred stream.
+- [Subnet Surface History](/docs/api-reference/subnets/subnet-surface-history) — `GET /api/v1/subnets/{netuid}/surface-history`  
+  Fetch one subnet's surface audit trail.
+- [Subnet Trajectory](/docs/api-reference/subnets/subnet-trajectory) — `GET /api/v1/subnets/{netuid}/trajectory`  
+  Fetch the week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots (computed live from the store).
+- [Subnet Treasury](/docs/api-reference/subnets/subnet-treasury) — `GET /api/v1/subnets/{netuid}/treasury`  
+  Read what one subnet's own published source declares it allocates to a treasury, against what the chain shows.
+- [Subnet Turnover](/docs/api-reference/subnets/subnet-turnover) — `GET /api/v1/subnets/{netuid}/turnover`  
+  Fetch validator-set & registration turnover (churn) for one subnet between a window's start and end snapshots — validators entered/exited + retention, UID deregistrations, and a 0-100 stability score.
+- [Subnet Validator Economics](/docs/api-reference/subnets/subnet-validator-economics) — `GET /api/v1/subnets/{netuid}/validator-economics`  
+  Fetch what it costs to become a validator on one subnet and whether a permit there earns: the permit floor and the earning floor (which differ by a median of ~7x — a permit is not income), the TAO to reach each priced against live AMM pool reserves plus the registration burn, how many validator slots are open, the commission (take) distribution across permit-holders, whether the emission gate is open and the daily TAO inflow, and the live StakeThreshold/TaoWeight the floors were computed against.
+- [Subnet Validator Economics History](/docs/api-reference/subnets/subnet-validator-economics-history) — `GET /api/v1/subnets/{netuid}/validator-economics/history`  
+  Fetch whether validating on one subnet is getting cheaper or more expensive: a daily series of the observed permit floor and earning floor in alpha, the validator set composition as three separate counts, and the emission-gate state with daily TAO inflow, over a 7d/30d/90d window (default 30d), newest first.
+- [Subnet Validators](/docs/api-reference/subnets/subnet-validators) — `GET /api/v1/subnets/{netuid}/validators`  
+  Fetch the validators (validator_permit) of one subnet ranked by stake, computed live from the neurons store.
+- [Subnet Wallets](/docs/api-reference/subnets/subnet-wallets) — `GET /api/v1/subnets/{netuid}/wallets`  
+  Fetch one subnet's declared wallets: the chain-derived owner keys, plus any treasury, burn, payment-collector or multisig address the team has published and somebody has evidenced.
+- [Subnet Weight Setters](/docs/api-reference/subnets/subnet-weight-setters) — `GET /api/v1/subnets/{netuid}/weights/setters`  
+  Fetch the per-subnet weight-setter leaderboard over a 7d or 30d window: the individual validators behind /weights ranked by activity, each with its WeightsSet count, its share of the subnet's total weight-setting, and when it first and last set weights in the window, computed live from the account_events WeightsSet stream.
+- [Subnet Weights](/docs/api-reference/subnets/subnet-weights) — `GET /api/v1/subnets/{netuid}/weights`  
+  Fetch validator weight-setting activity for one subnet over a 7d or 30d window: the distinct weight-setting validators, the WeightsSet event count, and the average updates per validator, computed live from the account_events WeightsSet stream.
+- [Subnet Yield](/docs/api-reference/subnets/subnet-yield) — `GET /api/v1/subnets/{netuid}/yield`  
+  Fetch the per-UID emission yield (emission/stake return rate) for one subnet over the current metagraph snapshot, ranked high to low with a distribution summary (subnet aggregate yield, mean, p25/median/p75/p90 percentiles), a validator/miner split, and a per-UID above/below-median label, computed live from the neurons store.
+- [Subnet Yield History](/docs/api-reference/subnets/subnet-yield-history) — `GET /api/v1/subnets/{netuid}/yield/history`  
+  Fetch the per-day emission-yield distribution trend for one subnet over a 7d/30d/90d window: the subnet-wide return plus the mean, median, and p25/p75/p90 of the per-UID emission-per-stake yields, one point per day (computed live from the neuron_daily rollup).
+- [Subnets](/docs/api-reference/subnets/subnets) — `GET /api/v1/subnets`  
+  List active Finney subnets.
+- [Subnets By Network](/docs/api-reference/subnets/subnets-by-network) — `GET /api/v1/{network}/subnets`  
+  Network-addressed form of the route above.

--- a/apps/ui/content/docs/api-reference/subnets/meta.json
+++ b/apps/ui/content/docs/api-reference/subnets/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Subnets",
   "pages": [
+    "index",
     "deregistration-ranking",
     "domain-summary",
     "domains",

--- a/apps/ui/content/docs/api-reference/surfaces/index.mdx
+++ b/apps/ui/content/docs/api-reference/surfaces/index.mdx
@@ -1,0 +1,13 @@
+---
+title: Surfaces
+description: Every Surfaces endpoint in the metagraphed API, with its method and path.
+---
+
+3 endpoints.
+
+- [Subnet Surfaces](/docs/api-reference/surfaces/subnet-surfaces) — `GET /api/v1/subnets/{netuid}/surfaces`  
+  List curated public surfaces for one subnet.
+- [Surface Verify](/docs/api-reference/surfaces/surface-verify) — `GET /api/v1/surfaces/{surface_id}/verify`  
+  Probe ONE registered surface right now and report whether it is actually callable.
+- [Surfaces](/docs/api-reference/surfaces/surfaces) — `GET /api/v1/surfaces`  
+  List curated public surfaces.

--- a/apps/ui/content/docs/api-reference/surfaces/meta.json
+++ b/apps/ui/content/docs/api-reference/surfaces/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Surfaces",
   "pages": [
+    "index",
     "subnet-surfaces",
     "surface-verify",
     "surfaces"

--- a/apps/ui/content/docs/api-reference/validators/index.mdx
+++ b/apps/ui/content/docs/api-reference/validators/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Validators
+description: Every Validators endpoint in the metagraphed API, with its method and path.
+---
+
+6 endpoints.
+
+- [Compare Validators](/docs/api-reference/validators/compare-validators) — `GET /api/v1/compare/validators`  
+  Place several validators side by side for a stake/delegate decision: each hotkey's take rate, estimated APY, nominator count, on-chain identity, and cross-subnet stake/emission/trust aggregates.
+- [Global Validators](/docs/api-reference/validators/global-validators) — `GET /api/v1/validators`  
+  Fetch the network-wide validator/operator leaderboard: validator-permit identities grouped across all current subnet memberships, with trust metrics, cross-subnet stake/emission totals, stake dominance, and top membership rows.
+- [Validator Detail](/docs/api-reference/validators/validator-detail) — `GET /api/v1/validators/{hotkey}`  
+  Fetch cross-subnet detail for one validator identity: its validator_permit=1 rows aggregated across every subnet it operates in — cross-subnet totals (stake, emission, avg/max trust) plus a full per-subnet performance table.
+- [Validator Economics Ranking](/docs/api-reference/validators/validator-economics-ranking) — `GET /api/v1/validators/economics`  
+  Fetch every subnet ranked by what it costs to become an EARNING validator there.
+- [Validator History](/docs/api-reference/validators/validator-history) — `GET /api/v1/validators/{hotkey}/history`  
+  Fetch cross-subnet staked-over-time + rewards-per-1000-TAO history for one validator: one point per day, summed across every subnet it operates in that day (stake/emission totals, subnet count, and a normalized reward rate), computed live from the neuron_daily rollup tier.
+- [Validator Nominators](/docs/api-reference/validators/validator-nominators) — `GET /api/v1/validators/{hotkey}/nominators`  
+  Fetch the nominator list for one validator: who has staked to it (across every subnet it operates in) over a 7d/30d/90d window, each with staked/unstaked/net/gross TAO and last activity, ranked by net_staked (default), gross_staked, or last_activity.

--- a/apps/ui/content/docs/api-reference/validators/meta.json
+++ b/apps/ui/content/docs/api-reference/validators/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Validators",
   "pages": [
+    "index",
     "compare-validators",
     "global-validators",
     "validator-detail",

--- a/apps/ui/content/docs/api-reference/webhooks/index.mdx
+++ b/apps/ui/content/docs/api-reference/webhooks/index.mdx
@@ -1,0 +1,9 @@
+---
+title: Webhooks
+description: Every Webhooks endpoint in the metagraphed API, with its method and path.
+---
+
+1 endpoint.
+
+- [Webhook Subscription](/docs/api-reference/webhooks/webhook-subscription) — `GET /api/v1/webhooks/subscriptions/{id}`  
+  Read back one webhook subscription and its recent delivery outcomes.

--- a/apps/ui/content/docs/api-reference/webhooks/meta.json
+++ b/apps/ui/content/docs/api-reference/webhooks/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Webhooks",
   "pages": [
+    "index",
     "webhook-subscription"
   ]
 }

--- a/apps/ui/scripts/generate-openapi-docs.ts
+++ b/apps/ui/scripts/generate-openapi-docs.ts
@@ -151,6 +151,64 @@ function primaryTag(tags) {
   return tags.find((t) => t !== CATCH_ALL_TAG) ?? tags[0];
 }
 
+/** First sentence of a description, for a one-line entry in a group index. */
+function firstSentence(text) {
+  const flat = String(text).replace(/\s+/g, " ").trim();
+  if (!flat) return "";
+  const end = flat.search(/\.\s|\.$/);
+  return end === -1 ? flat : flat.slice(0, end + 1);
+}
+
+/**
+ * Escape the two characters MDX treats as syntax, for prose taken from the spec.
+ *
+ * Operation descriptions are written for an API reference, not for MDX, and they
+ * are full of both: `?counterparty=<ss58>` parses as an unclosed JSX tag and
+ * `{network}` as a JS expression. Either one fails the build outright — which is
+ * how this was caught, rather than by rendering wrongly in production.
+ */
+function escapeMdx(text) {
+  return String(text).replace(/([<{])/g, "\\$1");
+}
+
+/**
+ * The index page for one tag folder (#11204).
+ *
+ * WHY THIS IS GENERATED, not hand-written: every operation page links its own
+ * group path (`/docs/api-reference/accounts`) in the docs navigation, and those
+ * 27 paths had no page behind them — they 404'd. So the docs shipped ~300
+ * internal links to 404s, a reader clicking a sidebar category got an error,
+ * and the site-wide BreadcrumbList (#11230) named those URLs as crumb targets,
+ * which Google validates.
+ *
+ * Generating it means a new API tag gets its index automatically, rather than
+ * silently reintroducing the same 404 the next time the spec grows a group.
+ *
+ * It is a real page, not a stub: every operation in the group with its title,
+ * method, path and first line of prose. That also flattens the docs tree —
+ * before this, reaching some reference pages took eleven hops from /docs.
+ */
+function tagIndexPage(tag, operations) {
+  const title = tagTitle(tag);
+  const rows = [...operations]
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+    .map((op) => {
+      // The method+path needs no escaping — it is inside a code span, where MDX
+      // does not parse JSX. The description is bare prose and does.
+      const line = `- [${escapeMdx(op.title)}](/docs/api-reference/${tag}/${op.slug}) — \`${op.method} ${op.route}\``;
+      return op.description ? `${line}  \n  ${escapeMdx(op.description)}` : line;
+    })
+    .join("\n");
+  return (
+    `---\n` +
+    `title: ${title}\n` +
+    `description: Every ${title} endpoint in the metagraphed API, with its method and path.\n` +
+    `---\n\n` +
+    `${operations.length} endpoint${operations.length === 1 ? "" : "s"}.\n\n` +
+    `${rows}\n`
+  );
+}
+
 async function main() {
   // path.resolve (CWD-relative) -- this script always runs as
   // `node scripts/generate-openapi-docs.ts` from apps/ui/.
@@ -164,6 +222,26 @@ async function main() {
     }
   }
   splitOperationSummaries(spec);
+
+  // #11204: what each tag's index page lists. Collected AFTER
+  // splitOperationSummaries, so `summary` is the short humanized title and
+  // `description` is the original prose — the same pair the operation page
+  // itself renders.
+  const operationsByTag = new Map();
+  for (const [route, methods] of Object.entries(spec.paths ?? {})) {
+    for (const [method, op] of Object.entries(methods ?? {})) {
+      if (!op || typeof op !== "object" || !op.operationId) continue;
+      const tag = primaryTag(op.tags);
+      if (!operationsByTag.has(tag)) operationsByTag.set(tag, []);
+      operationsByTag.get(tag).push({
+        slug: kebabCase(op.operationId),
+        title: op.summary ?? humanizeOperationId(op.operationId),
+        method: method.toUpperCase(),
+        route,
+        description: firstSentence(op.description ?? ""),
+      });
+    }
+  }
 
   // index.mdx is hand-authored (a landing page, not generated), but lives
   // inside OUTPUT_DIR alongside the generated tree -- preserve it across
@@ -226,9 +304,16 @@ async function main() {
   }
 
   for (const [tag, pages] of pagesByTag) {
+    // #11204: the group's own page. Without it `/docs/api-reference/<tag>` —
+    // which every page in the group links, and which the site-wide breadcrumb
+    // names as a crumb target — is a 404.
+    const operations = (operationsByTag.get(tag) ?? []).filter((op) => pages.includes(op.slug));
+    await writeFile(path.join(OUTPUT_DIR, tag, "index.mdx"), tagIndexPage(tag, operations));
     await writeFile(
       path.join(OUTPUT_DIR, tag, "meta.json"),
-      JSON.stringify({ title: tagTitle(tag), pages: pages.sort() }, null, 2) + "\n",
+      // "index" first so the group page heads its own section in the nav,
+      // matching how the reference root orders its own index.
+      JSON.stringify({ title: tagTitle(tag), pages: ["index", ...pages.sort()] }, null, 2) + "\n",
     );
   }
 


### PR DESCRIPTION
Part of #11204. Found by auditing crawl reachability across every entity space after #11231 / #11232.

## ~290 docs pages each linked a 404

Every generated operation page links its own group in the docs nav:

```
/docs/api-reference/accounts/account-balance
  └─ links → /docs/api-reference/accounts     ← 404
```

The generator created each tag folder and its `meta.json`, but never an `index.mdx` — so all **25** group paths were 404s, linked from ~290 pages, and a reader clicking a sidebar category got an error.

### It also broke structured data

The site-wide `BreadcrumbList` from #11230 derives crumbs from the path, so a reference page named `/docs/api-reference/accounts` as a **crumb target** — and Google validates breadcrumb URLs. Before:

```
https://metagraph.sh/                                   200
https://metagraph.sh/docs                               200
https://metagraph.sh/docs/api-reference                 200
https://metagraph.sh/docs/api-reference/accounts        404  ←
https://metagraph.sh/docs/api-reference/accounts/account-balance  200
```

Every crumb in that chain now resolves. Verified all 25 groups: **0 non-200**, was 25.

## Generated, not hand-written

25 files is a tempting hand-fix. It belongs in the generator so a new API tag gets its index automatically, rather than silently reintroducing the same 404 the next time the spec grows a group.

Each index is a real page, not a stub — every endpoint in the group with title, method, path and first line of prose:

```mdx
---
title: Contracts
description: Every Contracts endpoint in the metagraphed API, with its method and path.
---

3 endpoints.

- [API Index](/docs/api-reference/contracts/api-index) — `GET /api/v1`
  List backend API routes and response envelope metadata.
```

That also **flattens the tree**. A BFS from `/docs` following only internal links took **11 hops** to converge before this (348 pages reachable); the group indexes cut that dramatically by giving each of the 25 sections one hub.

## Spec prose is not MDX, and the build proved it

The first regeneration failed the build outright:

```
Expected a closing tag for `<ss58>` before the end of `paragraph`
```

Operation descriptions are written for an API reference: `?counterparty=<ss58>` parses as an unclosed JSX tag and `{network}` as a JS expression. Both are escaped now. The method+path needs no escaping — it lives inside a code span, where MDX does not parse either.

Good failure mode: a build error, not a page that renders wrongly in production.

## The wider audit this came from

| space | linked | total | status |
|---|---|---|---|
| subnets | 30 → **129** | 129 | fixed, #11231 |
| providers | 25 → **138** | 138 | fixed, #11232 |
| docs | **321** | 321 | already complete — crawl converges at depth 12 with 348 reachable, **0 orphaned** |
| api-reference groups | 0 | 25 | **this PR** |
| validators | 50 | 1,023 | deliberately left — see below |

`/validators` still links 50 of 1,023, unchanged and on purpose: a thousand links on one hub reads as link-farming, validator pages are not the demand Search Console records, and this site has already lost impressions once to indexing volume. That one needs the GSC index report to decide, not a guess.

I also checked and found **clean**, so no change: the sitemap (1,628 URLs, zero duplicates, zero wrong-host, **zero blocked by robots.txt**), and every URL advertised by `llms.txt`, `llms-full.txt`, `agent.md` and `agent-workflows.md` — 147 links, all resolving, with the only apparent failures turning out to be `{templated}` paths and my own truncating regex.

## Validation

Root: `validate` (exit 0), `lint`, `format:check`, `validate-ui-docs-drift` (*"API reference docs are current (341 generated pages)"* — this is the CI gate that would fail if the generated tree were not committed).

`apps/ui`: `lint` (0 errors, 8 warnings, all pre-existing), `format:check`, `typecheck`, `test` (**257 files, 2130 tests**), `test:e2e` (**106 passed**, zero `[api-stub] MISS`), `build:worker:e2e`.

All 25 group pages verified 200 against the real Worker build, and the breadcrumb chain verified end to end.
