### PR TITLE
fix(watchdog): give the lane alarm a token that can write, and stop silencing it

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -849,7 +849,23 @@ export async function runLaneAlarm(
   const db = laneHealthStore(env) as unknown as StatementClientLike | undefined;
   if (!db?.query) return { ok: false, reason: "no lane_health store bound" };
 
-  const token = typeof env?.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : "";
+  // ITS OWN SECRET, falling back to the shared one.
+  //
+  // `GITHUB_TOKEN` is declared, in workers/env-extra.d.ts, as the upgrade
+  // radar's rate-limit token: "public-repo read-only metadata", and a lane that
+  // "still runs without it". This file's header read that as "already
+  // provisioned on this Worker" and inferred it could open issues. Opening an
+  // issue needs `issues: write` on THIS repository, which a public-read token
+  // does not carry -- and the result was an alarm that has never filed one.
+  //
+  // Split for the same reason GITHUB_SIGNALS_TOKEN was split off it: the two
+  // want different scopes, and sharing one credential means the weaker
+  // requirement silently sets the ceiling. The fallback keeps this a no-op
+  // wherever the shared token does happen to have write access.
+  const token =
+    (typeof env?.LANE_ALARM_GITHUB_TOKEN === "string"
+      ? env.LANE_ALARM_GITHUB_TOKEN
+      : "") || (typeof env?.GITHUB_TOKEN === "string" ? env.GITHUB_TOKEN : "");
   const repo =
     typeof env?.LANE_ALARM_REPO === "string" && env.LANE_ALARM_REPO
       ? env.LANE_ALARM_REPO
@@ -879,16 +895,18 @@ export async function runLaneAlarm(
   // duplicate of every alarm still outstanding, which is the failure that makes
   // an alerting system get muted.
   const openAlarms = github ? await github.listOpen().catch(() => null) : null;
-  if (github && openAlarms === null) {
-    // Deliberately NOT falling back to `{}`. An unreadable issue list is
-    // indistinguishable from "no alarms are open", and acting on that
-    // assumption opens a duplicate of everything currently outstanding.
-    return {
-      ok: false,
-      reason: "issue_list_unavailable",
-      lanes: Object.keys(latest).length,
-    };
-  }
+  // Deliberately NOT read as `{}`. An unreadable issue list is
+  // indistinguishable from "no alarms are open", and acting on that assumption
+  // opens a duplicate of everything currently outstanding.
+  //
+  // But it must not go the other way either. Returning here -- which is what
+  // this did -- SILENCED the per-lane captures below, so the one failure mode
+  // where GitHub is unreachable also lost the second channel that could still
+  // have reported the lanes. Quieter, in the moment that needs louder.
+  //
+  // So: still plan, still record every alarming lane, and suppress only the
+  // WRITES, which are the part a stale list makes dangerous.
+  const listUnavailable = Boolean(github) && openAlarms === null;
 
   const plan = laneAlarmPlan({
     latest,
@@ -921,7 +939,7 @@ export async function runLaneAlarm(
       fingerprintDetail: alarm.lane,
       errorCode: alarm.kind === "stale" ? "lane_stale" : "lane_silent",
     }).catch(() => false);
-    if (!github) continue;
+    if (!github || listUnavailable) continue;
     const number = await github
       .open(alarm, laneAlarmTitle(alarm.lane), body)
       .catch(() => null);
@@ -943,12 +961,29 @@ export async function runLaneAlarm(
   // Its OWN fingerprint, deliberately: filed under a lane it would hide behind
   // that lane's alarm and read as one more stale producer, when it is the
   // opposite -- the watchdog cannot report at all.
-  if (github && plan.open.length > 0 && opened === 0) {
+  if (listUnavailable) {
+    // Its own code, because the two are different problems with different
+    // fixes: this one is "we could not ask GitHub what is already open", and
+    // the one below is "we asked, and it refused everything we sent".
+    await record(env as never, {
+      error: new Error(
+        `lane-alarm could not read its issue list: ${plan.open.length} alarming lane(s) ` +
+          "recorded but none filed, because opening without the list would " +
+          "duplicate every outstanding alarm.",
+      ),
+      route: "watchdog:lane-alarm",
+      fingerprintDetail: "delivery",
+      errorCode: "alarm_list_unavailable",
+    }).catch(() => false);
+  }
+  if (github && !listUnavailable && plan.open.length > 0 && opened === 0) {
     await record(env as never, {
       error: new Error(
         `lane-alarm delivered nothing: ${plan.open.length} alarming lane(s) planned, ` +
-          "GitHub accepted none. The alarm's only push channel is not working " +
-          "-- check GITHUB_TOKEN's issues:write scope on this Worker.",
+          "GitHub accepted none. The alarm's only push channel is not working. " +
+          "Opening an issue needs `issues: write` on this repository; " +
+          "GITHUB_TOKEN is the upgrade radar's public-read token and does not " +
+          "carry it. Set LANE_ALARM_GITHUB_TOKEN to a credential that does.",
       ),
       route: "watchdog:lane-alarm",
       fingerprintDetail: "delivery",
@@ -958,7 +993,7 @@ export async function runLaneAlarm(
 
   // Guarded as a whole rather than per entry: with no client there are no open
   // alarms to have recovered, so the loop body is unreachable, not skipped.
-  if (github) {
+  if (github && !listUnavailable) {
     for (const entry of plan.close) {
       const ok = await github
         .close(entry.issue, laneAlarmRecoveryComment(entry.lane, entry.record))
@@ -987,6 +1022,7 @@ export async function runLaneAlarm(
     suppressed: plan.suppressed,
     opened,
     closed,
-    delivered: Boolean(github),
+    delivered: Boolean(github) && !listUnavailable,
+    ...(listUnavailable ? { reason: "issue_list_unavailable" } : {}),
   };
 }

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -947,9 +947,14 @@ describe("runLaneAlarm", () => {
     assert.deepEqual(github.closed, [4242]);
   });
 
-  test("an unreadable issue list stops the tick rather than duplicating every alarm", async () => {
+  test("an unreadable issue list stops the WRITES, and still records every lane", async () => {
     // The single most damaging thing this could do: treat a failed list as
     // "nothing is open" and re-open every outstanding alarm, every tick.
+    //
+    // The second most damaging is what the fix for that used to do -- return
+    // early, and take the per-lane captures with it. The one failure mode
+    // where GitHub is unreachable is exactly when the second channel matters,
+    // so the writes stop and the recording does not.
     const db = healthDb({
       latest: [
         {
@@ -966,16 +971,32 @@ describe("runLaneAlarm", () => {
     github.listOpen = async () => {
       throw new Error("502 from github");
     };
+    const seen: Array<{ errorCode?: string }> = [];
     const out = await runLaneAlarm(
       { ...TOKEN, ...db.env },
-      { github, now: () => NOW },
+      {
+        github,
+        now: () => NOW,
+        recordException: async (_env, payload) => {
+          seen.push(payload as { errorCode?: string });
+          return true;
+        },
+      },
     );
-    assert.deepEqual(out, {
-      ok: false,
-      reason: "issue_list_unavailable",
-      lanes: 1,
-    });
-    assert.deepEqual(github.opened, []);
+    assert.equal((out as { reason?: string }).reason, "issue_list_unavailable");
+    assert.equal((out as { delivered?: boolean }).delivered, false);
+    assert.deepEqual(github.opened, [], "nothing was filed blind");
+    // ...and the lane was still reported, on the channel that still worked.
+    assert.equal(
+      seen.filter((p) => p.errorCode === "lane_stale").length,
+      1,
+      "the alarming lane was still recorded",
+    );
+    assert.equal(
+      seen.filter((p) => p.errorCode === "alarm_list_unavailable").length,
+      1,
+      "and the dead list reported itself",
+    );
   });
 
   // The same failure through the door the client used to leave open: a non-2xx
@@ -1065,20 +1086,29 @@ describe("runLaneAlarm", () => {
       ],
       runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
     });
-    const github = fakeGitHub();
-    github.open = async () => null;
-    const out = await runLaneAlarm(
+    const throwing = async () => {
+      throw new Error("posthog down");
+    };
+
+    // Both captures on this path, because both are `.catch(() => false)` and a
+    // swallowed rejection is only safe if something proves it is swallowed.
+    const refused = fakeGitHub();
+    refused.open = async () => null;
+    const a = await runLaneAlarm(
       { ...TOKEN, ...db.env },
-      {
-        github,
-        now: () => NOW,
-        recordException: async () => {
-          throw new Error("posthog down");
-        },
-      },
+      { github: refused, now: () => NOW, recordException: throwing },
     );
-    assert.equal((out as { ok?: boolean }).ok, true);
-    assert.equal((out as { opened?: number }).opened, 0);
+    assert.equal((a as { ok?: boolean }).ok, true);
+    assert.equal((a as { opened?: number }).opened, 0);
+
+    const unlistable = fakeGitHub();
+    unlistable.listOpen = async () => null;
+    const b = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      { github: unlistable, now: () => NOW, recordException: throwing },
+    );
+    assert.equal((b as { ok?: boolean }).ok, true);
+    assert.equal((b as { delivered?: boolean }).delivered, false);
   });
 
   test("a tick that DELIVERS reports nothing extra", async () => {
@@ -1111,6 +1141,64 @@ describe("runLaneAlarm", () => {
     assert.deepEqual(
       seen.filter((p) => p.errorCode === "alarm_undelivered"),
       [],
+    );
+  });
+
+  // ITS OWN SECRET, falling back to the shared one. GITHUB_TOKEN is declared as
+  // the upgrade radar's public-READ token; opening an issue needs
+  // `issues: write` on this repository, and sharing one credential let the
+  // weaker requirement set the ceiling.
+  test("prefers LANE_ALARM_GITHUB_TOKEN, and falls back to GITHUB_TOKEN", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "a",
+          verdict: "stale",
+          age_ms: 1,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "a", since: NOW - 28 * HOUR, ticks: 100 }],
+    });
+    /** Every `authorization` header the run sent, for one env. */
+    async function authHeaders(
+      env: Record<string, unknown>,
+    ): Promise<string[]> {
+      const seen: string[] = [];
+      const fetchImpl = (async (url: string, init?: RequestInit) => {
+        seen.push(
+          String((init?.headers as Record<string, string>)?.authorization),
+        );
+        // An empty issue list, then accept the create.
+        return String(url).includes("state=open")
+          ? new Response("[]", { status: 200 })
+          : new Response(JSON.stringify({ number: 7 }), { status: 201 });
+      }) as unknown as typeof fetch;
+      await runLaneAlarm(env, { now: () => NOW, fetchImpl });
+      return seen;
+    }
+
+    const both = await authHeaders({
+      GITHUB_TOKEN: "read-only",
+      LANE_ALARM_GITHUB_TOKEN: "writer",
+      ...db.env,
+    });
+    assert.ok(both.length > 0, "the run actually called GitHub");
+    assert.deepEqual(
+      [...new Set(both)],
+      ["Bearer writer"],
+      "the write-scoped secret wins when both are set",
+    );
+
+    const sharedOnly = await authHeaders({
+      GITHUB_TOKEN: "read-only",
+      ...db.env,
+    });
+    assert.deepEqual(
+      [...new Set(sharedOnly)],
+      ["Bearer read-only"],
+      "and the shared one still works where it has the scope",
     );
   });
 

--- a/workers/env-extra.d.ts
+++ b/workers/env-extra.d.ts
@@ -79,6 +79,21 @@ interface Env {
    * GitHub throttles. */
   GITHUB_TOKEN?: string;
   /**
+   * Authenticates the lane alarm's ISSUE WRITES (src/lane-alarm.ts).
+   *
+   * Its own secret rather than sharing GITHUB_TOKEN above, for the same reason
+   * GITHUB_SIGNALS_TOKEN is: they want different scopes. GITHUB_TOKEN is a
+   * public-repo READ token for rate-limit relief, and the alarm needs
+   * `issues: write` on this repository -- so sharing one credential let the
+   * weaker requirement set the ceiling, and the alarm filed nothing for as long
+   * as it has existed while reporting itself healthy.
+   *
+   * Falls back to GITHUB_TOKEN when unset, so this is a no-op wherever that one
+   * does carry write access. An alarm that cannot deliver now says so
+   * (`alarm_undelivered`) rather than counting the refusal and moving on.
+   */
+  LANE_ALARM_GITHUB_TOKEN?: string;
+  /**
    * #8600: Ethereum MAINNET JSON-RPC endpoint for the TAO/USD index (ADR
    * 0025). Mainnet specifically -- every pool ADR 0025 names is Uniswap v3 on
    * Ethereum L1, not an L2.


### PR DESCRIPTION
Follow-up to #11245, which made the alarm's failure *visible* without saying what the failure **is**. It is the credential — and this repo's own declaration already said so.

## The token was never able to file an issue

`GITHUB_TOKEN` is declared in `workers/env-extra.d.ts` as the **upgrade radar's rate-limit credential**:

> "a fine-grained PAT with public-repo read-only metadata access… the radar still runs without it and simply reports null upstreams when GitHub throttles."

`src/lane-alarm.ts`'s header read that as *"GITHUB_TOKEN is already provisioned on this Worker"* and inferred it could open issues. Creating one needs `issues: write` on this repository.

**Confirmed, not assumed:**
- the radar's own GitHub reads are current — `v447`, published three hours before this was written — so the token is valid and authenticating; it just cannot write
- `wrangler secret list` carries no Discord, Slack, Telegram or webhook credential either, so **PostHog has been the only channel this fleet actually had**
- zero `alarm(lane):` issues exist, ever, across days of alarming lanes

`LANE_ALARM_GITHUB_TOKEN` becomes its own secret, for the same reason `GITHUB_SIGNALS_TOKEN` was split off the shared one: they want different scopes, and sharing a credential lets the weaker requirement set the ceiling. **It falls back to `GITHUB_TOKEN`**, so this is a no-op wherever that one does carry write access.

The one step I cannot take is minting the PAT — that needs GitHub account auth. Once it exists:

```bash
npx wrangler secret put LANE_ALARM_GITHUB_TOKEN --name metagraphed
```

Until then the alarm now *names* that as the remedy on every undelivered tick, instead of returning `opened: 0` to nobody.

## And #11245's own guard was too blunt — my change, corrected

Returning `issue_list_unavailable` early took the **per-lane captures** with it. The one failure mode where GitHub is unreachable is exactly when the second channel matters, so my fix made that case *quieter* — the direction this whole family of work exists to stop.

The writes stop; the recording does not. An unreadable list now records every alarming lane **and** reports itself under `alarm_list_unavailable`, kept distinct from `alarm_undelivered` because they are different problems with different fixes:

| code | means |
|---|---|
| `alarm_list_unavailable` | we could not ask GitHub what is already open |
| `alarm_undelivered` | we asked, and it refused everything we sent |

## Verification

- 71 tests, 3 new (token preference + fallback; recording survives an unreadable list; both best-effort captures survive telemetry itself throwing).
- Falsified individually against the pre-change code.
- **Patch coverage: 0 uncovered lines, 0 uncovered branches.**
- All 55 CI validators pass locally. Full suite: 21,049 pass.
