### PR TITLE
fix(lanes): a decline that says why, not just that it declined

### DIFF
--- a/src/attribution-sweep.ts
+++ b/src/attribution-sweep.ts
@@ -206,7 +206,11 @@ export interface SweepStoreDb {
 export async function persistSweep(
   db: SweepStoreDb | null | undefined,
   result: SweepResult,
-): Promise<{ ok: boolean; reason?: string }> {
+  // A DECLINE MUST SAY WHY, at the type level. `reason?: string` let a caller
+  // collapse the outcome to a boolean and lose the diagnosis, which is exactly
+  // what left the retry report reading "run() declined without throwing" while
+  // this function had already computed the answer.
+): Promise<{ ok: true } | { ok: false; reason: string }> {
   if (!db?.run) return { ok: false, reason: "no_store_binding" };
   try {
     await db.run(
@@ -362,7 +366,10 @@ export async function handleSweepBatch(
     run: async (netuid) => {
       const record = await deps.recordFor(netuid);
       const result = await sweepSubnet(netuid, record, deps);
-      return (await persistSweep(db, result)).ok;
+      // The store already says WHY it declined; returning `.ok` alone threw
+      // that away and left the retry reading "run() declined without throwing".
+      const written = await persistSweep(db, result);
+      return written.ok || written.reason;
     },
   });
 }

--- a/src/compute-declarations-lane.ts
+++ b/src/compute-declarations-lane.ts
@@ -329,8 +329,16 @@ export interface ComputeStoreDb {
 export async function persistComputeDeclaration(
   db: ComputeStoreDb | null | undefined,
   record: ComputeDeclarationRecord,
-): Promise<{ ok: boolean }> {
-  if (!db?.run) return { ok: false };
+  // A DECLINE MUST SAY WHY, at the type level. `reason?: string` let a caller
+  // collapse the outcome to a boolean and lose the diagnosis, which is exactly
+  // what left the retry report reading "run() declined without throwing" while
+  // this function had already computed the answer.
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  // NAMED, like its three sibling stores. A decline with no reason reaches the
+  // retry report as the generic "run() declined without throwing", which names
+  // the lane and not the fault -- and a missing binding is the one decline
+  // here that a redelivery cannot fix, so it is worth saying out loud.
+  if (!db?.run) return { ok: false, reason: "no_store_binding" };
   // A found:false row must carry no stanza, which the constraint enforces and
   // this makes true at the source rather than relying on the write to bounce.
   const miner = record.found ? record.miner : null;
@@ -387,7 +395,8 @@ export async function handleComputeDeclarationBatch(
       const record = await readComputeDeclaration(message, deps);
       // Nothing to write is a completed subject, not a failed one.
       if (!record) return true;
-      return (await persistComputeDeclaration(db, record)).ok;
+      const written = await persistComputeDeclaration(db, record);
+      return written.ok || written.reason;
     },
   });
 }

--- a/src/lane-queue.ts
+++ b/src/lane-queue.ts
@@ -119,9 +119,23 @@ export interface ConsumeResult {
 export interface ConsumeHandlers<TSubject> {
   /** Read a delivered body. Null means it can never be acted on. */
   parse(body: unknown): TSubject | null;
-  /** Do the work. Return false or throw to have the message redelivered;
-   * return true when the result is durably written. */
-  run(subject: TSubject): Promise<boolean>;
+  /**
+   * Do the work. `true` when the result is durably written; anything else has
+   * the message redelivered.
+   *
+   * A NON-EMPTY STRING IS A DECLINE THAT SAYS WHY, and it exists because
+   * `false` is the one failure with no diagnosis attached. A throw carries its
+   * message; a `false` carried nothing, so the loop below could only report
+   * "run() declined without throwing" -- which names the lane and not the bug.
+   *
+   * Measured 2026-08-15, 16 seconds after the retry reason first reached
+   * PostHog: `revenue-probe: 1 message(s) retried -- run() declined without
+   * throwing`. That is the right lane, and it is as far as the trail went,
+   * while `persistRevenueProbe` had already computed
+   * `write_failed: <driver message>` or `no_store_binding` and every handler
+   * threw it away collapsing the outcome to a boolean.
+   */
+  run(subject: TSubject): Promise<boolean | string>;
   /**
    * Called ONCE per batch when something was retried, with the first failure
    * and the count.
@@ -176,16 +190,22 @@ export async function consumeBatch<TSubject>(
         dropped += 1;
         continue;
       }
-      if (await handlers.run(subject)) {
+      const outcome = await handlers.run(subject);
+      if (outcome === true) {
         message.ack();
         done += 1;
       } else {
         message.retry();
         retried += 1;
-        // A HANDLER THAT RETURNS FALSE IS ALSO A FAILURE. It is the quieter of
-        // the two -- no stack, no message -- and leaving it unreported would
-        // keep exactly half of this fix.
-        firstFailure ??= "run() declined without throwing";
+        // A HANDLER THAT DECLINES IS ALSO A FAILURE. It is the quieter of the
+        // two -- no stack, no message -- and leaving it unreported would keep
+        // exactly half of this fix. A handler that knows WHY says so by
+        // returning the reason; `false` keeps the generic sentence, so a
+        // handler with nothing to add is not forced to invent something.
+        firstFailure ??=
+          typeof outcome === "string" && outcome
+            ? outcome
+            : "run() declined without throwing";
       }
     } catch (error) {
       message.retry();

--- a/src/origin-reachability.ts
+++ b/src/origin-reachability.ts
@@ -268,7 +268,11 @@ export interface OriginStoreDb {
 export async function persistOriginCheck(
   db: OriginStoreDb | null | undefined,
   check: OriginCheck,
-): Promise<{ ok: boolean; reason?: string }> {
+  // A DECLINE MUST SAY WHY, at the type level. `reason?: string` let a caller
+  // collapse the outcome to a boolean and lose the diagnosis, which is exactly
+  // what left the retry report reading "run() declined without throwing" while
+  // this function had already computed the answer.
+): Promise<{ ok: true } | { ok: false; reason: string }> {
   if (!db?.run) return { ok: false, reason: "no_store_binding" };
   try {
     await db.run(
@@ -394,7 +398,10 @@ export async function handleOriginBatch(
     run: async (origin) => {
       const surfaces = await deps.surfacesFor(origin);
       const check = await checkOrigin(origin, surfaces, deps);
-      return (await persistOriginCheck(db, check)).ok;
+      // Same as the sweep lane: the reason exists, so report it rather than
+      // collapsing the outcome to a boolean.
+      const written = await persistOriginCheck(db, check);
+      return written.ok || written.reason;
     },
   });
 }

--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -53,11 +53,20 @@ export interface RevenueStoreDb {
  * dispatch can record it rather than discard it, which is how #10172's frozen
  * series went unnoticed for five hours.
  */
-export async function persistRevenueProbe(
-  db: RevenueStoreDb | null | undefined,
-  result: RevenueProbeResult,
-): Promise<{
-  ok: boolean;
+/**
+ * What a probe pass did, and -- when it declined -- WHY.
+ *
+ * A DECLINE ALWAYS CARRIES A REASON, at the type level. One shape with
+ * `reason?: string` let every caller collapse the outcome to a boolean and lose
+ * the diagnosis, which is what left the retry report reading "run() declined
+ * without throwing" while this function had already computed the answer.
+ * Splitting the union makes the compiler ask, and removes the `?? false`
+ * fallback that would otherwise be a branch no test could reach.
+ *
+ * `ok: true` may still carry a reason: a pass that probed an empty eligible set
+ * succeeded and is still worth explaining.
+ */
+export type RevenueProbeOutcome = {
   written: number;
   failed: number;
   /**
@@ -69,8 +78,12 @@ export async function persistRevenueProbe(
    * them is what dead-lettered a deterministic extraction failure hourly.
    */
   retryable: boolean;
-  reason?: string;
-}> {
+} & ({ ok: true; reason?: string } | { ok: false; reason: string });
+
+export async function persistRevenueProbe(
+  db: RevenueStoreDb | null | undefined,
+  result: RevenueProbeResult,
+): Promise<RevenueProbeOutcome> {
   if (!db?.run) {
     // Nothing was recorded, so the next delivery is the only chance this work
     // gets. Retryable even though a missing binding will not fix itself: the
@@ -142,17 +155,41 @@ export async function persistRevenueProbe(
   // real state -- every surface skipped as ineligible -- but it is not success,
   // because a lane silently probing an empty set looks exactly like one whose
   // every surface passed.
-  return {
-    ok: observations.length > 0 || failures.length === 0,
-    written: observations.length,
-    failed: failures.length,
-    // The rows ARE on disk by here. Only a transient failure is worth another
-    // delivery; a terminal one would re-fetch and rewrite the identical row.
-    retryable: failures.some((failure) => !failure.terminal),
-    ...(observations.length === 0 && failures.length === 0
-      ? { reason: "no_eligible_surfaces" }
-      : {}),
-  };
+  const counts = { written: observations.length, failed: failures.length };
+  // The rows ARE on disk by here. Only a transient failure is worth another
+  // delivery; a terminal one would re-fetch and rewrite the identical row.
+  const retryable = failures.some((failure) => !failure.terminal);
+  // A pass that wrote nothing and failed something is the ONE decline this
+  // function used to make without saying why -- the only branch that set a
+  // reason was the probed-nothing case below. So the diagnosis travelled to
+  // `revenue_probe_failures`, which no route, watchdog or serving surface
+  // reads, and the retry report said "run() declined without throwing".
+  //
+  // Measured 2026-08-15: `sn-51-lium-revenue-for-validators` dead-lettered
+  // roughly hourly for 3.7 days in exactly this state, while its endpoint
+  // answered 200 and this repo's own extractor turned that payload into 20
+  // valid observations.
+  //
+  // THE SUBJECT RIDES WITH THE REASON: "fetch failed: HTTP 503" with no surface
+  // named is the same dead end one layer down. Bounded to two and a count,
+  // because a lane whose dependency is down fails every surface identically and
+  // a reason string is not a log.
+  if (observations.length === 0 && failures.length > 0) {
+    const named = failures
+      .slice(0, 2)
+      .map((failure) => `${failure.surface_id}: ${failure.reason}`)
+      .join("; ");
+    const more = failures.length > 2 ? ` (+${failures.length - 2} more)` : "";
+    return { ...counts, ok: false, retryable, reason: `${named}${more}` };
+  }
+  // A pass that observed nothing AND failed nothing probed nothing. That is a
+  // real state -- every surface skipped as ineligible -- but it is not success,
+  // because a lane silently probing an empty set looks exactly like one whose
+  // every surface passed.
+  if (observations.length === 0) {
+    return { ...counts, ok: true, retryable, reason: "no_eligible_surfaces" };
+  }
+  return { ...counts, ok: true, retryable };
 }
 
 /** One pass, end to end: probe the eligible surfaces and persist what came back. */
@@ -160,15 +197,11 @@ export async function runRevenueProbeLane(
   surfaces: ProbeSurfaceInput[],
   db: RevenueStoreDb | null | undefined,
   deps: Parameters<typeof runRevenueProbe>[1],
-): Promise<{
-  ok: boolean;
-  written: number;
-  failed: number;
-  skipped: number;
-  /** See persistRevenueProbe: whether another delivery could answer differently. */
-  retryable: boolean;
-  reason?: string;
-}> {
+  // DERIVED from the store's outcome rather than restated. This re-declared the
+  // shape with `reason?: string`, which collapsed the union one layer above and
+  // put the maybe back -- so the handler could not tell that a decline always
+  // carries a reason, and had to fall back to a branch no test could reach.
+): Promise<RevenueProbeOutcome & { skipped: number }> {
   const result = await runRevenueProbe(surfaces, deps);
   const persisted = await persistRevenueProbe(db, result);
   return { ...persisted, skipped: result.skipped.length };
@@ -429,7 +462,14 @@ export async function handleRevenueProbeBatch(
       //
       // A transient failure still retries: `retryable` is true for a fetch that
       // threw and for a write that did not land.
-      return outcome.ok || !outcome.retryable;
+      // Split rather than `||`ed, so the union narrows: after both guards
+      // `outcome` is the decline arm and its reason is a string, not a maybe.
+      if (outcome.ok) return true;
+      if (!outcome.retryable) return true;
+      // THE REASON, not just the decline. The union above guarantees a decline
+      // carries one, so there is no `?? false` fallback and no branch a test
+      // could not reach.
+      return outcome.reason;
     },
   });
 }

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -826,9 +826,11 @@ describe("consuming a sweep batch", () => {
       done: 0,
       retried: 1,
       dropped: 0,
-      // The quieter of the two failures -- no stack, no message. Returned
-      // now rather than only logged: see ConsumeResult.firstFailure.
-      firstFailure: "run() declined without throwing",
+      // THE REASON, not the generic decline. The store already knew why --
+      // there is no db here -- and collapsing that to `false` is what left
+      // production reading "run() declined without throwing", which names the
+      // lane and not the fault.
+      firstFailure: "no_store_binding",
     });
     assert.equal(m.calls.retried, 1);
   });

--- a/tests/compute-declarations-lane.test.ts
+++ b/tests/compute-declarations-lane.test.ts
@@ -433,7 +433,10 @@ describe("persistComputeDeclaration", () => {
         miner: {},
         validator: null,
       }),
-      { ok: false },
+      // NAMED, not a bare false. The reason rides out to the retry report, so
+      // "this lane is retrying" and "this lane has no store bound" stop
+      // looking the same in error tracking.
+      { ok: false, reason: "no_store_binding" },
     );
   });
 });

--- a/tests/lane-queue.test.ts
+++ b/tests/lane-queue.test.ts
@@ -62,6 +62,53 @@ describe("a retry reports its reason", () => {
     assert.deepEqual(seen, ["run() declined without throwing"]);
   });
 
+  // A DECLINE THAT SAYS WHY. `false` is the one failure with nothing attached:
+  // a throw carries its message, and a boolean carries a shrug. Measured 16
+  // seconds after the retry reason first reached PostHog --
+  // `revenue-probe: 1 message(s) retried -- run() declined without throwing` --
+  // which is the right lane and the end of the trail, while the store had
+  // already computed `write_failed: <driver message>`.
+  test("a STRING decline is reported as the reason", async () => {
+    const seen: string[] = [];
+    const a = msg({ id: 1 });
+    const result = await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => "write_failed: syntax error at or near",
+      onRetry: (reason) => void seen.push(reason),
+    });
+    assert.deepEqual(a.calls, ["retry"], "a decline still retries");
+    assert.deepEqual(seen, ["write_failed: syntax error at or near"]);
+    assert.equal(result.firstFailure, "write_failed: syntax error at or near");
+  });
+
+  test("an EMPTY string is not a reason, and keeps the generic one", async () => {
+    // A handler with nothing to add must not be able to report nothing at all
+    // by accident -- the empty string is falsy exactly where `false` is, and
+    // silently swallowing it would be the failure this whole seam exists to
+    // end.
+    const seen: string[] = [];
+    await consumeBatch([msg({ id: 1 }).message], {
+      parse: (b) => b as { id: number },
+      run: async () => "",
+      onRetry: (reason) => void seen.push(reason),
+    });
+    assert.deepEqual(seen, ["run() declined without throwing"]);
+  });
+
+  test("only `true` acks -- a truthy string is still a decline", async () => {
+    // The trap in widening a boolean return: `if (outcome)` would ACK on every
+    // reason string, turning the most diagnostic failures into silent
+    // successes. The check is `=== true`.
+    const a = msg({ id: 1 });
+    const result = await consumeBatch([a.message], {
+      parse: (b) => b as { id: number },
+      run: async () => "no_store_binding",
+    });
+    assert.deepEqual(a.calls, ["retry"]);
+    assert.equal(result.done, 0);
+    assert.equal(result.retried, 1);
+  });
+
   test("a non-Error throw still yields a readable reason", async () => {
     const seen: string[] = [];
     const a = msg({ id: 1 });

--- a/tests/origin-reachability.test.ts
+++ b/tests/origin-reachability.test.ts
@@ -568,7 +568,11 @@ describe("shapes the store can really produce", () => {
         surface_ids: [],
       },
     );
-    assert.match(String(out.reason), /a bare string/);
+    // Narrowed, not asserted through: the union now says a decline carries a
+    // reason and a success does not, so reading it requires establishing which
+    // one this is -- which is the property being tested.
+    assert.equal(out.ok, false);
+    assert.match(out.ok ? "" : out.reason, /a bare string/);
   });
 
   // "a driver returning no results key" retired with D1's envelope
@@ -715,7 +719,8 @@ describe("consuming an origin batch", () => {
       done: 0,
       retried: 1,
       dropped: 0,
-      firstFailure: "run() declined without throwing",
+      // The store's own reason, carried out to the retry report.
+      firstFailure: "no_store_binding",
     });
   });
 

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -169,6 +169,85 @@ describe("persistRevenueProbe", () => {
     assert.match(r.reason ?? "", /write_failed/);
   });
 
+  // THE FAILURE ROW HELD THE ANSWER AND NOBODY COULD REACH IT. A pass that
+  // fetched nothing and failed once returns ok:false/retryable:true, and used
+  // to carry NO reason -- the only branch that set one was the probed-nothing
+  // case. So the diagnosis went to `revenue_probe_failures`, which nothing
+  // reads, and the retry report said "run() declined without throwing".
+  //
+  // `sn-51-lium-revenue-for-validators` dead-lettered roughly hourly for 3.7
+  // days in exactly this state.
+  test("a decline carries the FAILURE's own reason, and its subject", async () => {
+    const { db } = recordingDb();
+    const r = await persistRevenueProbe(db, {
+      observations: [],
+      failures: [
+        {
+          surface_id: "sn-51-lium-revenue-for-validators",
+          netuid: 51,
+          reason: "fetch failed: HTTP 503",
+          observed_at: 1786320000000,
+          terminal: false,
+        },
+      ],
+      skipped: [],
+    });
+    assert.equal(r.ok, false);
+    assert.equal(
+      r.retryable,
+      true,
+      "a fetch failure is worth another delivery",
+    );
+    // The SUBJECT as well as the reason: "fetch failed: HTTP 503" with no
+    // surface named is the same dead end one layer down.
+    assert.equal(
+      r.reason,
+      "sn-51-lium-revenue-for-validators: fetch failed: HTTP 503",
+    );
+  });
+
+  test("many failures are summarised, not concatenated into a log", async () => {
+    // A lane whose dependency is down fails every surface identically. Two
+    // named and a count keeps the reason readable and bounded.
+    const { db } = recordingDb();
+    const r = await persistRevenueProbe(db, {
+      observations: [],
+      failures: ["a", "b", "c", "d"].map((id, i) => ({
+        surface_id: id,
+        netuid: i,
+        reason: "fetch failed: HTTP 503",
+        observed_at: 1786320000000,
+        terminal: false,
+      })),
+      skipped: [],
+    });
+    assert.equal(
+      r.reason,
+      "a: fetch failed: HTTP 503; b: fetch failed: HTTP 503 (+2 more)",
+    );
+  });
+
+  test("an observation alongside a failure is not a decline", async () => {
+    // Partial success is success for the queue: the rows landed, so a retry
+    // would re-fetch somebody else's API to write them again.
+    const { db } = recordingDb();
+    const r = await persistRevenueProbe(db, {
+      observations: [OBSERVATION],
+      failures: [
+        {
+          surface_id: "x",
+          netuid: 1,
+          reason: "fetch failed",
+          observed_at: 1786320000000,
+          terminal: false,
+        },
+      ],
+      skipped: [],
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.reason, undefined);
+  });
+
   test("a pass that probed nothing says so rather than reporting success", async () => {
     // A lane silently probing an empty set looks identical to one whose every
     // surface passed — which is exactly the state this issue was filed about.


### PR DESCRIPTION
#11256 put the retry reason on a channel somebody reads. **Sixteen seconds after it deployed**, production answered:

```
revenue-probe: 1 message(s) retried -- run() declined without throwing
```

Right lane. End of the trail. That PR said the next retry would *"say exactly what failed"* — it named the lane and not the fault. This finishes it.

## `false` is the one failure with nothing attached

A throw carries its message. A `false` carries a shrug, and `consumeBatch` could only render it as the generic sentence above — while every store underneath had **already computed the answer** and every handler threw it away collapsing the outcome to a boolean:

```ts
return (await persistSweep(db, result)).ok;      // reason: discarded
return (await persistOriginCheck(db, check)).ok; // reason: discarded
return outcome.ok || !outcome.retryable;         // reason: discarded
```

`run()` may now return a **string**: a decline, and this is why. `false` still works and still gets the generic sentence, so a handler with nothing to add is not forced to invent something.

**Only `=== true` acks.** That is the trap in widening a boolean return — `if (outcome)` would ack on every reason string, turning the most diagnostic failures into silent successes. There is a test for exactly that.

## And the revenue lane's reason was not in `reason` at all

This is the part that would have left SN51 undiagnosed even after #11256. `persistRevenueProbe` set a reason on exactly **one** branch — the probed-nothing case. A pass that fetched nothing and failed once, which is SN51's state for 3.7 days, returned `ok: false, retryable: true` and **no reason**, because the diagnosis was in the failure *row*, bound for `revenue_probe_failures` — the table nothing reads.

It now names the failing surfaces and their reasons, bounded to two and a count:

```
sn-51-lium-revenue-for-validators: fetch failed: HTTP 503
a: fetch failed: HTTP 503; b: fetch failed: HTTP 503 (+2 more)
```

The **subject** rides with the reason. "fetch failed: HTTP 503" with nothing named is the same dead end one layer down.

## A decline carries a reason, at the type level

| before | after |
| --- | --- |
| `{ ok: boolean; reason?: string }` | `{ ok: true } \| { ok: false; reason: string }` |

The optional is what let a caller drop the diagnosis, and it forced a `?? false` fallback that **no test could reach** — three of them, one per store. The union removes the branch and makes the compiler ask instead.

`runRevenueProbeLane` now **derives** its shape from the store's rather than restating it. Restating is what put the maybe back one layer up, which is how the handler ended up unable to tell that a decline always has a reason. `persistComputeDeclaration` gained a reason for its one decline, so all four lanes answer the same way.

## Verification

- 355 tests across the eight affected suites, all passing.
- **Patch coverage 100%** — 27/27 statements and 26/26 branches across five files, by diff intersection with `coverage-final.json`. The three previously-dead `?? false` branches are gone rather than excused.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:api`, `validate:unreferenced-exports`, `validate:type-duplicates`, `validate:schema-shape-duplicates`, `validate:startup-budget`, `validate:lane-topology`, `validate:boundary-casts` green.