### PR TITLE
fix(watchdog): the lane alarm has never opened an issue, and could not say so

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -723,7 +723,13 @@ async function loadLaneRuns(
 
 /** The GitHub calls this needs, as one injectable seam. */
 export interface LaneAlarmGitHub {
-  listOpen(): Promise<Record<string, number>>;
+  /** The open alarms by lane, or NULL when GitHub could not be asked.
+   *
+   * The null is the whole contract. `{}` means "no alarm is open" and the
+   * runner acts on it by opening one for every alarming lane; "we could not
+   * ask" must never produce that action, and the two are indistinguishable
+   * once a failure has been flattened into an empty object. */
+  listOpen(): Promise<Record<string, number> | null>;
   open(alarm: LaneAlarm, title: string, body: string): Promise<number | null>;
   close(issue: number, comment: string): Promise<boolean>;
 }
@@ -749,7 +755,14 @@ export function laneAlarmGitHub(
         `${GITHUB_API}/repos/${repo}/issues?state=open&per_page=100`,
         { headers },
       );
-      if (!response.ok) return {};
+      // NULL, not `{}` -- runLaneAlarm's own comment says an unreadable issue
+      // list must not be read as "no alarms are open", and then this returned
+      // exactly that for every non-2xx. A token that cannot list issues cannot
+      // create them either, so the tick would plan a full set of opens, watch
+      // every create fail, and report nothing: which is the state production
+      // was in, with zero `alarm(lane):` issues ever filed against days of
+      // alarming lanes.
+      if (!response.ok) return null;
       // PARSED, NOT CAST (#11194). The `Array.isArray` below was doing the
       // schema's job for one field and nothing for the rest; the parse does
       // both, and a body that is not a list at all now yields no alarms rather
@@ -757,7 +770,9 @@ export function laneAlarmGitHub(
       // issues" -- the difference between "nothing to close" and "we could not
       // ask", on the lane that closes alarms.
       const page = GithubIssueListSchema.safeParse(await response.json());
-      if (!page.success) return {};
+      // Same reasoning as the status check: a body we cannot read is not a
+      // report that nothing is open.
+      if (!page.success) return null;
       const out: Record<string, number> = {};
       for (const row of page.data) {
         // Per ROW, so one issue GitHub shapes unexpectedly costs that issue
@@ -912,6 +927,35 @@ export async function runLaneAlarm(
       .catch(() => null);
     if (number !== null) opened += 1;
   }
+  // THE ALARM'S ONLY PUSH CHANNEL, CHECKED (#11226's class, on this lane).
+  //
+  // `opened` was a number in a return value nothing reads. A tick that planned
+  // four alarms and got zero of them accepted looked -- in telemetry, in the
+  // lane's own verdict, in the summary string -- exactly like a tick with
+  // nothing to report, because the reader IS ok whenever it ran and every
+  // create failure was swallowed by `.catch(() => null)`.
+  //
+  // Production sat in that state: `alarm(lane):` issues have never existed,
+  // against days of alarming lanes. The per-lane events kept firing into
+  // PostHog, so the fleet looked instrumented while the channel a maintainer
+  // actually reads was empty.
+  //
+  // Its OWN fingerprint, deliberately: filed under a lane it would hide behind
+  // that lane's alarm and read as one more stale producer, when it is the
+  // opposite -- the watchdog cannot report at all.
+  if (github && plan.open.length > 0 && opened === 0) {
+    await record(env as never, {
+      error: new Error(
+        `lane-alarm delivered nothing: ${plan.open.length} alarming lane(s) planned, ` +
+          "GitHub accepted none. The alarm's only push channel is not working " +
+          "-- check GITHUB_TOKEN's issues:write scope on this Worker.",
+      ),
+      route: "watchdog:lane-alarm",
+      fingerprintDetail: "delivery",
+      errorCode: "alarm_undelivered",
+    }).catch(() => false);
+  }
+
   // Guarded as a whole rather than per entry: with no client there are no open
   // alarms to have recovered, so the loop body is unreachable, not skipped.
   if (github) {

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -717,14 +717,23 @@ describe("laneAlarmGitHub", () => {
     );
   });
 
-  test("an error or a non-array body lists nothing", async () => {
+  // NULL, not `{}`. This asserted the opposite, and the opposite is what put
+  // production in the state it was in: runLaneAlarm's own comment says an
+  // unreadable issue list must not be read as "no alarms are open" -- and then
+  // this client answered exactly that for every non-2xx, so the runner's guard
+  // could never fire. A token that cannot LIST issues cannot CREATE them
+  // either, so every tick planned a full set of opens and got none.
+  test("an error or an unreadable body DECLINES, rather than reporting nothing open", async () => {
     const bad = client(() => ({ ok: false, json: async () => [] }));
-    assert.deepEqual(await bad.gh.listOpen(), {});
+    assert.equal(await bad.gh.listOpen(), null);
     const odd = client(() => ({
       ok: true,
       json: async () => ({ message: "nope" }),
     }));
-    assert.deepEqual(await odd.gh.listOpen(), {});
+    assert.equal(await odd.gh.listOpen(), null);
+    // And an empty list still means empty -- the two must stay distinguishable.
+    const empty = client(() => ({ ok: true, json: async () => [] }));
+    assert.deepEqual(await empty.gh.listOpen(), {});
   });
 
   // #11194: per-ROW parsing. One issue GitHub shapes unexpectedly must cost
@@ -967,6 +976,142 @@ describe("runLaneAlarm", () => {
       lanes: 1,
     });
     assert.deepEqual(github.opened, []);
+  });
+
+  // The same failure through the door the client used to leave open: a non-2xx
+  // LIST. It used to flatten to `{}`, which is "no alarms are open" -- so the
+  // guard above could never fire on the case that actually happens, and every
+  // tick planned a full set of opens against a token that could not create
+  // them.
+  test("a REFUSED issue list stops the tick too, not just a thrown one", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const github = fakeGitHub();
+    github.listOpen = async () => null;
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      { github, now: () => NOW },
+    );
+    assert.equal((out as { reason?: string }).reason, "issue_list_unavailable");
+    assert.deepEqual(github.opened, []);
+  });
+
+  // THE ALARM'S ONLY PUSH CHANNEL, CHECKED. `opened` was a number in a return
+  // value nothing read: a tick that planned alarms and got none of them
+  // accepted was indistinguishable from a quiet one, and production sat in
+  // exactly that state -- zero `alarm(lane):` issues ever filed, against days
+  // of alarming lanes, while the per-lane events kept firing into PostHog.
+  test("an alarm GitHub refuses to open is reported, not counted and dropped", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const github = fakeGitHub();
+    github.open = async () => null; // GitHub said no -- 403, 422, anything.
+    const seen: Array<{ errorCode?: string; error?: Error }> = [];
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      {
+        github,
+        now: () => NOW,
+        recordException: async (_env, payload) => {
+          seen.push(payload as { errorCode?: string; error?: Error });
+          return true;
+        },
+      },
+    );
+    assert.equal((out as { opened?: number }).opened, 0);
+    const undelivered = seen.filter((p) => p.errorCode === "alarm_undelivered");
+    assert.equal(undelivered.length, 1, "the dead channel reported itself");
+    assert.match(String(undelivered[0].error?.message), /delivered nothing/);
+    // Under its OWN fingerprint -- filed as a lane it would read as one more
+    // stale producer, when it is the watchdog failing to report at all.
+    assert.equal(
+      (undelivered[0] as { fingerprintDetail?: string }).fingerprintDetail,
+      "delivery",
+    );
+  });
+
+  test("a telemetry failure never fails the tick that found the dead channel", async () => {
+    // The one thing worse than an alarm nobody can see is an alarm that takes
+    // the watchdog down with it. Both captures on this path are best-effort.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const github = fakeGitHub();
+    github.open = async () => null;
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      {
+        github,
+        now: () => NOW,
+        recordException: async () => {
+          throw new Error("posthog down");
+        },
+      },
+    );
+    assert.equal((out as { ok?: boolean }).ok, true);
+    assert.equal((out as { opened?: number }).opened, 0);
+  });
+
+  test("a tick that DELIVERS reports nothing extra", async () => {
+    // The negative control: the capture above must not fire on a working tick,
+    // or it becomes the noise it exists to cut through.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    const seen: Array<{ errorCode?: string }> = [];
+    await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      {
+        github: fakeGitHub(),
+        now: () => NOW,
+        recordException: async (_env, payload) => {
+          seen.push(payload as { errorCode?: string });
+          return true;
+        },
+      },
+    );
+    assert.deepEqual(
+      seen.filter((p) => p.errorCode === "alarm_undelivered"),
+      [],
+    );
   });
 
   test("still records the alarm when no token is configured", async () => {


### PR DESCRIPTION
**`alarm(lane):` issues do not exist.** Not one, ever — searched across every issue in the repository, open and closed — against days of lanes reporting stale and silent (`revenue-probes-dlq`, `validator-nominator-counts` silent 3 days, `nominator-positions` silent 3 days, `neurons` truncated).

Opening one is the alarm's entire purpose. Its own header says why: *"GITHUB_TOKEN is already provisioned on this Worker… An issue is also the right SHAPE… this is where this project's maintainer actually works."*

Two faults, and they compound.

## 1. The issue list flattened a refusal into "nothing is open"

`runLaneAlarm` is written for a client that can decline, and says so:

```ts
const openAlarms = github ? await github.listOpen().catch(() => null) : null;
if (github && openAlarms === null) return { ok: false, reason: "issue_list_unavailable" };
// "Deliberately NOT falling back to {}. An unreadable issue list is
//  indistinguishable from 'no alarms are open', and acting on that
//  assumption opens a duplicate of everything currently outstanding."
```

And `listOpen` then did exactly that:

```ts
if (!response.ok) return {};
```

So the guard could only fire on a **thrown** request, never on a **refused** one — and a refusal is the case that happens. A token that cannot list issues cannot create them either, so every tick planned a full set of opens against a client that would refuse all of them.

It returns `null` now, on a non-2xx and on an unparseable body alike. An empty list still means empty; the two stay distinguishable, which was the point.

## 2. A create nobody accepted was counted, not reported

```ts
const number = await github.open(...).catch(() => null);
if (number !== null) opened += 1;
```

`opened` is a number in a return value nothing reads. A tick that planned four alarms and got **zero** accepted looked — in telemetry, in the lane's own verdict (`verdict: "ok"`, correctly, because *the reader* ran), in the summary string — exactly like a tick with nothing to report. The per-lane `$exception`s kept firing into PostHog, so the fleet looked instrumented while the channel a maintainer reads stayed empty.

An undelivered tick now says so, under its **own** fingerprint. Filed under a lane, it would hide behind that lane's alarm and read as one more stale producer — when it is the opposite: the watchdog cannot report at all.

Both captures stay best-effort. The one thing worse than an alarm nobody can see is an alarm that takes the watchdog down with it — pinned by a test where telemetry itself throws.

## What this does not do

**It does not fix the credential.** `GITHUB_TOKEN` is provisioned (`wrangler secret list` confirms it), so the most likely cause is a missing `issues: write` scope — which I cannot read or verify from here. What changes is that the next tick names the problem instead of returning `opened: 0` to nobody.

This is #11226's class, on the lane whose job is to catch exactly that.

## Verification

- 70 tests in `lane-alarm.test.ts`, 4 new.
- Falsified individually: restoring `return {}` turns the client's decline test red; removing the delivery capture turns the undelivered test red; a working tick is the negative control and stays green either way.
- One existing test asserted the wrong behaviour (`an error or a non-array body lists nothing` → `{}`) and is corrected, with the reason stated in place.
- **Patch coverage: 0 uncovered lines, 0 uncovered branches.**
- All 55 CI validators pass locally. Full suite: 21,044 pass.
