### PR TITLE
fix(ui): the API reference's code samples were never highlighted, and said why

### DIFF
--- a/apps/ui/src/lib/openapi-shiki.test.ts
+++ b/apps/ui/src/lib/openapi-shiki.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, test } from "vitest";
+import { createHighlighterCore, isSpecialLang } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
-import { openapiShikiFactory } from "./openapi-shiki";
+import { acceptLanguageNames, openapiShikiFactory } from "./openapi-shiki";
 
 // A regression test for the Cloudflare Workers Builds OOM fix itself (see
 // this file's own comment): the whole point of a scoped shiki factory is
@@ -57,5 +59,98 @@ describe("openapiShikiFactory", () => {
     const second = await openapiShikiFactory.getOrInit();
 
     expect(second).toBe(first);
+  });
+});
+
+// --- the one incompatibility with fumadocs' highlighter ----------------------
+//
+// Measured on the deployed site: every code block on every /docs/api-reference
+// page rendered UNHIGHLIGHTED, and filed an unhandled `TypeError: Cannot read
+// properties of undefined (reading 'split')` doing it. fumadocs' `highlightHast`
+// always finishes with `highlighter.loadLanguage(<name>)`, and a highlighter
+// built by `createHighlighterCore` has no bundle to resolve a NAME against -- so
+// it reads a scope name off `undefined` and throws, even for a language it is
+// already holding.
+//
+// These drive the REAL shiki rather than a double, because a double would only
+// assert what I believed about `loadLanguage` -- and that was wrong twice before
+// this test existed. The failure is not about WHICH language is asked for (bash
+// and json both fail, and both are loaded), and it does not poison the registry
+// (`codeToHtml` keeps working around it).
+
+/** A bare core highlighter with two languages, matching the factory's shape. */
+async function core() {
+  const [bash, json, githubLight] = await Promise.all([
+    import("shiki/langs/bash.mjs"),
+    import("shiki/langs/json.mjs"),
+    import("shiki/themes/github-light.mjs"),
+  ]);
+  return createHighlighterCore({
+    langs: [bash.default, json.default],
+    themes: [githubLight.default],
+    engine: createJavaScriptRegexEngine(),
+  });
+}
+
+describe("the bug, pinned against the real shiki", () => {
+  test("an UNWRAPPED core highlighter throws on a name it already holds", async () => {
+    const raw = await core();
+    expect(raw.getLoadedLanguages()).toContain("bash");
+    // Verbatim what fumadocs' highlightHast does after deciding the language is
+    // fine -- and the CAST is the bug, quoted: shiki's own types say a core
+    // highlighter takes registrations, never a name, so this call is already
+    // illegal before it is wrong at runtime.
+    //
+    // If shiki ever makes it work, this test fails and the wrapper can go.
+    const byName = raw.loadLanguage as unknown as (lang: string) => Promise<void>;
+    await expect(byName("bash")).rejects.toThrow(/split/);
+  });
+});
+
+describe("acceptLanguageNames", () => {
+  test("a name already loaded is a no-op, not a throw", async () => {
+    const hl = acceptLanguageNames(await core());
+    await expect(hl.loadLanguage("bash")).resolves.toBeUndefined();
+    await expect(hl.loadLanguage("json")).resolves.toBeUndefined();
+    // An ALIAS counts as loaded -- getLoadedLanguages() reports them, and
+    // fumadocs asks for `js`, never `javascript`.
+    expect(hl.getLoadedLanguages()).toContain("sh");
+    await expect(hl.loadLanguage("sh")).resolves.toBeUndefined();
+  });
+
+  test("and highlighting still works afterwards", async () => {
+    const hl = acceptLanguageNames(await core());
+    await hl.loadLanguage("bash");
+    const html = hl.codeToHtml("echo hi", {
+      lang: "bash",
+      theme: "github-light",
+    });
+    // TOKENS, not one bare line: the Suspense placeholder this bug left in
+    // place renders exactly one `<span class="line">` per line, nothing inside.
+    expect(html.match(/<span/g)!.length).toBeGreaterThan(1);
+  });
+
+  test("a special language passes through -- it is what the fallback is", async () => {
+    const hl = acceptLanguageNames(await core());
+    expect(isSpecialLang("text")).toBe(true);
+    // fumadocs rewrites an unrecognised language to `text` before calling, so
+    // this is the arm every unknown language actually takes.
+    await expect(hl.loadLanguage("text")).resolves.toBeUndefined();
+  });
+
+  test("a registration object is still registered, not swallowed", async () => {
+    const hl = acceptLanguageNames(await core());
+    expect(hl.getLoadedLanguages()).not.toContain("python");
+    const python = await import("shiki/langs/python.mjs");
+    await hl.loadLanguage(python.default);
+    expect(hl.getLoadedLanguages()).toContain("python");
+  });
+
+  test("a name with no grammar names ITSELF, rather than blaming `split`", async () => {
+    // Unreachable through fumadocs (its guard rewrites unknown to `text`), so
+    // reaching it means this factory's language list is genuinely missing
+    // something -- and the message has to say which.
+    const hl = acceptLanguageNames(await core());
+    await expect(hl.loadLanguage("elixir")).rejects.toThrow(/no grammar registered for elixir/);
   });
 });

--- a/apps/ui/src/lib/openapi-shiki.ts
+++ b/apps/ui/src/lib/openapi-shiki.ts
@@ -1,5 +1,6 @@
 import { createShikiFactory } from "fumadocs-core/highlight/shiki";
-import { createHighlighterCore } from "shiki/core";
+import type { HighlighterCore } from "shiki/core";
+import { createHighlighterCore, isSpecialLang } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 // fumadocs-openapi's default shiki factory (fumadocs-core/highlight/shiki/full,
@@ -22,6 +23,94 @@ import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 // uses) mean Rollup can prove nothing else is reachable and excludes the
 // rest of shiki's language/theme catalog entirely -- verified by re-running
 // the same constrained-heap repro against this factory: build succeeds.
+/** What `HighlighterCore.loadLanguage` is DECLARED to take: registrations, and
+ * the handful of special language names shiki resolves internally. Notably not
+ * an arbitrary language name -- see acceptLanguageNames for who sends one
+ * anyway. */
+type LanguageArgument = Parameters<HighlighterCore["loadLanguage"]>[number];
+
+/** A highlighter whose `loadLanguage` also takes a plain language NAME.
+ *
+ * The widened signature is the point, not an accident: it is what fumadocs
+ * calls, and stating it here means a caller doing the same thing gets type
+ * agreement rather than a cast that hides the mismatch. */
+export type NameTolerantHighlighter = Omit<HighlighterCore, "loadLanguage"> & {
+  loadLanguage(...langs: Array<LanguageArgument | string>): Promise<void>;
+};
+
+/**
+ * Let `loadLanguage` accept a language NAME, which a core highlighter cannot.
+ *
+ * ## The bug this fixes
+ *
+ * Every code block on every /docs/api-reference page rendered UNHIGHLIGHTED in
+ * production, and filed an unhandled `TypeError: Cannot read properties of
+ * undefined (reading 'split')` while doing it. Measured on the deployed site,
+ * reproduced against a local production build.
+ *
+ * `createHighlighterCore` has no language bundle, so its `loadLanguage` accepts
+ * only REGISTRATIONS -- the grammar objects passed to `langs` above. Hand it a
+ * string and it looks up a scope name it does not have, then calls
+ * `.split('.')` on the `undefined` it got:
+ *
+ *     await core.loadLanguage("bash");   // throws, even though bash IS loaded
+ *
+ * And fumadocs' `highlightHast` (fumadocs-core/highlight/shiki) ALWAYS calls it
+ * with a string:
+ *
+ *     if (!isSpecialLang(lang) && !(lang in getBundledLanguages())
+ *         && !getLoadedLanguages().includes(lang)) lang = fallbackLanguage;
+ *     await Promise.all([..., highlighter.loadLanguage(lang)]);
+ *
+ * That guard is written for a BUNDLED highlighter, where a name resolves
+ * through the bundle. It correctly decides our language is fine -- it is in
+ * `getLoadedLanguages()` -- and then makes the one call a core highlighter
+ * cannot serve. So the highlight promise rejects for every block, and
+ * `useShikiDynamic` leaves its Suspense placeholder in place forever: the raw
+ * code, one bare `<span class="line">` per line, no tokens.
+ *
+ * ## Why the wrapper rather than a bundled highlighter
+ *
+ * `createHighlighter` from `shiki` is what fumadocs assumes, and it is exactly
+ * what the header above explains this app cannot afford: it pulls all ~180
+ * grammars into the module graph and OOMs the Nitro SSR pass. The incompatibility
+ * is one method, so one method is what this adapts.
+ *
+ * A name we already hold is a NO-OP -- there is nothing to load -- which is
+ * precisely what the bundled highlighter's own `loadLanguage` does for an
+ * already-loaded language. Registration objects pass straight through. A name we
+ * do not hold raises an error that NAMES it, rather than a TypeError about
+ * `split`: fumadocs' guard rewrites an unknown language to `text` before it gets
+ * here, so reaching that arm means this factory's language list is genuinely
+ * missing something, and the message should say so.
+ */
+export function acceptLanguageNames(core: HighlighterCore): NameTolerantHighlighter {
+  const loadRegistrations = core.loadLanguage.bind(core);
+  const loadLanguage = async (...langs: Array<LanguageArgument | string>): Promise<void> => {
+    // Split by what the core highlighter can actually take: a registration it
+    // can register, versus a name it can only look up in a bundle it has not
+    // got.
+    const registrations: LanguageArgument[] = [];
+    const names: string[] = [];
+    for (const lang of langs) {
+      if (typeof lang === "string") names.push(lang);
+      else registrations.push(lang);
+    }
+    const loaded = core.getLoadedLanguages();
+    const unknown = names.filter((name) => !isSpecialLang(name) && !loaded.includes(name));
+    if (unknown.length > 0) {
+      throw new Error(
+        `openapi-shiki: no grammar registered for ${unknown.join(", ")}. ` +
+          "Add it to the static imports in this file -- the OpenAPI page asks " +
+          "for whatever language its code samples declare.",
+      );
+    }
+    if (registrations.length === 0) return;
+    await loadRegistrations(...registrations);
+  };
+  return Object.assign(core, { loadLanguage });
+}
+
 const openapiShikiFactory = createShikiFactory({
   async init() {
     const [bash, javascript, go, python, java, csharp, rust, json, githubLight, githubDark] =
@@ -37,22 +126,24 @@ const openapiShikiFactory = createShikiFactory({
         import("shiki/themes/github-light.mjs"),
         import("shiki/themes/github-dark.mjs"),
       ]);
-    return createHighlighterCore({
-      langs: [
-        bash.default,
-        javascript.default,
-        go.default,
-        python.default,
-        java.default,
-        csharp.default,
-        rust.default,
-        json.default,
-      ],
-      // Matches createOpenAPIPageBase's own default shikiOptions.themes
-      // (fumadocs-openapi/ui/base.js) -- same visual result, scoped set.
-      themes: [githubLight.default, githubDark.default],
-      engine: createJavaScriptRegexEngine(),
-    });
+    return acceptLanguageNames(
+      await createHighlighterCore({
+        langs: [
+          bash.default,
+          javascript.default,
+          go.default,
+          python.default,
+          java.default,
+          csharp.default,
+          rust.default,
+          json.default,
+        ],
+        // Matches createOpenAPIPageBase's own default shikiOptions.themes
+        // (fumadocs-openapi/ui/base.js) -- same visual result, scoped set.
+        themes: [githubLight.default, githubDark.default],
+        engine: createJavaScriptRegexEngine(),
+      }),
+    );
   },
 });
 


### PR DESCRIPTION
Found in PostHog error tracking, reproduced against a local production build.

Every code block on **every `/docs/api-reference` page** rendered as plain text and filed an unhandled `TypeError: Cannot read properties of undefined (reading 'split')` doing it.

## The incompatibility, in one call

`createHighlighterCore` has no language bundle, so its `loadLanguage` takes only **registrations** — the grammar objects passed to `langs`. Hand it a *name* and it looks up a scope name it has not got, then splits the `undefined`:

```js
await core.loadLanguage("bash");   // throws — even though bash IS loaded
```

fumadocs' `highlightHast` always ends with exactly that call:

```js
if (!isSpecialLang(lang) && !(lang in getBundledLanguages())
    && !getLoadedLanguages().includes(lang)) lang = fallbackLanguage;
await Promise.all([..., highlighter.loadLanguage(lang)]);
```

That guard is written for a **bundled** highlighter, where a name resolves through the bundle. It correctly decides our language is fine — it *is* in `getLoadedLanguages()` — and then makes the one call a core highlighter cannot serve. The highlight promise rejects for every block, and `useShikiDynamic` leaves its Suspense placeholder in place: the raw code, one bare `<span class="line">` per line, no tokens.

Shiki's own types already say the call is illegal. The test quotes the cast that makes it compile, so what's being asserted is visible rather than implied.

## Why a wrapper, not a bundled highlighter

`createHighlighter` from `shiki` is what fumadocs assumes, and it is exactly what this factory exists to avoid — it pulls all ~180 grammars into the module graph and OOMs the Nitro SSR pass (#6275). The incompatibility is one method, so one method is what this adapts:

- a name we already hold → **no-op**, which is what a bundled highlighter does for an already-loaded language
- a registration object → passes through untouched
- a name we do **not** hold → an error that **names it**, instead of blaming `split`. Unreachable through fumadocs (its guard rewrites unknown → `text`, which is special), so reaching it means this factory's language list is genuinely missing something.

## Measured

Local production build of this branch, `/docs/api-reference/accounts/account-balance`:

| block | before | after |
|---|---|---|
| `curl` sample | **0** token spans | **4**, carrying `--shiki-light` / `--shiki-dark` |
| JSON response | **0** token spans | **111** |

```html
before  <code><span class="line">curl -X GET "https://api.metagraph.sh/…"</span></code>
after   <code><span class="line"><span style="--shiki-light:#6F42C1;…">curl</span>
                                 <span style="--shiki-light:#005CC5;…"> -X</span>…
```

I could not capture a clean scrolled screenshot — the browser pane went unresponsive after every scroll or resize. The DOM evidence above is the primary proof, and for a syntax-highlighting change it is the stronger one: token spans are either there or they are not.

## What is deliberately NOT in scope

A **second**, separate rejection remains on docs pages, from fumadocs-ui's own `DynamicCodeBlock` → `defaultShikiFactory`, which this build tree-shakes down to an empty bundle so it hits the same wall. It is one event per page load (PostHog: 1 occurrence in 24h), it is a factory this app does not own, and fixing it means routing every prose code block through our own highlighter — a change to visual output well beyond this bug. Left alone rather than bundled in.

## Verification

- 9 tests in `openapi-shiki.test.ts` — the **three existing ones that ratchet the language scope (the actual OOM guard) are untouched and still pass**; six new ones sit alongside.
- Falsified: reverting the wrapper's logic turns 3 of the 6 new tests red, and the 3 that stay green are the negative controls (the raw bug, the special-language arm, the registration arm).
- `apps/ui`: 2,136 tests, 257 files, all pass. Root: 21,040 pass.
- All 55 CI validators pass locally, after a root `npm run build`.
- tsc, eslint, and prettier clean — the latter run from the `apps/ui` workspace, which has its own config.
