### PR TITLE
fix(lanes): a retried message says why

### DIFF
--- a/src/lane-queue.ts
+++ b/src/lane-queue.ts
@@ -93,6 +93,27 @@ export interface ConsumeResult {
   retried: number;
   /** Acked WITHOUT doing the work: unparseable, or a subject that is gone. */
   dropped: number;
+  /**
+   * Why the first retry happened, or null when nothing was retried.
+   *
+   * RETURNED, not only reported. `onRetry` fires inside this call and every
+   * probe-job handler left it unset, so the reason went to `console.error` --
+   * and then the result carrying nothing about it was discarded by the
+   * dispatcher too. Workers logs are not a channel anybody watches here, so a
+   * lane could retry every message of every batch until it dead-lettered and
+   * leave no record a reader could reach.
+   *
+   * Measured 2026-08-15 on #11251: `sn-51-lium-revenue-for-validators` retried
+   * and dead-lettered roughly hourly for 3.7 days -- 89 rows on the DLQ -- while
+   * its endpoint answered 200 with a payload this repo's own extractor turns
+   * into 20 valid observations. The diagnosis existed on every one of those
+   * ticks and was thrown away each time.
+   *
+   * Null rather than the empty string: "nothing was retried" and "something was
+   * retried for a reason nobody recorded" are different answers, and a reporter
+   * has to be able to tell them apart.
+   */
+  firstFailure: string | null;
 }
 
 export interface ConsumeHandlers<TSubject> {
@@ -187,5 +208,5 @@ export async function consumeBatch<TSubject>(
       // Deliberately empty: see above.
     }
   }
-  return { done, retried, dropped };
+  return { done, retried, dropped, firstFailure };
 }

--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -17,6 +17,7 @@
 // it a nullable amount column would invite a reader to coalesce it to 0 -- the
 // exact confusion the lane exists to prevent (see migrations/neon/0016).
 import {
+  READABLE_PROVENANCES,
   runRevenueProbe,
   type ProbeSurfaceInput,
   type RevenueProbeResult,
@@ -230,6 +231,35 @@ export function eligibleRevenueSurfaces(
     // them so the reason a surface is skipped here matches the reason it would
     // have failed there.
     if (!revenue.shape || !revenue.currency) continue;
+    // AND THE TWO `probeEligibility` REFUSES WITHOUT, which this claimed to
+    // mirror and did not.
+    //
+    // The comment above says a surface skipped here is skipped for the reason
+    // it would have failed later. That was only ever true of `extractRevenue`.
+    // `probeEligibility` -- the gate the lane actually applies on delivery --
+    // opens with `role !== "external-revenue"` and then a readable
+    // `provenance`, and neither was asked here, so a surface that can never be
+    // probed was enqueued anyway, once an hour, forever.
+    //
+    // Measured 2026-08-15 against the published artifact: five surfaces carry a
+    // shape and a currency, and `sn-64-chutes-invocations-usage` is
+    // `role: "usage-proxy"` -- a usage signal, deliberately not revenue. The
+    // `revenue-probe` lane's verdict read `5 enqueued` every hour while four is
+    // the true number, so the count a reader judges the lane by overstated it.
+    //
+    // The other two gates are deliberately NOT copied. `auth_required` is
+    // carried below and checked there; `probe.enabled` is ASSERTED below rather
+    // than read, because the operational-surfaces artifact carries no `probe`
+    // block at all -- reading it here would make every surface ineligible and
+    // stop the lane dead. See the test that pins that to the build filter.
+    if (revenue.role !== "external-revenue") continue;
+    if (
+      !(READABLE_PROVENANCES as readonly string[]).includes(
+        revenue.provenance ?? "",
+      )
+    ) {
+      continue;
+    }
     out.push({
       id: String(surface.surface_id ?? ""),
       netuid: Number(surface.netuid),

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -772,7 +772,12 @@ describe("consuming a sweep batch", () => {
   test("acks a swept subnet", async () => {
     const m = message({ netuid: 64 });
     const out = await handleSweepBatch([m], store(), deps());
-    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 1,
+      retried: 0,
+      dropped: 0,
+      firstFailure: null,
+    });
     assert.equal(m.calls.acked, 1);
   });
 
@@ -817,7 +822,14 @@ describe("consuming a sweep batch", () => {
     // reading the store is concerned.
     const m = message({ netuid: 64 });
     const out = await handleSweepBatch([m], null, deps());
-    assert.deepEqual(out, { done: 0, retried: 1, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 0,
+      retried: 1,
+      dropped: 0,
+      // The quieter of the two failures -- no stack, no message. Returned
+      // now rather than only logged: see ConsumeResult.firstFailure.
+      firstFailure: "run() declined without throwing",
+    });
     assert.equal(m.calls.retried, 1);
   });
 
@@ -831,7 +843,12 @@ describe("consuming a sweep batch", () => {
       message({ netuid: -1 }),
     ];
     const out = await handleSweepBatch(bad, store(), deps());
-    assert.deepEqual(out, { done: 0, retried: 0, dropped: 4 });
+    assert.deepEqual(out, {
+      done: 0,
+      retried: 0,
+      dropped: 4,
+      firstFailure: null,
+    });
     for (const m of bad) assert.equal(m.calls.acked, 1);
   });
 
@@ -1069,7 +1086,14 @@ describe("the last of the queue shapes", () => {
         },
       },
     );
-    assert.deepEqual(out, { done: 0, retried: 1, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 0,
+      retried: 1,
+      dropped: 0,
+      // A thrown reason reaches the caller verbatim, which is what makes a
+      // dead-lettering lane answerable.
+      firstFailure: "artifact read exploded",
+    });
     assert.equal(calls.retried, 1);
   });
 

--- a/tests/lane-queue.test.ts
+++ b/tests/lane-queue.test.ts
@@ -42,6 +42,11 @@ describe("a retry reports its reason", () => {
     assert.deepEqual(a.calls, ["retry"]);
     assert.equal(result.retried, 1);
     assert.deepEqual(seen, [["r2 sql: HTTP 500", 1]]);
+    // RETURNED as well as reported. `onRetry` fires inside this call, and every
+    // probe-job handler left it unset -- so the reason went to console.error
+    // and the caller got a result carrying nothing about it. See
+    // ConsumeResult.firstFailure.
+    assert.equal(result.firstFailure, "r2 sql: HTTP 500");
   });
 
   test("a handler returning FALSE is reported too", async () => {
@@ -118,6 +123,9 @@ describe("a retry reports its reason", () => {
     });
     assert.equal(result.done, 1);
     assert.deepEqual(seen, [], "success is not something to report");
+    // Null, not "". "Nothing was retried" and "retried for a reason nobody
+    // recorded" are different answers, and a reporter has to tell them apart.
+    assert.equal(result.firstFailure, null);
   });
 
   test("a batch that only DROPS reports nothing", async () => {
@@ -132,6 +140,7 @@ describe("a retry reports its reason", () => {
     });
     assert.equal(result.dropped, 1);
     assert.deepEqual(seen, []);
+    assert.equal(result.firstFailure, null);
   });
 
   test("with no onRetry the loop still says so, on console.error", async () => {

--- a/tests/origin-reachability.test.ts
+++ b/tests/origin-reachability.test.ts
@@ -19,6 +19,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, test } from "vitest";
 import { SEND_BATCH_MAX } from "../src/lane-queue.ts";
+import { POSTHOG_PROJECT_TOKEN_ENV } from "../src/usage-telemetry.ts";
 import worker, {
   handleScheduled,
   probeOrigin,
@@ -681,7 +682,12 @@ describe("consuming an origin batch", () => {
   test("acks a checked origin", async () => {
     const m = message({ origin: "https://x.example" });
     const out = await handleOriginBatch([m], store(), deps() as never);
-    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 1,
+      retried: 0,
+      dropped: 0,
+      firstFailure: null,
+    });
     assert.equal(m.calls.acked, 1);
   });
 
@@ -705,7 +711,12 @@ describe("consuming an origin batch", () => {
   test("RETRIES when the check succeeded but the WRITE failed", async () => {
     const m = message({ origin: "https://x.example" });
     const out = await handleOriginBatch([m], null, deps() as never);
-    assert.deepEqual(out, { done: 0, retried: 1, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 0,
+      retried: 1,
+      dropped: 0,
+      firstFailure: "run() declined without throwing",
+    });
   });
 
   test("RETRIES when resolving the surfaces throws", async () => {
@@ -726,7 +737,12 @@ describe("consuming an origin batch", () => {
   test("ACKS a malformed message rather than looping it to the dead letter", async () => {
     const bad = [message({ origin: 42 }), message({}), message(null)];
     const out = await handleOriginBatch(bad, store(), deps() as never);
-    assert.deepEqual(out, { done: 0, retried: 0, dropped: 3 });
+    assert.deepEqual(out, {
+      done: 0,
+      retried: 0,
+      dropped: 3,
+      firstFailure: null,
+    });
     for (const m of bad) assert.equal(m.calls.acked, 1);
   });
 
@@ -853,6 +869,63 @@ describe("the origin queue, through the Worker's own handler", () => {
         { waitUntil: () => {} } as never,
       ),
     );
+  });
+
+  // THE REASON REACHES A CHANNEL SOMEBODY READS. `consumeBatch` computed it all
+  // along and every probe-job handler discarded the result, so a lane could
+  // retry every message of every batch until it dead-lettered with the cause
+  // recorded nowhere reachable -- which is how #11251 sat undiagnosable for 3.7
+  // days.
+  test("a retried batch reports WHY, as a $exception", async () => {
+    const posted: Record<string, unknown>[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      try {
+        const body = JSON.parse(String(init?.body ?? "null"));
+        if (body && typeof body === "object") posted.push(body);
+      } catch {
+        // The origin probe's own requests land here too and are not what this
+        // test reads.
+      }
+      return new Response("{}", { status: 200 });
+    }) as typeof fetch;
+    let retried = 0;
+    try {
+      await worker.queue!(
+        {
+          queue: "probe-jobs",
+          messages: [
+            {
+              body: {
+                job_type: "origin-reachability",
+                origin: "https://x.example",
+              },
+              ack: () => {},
+              retry: () => void (retried += 1),
+            },
+          ],
+        } as never,
+        env(registry, {
+          [POSTHOG_PROJECT_TOKEN_ENV]: "phc_test_token",
+        }) as never,
+        { waitUntil: () => {} } as never,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+    assert.equal(retried, 1, "with no store bound the write cannot land");
+    const exception = posted.find(
+      (body) => (body as { event?: string }).event === "$exception",
+    ) as { properties?: Record<string, unknown> } | undefined;
+    assert.ok(exception, "the retry reason must reach PostHog");
+    assert.equal(exception.properties?.error_code, "lane_retry");
+    assert.equal(exception.properties?.route, "lane:retry");
+    // ON THE JOB TYPE, not the queue. Since #10894 one queue carries all four
+    // lanes, so `batch.queue` is a constant -- and the fingerprint is the storm
+    // guard's throttle key, so it would drop the second lane to fail in a
+    // window as a repeat of the first.
+    const list = exception.properties?.$exception_list as { value: string }[];
+    assert.match(list[0].value, /^origin-reachability: 1 message\(s\) retried/);
   });
 
   test("an origin with no registered surfaces resolves to an empty list", async () => {

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -251,11 +251,81 @@ describe("eligibleRevenueSurfaces", () => {
             surface_id: "typo",
             netuid: 1,
             url: "https://example/typo",
-            revenue: { shape: "scalarr", currency: "USD" },
+            revenue: {
+              role: "external-revenue",
+              provenance: "probe-derived",
+              shape: "scalarr",
+              currency: "USD",
+            },
           },
         ],
       }).map((s) => s.id),
       ["typo"],
+    );
+  });
+
+  // THE TWO GATES THIS CLAIMED TO MIRROR AND DID NOT. `probeEligibility` -- the
+  // check the lane actually applies on delivery -- opens with the role and then
+  // a readable provenance, so a surface failing either was enqueued once an
+  // hour and could never be probed.
+  test("a role that is not external-revenue is not enqueued", () => {
+    // Measured on the published artifact: `sn-64-chutes-invocations-usage` is
+    // `usage-proxy` -- a usage signal, deliberately not revenue -- and it made
+    // the lane's own verdict read `5 enqueued` against four probeable surfaces,
+    // every hour.
+    assert.deepEqual(
+      eligibleRevenueSurfaces({
+        surfaces: [
+          {
+            surface_id: "sn-64-chutes-invocations-usage",
+            netuid: 64,
+            url: "https://example/usage",
+            revenue: {
+              role: "usage-proxy",
+              provenance: "probe-derived",
+              shape: "scalar",
+              currency: "USD",
+            },
+          },
+        ],
+      }),
+      [],
+    );
+  });
+
+  test("a provenance the store would refuse is not enqueued", () => {
+    // migrations/neon/0016 rejects any provenance outside the readable two:
+    // "a row claiming one of them means something wrote a figure it could not
+    // have read". Enqueueing one asks the lane to produce a row its own table
+    // will not accept.
+    assert.deepEqual(
+      eligibleRevenueSurfaces({
+        surfaces: [
+          {
+            surface_id: "attested",
+            netuid: 1,
+            url: "https://example/attested",
+            revenue: {
+              role: "external-revenue",
+              provenance: "operator-attested",
+              shape: "scalar",
+              currency: "USD",
+            },
+          },
+          // ...and a missing one is not readable either.
+          {
+            surface_id: "unset",
+            netuid: 2,
+            url: "https://example/unset",
+            revenue: {
+              role: "external-revenue",
+              shape: "scalar",
+              currency: "USD",
+            },
+          },
+        ],
+      }),
+      [],
     );
   });
 
@@ -511,6 +581,7 @@ describe("degenerate input", () => {
           netuid: 7,
           revenue: {
             role: "external-revenue",
+            provenance: "probe-derived",
             shape: "scalar",
             currency: "USD",
           },
@@ -749,7 +820,12 @@ describe("the queue lane (#10715)", () => {
   test("probes one surface per message and ACKS it on success", async () => {
     const m = message({ surface_id: surface.id });
     const out = await handleRevenueProbeBatch([m], store(), deps() as never);
-    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 1,
+      retried: 0,
+      dropped: 0,
+      firstFailure: null,
+    });
     assert.equal(m.calls.acked, 1);
   });
 
@@ -780,7 +856,12 @@ describe("the queue lane (#10715)", () => {
     );
     assert.equal(m.calls.retried, 0, "a deterministic failure must not retry");
     assert.equal(m.calls.acked, 1);
-    assert.deepEqual(out, { done: 1, retried: 0, dropped: 0 });
+    assert.deepEqual(out, {
+      done: 1,
+      retried: 0,
+      dropped: 0,
+      firstFailure: null,
+    });
   });
 
   test("a FETCH failure still RETRIES, because that one is transient", async () => {
@@ -828,7 +909,12 @@ describe("the queue lane (#10715)", () => {
       store(),
       deps({ surfaceFor: () => null }) as never,
     );
-    assert.deepEqual(out, { done: 0, retried: 0, dropped: 1 });
+    assert.deepEqual(out, {
+      done: 0,
+      retried: 0,
+      dropped: 1,
+      firstFailure: null,
+    });
     assert.equal(m.calls.acked, 1);
   });
 

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -832,7 +832,11 @@ import {
 } from "../src/projection-lanes.ts";
 import { TOP_HOLDERS_FLOW_LANE } from "../src/top-holders-flow-tier.ts";
 import { laneHealthStore } from "../src/lane-health-store.ts";
-import type { EnqueueResult, LaneMessage } from "../src/lane-queue.ts";
+import type {
+  ConsumeResult,
+  EnqueueResult,
+  LaneMessage,
+} from "../src/lane-queue.ts";
 import {
   OPERATIONAL_SURFACES_ARTIFACT,
   eligibleRevenueSurfaces,
@@ -2155,7 +2159,7 @@ async function runAttributionSweepJobs(
   messages: LaneMessage[],
   env: Env,
   ctx: ExecutionContext,
-): Promise<void> {
+): Promise<ConsumeResult> {
   // One subnet per message. The registry record is read HERE rather than
   // carried in the message, so a message that waited in the queue cannot
   // sweep a stale copy of the subnet's surfaces.
@@ -2164,7 +2168,7 @@ async function runAttributionSweepJobs(
     const byNetuid = new Map(
       (await sweepableSubnets(env)).map((s) => [s.netuid, s.record]),
     );
-    await handleSweepBatch(messages, store.db as SweepStoreDb, {
+    return await handleSweepBatch(messages, store.db as SweepStoreDb, {
       fetchText: fetchSweepText,
       recordFor: async (netuid: number) =>
         sweepRecordFor(env, netuid, byNetuid.get(netuid)),
@@ -2178,7 +2182,7 @@ async function runRevenueProbeJobs(
   messages: LaneMessage[],
   env: Env,
   ctx: ExecutionContext,
-): Promise<void> {
+): Promise<ConsumeResult> {
   // The eligible set is re-read HERE, so a message that waited cannot probe
   // a surface the registry has since withdrawn.
   const store = producerStore(env, ctx, [...REVENUE_OBSERVATION_TABLES]);
@@ -2192,7 +2196,7 @@ async function runRevenueProbeJobs(
         artifact.ok ? (artifact.data as Row | undefined) : null,
       ).map((s) => [s.id, s]),
     );
-    await handleRevenueProbeBatch(messages, store.db as RevenueStoreDb, {
+    return await handleRevenueProbeBatch(messages, store.db as RevenueStoreDb, {
       fetchPayload: (url: string) => fetchRevenuePayload(url),
       hash: sha256Hex,
       now: Date.now,
@@ -2207,15 +2211,19 @@ async function runComputeDeclarationJobs(
   messages: LaneMessage[],
   env: Env,
   ctx: ExecutionContext,
-): Promise<void> {
+): Promise<ConsumeResult> {
   const store = producerStore(env, ctx, [...COMPUTE_DECLARATIONS_TABLES]);
   try {
-    await handleComputeDeclarationBatch(messages, store.db as ComputeStoreDb, {
-      // The same token the link lane uses. Without one the GitHub API
-      // allows 60 requests an hour, which still covers 17 surfaces --
-      // so a missing token degrades the rate limit, never the lane.
-      githubAuth: githubAuthHeader(env),
-    });
+    return await handleComputeDeclarationBatch(
+      messages,
+      store.db as ComputeStoreDb,
+      {
+        // The same token the link lane uses. Without one the GitHub API
+        // allows 60 requests an hour, which still covers 17 surfaces --
+        // so a missing token degrades the rate limit, never the lane.
+        githubAuth: githubAuthHeader(env),
+      },
+    );
   } finally {
     store.close();
   }
@@ -2225,13 +2233,13 @@ async function runOriginReachabilityJobs(
   messages: LaneMessage[],
   env: Env,
   ctx: ExecutionContext,
-): Promise<void> {
+): Promise<ConsumeResult> {
   // The surfaces are resolved HERE, so a message that waited cannot check a
   // stale copy of what the registry advertises.
   const store = producerStore(env, ctx, [...ORIGIN_REACHABILITY_TABLES]);
   try {
     const byOrigin = surfacesByOrigin(await registeredSurfaces(env));
-    await handleOriginBatch(messages, store.db as OriginStoreDb, {
+    return await handleOriginBatch(messages, store.db as OriginStoreDb, {
       probe: probeOrigin,
       surfacesFor: async (origin: string) => byOrigin.get(origin) ?? [],
     });
@@ -2256,7 +2264,11 @@ async function runOriginReachabilityJobs(
  */
 const PROBE_JOB_HANDLERS: Record<
   ProbeJobType,
-  (messages: LaneMessage[], env: Env, ctx: ExecutionContext) => Promise<void>
+  (
+    messages: LaneMessage[],
+    env: Env,
+    ctx: ExecutionContext,
+  ) => Promise<ConsumeResult>
 > = {
   "attribution-sweep": runAttributionSweepJobs,
   "origin-reachability": runOriginReachabilityJobs,
@@ -2327,7 +2339,47 @@ export default {
       // would make a half-deployed rename look like a healthy queue draining.
       declineUnknownProbeJobs(unrecognised);
       for (const [jobType, messages] of byType) {
-        await PROBE_JOB_HANDLERS[jobType](messages, env, ctx);
+        const outcome = await PROBE_JOB_HANDLERS[jobType](messages, env, ctx);
+        // WHY A MESSAGE WENT BACK, on a channel somebody reads.
+        //
+        // `consumeBatch` has computed this since #10777 replaced a bare
+        // `catch { message.retry(); }` -- its comment says exactly why, that "a
+        // retry nobody can explain is how a lane dies silently". It then handed
+        // the string to `console.error` and returned a result every one of these
+        // handlers discarded. Workers logs are not a channel anybody watches
+        // here, so the reason reached nothing: not PostHog, not `lane_health`,
+        // and not the dead-letter verdict, which names the lost SUBJECT and
+        // never the cause.
+        //
+        // Measured on the first `alarm(lane):` issue this repo ever filed
+        // (#11251): `sn-51-lium-revenue-for-validators` retried and
+        // dead-lettered roughly hourly for 3.7 days -- 89 rows -- while its
+        // endpoint answered 200 and this repo's own extractor turned that
+        // payload into 20 valid observations. The diagnosis was recomputed on
+        // every one of those ticks and discarded each time.
+        //
+        // FINGERPRINTED ON THE JOB TYPE, not on `batch.queue`. Since #10894
+        // there is one queue for all four lanes, so the queue name is a
+        // constant -- and the fingerprint is also the storm guard's throttle
+        // key, so using it would put four independent lanes in one window and
+        // drop the second lane to fail as a repeat of the first. `jobType` IS
+        // the lane name these verdicts already use, and the set is closed by
+        // ProbeJobType.
+        //
+        // Unguarded: `recordExceptionEvent` wraps its whole body and returns
+        // false rather than rejecting, so there is no failure to catch, and a
+        // `.catch()` would be a branch no test could reach. Every message is
+        // acked or retried by the time this runs either way.
+        if (outcome.firstFailure !== null) {
+          await recordExceptionEvent(env, {
+            error: new Error(
+              `${jobType}: ${outcome.retried} message(s) retried -- ${outcome.firstFailure}`,
+            ),
+            route: "lane:retry",
+            fingerprintDetail: jobType,
+            errorCode: "lane_retry",
+          });
+        }
       }
       return;
     }


### PR DESCRIPTION
The lane alarm filed its first three issues last night. #11251 named a subject nobody could explain, and chasing it found the reason why nothing in this repo could.

> Rebuilt on `main` after #11254 landed — that refactor put all four probe lanes on one queue, which changes the right answer here (see *Fingerprinted on the job type* below). The diff is smaller and the fingerprint is better than the version this PR opened with.

## `sn-51-lium-revenue-for-validators`, measured

| | |
| --- | --- |
| dead-lettered | ~hourly for **3.7 days** — 89 rows on the DLQ |
| its endpoint, probed live 6× | **200**, ~0.5–1.1 s, `application/json`, 5,019 bytes |
| the live cron prober's own verdict | `ok`, `status_code: 200`, 736 ms |
| this repo's `extractRevenue` against that exact payload | **20 valid monthly observations** — Feb 2025 alone is **$203,822** |
| rows ever written | **zero** (`observed_at: null`, `excluded_reason: "not observed"` in `/api/v1/chain/revenue-coverage`) |

So the figures are obtainable, the lane has been failing to obtain them for months, and **the reason was recomputed on all 89 ticks and thrown away each time.**

## The seam existed and had no consumer

`consumeBatch` has built `firstFailure` since #10777 replaced a bare `catch { message.retry(); }` — its own comment says why: *"a retry nobody can explain is how a lane dies silently"*. It then handed the string to `console.error` (no probe-job handler passes `onRetry`) and returned a `ConsumeResult` carrying nothing about it, which the dispatcher discarded too.

Workers logs are not a channel anybody watches here, so the reason reached nothing — not PostHog, not `lane_health`, and not the dead-letter verdict, which names the lost **subject** and never the **cause**.

### Fingerprinted on the job type, not the queue

This is the part #11254 changed. With four lanes now sharing one `probe-jobs` queue, `batch.queue` is a **constant** — and the fingerprint is also the storm guard's throttle key, so keying on it would put four independent lanes in one window and drop the second lane to fail as a repeat of the first. `jobType` **is** the lane name these verdicts already use, and `ProbeJobType` closes the set.

## And the count that lane published was wrong

`eligibleRevenueSurfaces` claims it skips a surface *"for the reason it would have failed"* later. True of `extractRevenue`; **not** of `probeEligibility`, the gate actually applied on delivery, which opens with `role !== "external-revenue"` and then a readable `provenance`. Neither was asked.

Measured against the published artifact: five surfaces carry a shape and a currency, and `sn-64-chutes-invocations-usage` is `role: "usage-proxy"` — a usage signal, deliberately not revenue. It was enqueued every hour and could never be probed, so the `revenue-probe` verdict read **`5 enqueued`** against **four** probeable surfaces.

**The other two gates are deliberately not copied.** `auth_required` is carried and checked downstream; `probe.enabled` is *asserted* rather than read, because the operational-surfaces artifact carries no `probe` block at all — reading it there would make every surface ineligible and **stop the lane dead**. A test already pins that assumption to the build filter that justifies it, and it still passes.

## What this does not do

It does not fix SN51. It makes SN51 **answerable**: the next tick that retries it will say, in error tracking, exactly what failed. I could not determine the cause from outside — `revenue_probe_failures` holds it and **is read by nothing in the codebase** (no route, no watchdog, no serving surface).

## Verification

- 265 tests across the affected suites, all passing.
- **Patch coverage 100%** — `src/lane-queue.ts` 1/1, `src/revenue-observations.ts` 4/4 statements + 6/6 branches, `workers/api.ts` 7/7 + 2/2 — measured by intersecting `git diff -U0` with `coverage-final.json`.
- New tests pin behaviour rather than plumbing: a clean batch reports `null` rather than `""`, a dropped-only batch reports nothing, and a retried batch reaching the Worker's own `queue()` emits a `lane_retry` `$exception` whose message starts with the **lane** name.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:api`, `validate:unreferenced-exports`, `validate:startup-budget`, `validate:lane-topology` green.