### PR TITLE
fix(watchdog): retire the dead-letter lane whose queue was deleted

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -111,6 +111,25 @@ export const RETIRED_LANES: readonly string[] = [
   // therefore live, these two are written only from inside the Worker.
   "neurons",
   "tao-usd-index",
+  // The DLQ whose QUEUE was deleted (#10894, merged as #11254). Four probe
+  // dead letters collapsed into one `probe-jobs-dlq`, and `revenue-probes`
+  // went with the account's queue list.
+  //
+  // `handleDeadLetterBatch` is the ONLY writer for a `*-dlq` lane and it keys
+  // off `DEAD_LETTER_LANES`, so a queue no longer in that map can produce no
+  // verdict at all -- which is this list's exact criterion, reached through
+  // code rather than through a deleted file.
+  //
+  // Its last row is a real loss (`1 dead-lettered message(s) ... sn-51-lium-
+  // revenue-for-validators`) and it is frozen: the alarm re-raised it at
+  // 05:28Z on 2026-08-15 as #11267, twenty minutes after a human had closed
+  // #11251 explaining that the queue no longer exists. Without this it would
+  // re-file every half hour until the seven-day residue guard expired it.
+  //
+  // The loss itself is not dropped. The revenue producer re-reads its eligible
+  // set every tick, so a surface that keeps failing dead-letters again on
+  // `probe-jobs-dlq` and is reported there -- under a lane that has a writer.
+  "revenue-probes-dlq",
 ];
 
 /**

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -23,6 +23,10 @@ import {
   loadLatestLaneHealth,
 } from "../src/lane-health.ts";
 import { neonLaneKey } from "../src/neon-write.ts";
+import {
+  DEAD_LETTER_LANE_NAMES,
+  isDeadLetterQueue,
+} from "../src/dead-letter.ts";
 import { RAW_CAPTURE_STATE_NEON_LANE } from "../src/capture-state-neon-write.ts";
 import { NEURONS_NEON_LANE } from "../src/neurons-neon-write.ts";
 // The lane constant lives with its cron in the data-api Worker.
@@ -42,6 +46,10 @@ const PRODUCERS: Record<string, string | null> = {
   // assertion below rather than by a deleted file.
   neurons: null,
   "tao-usd-index": null,
+  // Its producer was a QUEUE, not a file -- justified by the code assertion
+  // below: nothing can write a `*-dlq` lane that DEAD_LETTER_LANES no longer
+  // names.
+  "revenue-probes-dlq": null,
 };
 
 function fakeDb(rows: Record<string, unknown>[]) {
@@ -95,6 +103,21 @@ describe("retired lanes (#10222)", () => {
         `${neonLaneKey(lane)} stays watched`,
       );
     }
+  });
+
+  test("a dead-letter lane whose QUEUE was deleted cannot be written", () => {
+    // #11254 collapsed four probe dead letters into one `probe-jobs-dlq` and
+    // deleted `revenue-probes` from the account. `handleDeadLetterBatch` is the
+    // ONLY writer for a `*-dlq` lane and it keys off DEAD_LETTER_LANES, so a
+    // queue no longer in that map can produce no verdict at all -- which is
+    // this list's criterion, reached through code rather than a deleted file.
+    assert.equal(isDeadLetterQueue("revenue-probes-dlq"), false);
+    assert.equal(DEAD_LETTER_LANE_NAMES.has("revenue-probes-dlq"), false);
+    assert.equal(isRetiredLane("revenue-probes-dlq"), true);
+    // ...and the lane that REPLACED it stays watched. Retiring the survivor
+    // would be suppression rather than cleanup, and it has a live writer.
+    assert.equal(isDeadLetterQueue("probe-jobs-dlq"), true);
+    assert.equal(isRetiredLane("probe-jobs-dlq"), false);
   });
 
   test("the POLLER's own bare lanes are NOT retired", () => {


### PR DESCRIPTION
#11254 collapsed four probe dead letters into one `probe-jobs-dlq` and removed `revenue-probes` from the account. **Its lane row stayed**, and a frozen row with no possible writer is exactly what `RETIRED_LANES` exists for — `loadLatestLaneHealth` takes the newest row per lane with no liveness bound, which is right while a producer exists and inverts the moment one is deleted.

## Not theoretical — it happened while I was watching

```
~04:5xZ  a human CLOSED #11251, explaining the queue no longer exists
05:28:46Z the alarm re-filed the identical lane as #11267
```

Twenty minutes apart. Without this it re-files every half hour until the seven-day residue guard expires the row on **2026-08-22**. Closing it by hand does not help; that is what the re-file demonstrates.

## Justified by code, because the producer was a queue

`tests/lane-health-retired.test.ts` refuses an entry that names no dead producer — **it failed on my first attempt here**, which is the gate working as designed. There is no file to point at, so the justification is asserted directly:

```ts
assert.equal(isDeadLetterQueue("revenue-probes-dlq"), false);
assert.equal(DEAD_LETTER_LANE_NAMES.has("revenue-probes-dlq"), false);
assert.equal(isRetiredLane("revenue-probes-dlq"), true);
// ...and the lane that REPLACED it stays watched
assert.equal(isDeadLetterQueue("probe-jobs-dlq"), true);
assert.equal(isRetiredLane("probe-jobs-dlq"), false);
```

`handleDeadLetterBatch` is the **only** writer for a `*-dlq` lane and keys off `DEAD_LETTER_LANES`, so a queue no longer in that map can produce no verdict at all. The converse assertion is the one that keeps this from becoming suppression: retiring the *survivor* would silence a lane that has a live writer.

## The loss is not dropped

`sn-51-lium-revenue-for-validators` is still failing and still dead-lettering — it appeared on `probe-jobs-dlq` at **04:34Z**. The revenue producer re-reads its eligible set every tick, so a surface that keeps failing is reported under a lane that has a writer. What this removes is a permanent alarm about a queue that no longer exists.

Only this one lane needs it: `attribution-sweeps-dlq` and `origin-reachability-dlq` were deleted by the same PR but never dead-lettered, so they carry no rows and adding them would be an exemption for nothing.

## Verification

- 185 passing across the six lane/self-health suites; 144 across the four most affected.
- The retirement gate rejected the entry until it was justified, and the new assertion is what justifies it.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:unreferenced-exports`, `validate:lane-topology` green.
- No executable statements changed (`src/lane-health.ts` diff is a list entry plus its reasoning), so there is no patch-coverage surface to move.