### PR TITLE
fix(ui): every subnet card unfurled with three tofu boxes, from one unencoded percent

### DIFF
--- a/apps/ui/src/lib/metagraphed/og-card-limits.ts
+++ b/apps/ui/src/lib/metagraphed/og-card-limits.ts
@@ -1,0 +1,47 @@
+// The /og card's field bounds, in ONE place.
+//
+// The card has two sides that deliberately share no code -- og-card.ts builds
+// the URL and is client-bundled, src/lib/og-image.ts renders it and is
+// Worker-only (it pulls in satori). They had two copies of these numbers, and a
+// copy that only the renderer enforced is exactly how a URL gets built that the
+// renderer then refuses: adding the first-party logo path (#11204) pushed the
+// worst legitimate card to 548 characters of query against a 512 cap, and /og
+// answers 414 above it -- an unfurl with no image at all.
+//
+// Constants only, no imports, so both sides can take it without either one
+// dragging the other's dependencies in.
+
+/** Per-field caps. Every one is enforced on BOTH sides. */
+export const OG_LIMITS = {
+  title: 110,
+  subtitle: 90,
+  eyebrow: 32,
+  statLabel: 24,
+  statValue: 28,
+  /** A bare DNS name, never a URL — see normalizeLogoHost. */
+  logoHost: 80,
+  /**
+   * The renderer's guard on total query size.
+   *
+   * This bounds PARSE cost on an unauthenticated endpoint; it is not what keeps
+   * the card from overflowing -- the per-field caps above do that, after
+   * parsing. So it has to be generous enough that no legitimate card is ever
+   * refused: the fields sum to ~550 characters once encoded, and a title in a
+   * script that percent-encodes to three bytes a character multiplies part of
+   * that severalfold. 2048 leaves room for both while still refusing input
+   * that could only be someone probing the endpoint.
+   */
+  query: 2048,
+} as const;
+
+/**
+ * Bound one card field, ending it with an ellipsis when it had to be cut.
+ *
+ * The single truncation rule for the card. Both sides apply it: the builder so
+ * the URL stays short and honest about what will be painted, the renderer
+ * because /og is public and must never trust its query.
+ */
+export function clampCardText(value: string | null | undefined, max: number): string {
+  const trimmed = (value || "").trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+}

--- a/apps/ui/src/lib/metagraphed/og-card.test.ts
+++ b/apps/ui/src/lib/metagraphed/og-card.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOgImageUrl,
+  firstPartyLogoPath,
+  healthFromStatusCounts,
+  logoHostFrom,
+  ogImageMeta,
+} from "./og-card";
+import { OG_LIMITS } from "./og-card-limits";
+
+// The route → card adapters (#11204). Each one exists because the obvious
+// reduction threw away the better answer; the tests below pin the case that
+// motivated it, not just the happy path.
+
+describe("firstPartyLogoPath — the registry's own curated logo", () => {
+  it("accepts both shapes the registry actually stores", () => {
+    // Subnets: a content-addressed cache entry (all 60 that have a logo).
+    expect(firstPartyLogoPath(`https://metagraph.sh/logos/cache/${"a".repeat(64)}.png`)).toBe(
+      `/logos/cache/${"a".repeat(64)}.png`,
+    );
+    // Providers: a slug (102 of 138).
+    expect(firstPartyLogoPath("https://metagraph.sh/logos/404-gen.png")).toBe("/logos/404-gen.png");
+    expect(firstPartyLogoPath("https://metagraph.sh/logos/albedo.svg")).toBe("/logos/albedo.svg");
+  });
+
+  it("takes the light/dark object form the same way BrandIcon does", () => {
+    expect(firstPartyLogoPath({ light: "https://metagraph.sh/logos/adtao.png" })).toBe(
+      "/logos/adtao.png",
+    );
+  });
+
+  it("refuses anything that is not ours, and anything off the two shapes", () => {
+    // A third-party host, even at a path that would otherwise match: the asset
+    // is read from OUR ASSETS binding, so the origin is not the caller's.
+    expect(firstPartyLogoPath("https://evil.example/logos/404-gen.png")).toBeNull();
+    // Traversal cannot be spelled — the name charset excludes ".".
+    expect(firstPartyLogoPath("https://metagraph.sh/logos/../../secret.png")).toBeNull();
+    expect(firstPartyLogoPath("https://metagraph.sh/logos/nested/dir/x.png")).toBeNull();
+    expect(firstPartyLogoPath("https://metagraph.sh/logos/script.svg.js")).toBeNull();
+    expect(firstPartyLogoPath("https://metagraph.sh/index.html")).toBeNull();
+    expect(firstPartyLogoPath(null, undefined, "")).toBeNull();
+  });
+
+  it("returns the FIRST usable candidate, so callers can pass a preference order", () => {
+    expect(
+      firstPartyLogoPath("https://example.com/x.png", "https://metagraph.sh/logos/almanac.png"),
+    ).toBe("/logos/almanac.png");
+  });
+});
+
+describe("logoHostFrom — our own host is not an identity", () => {
+  it("skips a first-party logo URL so the entity's real site wins", () => {
+    // This is the bug: the registry caches a subnet's logo on OUR domain, so
+    // reducing it to a host asked the favicon proxy for metagraph.sh — which
+    // has no icon there, so all 60 subnets with a curated logo showed a
+    // monogram. The website is the next-best identity and must not be shadowed.
+    expect(
+      logoHostFrom(`https://metagraph.sh/logos/cache/${"b".repeat(64)}.png`, "https://chutes.ai"),
+    ).toBe("chutes.ai");
+  });
+
+  it("returns null rather than our own host when there is no other candidate", () => {
+    expect(logoHostFrom("https://metagraph.sh/logos/404-gen.png")).toBeNull();
+  });
+
+  it("still reduces a third-party URL, and accepts a bare host", () => {
+    expect(logoHostFrom("https://Apex.Macrocosmos.ai/path?q=1")).toBe("apex.macrocosmos.ai");
+    expect(logoHostFrom("chutes.ai")).toBe("chutes.ai");
+    expect(logoHostFrom("not a url", "https://tao.bot")).toBe("tao.bot");
+  });
+});
+
+describe("healthFromStatusCounts — a summary of probe verdicts, not a judgement", () => {
+  it("summarizes the three cases", () => {
+    expect(healthFromStatusCounts({ ok: 8 })).toBe("ok");
+    expect(healthFromStatusCounts({ ok: 6, down: 2 })).toBe("warn");
+    expect(healthFromStatusCounts({ down: 3 })).toBe("down");
+  });
+
+  it("declines to answer when there is nothing to summarize", () => {
+    // Null, not "unknown": the card falls back to its brand bullet rather than
+    // asserting a health state nothing measured.
+    expect(healthFromStatusCounts(null)).toBeNull();
+    expect(healthFromStatusCounts(undefined)).toBeNull();
+    expect(healthFromStatusCounts({})).toBeNull();
+    expect(healthFromStatusCounts({ ok: 0, down: 0 })).toBeNull();
+  });
+
+  it("ignores non-numeric counts rather than counting them as endpoints", () => {
+    expect(healthFromStatusCounts({ ok: 4, bogus: Number.NaN } as Record<string, number>)).toBe(
+      "ok",
+    );
+  });
+});
+
+describe("buildOgImageUrl", () => {
+  it("carries the first-party logo path as logop, which the renderer prefers", () => {
+    const url = new URL(
+      buildOgImageUrl({ title: "404-GEN", logoPath: "/logos/404-gen.png", entity: true }),
+    );
+    expect(url.searchParams.get("logop")).toBe("/logos/404-gen.png");
+  });
+
+  it("omits every absent field so the card's own fallbacks apply", () => {
+    const url = new URL(buildOgImageUrl({ title: "Chutes" }));
+    expect(url.searchParams.get("logop")).toBeNull();
+    expect(url.searchParams.get("logo")).toBeNull();
+    expect(url.searchParams.get("status")).toBeNull();
+  });
+
+  it("clamps every field, so the URL says only what the card will paint", () => {
+    const url = new URL(
+      buildOgImageUrl({
+        title: "t".repeat(500),
+        subtitle: "s".repeat(500),
+        eyebrow: "e".repeat(500),
+        stats: [{ label: "l".repeat(500), value: "v".repeat(500) }],
+      }),
+    );
+    expect(url.searchParams.get("title")).toHaveLength(OG_LIMITS.title);
+    expect(url.searchParams.get("subtitle")).toHaveLength(OG_LIMITS.subtitle);
+    expect(url.searchParams.get("eyebrow")).toHaveLength(OG_LIMITS.eyebrow);
+    expect(url.searchParams.get("stat1")).toHaveLength(OG_LIMITS.statLabel);
+    expect(url.searchParams.get("stat1v")).toHaveLength(OG_LIMITS.statValue);
+  });
+
+  it("cannot build a URL the renderer would refuse, even at every field's cap", () => {
+    // The regression this guards: /og answers 414 over OG_LIMITS.query and the
+    // page unfurls with NO image. Adding the first-party logo path took the
+    // worst legitimate card to 548 characters against a 512 cap.
+    const url = new URL(
+      buildOgImageUrl({
+        title: "t".repeat(OG_LIMITS.title),
+        subtitle: "s".repeat(OG_LIMITS.subtitle),
+        eyebrow: "e".repeat(OG_LIMITS.eyebrow),
+        logoPath: `/logos/cache/${"c".repeat(64)}.png`,
+        logoHost: `${"h".repeat(OG_LIMITS.logoHost - 4)}.com`,
+        status: "unknown",
+        entity: true,
+        stats: [1, 2, 3].map(() => ({
+          label: "l".repeat(OG_LIMITS.statLabel),
+          value: "v".repeat(OG_LIMITS.statValue),
+        })),
+      }),
+    );
+    expect(url.search.length).toBeLessThanOrEqual(OG_LIMITS.query);
+  });
+});
+
+describe("ogImageMeta", () => {
+  it("emits the alt text a route-owned card was silently missing", () => {
+    // Only the server-injected card carried og:image:alt, so every page that
+    // took ownership of its own card lost what a screen reader announces.
+    const meta = ogImageMeta({ title: "Chutes", subtitle: "SN64 — compute" });
+    expect(meta).toContainEqual({ property: "og:image:alt", content: "Chutes — SN64 — compute" });
+    expect(meta).toContainEqual({ name: "twitter:image:alt", content: "Chutes — SN64 — compute" });
+  });
+
+  it("falls back to the title alone when there is no subtitle", () => {
+    const meta = ogImageMeta({ title: "Chutes" });
+    expect(meta).toContainEqual({ property: "og:image:alt", content: "Chutes" });
+  });
+
+  it("points every image tag at the same card", () => {
+    const meta = ogImageMeta({ title: "Chutes" });
+    const urls = new Set(
+      meta
+        .filter((tag) => "property" in tag || tag.name === "twitter:image")
+        .map((tag) => tag.content)
+        .filter((content) => content.includes("/og?")),
+    );
+    expect(urls.size).toBe(1);
+  });
+});

--- a/apps/ui/src/lib/metagraphed/og-card.ts
+++ b/apps/ui/src/lib/metagraphed/og-card.ts
@@ -1,4 +1,5 @@
 import { SITE_ORIGIN } from "./identity";
+import { clampCardText, OG_LIMITS } from "./og-card-limits";
 
 // Builds the /og card URL a route puts in its own og:image (#8489).
 //
@@ -37,6 +38,13 @@ export interface OgCardOptions {
    * SSRF-safe icon proxy; absent, it falls back to a monogram. */
   logoHost?: string | null;
   /**
+   * Path to one of OUR OWN cached logo assets (use `firstPartyLogoPath`),
+   * e.g. `/logos/cache/<sha256>.png`. Preferred over `logoHost` when present:
+   * it is the logo the registry curated, and the card reads it from the
+   * Worker's ASSETS binding rather than guessing at a favicon.
+   */
+  logoPath?: string | null;
+  /**
    * Health state ("ok" | "warn" | "down" | "unknown") — colours the card's
    * footer dot the way the site's health pill colours itself. Anything outside
    * that vocabulary is dropped by the renderer rather than guessed at.
@@ -59,15 +67,22 @@ export interface OgCardOptions {
  * Absolute /og URL carrying this page's card content.
  *
  * Only non-empty values are appended, so the card's own fallbacks apply
- * naturally and the URL stays short -- the endpoint rejects a query over
- * MAX_QUERY_LENGTH (512), and every param here is additionally length-bounded
- * on the render side.
+ * naturally and the URL stays short -- the endpoint refuses an over-long query
+ * outright, and every param is bounded on both sides from OG_LIMITS.
  */
 export function buildOgImageUrl(options: OgCardOptions): string {
-  const params = new URLSearchParams({ title: options.title });
-  if (options.subtitle) params.set("subtitle", options.subtitle);
-  if (options.eyebrow) params.set("eyebrow", options.eyebrow);
-  if (options.logoHost) params.set("logo", options.logoHost);
+  // Clamped HERE as well as in the renderer, from the same shared bounds. The
+  // renderer truncates anyway, so an over-long value only ever bought a longer
+  // URL -- and once the first-party logo path joined the query (#11204) that
+  // slack was enough to push a legitimate card past the endpoint's own
+  // MAX_QUERY_LENGTH, which answers 414 and unfurls with no image at all.
+  const params = new URLSearchParams({ title: clampCardText(options.title, OG_LIMITS.title) });
+  const subtitle = clampCardText(options.subtitle, OG_LIMITS.subtitle);
+  if (subtitle) params.set("subtitle", subtitle);
+  const eyebrow = clampCardText(options.eyebrow, OG_LIMITS.eyebrow);
+  if (eyebrow) params.set("eyebrow", eyebrow);
+  if (options.logoPath) params.set("logop", options.logoPath);
+  if (options.logoHost) params.set("logo", options.logoHost.slice(0, OG_LIMITS.logoHost));
   if (options.status) params.set("status", options.status);
   // The flag tells the renderer which fallback to use when there is no icon: a
   // monogram for a named thing, our mark for one of our own pages. "TA" is
@@ -77,9 +92,13 @@ export function buildOgImageUrl(options: OgCardOptions): string {
   // Only the first three stats are rendered; sending more would just push the
   // URL toward the length cap for content the card ignores.
   (options.stats ?? []).slice(0, 3).forEach((stat, index) => {
-    if (!stat.label || !stat.value) return;
-    params.set(`stat${index + 1}`, stat.label);
-    params.set(`stat${index + 1}v`, stat.value);
+    const label = clampCardText(stat.label, OG_LIMITS.statLabel);
+    const value = clampCardText(stat.value, OG_LIMITS.statValue);
+    // Both halves required, matching readCardParams: a value with no label is
+    // unreadable, and a label with no value is an empty promise.
+    if (!label || !value) return;
+    params.set(`stat${index + 1}`, label);
+    params.set(`stat${index + 1}v`, value);
   });
   return `${SITE_ORIGIN}/og?${params.toString()}`;
 }
@@ -106,7 +125,14 @@ export function logoHostFrom(
     try {
       // Accept a bare host too, not just an absolute URL.
       const url = new URL(raw.includes("://") ? raw : `https://${raw}`);
-      if (url.hostname) return url.hostname.toLowerCase();
+      // OUR host is never an identity signal. The registry caches an entity's
+      // logo at metagraph.sh/logos/cache/<sha>.<ext>, and reducing that to a
+      // host asks the favicon proxy for METAGRAPHED's icon — so an entity that
+      // has a curated logo would wear our mark, or (as today, since the proxy
+      // has no icon for us) fall through to a monogram. Those URLs are handled
+      // by firstPartyLogoPath instead; here they must not shadow the entity's
+      // own website, which is the next-best identity we have.
+      if (url.hostname && !isFirstPartyHost(url.hostname)) return url.hostname.toLowerCase();
     } catch {
       // Unparseable candidate — try the next one rather than failing the card.
     }
@@ -114,14 +140,90 @@ export function logoHostFrom(
   return null;
 }
 
+const SITE_HOST = new URL(SITE_ORIGIN).hostname.toLowerCase();
+
+function isFirstPartyHost(hostname: string): boolean {
+  return hostname.toLowerCase() === SITE_HOST;
+}
+
+/**
+ * The two shapes the registry's own logo assets take: a subnet's
+ * content-addressed cache entry, and a provider's slug.
+ *
+ * Mirrors `LOGO_ASSET_PATH` in src/lib/og-image.ts, which validates the param
+ * again on the way in — /og is a public endpoint and must never trust a
+ * caller, including us. The name charset excludes `.`, so `..` cannot be
+ * spelled and the path can only ever name an image this repo ships.
+ */
+const LOGO_ASSET_PATH =
+  /^\/logos\/(?:cache\/[0-9a-f]{64}|[a-z0-9][a-z0-9-]{0,62})\.(?:png|svg|jpg|jpeg|webp)$/;
+
+/** The first candidate that is one of OUR OWN logo assets, as a path. */
+export function firstPartyLogoPath(
+  ...candidates: Array<string | { light?: string; dark?: string } | null | undefined>
+): string | null {
+  for (const candidate of candidates) {
+    const raw =
+      typeof candidate === "string" ? candidate : (candidate?.dark ?? candidate?.light ?? null);
+    if (!raw) continue;
+    try {
+      const url = new URL(raw, SITE_ORIGIN);
+      if (!isFirstPartyHost(url.hostname)) continue;
+      if (LOGO_ASSET_PATH.test(url.pathname)) {
+        return url.pathname;
+      }
+    } catch {
+      // Unparseable candidate — try the next one.
+    }
+  }
+  return null;
+}
+
+/**
+ * Summarize per-endpoint probe verdicts into the card's one status dot.
+ *
+ * A SUMMARY of probe-derived counts, never a health judgement of our own: the
+ * input is `endpoint_summary.by_status`, which the prober owns, and the rule is
+ * the obvious one — all monitored endpoints ok is ok, none ok is down, a mix is
+ * warn. Returns null when there is nothing to summarize, so the card falls back
+ * to its brand-coloured bullet instead of asserting "unknown".
+ *
+ * Lives here because this is where a route's data becomes card params, next to
+ * logoHostFrom and firstPartyLogoPath.
+ */
+export function healthFromStatusCounts(
+  byStatus: Record<string, number> | undefined | null,
+): "ok" | "warn" | "down" | null {
+  if (!byStatus) return null;
+  let ok = 0;
+  let total = 0;
+  for (const [status, count] of Object.entries(byStatus)) {
+    if (typeof count !== "number" || !Number.isFinite(count) || count <= 0) continue;
+    total += count;
+    if (status === "ok") ok += count;
+  }
+  if (total === 0) return null;
+  if (ok === total) return "ok";
+  return ok === 0 ? "down" : "warn";
+}
+
 /** The og:image + twitter:image meta a route's head() returns. */
 export function ogImageMeta(options: OgCardOptions) {
   const url = buildOgImageUrl(options);
+  // #11204: og:image:alt was emitted ONLY by the server-injected card, so every
+  // page that took ownership of its own card silently lost it -- all 129 subnet
+  // pages, every validator, account, doc and news page. It is what a screen
+  // reader announces for an unfurl and what several platforms show as the
+  // caption, and the card's own copy is exactly the right text: it IS what the
+  // image says. Built the same way server.ts builds its own.
+  const alt = options.subtitle ? `${options.title} — ${options.subtitle}` : options.title;
   return [
     { property: "og:image", content: url },
     { property: "og:image:width", content: "1200" },
     { property: "og:image:height", content: "630" },
+    { property: "og:image:alt", content: alt },
     { name: "twitter:image", content: url },
+    { name: "twitter:image:alt", content: alt },
   ];
 }
 
@@ -143,6 +245,12 @@ export function routeOwnsOgImage(pathname: string): boolean {
     /^\/subnets\/[^/]+\/?$/.test(pathname) ||
     /^\/validators\/[^/]+\/?$/.test(pathname) ||
     /^\/accounts\/[^/]+\/?$/.test(pathname) ||
+    // #11204: /providers/* too. All 138 provider pages were unfurling the
+    // pathname-derived card -- the raw slug as a title ("404-gen"), no logo and
+    // no numbers -- because server.ts builds that card from the URL alone. The
+    // route has the provider's real name, its curated logo and its endpoint
+    // counts in loaderData, and 102 of the 138 have a logo to show.
+    /^\/providers\/[^/]+\/?$/.test(pathname) ||
     // #8624: /docs/* too. The docs splat route has the page's real title and
     // description in loaderData; server.ts, working from the pathname alone,
     // gave all 20 doc pages the identical brand card. Note this matches the

--- a/apps/ui/src/lib/og-image.test.ts
+++ b/apps/ui/src/lib/og-image.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CARD_GLYPHS,
+  fontSubsetText,
   glyphsForMarkup,
+  googleFontUrl,
+  loadCardFont,
   iconProxyUrl,
   markDataUri,
   monogramFor,
   normalizeLogoHost,
+  normalizeLogoPath,
+  assetsBindingFrom,
+  resolveLocalLogo,
   normalizeSubtitle,
   normalizeTitle,
   readCardParams,
@@ -98,6 +105,7 @@ describe("readCardParams (#8489)", () => {
     expect(readCardParams(p)).toEqual({
       eyebrow: "Subnet",
       logoHost: null,
+      logoPath: null,
       entity: false,
       status: null,
       stats: [
@@ -130,6 +138,7 @@ describe("readCardParams (#8489)", () => {
       eyebrow: null,
       stats: [],
       logoHost: null,
+      logoPath: null,
       entity: false,
       status: null,
     });
@@ -595,5 +604,201 @@ describe("ink foot (#8622) — the card ends on the app's dark theme, not a whit
 
     const theirs = renderCardMarkup({ ...base, stats: [], icon: "data:image/png;base64,AAAA" });
     expect(theirs).toMatch(/margin-top:4px;background:#FFFFFF;border:1px solid #E9EAEA;/);
+  });
+});
+
+describe("font subset request (#11204) — the bug that painted three tofu boxes", () => {
+  // The live /subnets/1 card, verbatim: an em dash in the subtitle, an ellipsis
+  // from truncation, a tau in the price and a percent in the emission share.
+  const APEX = {
+    title: "Apex",
+    subtitle:
+      "Apex (SN1): Bittensor subnet 1 — interfaces, endpoints, schemas, machine-readable on Metagraphed…",
+    eyebrow: "Subnet",
+    entity: true,
+    stats: [
+      { label: "Netuid", value: "SN1" },
+      { label: "Price", value: "0.0080 τ" },
+      { label: "Emission", value: "0.61%" },
+    ],
+  };
+
+  it("percent-encodes the subset text, which is the entire fix", () => {
+    // workers-og's loadGoogleFont encodes `family` and interpolates `text` RAW.
+    // One `%` in the copy — an emission share of "0.61%" is enough — leaves a
+    // bare percent in the query value, Google stops decoding the parameter, and
+    // the %E2%80%94 / %E2%80%A6 / %CF%84 escapes for "—", "…" and "τ" are
+    // subset as their literal hex letters. Measured against the live endpoint:
+    // with the percent encoded all three glyphs come back, without it none do.
+    const text = "0.61% Rock & Roll #1 a+b —…τ";
+    const url = new URL(googleFontUrl("Space Grotesk", 700, text));
+    expect(url.searchParams.get("text")).toBe(text);
+    expect(url.searchParams.get("family")).toBe("Space Grotesk:wght@700");
+  });
+
+  it("would NOT survive the raw interpolation it replaces", () => {
+    // Proves the assertion above can fail: the same string built the way
+    // workers-og builds it loses everything from the first "&" onward, and the
+    // "#" turns the rest into a fragment.
+    const text = "0.61% Rock & Roll #1 a+b —…τ";
+    const raw = new URL(`https://fonts.googleapis.com/css2?family=X&text=${text}`);
+    expect(raw.searchParams.get("text")).not.toBe(text);
+  });
+
+  it("subsets every character the real subnet card paints", () => {
+    const markup = renderCardMarkup(APEX);
+    const subset = new Set(fontSubsetText(markup));
+    for (const char of glyphsForMarkup(markup)) {
+      if ((char.codePointAt(0) ?? 0) < 0x20) continue;
+      expect(subset.has(char)).toBe(true);
+    }
+    for (const char of "—…τ%") expect(subset.has(char)).toBe(true);
+  });
+
+  it("needs no card-specific extras for that card, so the request is cacheable", () => {
+    // The fixed repertoire is what lets caches.default hit: a per-card subset
+    // put the card's own prose in the URL, so every render missed.
+    expect(fontSubsetText(renderCardMarkup(APEX))).toBe(CARD_GLYPHS);
+  });
+
+  it("appends genuinely exotic characters, sorted so two cards can share an entry", () => {
+    const extra = fontSubsetText(renderCardMarkup({ ...APEX, title: "Ωmega ыдра" })).slice(
+      CARD_GLYPHS.length,
+    );
+    expect(extra).toContain("Ω");
+    expect(extra).toContain("ы");
+    expect([...extra]).toStrictEqual([...extra].sort());
+  });
+
+  it("never sends the newlines between tags — they are not glyphs", () => {
+    // glyphsForMarkup keeps them (it reports what the template contains);
+    // the subset request must not, or the URL varies for nothing.
+    const isControl = (text: string) => [...text].some((c) => (c.codePointAt(0) ?? 0) < 0x20);
+    expect(isControl(glyphsForMarkup(renderCardMarkup(APEX)))).toBe(true);
+    expect(isControl(fontSubsetText(renderCardMarkup(APEX)))).toBe(false);
+  });
+});
+
+describe("loadCardFont (#11204) — we own the two fetches, not workers-og", () => {
+  const truetypeCss = (url: string) =>
+    `@font-face {\n  font-family: 'X';\n  src: url(${url}) format('truetype');\n}`;
+
+  it("resolves the TrueType face and asks for it with the UA that returns one", async () => {
+    // Google serves woff2 to anything modern, and satori cannot parse woff2.
+    const seen: Array<{ url: string; ua: string | null }> = [];
+    const fetchImpl = (async (input: string, init?: RequestInit) => {
+      seen.push({ url: String(input), ua: new Headers(init?.headers).get("user-agent") });
+      return seen.length === 1
+        ? new Response(truetypeCss("https://fonts.gstatic.com/l/font?kit=abc"))
+        : new Response(new Uint8Array([1, 2, 3]));
+    }) as unknown as typeof fetch;
+
+    const bytes = await loadCardFont("Test Alpha", 700, "abc", fetchImpl);
+    expect(new Uint8Array(bytes)).toStrictEqual(new Uint8Array([1, 2, 3]));
+    expect(seen[0]?.url).toBe(googleFontUrl("Test Alpha", 700, "abc"));
+    expect(seen[0]?.ua).toMatch(/Safari\/533/);
+    expect(seen[1]?.url).toBe("https://fonts.gstatic.com/l/font?kit=abc");
+  });
+
+  it("rejects when the CSS carries no TrueType face rather than returning junk", async () => {
+    const fetchImpl = (async () =>
+      new Response("@font-face { src: url(x.woff2) format('woff2'); }")) as unknown as typeof fetch;
+    await expect(loadCardFont("Test Beta", 400, "abc", fetchImpl)).rejects.toThrow(/No TrueType/);
+  });
+
+  it("rejects on a non-ok response instead of subsetting an error page", async () => {
+    const fetchImpl = (async () =>
+      new Response("nope", { status: 503 })) as unknown as typeof fetch;
+    await expect(loadCardFont("Test Gamma", 400, "abc", fetchImpl)).rejects.toThrow(/503/);
+  });
+
+  it("fetches a face once per isolate — the fixed repertoire makes that one entry", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response(truetypeCss("https://fonts.gstatic.com/l/font?kit=d"))
+        : new Response(new Uint8Array([9]));
+    }) as unknown as typeof fetch;
+
+    await loadCardFont("Test Delta", 500, "abc", fetchImpl);
+    await loadCardFont("Test Delta", 500, "abc", fetchImpl);
+    // The CSS and the binary, once each — not four fetches.
+    expect(calls).toBe(2);
+  });
+
+  it("does NOT memoize a failure, or one hiccup blanks every later card", async () => {
+    let attempt = 0;
+    const fetchImpl = (async () => {
+      attempt += 1;
+      if (attempt === 1) return new Response("nope", { status: 500 });
+      return attempt === 2
+        ? new Response(truetypeCss("https://fonts.gstatic.com/l/font?kit=e"))
+        : new Response(new Uint8Array([7]));
+    }) as unknown as typeof fetch;
+
+    await expect(loadCardFont("Test Epsilon", 400, "abc", fetchImpl)).rejects.toThrow(/500/);
+    expect(new Uint8Array(await loadCardFont("Test Epsilon", 400, "abc", fetchImpl))).toStrictEqual(
+      new Uint8Array([7]),
+    );
+  });
+});
+
+describe("first-party logo assets (#11204) — read, never fetched", () => {
+  it("accepts the two shapes the registry stores and nothing else", () => {
+    expect(normalizeLogoPath(`/logos/cache/${"a".repeat(64)}.png`)).toBe(
+      `/logos/cache/${"a".repeat(64)}.png`,
+    );
+    expect(normalizeLogoPath("/logos/404-gen.png")).toBe("/logos/404-gen.png");
+    expect(normalizeLogoPath("/logos/albedo.svg")).toBe("/logos/albedo.svg");
+  });
+
+  it("refuses traversal, nesting, absolute URLs and unknown extensions", () => {
+    // The endpoint is public, so the param is validated here too even though
+    // firstPartyLogoPath already validated it on the way out.
+    expect(normalizeLogoPath("/logos/../../etc/passwd.png")).toBeNull();
+    expect(normalizeLogoPath("/logos/a/b.png")).toBeNull();
+    expect(normalizeLogoPath("https://evil.example/logos/x.png")).toBeNull();
+    expect(normalizeLogoPath("/logos/x.js")).toBeNull();
+    expect(normalizeLogoPath("/logos/CAPS.png")).toBeNull();
+    expect(normalizeLogoPath(null)).toBeNull();
+  });
+
+  it("reads the asset through the ASSETS binding, not the network", async () => {
+    // This Worker SERVES metagraph.sh, and a Worker fetching its own custom
+    // domain gets 522 — so a plain fetch would never resolve the logo.
+    const seen: string[] = [];
+    const assets = {
+      fetch: async (input: Request) => {
+        seen.push(input.url);
+        return new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-type": "image/png" },
+        });
+      },
+    };
+    const uri = await resolveLocalLogo("/logos/404-gen.png", assets, "https://metagraph.sh");
+    expect(uri).toBe("data:image/png;base64,AQID");
+    expect(seen).toStrictEqual(["https://metagraph.sh/logos/404-gen.png"]);
+  });
+
+  it("falls through to the monogram on a miss instead of an empty tile", async () => {
+    const missing = { fetch: async () => new Response("", { status: 404 }) };
+    expect(await resolveLocalLogo("/logos/x.png", missing, "https://metagraph.sh")).toBeNull();
+    const throwing = {
+      fetch: async () => {
+        throw new Error("binding exploded");
+      },
+    };
+    expect(await resolveLocalLogo("/logos/x.png", throwing, "https://metagraph.sh")).toBeNull();
+    expect(await resolveLocalLogo("/logos/x.png", null, "https://metagraph.sh")).toBeNull();
+  });
+
+  it("narrows env to a real binding, so a missing one degrades quietly", () => {
+    const assets = { fetch: async () => new Response("") };
+    expect(assetsBindingFrom({ ASSETS: assets })).toBe(assets);
+    expect(assetsBindingFrom({})).toBeNull();
+    expect(assetsBindingFrom(null)).toBeNull();
+    expect(assetsBindingFrom(undefined)).toBeNull();
+    expect(assetsBindingFrom({ ASSETS: { fetch: "not a function" } })).toBeNull();
   });
 });

--- a/apps/ui/src/lib/og-image.ts
+++ b/apps/ui/src/lib/og-image.ts
@@ -38,6 +38,8 @@
 // it pulls in a yoga `.wasm` that Node's ESM loader can't resolve, which would
 // break `vite dev` SSR for every route. It only has to work on the Cloudflare
 // Worker, which reaches the dynamic import only on an actual /og request.
+import { clampCardText, OG_LIMITS } from "./metagraphed/og-card-limits";
+
 type WorkersOg = typeof import("workers-og");
 
 const OG_PATH = "/og";
@@ -152,21 +154,13 @@ function isHealthState(value: string): boolean {
 // edge cache for its full 7-day stale-while-revalidate window. Bumped to "3"
 // for the #8489 rebuild -- every previously cached card is the old plain-text
 // one and must be retired -- and to "4" for the light-theme pass, which
-// changes every pixel of every card.
-const CARD_VERSION = "4";
+// changes every pixel of every card. "5" retires every card cached with the
+// broken font subset (#11204): each one painted `.notdef` boxes for the em
+// dash, the ellipsis and the tau, and would otherwise keep serving them for
+// the full 7-day stale-while-revalidate window after the fix ships.
+const CARD_VERSION = "5";
 
-const MAX_SUBTITLE_LENGTH = 90;
 const DEFAULT_TITLE = "Metagraphed";
-const MAX_TITLE_LENGTH = 110;
-// #8489: bounds for the new entity params, same posture as title/subtitle --
-// this is an unauthenticated endpoint crawlers hit, so every interpolated
-// value is both length-bounded AND escaped.
-const MAX_EYEBROW_LENGTH = 32;
-const MAX_STAT_LABEL_LENGTH = 24;
-const MAX_STAT_VALUE_LENGTH = 28;
-/** A bare DNS name, e.g. "chutes.ai". Never a URL — see readCardParams. */
-const MAX_LOGO_HOST_LENGTH = 80;
-const MAX_QUERY_LENGTH = 512;
 const CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
 
 /**
@@ -252,8 +246,7 @@ export function sanitizeText(value: string): string {
 }
 
 export function normalizeTitle(value: string | null): string {
-  const trimmed = (value || DEFAULT_TITLE).trim() || DEFAULT_TITLE;
-  return trimmed.length > MAX_TITLE_LENGTH ? `${trimmed.slice(0, MAX_TITLE_LENGTH - 1)}…` : trimmed;
+  return clampCardText((value || "").trim() || DEFAULT_TITLE, OG_LIMITS.title);
 }
 
 /**
@@ -263,11 +256,7 @@ export function normalizeTitle(value: string | null): string {
  * bounded like the title so a long one can't overflow the card.
  */
 export function normalizeSubtitle(value: string | null): string {
-  const trimmed = (value || "").trim();
-  if (!trimmed) return SUBTITLE;
-  return trimmed.length > MAX_SUBTITLE_LENGTH
-    ? `${trimmed.slice(0, MAX_SUBTITLE_LENGTH - 1)}…`
-    : trimmed;
+  return clampCardText((value || "").trim() || SUBTITLE, OG_LIMITS.subtitle);
 }
 
 /**
@@ -278,9 +267,7 @@ export function normalizeSubtitle(value: string | null): string {
  * `?:` rather than scattered emptiness checks.
  */
 export function normalizeParam(value: string | null, max: number): string | null {
-  const trimmed = (value || "").trim();
-  if (!trimmed) return null;
-  return trimmed.length > max ? `${trimmed.slice(0, max - 1)}…` : trimmed;
+  return clampCardText(value, max) || null;
 }
 
 /** One "LABEL / value" cell in the card's stat rail. */
@@ -319,11 +306,13 @@ export function readCardParams(params: URLSearchParams): {
   eyebrow: string | null;
   stats: OgStat[];
   logoHost: string | null;
+  logoPath: string | null;
   entity: boolean;
   status: string | null;
 } {
-  const eyebrow = normalizeParam(params.get("eyebrow"), MAX_EYEBROW_LENGTH);
+  const eyebrow = normalizeParam(params.get("eyebrow"), OG_LIMITS.eyebrow);
   const logoHost = normalizeLogoHost(params.get("logo"));
+  const logoPath = normalizeLogoPath(params.get("logop"));
   const entity = params.get("entity") === "1";
   const rawStatus = (params.get("status") || "").trim().toLowerCase();
   const status = isHealthState(rawStatus) ? rawStatus : null;
@@ -333,13 +322,13 @@ export function readCardParams(params: URLSearchParams): {
     ["stat2", "stat2v"],
     ["stat3", "stat3v"],
   ] as const) {
-    const label = normalizeParam(params.get(labelKey), MAX_STAT_LABEL_LENGTH);
-    const value = normalizeParam(params.get(valueKey), MAX_STAT_VALUE_LENGTH);
+    const label = normalizeParam(params.get(labelKey), OG_LIMITS.statLabel);
+    const value = normalizeParam(params.get(valueKey), OG_LIMITS.statValue);
     // Both halves required: a value with no label is unreadable, and a label
     // with no value is an empty promise.
     if (label && value) stats.push({ label, value });
   }
-  return { eyebrow, stats, logoHost, entity, status };
+  return { eyebrow, stats, logoHost, logoPath, entity, status };
 }
 
 /**
@@ -370,9 +359,44 @@ export function iconProxyUrl(host: string): string {
  * userinfo, ports, IP literals, and the localhost/.local/.internal family,
  * mirroring the proxy's own validation rather than trusting it blindly.
  */
+/**
+ * The registry's own logo assets, the only paths `logop` may name.
+ *
+ * Two shapes, both committed under apps/ui/public/logos and both measured
+ * against the live registry: subnets carry a content-addressed cache entry
+ * (`cache/<sha256>.<ext>`, all 60 of them), providers a slug (`<slug>.<ext>`,
+ * 102 of 138). Pinning the whole path rather than sanitizing it is what makes
+ * this safe: the name charset excludes `.`, so `..` cannot be spelled, and
+ * there is no way to name anything but an image this repo ships.
+ */
+const LOGO_ASSET_PATH =
+  /^\/logos\/(?:cache\/[0-9a-f]{64}|[a-z0-9][a-z0-9-]{0,62})\.(?:png|svg|jpg|jpeg|webp)$/;
+
+/**
+ * Validate the `logop` param as one of OUR OWN cached logo assets.
+ *
+ * Why this exists alongside `logo` (a hostname resolved through the icon
+ * proxy): the registry stores a subnet's logo as a first-party cached copy,
+ * `https://metagraph.sh/logos/cache/<sha256>.png`. Reducing that to a HOST the
+ * way every other candidate is reduced yields `metagraph.sh` and then asks a
+ * favicon aggregator for OUR site's icon -- throwing away a working, curated
+ * image. All 60 subnets that have a logo hit that path, so all 60 cards showed
+ * a two-letter monogram.
+ *
+ * A path is safe here where a URL would not be because the ORIGIN is not the
+ * caller's to choose: the asset is read through the Worker's own ASSETS
+ * binding, never fetched. That also sidesteps the trap that makes the obvious
+ * implementation fail -- this Worker serves metagraph.sh, and a Worker cannot
+ * fetch its own custom domain (Cloudflare answers 522).
+ */
+export function normalizeLogoPath(value: string | null): string | null {
+  const raw = (value || "").trim();
+  return LOGO_ASSET_PATH.test(raw) ? raw : null;
+}
+
 export function normalizeLogoHost(value: string | null): string | null {
   const raw = (value || "").trim().toLowerCase();
-  if (!raw || raw.length > MAX_LOGO_HOST_LENGTH) return null;
+  if (!raw || raw.length > OG_LIMITS.logoHost) return null;
   // Plain DNS name only: labels of alphanumerics/hyphens, at least one dot,
   // and a non-numeric TLD (which also rules out bare IPv4 literals).
   if (!/^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/.test(raw)) return null;
@@ -600,8 +624,218 @@ export function renderCardMarkup(opts: {
  * paint.
  */
 export function glyphsForMarkup(markup: string): string {
-  return markup.replace(/<[^>]*>/g, "");
+  const text = markup.replace(/<[^>]*>/g, "");
+  // Deduped: subsetting is per code point, so repeats never bought anything.
+  // Spread, not split(""): a split would cut astral characters in half and
+  // subset two broken halves of an emoji.
+  return [...new Set([...text])].join("");
 }
+
+/** U+0020..U+007E, built rather than typed so no escaping can go wrong. */
+const ASCII_PRINTABLE = Array.from({ length: 0x7e - 0x20 + 1 }, (_, index) =>
+  String.fromCharCode(0x20 + index),
+).join("");
+
+/**
+ * The non-ASCII characters this card is *designed* to paint.
+ *
+ * `…` is emitted by all three normalizers when they truncate; `·` and `—`
+ * separate the clauses of an entity subtitle; `τ` is in every TAO value. The
+ * rest are the typographic characters ordinary prose drags in (smart quotes
+ * from a subnet description, a `×`, a `°`). All are one glyph each.
+ */
+const TYPOGRAPHIC_GLYPHS = "·×–—‘’“”•…→τ€°";
+
+/**
+ * The repertoire EVERY card is subset to, whatever it happens to say.
+ *
+ * Requesting a fixed set rather than exactly this card's characters is what
+ * makes the font request cacheable: the URL is then identical for almost every
+ * card, so `caches.default` (and the per-isolate memo below) actually hit,
+ * instead of missing on every render because the query carried that card's
+ * prose. Measured: 108 glyphs of Space Grotesk is ~20KB per weight and 109 of
+ * Inter ~38KB, ~173KB for the six faces — paid once per isolate rather than
+ * six network round trips per uncached card.
+ *
+ * It also makes coverage DETERMINISTIC. A per-card subset means the answer to
+ * "is this glyph in the font" depends on what the card says, which is exactly
+ * the coupling that produced tofu; with a fixed base, anything in this string
+ * is always present and only genuinely exotic input takes the slow path.
+ */
+export const CARD_GLYPHS = ASCII_PRINTABLE + TYPOGRAPHIC_GLYPHS;
+
+/**
+ * The `text=` subset request for a card: the fixed repertoire, plus whatever
+ * this card paints that isn't already in it.
+ *
+ * Extras are sorted so two cards needing the same exotic characters produce the
+ * same URL and share a cache entry, and control characters are dropped — the
+ * markup is full of newlines between tags, and they are not glyphs.
+ */
+export function fontSubsetText(markup: string): string {
+  const base = new Set(CARD_GLYPHS);
+  const extra = [...glyphsForMarkup(markup)]
+    .filter((char) => {
+      if (base.has(char)) return false;
+      const code = char.codePointAt(0) ?? 0;
+      return code >= 0x20 && code !== 0x7f && !(code >= 0x80 && code <= 0x9f);
+    })
+    .sort()
+    .join("");
+  return CARD_GLYPHS + extra;
+}
+
+/**
+ * The Google Fonts CSS URL for one subset face.
+ *
+ * `text` is percent-encoded, and THAT is the whole point of this function
+ * existing (#11204). workers-og's own `loadGoogleFont` encodes `family` and
+ * interpolates `text` raw:
+ *
+ *     `https://fonts.googleapis.com/css2?${keys.map(k => `${k}=${n[k]}`).join("&")}`
+ *
+ * So one `%` anywhere in the card's copy — an emission share of `0.61%` is
+ * enough — leaves a bare `%` in the query value, Google stops decoding the
+ * whole parameter, and the `%E2%80%94` / `%E2%80%A6` / `%CF%84` escapes the URL
+ * serializer produced for `—`, `…` and `τ` are subset as the LITERAL hex
+ * letters instead. Measured against the live endpoint: the same request with
+ * the `%` encoded returns all three glyphs, without it returns none of them.
+ * That is why every subnet card painted three `.notdef` boxes while a card with
+ * no stats rendered the identical subtitle correctly.
+ *
+ * Encoding the text before handing it to workers-og would fix today's symptom
+ * and arm a worse one: a future version that encodes correctly would then
+ * double-encode ours, silently, with no test able to see it. Owning the two
+ * fetches is ~20 lines and removes the guess entirely.
+ */
+export function googleFontUrl(family: string, weight: number, text: string): string {
+  return (
+    "https://fonts.googleapis.com/css2" +
+    `?family=${encodeURIComponent(family)}:wght@${weight}` +
+    `&text=${encodeURIComponent(text)}`
+  );
+}
+
+/**
+ * An ancient Safari UA, deliberately.
+ *
+ * Google Fonts serves woff2 to anything modern, and satori cannot parse woff2 —
+ * it needs ttf/otf. This UA is what makes the css2 endpoint answer with a
+ * `format('truetype')` face. Inherited from workers-og, and load-bearing:
+ * change it and every card silently becomes the 1px fallback PNG.
+ */
+const FONT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) " +
+  "AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1";
+
+/** Subset faces are immutable for a given (family, weight, text) — hold them. */
+const FONT_CACHE_CONTROL = "public, max-age=2592000";
+
+/**
+ * Per-isolate memo of in-flight and resolved faces.
+ *
+ * Keyed on the CSS URL, which is a total function of (family, weight, text) —
+ * so with the fixed repertoire above this is one entry per face for the life of
+ * the isolate, and concurrent renders share a single fetch rather than racing.
+ */
+const fontMemo = new Map<string, Promise<ArrayBuffer>>();
+
+async function fetchFontBinary(
+  family: string,
+  weight: number,
+  text: string,
+  fetchImpl: typeof fetch,
+): Promise<ArrayBuffer> {
+  const cssResponse = await fetchImpl(googleFontUrl(family, weight, text), {
+    headers: { "user-agent": FONT_USER_AGENT },
+  });
+  if (!cssResponse.ok) {
+    throw new Error(`Google Fonts CSS ${cssResponse.status} for ${family} ${weight}`);
+  }
+  // A gstatic font URL never contains ")", so this is bounded rather than the
+  // greedy `(.+)` workers-og used.
+  const source = (await cssResponse.text()).match(
+    /src:\s*url\(([^)]+)\)\s*format\('(?:opentype|truetype)'\)/,
+  )?.[1];
+  if (!source) throw new Error(`No TrueType face in Google Fonts CSS for ${family} ${weight}`);
+  const fontResponse = await fetchImpl(source);
+  if (!fontResponse.ok) {
+    throw new Error(`Google Fonts binary ${fontResponse.status} for ${family} ${weight}`);
+  }
+  return await fontResponse.arrayBuffer();
+}
+
+/**
+ * One subset face, through the isolate memo and the edge cache.
+ *
+ * workers-og cached the CSS response but never the font binary, and keyed that
+ * cache on a URL carrying the card's prose — so in practice it re-fetched both
+ * on every uncached card. Caching the binary subsumes the CSS lookup, so a warm
+ * isolate renders a card with zero external requests.
+ *
+ * Both cache layers are best-effort: a cache that is unavailable or refuses the
+ * key must degrade to a plain fetch, never fail the card.
+ */
+export async function loadCardFont(
+  family: string,
+  weight: number,
+  text: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ArrayBuffer> {
+  const cssUrl = googleFontUrl(family, weight, text);
+  const memoized = fontMemo.get(cssUrl);
+  if (memoized) return await memoized;
+
+  const pending = (async () => {
+    const cacheKey = new Request(`${cssUrl}&fmt=ttf`);
+    try {
+      const hit = await cacheStorage?.match(cacheKey);
+      if (hit) return await hit.arrayBuffer();
+    } catch {
+      // No usable edge cache — fetch it.
+    }
+    const bytes = await fetchFontBinary(family, weight, text, fetchImpl);
+    try {
+      await cacheStorage?.put(
+        cacheKey,
+        new Response(bytes, {
+          headers: { "cache-control": FONT_CACHE_CONTROL, "content-type": "font/ttf" },
+        }),
+      );
+    } catch {
+      // Caching is an optimisation; the face is already in hand.
+    }
+    return bytes;
+  })();
+
+  fontMemo.set(cssUrl, pending);
+  // Never memoize a rejection: one Google Fonts hiccup would otherwise blank
+  // every card this isolate goes on to render.
+  pending.catch(() => fontMemo.delete(cssUrl));
+  return await pending;
+}
+
+/**
+ * The card's font stack, in satori's resolution order.
+ *
+ * Space Grotesk is the display face; Inter is listed AFTER it so satori reaches
+ * for it per glyph rather than for whole runs. It has to be there at all
+ * because Space Grotesk has no Greek coverage and every TAO value contains τ —
+ * verified against a real satori render, since the local Chromium preview
+ * substitutes a system font and hides the gap completely.
+ *
+ * Inter carries weight 500 as well as 400/700: the stat labels and the eyebrow
+ * pill are painted at 500, so without it the fallback for a glyph in those runs
+ * had to be resolved from a weight satori was not asked for.
+ */
+const CARD_FONT_FACES = [
+  { name: "Space Grotesk", weight: 700 },
+  { name: "Space Grotesk", weight: 500 },
+  { name: "Space Grotesk", weight: 400 },
+  { name: "Inter", weight: 700 },
+  { name: "Inter", weight: 500 },
+  { name: "Inter", weight: 400 },
+] as const;
 
 function makeCacheKey(url: URL, title: string, subtitle: string): Request {
   const cacheUrl = new URL(url);
@@ -621,6 +855,7 @@ function makeCacheKey(url: URL, title: string, subtitle: string): Request {
     "stat3",
     "stat3v",
     "logo",
+    "logop",
     "entity",
     "status",
   ]) {
@@ -668,25 +903,97 @@ const MAX_ICON_BYTES = 256 * 1024;
  * Every failure mode returns null rather than throwing: an OG card must render
  * something even when the icon service is down.
  */
+async function inlineImage(response: Response): Promise<string | null> {
+  if (!response.ok) return null;
+  const type = response.headers.get("content-type") || "";
+  if (!type.startsWith("image/")) return null;
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_ICON_BYTES) return null;
+  // btoa needs a binary string; chunked so a large icon can't blow the
+  // argument limit with String.fromCharCode(...spread).
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 8192) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
+  }
+  return `data:${type.split(";")[0]};base64,${btoa(binary)}`;
+}
+
 export async function resolveIcon(
   host: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<string | null> {
   try {
-    const response = await fetchImpl(iconProxyUrl(host));
-    if (!response.ok) return null;
-    const type = response.headers.get("content-type") || "";
-    if (!type.startsWith("image/")) return null;
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength === 0 || bytes.byteLength > MAX_ICON_BYTES) return null;
-    // btoa needs a binary string; chunked so a large icon can't blow the
-    // argument limit with String.fromCharCode(...spread).
-    let binary = "";
-    for (let i = 0; i < bytes.length; i += 8192) {
-      binary += String.fromCharCode(...bytes.subarray(i, i + 8192));
-    }
-    return `data:${type.split(";")[0]};base64,${btoa(binary)}`;
+    return await inlineImage(await fetchImpl(iconProxyUrl(host)));
   } catch {
+    return null;
+  }
+}
+
+/** The Worker's static-asset binding — what serves apps/ui/public. */
+export interface AssetsBinding {
+  fetch(input: Request): Promise<Response>;
+}
+
+/**
+ * Narrow the Worker `env` to its ASSETS binding, or null when absent.
+ *
+ * Falls back to `globalThis.__env__`, and that fallback is the one that
+ * actually fires: this module runs inside the Nitro app, which reaches our
+ * fetch handler through `nitroApp.fetch(request)` — a call that carries no env
+ * at all. Nitro's Cloudflare entry assigns the real env to `globalThis.__env__`
+ * as the first statement of its own fetch handler, before any dispatch, so it
+ * is populated by the time a request reaches us. Verified against a real
+ * `wrangler dev` build, where the passed env has no ASSETS and this does.
+ *
+ * The passed env is still preferred: it is the direct, documented route, and
+ * keeps this working if the preset ever hands us the real thing.
+ */
+export function assetsBindingFrom(env: unknown): AssetsBinding | null {
+  for (const candidate of [env, (globalThis as { __env__?: unknown }).__env__]) {
+    const assets = (candidate as { ASSETS?: unknown } | null | undefined)?.ASSETS;
+    if (typeof (assets as AssetsBinding | undefined)?.fetch === "function") {
+      return assets as AssetsBinding;
+    }
+  }
+  return null;
+}
+
+/**
+ * Inline one of our own cached logo assets, read through the ASSETS binding.
+ *
+ * The binding, not `fetch`: these assets are served by THIS Worker on
+ * metagraph.sh, and a Worker fetching its own custom domain gets a 522 rather
+ * than the file. Reading the binding is also strictly faster -- no edge round
+ * trip at all -- and is what keeps the origin out of the caller's hands.
+ *
+ * Returns null on anything unexpected so the card falls through to the
+ * monogram, exactly as an unresolvable third-party icon does.
+ */
+export async function resolveLocalLogo(
+  path: string,
+  assets: AssetsBinding | null,
+  origin: string,
+): Promise<string | null> {
+  if (!assets) {
+    console.error(`OG logo: no ASSETS binding, cannot read ${path}`);
+    return null;
+  }
+  try {
+    // A Request, not a bare string: the assets binding is a Fetcher, and
+    // handing it a constructed Request is the form its own docs use.
+    const response = await assets.fetch(new Request(new URL(path, origin).toString()));
+    const inlined = await inlineImage(response);
+    // The path already passed LOGO_ASSET_PATH, so we believe this asset exists.
+    // If it doesn't, a curated logo has gone missing and the card is silently
+    // degrading to a monogram -- say so rather than letting it be invisible.
+    if (!inlined) {
+      console.error(
+        `OG logo unresolved: ${path} (${response.status} ${response.headers.get("content-type")})`,
+      );
+    }
+    return inlined;
+  } catch (error) {
+    console.error(`OG logo read failed: ${path}`, error);
     return null;
   }
 }
@@ -702,19 +1009,23 @@ function fallbackImageResponse(status = 200): Response {
 }
 
 // Render the /og card, or return null when the path doesn't match.
-export async function handleOgImage(request: Request): Promise<Response | null> {
+//
+// `env` is threaded in for the ASSETS binding only -- it is what lets a card
+// carry the registry's own cached logo (see resolveLocalLogo). Optional, so a
+// caller without an env still renders every other card correctly.
+export async function handleOgImage(request: Request, env?: unknown): Promise<Response | null> {
   const url = new URL(request.url);
   if (url.pathname !== OG_PATH) return null;
   if (request.method !== "GET" && request.method !== "HEAD") {
     return new Response("Method Not Allowed", { status: 405, headers: { allow: "GET, HEAD" } });
   }
-  if (url.search.length > MAX_QUERY_LENGTH) {
+  if (url.search.length > OG_LIMITS.query) {
     return new Response("Query Too Large", { status: 414 });
   }
 
   const normalizedTitle = normalizeTitle(url.searchParams.get("title"));
   const normalizedSubtitle = normalizeSubtitle(url.searchParams.get("subtitle"));
-  const { eyebrow, stats, logoHost, entity, status } = readCardParams(url.searchParams);
+  const { eyebrow, stats, logoHost, logoPath, entity, status } = readCardParams(url.searchParams);
   const cacheKey = makeCacheKey(url, normalizedTitle, normalizedSubtitle);
   const cached = await cacheStorage?.match(cacheKey);
   if (cached) {
@@ -736,9 +1047,8 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
   // Failure here returns the fallback PNG rather than throwing, since this runs
   // outside server.ts's try/catch.
   let ImageResponse: WorkersOg["ImageResponse"];
-  let loadGoogleFont: WorkersOg["loadGoogleFont"];
   try {
-    ({ ImageResponse, loadGoogleFont } = await import("workers-og"));
+    ({ ImageResponse } = await import("workers-og"));
   } catch (error) {
     console.error("Failed to load workers-og", error);
     return fallbackImageResponse();
@@ -746,7 +1056,14 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
 
   // Resolve the entity icon before rendering so an unresolvable one degrades
   // to a monogram instead of an empty tile -- see resolveIcon.
-  const icon = logoHost ? await resolveIcon(logoHost) : null;
+  //
+  // Our own cached asset wins when there is one: it is the logo the registry
+  // curated for that entity, read straight from the ASSETS binding, where the
+  // proxy path is a favicon lookup that may well miss (it has no icon for
+  // apex.macrocosmos.ai, for instance).
+  const icon =
+    (logoPath ? await resolveLocalLogo(logoPath, assetsBindingFrom(env), url.origin) : null) ??
+    (logoHost ? await resolveIcon(logoHost) : null);
 
   // Build the markup FIRST so the font subset can be derived from it -- see
   // glyphsForMarkup for why a hand-maintained glyph list is a bug generator.
@@ -759,47 +1076,31 @@ export async function handleOgImage(request: Request): Promise<Response | null> 
     entity,
     status,
   });
-  // Subset each weight to only the glyphs actually painted (smaller + faster
-  // fetch) plus the tau, which Space Grotesk lacks entirely and Inter supplies.
-  const glyphs = glyphsForMarkup(markup);
-  let bold: ArrayBuffer;
-  let regular: ArrayBuffer;
-  let medium: ArrayBuffer;
-  let fallbackBold: ArrayBuffer;
-  let fallbackRegular: ArrayBuffer;
-  try {
-    [bold, regular, medium, fallbackBold, fallbackRegular] = await Promise.all([
-      loadGoogleFont({ family: "Space Grotesk", weight: 700, text: glyphs }),
-      loadGoogleFont({ family: "Space Grotesk", weight: 400, text: glyphs }),
-      loadGoogleFont({ family: "Space Grotesk", weight: 500, text: glyphs }),
-      // #8489: Space Grotesk has NO Greek coverage, so the tau in every TAO
-      // value ("0.0832 τ") rasterizes as a tofu box. Caught by rendering the
-      // card through real satori -- the local Chromium preview substituted a
-      // system font and showed a perfect tau, hiding it completely. Inter is
-      // registered as a per-glyph fallback so the display face stays Space
-      // Grotesk and only the glyphs it lacks come from Inter.
-      loadGoogleFont({ family: "Inter", weight: 700, text: glyphs }),
-      loadGoogleFont({ family: "Inter", weight: 400, text: glyphs }),
-    ]);
-  } catch (error) {
-    console.error("Failed to load OG image fonts", error);
+  // One subset request per face, covering the fixed repertoire plus anything
+  // exotic this particular card paints -- see fontSubsetText and googleFontUrl.
+  const subsetText = fontSubsetText(markup);
+  const loaded = await Promise.allSettled(
+    CARD_FONT_FACES.map((face) => loadCardFont(face.name, face.weight, subsetText)),
+  );
+  // allSettled, not all: a card missing one weight still reads correctly, where
+  // one failed request rejecting the whole batch serves a 1px PNG for every
+  // unfurl until the cache turns over. Only a total failure is unrenderable --
+  // satori needs at least one face.
+  const fonts = CARD_FONT_FACES.flatMap((face, index) => {
+    const result = loaded[index];
+    if (result?.status !== "fulfilled") {
+      console.error(`OG font unavailable: ${face.name} ${face.weight}`, result?.reason);
+      return [];
+    }
+    return [{ name: face.name, data: result.value, weight: face.weight, style: "normal" as const }];
+  });
+  if (fonts.length === 0) {
+    console.error("Failed to load any OG image font");
     return fallbackImageResponse();
   }
 
   try {
-    const image = new ImageResponse(markup, {
-      width: 1200,
-      height: 630,
-      fonts: [
-        { name: "Space Grotesk", data: bold, weight: 700, style: "normal" },
-        { name: "Space Grotesk", data: medium, weight: 500, style: "normal" },
-        { name: "Space Grotesk", data: regular, weight: 400, style: "normal" },
-        // Fallback only -- listed after the display face, so satori reaches
-        // for it per-glyph rather than for whole runs.
-        { name: "Inter", data: fallbackBold, weight: 700, style: "normal" },
-        { name: "Inter", data: fallbackRegular, weight: 400, style: "normal" },
-      ],
-    });
+    const image = new ImageResponse(markup, { width: 1200, height: 630, fonts });
     const response = withOgHeaders(image);
     await cacheStorage?.put(cacheKey, response.clone());
     return response;

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -3,6 +3,12 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading } from "@/components/metagraphed/states";
 import { RoutePending } from "@/components/metagraphed/primitives";
 import { providerQuery } from "@/lib/metagraphed/queries";
+import {
+  firstPartyLogoPath,
+  healthFromStatusCounts,
+  logoHostFrom,
+  ogImageMeta,
+} from "@/lib/metagraphed/og-card";
 import { ProviderDetail } from "./-providers-slug-page";
 import {
   entityNotFoundMeta,
@@ -26,7 +32,18 @@ export const Route = createFileRoute("/providers/$slug")({
   loader: async ({ context, params }) => {
     try {
       const { data } = await context.queryClient.ensureQueryData(providerQuery(params.slug));
-      return { name: data.name ?? null };
+      return {
+        name: data.name ?? null,
+        // #11204: the card's own fields. The registry curates a logo for 102 of
+        // the 138 providers, and the counts are what the page's pulse tiles
+        // lead with -- the same three facts, on the card that travels.
+        iconUrl: data.icon_url ?? null,
+        website: data.website ?? null,
+        endpoints: data.endpoints_count ?? null,
+        surfaces: data.surfaces_count ?? null,
+        subnets: typeof data.subnet_count === "number" ? data.subnet_count : null,
+        byStatus: data.endpoint_summary?.by_status ?? null,
+      };
     } catch (error) {
       // #8624: only a 404 from our own API means "no such entity". Any other
       // failure keeps returning null so the page still renders and the
@@ -49,6 +66,32 @@ export const Route = createFileRoute("/providers/$slug")({
         { name: "description", content: description },
         { property: "og:title", content: title },
         { property: "og:description", content: description },
+        // #11204: this route owns its own og:image (routeOwnsOgImage matches
+        // it, so src/server.ts skips its pathname-derived injection). That card
+        // said "404-gen" with no logo and no numbers; this one says "404-GEN",
+        // shows the registry's curated logo and carries the counts.
+        ...ogImageMeta({
+          title: name,
+          subtitle: description,
+          eyebrow: "Provider",
+          logoPath: firstPartyLogoPath(loaderData?.iconUrl),
+          logoHost: logoHostFrom(loaderData?.iconUrl, loaderData?.website),
+          status: healthFromStatusCounts(loaderData?.byStatus),
+          // The page's own pulse tiles lead with endpoints and surfaces; the
+          // subnet count is what distinguishes a one-subnet team from an
+          // infrastructure provider serving thirty.
+          stats: [
+            ...(loaderData?.endpoints != null
+              ? [{ label: "Endpoints", value: String(loaderData.endpoints) }]
+              : []),
+            ...(loaderData?.surfaces != null
+              ? [{ label: "Surfaces", value: String(loaderData.surfaces) }]
+              : []),
+            ...(loaderData?.subnets != null
+              ? [{ label: "Subnets", value: String(loaderData.subnets) }]
+              : []),
+          ],
+        }),
       ],
     };
   },

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -3,7 +3,7 @@ import { AppShell } from "@/components/metagraphed/app-shell";
 import { EmptyState, PageHeading } from "@/components/metagraphed/states";
 import { economicsQuery, subnetProfileQuery } from "@/lib/metagraphed/queries";
 import { formatTao } from "@/lib/metagraphed/format";
-import { logoHostFrom, ogImageMeta } from "@/lib/metagraphed/og-card";
+import { firstPartyLogoPath, logoHostFrom, ogImageMeta } from "@/lib/metagraphed/og-card";
 import {
   entityNotFoundMeta,
   isMissingEntityError,
@@ -146,6 +146,10 @@ export const Route = createFileRoute("/subnets/$netuid")({
           title: loaderData?.name || `Subnet ${params.netuid}`,
           subtitle: description,
           eyebrow: "Subnet",
+          // The registry's curated logo first (a first-party cached asset the
+          // card reads from the ASSETS binding), then the subnet's own website
+          // as a favicon lookup, then the monogram.
+          logoPath: firstPartyLogoPath(loaderData?.iconUrl),
           logoHost: logoHostFrom(loaderData?.iconUrl, loaderData?.website),
           // The health state colours the card's footer dot instead of
           // spending a whole stat cell on a one-word string.

--- a/apps/ui/src/server.seo.test.ts
+++ b/apps/ui/src/server.seo.test.ts
@@ -24,11 +24,15 @@ describe("docs pages own their OG card (#8624)", () => {
     expect(routeOwnsOgImage("/docs/")).toBe(false);
   });
 
-  it("still matches the three entity routes and nothing else", () => {
+  it("still matches the entity detail routes and nothing else", () => {
     expect(routeOwnsOgImage("/subnets/64")).toBe(true);
     expect(routeOwnsOgImage("/validators/5Grwva")).toBe(true);
     expect(routeOwnsOgImage("/accounts/5Grwva")).toBe(true);
-    for (const p of ["/", "/subnets", "/agents", "/blocks/123", "/providers/x"]) {
+    // #11204: providers joined them. Their 138 pages were unfurling the raw
+    // slug with no logo and no counts, from the pathname alone.
+    expect(routeOwnsOgImage("/providers/latent")).toBe(true);
+    // The hub is not a detail page and keeps its section copy.
+    for (const p of ["/", "/subnets", "/agents", "/blocks/123", "/providers", "/apis/providers"]) {
       expect(routeOwnsOgImage(p), p).toBe(false);
     }
   });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -1040,7 +1040,9 @@ export default {
       console.error("[analytics-proxy] request handling failed:", error);
     }
     if (analyticsResponse) return analyticsResponse;
-    const ogResponse = await handleOgImage(request);
+    // env carries the ASSETS binding, which is how a card inlines the
+    // registry's own cached logo for an entity -- see resolveLocalLogo.
+    const ogResponse = await handleOgImage(request, env);
     if (ogResponse) return ogResponse;
     const artifactRedirect = handleArtifactHostRedirect(request);
     if (artifactRedirect) return artifactRedirect;


### PR DESCRIPTION
Closes #11238. Part of #11204.

## The defect

Every subnet card that unfurls from `metagraph.sh` paints three `.notdef` tofu boxes — you can read
"NOTDEF" in them at full size. Production, right now, vs. this branch rendered through `workerd`:

| | em dash | ellipsis | tau |
|---|---|---|---|
| live `/subnets/1` card | ▯ | ▯ | ▯ |
| this branch | — | … | τ |

## Root cause

`workers-og`'s `loadGoogleFont` percent-encodes `family` and interpolates `text` **raw**. The card
derives its subset from the rendered markup, so the emission stat `0.61%` leaves a bare `%` in the
query; Google stops decoding the value and subsets the *literal hex letters* of the `%E2%80%94` /
`%E2%80%A6` / `%CF%84` escapes instead of the characters they encode.

Measured against the live endpoint with the real production glyph string:

| `text=` sent | glyphs | em dash | ellipsis | `%` |
|---|---|---|---|---|
| raw, trailing `%` (today) | 49 | **MISSING** | **MISSING** | OK |
| `%` stripped | 46 | OK | OK | missing |
| `%` properly encoded | 47 | OK | OK | OK |

That is why stats were the trigger — the only thing that introduces a `%`. The same card with no
stats rendered the identical subtitle correctly, which is what made this look like a length problem.
The tau is the same failure, older: #8489's Inter per-glyph fallback is real, but the tau never
reached Google's request intact, so it has been tofu since it shipped.

## Approach

**Own the two fetches** rather than pre-encoding around the library. Passing pre-encoded text to
`loadGoogleFont` would fix today's symptom and arm a worse one — a future version that encodes
correctly would double-encode ours, silently, with no test able to see it.

The subset is now a **fixed repertoire plus this card's extras** (printable ASCII + 14 typographic
characters, ~20 KB per Space Grotesk face and ~38 KB per Inter face). Two consequences beyond the
bug: the request URL is constant for almost every card, so the isolate memo and `caches.default`
actually hit — a warm isolate renders with **zero** external requests, and an uncached card dropped
from 1.14 s to 0.20 s locally. And coverage stops depending on what the card happens to say, which
is the coupling that produced the tofu in the first place.

`Promise.allSettled`, not `all`: one failed weight now costs that weight, not a 1 px PNG for every
unfurl until the cache turns over. `Inter` gains weight 500, the weight the stat labels and eyebrow
are actually painted at.

## Four defects found in the same surface

1. **All 60 subnets with a curated logo showed a monogram.** The registry stores logos first-party
   (`/logos/cache/<sha256>.<ext>`; `/logos/<slug>.<ext>` for providers, 102 of 138), and
   `logoHostFrom` reduced that URL to a *hostname* — `metagraph.sh` — then asked the favicon proxy
   for our own icon. Read through the **ASSETS binding** instead: this Worker serves `metagraph.sh`
   and cannot fetch its own custom domain (522, cf. #10194), and the binding is faster anyway.
   The env our handler receives has no ASSETS at all — Nitro reaches us via `nitroApp.fetch(request)`
   — so it falls back to `globalThis.__env__`, which Nitro's Cloudflare entry sets before dispatch.
   Verified against a real `wrangler dev` build, not assumed.
2. **All 138 `/providers/{slug}` pages** unfurled the pathname-derived card: the raw slug (`404-gen`,
   not `404-GEN`), no logo, no numbers. They now emit their own, with the curated logo and the counts
   the page's own pulse tiles lead with.
3. **`og:image:alt` was emitted only by the server-injected card**, so every route-owned page
   silently lost it — all 129 subnet pages, every validator, account, doc and news page.
4. **The field bounds were duplicated** across the builder and the renderer, and only the renderer
   enforced them. Adding the logo path takes the worst legitimate card to **548** characters against
   a 512 cap that answers **414** — an unfurl with no image at all. Now one shared source, enforced
   on both sides, with a test at every field's cap.

`CARD_VERSION` → `5`, so the ~7 days of already-cached tofu cards are retired rather than served out.

## Verification

- **Real `workerd` renders**, not the Chromium preview — which substitutes a system font and hides
  exactly this class of bug. Subnet card (icon-proxy path), subnet card (first-party logo) and
  provider card all render correctly; zero `OG logo` / `OG font` errors in the Worker log.
- Font coverage checked by reading the returned TrueType `cmap` for all six faces: every character
  the production card paints is covered, and the card needs no extras beyond the fixed repertoire.
- The encoding assertion round-trips the built URL through a parser, with a companion test proving
  the raw form it replaces **fails** that same assertion.
- `tsc --noEmit`, `vitest run` (258 files, 2163 tests), `lint` (0 errors), `format:check` — all green
  after rebasing onto `8df97f7`.

## Deliberately not in scope

- The API worker's own landing card (`src/og-image.ts` on `api.metagraph.sh`) — that is #11075.
- Hairline line-art logos with heavy baked-in padding (Apex's is one) render faint at 64 px on the
  card's tile. That is an asset characteristic, not a rendering defect; the site's own `BrandIcon`
  has the same constraint.
