### PR TITLE
fix(r2-sql): validate testnet rows, and read the body ceiling from a declared field

### DIFF
--- a/src/r2-sql.ts
+++ b/src/r2-sql.ts
@@ -39,6 +39,7 @@ import { z } from "zod";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { LAKEHOUSE_ROW_SCHEMAS } from "../schemas-src/lakehouse.ts";
+import { LAKEHOUSE_NAMESPACES } from "./chain-network.ts";
 import { R2SqlBodySchema } from "../schemas-src/r2-sql-envelope.ts";
 
 /** Personal/API token with R2 SQL read access (wrangler secret). */
@@ -386,7 +387,7 @@ const MaxBodyBytesSchema = z.coerce
 
 /** The body-size ceiling for this deployment, or 0 when disabled. */
 export function maxBodyBytes(env: Env | null | undefined): number {
-  const raw = env?.[R2_SQL_MAX_BODY_BYTES_ENV as keyof Env];
+  const raw = env?.R2_SQL_MAX_BODY_BYTES;
   if (raw === undefined || raw === null || String(raw).trim() === "") {
     return R2_SQL_MAX_BODY_BYTES_DEFAULT;
   }
@@ -485,12 +486,42 @@ export function catalogRowSchema(
   sql: string,
 ): { safeParse: (value: unknown) => { success: boolean } } | null {
   const kind = r2SqlQueryKind(sql);
-  const table = kind.startsWith("chain.") ? kind.slice("chain.".length) : kind;
+  const table = unqualify(kind);
   const schemas = LAKEHOUSE_ROW_SCHEMAS as Record<
     string,
     { safeParse: (value: unknown) => { success: boolean } } | undefined
   >;
   return schemas[table] ?? null;
+}
+
+/**
+ * `chain.blocks` -> `blocks`, `chain_testnet.blocks` -> `blocks`, anything
+ * else unchanged.
+ *
+ * EVERY LAKEHOUSE NAMESPACE, not just `chain`. This tested `chain.` alone, so
+ * a `chain_testnet.*` statement kept its namespace, matched no key, and every
+ * testnet read skipped row validation entirely — silently, because an
+ * unvalidated read is indistinguishable from a validated one that passed.
+ * Testnet is a served network, so that was a live hole in real responses.
+ *
+ * Testnet carries the same table NAMES written by the same decoder on the same
+ * tick, so it shares mainnet's row schemas; `LAKEHOUSE_ROW_SCHEMAS` is keyed by
+ * bare table name for exactly that reason. Derived from `LAKEHOUSE_NAMESPACES`
+ * rather than listing the prefixes again, so a third network cannot be added
+ * there and land unvalidated here — which is the shape of the bug this fixes.
+ *
+ * An unrecognised namespace is still returned whole and still resolves to no
+ * schema. That is deliberate: inventing a schema for `foo.blocks` because it
+ * ends in a name we know would validate a table this repo has no description
+ * of.
+ */
+function unqualify(kind: string): string {
+  for (const namespace of Object.values(LAKEHOUSE_NAMESPACES)) {
+    if (kind.startsWith(`${namespace}.`)) {
+      return kind.slice(namespace.length + 1);
+    }
+  }
+  return kind;
 }
 
 /**

--- a/tests/r2-sql.test.ts
+++ b/tests/r2-sql.test.ts
@@ -21,6 +21,7 @@ import {
   R2_SQL_MAX_BODY_BYTES_DEFAULT,
   R2_SQL_MAX_BODY_BYTES_ENV,
   R2_SQL_TOKEN_ENV,
+  maxBodyBytes,
   safeBlockNumber,
   safeHexLiteral,
   safeSs58Literal,
@@ -1431,6 +1432,108 @@ describe("a lakehouse read is VALIDATED, not cast (#11000)", () => {
         ...noCapture,
       }),
       [{ x: "free" }],
+    );
+  });
+
+  // TESTNET IS A SERVED NETWORK. The lookup tested for a `chain.` prefix
+  // alone, so a `chain_testnet.*` statement kept its namespace, matched no
+  // key, and resolved to no schema -- every testnet read skipped validation
+  // entirely. Silently, because an unvalidated read looks exactly like a
+  // validated one that passed.
+  test("a testnet read is validated against the same row schema", async () => {
+    const rows = await r2SqlQuery(
+      mockEnv(TOKEN),
+      "SELECT block_number FROM chain_testnet.blocks LIMIT 1",
+      {
+        fetch: streamOf({
+          success: true,
+          result: { rows: [{ block_number: "not-a-height" }] },
+        }),
+        ...noCapture,
+      },
+    );
+    // Refused, not served -- the mainnet behaviour, now reached from testnet.
+    assert.equal(rows, null);
+  });
+
+  test("a legitimate testnet row still comes back", async () => {
+    // The other half, and the one that catches an over-eager fix: refusing
+    // everything would also make the test above pass.
+    assert.deepEqual(
+      await r2SqlQuery(
+        mockEnv(TOKEN),
+        "SELECT block_number FROM chain_testnet.blocks LIMIT 1",
+        {
+          fetch: streamOf({
+            success: true,
+            result: { rows: [{ block_number: 42 }] },
+          }),
+          ...noCapture,
+        },
+      ),
+      [{ block_number: 42 }],
+    );
+  });
+
+  test("a namespace that merely starts like one is left unqualified", async () => {
+    // `chain_other.blocks` is not a lakehouse namespace. Stripping any prefix
+    // that ends in a known table name would validate a table this repo has no
+    // description of -- so the match requires the full namespace and its dot.
+    assert.deepEqual(
+      await r2SqlQuery(
+        mockEnv(TOKEN),
+        "SELECT block_number FROM chain_other.blocks LIMIT 1",
+        {
+          fetch: streamOf({
+            success: true,
+            result: { rows: [{ block_number: "not-a-height" }] },
+          }),
+          ...noCapture,
+        },
+      ),
+      [{ block_number: "not-a-height" }],
+    );
+  });
+});
+
+describe("the body ceiling reads a declared field, not a cast (#11067)", () => {
+  test("an unset ceiling falls back to the default", () => {
+    // `env.R2_SQL_MAX_BODY_BYTES` was reached through `as keyof Env`, which
+    // typechecked precisely BECAUSE it asserted past the interface the field
+    // was missing from. Declaring it makes the read ordinary; this pins that
+    // the behaviour did not move with it.
+    assert.equal(maxBodyBytes(mockEnv(TOKEN)), R2_SQL_MAX_BODY_BYTES_DEFAULT);
+    assert.equal(maxBodyBytes(null), R2_SQL_MAX_BODY_BYTES_DEFAULT);
+    assert.equal(maxBodyBytes(undefined), R2_SQL_MAX_BODY_BYTES_DEFAULT);
+  });
+
+  test("an explicit ceiling is honoured, and 0 disables the cap", () => {
+    const withCeiling = (value: string) => ({
+      ...mockEnv(TOKEN),
+      [R2_SQL_MAX_BODY_BYTES_ENV]: value,
+    });
+    assert.equal(maxBodyBytes(withCeiling("2048")), 2048);
+    // A real "0" turns the cap off -- an operator must be able to open a
+    // safety valve they have decided is in the way.
+    assert.equal(maxBodyBytes(withCeiling("0")), 0);
+  });
+
+  test("a blank or unparseable ceiling falls back rather than throwing", () => {
+    const withCeiling = (value: string) => ({
+      ...mockEnv(TOKEN),
+      [R2_SQL_MAX_BODY_BYTES_ENV]: value,
+    });
+    assert.equal(
+      maxBodyBytes(withCeiling("   ")),
+      R2_SQL_MAX_BODY_BYTES_DEFAULT,
+    );
+    assert.equal(
+      maxBodyBytes(withCeiling("not-a-number")),
+      R2_SQL_MAX_BODY_BYTES_DEFAULT,
+    );
+    assert.equal(
+      maxBodyBytes(withCeiling("-1")),
+      R2_SQL_MAX_BODY_BYTES_DEFAULT,
     );
   });
 });

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -245,6 +245,12 @@ interface Env {
   R2_SQL_ACCOUNT_ID?: string;
   R2_SQL_WAREHOUSE?: string;
   R2_SQL_RATE_LIMIT_COOLDOWN_MS?: string;
+  /** Response-body ceiling for an R2 SQL read, bytes; "0" disables the cap.
+   * Bounds the 128 MB isolate against `chain.extrinsics.call_args`, which is
+   * unbounded regardless of engine. Read via `as keyof Env` until #11067 —
+   * a cast that typechecked precisely because it asserted past the interface
+   * this field was missing from. */
+  R2_SQL_MAX_BODY_BYTES?: string;
 }
 
 // RPC reverse-proxy usage telemetry on Workers Analytics Engine (#9228).


### PR DESCRIPTION
Two gaps recorded in #11067, both small and neither dependent on the routing decision that issue is really about. #11067 stays open for the routing rule and the guarantee-tests; this closes its two named side-gaps.

## Testnet reads were skipping row validation entirely

`catalogRowSchema` tested for a `chain.` prefix alone:

```ts
const table = kind.startsWith("chain.") ? kind.slice("chain.".length) : kind;
```

`"chain_testnet.blocks".startsWith("chain.")` is **false** — the character after `chain` is `_`, not `.`. So the statement kept its namespace, matched no key in `LAKEHOUSE_ROW_SCHEMAS`, and resolved to `null`, which the reader treats as "unvalidated, and that is fine".

Testnet is a served network, so this was a live hole in real responses — and a silent one, because an unvalidated read is indistinguishable from a validated one that passed. Nothing logs, nothing declines.

The strip now derives from `LAKEHOUSE_NAMESPACES` in `chain-network.ts` rather than listing the prefixes a second time, so a third network cannot be added there and land unvalidated here — which is exactly the shape of this bug. Sharing mainnet's schemas is correct rather than merely convenient: testnet carries the same table *names*, written by the same decoder on the same tick, which is why `LAKEHOUSE_ROW_SCHEMAS` is keyed by bare table name in the first place.

The match still requires the full namespace **and its dot**, so `chain_other.blocks` stays unqualified and unvalidated. Inventing a schema for a table this repo has no description of would be worse than not validating it, and that limit is already documented on the function.

## The body ceiling was read through a cast

`R2_SQL_MAX_BODY_BYTES` is now declared in `env-extra.d.ts` and read as an ordinary field. It was reached via `as keyof Env` — a cast that typechecked **precisely because** it asserted past the interface the field was missing from. The declaration is what makes the read checkable at all.

## Verification

- `tests/r2-sql.test.ts`: 80 pass. Six added.
- Two of the six exist to stop an over-eager fix: a legitimate testnet row must still come back, and a namespace that merely *starts* like a known one must stay unqualified. Refusing everything would satisfy the headline test alone.
- The fix is observable in test stderr, not just in an assertion: `[r2-sql] row_schema chain_testnet.blocks ... a row did not match the catalog schema for chain_testnet.blocks` — that line could not be produced before this change.
- `typecheck`, `lint`, `format:check`, `validate:lakehouse-readers`, `validate:untyped-lakehouse-reads`, `validate:lakehouse-types-drift`, `validate:private-boundary`, `validate:type-duplicates`: all pass.
- Rebuilt on `39b653faf` (current main at time of push), not rebased from a stale base; gates re-run after the rebuild.

No visual surface is touched.