### PR TITLE
fix(revenue): the SN51 probe was 403'd for not saying who it is

### DIFF
--- a/src/revenue-observations.ts
+++ b/src/revenue-observations.ts
@@ -324,12 +324,44 @@ export async function sha256Hex(text: string): Promise<string> {
  * a 500 with a JSON error body must not have that body handed to an extractor,
  * which would read a field name off it and write whatever it found.
  */
+/**
+ * How this lane identifies itself to somebody else's billing API.
+ *
+ * Matches the probe family's spelling (`metagraphed-smoke-probe/0.0`,
+ * `metagraphed-subtensor-rpc-probe/0.0`) so an operator grepping their access
+ * log sees one recognisable family rather than four unrelated strings.
+ */
+export const REVENUE_PROBE_USER_AGENT = "metagraphed-revenue-probe/0.0";
+
 export async function fetchRevenuePayload(
   url: string,
   { timeoutMs = 10_000 }: { timeoutMs?: number } = {},
 ): Promise<{ payload: unknown; raw: string }> {
   const response = await fetch(url, {
-    headers: { accept: "application/json" },
+    headers: {
+      accept: "application/json",
+      // NAMED, and this is not a courtesy -- it is what makes the lane work.
+      //
+      // Workers send no User-Agent by default, and a WAF that refuses UA-less
+      // traffic answers 403. Measured 2026-08-15 against
+      // https://lium.io/api/billing/revenue-for-validators:
+      //
+      //   no User-Agent header     -> 403  (3/3)
+      //   any User-Agent           -> 200
+      //
+      // That is the whole of SN51's outage. The surface was never down: a plain
+      // curl and the live cron health prober both got 200 throughout, the
+      // prober because src/health-probe-core.ts has always sent
+      // `metagraphed-smoke-probe/0.0`. This lane was the one caller not
+      // identifying itself, so it 403'd, wrote a failure row, retried, and
+      // dead-lettered roughly hourly for 3.7 days -- while the payload it could
+      // not reach parses into 20 valid monthly observations.
+      //
+      // Same shape as every other outbound identity in this repo, so an
+      // operator reading their logs can tell who we are and rate-limit us
+      // deliberately rather than by accident.
+      "user-agent": REVENUE_PROBE_USER_AGENT,
+    },
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) {

--- a/tests/revenue-observations.test.ts
+++ b/tests/revenue-observations.test.ts
@@ -21,6 +21,7 @@ import {
   enqueueRevenueProbes,
   handleRevenueProbeBatch,
   fetchRevenuePayload,
+  REVENUE_PROBE_USER_AGENT,
   loadRevenueObservations,
   persistRevenueProbe,
   runRevenueProbeLane,
@@ -612,6 +613,30 @@ describe("fetchRevenuePayload", () => {
     } finally {
       globalThis.fetch = original;
     }
+  });
+
+  // THE HEADER THAT WAS THE OUTAGE. Workers send no User-Agent by default, and
+  // a WAF that refuses UA-less traffic answers 403. Measured 2026-08-15 against
+  // lium.io: no User-Agent -> 403 (3/3), any User-Agent -> 200. That is the
+  // whole of SN51's 3.7-day failure -- the surface was never down, and the live
+  // health prober got 200 throughout because it has always identified itself.
+  test("identifies itself, or a WAF refuses the lane and not the URL", async () => {
+    const original = globalThis.fetch;
+    let sent: Headers | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      sent = new Headers(init?.headers);
+      return new Response("{}");
+    }) as typeof fetch;
+    try {
+      await fetchRevenuePayload("https://example/x");
+    } finally {
+      globalThis.fetch = original;
+    }
+    assert.equal(sent?.get("user-agent"), REVENUE_PROBE_USER_AGENT);
+    assert.equal(sent?.get("accept"), "application/json");
+    // One recognisable family in somebody else's access log, so they can rate
+    // limit us deliberately rather than by accident.
+    assert.match(REVENUE_PROBE_USER_AGENT, /^metagraphed-/);
   });
 
   test("returns the parsed body and the exact text it came from", async () => {


### PR DESCRIPTION
`sn-51-lium-revenue-for-validators` has failed on every tick since 2026-08-11 — 89 dead-lettered messages — and the cause is **one absent request header**.

Workers send no `User-Agent` by default, and a WAF that refuses UA-less traffic answers 403. Measured against `https://lium.io/api/billing/revenue-for-validators`:

| request | result |
| --- | --- |
| **no `User-Agent` header** | **403** (3 of 3) |
| any `User-Agent` | 200 |
| plain curl | 200 (6 of 6) |
| the live cron health prober | `ok`, 736 ms, throughout |

**The surface was never down.** The health prober passes because `src/health-probe-core.ts` has always sent `metagraphed-smoke-probe/0.0`. This lane was the one outbound caller in the repo not identifying itself.

## What it cost

`/api/v1/chain/revenue-coverage` reports `observed_count: 1` of 129 subnets. SN51 is the **second-largest subnet by emission** and its figures were sitting behind that 403 the whole time — the payload this lane could not reach parses into **20 valid monthly observations**, February 2025 alone being **$203,822**. Verified by running this repo's own `extractRevenue` against the live body.

## Why it took four days to see

The reason existed on every one of those 89 ticks and reached nobody:

- written to `revenue_probe_failures`, which **no route, watchdog or serving surface reads**;
- the retry carrying it went to `console.error`;
- the dead-letter verdict could name the lost **subject** and never the **cause**.

#11256 and #11263 put that reason on a channel somebody reads. It answered on the first tick after deploying:

```
revenue-probe: 1 message(s) retried --
  sn-51-lium-revenue-for-validators: fetch failed: HTTP 403
```

Two hours from "a subject with no explanation" to a one-line fix.

## The header

`metagraphed-revenue-probe/0.0`, matching the probe family's existing spelling (`metagraphed-smoke-probe/0.0`, `metagraphed-subtensor-rpc-probe/0.0`), so an operator grepping their access log sees one recognisable family rather than four unrelated strings — and can rate limit us deliberately rather than by accident.

## Verification

- 95 tests across the three revenue/probe suites.
- **Patch coverage 100%** on the changed line.
- The test asserts the header **is sent**, not merely that the fetch succeeded — a test that only checked the happy path would have passed before this change too.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:api`, `validate:unreferenced-exports` green.

## Not in this PR

The same telemetry surfaced a second, unrelated fault in the same window, which deserves its own change:

```
compute-declaration: 1 message(s) retried -- new row for relation
"compute_declarations" violates check constraint
"compute_declarations_finding_needs_a_stanza"
```