### PR TITLE
feat(seo): one graph per page, and it names the MCP server

### DIFF
--- a/apps/ui/src/lib/metagraphed/json-ld.test.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { breadcrumbListJsonLd, stringifyJsonLd, subnetDatasetJsonLd } from "./json-ld";
+import {
+  apiRecordUrl,
+  breadcrumbListJsonLd,
+  JSONLD_IDS,
+  siteGraphNodes,
+  stringifyJsonLd,
+  providerDatasetJsonLd,
+  subnetDatasetJsonLd,
+  techArticleJsonLd,
+} from "./json-ld";
 
 describe("stringifyJsonLd (#11204)", () => {
   it("neutralizes a script break-out in any string it serializes", () => {
@@ -99,12 +108,213 @@ describe("subnetDatasetJsonLd (#11204)", () => {
     );
   });
 
+  it("REFERENCES the site's organization and catalog instead of restating them", () => {
+    // Before: an inline `creator: { "@type": "Organization", ... }` on all 129
+    // subnet pages, which minted a second publisher unrelated to the site's own
+    // and left every Dataset an island. The @id references are what merge the
+    // route's block with the server-injected one into a single graph.
+    const out = subnetDatasetJsonLd(base) as unknown as Record<string, unknown>;
+    expect(out.creator).toStrictEqual({ "@id": JSONLD_IDS.org });
+    expect(out.publisher).toStrictEqual({ "@id": JSONLD_IDS.org });
+    expect(out.includedInDataCatalog).toStrictEqual({ "@id": JSONLD_IDS.catalog });
+    // And the referenced nodes must actually be declared on the page.
+    const ids = (siteGraphNodes() as Array<Record<string, unknown>>).map((node) => node["@id"]);
+    expect(ids).toContain(JSONLD_IDS.org);
+    expect(ids).toContain(JSONLD_IDS.catalog);
+  });
+
   it("prefers the subnet's own description but ignores a blank one", () => {
     expect(subnetDatasetJsonLd({ ...base, description: "Open competitions." }).description).toBe(
       "Open competitions.",
     );
     expect(subnetDatasetJsonLd({ ...base, description: "   " }).description).toContain(
       "Registry record",
+    );
+  });
+});
+
+describe("siteGraphNodes (#11204) — one graph, one publisher", () => {
+  const nodes = () => siteGraphNodes() as Array<Record<string, unknown>>;
+  const byId = (id: string) => nodes().find((node) => node["@id"] === id);
+
+  it("declares each site-wide node exactly once, with a stable @id", () => {
+    const ids = nodes().map((node) => node["@id"]);
+    expect(ids).toStrictEqual([
+      JSONLD_IDS.org,
+      JSONLD_IDS.website,
+      JSONLD_IDS.catalog,
+      JSONLD_IDS.restApi,
+      JSONLD_IDS.mcp,
+    ]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("REFERENCES the organization rather than restating it", () => {
+    // The defect this replaces: server.ts open-coded an Organization and the
+    // subnet route open-coded a second one inside its Dataset, so every subnet
+    // page described two unrelated publishers and linked neither.
+    for (const id of [JSONLD_IDS.website, JSONLD_IDS.catalog]) {
+      expect(byId(id)?.publisher).toStrictEqual({ "@id": JSONLD_IDS.org });
+    }
+    for (const id of [JSONLD_IDS.restApi, JSONLD_IDS.mcp]) {
+      expect(byId(id)?.provider).toStrictEqual({ "@id": JSONLD_IDS.org });
+    }
+  });
+
+  it("gives an AI crawler a typed pointer to the MCP server", () => {
+    // The whole point for answer engines: a crawler on any page learns, in
+    // machine-readable form, that this data is reachable over MCP.
+    const mcp = byId(JSONLD_IDS.mcp);
+    expect(mcp?.["@type"]).toBe("WebAPI");
+    expect(mcp?.url).toBe("https://api.metagraph.sh/mcp");
+    expect(mcp?.documentation).toBe("https://metagraph.sh/docs/mcp");
+    // The descriptor, not a restated tool list — that changes every release.
+    expect(mcp?.sameAs).toStrictEqual([
+      "https://api.metagraph.sh/.well-known/mcp/server-card.json",
+    ]);
+  });
+
+  it("claims software only for services we actually operate", () => {
+    // Describing a third-party subnet's API as an application we vouch for
+    // would be an over-claim; describing OUR OWN is exactly what we may say.
+    for (const id of [JSONLD_IDS.restApi, JSONLD_IDS.mcp]) {
+      expect(String(byId(id)?.url)).toContain("api.metagraph.sh");
+    }
+  });
+
+  it("exposes semantic search as the catalog's action, not keyword search", () => {
+    const target = (byId(JSONLD_IDS.catalog)?.potentialAction as Record<string, unknown>)
+      ?.target as Record<string, unknown>;
+    expect(String(target?.urlTemplate)).toContain("/api/v1/search/semantic?q={search_term_string}");
+  });
+});
+
+describe("apiRecordUrl (#11204) — the machine-readable copy of a page", () => {
+  it("maps every entity detail route to its verified API record", () => {
+    // Each of these answers 200 on the live API; an alternate pointing at a
+    // 404 is worse than none, because it advertises a format that isn't there.
+    expect(apiRecordUrl("/subnets/64")).toBe("https://api.metagraph.sh/api/v1/subnets/64");
+    expect(apiRecordUrl("/validators/5Grwva")).toBe(
+      "https://api.metagraph.sh/api/v1/validators/5Grwva",
+    );
+    expect(apiRecordUrl("/accounts/5Grwva")).toBe(
+      "https://api.metagraph.sh/api/v1/accounts/5Grwva",
+    );
+    expect(apiRecordUrl("/providers/404-gen")).toBe(
+      "https://api.metagraph.sh/api/v1/providers/404-gen",
+    );
+    expect(apiRecordUrl("/blocks/8725436")).toBe("https://api.metagraph.sh/api/v1/blocks/8725436");
+    expect(apiRecordUrl("/extrinsics/0xabc")).toBe(
+      "https://api.metagraph.sh/api/v1/extrinsics/0xabc",
+    );
+  });
+
+  it("maps the hubs to their collection routes, including /apis/providers", () => {
+    expect(apiRecordUrl("/subnets")).toBe("https://api.metagraph.sh/api/v1/subnets");
+    expect(apiRecordUrl("/validators/")).toBe("https://api.metagraph.sh/api/v1/validators");
+    expect(apiRecordUrl("/apis/providers")).toBe("https://api.metagraph.sh/api/v1/providers");
+  });
+
+  it("returns null for pages that are not one record", () => {
+    for (const path of ["/", "/docs", "/docs/mcp", "/agents", "/subnets/64/history", "/status"]) {
+      expect(apiRecordUrl(path), path).toBeNull();
+    }
+  });
+
+  it("does not re-encode a segment the pathname already encoded", () => {
+    // Double-encoding would produce %2520 and a 404 on an otherwise valid key.
+    expect(apiRecordUrl("/accounts/5Grwva%20x")).toBe(
+      "https://api.metagraph.sh/api/v1/accounts/5Grwva%20x",
+    );
+  });
+});
+
+describe("techArticleJsonLd (#11204) — the pages an answer engine quotes", () => {
+  const base = { headline: "MCP", url: "https://metagraph.sh/docs/mcp" };
+
+  it("ties the prose to the catalog it documents", () => {
+    // `about` is what lets a consumer follow a quoted sentence back to the
+    // machine-readable record, and from there to the REST and MCP endpoints.
+    const out = techArticleJsonLd(base) as unknown as Record<string, unknown>;
+    expect(out["@type"]).toBe("TechArticle");
+    expect(out.about).toStrictEqual({ "@id": JSONLD_IDS.catalog });
+    expect(out.isPartOf).toStrictEqual({ "@id": JSONLD_IDS.website });
+    expect(out.author).toStrictEqual({ "@id": JSONLD_IDS.org });
+    expect(out.publisher).toStrictEqual({ "@id": JSONLD_IDS.org });
+    expect(out.mainEntityOfPage).toBe(base.url);
+  });
+
+  it("omits a blank description rather than emitting an empty string", () => {
+    expect(techArticleJsonLd(base)).not.toHaveProperty("description");
+    expect(techArticleJsonLd({ ...base, description: "   " })).not.toHaveProperty("description");
+    expect(techArticleJsonLd({ ...base, description: " Tools. " })).toHaveProperty(
+      "description",
+      "Tools.",
+    );
+  });
+
+  it("asserts no dateModified, because the loader carries no timestamp", () => {
+    // A made-up date is a freshness claim we cannot support.
+    expect(techArticleJsonLd(base)).not.toHaveProperty("dateModified");
+    expect(techArticleJsonLd(base)).not.toHaveProperty("datePublished");
+  });
+
+  it("references only nodes the page actually declares", () => {
+    const declared = new Set(
+      (siteGraphNodes() as Array<Record<string, unknown>>).map((node) => node["@id"]),
+    );
+    const article = techArticleJsonLd(base) as unknown as Record<string, unknown>;
+    for (const key of ["about", "isPartOf", "author", "publisher"]) {
+      expect(declared).toContain((article[key] as { "@id": string })["@id"]);
+    }
+  });
+});
+
+describe("providerDatasetJsonLd (#11204) — 138 records that had no node", () => {
+  const base = {
+    slug: "404-gen",
+    url: "https://metagraph.sh/providers/404-gen",
+    apiUrl: "https://api.metagraph.sh/api/v1/providers/404-gen",
+    artifactUrl: "https://api.metagraph.sh/metagraph/providers/404-gen.json",
+  };
+
+  it("carries the same catalog wiring the subnet records do", () => {
+    // The reason both go through one builder: a second copy is exactly how the
+    // creator/publisher/includedInDataCatalog wiring lands on one and not the
+    // other.
+    const out = providerDatasetJsonLd({ ...base, name: "404-GEN" }) as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(out["@type"]).toBe("Dataset");
+    expect(out.name).toBe("404-GEN — provider record");
+    expect(out.identifier).toBe("404-gen");
+    expect(out.creator).toStrictEqual({ "@id": JSONLD_IDS.org });
+    expect(out.includedInDataCatalog).toStrictEqual({ "@id": JSONLD_IDS.catalog });
+    expect((out.distribution as Array<{ contentUrl: string }>).map((d) => d.contentUrl)).toEqual([
+      base.apiUrl,
+      base.artifactUrl,
+    ]);
+  });
+
+  it("falls back to the slug when the registry holds no name", () => {
+    expect(providerDatasetJsonLd(base).name).toBe("404-gen — provider record");
+    expect(providerDatasetJsonLd({ ...base, name: "  " }).name).toBe("404-gen — provider record");
+  });
+
+  it("describes OUR record, never the provider as an organization", () => {
+    // Emitting an Organization would assert a third party's identity on their
+    // behalf — the over-claim the registry exists not to make.
+    const out = providerDatasetJsonLd(base) as unknown as Record<string, unknown>;
+    expect(out["@type"]).not.toBe("Organization");
+    expect(String(out.description)).toContain("Registry record for");
+  });
+
+  it("omits sameAs rather than attaching the record to nothing", () => {
+    expect(providerDatasetJsonLd(base)).not.toHaveProperty("sameAs");
+    expect(providerDatasetJsonLd({ ...base, sameAs: "https://www.404.xyz/" })).toHaveProperty(
+      "sameAs",
+      ["https://www.404.xyz/"],
     );
   });
 });

--- a/apps/ui/src/lib/metagraphed/json-ld.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.ts
@@ -1,4 +1,4 @@
-import { SITE_ORIGIN } from "./identity";
+import { API_ORIGIN, GITHUB_REPO_URL, SITE_ORIGIN, X_PROFILE_URL } from "./identity";
 
 /**
  * Pure schema.org JSON-LD builders (#11204 item 4).
@@ -40,6 +40,178 @@ export function stringifyJsonLd(value: unknown): string {
   );
 }
 
+/**
+ * Stable `@id`s for the nodes that exist ONCE across the whole site.
+ *
+ * These are what turn a page's markup from a pile of disconnected objects into
+ * a graph. A page emits two `<script type="application/ld+json">` blocks — the
+ * server-injected site graph and, on an entity route, that route's own node —
+ * and a consumer merges them by `@id`. So an entity node must REFERENCE
+ * `{ "@id": JSONLD_IDS.org }` rather than restating an inline Organization: an
+ * inline copy mints a second, unrelated entity every time, which is the exact
+ * opposite of what structured data is for.
+ *
+ * Fragment identifiers on the origins, not invented URLs, so each `@id` is
+ * dereferenceable to the thing it names.
+ */
+export const JSONLD_IDS = {
+  org: `${SITE_ORIGIN}/#org`,
+  website: `${SITE_ORIGIN}/#website`,
+  /** The registry as a whole: the thing every per-subnet Dataset belongs to. */
+  catalog: `${SITE_ORIGIN}/#catalog`,
+  /** The public REST API. */
+  restApi: `${API_ORIGIN}/#api`,
+  /** The Model Context Protocol server. */
+  mcp: `${API_ORIGIN}/#mcp`,
+} as const;
+
+/** A bare `@id` reference to another node in the page's merged graph. */
+function ref(id: string) {
+  return { "@id": id };
+}
+
+/**
+ * The nodes every page carries, in the order a reader would want them.
+ *
+ * Lives here rather than inline in server.ts so the site graph and the entity
+ * routes share ONE definition of who we are — server.ts open-coded the
+ * Organization and WebSite, and an entity route open-coded a second
+ * Organization inside its Dataset, so the same publisher was described twice
+ * with different fields and no link between them.
+ *
+ * The two WebAPI nodes are the point of this for AI answer engines: a crawler
+ * reading any page of this site now finds, typed and machine-readable, that the
+ * data behind the page is available over a documented REST API and an MCP
+ * server, published by a named organization. That claim is honest in a way the
+ * per-subnet markup deliberately is not — these are OUR services, so describing
+ * them as software we vouch for is exactly what we are entitled to say.
+ */
+export function siteGraphNodes(): unknown[] {
+  return [
+    {
+      "@type": "Organization",
+      "@id": JSONLD_IDS.org,
+      name: "Metagraphed",
+      url: SITE_ORIGIN,
+      description:
+        "The Bittensor subnet integration registry — what each subnet exposes (APIs, docs, schemas), whether it is healthy, and how to call it.",
+      // #11204: the profiles that let a search engine resolve "Metagraphed" to
+      // one entity rather than treating each surface as an unrelated site.
+      // Only accounts this project actually controls are listed — a sameAs is
+      // an identity claim, and a wrong one merges us with someone else.
+      sameAs: [GITHUB_REPO_URL, X_PROFILE_URL],
+    },
+    {
+      "@type": "WebSite",
+      "@id": JSONLD_IDS.website,
+      url: SITE_ORIGIN,
+      name: "Metagraphed",
+      publisher: ref(JSONLD_IDS.org),
+      potentialAction: {
+        "@type": "SearchAction",
+        target: {
+          "@type": "EntryPoint",
+          urlTemplate: `${SITE_ORIGIN}/subnets?q={search_term_string}`,
+        },
+        "query-input": "required name=search_term_string",
+      },
+    },
+    {
+      // The registry itself. Each subnet page's Dataset says
+      // `includedInDataCatalog` back to this, which is what makes 129 isolated
+      // Datasets read as one catalog rather than 129 unrelated files — the
+      // relationship dataset indexes and answer engines actually traverse.
+      "@type": "DataCatalog",
+      "@id": JSONLD_IDS.catalog,
+      name: "Metagraphed — the Bittensor subnet integration registry",
+      description:
+        "Per-subnet records of what each Bittensor subnet publishes: APIs, documentation, schemas, endpoints, probe-derived health and economics.",
+      url: `${SITE_ORIGIN}/subnets`,
+      publisher: ref(JSONLD_IDS.org),
+      isAccessibleForFree: true,
+      potentialAction: {
+        // Natural-language search over the registry, which is the entry point
+        // an agent wants and the one a keyword SearchAction cannot express.
+        "@type": "SearchAction",
+        target: {
+          "@type": "EntryPoint",
+          urlTemplate: `${API_ORIGIN}/api/v1/search/semantic?q={search_term_string}`,
+          contentType: "application/json",
+        },
+        "query-input": "required name=search_term_string",
+      },
+    },
+    {
+      "@type": "WebAPI",
+      "@id": JSONLD_IDS.restApi,
+      name: "Metagraphed REST API",
+      description:
+        "Public, read-only JSON over every registry record: subnets, surfaces, endpoints, providers, health and economics.",
+      url: `${API_ORIGIN}/api/v1`,
+      documentation: `${SITE_ORIGIN}/docs/api-reference`,
+      provider: ref(JSONLD_IDS.org),
+      termsOfService: `${SITE_ORIGIN}/docs/limits`,
+      isAccessibleForFree: true,
+    },
+    {
+      "@type": "WebAPI",
+      "@id": JSONLD_IDS.mcp,
+      name: "Metagraphed MCP server",
+      description:
+        "Model Context Protocol endpoint: an AI agent queries the Bittensor subnet registry as tools — discover subnets by capability, read live health, and fetch the schema needed to call a subnet's API.",
+      url: `${API_ORIGIN}/mcp`,
+      documentation: `${SITE_ORIGIN}/docs/mcp`,
+      provider: ref(JSONLD_IDS.org),
+      isAccessibleForFree: true,
+      // The transport an agent needs to know before it can connect. `sameAs`
+      // points at the machine-readable descriptor rather than restating the
+      // tool list, which changes with every release.
+      sameAs: [`${API_ORIGIN}/.well-known/mcp/server-card.json`],
+    },
+  ];
+}
+
+/**
+ * Routes whose page has a single machine-readable record behind it.
+ *
+ * Every path and collection here was verified to answer 200 on the live API
+ * before being listed -- a `rel="alternate"` pointing at a 404 is worse than no
+ * alternate at all, because it advertises a machine format that does not exist.
+ */
+const API_RECORD_COLLECTIONS = [
+  "subnets",
+  "validators",
+  "accounts",
+  "providers",
+  "blocks",
+  "extrinsics",
+] as const;
+
+/**
+ * The JSON record for a page, or null when the page is not one record.
+ *
+ * This is what backs the `<link rel="alternate" type="application/json">` the
+ * server injects: the oldest and most widely understood way to say "there is a
+ * machine-readable copy of this page, here". The site already advertised its
+ * RSS and Atom feeds this way and never advertised its own data.
+ *
+ * Kept pure and pathname-only so it can be tested without a router, and so the
+ * ONE injection point in server.ts covers every entity family at once rather
+ * than six route files each remembering to do it.
+ */
+export function apiRecordUrl(pathname: string): string | null {
+  const trimmed = pathname.replace(/\/+$/, "") || "/";
+  for (const collection of API_RECORD_COLLECTIONS) {
+    if (trimmed === `/${collection}`) return `${API_ORIGIN}/api/v1/${collection}`;
+    const detail = new RegExp(`^/${collection}/([^/]+)$`).exec(trimmed);
+    // Already URL-encoded as part of the pathname; re-encoding would double it.
+    if (detail?.[1]) return `${API_ORIGIN}/api/v1/${collection}/${detail[1]}`;
+  }
+  // The providers hub lives at /apis/providers, and the directory it links.
+  if (trimmed === "/apis/providers") return `${API_ORIGIN}/api/v1/providers`;
+  return null;
+}
+
 export interface BreadcrumbCrumb {
   name: string;
   /** Absolute URL — a crawler cannot resolve a relative `item`. */
@@ -56,6 +228,49 @@ export function breadcrumbListJsonLd(crumbs: BreadcrumbCrumb[]) {
       name: crumb.name,
       item: crumb.item,
     })),
+  };
+}
+
+export interface TechArticleInput {
+  /** The page's own title. */
+  headline: string;
+  description?: string | null;
+  /** Canonical URL for this page. */
+  url: string;
+}
+
+/**
+ * schema.org TechArticle for one documentation page.
+ *
+ * Docs are the pages an answer engine quotes — "how do I call a Bittensor
+ * subnet's API", "what does readiness mean here" — and they carried no node at
+ * all, so the ~49 most quotable pages on the site were untyped prose under a
+ * generic site graph.
+ *
+ * `about` pointing at the catalog is the part that does work beyond the type
+ * name: it states that this prose documents THAT data, which is what lets a
+ * consumer follow a quoted sentence back to the machine-readable record behind
+ * it — and, from the catalog, on to the REST and MCP endpoints.
+ *
+ * Deliberately no `dateModified`: the loader carries no timestamp, and a date
+ * we made up would be a claim about freshness we cannot support. Deliberately
+ * not FAQPage either — these are reference pages, not question/answer pairs,
+ * and marking them up as FAQ to chase a rich result is the kind of over-claim
+ * that costs more than it earns.
+ */
+export function techArticleJsonLd(input: TechArticleInput) {
+  const description = input.description?.trim();
+  return {
+    "@type": "TechArticle",
+    headline: input.headline,
+    ...(description ? { description } : {}),
+    url: input.url,
+    mainEntityOfPage: input.url,
+    inLanguage: "en",
+    author: ref(JSONLD_IDS.org),
+    publisher: ref(JSONLD_IDS.org),
+    isPartOf: ref(JSONLD_IDS.website),
+    about: ref(JSONLD_IDS.catalog),
   };
 }
 
@@ -89,20 +304,87 @@ export interface SubnetDatasetInput {
  * what a dataset consumer wants and what Google's dataset index reads.
  */
 export function subnetDatasetJsonLd(input: SubnetDatasetInput) {
-  const label = input.name ? `${input.name} (Subnet ${input.netuid})` : `Subnet ${input.netuid}`;
-  const description =
-    input.description?.trim() ||
-    `Registry record for Bittensor subnet ${input.netuid}: published interfaces, endpoints, schemas, health and economics.`;
-  return {
-    "@type": "Dataset",
-    name: label,
-    description,
-    url: input.url,
+  return registryDatasetJsonLd({
+    ...input,
+    name: input.name ? `${input.name} (Subnet ${input.netuid})` : `Subnet ${input.netuid}`,
     // The netuid is the subnet's stable on-chain identifier, and the term a
     // reader is most likely to have searched to arrive here.
     identifier: String(input.netuid),
+    description:
+      input.description?.trim() ||
+      `Registry record for Bittensor subnet ${input.netuid}: published interfaces, endpoints, schemas, health and economics.`,
+  });
+}
+
+export interface ProviderDatasetInput {
+  /** Registry slug — the provider's stable key and its URL segment. */
+  slug: string;
+  name?: string | null;
+  description?: string | null;
+  url: string;
+  apiUrl: string;
+  artifactUrl: string;
+  /** The provider's own site, when the registry holds one. */
+  sameAs?: string | null;
+}
+
+/**
+ * schema.org Dataset for one provider's registry record.
+ *
+ * Dataset, and NOT an `Organization` node for the provider itself — the same
+ * restraint the subnet records ship under. This page publishes OUR measured
+ * record of a third party: the endpoints they operate, the surfaces we found,
+ * the health we probed. Emitting an `Organization` would be asserting an
+ * identity for a company on their behalf, which is exactly the over-claim the
+ * registry exists not to make.
+ */
+export function providerDatasetJsonLd(input: ProviderDatasetInput) {
+  const name = input.name?.trim() || input.slug;
+  return registryDatasetJsonLd({
+    ...input,
+    name: `${name} — provider record`,
+    identifier: input.slug,
+    description:
+      input.description?.trim() ||
+      `Registry record for ${name}: the public endpoints and operational surfaces this provider runs for Bittensor subnets, with probe-derived health.`,
+  });
+}
+
+interface RegistryDatasetInput {
+  name: string;
+  identifier: string;
+  description: string;
+  url: string;
+  apiUrl: string;
+  artifactUrl: string;
+  sameAs?: string | null;
+}
+
+/**
+ * The shape every registry record shares: a named, freely accessible dataset
+ * inside our catalog, distributed as the two JSON representations the page
+ * already links.
+ *
+ * One builder rather than one per entity kind, because the parts that differ
+ * are only the label, the identifier and the fallback sentence -- and a second
+ * copy is how the `creator`/`publisher`/`includedInDataCatalog` wiring ends up
+ * on subnets and missing on providers.
+ */
+function registryDatasetJsonLd(input: RegistryDatasetInput) {
+  return {
+    "@type": "Dataset",
+    name: input.name,
+    description: input.description,
+    url: input.url,
+    identifier: input.identifier,
     isAccessibleForFree: true,
-    creator: { "@type": "Organization", name: "Metagraphed", url: SITE_ORIGIN },
+    // References, not a restated Organization. The inline copy this replaces
+    // minted a second, unrelated publisher on every one of the 129 subnet
+    // pages, so nothing tied the record to the site that publishes it.
+    creator: ref(JSONLD_IDS.org),
+    publisher: ref(JSONLD_IDS.org),
+    // What makes 129 Datasets one catalog rather than 129 loose files.
+    includedInDataCatalog: ref(JSONLD_IDS.catalog),
     distribution: [
       {
         "@type": "DataDownload",

--- a/apps/ui/src/routes/docs.$.tsx
+++ b/apps/ui/src/routes/docs.$.tsx
@@ -2,6 +2,8 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { docsSource } from "@/lib/docs-source";
 import { ogImageMeta } from "@/lib/metagraphed/og-card";
+import { stringifyJsonLd, techArticleJsonLd } from "@/lib/metagraphed/json-ld";
+import { SITE_ORIGIN } from "@/lib/metagraphed/identity";
 import { openapi } from "@/lib/openapi-source";
 import type { OpenAPIPreloaded } from "@/lib/openapi-preload-context";
 import { DocsSplatPage } from "./-docs-splat-page";
@@ -37,7 +39,7 @@ export const Route = createFileRoute("/docs/$")({
     const slugs = params._splat?.split("/") ?? [];
     return serverLoader({ data: slugs });
   },
-  head: ({ loaderData }) => ({
+  head: ({ loaderData, params }) => ({
     meta: [
       { title: loaderData ? `${loaderData.title} — Metagraphed Docs` : "Metagraphed Docs" },
       { name: "description", content: loaderData?.description ?? "" },
@@ -62,6 +64,26 @@ export const Route = createFileRoute("/docs/$")({
         entity: false,
       }),
     ],
+    // #11204: docs are the pages an answer engine quotes, and they carried no
+    // node of their own. TechArticle types the prose and, via `about`, ties it
+    // to the catalog the prose documents -- so a quoted sentence leads back to
+    // the machine-readable record, and from there to the REST and MCP
+    // endpoints. Emitted only when the page actually loaded: a node built from
+    // a missing title would assert a document that isn't there.
+    scripts: loaderData
+      ? [
+          {
+            type: "application/ld+json",
+            children: stringifyJsonLd(
+              techArticleJsonLd({
+                headline: loaderData.title,
+                description: loaderData.description,
+                url: `${SITE_ORIGIN}/docs/${params._splat ?? ""}`.replace(/\/+$/, ""),
+              }),
+            ),
+          },
+        ]
+      : [],
   }),
 });
 

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -9,6 +9,9 @@ import {
   logoHostFrom,
   ogImageMeta,
 } from "@/lib/metagraphed/og-card";
+import { providerDatasetJsonLd, stringifyJsonLd } from "@/lib/metagraphed/json-ld";
+import { SITE_ORIGIN } from "@/lib/metagraphed/identity";
+import { API_BASE } from "@/lib/metagraphed/config";
 import { ProviderDetail } from "./-providers-slug-page";
 import {
   entityNotFoundMeta,
@@ -92,6 +95,25 @@ export const Route = createFileRoute("/providers/$slug")({
               : []),
           ],
         }),
+      ],
+      // #11204: the provider pages carried no node of their own, so 138 registry
+      // records were untyped prose. Dataset, matching the subnet treatment --
+      // and deliberately NOT an Organization for the provider, which would be
+      // asserting a third party's identity on their behalf.
+      scripts: [
+        {
+          type: "application/ld+json",
+          children: stringifyJsonLd(
+            providerDatasetJsonLd({
+              slug: params.slug,
+              name: loaderData?.name ?? null,
+              url: `${SITE_ORIGIN}/providers/${encodeURIComponent(params.slug)}`,
+              apiUrl: `${API_BASE}/api/v1/providers/${encodeURIComponent(params.slug)}`,
+              artifactUrl: `${API_BASE}/metagraph/providers/${encodeURIComponent(params.slug)}.json`,
+              sameAs: loaderData?.website ?? null,
+            }),
+          ),
+        },
       ],
     };
   },

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -4,14 +4,13 @@ import { consumeLastCapturedError } from "./lib/error-capture";
 import { renderErrorPage } from "./lib/error-page";
 import { handleOgImage } from "./lib/og-image";
 import { routeOwnsOgImage } from "./lib/metagraphed/og-card";
-import { breadcrumbListJsonLd, stringifyJsonLd } from "./lib/metagraphed/json-ld";
 import {
-  API_ORIGIN,
-  GITHUB_REPO_URL,
-  SITE_ORIGIN,
-  X_HANDLE,
-  X_PROFILE_URL,
-} from "./lib/metagraphed/identity";
+  apiRecordUrl,
+  breadcrumbListJsonLd,
+  siteGraphNodes,
+  stringifyJsonLd,
+} from "./lib/metagraphed/json-ld";
+import { API_ORIGIN, SITE_ORIGIN, X_HANDLE } from "./lib/metagraphed/identity";
 import { handleAnalyticsProxy, type PostHogAssetContext } from "./lib/analytics-proxy";
 
 type ServerEntry = {
@@ -516,36 +515,10 @@ function titleCaseSlug(slug: string): string {
 // results); the per-subnet Dataset lives in the route's own head(), where the
 // loader data it describes is available.
 export function buildJsonLd(pathname: string): string {
-  const graph: unknown[] = [
-    {
-      "@type": "Organization",
-      "@id": `${SITE_ORIGIN}/#org`,
-      name: "Metagraphed",
-      url: SITE_ORIGIN,
-      description:
-        "The Bittensor subnet integration registry — what each subnet exposes (APIs, docs, schemas), whether it is healthy, and how to call it.",
-      // #11204: the profiles that let a search engine resolve "Metagraphed" to
-      // one entity rather than treating each surface as an unrelated site.
-      // Only accounts this project actually controls are listed — a sameAs is
-      // an identity claim, and a wrong one merges us with someone else.
-      sameAs: [GITHUB_REPO_URL, X_PROFILE_URL],
-    },
-    {
-      "@type": "WebSite",
-      "@id": `${SITE_ORIGIN}/#website`,
-      url: SITE_ORIGIN,
-      name: "Metagraphed",
-      publisher: { "@id": `${SITE_ORIGIN}/#org` },
-      potentialAction: {
-        "@type": "SearchAction",
-        target: {
-          "@type": "EntryPoint",
-          urlTemplate: `${SITE_ORIGIN}/subnets?q={search_term_string}`,
-        },
-        "query-input": "required name=search_term_string",
-      },
-    },
-  ];
+  // The site nodes are defined in json-ld.ts, not here: an entity route's own
+  // markup has to reference them by @id, and two hand-written copies of the
+  // same Organization is how a page ends up describing two publishers.
+  const graph: unknown[] = [...siteGraphNodes()];
   const breadcrumb = buildBreadcrumb(pathname);
   if (breadcrumb) graph.push(breadcrumb);
   return stringifyJsonLd({
@@ -906,6 +879,15 @@ function injectAnalytics(response: Response, request: Request): Response {
   // a static homepage value.
   const ogUrlTag = `<meta property="og:url" content="${escapeHtmlAttr(canonicalUrl)}">`;
   const jsonLdTag = `<script type="application/ld+json">${buildJsonLd(pathname)}</script>`;
+  // #11204: the machine-readable copy of THIS page. The site advertised its RSS
+  // and Atom feeds this way and never advertised its own data, so a crawler
+  // that had just read a subnet page had no typed pointer to the JSON record
+  // behind it. One injection point covers every entity family and hub, rather
+  // than six route files each having to remember.
+  const apiRecord = apiRecordUrl(pathname);
+  const apiAlternateTag = apiRecord
+    ? `<link rel="alternate" type="application/json" href="${escapeHtmlAttr(apiRecord)}" title="Metagraphed API record for this page">`
+    : "";
   // #8489: the three entity detail routes emit their own og:image in head(),
   // where loaderData is available and the card can carry real per-entity data.
   // Skipping them here is what keeps exactly ONE og:image tag on the page --
@@ -941,6 +923,7 @@ function injectAnalytics(response: Response, request: Request): Response {
               element.append(canonicalTag, { html: true });
               element.append(ogUrlTag, { html: true });
               element.append(jsonLdTag, { html: true });
+              if (apiAlternateTag) element.append(apiAlternateTag, { html: true });
               element.append(SEO_DEFAULT_TAGS, { html: true });
               if (!routeOwnsCard) element.append(ogImageTags, { html: true });
               element.append(WEB_VITALS_SNIPPET, { html: true });


### PR DESCRIPTION
Closes #11240. Part of #11204.

## The defect

`/subnets/64` emitted **two disconnected JSON-LD documents**:

```
block 1: [Dataset]
block 2: [Organization, WebSite, BreadcrumbList]
```

and the `Dataset` carried an **inline** `creator: { "@type": "Organization", name: "Metagraphed" }`
rather than a reference — so all 129 subnet pages minted a second publisher entity unrelated to the
site's own, with nothing linking the record to the site that publishes it. Two hand-written copies of
the same organization is also how the two drift.

## After

Verified by parsing a real `workerd` render, merging every `ld+json` block and checking that no
`@id` is referenced without being declared:

| page | nodes | dangling refs |
|---|---|---|
| `/subnets/64` | `Dataset, Organization, WebSite, DataCatalog, WebAPI, WebAPI, BreadcrumbList` | none |
| `/providers/404-gen` | `Dataset, Organization, WebSite, DataCatalog, WebAPI, WebAPI, BreadcrumbList` | none |
| `/docs/mcp` | `TechArticle, Organization, WebSite, DataCatalog, WebAPI, WebAPI, BreadcrumbList` | none |

## What the graph now says

- **A `DataCatalog`**, with every registry `Dataset` pointing back at it via `includedInDataCatalog`.
  129 subnet records read as one registry rather than 129 loose files — the edge dataset indexes and
  answer engines actually traverse.
- **`WebAPI` nodes for the REST API and the MCP server, on every page**, each with `provider` and
  `documentation`. A crawler reading any page now finds, typed and machine-readable, that this data
  is reachable over MCP at `api.metagraph.sh/mcp`. `llms.txt` and `/.well-known/mcp.json` already
  said this well; nothing in the markup a crawler was actually reading said it at all.
- **`TechArticle` on the ~49 docs pages**, with `about` pointing at the catalog — so a quoted
  sentence leads back to the machine-readable record, and from there to the endpoints. These are the
  pages an answer engine quotes and they carried no node.
- **`Dataset` on the 138 provider pages**, which carried nothing.
- **`<link rel="alternate" type="application/json">`** on every page that is one record. The site
  advertised its RSS and Atom feeds this way and had never advertised its own data.

Both `Dataset` kinds go through one builder, because a second copy is exactly how the
`creator`/`publisher`/`includedInDataCatalog` wiring lands on subnets and quietly misses providers.

## Restraint, kept deliberately

- **No `FAQPage`** on docs. They are reference pages, not question/answer pairs; marking them up as
  FAQ to chase a rich result is an over-claim.
- **No `Organization` node for a provider.** This site publishes OUR measured record *of* a third
  party — asserting an identity for a company on their behalf is precisely the claim the registry
  exists not to make. Same reason subnet pages are `Dataset` and not `SoftwareApplication`/`WebAPI`.
- **No `dateModified`** on docs: the loader carries no timestamp, and a made-up date is a freshness
  claim that cannot be supported.

## Verification

- Every route in the `rel="alternate"` mapping was checked against the live API before being listed
  (all six detail families and six collections answer 200) — an alternate pointing at a 404 is worse
  than none, because it advertises a machine format that is not there.
- A test asserts each entity node references only `@id`s the site graph actually declares, so a
  future node cannot dangle silently.
- `tsc --noEmit`, `vitest run` (258 files, 2181 tests), `lint` (0 errors), `format:check` — green.
