### PR TITLE
fix(watchdog): what the lane alarm writes, now that it can write

### DIFF
--- a/schemas-src/foreign-wire.ts
+++ b/schemas-src/foreign-wire.ts
@@ -29,11 +29,19 @@ import { z } from "zod";
  * whose title matches. A PR that happened to match would have been closed as
  * though it were an alarm, so this field is checked for existence and never
  * for shape -- which is exactly what `unknown` says.
+ *
+ * `updated_at` is how the alarm tells a loss it has already reported from one
+ * it has not. GitHub stamps it on every write to the issue, including the
+ * alarm's own comments, so "newer than this" means "since we last said
+ * anything here" without the alarm keeping state of its own. Nullish because
+ * the alarm treats an unreadable timestamp as "do not comment" rather than as
+ * "comment always" -- see laneAlarmPlan.
  */
 export const GithubIssueSchema = z.object({
   number: z.number().nullish(),
   title: z.string().nullish(),
   pull_request: z.unknown().optional(),
+  updated_at: z.string().nullish(),
 });
 
 /**

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -725,7 +725,7 @@ function issueOpening(alarm: LaneAlarm, forHow: string): string {
   if (isDeadLetterLane(alarm.lane)) {
     return (
       `\`${alarm.lane}\` has dead-lettered **${alarm.ticks} time(s)** in the **${forHow}** since the first loss. ` +
-      "Each row is a message that exhausted its retries and was acked to keep it out of a second-order queue -- so this is a count of losses, not of ticks."
+      "Each one is a batch whose messages exhausted their retries and were acked to keep them out of a second-order queue -- so this is a count of losses, not of ticks."
     );
   }
   switch (alarm.kind) {

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -474,9 +474,22 @@ export interface LaneAlarmPlanInput {
    */
   observedMaxGap: Record<string, number | null>;
   /** Lanes that already have an open alarm issue. */
-  openAlarms: Record<string, number>;
+  openAlarms: Record<string, LaneAlarmOpenIssue>;
   nowMs: number;
   minStaleMs: number;
+}
+
+/**
+ * An alarm issue that is already open, and when it was last written to.
+ *
+ * The timestamp is what lets a lane report a SECOND finding into an issue that
+ * is already open. `updatedAt` is null when GitHub's stamp could not be read,
+ * and the plan then declines to comment -- see the `update` list for why that
+ * is the safe direction.
+ */
+export interface LaneAlarmOpenIssue {
+  issue: number;
+  updatedAt: number | null;
 }
 
 export interface LaneAlarmPlan {
@@ -485,6 +498,51 @@ export interface LaneAlarmPlan {
   /** Lanes that recovered and whose issue should close. Never carries a null
    * record: an entry only exists because a record said `ok`. */
   close: { lane: string; issue: number; record: LaneHealthRecord }[];
+  /**
+   * Losses to report into an alarm issue that is ALREADY OPEN (#11248's blind
+   * spot, found once the alarm could finally write).
+   *
+   * ## WHY AN OPEN ISSUE IS NOT THE END OF THE STORY
+   *
+   * `fresh` below drops every lane that already has one, which is right for a
+   * producer: an issue saying "this lane is stale" stays true while it stays
+   * stale, and a second issue every half hour is the noise that gets an alarm
+   * muted.
+   *
+   * A DEAD-LETTER LANE IS NOT THAT SHAPE. Nothing writes it a row except
+   * `handleDeadLetterBatch`, and only when a message has just been lost -- so
+   * its rows are EVENTS, not a repeated verdict about one condition. And
+   * nothing ever writes it `ok`: a lost message is not un-lost, so the close
+   * loop below can never fire for one, and the issue stays open by design.
+   *
+   * Those two facts together made a hole: the first loss opened an issue, and
+   * from that moment every FURTHER loss on that queue was reported nowhere. The
+   * lane was already in `openAlarms`, so `fresh` dropped it; the issue was
+   * already open, so nothing reopened it; no `ok` ever arrived, so nothing
+   * closed it either. The alarm went quiet exactly as the queue got worse --
+   * the failure mode the whole file is shaped against, reached from the other
+   * direction.
+   *
+   * ## THE TEST, AND WHY IT NEEDS NO STATE
+   *
+   * A dead-letter lane writes only on loss, so "a row newer than the last time
+   * we wrote to the issue" IS "a loss we have not reported". GitHub stamps
+   * `updated_at` on every write including the alarm's own comment, so the
+   * comparison de-duplicates itself: one comment per loss, and the comment
+   * moves the mark.
+   *
+   * A human commenting on the issue in the same window also moves it, and can
+   * therefore swallow one report. That is the acceptable direction: it costs a
+   * comment precisely when somebody is already reading the issue, whereas the
+   * alternative -- keeping our own high-water mark -- is durable state this
+   * reader has deliberately never had. An unreadable `updated_at` declines for
+   * the same reason: no mark means no way to tell a new loss from an old one,
+   * and commenting on every tick is worse than commenting on none.
+   *
+   * Bounded without a cap: at most one comment per dead-letter lane per tick,
+   * and `DEAD_LETTER_LANES` has five entries.
+   */
+  update: { lane: string; issue: number; record: LaneHealthRecord }[];
   /** Alarms that qualified but lost to the per-tick cap. Reported, not dropped. */
   suppressed: number;
 }
@@ -603,17 +661,40 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
   const open = fresh.slice(0, LANE_ALARM_MAX_OPENS_PER_TICK);
 
   const close: LaneAlarmPlan["close"] = [];
-  for (const [lane, issue] of Object.entries(openAlarms)) {
+  for (const [lane, open] of Object.entries(openAlarms)) {
     const record = latest[lane] ?? null;
     // Only `ok` closes. A lane that went `unknown` has not recovered -- the
     // watchdog could not evaluate it -- and closing on an absence of
     // measurement is the confident-wrong-answer this repo avoids everywhere
     // else. A lane with no record at all keeps its issue for the same reason.
     if (record?.verdict !== "ok") continue;
-    close.push({ lane, issue, record });
+    close.push({ lane, issue: open.issue, record });
   }
 
-  return { open, close, suppressed: fresh.length - open.length };
+  // Further losses on a queue whose alarm is already open. See
+  // LaneAlarmPlan.update for the whole argument.
+  //
+  // Gated on `qualified` -- not merely on having a row -- so a second report
+  // still has to clear every bound the first one did: the residue guard that
+  // drops a lane nothing has written in a week, and the stale floor. A lane
+  // that stopped qualifying has stopped alarming, and an issue about it should
+  // stop growing too. Membership rather than the alarm itself, because what a
+  // recurrence needs is the NEWEST row, and `alarm.since` is the oldest.
+  const qualifiedLanes = new Set(qualified.map((alarm) => alarm.lane));
+  const update: LaneAlarmPlan["update"] = [];
+  for (const [lane, openIssue] of Object.entries(openAlarms)) {
+    if (!isDeadLetterLane(lane)) continue;
+    if (!qualifiedLanes.has(lane)) continue;
+    if (openIssue.updatedAt === null) continue;
+    // Indexed without a guard: membership above is derived from `latest`, so a
+    // qualified lane has a record by construction. A `?? continue` here would
+    // be a branch no test could reach.
+    const record = latest[lane];
+    if (record.checked_at <= openIssue.updatedAt) continue;
+    update.push({ lane, issue: openIssue.issue, record });
+  }
+
+  return { open, close, update, suppressed: fresh.length - open.length };
 }
 
 function humanDuration(ms: number): string {
@@ -664,6 +745,27 @@ export function laneAlarmIssueBody(alarm: LaneAlarm, nowMs: number): string {
     "`GET /api/v1/self-health`.",
   );
   return lines.join("\n");
+}
+
+/**
+ * The comment a FURTHER loss earns on an alarm issue that is already open.
+ *
+ * States the loss and then says why it arrived as a comment rather than as its
+ * own issue, because the alternative reading -- "the alarm re-fired for the
+ * same thing" -- is what would get these muted. See LaneAlarmPlan.update.
+ */
+export function laneAlarmLossComment(
+  lane: string,
+  record: LaneHealthRecord,
+): string {
+  const detail = record.detail ? `: \`${record.detail}\`` : "";
+  return (
+    `\`${lane}\` lost more at ${new Date(record.checked_at).toISOString()}${detail}.\n\n` +
+    "Reported here rather than as a new issue because this one is still open. " +
+    "A dead-letter lane never reports `ok` -- nothing un-loses a message -- so " +
+    "this issue will not close itself; closing it is a decision, and the next " +
+    "loss after it closes opens a fresh alarm."
+  );
 }
 
 /** The recovery comment. States what recovered and how long it was out. */
@@ -729,8 +831,12 @@ export interface LaneAlarmGitHub {
    * runner acts on it by opening one for every alarming lane; "we could not
    * ask" must never produce that action, and the two are indistinguishable
    * once a failure has been flattened into an empty object. */
-  listOpen(): Promise<Record<string, number> | null>;
+  listOpen(): Promise<Record<string, LaneAlarmOpenIssue> | null>;
   open(alarm: LaneAlarm, title: string, body: string): Promise<number | null>;
+  /** Say something on an issue that stays open. Its own method rather than a
+   * flag on `close`, because reporting a further loss and closing on recovery
+   * are opposite outcomes that happen to share a request. */
+  comment(issue: number, body: string): Promise<boolean>;
   close(issue: number, comment: string): Promise<boolean>;
 }
 
@@ -773,7 +879,7 @@ export function laneAlarmGitHub(
       // Same reasoning as the status check: a body we cannot read is not a
       // report that nothing is open.
       if (!page.success) return null;
-      const out: Record<string, number> = {};
+      const out: Record<string, LaneAlarmOpenIssue> = {};
       for (const row of page.data) {
         // Per ROW, so one issue GitHub shapes unexpectedly costs that issue
         // and not the whole page -- see GithubIssueListSchema.
@@ -786,7 +892,17 @@ export function laneAlarmGitHub(
         const title = issue.title ?? "";
         if (!title.startsWith(LANE_ALARM_TITLE_PREFIX)) continue;
         const lane = title.slice(LANE_ALARM_TITLE_PREFIX.length).trim();
-        if (lane && typeof issue.number === "number") out[lane] = issue.number;
+        if (!lane || typeof issue.number !== "number") continue;
+        // A stamp we cannot read becomes null rather than 0. Zero would date
+        // the issue to 1970 and make every dead-letter row look newer than it,
+        // which is a comment every tick -- see LaneAlarmPlan.update.
+        const parsedAt = issue.updated_at
+          ? Date.parse(issue.updated_at)
+          : Number.NaN;
+        out[lane] = {
+          issue: issue.number,
+          updatedAt: Number.isFinite(parsedAt) ? parsedAt : null,
+        };
       }
       return out;
     },
@@ -801,6 +917,13 @@ export function laneAlarmGitHub(
       return typeof created.data?.number === "number"
         ? created.data.number
         : null;
+    },
+    async comment(issue, body) {
+      const response = await fetchImpl(
+        `${GITHUB_API}/repos/${repo}/issues/${issue}/comments`,
+        { method: "POST", headers, body: JSON.stringify({ body }) },
+      );
+      return response.ok;
     },
     async close(issue, comment) {
       // Comment first: a close that lands without its reason is an issue whose
@@ -920,6 +1043,7 @@ export async function runLaneAlarm(
 
   let opened = 0;
   let closed = 0;
+  let commented = 0;
   for (const alarm of plan.open) {
     const body = laneAlarmIssueBody(alarm, nowMs);
     // PostHog stays a second channel rather than the only one. It is recorded
@@ -1000,6 +1124,25 @@ export async function runLaneAlarm(
         .catch(() => false);
       if (ok) closed += 1;
     }
+    for (const entry of plan.update) {
+      // Recorded to PostHog too, and for the same reason the opens are: the
+      // GitHub write is one channel, and a loss nobody can see is the thing
+      // this whole list exists to end. Its own code, because "more was lost on
+      // a queue already alarming" is a different event from the first loss.
+      await record(env as never, {
+        error: new Error(
+          `lane ${entry.lane} lost more while already alarming` +
+            (entry.record.detail ? ` -- ${entry.record.detail}` : ""),
+        ),
+        route: "watchdog:lane-alarm",
+        fingerprintDetail: entry.lane,
+        errorCode: "lane_lost_again",
+      }).catch(() => false);
+      const ok = await github
+        .comment(entry.issue, laneAlarmLossComment(entry.lane, entry.record))
+        .catch(() => false);
+      if (ok) commented += 1;
+    }
   }
 
   await recordLaneVerdict(db, {
@@ -1010,7 +1153,7 @@ export async function runLaneAlarm(
     // and a healthy platform look identical.
     verdict: "ok",
     age_ms: null,
-    detail: `${plan.open.length} alarming, ${plan.close.length} recovered, ${Object.keys(latest).length} lanes`,
+    detail: `${plan.open.length} alarming, ${plan.close.length} recovered, ${plan.update.length} recurred, ${Object.keys(latest).length} lanes`,
     checked_at: nowMs,
   });
 
@@ -1019,9 +1162,11 @@ export async function runLaneAlarm(
     lanes: Object.keys(latest).length,
     alarming: plan.open.length,
     recovered: plan.close.length,
+    recurred: plan.update.length,
     suppressed: plan.suppressed,
     opened,
     closed,
+    commented,
     delivered: Boolean(github) && !listUnavailable,
     ...(listUnavailable ? { reason: "issue_list_unavailable" } : {}),
   };

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -705,16 +705,50 @@ function humanDuration(ms: number): string {
 }
 
 /**
+ * The opening sentence, one per fault, and THREE FAULTS EXIST.
+ *
+ * This branched `stale` against everything-else, so an `unknown` alarm was
+ * described as "has written no verdict at all ... its watchdog appears to have
+ * stopped running", which is the opposite of what `unknown` means: the watchdog
+ * IS running and IS writing, and what it is saying is that it could not
+ * evaluate the lane. #10695 added the verdict to the OPEN path and this
+ * sentence was not told. The three are kept apart here rather than at the call
+ * site so the compiler checks the set: `LaneAlarmKind` is derived from the
+ * published schema, and a fourth member stops this switch compiling.
+ *
+ * A DEAD-LETTER LANE OUTRANKS ITS KIND. Its rows are losses, not ticks, so
+ * "reported stale on every tick (89 consecutive verdicts)" -- measured on the
+ * first issue this alarm ever filed -- described 89 separate lost messages as
+ * one condition observed 89 times.
+ */
+function issueOpening(alarm: LaneAlarm, forHow: string): string {
+  if (isDeadLetterLane(alarm.lane)) {
+    return (
+      `\`${alarm.lane}\` has dead-lettered **${alarm.ticks} time(s)** in the **${forHow}** since the first loss. ` +
+      "Each row is a message that exhausted its retries and was acked to keep it out of a second-order queue -- so this is a count of losses, not of ticks."
+    );
+  }
+  switch (alarm.kind) {
+    case "stale":
+      return `\`${alarm.lane}\` has reported **stale** on every tick for **${forHow}** (${alarm.ticks} consecutive verdicts).`;
+    case "unknown":
+      return (
+        `\`${alarm.lane}\` has reported **unknown** on every tick for **${forHow}** (${alarm.ticks} consecutive verdicts). ` +
+        "The watchdog is running; what it cannot do is evaluate this lane, so nothing here is a measurement -- neither a breach nor a clean bill."
+      );
+    case "silent":
+      return `\`${alarm.lane}\` has written **no verdict at all** for **${forHow}**. Its watchdog appears to have stopped running -- the last verdict it did write said \`${alarm.detail ?? "ok"}\`, so nothing else will report this.`;
+  }
+}
+
+/**
  * The issue body. Written to be actionable without opening anything else:
  * which lane, which fault, how long, what the watchdog said, and the query that
  * shows the history.
  */
 export function laneAlarmIssueBody(alarm: LaneAlarm, nowMs: number): string {
   const forHow = humanDuration(nowMs - alarm.since);
-  const opening =
-    alarm.kind === "stale"
-      ? `\`${alarm.lane}\` has reported **stale** on every tick for **${forHow}** (${alarm.ticks} consecutive verdicts).`
-      : `\`${alarm.lane}\` has written **no verdict at all** for **${forHow}**. Its watchdog appears to have stopped running -- the last verdict it did write said \`${alarm.detail ?? "ok"}\`, so nothing else will report this.`;
+  const opening = issueOpening(alarm, forHow);
   const lines = [
     opening,
     "",
@@ -726,7 +760,15 @@ export function laneAlarmIssueBody(alarm: LaneAlarm, nowMs: number): string {
   if (alarm.age_ms !== null) {
     lines.push(`| lane was behind by | ${humanDuration(alarm.age_ms)} |`);
   }
-  if (alarm.cadence_ms !== null) {
+  // NOT FOR A DEAD-LETTER LANE, and this is the same call laneAlarmSummary
+  // already makes one floor up (#10809, in the other direction). A cadence next
+  // to a duration invites "cycles missed", and for a queue that is meaningless:
+  // the producer's hourly cadence has nothing to do with when a message was
+  // lost. Measured: `41.0h against a 1.0h cadence` was triaged as the most
+  // urgent lane in the fleet, ahead of six that were genuinely dead. The
+  // summary stopped saying it and the ISSUE BODY went on saying it -- the first
+  // one this alarm ever filed carried `observed cadence | 1.0h`.
+  if (alarm.cadence_ms !== null && !isDeadLetterLane(alarm.lane)) {
     lines.push(`| observed cadence | ${humanDuration(alarm.cadence_ms)} |`);
   }
   if (alarm.detail) {
@@ -740,9 +782,16 @@ export function laneAlarmIssueBody(alarm: LaneAlarm, nowMs: number): string {
     `ORDER BY checked_at DESC LIMIT 40;`,
     "```",
     "",
-    "Closed automatically on the first `ok` verdict. Opened by the lane-health",
-    "reader (`src/lane-alarm.ts`); the record it reads is also served at",
-    "`GET /api/v1/self-health`.",
+    // A PROMISE THIS ISSUE CAN KEEP. "Closed automatically on the first `ok`
+    // verdict" is true of a producer and impossible for a dead-letter lane --
+    // nothing writes one `ok`, so the sentence told the reader to wait for an
+    // event that cannot happen, on the one lane whose issue a human has to
+    // close.
+    isDeadLetterLane(alarm.lane)
+      ? "This will NOT close itself: nothing writes a dead-letter lane `ok`, because\nnothing un-loses a message. Closing it is a decision, and the next loss after\nit closes opens a fresh alarm. Until then, further losses arrive here as\ncomments."
+      : "Closed automatically on the first `ok` verdict.",
+    "Opened by the lane-health reader (`src/lane-alarm.ts`); the record it reads",
+    "is also served at `GET /api/v1/self-health`.",
   );
   return lines.join("\n");
 }

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -1231,6 +1231,42 @@ describe("runLaneAlarm", () => {
     ]);
   });
 
+  // The GitHub write is the load-bearing half here, so neither a loss with no
+  // detail to quote nor a capture pipeline that throws may cost it. Same
+  // contract every other write in this file keeps: the second channel failing
+  // must not take the first one with it.
+  test("a detail-less loss still comments, even when the capture throws", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "sync-batches-dlq",
+          verdict: "stale",
+          age_ms: null,
+          detail: null,
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "sync-batches-dlq", since: NOW - 28 * HOUR, ticks: 2 }],
+    });
+    const github = fakeGitHub({
+      "sync-batches-dlq": { issue: 55, updatedAt: NOW - HOUR },
+    });
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      {
+        github,
+        now: () => NOW,
+        recordException: async () => {
+          throw new Error("posthog is down");
+        },
+      },
+    );
+    assert.equal(out.commented, 1);
+    assert.equal(github.commented.length, 1);
+    // No detail means no trailing quote, not a dangling separator.
+    assert.doesNotMatch(github.commented[0].body, /--\s*$/m);
+  });
+
   test("a comment GitHub refuses is not counted as delivered", async () => {
     const db = healthDb({
       latest: [

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -40,6 +40,7 @@ import {
   LANE_STALE_RUN_SQL,
   laneAlarmGitHub,
   laneAlarmIssueBody,
+  laneAlarmLossComment,
   laneAlarmPlan,
   laneAlarmRecoveryComment,
   laneAlarmTitle,
@@ -49,6 +50,7 @@ import {
   runLaneAlarm,
   type LaneAlarm,
   type LaneAlarmGitHub,
+  type LaneAlarmOpenIssue,
 } from "../src/lane-alarm.ts";
 import type { LaneHealthRecord } from "../src/lane-health.ts";
 
@@ -467,7 +469,7 @@ describe("laneAlarmPlan", () => {
       ...base,
       latest: { a: record({ lane: "a" }) },
       runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
-      openAlarms: { a: 4242 },
+      openAlarms: { a: { issue: 4242, updatedAt: NOW } },
     });
     assert.deepEqual(plan.open, []);
     assert.equal(plan.suppressed, 0);
@@ -493,7 +495,7 @@ describe("laneAlarmPlan", () => {
     const plan = laneAlarmPlan({
       ...base,
       latest: { a: record({ lane: "a", verdict: "ok" }) },
-      openAlarms: { a: 77 },
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
     });
     assert.deepEqual(
       plan.close.map((c) => ({ lane: c.lane, issue: c.issue })),
@@ -505,13 +507,16 @@ describe("laneAlarmPlan", () => {
     const plan = laneAlarmPlan({
       ...base,
       latest: { a: record({ lane: "a", verdict: "unknown" }) },
-      openAlarms: { a: 77 },
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
     });
     assert.deepEqual(plan.close, []);
   });
 
   test("does NOT close a lane that has no record at all", () => {
-    const plan = laneAlarmPlan({ ...base, openAlarms: { a: 77 } });
+    const plan = laneAlarmPlan({
+      ...base,
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
+    });
     assert.deepEqual(plan.close, []);
   });
 
@@ -520,9 +525,118 @@ describe("laneAlarmPlan", () => {
       ...base,
       latest: { a: record({ lane: "a" }) },
       runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
-      openAlarms: { a: 77 },
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
     });
     assert.deepEqual(plan.close, []);
+  });
+
+  // A DEAD-LETTER LANE IS THE ONE THAT NEVER RECOVERS, and that had a cost
+  // nobody had paid yet: nothing writes it `ok`, so its issue never closes, and
+  // while the issue is open `fresh` drops the lane -- so the FIRST loss was
+  // reported and every one after it was reported nowhere. These four cases are
+  // the whole of when a second report is earned.
+  const DLQ = "revenue-probes-dlq";
+  /** A dead-letter lane mid-alarm: one loss recorded, its issue already open. */
+  function dlqBase(over: { updatedAt?: number | null } = {}) {
+    return {
+      ...base,
+      latest: {
+        [DLQ]: record({ lane: DLQ, detail: "2 dead-lettered message(s)" }),
+      },
+      runs: { [DLQ]: { since: NOW - 28 * HOUR, ticks: 3 } },
+      openAlarms: {
+        [DLQ]: {
+          issue: 55,
+          updatedAt:
+            "updatedAt" in over ? (over.updatedAt ?? null) : NOW - HOUR,
+        },
+      },
+    };
+  }
+
+  test("a further loss is reported into the issue that is already open", () => {
+    // The row is newer than the last thing written to the issue, and a
+    // dead-letter lane only writes a row when a message is lost -- so this IS
+    // a loss nobody has been told about.
+    const plan = laneAlarmPlan(dlqBase());
+    assert.deepEqual(
+      plan.update.map((u) => ({ lane: u.lane, issue: u.issue })),
+      [{ lane: DLQ, issue: 55 }],
+    );
+    // And still exactly one issue, not a second.
+    assert.deepEqual(plan.open, []);
+  });
+
+  test("a loss already reported does not comment twice", () => {
+    // The alarm's own comment moves `updated_at`, which is what makes the
+    // comparison self-limiting: one comment per loss, not one per tick.
+    const plan = laneAlarmPlan(dlqBase({ updatedAt: NOW }));
+    assert.deepEqual(plan.update, []);
+  });
+
+  test("an unreadable issue timestamp declines, rather than commenting every tick", () => {
+    // No mark means no way to tell a new loss from an old one. Commenting on
+    // none is recoverable; commenting on every tick is how an alarm gets muted.
+    const plan = laneAlarmPlan(dlqBase({ updatedAt: null }));
+    assert.deepEqual(plan.update, []);
+  });
+
+  test("a PRODUCER lane never comments -- its rows are one verdict, not events", () => {
+    // The distinction the whole list rests on. A staleness watchdog writes
+    // `stale` every tick about ONE condition, so "a row newer than the issue"
+    // is true every half hour and means nothing new.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { a: record({ lane: "a", checked_at: NOW }) },
+      runs: { a: { since: NOW - 28 * HOUR, ticks: 112 } },
+      openAlarms: { a: { issue: 77, updatedAt: NOW - HOUR } },
+    });
+    assert.deepEqual(plan.update, []);
+  });
+
+  test("a dead-letter lane that has stopped qualifying stops growing its issue", () => {
+    // Residue: nothing has been written to this lane in over a week, so the
+    // stale loop drops it as an outage that no longer exists. An issue about it
+    // must stop accumulating too -- the second report is held to every bound
+    // the first one cleared.
+    const stale = NOW - 8 * 24 * HOUR;
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: { [DLQ]: record({ lane: DLQ, checked_at: stale }) },
+      runs: { [DLQ]: { since: stale, ticks: 1 } },
+      openAlarms: { [DLQ]: { issue: 55, updatedAt: stale - HOUR } },
+    });
+    assert.deepEqual(plan.update, []);
+    assert.deepEqual(plan.open, []);
+  });
+});
+
+describe("laneAlarmLossComment", () => {
+  test("names the loss, and why it is a comment rather than a new issue", () => {
+    const body = laneAlarmLossComment(
+      "revenue-probes-dlq",
+      record({
+        lane: "revenue-probes-dlq",
+        detail: "1 dead-lettered message(s) on revenue-probes-dlq (sn-51)",
+        checked_at: NOW,
+      }),
+    );
+    assert.match(body, /`revenue-probes-dlq` lost more at /);
+    assert.ok(body.includes(new Date(NOW).toISOString()));
+    assert.match(body, /sn-51/);
+    // The reader has to be told this is not the alarm re-firing for the same
+    // thing, or these get muted as duplicates.
+    assert.match(body, /still open/);
+    assert.match(body, /never reports `ok`/);
+  });
+
+  test("a loss with no detail still reports the loss", () => {
+    const body = laneAlarmLossComment(
+      "sync-batches-dlq",
+      record({ lane: "sync-batches-dlq", detail: null, checked_at: NOW }),
+    );
+    assert.match(body, /`sync-batches-dlq` lost more at /);
+    assert.ok(!body.includes("``"));
   });
 });
 
@@ -710,11 +824,71 @@ describe("laneAlarmGitHub", () => {
         {},
       ],
     }));
-    assert.deepEqual(await gh.listOpen(), { "neurons-staleness": 1 });
+    assert.deepEqual(await gh.listOpen(), {
+      "neurons-staleness": { issue: 1, updatedAt: null },
+    });
     assert.match(
       seen[0].url,
       /\/repos\/o\/r\/issues\?state=open&per_page=100$/,
     );
+  });
+
+  // The mark a recurrence is measured against. Without it the alarm has no way
+  // to tell a loss it has already reported from one it has not, and a
+  // dead-letter lane's issue either grows every tick or never grows at all.
+  test("carries when each issue was last written to, as epoch ms", async () => {
+    const { gh } = client(() => ({
+      ok: true,
+      json: async () => [
+        {
+          number: 1,
+          title: `${LANE_ALARM_TITLE_PREFIX}revenue-probes-dlq`,
+          updated_at: "2026-08-15T03:28:00.000Z",
+        },
+      ],
+    }));
+    assert.deepEqual(await gh.listOpen(), {
+      "revenue-probes-dlq": {
+        issue: 1,
+        updatedAt: Date.parse("2026-08-15T03:28:00.000Z"),
+      },
+    });
+  });
+
+  // NULL, not 0. Zero dates the issue to 1970, which makes every dead-letter
+  // row look newer than it -- a comment every tick, on the lane whose whole
+  // point is that it only speaks when something was lost.
+  test("an unreadable timestamp becomes null, not the epoch", async () => {
+    const { gh } = client(() => ({
+      ok: true,
+      json: async () => [
+        {
+          number: 1,
+          title: `${LANE_ALARM_TITLE_PREFIX}a`,
+          updated_at: "not a date",
+        },
+        { number: 2, title: `${LANE_ALARM_TITLE_PREFIX}b`, updated_at: null },
+      ],
+    }));
+    assert.deepEqual(await gh.listOpen(), {
+      a: { issue: 1, updatedAt: null },
+      b: { issue: 2, updatedAt: null },
+    });
+  });
+
+  test("comments on an issue that stays open", async () => {
+    const { gh, seen } = client(() => ({ ok: true, json: async () => ({}) }));
+    assert.equal(await gh.comment(55, "lost more"), true);
+    assert.match(seen[0].url, /\/repos\/o\/r\/issues\/55\/comments$/);
+    assert.equal(seen[0].init?.method, "POST");
+    assert.deepEqual(JSON.parse(String(seen[0].init?.body)), {
+      body: "lost more",
+    });
+  });
+
+  test("a refused comment reports false rather than throwing", async () => {
+    const { gh } = client(() => ({ ok: false, json: async () => ({}) }));
+    assert.equal(await gh.comment(55, "lost more"), false);
   });
 
   // NULL, not `{}`. This asserted the opposite, and the opposite is what put
@@ -748,7 +922,9 @@ describe("laneAlarmGitHub", () => {
         { number: 1, title: `${LANE_ALARM_TITLE_PREFIX}neurons-staleness` },
       ],
     }));
-    assert.deepEqual(await gh.listOpen(), { "neurons-staleness": 1 });
+    assert.deepEqual(await gh.listOpen(), {
+      "neurons-staleness": { issue: 1, updatedAt: null },
+    });
   });
 
   test("opens an issue and returns its number", async () => {
@@ -826,19 +1002,28 @@ describe("laneAlarmGitHub", () => {
 
 describe("runLaneAlarm", () => {
   /** A GitHub double that records what it was asked to do. */
-  function fakeGitHub(open: Record<string, number> = {}): LaneAlarmGitHub & {
+  function fakeGitHub(
+    open: Record<string, LaneAlarmOpenIssue> = {},
+  ): LaneAlarmGitHub & {
     opened: string[];
     closed: number[];
+    commented: { issue: number; body: string }[];
   } {
     const opened: string[] = [];
     const closed: number[] = [];
+    const commented: { issue: number; body: string }[] = [];
     return {
       opened,
       closed,
+      commented,
       listOpen: async () => open,
       open: async (alarm) => {
         opened.push(alarm.lane);
         return 100 + opened.length;
+      },
+      comment: async (issue, body) => {
+        commented.push({ issue, body });
+        return true;
       },
       close: async (issue) => {
         closed.push(issue);
@@ -920,7 +1105,7 @@ describe("runLaneAlarm", () => {
       "lane-alarm",
       "ok",
       null,
-      "1 alarming, 0 recovered, 1 lanes",
+      "1 alarming, 0 recovered, 0 recurred, 1 lanes",
       NOW,
     ]);
   });
@@ -937,7 +1122,9 @@ describe("runLaneAlarm", () => {
         },
       ],
     });
-    const github = fakeGitHub({ "neurons-staleness": 4242 });
+    const github = fakeGitHub({
+      "neurons-staleness": { issue: 4242, updatedAt: NOW },
+    });
     const out = await runLaneAlarm(
       { ...TOKEN, ...db.env },
       { github, now: () => NOW, recordException: async () => true },
@@ -945,6 +1132,93 @@ describe("runLaneAlarm", () => {
     assert.equal(out.recovered, 1);
     assert.equal(out.closed, 1);
     assert.deepEqual(github.closed, [4242]);
+  });
+
+  // THE END OF THE HOLE THE TOKEN OPENED. A dead-letter lane never reports
+  // `ok`, so its issue never closes -- and while it was open the lane was
+  // dropped from `fresh`, which meant the first lost message was filed and
+  // every one after it was reported NOWHERE. Both channels get it now.
+  test("a further dead-letter loss comments on the open issue, and records", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "revenue-probes-dlq",
+          verdict: "stale",
+          age_ms: null,
+          detail: "2 dead-lettered message(s) on revenue-probes-dlq (sn-51)",
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "revenue-probes-dlq", since: NOW - 28 * HOUR, ticks: 4 }],
+    });
+    const github = fakeGitHub({
+      // Last written to an hour ago; the row above landed since.
+      "revenue-probes-dlq": { issue: 55, updatedAt: NOW - HOUR },
+    });
+    const seen: Array<{ errorCode?: string }> = [];
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      {
+        github,
+        now: () => NOW,
+        recordException: async (_env, payload) => {
+          seen.push(payload as { errorCode?: string });
+          return true;
+        },
+      },
+    );
+    assert.equal(out.recurred, 1);
+    assert.equal(out.commented, 1);
+    assert.equal(github.commented.length, 1);
+    assert.equal(github.commented[0].issue, 55);
+    assert.match(github.commented[0].body, /sn-51/);
+    // NOT a second issue, and not a close either.
+    assert.deepEqual(github.opened, []);
+    assert.deepEqual(github.closed, []);
+    // Its own code: "more was lost on a queue already alarming" is a different
+    // event from the first loss, and must not fingerprint as a repeat of it.
+    assert.deepEqual(
+      seen.map((p) => p.errorCode),
+      ["lane_lost_again"],
+    );
+    // And the reader's own verdict counts it, so a tick that only commented
+    // does not read as a tick with nothing to report.
+    assert.deepEqual(db.written[0].values, [
+      "lane-alarm",
+      "ok",
+      null,
+      "0 alarming, 0 recovered, 1 recurred, 1 lanes",
+      NOW,
+    ]);
+  });
+
+  test("a comment GitHub refuses is not counted as delivered", async () => {
+    const db = healthDb({
+      latest: [
+        {
+          lane: "revenue-probes-dlq",
+          verdict: "stale",
+          age_ms: null,
+          detail: "1 dead-lettered message(s)",
+          checked_at: NOW,
+        },
+      ],
+      runs: [{ lane: "revenue-probes-dlq", since: NOW - 28 * HOUR, ticks: 4 }],
+    });
+    const github = fakeGitHub({
+      "revenue-probes-dlq": { issue: 55, updatedAt: NOW - HOUR },
+    });
+    github.comment = async () => {
+      throw new Error("502 from github");
+    };
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      { github, now: () => NOW, recordException: async () => true },
+    );
+    // Planned, so the finding is still reported; not delivered, so the count
+    // stays honest -- the same distinction `opened` draws for a failed create.
+    assert.equal(out.recurred, 1);
+    assert.equal(out.commented, 0);
   });
 
   test("an unreadable issue list stops the WRITES, and still records every lane", async () => {
@@ -1324,7 +1598,7 @@ describe("runLaneAlarm", () => {
         { lane: "a", verdict: "ok", age_ms: 1, detail: null, checked_at: NOW },
       ],
     });
-    const github = fakeGitHub({ a: 5 });
+    const github = fakeGitHub({ a: { issue: 5, updatedAt: NOW } });
     github.close = async () => {
       throw new Error("rate limited");
     };

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -665,6 +665,45 @@ describe("laneAlarmIssueBody", () => {
     assert.match(body, /FROM lane_health WHERE lane = 'neurons-staleness'/);
   });
 
+  // #10695 added `unknown` to the OPEN path and never told this sentence, so
+  // an unknown alarm was described as a watchdog that had STOPPED -- the exact
+  // opposite of what the verdict means. The watchdog is running; it is the
+  // measurement that did not happen.
+  test("an unknown body does not claim the watchdog stopped", () => {
+    const body = laneAlarmIssueBody(alarm({ kind: "unknown", ticks: 4 }), NOW);
+    assert.match(body, /reported \*\*unknown\*\* on every tick/);
+    assert.match(body, /4 consecutive verdicts/);
+    assert.match(body, /The watchdog is running/);
+    assert.doesNotMatch(body, /no verdict at all/);
+    assert.doesNotMatch(body, /appears to have stopped running/);
+  });
+
+  // THE FIRST ISSUE THIS ALARM EVER FILED (#11251) said all three of these
+  // things about a dead-letter lane, and all three were wrong.
+  test("a dead-letter body counts losses, drops the cadence, and promises nothing", () => {
+    const body = laneAlarmIssueBody(
+      alarm({
+        lane: "revenue-probes-dlq",
+        ticks: 89,
+        age_ms: null,
+        detail: "1 dead-lettered message(s) on revenue-probes-dlq (sn-51)",
+      }),
+      NOW,
+    );
+    // Rows are LOSSES, not one condition observed 89 times.
+    assert.match(body, /dead-lettered \*\*89 time\(s\)\*\*/);
+    assert.match(body, /a count of losses, not of ticks/);
+    assert.doesNotMatch(body, /on every tick/);
+    // The cadence belongs to the producer and says nothing about when a
+    // message was lost -- the misreading #10809 measured, in the other
+    // direction.
+    assert.doesNotMatch(body, /observed cadence/);
+    // And it must not promise a close that cannot happen.
+    assert.match(body, /will NOT close itself/);
+    assert.match(body, /further losses arrive here as\ncomments/);
+    assert.doesNotMatch(body, /Closed automatically/);
+  });
+
   test("a silent body says the watchdog stopped, and what it last said", () => {
     const body = laneAlarmIssueBody(
       alarm({ kind: "silent", ticks: 0, detail: "ok", age_ms: null }),


### PR DESCRIPTION
`LANE_ALARM_GITHUB_TOKEN` is provisioned. At **03:28:47–49Z** the alarm filed the first three `alarm(lane):` issues in this repo's history — #11251, #11252, #11253 — and `alarm_undelivered` fired at 02:58 and not at 03:28. The channel works.

Reading what it actually wrote found four defects, all of which only a filed issue could have surfaced.

## 1. A dead-letter lane's second loss had nowhere to go

`handleDeadLetterBatch` is the only writer for the five `*-dlq` lanes, and it writes one verdict: `stale`, once per dead-lettered batch. Nothing writes them `ok` — nothing un-loses a message — so `laneAlarmPlan`'s close rule can never fire for one and its issue stays open. **That part is correct**: closing the only record of a loss is a decision a person makes.

What was not correct is what an open issue then did to the lane. `fresh` drops every lane already in `openAlarms` — right for a producer, where an issue saying "this lane is stale" stays true while it stays stale. A dead-letter lane is not that shape: **its rows are events, not one verdict repeated**. So the first loss opened an issue and every loss after it was reported nowhere. Already in `openAlarms`, so nothing re-opened; no `ok`, so nothing closed. The alarm went quiet exactly as the queue got worse.

A further loss now comments on the open issue, de-duplicated against data already fetched: GitHub stamps `updated_at` on every write **including the alarm's own comment**, so a row newer than that mark is a loss nobody has been told about, and the comment moves the mark. One comment per loss, not one per tick. Producer lanes are excluded — they write every tick, where the same test would comment every thirty minutes — and an unreadable stamp declines rather than commenting always.

## 2–4. The body of #11251 said three untrue things

| it said | the truth |
| --- | --- |
| "reported **stale** on every tick for 3.7 days (89 consecutive verdicts)" | 89 rows are **89 lost messages**, not one condition seen 89 times |
| `\| observed cadence \| 1.0h \|` | `laneAlarmSummary` stopped saying this after #10809 measured the misreading — `41.0h against a 1.0h cadence` was triaged as the fleet's most urgent lane. The summary was fixed; the **body** was not |
| "Closed automatically on the first `ok` verdict." | impossible for this lane, ever — it told the reader to wait for an event that cannot occur |

And a fourth, found writing the switch that separates them: the opening branched `stale` against everything-else, so an **`unknown`** alarm was rendered with the SILENT text — *"has written no verdict at all … its watchdog appears to have stopped running"*. That is the opposite of what `unknown` means: the watchdog is running, and the measurement is what did not happen. #10695 added the verdict to the open path and this sentence was never told. The three kinds are now a switch over the schema-derived union, so a fourth member cannot be added without this compiling first.

## Bounds

At most one comment per dead-letter lane per tick, against five declared lanes — bounded without needing a cap. The recurrence is gated on `qualified`, so a second report clears every bound the first did (the seven-day residue guard, the stale floor). Recorded to PostHog under its own `lane_lost_again` code, so "more was lost on a queue already alarming" does not fingerprint as a repeat of the first loss.

## Verification

- `tests/lane-alarm.test.ts`: **87 passing**, +9 for this change.
- **Patch coverage 100%** — 42/42 statements and 35/35 branches on the changed lines, measured by intersecting `git diff -U0 origin/main...HEAD` with `coverage-final.json`.
- `typecheck`, `lint`, `format:check`, `validate:schemas`, `validate:boundary-casts`, `validate:contract-drift`, `validate:unreferenced-exports` all green after rebasing onto `89de582b1`.