### PR TITLE
fix(watchdog): the alarm closed two issues for lanes that are 76 hours dead

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -226,19 +226,80 @@ export async function loadLatestLaneHealth(
       // predicate shared by every caller, and so a row that outlives its
       // deletion is still visible to anyone querying the table directly.
       if (isRetiredLane(lane)) continue;
-      out[lane] = {
+      const record: LaneHealthRecord = {
         lane,
         verdict: normalizeVerdict(row.verdict),
         age_ms: toIntOrNull(row.age_ms),
         detail: row.detail == null ? null : String(row.detail),
         checked_at: toIntOrNull(row.checked_at) ?? 0,
       };
+      // TIES ARE REAL, AND THIS USED TO RESOLVE THEM BY ROW ORDER.
+      //
+      // The MAX above is not unique. `lane_health` has no key, recordLaneVerdict
+      // INSERTs, and its prune deletes `checked_at < ?` -- strictly less -- so
+      // two rows written at the SAME stamp both survive and both match. This
+      // loop then assigned unconditionally, so "the newest verdict" was
+      // whichever row the driver happened to yield last, which nothing orders.
+      //
+      // It is not hypothetical. Several lanes are stamped with the PRODUCER's
+      // pass time rather than the check time, so the stamp freezes while the
+      // producer is down and every later write lands on top of it -- a sync
+      // flush writing `ok` ("127 statement(s) flushed") beside a staleness
+      // watchdog writing `unknown` ("no verdict for 4597m"), same lane, same
+      // millisecond.
+      //
+      // Measured 2026-08-15 03:58Z, on the first day the lane alarm could
+      // write: it read the `ok` side of that tie for `nominator-positions` and
+      // `validator-nominator-counts` and CLOSED both issues as recovered, while
+      // /api/v1/self-health served `unknown` for the same lanes at the same
+      // millisecond. Both had been dead for 76 hours. A false recovery is the
+      // worst thing an alarm can report -- it is indistinguishable from the
+      // outage being over.
+      //
+      // So a tie resolves to the WORST verdict, never the kindest. This is the
+      // same rule migrations/neon/0006 states for the column itself -- that
+      // collapsing `unknown` into `ok` "would report an unmeasured lane as a
+      // healthy one" -- applied to the read. A genuine recovery is untouched:
+      // the producer ran, so its stamp ADVANCES and its row is the unique max.
+      // NEWER WINS; only a TIE is broken by severity. Both halves matter, and
+      // ordering by severity alone would be a different bug: it would let an
+      // older finding outrank a genuine recovery, which is the false-alarm
+      // mirror of the false-recovery above. Written against `checked_at` rather
+      // than trusting the SQL to have already reduced the set, so the reader is
+      // correct on whatever it is handed.
+      const seen = out[lane];
+      const newer = !seen || record.checked_at > seen.checked_at;
+      const worseAtTheSameInstant =
+        seen !== undefined &&
+        record.checked_at === seen.checked_at &&
+        VERDICT_SEVERITY[record.verdict] > VERDICT_SEVERITY[seen.verdict];
+      if (newer || worseAtTheSameInstant) out[lane] = record;
     }
     return out;
   } catch {
     return {};
   }
 }
+
+/**
+ * How bad each verdict is, for the one question that needs them ordered: which
+ * of two rows tied at the same `checked_at` is the lane's verdict.
+ *
+ * `Record<LaneVerdict, …>` rather than a lookup with a default, so a verdict
+ * added to LANE_VERDICTS stops this compiling until somebody decides where it
+ * sits. A default would silently rank a new verdict as the safest thing in the
+ * table, which is the direction that loses findings.
+ *
+ * `stale` above `unknown` because it is the more specific claim: a breach was
+ * measured, rather than a measurement failing to happen. Both are findings and
+ * both alarm, so the ordering between them decides only which one a reader is
+ * shown first -- whereas `ok` sitting at the bottom is the load-bearing part.
+ */
+const VERDICT_SEVERITY: Record<LaneVerdict, number> = {
+  ok: 0,
+  unknown: 1,
+  stale: 2,
+};
 
 function normalizeVerdict(value: unknown): LaneVerdict {
   // Anything the schema does not name reads as `unknown` rather than being served

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -165,6 +165,98 @@ describe("loadLatestLaneHealth", () => {
     assert.match(calls[0].sql, /MAX\(checked_at\)[\s\S]*GROUP BY lane/);
   });
 
+  // TWO ROWS CAN TIE AT THE MAX, and this used to resolve by row order.
+  //
+  // `lane_health` has no key, recordLaneVerdict INSERTs, and its prune deletes
+  // `checked_at < ?` -- strictly less -- so same-stamp rows both survive and
+  // both match the MAX. Several lanes are stamped with the PRODUCER's pass time
+  // rather than the check time, so the stamp freezes while the producer is down
+  // and later writes land on top of it: a sync flush writing `ok` beside a
+  // staleness watchdog writing `unknown`, same lane, same millisecond.
+  //
+  // Measured 2026-08-15 03:58Z: the lane alarm read the `ok` side of exactly
+  // that tie and CLOSED #11252 and #11253 as recovered, while
+  // /api/v1/self-health served `unknown` for the same lanes at the same
+  // millisecond. Both lanes had been dead 76 hours.
+  const tiedRows = (first: string, second: string) => [
+    {
+      lane: "validator-nominator-counts",
+      verdict: first,
+      age_ms: null,
+      detail:
+        first === "ok" ? "127 statement(s) flushed" : "no verdict for 4597m",
+      checked_at: NOW,
+    },
+    {
+      lane: "validator-nominator-counts",
+      verdict: second,
+      age_ms: null,
+      detail:
+        second === "ok" ? "127 statement(s) flushed" : "no verdict for 4597m",
+      checked_at: NOW,
+    },
+  ];
+
+  test("a tie resolves to the WORST verdict, whichever row comes first", async () => {
+    for (const [a, b] of [
+      ["ok", "unknown"],
+      ["unknown", "ok"],
+    ]) {
+      const { db } = fakeDb(tiedRows(a, b));
+      const latest = await loadLatestLaneHealth(db);
+      assert.equal(
+        latest["validator-nominator-counts"].verdict,
+        "unknown",
+        `order ${a},${b}: a finding must survive a tie with ok`,
+      );
+      // And it carries THAT row's detail, so the reader is not shown the
+      // reassuring half of a contradiction.
+      assert.match(
+        latest["validator-nominator-counts"].detail ?? "",
+        /no verdict for/,
+      );
+    }
+  });
+
+  test("a measured breach outranks an unmeasurable one on a tie", async () => {
+    for (const [a, b] of [
+      ["stale", "unknown"],
+      ["unknown", "stale"],
+    ]) {
+      const { db } = fakeDb(tiedRows(a, b));
+      const latest = await loadLatestLaneHealth(db);
+      assert.equal(latest["validator-nominator-counts"].verdict, "stale");
+    }
+  });
+
+  // THE PROPERTY THAT MUST NOT REGRESS, and it caught a real flaw in the first
+  // draft of this fix: ordering by severity ALONE lets an older finding outrank
+  // a genuine recovery, which is the false-ALARM mirror of the false-recovery
+  // above. A lane that really recovers is not a tie at all -- the producer ran,
+  // so its stamp advances -- and the reader now says so explicitly rather than
+  // relying on the SQL having already reduced the set.
+  test("a NEWER ok still wins outright over an older finding", async () => {
+    const { db } = fakeDb([
+      {
+        lane: "a",
+        verdict: "stale",
+        age_ms: 1,
+        detail: "behind",
+        checked_at: NOW - 1,
+      },
+      {
+        lane: "a",
+        verdict: "ok",
+        age_ms: 1,
+        detail: "recovered",
+        checked_at: NOW,
+      },
+    ]);
+    const latest = await loadLatestLaneHealth(db);
+    assert.equal(latest.a.verdict, "ok");
+    assert.equal(latest.a.checked_at, NOW);
+  });
+
   test("a verdict this build does not know reads as unknown, not as ok", async () => {
     const { db } = fakeDb([
       {


### PR DESCRIPTION
`loadLatestLaneHealth` resolved a tie by row order. On the first day the lane alarm could actually write, that cost two **false recoveries** — the worst thing an alarm can report, because it is indistinguishable from the outage being over.

## The tie is real, not theoretical

`lane_health` has no key. `recordLaneVerdict` INSERTs, and its prune deletes `checked_at < ?` — **strictly** less — so two rows written at the same stamp both survive and both match `MAX(checked_at)`. The reader then did `out[lane] = row` unconditionally, so "the newest verdict" was whichever row the driver happened to yield last. Nothing orders that.

Several lanes are stamped with the **producer's** pass time rather than the check time, so the stamp *freezes* while the producer is down and every later write lands on top of it. Two writers then collide on one millisecond:

| writer | verdict | detail |
| --- | --- | --- |
| sync flush | `ok` | `127 statement(s) flushed` |
| staleness watchdog | `unknown` | `no verdict for 4597m` |

Same lane. Same millisecond.

## What it cost, measured

**2026-08-15 03:58Z.** The alarm read the `ok` side of that tie and closed both issues it had opened thirty minutes earlier:

```
#11252 validator-nominator-counts — closed citing ok at 2026-08-11T23:27:52.032Z
#11253 nominator-positions        — closed citing ok at 2026-08-11T23:35:17.052Z
```

`GET /api/v1/self-health` served **`unknown` for both lanes at those exact milliseconds** — sampled 8 times, stable. Both lanes had been silent for 76 hours and still are. The detail even recomputes each tick (`4597m` → `4606m`) while `checked_at` never moves, which is the visible signature of rows piling up at one frozen stamp.

## The rule

**Newer wins; only a tie is broken, and it breaks to the worst verdict.** That is what `migrations/neon/0006` already says about the column — collapsing `unknown` into `ok` *"would report an unmeasured lane as a healthy one"* — applied to the read.

**Both halves matter.** Ordering by severity *alone* is a different bug in the opposite direction: an older finding would outrank a genuine recovery. The first draft of this fix did exactly that, and the regression test caught it — which is why that test is in the diff and why it says so. A real recovery is not a tie at all: the producer ran, so its stamp advances and its row is the unique max.

`VERDICT_SEVERITY` is `Record<LaneVerdict, number>` rather than a lookup with a default, so a verdict added to `LANE_VERDICTS` stops this compiling until somebody decides where it sits. A default would silently rank a new verdict as the safest thing in the table — the direction that loses findings.

## What this does not fix

The underlying stamping (`checked_at` = the producer's pass time, not the check time) and the resulting unbounded row growth at a frozen stamp are both still there. This makes the *read* safe against them, which is the part that was actively closing real alarms. Changing the stamp semantics touches every consumer of `age_ms` and is not something to do in the same change.

## Verification

- 167 tests across the six lane/self-health suites, all passing.
- **Patch coverage 100%** — 7/7 statements, 9/9 branches on the changed lines, by diff intersection with `coverage-final.json`.
- Both tie orderings asserted explicitly (`ok,unknown` and `unknown,ok`), so the test cannot pass by accident of row order — which is the exact failure being fixed.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:schemas`, `validate:unreferenced-exports`, `validate:boundary-casts` green.