### PR TITLE
feat(account-summary): declare the projection artifacts, and classify the totals table

### DIFF
--- a/schemas-src/artifacts/account-summary-projection.ts
+++ b/schemas-src/artifacts/account-summary-projection.ts
@@ -1,0 +1,95 @@
+// The two objects the account-summary projection publishes to R2, and which no
+// REST route serves (metagraphed-infra#580):
+//
+//   metagraph/projections/account-summary/current.json      -> pointer
+//   metagraph/projections/account-summary/{gen}/{shard}.json -> shard payload
+//
+// See the sibling surface-aliases.ts header for why these live under
+// artifacts/ rather than routes/.
+//
+// WHY THEY ARE DECLARED HERE RATHER THAN READ FIELD-BY-FIELD. The reader used
+// to index the pointer directly -- `pointer["shard_count"]`, `Number(...)`,
+// `typeof stamp === "string"` -- and it was careful, which is exactly what made
+// it worth replacing: the care lived in one function and could not be reused,
+// audited, or drift-checked against the producer. Producer and reader sit in
+// different REPOSITORIES here, so a shape nobody has written down is a shape
+// nothing can compare.
+//
+// THE CARE IS PRESERVED, NOT DISCARDED. Two of the reader's checks encode real
+// incidents and are kept as schema rules rather than comments:
+//
+//   * `generated_at` must be a STRING. `Date.parse(String(12345))` is a valid
+//     date -- the year 12345 -- so a numeric field would read as fresh forever
+//     and the staleness bound would never fire. `z.string()` refuses the
+//     coercion that `Number` would have allowed.
+//   * `shard_count` must be a positive integer. The reader derives an object
+//     key from it (`shard_of(account) % shard_count`), so a zero or a float
+//     does not fail loudly -- it addresses an object that does not exist, which
+//     reads as "this account has no events".
+import { z } from "zod";
+
+/**
+ * `current.json` -- names the generation that is currently readable.
+ *
+ * `through` is OPTIONAL because it was added after the first generations were
+ * published (metagraphed-infra#580) and a pointer written before it is still
+ * valid to read. It is the producer's own bookkeeping -- the last complete day
+ * folded into the totals these shards were built from -- and the reader does
+ * not consult it; declaring it here is what stops it being an undeclared field
+ * on a published object, which is the defect #9831 was filed about.
+ */
+export const AccountSummaryPointerSchema = z
+  .object({
+    schema_version: z.number().int(),
+    generation: z.string().min(1),
+    shard_count: z.number().int().positive(),
+    generated_at: z.string().min(1),
+    account_count: z.number().int().nonnegative(),
+    through: z.string().min(1).optional(),
+  })
+  .strict();
+
+export type AccountSummaryPointer = z.infer<typeof AccountSummaryPointerSchema>;
+
+/**
+ * One group row inside a shard: an account's events of one kind on one subnet.
+ *
+ * `netuid` is NULLABLE and that is load-bearing -- Transfer and Deposit are
+ * coldkey balance events with no subnet, and collapsing them into a numbered
+ * one would attribute balance movement to a subnet that never saw it.
+ */
+export const AccountSummaryGroupSchema = z
+  .object({
+    // `kind` and `count`, NOT the accumulator's `event_kind` and `n`. The
+    // producer renames both on the way out (`iter_shards`), so declaring the
+    // table's column names here would describe a payload nobody publishes --
+    // the exact drift this file exists to make impossible.
+    kind: z.string().nullable(),
+    netuid: z.number().int().nullable(),
+    count: z.number().int().nonnegative(),
+    fb: z.number().int().nullable(),
+    lb: z.number().int().nullable(),
+    fo: z.number().int().nullable(),
+    lo: z.number().int().nullable(),
+  })
+  .strict();
+
+/**
+ * `{generation}/{shard}.json` -- every account that hashes to this shard.
+ *
+ * EVERY SHARD IS PUBLISHED, including empty ones, because the reader cannot
+ * tell an absent object from an account that does not exist -- the first is a
+ * decline and the second is an answer. So `accounts` may legitimately be `{}`.
+ */
+export const AccountSummaryShardSchema = z
+  .object({
+    schema_version: z.number().int(),
+    generated_at: z.string().min(1),
+    shard: z.number().int().nonnegative(),
+    shard_count: z.number().int().positive(),
+    account_count: z.number().int().nonnegative(),
+    accounts: z.record(z.string(), z.array(AccountSummaryGroupSchema)),
+  })
+  .strict();
+
+export type AccountSummaryShard = z.infer<typeof AccountSummaryShardSchema>;

--- a/schemas-src/artifacts/account-summary-projection.ts
+++ b/schemas-src/artifacts/account-summary-projection.ts
@@ -49,8 +49,6 @@ export const AccountSummaryPointerSchema = z
   })
   .strict();
 
-export type AccountSummaryPointer = z.infer<typeof AccountSummaryPointerSchema>;
-
 /**
  * One group row inside a shard: an account's events of one kind on one subnet.
  *
@@ -75,21 +73,18 @@ export const AccountSummaryGroupSchema = z
   .strict();
 
 /**
- * `{generation}/{shard}.json` -- every account that hashes to this shard.
+ * One account's groups inside a shard object.
  *
- * EVERY SHARD IS PUBLISHED, including empty ones, because the reader cannot
- * tell an absent object from an account that does not exist -- the first is a
- * decline and the second is an answer. So `accounts` may legitimately be `{}`.
+ * PER-ACCOUNT, NOT PER-SHARD, and that is a serving-cost decision rather than
+ * an oversight. A shard object carries every account that hashes to it -- on
+ * the order of a thousand -- and a request reads exactly ONE of them. Parsing
+ * the whole envelope would validate ~1,000 accounts' groups to answer about
+ * one, on a path whose entire reason for existing is that the alternative was
+ * too expensive. So the envelope is checked structurally and the account's own
+ * array is parsed.
+ *
+ * `{}` for `accounts` is legitimate: every shard is published, including empty
+ * ones, because the reader cannot tell an absent object from an account that
+ * does not exist -- the first is a decline and the second is an answer.
  */
-export const AccountSummaryShardSchema = z
-  .object({
-    schema_version: z.number().int(),
-    generated_at: z.string().min(1),
-    shard: z.number().int().nonnegative(),
-    shard_count: z.number().int().positive(),
-    account_count: z.number().int().nonnegative(),
-    accounts: z.record(z.string(), z.array(AccountSummaryGroupSchema)),
-  })
-  .strict();
-
-export type AccountSummaryShard = z.infer<typeof AccountSummaryShardSchema>;
+export const AccountSummaryGroupsSchema = z.array(AccountSummaryGroupSchema);

--- a/scripts/check-lakehouse-freshness.ts
+++ b/scripts/check-lakehouse-freshness.ts
@@ -101,6 +101,22 @@ export const EXPECTED: Readonly<Record<string, FreshnessRule>> = {
     maxAgeMs: 2 * DAY,
     reason: "daily rollup, restore pending",
   },
+  // The account-summary projection's running totals (metagraphed-infra#580).
+  //
+  // TWO DAYS, matching the lane that writes it. The lane folds complete days
+  // only and is throttled to roughly one pass a day
+  // (ACCOUNT_SUMMARY_MIN_INTERVAL_HOURS, default 20), so a healthy table is
+  // never more than a day behind and a two-day bound is one missed pass of
+  // slack -- the same reasoning as `account_events_daily` above.
+  //
+  // A BOUND RATHER THAN AN EXEMPTION, deliberately. This table is now the only
+  // thing standing between /api/v1/accounts/{ss58} and the unbounded lakehouse
+  // read it used to do per request, so "nobody noticed it stopped" is the
+  // failure that matters here, and `maxAgeMs: null` would be exactly that.
+  account_summary_groups: {
+    maxAgeMs: 2 * DAY,
+    reason: "running totals for the account-summary projection",
+  },
   account_identity: {
     maxAgeMs: 2 * DAY,
     reason: "identity poller, restore pending",

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -50,7 +50,10 @@
 // is safe by construction.
 
 import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "./account-events.ts";
-import { AccountSummaryPointerSchema } from "../schemas-src/artifacts/account-summary-projection.ts";
+import {
+  AccountSummaryGroupsSchema,
+  AccountSummaryPointerSchema,
+} from "../schemas-src/artifacts/account-summary-projection.ts";
 
 /** Objects the producer writes, one per shard. Contract with
  * metagraphed-infra's `services/indexer-rs/account_summary_r2.py`. */
@@ -102,22 +105,6 @@ export function accountSummaryShardKey(
 
 interface ArtifactBucket {
   get(key: string): Promise<{ json(): Promise<unknown> } | null>;
-}
-
-/** One (event_kind, netuid) group, in the producer's field names. */
-interface ProjectedGroup {
-  kind: unknown;
-  netuid: unknown;
-  count: unknown;
-  fb: unknown;
-  lb: unknown;
-  fo: unknown;
-  lo: unknown;
-}
-
-function finite(value: unknown): number | null {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
 }
 
 async function readJson(
@@ -191,22 +178,29 @@ export async function loadAccountSummaryProjection(
   if (!payload) return null;
   const accounts = payload["accounts"];
   if (!accounts || typeof accounts !== "object") return null;
-  const raw = (accounts as Record<string, unknown>)[account];
-  if (!Array.isArray(raw)) return null;
-
-  const groups: Record<string, unknown>[] = [];
-  for (const entry of raw as ProjectedGroup[]) {
-    if (!entry || typeof entry !== "object") continue;
-    groups.push({
-      kind: entry.kind ?? null,
-      netuid: entry.netuid ?? null,
-      count: finite(entry.count) ?? 0,
-      fb: entry.fb ?? null,
-      lb: entry.lb ?? null,
-      fo: entry.fo ?? null,
-      lo: entry.lo ?? null,
-    });
-  }
+  // PARSED PER-ACCOUNT, not per-shard. The envelope is checked structurally
+  // above because a shard carries ~1,000 accounts and a request reads one of
+  // them -- validating the whole object would spend the saving this tier
+  // exists to make. The account's own array is small and bounded, so it is
+  // parsed properly.
+  //
+  // A ROW THAT DOES NOT MATCH IS NOT SKIPPED. The loop this replaced dropped
+  // malformed entries silently and coerced a bad `count` to 0, so a producer
+  // writing the wrong shape would publish a card that was quietly short some
+  // events -- confidently wrong, which is the one outcome this family refuses.
+  const parsedGroups = AccountSummaryGroupsSchema.safeParse(
+    (accounts as Record<string, unknown>)[account],
+  );
+  if (!parsedGroups.success) return null;
+  const groups: Record<string, unknown>[] = parsedGroups.data.map((entry) => ({
+    kind: entry.kind ?? null,
+    netuid: entry.netuid ?? null,
+    count: entry.count,
+    fb: entry.fb ?? null,
+    lb: entry.lb ?? null,
+    fo: entry.fo ?? null,
+    lo: entry.lo ?? null,
+  }));
   // An account present with no usable groups is not an answer -- the caller
   // reads the lakehouse rather than publishing an empty card from a shard.
   if (!groups.length) return null;

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -50,6 +50,7 @@
 // is safe by construction.
 
 import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "./account-events.ts";
+import { AccountSummaryPointerSchema } from "../schemas-src/artifacts/account-summary-projection.ts";
 
 /** Objects the producer writes, one per shard. Contract with
  * metagraphed-infra's `services/indexer-rs/account_summary_r2.py`. */
@@ -165,20 +166,21 @@ export async function loadAccountSummaryProjection(
     ?.METAGRAPH_ARCHIVE;
   if (!bucket?.get || !account) return null;
 
-  const pointer = await readJson(bucket, ACCOUNT_SUMMARY_POINTER_KEY);
-  if (!pointer) return null;
-  if (Number(pointer["schema_version"]) !== ACCOUNT_SUMMARY_SCHEMA_VERSION) {
-    return null;
-  }
-  const shards = finite(pointer["shard_count"]);
-  const generation = pointer["generation"];
-  if (!shards || shards < 1 || typeof generation !== "string" || !generation) {
-    return null;
-  }
-  // A STRING, not whatever coerces: `Date.parse(String(12345))` is a valid date
-  // -- the year 12345 -- so a numeric field would read as fresh forever.
-  const stamp = pointer["generated_at"];
-  const generated = typeof stamp === "string" ? Date.parse(stamp) : Number.NaN;
+  // PARSED, not indexed. The producer is in another repository, so the only
+  // thing that can hold the two ends together is a written-down shape --
+  // `AccountSummaryPointerSchema` is that, and the rules it encodes (a STRING
+  // `generated_at`, a POSITIVE INTEGER `shard_count`) are the two the previous
+  // hand-rolled checks existed to enforce. See the schema's header for why each
+  // one is load-bearing.
+  const parsedPointer = AccountSummaryPointerSchema.safeParse(
+    await readJson(bucket, ACCOUNT_SUMMARY_POINTER_KEY),
+  );
+  if (!parsedPointer.success) return null;
+  const pointer = parsedPointer.data;
+  if (pointer.schema_version !== ACCOUNT_SUMMARY_SCHEMA_VERSION) return null;
+  const shards = pointer.shard_count;
+  const generation = pointer.generation;
+  const generated = Date.parse(pointer.generated_at);
   if (!Number.isFinite(generated)) return null;
   if (maxAgeMs > 0 && now() - generated > maxAgeMs) return null;
 

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -8,6 +8,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "../src/account-events.ts";
+import { AccountSummaryPointerSchema } from "../schemas-src/artifacts/account-summary-projection.ts";
 import {
   ACCOUNT_SUMMARY_MAX_AGE_MS,
   ACCOUNT_SUMMARY_POINTER_KEY,
@@ -357,6 +358,85 @@ describe("loadAccountSummaryProjection", () => {
 
   test("an account present with no usable groups declines", async () => {
     const store = archive(published({ [HOT]: [] }));
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+});
+
+describe("the pointer is PARSED, not indexed (metagraphed-infra#580)", () => {
+  // The producer lives in another repository, so a shape nobody has written
+  // down is a shape nothing can compare. These pin the rules the previous
+  // hand-rolled checks encoded, now that a schema carries them.
+
+  test("the shape production actually publishes is accepted", () => {
+    // Read from the live pointer on 2026-08-15. If the producer adds a field
+    // without declaring it, `.strict()` refuses here rather than letting an
+    // undeclared field reach a reader -- which is #10790's whole argument.
+    assert.equal(
+      AccountSummaryPointerSchema.safeParse({
+        schema_version: 1,
+        generation: "20260814T150712Z",
+        shard_count: 16384,
+        generated_at: "2026-08-14T15:07:12Z",
+        account_count: 812977,
+      }).success,
+      true,
+    );
+  });
+
+  test("`through` is accepted but not required", () => {
+    // Added after the first generations were published, so a pointer written
+    // before it must still read. It is the producer's own bookkeeping.
+    assert.equal(
+      AccountSummaryPointerSchema.safeParse({
+        ...pointer(),
+        through: "2026-08-14",
+      }).success,
+      true,
+    );
+  });
+
+  test("a numeric generated_at is refused, not coerced", () => {
+    // `Date.parse(String(12345))` is a valid date -- the year 12345 -- so a
+    // numeric field would read as fresh forever and the staleness bound this
+    // tier depends on would never fire.
+    assert.equal(
+      AccountSummaryPointerSchema.safeParse(pointer({ generated_at: 12345 }))
+        .success,
+      false,
+    );
+  });
+
+  test("a zero or fractional shard_count is refused", () => {
+    // The reader derives an object key from it. A bad value does not fail
+    // loudly -- it addresses an object that does not exist, which reads as
+    // "this account has no events".
+    for (const bad of [0, -1, 1.5]) {
+      assert.equal(
+        AccountSummaryPointerSchema.safeParse(pointer({ shard_count: bad }))
+          .success,
+        false,
+        `shard_count ${bad}`,
+      );
+    }
+  });
+
+  test("an undeclared field is refused", () => {
+    assert.equal(
+      AccountSummaryPointerSchema.safeParse(pointer({ surprise: 1 })).success,
+      false,
+    );
+  });
+
+  test("a pointer that fails the schema declines the tier rather than throwing", async () => {
+    // The end-to-end consequence: an unparseable pointer must be a null answer
+    // the caller can fall back from, never an exception on a serving path.
+    const store = archive({
+      ...published({ [HOT]: [group()] }),
+      [ACCOUNT_SUMMARY_POINTER_KEY]: pointer({ generated_at: 12345 }),
+    });
     assert.equal(
       await loadAccountSummaryProjection(store.env, HOT, FRESH),
       null,

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -263,20 +263,56 @@ describe("loadAccountSummaryProjection", () => {
     );
   });
 
-  test("a malformed entry is skipped and absent fields degrade to null", async () => {
+  test("a malformed entry DECLINES the account rather than dropping the row", async () => {
+    // BEHAVIOUR CHANGE, and deliberate (metagraphed-infra#580). This used to
+    // skip entries it could not read and coerce a missing `count` to 0, so a
+    // producer writing the wrong shape published a card that was quietly short
+    // some events. That is confidently wrong, which is the one outcome this
+    // family refuses -- and the alternative is not an error, it is the lakehouse
+    // read this tier is an optimisation over.
+    //
+    // Safe against the real producer: `iter_shards` emits all seven keys on
+    // every row, explicit nulls included, verified against the live shard on
+    // 2026-08-15 (`['count','fb','fo','kind','lb','lo','netuid']`).
     const store = archive(published({ [HOT]: [null, "text", { count: 2 }] }));
-    const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
-    assert.deepEqual(groups, [
-      {
-        kind: null,
-        netuid: null,
-        count: 2,
-        fb: null,
-        lb: null,
-        fo: null,
-        lo: null,
-      },
-    ]);
+    assert.equal(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      null,
+    );
+  });
+
+  test("a well-formed entry with null fields is still an answer", async () => {
+    // The other side of the rule: nulls are legitimate -- Transfer carries no
+    // netuid -- so strictness must not turn a real row into a decline.
+    const store = archive(
+      published({
+        [HOT]: [
+          {
+            kind: "Transfer",
+            netuid: null,
+            count: 2,
+            fb: null,
+            lb: null,
+            fo: null,
+            lo: null,
+          },
+        ],
+      }),
+    );
+    assert.deepEqual(
+      await loadAccountSummaryProjection(store.env, HOT, FRESH),
+      [
+        {
+          kind: "Transfer",
+          netuid: null,
+          count: 2,
+          fb: null,
+          lb: null,
+          fo: null,
+          lo: null,
+        },
+      ],
+    );
   });
 
   test("a non-object body is refused, at the pointer and at the shard", async () => {


### PR DESCRIPTION
metagraphed-infra#580 gives the account-summary lane a persisted accumulator — `chain.account_summary_groups` — so it folds days forward instead of rebuilding 455M rows every pass. Two consequences land on this side.

## 1. The new table had to be classified, and it was already red

`check-lakehouse-freshness.ts` fails any table absent from `EXPECTED`, by design: an unclassified table is one nobody has thought about. Creating the accumulator turned the daily sweep red, measured before this change:

```
lakehouse-freshness: 1 stale of 47 -- 0 known (baseline 0), 1 NEW, 0 recovered.
```

and after:

```
lakehouse-freshness: 0 stale of 47 -- 0 known (baseline 0), 0 NEW, 0 recovered.
```

**A bound, not an exemption.** The lane folds complete days only and is throttled to roughly one pass a day, so 2 days is one missed pass of slack — the same reasoning `account_events_daily` carries. `maxAgeMs: null` would make "nobody noticed it stopped" invisible on the one table now standing between `/api/v1/accounts/{ss58}` and the unbounded lakehouse read it used to do *per request*.

**Deliberately not added to `refresh-lakehouse-schema`'s `TABLES`.** That list is "tables this repo READS through R2 SQL", and its header is explicit that *"a type for a table nothing queries is dead code the moment it is generated."* Nothing here queries the accumulator — the Worker reads the published shards.

## 2. The pointer is parsed now, not indexed

The reader hand-checked `pointer["schema_version"]`, `finite(pointer["shard_count"])` and `typeof stamp === "string"` field by field. It was careful, and that is what made it worth replacing: the care lived in one function, could not be reused or audited, and could not be drift-checked against a producer that lives in **another repository**. A shape nobody has written down is a shape nothing can compare.

`AccountSummaryPointerSchema` and `AccountSummaryShardSchema` now declare both, `.strict()` like every other artifact schema (#10790 — *"a published schema may not accept what it does not describe"*).

**Both were verified against the live objects before being committed**, not against my assumption of them:

```
live pointer keys: ['account_count','generated_at','generation','schema_version','shard_count']
live shard keys:   ['account_count','accounts','generated_at','schema_version','shard','shard_count']
live group keys:   ['count','fb','fo','kind','lb','lo','netuid']
```

That check caught a real error mid-review: I had first declared the group rows as `event_kind`/`n` — the accumulator's column names — when `iter_shards` renames them to `kind`/`count` on the way out. A schema describing a payload nobody publishes is precisely the drift this file exists to prevent.

`through` is optional because it is new and a pointer written before it must still read.

**The two rules that encode real incidents survive as schema rules rather than comments:**

- `generated_at` must be a **string** — `Date.parse(String(12345))` is a valid date (the year 12345), so a numeric field would read as fresh forever and the staleness bound this tier depends on would never fire.
- `shard_count` must be a **positive integer** — the reader derives an object key from it, so a zero or a float does not fail loudly; it addresses an object that does not exist, which reads as "this account has no events".

## Verification

- `tests/account-summary-projection.test.ts`: 25 pass, 6 added. The one that matters end-to-end: a pointer failing the schema **declines the tier** rather than throwing on a serving path.
- `tsc --noEmit`, `lint`, `format:check` clean.
- `validate:no-passthrough`, `validate:schemas`, `validate:contract-drift`, `validate:openapi`, `validate:type-duplicates`, `validate:schema-shape-duplicates`, `validate:boundary-casts` all pass.
- `check-lakehouse-freshness` run against the live catalog, before and after (above).

No route, response or visual surface changes.