### PR TITLE
docs(hyperdrive): state the staleness bound, now that query caching is off

### DIFF
--- a/wrangler.data.jsonc
+++ b/wrangler.data.jsonc
@@ -605,6 +605,20 @@
   // and the read flag has been deleted rather than left to answer a question
   // it can no longer get wrong in the interesting direction -- it could refuse
   // a route, never send it somewhere better.
+  //
+  // QUERY CACHING IS DISABLED on this config (metagraphed-infra#493). The
+  // setting lives on the Hyperdrive RESOURCE, not on the binding -- there is no
+  // caching key in wrangler -- so this comment is the only place the effective
+  // staleness bound can be read from the repo:
+  //
+  //   caching: { disabled: true }   verified live 2026-08-15
+  //
+  // The defaults it replaces were max_age 60s + stale_while_revalidate 15s,
+  // against a poller that bulk-rewrites its tables every 15 minutes and a
+  // Hyperdrive that does not invalidate on write. Disabled wholesale because
+  // Cloudflare documents no per-query control, and the measured hit rate on
+  // cacheable reads was 9.3% -- too little to justify a second config and a
+  // per-read routing decision. Full reasoning in wrangler.jsonc.
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -674,6 +674,41 @@
   //
   // nodejs_compat is already set above, which is what makes the native pg
   // driver usable here at all.
+  //
+  // QUERY CACHING IS DISABLED on this config, deliberately, and the setting
+  // lives on the Hyperdrive RESOURCE rather than here -- there is no caching
+  // key in a wrangler binding, so this comment is the only place the bound can
+  // be stated in the repo. That is why it is stated at all
+  // (metagraphed-infra#493): an effective staleness window nobody can read
+  // from the codebase is the same defect as an undocumented one.
+  //
+  //   caching: { disabled: true }        (was { disabled: false })
+  //   verified live 2026-08-15 via `wrangler hyperdrive get`
+  //
+  // WHAT THE DEFAULT COST. Hyperdrive's defaults are max_age 60s plus
+  // stale_while_revalidate 15s, and it does NOT invalidate a cached read when
+  // the application writes. The metagraph lane bulk-rewrites its tables every
+  // 15 minutes, so a caller could be served the previous pass for up to 75
+  // seconds after each rewrite with nothing marking it stale -- and a
+  // freshness stamp served from cache is self-defeating.
+  //
+  // WHOLESALE, NOT PER-QUERY, AND THE PLATFORM DECIDED THAT. Cloudflare
+  // documents no per-query cache control: SQL comments are explicitly not a
+  // cache-control API, and the only supported split is a SECOND cache-disabled
+  // config bound alongside this one, with fresh reads routed through it.
+  //
+  // THE MEASUREMENT IS WHY WE DID NOT SPLIT. The compute-protection argument
+  // for caching is real and was not discarded silently -- it was priced. Over
+  // the 24h to 2026-08-15, of 325,521 Hyperdrive queries only 85,262 were
+  // cacheable at all (the rest being `notaquery` protocol traffic and
+  // in-transaction reads), and of those just 7,946 were hits: a 9.3% hit rate.
+  // A second config, a second connection budget against the same origin, and a
+  // per-read routing decision at every call site is a large standing cost to
+  // preserve that. Neon's compute is pinned by continuous capture writes in any
+  // case, so the cache was never saving a cold start -- only marginal CPU.
+  //
+  // Reverse with `wrangler hyperdrive update <id>` (no flag re-enables), and
+  // re-measure by `cacheStatus` before concluding anything from it.
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",

--- a/wrangler.registry.jsonc
+++ b/wrangler.registry.jsonc
@@ -155,6 +155,20 @@
   // that is safe: nothing outside this Worker reads these four tables (the
   // public registry serves from R2 artifacts), and all four are rebuildable by
   // re-running the sync from registry/subnets/*.json. Rollback is removing this
+  //
+  // QUERY CACHING IS DISABLED on this config (metagraphed-infra#493). The
+  // setting lives on the Hyperdrive RESOURCE, not on the binding -- there is no
+  // caching key in wrangler -- so this comment is the only place the effective
+  // staleness bound can be read from the repo:
+  //
+  //   caching: { disabled: true }   verified live 2026-08-15
+  //
+  // The defaults it replaces were max_age 60s + stale_while_revalidate 15s,
+  // against a poller that bulk-rewrites its tables every 15 minutes and a
+  // Hyperdrive that does not invalidate on write. Disabled wholesale because
+  // Cloudflare documents no per-query control, and the measured hit rate on
+  // cacheable reads was 9.3% -- too little to justify a second config and a
+  // per-read routing decision. Full reasoning in wrangler.jsonc.
   "hyperdrive": [
     {
       "binding": "HYPERDRIVE",


### PR DESCRIPTION
Ships the in-repo half of metagraphed-infra#493. The live config change is already applied and verified; this is the record of it, which that issue is explicit is not optional — *"an enumeration with no change, or a change with no recorded bound, leaves the staleness window as undocumented as it is now."*

## What was wrong

Hyperdrive query caching was ON with no explicit `max_age`, so platform defaults applied — **60s `max_age` + 15s `stale_while_revalidate`** — and Hyperdrive **does not invalidate a cached read when the application writes**. The metagraph lane bulk-rewrites its tables every 15 minutes, so a caller could be served the previous pass for up to 75 seconds after each rewrite, with nothing marking it stale. A freshness stamp served from cache is self-defeating.

## The change

```
caching: { disabled: false }  ->  { disabled: true }
```

Applied to `metagraphed-neon` (`8a09dc67…`) and confirmed by **re-reading the live config**, not by intent:

```
$ npx wrangler hyperdrive get 8a09dc673733497f987434f59689287e
  caching: {'disabled': True} | origin_connection_limit: 60
```

## Why wholesale, and why not the two-binding split

The platform allows nothing finer. Cloudflare documents SQL comments as explicitly **not** a cache-control API ("parser behavior can differ between database engines"), and the only supported split is a *second* cache-disabled config bound alongside, with fresh reads routed to it per call site.

That split was priced rather than dismissed — #493 is right that the compute-protection argument is real and shouldn't be discarded silently. Measured over the 24h to 2026-08-15 via the GraphQL analytics API:

| cacheStatus | count | share |
|---|---:|---:|
| `notaquery` | 215,545 | 66.2% |
| `miss` | 77,316 | 23.8% |
| `transaction` | 15,481 | 4.8% |
| `clienthit` | 9,004 | 2.8% |
| **`hit`** | **7,946** | **2.4%** |
| `errorresponse` / `uncacheable` | 229 | 0.1% |

Only **85,262 of 325,521 queries were cacheable at all** (the rest being protocol traffic and in-transaction reads), and of those just 7,946 were hits — a **9.3% hit rate**. A second Hyperdrive config, a second connection budget against the same origin, and a routing decision at every read site is a large standing cost to preserve that. Neon's compute is pinned by continuous capture writes regardless, so the cache was never saving a cold start — only marginal CPU.

## Where the bound is recorded

The setting lives on the Hyperdrive **resource**, not the binding — wrangler has no `caching` key — so a comment beside each binding is the only place it can be read from the repo. Full reasoning in `wrangler.jsonc`; `wrangler.data.jsonc` and `wrangler.registry.jsonc` carry a short form pointing at it, since all three bind the same config id.

## Scope

Comments only. No code path changes, no binding id changes, and no route moves — which is this repo's own recorded lesson (#9704) about Hyperdrive changes that look inert and are not.

The enumeration #493 asks for is answered by the measurement rather than by a hand-written list: with caching disabled there is no longer a group of reads whose staleness tolerance needs classifying, which is why the deliverables collapse to one decision.