### PR TITLE
fix(seo): bound the hand-written docs descriptions too

### DIFF
--- a/apps/ui/src/routes/docs.$.tsx
+++ b/apps/ui/src/routes/docs.$.tsx
@@ -4,6 +4,7 @@ import { docsSource } from "@/lib/docs-source";
 import { buildOgImageUrl, ogImageMeta } from "@/lib/metagraphed/og-card";
 import { stringifyJsonLd, techArticleJsonLd } from "@/lib/metagraphed/json-ld";
 import { SITE_ORIGIN } from "@/lib/metagraphed/identity";
+import { clampText } from "@/lib/metagraphed/truncate";
 import { openapi } from "@/lib/openapi-source";
 import type { OpenAPIPreloaded } from "@/lib/openapi-preload-context";
 import { DocsSplatPage } from "./-docs-splat-page";
@@ -112,6 +113,22 @@ function isOpenAPIFrontmatter(value: unknown): value is { preload: string[] } {
   );
 }
 
+/**
+ * Bound for the docs `<meta name="description">`.
+ *
+ * The generated API-reference pages are already written to 155 (#11258). The
+ * 25 HAND-WRITTEN pages are not: their frontmatter `description` is also the
+ * visible `<DocsDescription>` subtitle, deliberately written as prose, and the
+ * longest runs to 256 characters. Google truncates around 160 either way; this
+ * cuts at a word boundary so the snippet ends deliberately rather than wherever
+ * the pixel budget happened to run out.
+ *
+ * Applied HERE and not to the frontmatter, so the page keeps the full sentence
+ * on screen and only the head is bounded — the same split `metaDescription`
+ * draws for the generated pages.
+ */
+const DOCS_META_DESCRIPTION_MAX = 160;
+
 const serverLoader = createServerFn({ method: "GET" })
   .validator((slugs: string[]) => slugs)
   .handler(async ({ data: slugs }) => {
@@ -144,7 +161,10 @@ const serverLoader = createServerFn({ method: "GET" })
       // shipping `<meta name="description" content="">`, an EMPTY description
       // on 83% of the docs. This reads the meta-only key when there is one, so
       // the head is correct without changing what the page looks like.
-      description: page.data.description || data.metaDescription || "",
+      description: clampText(
+        page.data.description || data.metaDescription || "",
+        DOCS_META_DESCRIPTION_MAX,
+      ),
       // Git-derived at build time (source.config.ts docs.lastModified), and
       // already rendered on the page as "Last updated" -- so the structured
       // data below states a date the reader can see, which is the rule.

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -92,3 +92,54 @@ test.describe("#11204 indexable routes answer, retired routes redirect permanent
     });
   }
 });
+
+// #11261: what the docs <head> says, against the raw response.
+//
+// Two separate budgets that were both wrong. The 290 generated API-reference
+// pages shipped `content=""` — an EMPTY description, worse than none, on 83% of
+// the docs (#11258). The 25 hand-written pages ran the other way, to 256
+// characters, because their frontmatter `description` is also the visible
+// subtitle and was written as prose.
+//
+// Both are bounded in the head now, and NEITHER changes what the page shows.
+const DOCS_META_MAX = 160;
+
+test.describe("#11258 docs pages describe themselves, within budget", () => {
+  const PAGES = [
+    "/docs",
+    "/docs/feeds",
+    "/docs/mcp",
+    "/docs/economics",
+    "/docs/api-reference/subnets/domains",
+    "/docs/api-reference/blocks/block-detail-by-network",
+  ];
+
+  for (const path of PAGES) {
+    test(`${path} has a non-empty description inside the budget`, async ({ request }) => {
+      const html = await (await request.get(path)).text();
+      const raw = /<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? null;
+      expect(raw, `${path} emits no description meta tag at all`).not.toBeNull();
+      // Entities inflate the raw attribute (&#x27; is 6 characters for one
+      // apostrophe), so measure the decoded value — measuring the raw string
+      // reports a page as over budget when it is not.
+      const decoded = raw!
+        .replace(/&#x27;/g, "'")
+        .replace(/&amp;/g, "&")
+        .replace(/&quot;/g, '"');
+      expect(decoded.length, `${path} description is empty`).toBeGreaterThan(0);
+      expect(decoded.length, `${path}: ${decoded.length} chars`).toBeLessThanOrEqual(DOCS_META_MAX);
+      // Markdown renders literally in a meta tag.
+      expect(decoded, `${path} carries markdown`).not.toContain("`");
+    });
+  }
+
+  test("bounding the head does not truncate what the page shows", async ({ request }) => {
+    // /docs/feeds carries the longest hand-written description (256 chars). The
+    // subtitle under the H1 must still be all of it.
+    const html = await (await request.get("/docs/feeds")).text();
+    const subtitle = /<h1[^>]*>[\s\S]*?<\/h1>\s*<p[^>]*>([\s\S]*?)<\/p>/.exec(html)?.[1] ?? "";
+    const text = subtitle.replace(/<[^>]+>/g, "");
+    expect(text.length).toBeGreaterThan(DOCS_META_MAX);
+    expect(text).toContain("no API key");
+  });
+});


### PR DESCRIPTION
Closes #11264. Part of #11204.

## The gap #11258 left

That PR wrote the 290 generated API-reference descriptions to 155 characters and left the **25
hand-written docs pages** running the other way — up to **256**:

| chars | page |
|---|---|
| 256 | `/docs/feeds` |
| 246 | `/docs/chain-events` |
| 240 | `/docs` |
| 222 | `/docs/extrinsics` |

Two sets of docs pages on one site, one written to a budget and one not.

## Why the frontmatter cannot just be shortened

For these pages, frontmatter `description` is **also the visible `<DocsDescription>` subtitle** under
the H1 — deliberate prose. Cutting it to 160 would shorten what the reader sees to satisfy a crawler.

So the head is bounded and the page is left alone, the same split #11258 drew for the generated
pages. Verified on a real render:

```
/docs/feeds   visible subtitle: 256 chars   <meta name="description">: 158 chars
```

## The measurement trap, which my own first sweep fell into

Entities inflate the raw attribute — `&#x27;` is six characters for one apostrophe — so measuring the
raw string reports a compliant page as over budget. My sitemap sweep flagged
`/docs/api-reference/accounts/account-subnet-position-history` at 164 when the actual value is 149.
**The e2e gate decodes before measuring**, and says so.

## Verification

- e2e `indexable-routes.spec.ts` extended: every sampled docs page emits a non-empty description
  ≤160 decoded characters with no markdown, plus an assertion that the longest page's visible
  subtitle is still **longer** than the budget — so a future change that "fixes" this by truncating
  the frontmatter fails.
- 131 e2e passed; `tsc`, `vitest` (2205), `format:check`, `lint` green.

## Deliberately not changed

7 of 129 subnet titles exceed 60 characters (longest 68: `SN72 · StreetVision by NATIX — API,
health & economics | Metagraphed`). Google truncates the tail, and the tail is ` | Metagraphed` — the
netuid alias and project name, the tokens that actually match a query, survive. Reshaping the
template for 7 pages would gain nothing and cost the other 122 their brand suffix.
