### PR TITLE
fix(mcp): a reconnecting client takes the stream back instead of being refused

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17803,6 +17803,7 @@ async function readLimitedMcpBody(request: Request) {
       error: jsonResponse(
         rpcError(null, RPC_PARSE_ERROR, "Request body is not valid JSON."),
         400,
+        { [MCP_REFUSAL_HEADER]: "invalid_json" },
       ),
     };
   }
@@ -17826,6 +17827,7 @@ function validateMcpProtocolVersionHeader(request: Request) {
         `${MCP_PROTOCOL_VERSIONS.join(", ")}.`,
     ),
     400,
+    { [MCP_REFUSAL_HEADER]: "unsupported_protocol_version" },
   );
 }
 
@@ -18069,6 +18071,16 @@ async function handleMcpTerminateRequest(request: Request, env: Env) {
  * this purpose (#8608 added it so a 429 is actionable), rather than by
  * threading a label up from each `return`.
  */
+/**
+ * How a refusal names itself to the telemetry that reads it back.
+ *
+ * A RESPONSE HEADER rather than a thrown label, because these refusals are
+ * early returns from four different gates and the recorder sees only the
+ * Response. It never reaches a client's own tooling as anything but an extra
+ * header, and it carries a fixed vocabulary -- never a caller-supplied value.
+ */
+export const MCP_REFUSAL_HEADER = "x-mcp-refusal";
+
 export function mcpRefusalReason(response: Response): string | null {
   switch (response.status) {
     case 429: {
@@ -18095,8 +18107,18 @@ export function mcpRefusalReason(response: Response): string | null {
       return "method_not_allowed";
     case 413:
       return "body_too_large";
+    // FOUR DIFFERENT FAULTS wear this status, and `bad_request` named none of
+    // them: a body that is not JSON, a protocol version this server does not
+    // speak, an empty batch, and a batch over the ceiling. Measured on the
+    // deployed version: 27 of these from REAL Claude clients in a week, with
+    // nothing anywhere saying which -- the same "an anonymous number somebody
+    // has to go and decode" problem the 409 note below already describes.
+    //
+    // Split on a header the refusal sets, exactly as 429 splits on
+    // `x-ratelimit-scope` above: the alternative is threading a label up from
+    // each `return`, through code whose whole shape is early returns.
     case 400:
-      return "bad_request";
+      return response.headers.get(MCP_REFUSAL_HEADER) ?? "bad_request";
     case 401:
       return "unauthorized";
     default:
@@ -18500,6 +18522,7 @@ async function dispatchMcpRequest(
       return jsonResponse(
         rpcError(null, RPC_INVALID_REQUEST, "Empty JSON-RPC batch."),
         400,
+        { [MCP_REFUSAL_HEADER]: "empty_batch" },
       );
     }
     if (body.length > MAX_MCP_BATCH_LENGTH) {
@@ -18510,6 +18533,7 @@ async function dispatchMcpRequest(
           `JSON-RPC batch length exceeds the maximum of ${MAX_MCP_BATCH_LENGTH}.`,
         ),
         400,
+        { [MCP_REFUSAL_HEADER]: "batch_too_large" },
       );
     }
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17962,24 +17962,28 @@ async function handleMcpStreamRequest(request: Request, env: Env) {
     `https://mcp-session-hub.internal/stream?sessionId=${encodeURIComponent(rawSessionId)}`,
   );
   if (!upstream.ok) {
-    // 404 (session unknown/already terminated) or 409 (a stream is already
-    // open for this session) from the DO -- pass the status through with a
-    // client-facing message, never the DO's own internal response body.
+    // 404 (session unknown/already terminated) from the DO -- a client-facing
+    // message, never the DO's own internal response body.
+    //
+    // THE 409 ARM IS GONE with the refusal that produced it. `/stream` now
+    // answers 200 or 404 and nothing else: a second GET takes the channel over
+    // rather than being told a stream is already open, because the stream we
+    // were holding is the doubtful one and the client asking now is not. The
+    // branch (and the test that stubbed a 409 to reach it) described a state
+    // production can no longer produce.
     return jsonResponse(
       rpcError(
         null,
         RPC_INVALID_REQUEST,
-        upstream.status === 409
-          ? "A stream is already open for this session."
-          : // #8632: "call initialize again" was wrong advice -- initialize
-            // mints a session id but does NOT register it here, so following
-            // it produces this same 404 forever. The missing step is the
-            // subscription.
-            "No stream is open for this Mcp-Session-Id. A session is only " +
-              "registered by resources/subscribe -- call it (on " +
-              "metagraph://chain/stream or metagraph://subnet/{netuid}/status) " +
-              "before opening the GET stream. If the session has since expired, " +
-              "re-run initialize and subscribe again.",
+        // #8632: "call initialize again" was wrong advice -- initialize
+        // mints a session id but does NOT register it here, so following
+        // it produces this same 404 forever. The missing step is the
+        // subscription.
+        "No stream is open for this Mcp-Session-Id. A session is only " +
+          "registered by resources/subscribe -- call it (on " +
+          "metagraph://chain/stream or metagraph://subnet/{netuid}/status) " +
+          "before opening the GET stream. If the session has since expired, " +
+          "re-run initialize and subscribe again.",
       ),
       // 405, not 404, for the no-subscription case. The Streamable HTTP transport
       // names 405 as the sanctioned "this endpoint offers no SSE stream", and a
@@ -17992,9 +17996,8 @@ async function handleMcpStreamRequest(request: Request, env: Env) {
       // and began reconnecting — which is the churn that then walked into the
       // OAuth-route 401 (see matchesMcpApiRoute in src/github-oauth.ts).
       //
-      // 409 keeps its own status: a stream IS on offer there, just already taken.
-      upstream.status === 409 ? 409 : 405,
-      upstream.status === 409 ? undefined : { allow: "POST, DELETE, OPTIONS" },
+      405,
+      { allow: "POST, DELETE, OPTIONS" },
     );
   }
   return new Response(upstream.body, {

--- a/src/usage-telemetry.ts
+++ b/src/usage-telemetry.ts
@@ -871,6 +871,15 @@ export const MCP_ERROR_TYPE_BY_CODE: Record<string, McpErrorType> = {
   // `_rate_limited$` suffixes do not match, and the rest are unlike anything
   // this codebase's handlers mint.
   bad_request: "validation",
+  // The four faults `bad_request` used to be. All `validation` -- they are OUR
+  // refusal of a caller's request, the same reading bad_request already
+  // carried -- but each names what to change: 27 of these arrived from real
+  // Claude clients in a week under one label that said only "something was
+  // wrong with your POST".
+  invalid_json: "validation",
+  unsupported_protocol_version: "validation",
+  empty_batch: "validation",
+  batch_too_large: "validation",
   blocked: "permission",
   body_too_large: "validation",
   daily_quota: "rate_limited",

--- a/tests/mcp-analytics-completeness.test.ts
+++ b/tests/mcp-analytics-completeness.test.ts
@@ -113,7 +113,23 @@ describe("pre-dispatch refusals reach the $mcp_* family", () => {
     ],
     [429, { "x-ratelimit-scope": "blocked" }, "blocked", "permission"],
     [401, {}, "unauthorized", "permission"],
+    // The bare 400 keeps the generic label -- a refusal that sets no header is
+    // one this vocabulary has not been taught yet, and it must still bucket.
     [400, {}, "bad_request", "validation"],
+    [400, { "x-mcp-refusal": "invalid_json" }, "invalid_json", "validation"],
+    [
+      400,
+      { "x-mcp-refusal": "unsupported_protocol_version" },
+      "unsupported_protocol_version",
+      "validation",
+    ],
+    [400, { "x-mcp-refusal": "empty_batch" }, "empty_batch", "validation"],
+    [
+      400,
+      { "x-mcp-refusal": "batch_too_large" },
+      "batch_too_large",
+      "validation",
+    ],
     [405, {}, "method_not_allowed", "validation"],
     [413, {}, "body_too_large", "validation"],
     // Named after the refusal usage_event started landing and showed 8 of

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1902,20 +1902,39 @@ describe("MCP transport handling", () => {
       assert.doesNotMatch(body.error.message, /call initialize again/);
     });
 
-    test("a 409 from the session hub (a stream is already open) passes through as 409", async () => {
-      const hub = fakeMcpSessionHubBinding({
-        "/stream": () => new Response(null, { status: 409 }),
-      });
-      const request = new Request(MCP_URL, {
-        method: "GET",
-        headers: { "mcp-session-id": A_SESSION_ID },
-      });
-      const response = await handleMcpRequest(request, {
-        MCP_SESSION_HUB: hub,
-      } as unknown as Env);
-      assert.equal(response.status, 409);
-      const body = (await response.json()) as Row;
-      assert.match(body.error.message, /already open/);
+    // The 409 pass-through is gone with the refusal that produced it: a second
+    // GET now TAKES OVER the channel rather than being refused, so `/stream`
+    // answers 200 or 404 and nothing else. Its test stubbed a 409 the hub can
+    // no longer return -- a state production cannot reach, asserted anyway.
+    //
+    // What replaces it is the property that actually matters and held either
+    // way: whatever the hub declines with, the client is told what to DO about
+    // it, and never handed the hub's own internal body.
+    test("any decline from the session hub is a 405 that names the missing step", async () => {
+      for (const status of [404, 409, 500]) {
+        const hub = fakeMcpSessionHubBinding({
+          "/stream": () =>
+            new Response(JSON.stringify({ error: "internal detail" }), {
+              status,
+            }),
+        });
+        const request = new Request(MCP_URL, {
+          method: "GET",
+          headers: { "mcp-session-id": A_SESSION_ID },
+        });
+        const response = await handleMcpRequest(request, {
+          MCP_SESSION_HUB: hub,
+        } as unknown as Env);
+        assert.equal(response.status, 405, `hub ${status}`);
+        assert.equal(response.headers.get("allow"), "POST, DELETE, OPTIONS");
+        const body = (await response.json()) as Row;
+        assert.match(body.error.message, /resources\/subscribe/);
+        assert.doesNotMatch(
+          body.error.message,
+          /internal detail/,
+          "the hub's own body never reaches a client",
+        );
+      }
     });
 
     // The canonical initialize-then-GET sequence ALWAYS lands here, because a

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -33,6 +33,8 @@ import {
   toolResultContent,
   MCP_SERVER_INFO,
   MAX_MCP_BATCH_LENGTH,
+  MCP_REFUSAL_HEADER,
+  mcpRefusalReason,
   MAX_MCP_BODY_BYTES,
   listToolDefinitions,
   UNTRUSTED_DATA_NOTE,
@@ -1338,6 +1340,64 @@ describe("MCP transport handling", () => {
     assert.equal(res.body.error.code, -32600);
     assert.match(res.body.error.message, /batch length exceeds/);
     assert.deepEqual(calls, []);
+  });
+
+  // Four faults wore one label. `bad_request` told a reader that something was
+  // wrong with a POST and nothing about WHICH -- and 27 of them arrived from
+  // real Claude clients in a week, undiagnosable. Each gate names itself now,
+  // through the same header mechanism 429 already splits on.
+  //
+  // Driven through the real entry point rather than by handing mcpRefusalReason
+  // a synthetic Response: what has to hold is that the GATES set the header, and
+  // a unit test of the mapping cannot see whether they do.
+  test("each 400 gate names its own refusal, so telemetry can tell them apart", async () => {
+    const seen: Array<[string, string | null]> = [];
+
+    const notJson = await handleMcpRequest(
+      new Request(MCP_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{not json",
+      }),
+      {} as unknown as Env,
+      makeDeps(),
+    );
+    seen.push(["invalid_json", notJson.headers.get(MCP_REFUSAL_HEADER)]);
+
+    const badVersion = await rpc(
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      { headers: { "mcp-protocol-version": "1999-01-01" } },
+    );
+    seen.push([
+      "unsupported_protocol_version",
+      badVersion.headers.get(MCP_REFUSAL_HEADER),
+    ]);
+
+    const empty = await rpc([]);
+    seen.push(["empty_batch", empty.headers.get(MCP_REFUSAL_HEADER)]);
+
+    const tooLong = await rpc(
+      Array.from({ length: MAX_MCP_BATCH_LENGTH + 1 }, (_, index) => ({
+        jsonrpc: "2.0",
+        id: index + 1,
+        method: "tools/list",
+      })),
+    );
+    seen.push(["batch_too_large", tooLong.headers.get(MCP_REFUSAL_HEADER)]);
+
+    for (const [expected, actual] of seen) {
+      assert.equal(actual, expected);
+      // And the label the recorder derives from it, which is the whole point.
+      assert.equal(
+        mcpRefusalReason(
+          new Response(null, {
+            status: 400,
+            headers: { [MCP_REFUSAL_HEADER]: actual as string },
+          }),
+        ),
+        expected,
+      );
+    }
   });
 
   test("an oversized decoded body is rejected before JSON parsing", async () => {

--- a/tests/mcp-session-hub.test.ts
+++ b/tests/mcp-session-hub.test.ts
@@ -6,12 +6,15 @@
 // APIs under Node/vitest -- nothing in this file needs WebSocketPair, so
 // there is no v8-ignored branch to account for.
 import assert from "node:assert/strict";
+import { buildSubnetStatusResourceUri } from "../src/subnet-status-subscribe.ts";
 import { test, vi } from "vitest";
 import {
   MCP_CHAIN_STREAM_RESOURCE_URI,
   MCP_SESSION_ID_MAX_LENGTH,
   MCP_SESSION_IDLE_TTL_MS,
+  MCP_SESSION_KEEPALIVE_FRAME,
   MCP_SESSION_MAX_STREAM_DURATION_MS,
+  MCP_SESSION_STREAM_KEEPALIVE_MS,
   McpSessionHub,
   buildResourceUpdatedNotification,
   formatMcpSseEvent,
@@ -376,7 +379,15 @@ test("handleStream: opens fine with no sessionId query param (already known from
   await res.body!.cancel();
 });
 
-test("handleStream: a second concurrent stream request for the same session is rejected with 409", async () => {
+// WAS A 409, and the refusal was measured doing harm: 112 of them on one
+// deployed version, every one from a real client reconnecting on a five-minute
+// metronome -- the same period as this class's own stream cap, whose entire
+// design depends on that reconnect being allowed.
+//
+// The refusal asked "is a stream registered?" when what matters is "is a stream
+// ALIVE?", and those come apart whenever a connection drops without the
+// runtime running `cancel`. Then the corpse holds the slot forever.
+test("handleStream: a second GET TAKES OVER, and the first stream is closed", async () => {
   const hub = new McpSessionHub(stubState(), mockEnv());
   await hub.fetch(
     jsonRequest("https://mcp-session-hub.internal/subscribe", {
@@ -388,11 +399,130 @@ test("handleStream: a second concurrent stream request for the same session is r
     new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
   );
   assert.equal(first.status, 200);
+  const firstReader = first.body!.getReader();
+
   const second = await hub.fetch(
     new Request("https://mcp-session-hub.internal/stream?sessionId=session-1"),
   );
-  assert.equal(second.status, 409);
-  await first.body!.cancel();
+  assert.equal(second.status, 200, "the client asking now is the live one");
+
+  // The first stream is ENDED, not abandoned: a client holding it reads EOF
+  // and reconnects rather than waiting forever on a channel we stopped using.
+  assert.equal((await firstReader.read()).done, true);
+
+  // And the notification channel belongs to the second.
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/notify", {
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  const secondReader = second.body!.getReader();
+  const frame = new TextDecoder().decode((await secondReader.read()).value);
+  assert.match(frame, /notifications\/resources\/updated/);
+  await secondReader.cancel();
+});
+
+// The other half of the repair: nothing used to be written to an idle stream,
+// so a connection dropped without `cancel` was discovered only by the next real
+// notification -- which on a quiet session is never.
+// A frame that never landed must not consume an event id: the ids are the only
+// record of what a client has seen, and a gap in them is a gap in that record.
+test("deliverNow: a failed enqueue leaves the uri pending AND the sequence untouched", async () => {
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  await hub.fetch(
+    jsonRequest("https://mcp-session-hub.internal/subscribe", {
+      sessionId: "session-1",
+      uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+    }),
+  );
+  hub.streamController = {
+    enqueue: () => {
+      throw new Error("stream is gone");
+    },
+  } as unknown as ReadableStreamDefaultController;
+  hub.pendingUris.add(MCP_CHAIN_STREAM_RESOURCE_URI);
+  const before = hub.sequence;
+
+  hub.deliverNow(MCP_CHAIN_STREAM_RESOURCE_URI);
+
+  assert.equal(hub.sequence, before, "an undelivered frame consumed no id");
+  assert.equal(
+    hub.pendingUris.has(MCP_CHAIN_STREAM_RESOURCE_URI),
+    true,
+    "and the uri is still owed to the client",
+  );
+  assert.equal(hub.streamController, null, "the dead stream was released");
+});
+
+// The invariant deliverNow's own comment describes, now that ONE guard owns it:
+// when the flush loop's first enqueue throws, it releases the stream -- and
+// every REMAINING pending uri must stay pending rather than being dropped by a
+// silent no-op that still deleted it.
+test("deliverNow: once the stream dies mid-flush, the rest stay pending", async () => {
+  const hub = new McpSessionHub(stubState(), mockEnv());
+  const second = buildSubnetStatusResourceUri(7);
+  for (const uri of [MCP_CHAIN_STREAM_RESOURCE_URI, second]) {
+    await hub.fetch(
+      jsonRequest("https://mcp-session-hub.internal/subscribe", {
+        sessionId: "session-1",
+        uri,
+      }),
+    );
+    hub.pendingUris.add(uri);
+  }
+  hub.streamController = {
+    enqueue: () => {
+      throw new Error("stream is gone");
+    },
+  } as unknown as ReadableStreamDefaultController;
+
+  for (const uri of [...hub.pendingUris]) hub.deliverNow(uri);
+
+  assert.deepEqual(
+    [...hub.pendingUris].sort(),
+    [MCP_CHAIN_STREAM_RESOURCE_URI, second].sort(),
+    "both are still owed; the second never even had a stream to try",
+  );
+  assert.equal(hub.sequence, 0, "and neither consumed an event id");
+});
+
+test("handleStream: an idle stream is kept alive, and a dead one is discovered", async () => {
+  vi.useFakeTimers();
+  try {
+    const hub = new McpSessionHub(stubState(), mockEnv());
+    await hub.fetch(
+      jsonRequest("https://mcp-session-hub.internal/subscribe", {
+        sessionId: "session-1",
+        uri: MCP_CHAIN_STREAM_RESOURCE_URI,
+      }),
+    );
+    const res = await hub.fetch(
+      new Request(
+        "https://mcp-session-hub.internal/stream?sessionId=session-1",
+      ),
+    );
+    const reader = res.body!.getReader();
+
+    vi.advanceTimersByTime(MCP_SESSION_STREAM_KEEPALIVE_MS);
+    const frame = new TextDecoder().decode((await reader.read()).value);
+    assert.equal(frame, MCP_SESSION_KEEPALIVE_FRAME);
+    assert.match(frame, /^:/, "an SSE comment, ignored by every client");
+
+    // Now the connection dies WITHOUT the runtime telling us -- the case that
+    // produced the metronome. The next keepalive finds it, within 30 seconds,
+    // and releases the slot so the client's reconnect is served.
+    hub.streamController = {
+      enqueue: () => {
+        throw new Error("stream is gone");
+      },
+    } as unknown as ReadableStreamDefaultController;
+    vi.advanceTimersByTime(MCP_SESSION_STREAM_KEEPALIVE_MS);
+    assert.equal(hub.streamController, null);
+    assert.equal(hub.streamKeepaliveTimer, null);
+    await reader.cancel();
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 test("handleNotify: with a stream already open, delivers immediately (deliverNow) instead of coalescing into pendingUris", async () => {
@@ -466,8 +596,24 @@ test("handleStream: auto-closes after MCP_SESSION_MAX_STREAM_DURATION_MS, per th
     await vi.runAllTimersAsync();
     assert.equal(hub.streamController, null);
     assert.equal(hub.streamCloseTimer, null);
-    const { done } = await reader.read();
-    assert.equal(done, true);
+    assert.equal(hub.streamKeepaliveTimer, null, "the keepalive stops with it");
+    // Drain the keepalives the stream wrote while it was idle, then EOF. The
+    // frames are the point of them: an idle stream is now visibly alive.
+    let read = await reader.read();
+    let keepalives = 0;
+    while (!read.done) {
+      assert.equal(
+        new TextDecoder().decode(read.value),
+        MCP_SESSION_KEEPALIVE_FRAME,
+      );
+      keepalives += 1;
+      read = await reader.read();
+    }
+    assert.equal(read.done, true);
+    assert.ok(
+      keepalives > 0,
+      "an idle stream did not sit silent for 5 minutes",
+    );
   } finally {
     vi.useRealTimers();
   }

--- a/workers/mcp-session-hub.ts
+++ b/workers/mcp-session-hub.ts
@@ -91,6 +91,26 @@ export function isValidMcpSessionId(id: unknown): id is string {
 // residency for an abandoned/misbehaving one.
 export const MCP_SESSION_MAX_STREAM_DURATION_MS = 5 * 60 * 1000;
 
+/**
+ * How often an otherwise-idle stream writes a comment frame.
+ *
+ * THE STREAM HAS NOTHING TO SAY MOST OF THE TIME, and that is its normal
+ * state: it carries `notifications/resources/updated`, so a session watching a
+ * quiet subnet writes nothing for minutes. An idle TCP connection is what every
+ * intermediary in the path reaps -- and when one is reaped without the
+ * ReadableStream's `cancel` running, this object keeps believing it holds a
+ * live stream. See handleStream for what that cost.
+ *
+ * 30 seconds, comfortably under the shortest idle timeout in the path, and at
+ * most nine writes over the stream's whole bounded life. SSE comment frames
+ * (`: ...`) are ignored by every conformant client, including the EventSource
+ * built into browsers -- they exist in the spec for exactly this.
+ */
+export const MCP_SESSION_STREAM_KEEPALIVE_MS = 30 * 1000;
+
+/** The comment frame itself. Content is irrelevant; the bytes are the point. */
+export const MCP_SESSION_KEEPALIVE_FRAME = ": keepalive\n\n";
+
 // How long a session may sit with no subscribe/stream/touch activity before
 // this class self-terminates it (via a Durable Object alarm). Bounds a
 // session's total lifetime independent of whether any client ever reconnects
@@ -151,6 +171,7 @@ export class McpSessionHub implements DurableObject {
   terminated: boolean;
   streamController: ReadableStreamDefaultController | null;
   streamCloseTimer: ReturnType<typeof setTimeout> | null;
+  streamKeepaliveTimer: ReturnType<typeof setInterval> | null;
   hydrated: boolean;
   sessionId: string | null;
 
@@ -163,6 +184,7 @@ export class McpSessionHub implements DurableObject {
     this.terminated = false;
     this.streamController = null;
     this.streamCloseTimer = null;
+    this.streamKeepaliveTimer = null;
     this.hydrated = false;
     // A Durable Object cannot recover the string it was named with
     // (idFromName is one-way -- there is no idToName) -- every route that
@@ -487,22 +509,49 @@ export class McpSessionHub implements DurableObject {
     // and nulled the controller, every REMAINING pending uri was dropped
     // instead of being kept for the next open -- the exact opposite of what the
     // catch block is written to do.
-    if (!this.streamController) return;
-    this.sequence += 1;
+    //
+    // The absence check itself lives in writeToStream, which is now the only
+    // place that touches the controller: two guards for one fact is two places
+    // for it to be got wrong, and only the one beside the write can be sure.
+    //
+    // The sequence advances only on a frame that LANDED. It used to advance
+    // first, so an enqueue that threw still consumed an id -- and the ids are
+    // what a Last-Event-ID replay would count on, so a gap in them is a gap in
+    // the only record of what a client has seen.
     const frame = formatMcpSseEvent(
-      this.sequence,
+      this.sequence + 1,
       buildResourceUpdatedNotification(uri),
     );
+    if (!this.writeToStream(frame)) return;
+    this.sequence += 1;
+    this.pendingUris.delete(uri);
+  }
+
+  /**
+   * Write one frame, and tear the stream down if it will not take it.
+   *
+   * ONE WRITE PATH for notifications and keepalives alike, because "the
+   * enqueue threw" means the same thing either way: the stream is gone. The
+   * keepalive going through here is what turns a silently-dead connection into
+   * a discovered-dead one within 30 seconds -- previously nothing wrote to an
+   * idle stream at all, so a corpse was found only by the next real
+   * notification, which on a quiet session might be never.
+   *
+   * Returns whether the frame landed, so a caller can decide what to do with
+   * what it was trying to say. deliverNow leaves the uri pending for the next
+   * open; a keepalive has nothing to keep.
+   */
+  private writeToStream(frame: string): boolean {
+    if (!this.streamController) return false;
     try {
       this.streamController.enqueue(new TextEncoder().encode(frame));
-      this.pendingUris.delete(uri);
+      return true;
     } catch (error) {
-      // stream already closed/errored -- leave it pending for the next open
-      this.streamController = null;
       // #8997: the client silently stops receiving server-initiated messages,
-      // and nothing anywhere said so. Bounded, not a storm risk: clearing
-      // streamController above means handleNotify takes the pendingUris branch
-      // from here on, so this fires at most once per opened stream.
+      // and nothing anywhere said so. Bounded, not a storm risk: clearing the
+      // stream state means handleNotify takes the pendingUris branch from here
+      // on, so this fires at most once per opened stream.
+      this.clearStreamState();
       this.emit(() =>
         recordExceptionEvent(this.env, {
           error,
@@ -510,6 +559,45 @@ export class McpSessionHub implements DurableObject {
           errorCode: "upstream_unavailable",
         }),
       );
+      return false;
+    }
+  }
+
+  /**
+   * Forget the stream without touching the controller.
+   *
+   * For the two cases where the controller is ALREADY gone: the runtime ran
+   * `cancel`, or an enqueue threw. Calling `close()` on either would throw
+   * again in the middle of the handler that is cleaning up.
+   */
+  private clearStreamState(): void {
+    this.streamController = null;
+    // Casts: @types/node's global clear* overloads (auto-included repo-wide
+    // since scripts/tests run under real Node) do not cleanly accept a
+    // `Timeout | null` union even though each half is individually valid --
+    // see the workers/-specifics note in docs/typescript-migration-checklist.md.
+    clearTimeout(this.streamCloseTimer as unknown as number);
+    this.streamCloseTimer = null;
+    clearInterval(this.streamKeepaliveTimer as unknown as number);
+    this.streamKeepaliveTimer = null;
+  }
+
+  /**
+   * End the stream WE hold, from our side.
+   *
+   * The duration cap, a takeover by a newer GET, and termination all want this
+   * exact sequence, and each used to inline its own partial version -- the
+   * duration cap in particular closed the controller and nulled it without ever
+   * clearing the timers, which is how a takeover could inherit a stale one.
+   */
+  private closeStream(): void {
+    const controller = this.streamController;
+    this.clearStreamState();
+    if (!controller) return;
+    try {
+      controller.close();
+    } catch {
+      // already closed by the runtime; the state is cleared either way
     }
   }
 
@@ -533,18 +621,7 @@ export class McpSessionHub implements DurableObject {
     const effectiveSessionId = sessionId ?? this.sessionId;
     if (!this.terminated) {
       this.terminated = true;
-      if (this.streamController) {
-        try {
-          this.streamController.close();
-        } catch {
-          // already closed
-        }
-        this.streamController = null;
-      }
-      if (this.streamCloseTimer) {
-        clearTimeout(this.streamCloseTimer);
-        this.streamCloseTimer = null;
-      }
+      this.closeStream();
       const hadChain = this.subscribedUris.has(MCP_CHAIN_STREAM_RESOURCE_URI);
       const hadStatus = [...this.subscribedUris].some(
         (u) => parseSubnetStatusResourceUri(u) != null,
@@ -602,16 +679,29 @@ export class McpSessionHub implements DurableObject {
         headers: { "content-type": "application/json" },
       });
     }
-    if (this.streamController) {
-      return new Response(
-        JSON.stringify({
-          error:
-            "a stream is already open for this session; only one concurrent " +
-            "SSE stream per session is supported",
-        }),
-        { status: 409, headers: { "content-type": "application/json" } },
-      );
-    }
+    // THE NEWEST GET WINS, and this used to be a 409.
+    //
+    // Measured on the deployed server: 112 `stream_taken` refusals on one
+    // version, every one of them from a REAL client (claude-code, python-httpx)
+    // rather than a scanner, arriving on a five-minute metronome for
+    // three-quarters of an hour at a time. That is a client reconnecting and
+    // being told no, over and over, while its session sits with no push channel
+    // at all.
+    //
+    // The refusal was answering the wrong question. It asked "is a stream
+    // registered?" when what matters is "is a stream ALIVE?" -- and those come
+    // apart constantly, because a dropped connection does not reliably run the
+    // ReadableStream's `cancel` callback. When it does not, `streamController`
+    // stays set on a corpse and every reconnect is refused for the life of the
+    // session. This class's own five-minute cap depends on the reconnect it was
+    // refusing: the whole design is "we close, the client comes back".
+    //
+    // So the stream we are HOLDING is the doubtful one, and the client asking
+    // right now is demonstrably present. Closing the old one and handing over
+    // is strictly better in every case: if it was dead, the session is repaired;
+    // if it was alive, that client just replaced its own channel, which is what
+    // it asked to do.
+    this.closeStream();
     void this.touch();
     const stream = new ReadableStream({
       start: (controller) => {
@@ -621,31 +711,22 @@ export class McpSessionHub implements DurableObject {
         for (const uri of this.pendingUris) {
           this.deliverNow(uri);
         }
+        // The bytes that keep an idle stream from being reaped. Enqueued
+        // through the same guarded path a notification takes, so a keepalive
+        // landing on a stream that HAS died tears it down here -- which is the
+        // second half of the repair: the connection is now discovered dead
+        // within 30 seconds rather than never.
+        this.streamKeepaliveTimer = setInterval(() => {
+          this.writeToStream(MCP_SESSION_KEEPALIVE_FRAME);
+        }, MCP_SESSION_STREAM_KEEPALIVE_MS);
         this.streamCloseTimer = setTimeout(() => {
-          try {
-            controller.close();
-          } catch {
-            // already closed
-          }
-          this.streamController = null;
-          this.streamCloseTimer = null;
+          this.closeStream();
         }, MCP_SESSION_MAX_STREAM_DURATION_MS);
       },
+      // The client went away and the runtime told us. Clear the state without
+      // closing the controller -- it is already gone.
       cancel: () => {
-        // clearTimeout(null) is a safe no-op, and this callback can only
-        // ever run while the stream is still "readable" -- which by
-        // construction means streamCloseTimer is already set (start() sets
-        // it synchronously before returning control to any caller) -- so an
-        // unconditional clear is simpler than a defensive guard that can
-        // never see a falsy value.
-        this.streamController = null;
-        // Cast needed because @types/node's global clearTimeout overloads
-        // (auto-included repo-wide since scripts/tests run under real Node)
-        // don't cleanly accept a `Timeout | null` union even though each
-        // half is individually valid -- see the workers/-specifics note in
-        // docs/typescript-migration-checklist.md.
-        clearTimeout(this.streamCloseTimer as unknown as number);
-        this.streamCloseTimer = null;
+        this.clearStreamState();
       },
     });
     void url; // reserved for a future Last-Event-ID replay-from-cursor read


### PR DESCRIPTION
Found by reading PostHog MCP analytics rather than by looking at the code: **112 `stream_taken` refusals on the deployed version, every one of them from a real client** — claude-code and python-httpx, never a scanner — arriving on a five-minute metronome for three-quarters of an hour at a stretch, sustained across four days.

Five minutes is `MCP_SESSION_MAX_STREAM_DURATION_MS`. This class closes the SSE stream on that timer and depends on the client coming back. **The reconnect it depends on is exactly what it was refusing.**

```
15:19:58  15:24:58  15:29:59  15:34:58  15:39:59
15:44:58  15:49:59  15:54:59  16:00:00  16:04:59   ← all claude-code, all 409
```

## Why the refusal was answering the wrong question

`if (this.streamController) return 409` asks *"is a stream **registered**?"* when what matters is *"is a stream **alive**?"* — and those come apart constantly, because a dropped connection does not reliably run the ReadableStream's `cancel` callback. When it does not, `streamController` stays set on a corpse and **every reconnect is refused for the life of the session**, which then has no push channel at all, silently, while the server files the client's own reconnect as the client's error.

Nothing could correct it. `deliverNow` only releases a dead stream when it has something to deliver, and this stream carries `resources/updated` — a session watching a quiet subnet writes nothing for hours.

So: the stream we **hold** is the doubtful one, and the client asking right now is not. The newest GET takes the channel over. If the old one was dead, the session is repaired; if it was alive, that client just replaced its own channel, which is what it asked to do.

## And why an idle stream stopped being silent

Nothing was ever written between notifications — which is what let an intermediary reap the connection in the first place. A 30-second SSE comment frame (`: keepalive`, ignored by every conformant client, in the spec for exactly this) goes through the same guarded write path a notification takes, so a connection that **has** died is discovered within 30 seconds instead of never.

## Four faults stop sharing one label

`mcpRefusalReason` mapped every 400 to `bad_request`, and four gates produce one: a body that is not JSON, an unsupported protocol version, an empty batch, a batch over the ceiling. **27 of these from real Claude clients in a week**, under a label that says only "something was wrong with your POST".

Split on a response header the refusing gate sets — exactly as 429 already splits on `x-ratelimit-scope`. All four bucket as `validation`, the reading `bad_request` already had; what changes is that the caller is told which thing to change. The bare 400 keeps the generic label deliberately: a gate that sets no header is one this vocabulary has not been taught yet, and it must still bucket rather than fall through to `internal`.

## What else fell out

- **One guard for one fact.** `writeToStream` is the only thing that touches the controller; `deliverNow`'s duplicate check is gone.
- **The sequence advances only on a frame that landed.** It used to advance first, so an enqueue that threw still consumed an event id — and those ids are the only record of what a client has seen.
- **`closeStream` / `clearStreamState`** replace three partial inline teardowns. The duration cap in particular closed the controller without clearing its own timer, which is how a takeover could inherit a stale one.
- **The 409 pass-through in `src/mcp-server.ts` went with the refusal that produced it.** `/stream` answers 200 or 404 now. Its test stubbed a 409 the hub can no longer return — a state production cannot reach, asserted anyway. What replaces it asserts the property that held either way, across every decline: the client is told what to **do**, and never handed the Durable Object's own body.

## Verification

- **Patch coverage measured by intersecting the diff with the coverage report: 0 uncovered lines, 0 uncovered branches.**
- Full suite: 21,034 pass, 921 files, zero failures.
- All 55 CI validators pass locally, including `validate:boundary-casts` from #11233.
- Every claim falsified: restoring the 409 turns the takeover test red; removing the keepalive interval turns the keepalive test red; dropping one gate's refusal header turns the label test red.

## Expected effect

`stream_taken` goes to zero — 113 of the ~305 null-tool transport refusals on the current version. The remainder are MCP directory crawlers (`undici`, `MCPCensus`, `AIVE-MCP-EndpointProbe`, `agent-tools.cloud-crawler`) HEADing `/mcp`, which get a correct 405 with `Allow` and are working as designed.
