### PR TITLE
fix(watchdog): the alarm was fighting itself — one loop opened, the other closed

### DIFF
--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -668,6 +668,40 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     // measurement is the confident-wrong-answer this repo avoids everywhere
     // else. A lane with no record at all keeps its issue for the same reason.
     if (record?.verdict !== "ok") continue;
+    // AND AN `ok` THAT HAS STOPPED BEING SAID IS NOT A RECOVERY.
+    //
+    // This loop read the STORED verdict while the silence loop above reads the
+    // same rows through a liveness bound, so the two disagreed about the same
+    // lane on the same tick -- and the alarm fought itself. `laneSilenceCadenceMs`
+    // and `laneSilenceThresholdMs` are already resolved here for the open path;
+    // the close path simply never asked.
+    //
+    // Measured 2026-08-15, on the first day this alarm could write:
+    //
+    //   03:28Z  opened  #11252 validator-nominator-counts  (silent 3.2 days)
+    //   03:58Z  CLOSED  "reported ok at 2026-08-11T23:27:52Z"
+    //   04:28Z  opened  #11261                              (same lane, same fault)
+    //   04:58Z  CLOSED  again
+    //
+    // Neither lane changed state at any point -- both had been silent since
+    // 2026-08-11. The stored row really did say `ok` ("127 statement(s)
+    // flushed"): a sync flush stamped with the producer's own pass time, four
+    // days old and never revised. `GET /api/v1/self-health` showed `unknown`
+    // for those lanes throughout, because `withLaneHealth` applies exactly this
+    // bound before serving. The alarm was the only reader taking a four-day-old
+    // `ok` at face value, and a false recovery is the worst thing it can
+    // report: indistinguishable from the outage being over.
+    //
+    // Same predicate as the silent loop, deliberately. Two spellings of "has
+    // this lane stopped speaking" is how they came to disagree in the first
+    // place.
+    const cadenceMs = cadenceFor(lane);
+    if (
+      cadenceMs !== null &&
+      nowMs - record.checked_at >= laneSilenceThresholdMs(cadenceMs)
+    ) {
+      continue;
+    }
     close.push({ lane, issue: open.issue, record });
   }
 

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -503,6 +503,72 @@ describe("laneAlarmPlan", () => {
     );
   });
 
+  // AN `ok` THAT HAS STOPPED BEING SAID IS NOT A RECOVERY, and until this the
+  // alarm fought itself: the silent loop opened an issue because the lane had
+  // stopped speaking, and the close loop shut it because the stored row said
+  // `ok`. Measured on the first day this alarm could write --
+  //
+  //   03:28Z opened #11252 (silent 3.2 days) -> 03:58Z CLOSED "reported ok at
+  //   2026-08-11T23:27:52Z" -> 04:28Z opened #11261 -> 04:58Z CLOSED again
+  //
+  // -- while neither lane changed state at any point.
+  test("does NOT close a lane whose `ok` is older than its silence bound", () => {
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({
+          lane: "a",
+          verdict: "ok",
+          // The shape that did it: a sync flush stamped with the producer's own
+          // pass time, days old and never revised.
+          detail: "127 statement(s) flushed",
+          checked_at: NOW - 76 * HOUR,
+        }),
+      },
+      observedMaxGap: { a: 24 * HOUR },
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
+    });
+    assert.deepEqual(plan.close, [], "a four-day-old ok is not a recovery");
+    // ...and the lane is still a finding, so the issue stays open rather than
+    // being closed and immediately re-opened.
+    assert.deepEqual(plan.open, [], "its issue is already open");
+  });
+
+  test("a lane that really recovered still closes", () => {
+    // The property that must not regress: a recovery writes a FRESH row, so
+    // the same bound leaves it alone.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({ lane: "a", verdict: "ok", checked_at: NOW - 60_000 }),
+      },
+      observedMaxGap: { a: 24 * HOUR },
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
+    });
+    assert.deepEqual(
+      plan.close.map((c) => c.issue),
+      [77],
+    );
+  });
+
+  test("an UNCALIBRATED lane still closes on ok", () => {
+    // No cadence sample means no bound that is not a guess -- the same rule the
+    // silent loop follows, so the two paths cannot disagree about which lanes
+    // they can judge.
+    const plan = laneAlarmPlan({
+      ...base,
+      latest: {
+        a: record({ lane: "a", verdict: "ok", checked_at: NOW - 76 * HOUR }),
+      },
+      observedMaxGap: { a: null },
+      openAlarms: { a: { issue: 77, updatedAt: NOW } },
+    });
+    assert.deepEqual(
+      plan.close.map((c) => c.issue),
+      [77],
+    );
+  });
+
   test("does NOT close on `unknown` -- absence of measurement is not recovery", () => {
     const plan = laneAlarmPlan({
       ...base,


### PR DESCRIPTION
**#11260 did not fix the false recovery.** It was the wrong diagnosis, and the alarm closed #11261 and #11262 again at **04:58Z** with that change deployed. This is the actual mechanism.

## The two loops read the same rows through different rules

`laneAlarmPlan`'s **silent** loop asks whether a lane has stopped speaking — `laneSilenceCadenceMs` floored by the producer's declared cadence, widened by `laneSilenceThresholdMs`. Its **close** loop asked only what the stored row said.

So on one tick, for one lane, the alarm concluded both *"this has gone quiet, raise it"* and *"this reported ok, it recovered"*:

```
03:28Z  opened  #11252 validator-nominator-counts  (silent 3.2 days)
03:58Z  CLOSED  "reported ok at 2026-08-11T23:27:52.032Z"
04:28Z  opened  #11261                              (same lane, same fault)
04:58Z  CLOSED  again
```

Neither lane changed state at any point. Both have been silent since 2026-08-11. Two issue numbers burned per hour, and a recovery comment left in the record that is simply false.

## There was no tie — where #11260 went wrong

The stored row really does say `ok`, with detail `127 statement(s) flushed`: a sync flush stamped with the producer's **own pass time**, four days old and never revised.

I saw `GET /api/v1/self-health` serving `unknown` for that lane at that same millisecond and concluded two rows were tied at `MAX(checked_at)`. They are not. `withLaneHealth` **derives** that `unknown`:

```ts
verdict: silent ? ("unknown" as const) : row.verdict,
detail: silent ? `no verdict for ${...}m (cadence ~${...}m)` : row.detail,
```

The serving surface had been applying the liveness bound all along — that is where the `no verdict for 4606m` text comes from. The alarm was the **only** reader taking a four-day-old `ok` at face value.

#11260 stands on its own merits (a tie must break to the worst verdict, and that is now asserted), but it fixed a mechanism this bug does not use, and I said it would stop the closes. It did not.

## The fix

The close path applies the same predicate the silent loop already uses, from the same `cadenceFor` resolution. **Two spellings of "has this lane stopped speaking" is how they came to disagree in the first place.**

| case | behaviour |
| --- | --- |
| `ok` older than the silence bound | **does not close** — the fix |
| `ok` written a minute ago | closes, unchanged |
| uncalibrated (no cadence sample) | closes, unchanged — no sample means no bound that is not a guess, exactly as the silent loop decides, so neither path can judge a lane the other cannot |

## Verification

- 90 tests in `tests/lane-alarm.test.ts`, 182 across the six lane/self-health suites.
- **Patch coverage 100%** — 3/3 statements, 4/4 branches, by diff intersection with `coverage-final.json`.
- The regression test is the one that matters: a lane that really recovered writes a *fresh* row, so the same bound leaves it alone.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:unreferenced-exports`, `validate:boundary-casts` green.