### PR TITLE
fix(emission): the drift check read 128 netuids while the chain had 129

### DIFF
--- a/src/emission-drift-check.ts
+++ b/src/emission-drift-check.ts
@@ -26,6 +26,7 @@
 
 import {
   DEFAULT_EMISSION_GATE_EXPONENT,
+  decodeLeU16,
   decodeLeU64,
   decodeLeU128,
   u64f64U128ToFloat,
@@ -41,7 +42,42 @@ import {
 } from "./emission-pipeline.ts";
 import { createSubtensorPinnedStorage } from "./subtensor-pinned-storage.ts";
 
-const MAX_NETUID = 128;
+/**
+ * Hard ceiling on how many netuids are probed.
+ *
+ * NOT the expected count. The range comes from `SubtensorModule.TotalNetworks`
+ * (see probedNetuids) so a new subnet is read the moment it exists; this only
+ * bounds a chain reporting something absurd, and must stay well above
+ * `SubnetLimit` or a legitimately grown network would be silently truncated --
+ * which is the exact failure it replaced.
+ */
+const MAX_PROBED_NETUIDS = 1024;
+
+/**
+ * The netuids to read, from the chain's own count.
+ *
+ * WAS `Array.from({ length: 128 })`, and the 129th subnet had already arrived.
+ * `TotalNetworks` was 129 while this read 0..127, so netuid 128's channels were
+ * missing from every sum -- and the aggregate identity is a SUM, so the check
+ * reported the network as drifting by exactly the emission of the subnet it had
+ * not looked at. Measured 2026-08-14: Δ -110,236 to -125,520 rao against
+ * netuid 128 (`ByteLeap`) carrying tao_in_emission of ~120,705 rao and moving
+ * per block. The alarm was right that something was wrong and wrong about what.
+ *
+ * NO `+ 1` HERE, unlike src/chain-burn.ts's otherwise-identical probe. That
+ * lane reads one past the count as cheap insurance, because an absent key is
+ * simply null to it. Here an absent key is not free: emission_enabled is
+ * ABSENT-MEANS-ENABLED (see emissionIdentityChecks' fourth check), so a
+ * phantom netuid would enter the reconstruction as an enabled subnet with no
+ * emission and shift every share. `TotalNetworks` is a count and netuids are
+ * 0-indexed from root, so the count IS the exclusive upper bound.
+ */
+export function probedNetuids(totalNetworks: number): number[] {
+  return Array.from(
+    { length: Math.min(totalNetworks, MAX_PROBED_NETUIDS) },
+    (_, i) => i,
+  );
+}
 
 const MAPS = {
   moving_price: "1abf1b0f4fd14f7b72ee50f9d91d5915",
@@ -58,6 +94,8 @@ const VALUES = {
   emission_gate_bar: "7c9b0d2964cc73e7519676c3cc4d5df9",
   emission_bar_quantile: "a772007dde2ed63e0f21b5f9d7f16650",
   emission_gate_exponent: "88c70e8dd0cf4af3aeb977ba2eee1df4",
+  // twox128("TotalNetworks") -- the netuid range, read rather than assumed.
+  total_networks: "5f3bb7bcd0a076a48abf8c256d221721",
   total_issuance: "57c875e4cff74148e4628f264b974c80",
 } as const;
 
@@ -102,17 +140,27 @@ export async function checkEmissionDrift(
   options: EmissionDriftCheckOptions,
 ): Promise<EmissionDriftResult> {
   const storage = createSubtensorPinnedStorage(options);
-  const netuids = Array.from({ length: MAX_NETUID }, (_, i) => i);
 
   const { blockNumber, blockHash } = await storage.pinHead();
+
+  // VALUES first, because the netuid range is one of them now.
+  const values: Record<string, string | null> = {};
+  for (const [name, hash] of Object.entries(VALUES)) {
+    values[name] = await storage.readValue(hash, blockHash);
+  }
+
+  const totalNetworks = decodeLeU16(values.total_networks);
+  if (totalNetworks === null) {
+    // Never assumed, for the same reason block emission is not: guessing the
+    // range is how this check came to report a drift that was its own blind
+    // spot. A partial read must never be scored as if it were a complete one.
+    throw new Error("could not read TotalNetworks -- netuid range unknown");
+  }
+  const netuids = probedNetuids(totalNetworks);
 
   const maps: Record<string, Map<number, string>> = {};
   for (const [name, hash] of Object.entries(MAPS)) {
     maps[name] = await storage.readNetuidMap(hash, blockHash, netuids);
-  }
-  const values: Record<string, string | null> = {};
-  for (const [name, hash] of Object.entries(VALUES)) {
-    values[name] = await storage.readValue(hash, blockHash);
   }
 
   const theta = u64f64U128ToFloat(decodeLeU128(values.emission_gate_bar) ?? 0n);

--- a/tests/emission-drift-check.test.ts
+++ b/tests/emission-drift-check.test.ts
@@ -8,7 +8,10 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import fixture from "./fixtures/emission-pipeline.json" with { type: "json" };
-import { checkEmissionDrift } from "../src/emission-drift-check.ts";
+import {
+  checkEmissionDrift,
+  probedNetuids,
+} from "../src/emission-drift-check.ts";
 import {
   DEFAULT_EMISSION_GATE_EXPONENT,
   decodeLeU64,
@@ -194,5 +197,88 @@ describe("checkEmissionDrift", () => {
     } finally {
       globalThis.fetch = realFetch;
     }
+  });
+});
+
+// --- the netuid range is READ, not assumed (the 129th subnet) ---------------
+//
+// `Array.from({ length: 128 })` read netuids 0..127 while TotalNetworks was
+// already 129. The aggregate identity is a SUM, so the check reported the
+// network as drifting by exactly the emission of the subnet it had not looked
+// at -- measured in production as Δ -110,236 to -125,520 rao, against netuid
+// 128 carrying ~120,705 rao of tao_in_emission. Right that something was
+// wrong; wrong about what.
+
+describe("the netuid range", () => {
+  /** The item hash TotalNetworks is served under, from the fixture itself. */
+  const TOTAL_NETWORKS_HASH = (fixture.item_hashes as Record<string, string>)
+    .total_networks;
+
+  /** Every netuid the run actually asked the chain about. */
+  function netuidsRead(
+    calls: { method: string; params: unknown[] }[],
+  ): number[] {
+    const seen = new Set<number>();
+    for (const call of calls) {
+      if (call.method !== "state_queryStorageAt") continue;
+      for (const key of call.params[0] as string[]) {
+        const suffix = key.slice(-4);
+        seen.add(
+          Number.parseInt(suffix.slice(0, 2), 16) +
+            Number.parseInt(suffix.slice(2, 4), 16) * 256,
+        );
+      }
+    }
+    return [...seen].sort((a, b) => a - b);
+  }
+
+  /** Serve the fixture, but report a different TotalNetworks. */
+  function withTotalNetworks(hex: string | null) {
+    return fixtureFetch((method, params) => {
+      if (method !== "state_getStorage") return undefined;
+      const key = params[0] as string;
+      return key.endsWith(TOTAL_NETWORKS_HASH) ? hex : undefined;
+    });
+  }
+
+  test("follows TotalNetworks, so a NEW subnet is read the block it appears", async () => {
+    // 129 subnets means netuids 0..128 -- the case production was in.
+    const { impl, calls } = withTotalNetworks("0x8100");
+    await checkEmissionDrift({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+    const read = netuidsRead(calls);
+    assert.equal(read.at(-1), 128, "the newest subnet was read");
+    assert.equal(read.length, 129);
+  });
+
+  test("does NOT probe one past the count, unlike the burn lane", async () => {
+    // src/chain-burn.ts deliberately reads `total + 1` as cheap insurance,
+    // because an absent key is simply null to it. Here it is not free:
+    // emission_enabled is ABSENT-MEANS-ENABLED, so a phantom netuid would
+    // enter the reconstruction as an enabled subnet with no emission and shift
+    // every share.
+    const { impl, calls } = withTotalNetworks("0x8000");
+    await checkEmissionDrift({ rpcUrl: "https://rpc.test", fetchImpl: impl });
+    const read = netuidsRead(calls);
+    assert.equal(read.at(-1), 127);
+    assert.equal(read.length, 128);
+  });
+
+  test("an unreadable count throws rather than guessing a range", async () => {
+    // The same rule the block-emission read follows: a partial read must never
+    // be scored as if it were a complete one. Guessing the range is precisely
+    // how this check came to report its own blind spot as chain drift.
+    const { impl } = withTotalNetworks(null);
+    await assert.rejects(
+      () => checkEmissionDrift({ rpcUrl: "https://rpc.test", fetchImpl: impl }),
+      /TotalNetworks/,
+    );
+  });
+
+  test("probedNetuids caps an absurd count instead of minting a million keys", () => {
+    assert.deepEqual(probedNetuids(3), [0, 1, 2]);
+    assert.equal(probedNetuids(65535).length, 1024);
+    // A chain reporting zero subnets reads none -- and the identity checks
+    // then fail loudly on an empty sum, which is the correct outcome.
+    assert.deepEqual(probedNetuids(0), []);
   });
 });

--- a/tests/fixtures/emission-pipeline.json
+++ b/tests/fixtures/emission-pipeline.json
@@ -17,13 +17,15 @@
     "emission_gate_bar": "7c9b0d2964cc73e7519676c3cc4d5df9",
     "emission_bar_quantile": "a772007dde2ed63e0f21b5f9d7f16650",
     "emission_gate_exponent": "88c70e8dd0cf4af3aeb977ba2eee1df4",
-    "total_issuance": "57c875e4cff74148e4628f264b974c80"
+    "total_issuance": "57c875e4cff74148e4628f264b974c80",
+    "total_networks": "5f3bb7bcd0a076a48abf8c256d221721"
   },
   "values": {
     "emission_gate_bar": "0x9d7438777bb45f020000000000000000",
     "emission_bar_quantile": "0x00000000000000c00000000000000000",
     "emission_gate_exponent": null,
-    "total_issuance": "0x974c8037cfb92700"
+    "total_issuance": "0x974c8037cfb92700",
+    "total_networks": "0x8000"
   },
   "maps": {
     "moving_price": {


### PR DESCRIPTION
The emission-drift alarm has been firing every 30 minutes for days. **It was right that something was wrong and wrong about what** — it has been reporting the network as drifting by exactly the emission of the subnet it never looked at.

## The bug

`checkEmissionDrift` enumerated `Array.from({ length: 128 })` — netuids **0..127** — while `SubtensorModule.TotalNetworks` was already **129**. The aggregate identity is a *sum* over that list, so netuid 128's channels were simply absent from the left-hand side:

```
sum_tao_channels_equals_block_emission
Σ(tao_in + excess) = 499889507 rao vs block emission 500000000 rao
(Δ -110493 rao, tolerance ±1000)
```

Netuid 128 is `ByteLeap` — `emission_enabled`, `tao_in_emission` ≈ **120,705 rao**, moving every block. That is the drift, and why it wandered between −110,236 and −125,520 instead of sitting still.

## A/B against the live chain

Block 8846913, same code, one line different:

| netuid range | eligible | identities_failed | Δ | max_share_error |
|---|---|---|---|---|
| `0..127` (old) | 126 | **1** | −110,493 rao | 1.002e-4 |
| `0..128` (derived) | 127 | **0** | clean | 1.581e-6 |

The per-subnet share error falls **63×** with it, because the reconstruction renormalises over the subnets it was handed. So the *second* message sharing this alarm's fingerprint — `per-subnet reconstruction drift — netuid 100 off by 2.918e-3` — was the same bug seen from the other end. One fix, both messages.

## The range is read now, not assumed

From `TotalNetworks`, pinned to the same block hash as every other read in this module, so a new subnet is included the block it appears rather than the next time someone edits a constant.

An unreadable count **throws** rather than falling back to a guess — the same rule the block-emission read already follows (`could not derive block emission from TotalIssuance`). Guessing the range is precisely how this check came to report its own blind spot as chain drift.

**Deliberately no `+ 1`**, unlike `src/chain-burn.ts`'s otherwise-identical probe. That lane reads one past the count as cheap insurance because an absent key is simply `null` to it. Here it is not free: `emission_enabled` is **absent-means-enabled** (the trap `emissionIdentityChecks`' fourth check exists to catch), so a phantom netuid would enter the reconstruction as an enabled subnet with no emission and shift *every* share — turning a fix for one missing subnet into a fault on all of them. `chain-burn` already wrote the comment about this off-by-one dropping "the newest subnet"; this module just never got it.

## Verification

- **A/B against the live chain**, above — not a fixture argument with itself.
- The committed fixture gains its own `total_networks` (128, matching the netuids it captured), so the baseline reproduces exactly what it did before and the four identity checks still pass on it **unchanged**.
- Four new tests: the range follows `TotalNetworks` (a chain reporting 129 reads netuid 128); it does **not** probe one past; an unreadable count throws; the cap bounds an absurd count.
- Falsified: restoring the hardcoded 128 turns the "reads the newest subnet" test red while the other three stay green.
- **Patch coverage: 0 uncovered lines, 0 uncovered branches** on the diff.
- All 55 CI validators pass locally. Full suite: 21,044 pass.
