### PR TITLE
fix(watchdog): stop suppressing account-summary, which is healthy and was never remediable by the fix its entry named

### DIFF
--- a/scripts/check-lane-status.ts
+++ b/scripts/check-lane-status.ts
@@ -156,12 +156,26 @@ export const EXPECTED_LANES: Readonly<Record<string, LaneRule>> = {
  * outage that is already tracked, and the sweep reports a lane that LEAVES this
  * set so the baseline has to shrink. A baseline that is only ever added to
  * becomes a way of not looking.
+ *
+ * EMPTY, AND THE ONE ENTRY IT HELD IS WHY THAT MATTERS. `account-summary-status`
+ * sat here from 2026-08-14, and `regressions` filters this map out before the
+ * webhook fires -- so the lane died on every pass for a day and nothing could
+ * report it. The two-day pre-warning the reader's trust bound buys was spent
+ * on silence.
+ *
+ * Worse, the entry named its own remedy wrongly: it said metagraphed-infra#570
+ * would move the lane to "its own sized container class", and that could never
+ * have worked -- `standard-4` is the largest named type, so a new class
+ * inherits the same 12,221 MB ceiling. Anyone reading the baseline to decide
+ * whether to worry was told a fix was coming that could not fix it.
+ *
+ * The lane was fixed for real in metagraphed-infra#584 (fold days forward
+ * rather than rebuild 455M rows) plus #585/#586/#587, and now completes at
+ * 2,156 MB against that ceiling. An entry here should record an outage that is
+ * genuinely tracked AND genuinely remediable, and should be deleted the day it
+ * stops being either.
  */
-export const KNOWN_STALE: Readonly<Record<string, string>> = {
-  "account-summary-status.json":
-    "SIGKILLed inside window 20 of 21 on every pass since 2026-08-14 15:07Z; " +
-    "metagraphed-infra#570 moves it to its own sized container class",
-};
+export const KNOWN_STALE: Readonly<Record<string, string>> = {};
 
 export interface LaneReading {
   lane: string;


### PR DESCRIPTION
`KNOWN_STALE` held one entry from 2026-08-14, and `regressions` filters this map out **before the webhook fires** — so the account-summary lane died on every pass for a day and nothing could report it. The two-day pre-warning the reader's three-day trust bound buys was spent on silence.

That is this file's own stated failure mode, from its own header: *"A baseline that is only ever added to becomes a way of not looking."*

## The entry also named its remedy wrongly

> `metagraphed-infra#570 moves it to its own sized container class`

That could never have worked. `wrangler.decode-r2.jsonc` documents `standard-4` as **the largest named type**, so a new container class inherits the same 12,221 MB ceiling. A placement change cannot buy memory headroom. Anyone reading the baseline to decide whether to worry was told a fix was coming that could not fix it.

## The lane is fixed, and verified before removing this

metagraphed-infra#584 — fold days forward from a persisted watermark rather than rebuild 455M rows — plus #585, #586, #587.

```
account-summary   ok: true    accounts: 813,324    peak_rss_mb: 2,156 / 12,221
pointer           generated_at 2026-08-15T06:26:57Z    through 2026-08-14
```

Was 7,246 MB and a SIGKILL at window 20 of 21.

And the sweep itself, run live against production with the baseline **already empty**:

```
ok    account-summary-status.json: 0.2h
lane-status: 0 failing of 7 -- 0 known (baseline 0), 0 NEW, 0 recovered.
```

So this is not "remove the entry and hope" — the check passes without it.

## What the header now says

The rationale is recorded in place rather than left for the next person to infer: an entry belongs here only while an outage is **both** genuinely tracked **and** genuinely remediable, and should be deleted the day it stops being either. This one stopped being the second almost immediately and stayed for a day.

`tests/lane-status.test.ts`: 19 pass. `tsc`, `lint`, `format:check` clean.