### PR TITLE
fix(seo): 161 weekly digests were reachable from nothing

### DIFF
--- a/apps/ui/src/components/metagraphed/app-shell.tsx
+++ b/apps/ui/src/components/metagraphed/app-shell.tsx
@@ -517,6 +517,11 @@ function SiteFooter() {
           <FooterLink to="/status">Status</FooterLink>
           <FooterLink to="/contribute">Contribute</FooterLink>
           <FooterLink to="/agents">For agents</FooterLink>
+          {/* #11266: the ONLY link to /news anywhere on the site. Its 161
+              weekly digests were reachable from /news and from nowhere else,
+              and /news itself from nothing at all -- so the whole subtree was
+              unreachable by a crawler, sitemap included. */}
+          <FooterLink to="/news">Weekly digests</FooterLink>
           <FooterLink to="/about">About</FooterLink>
         </FooterCol>
         <FooterCol title="Guides">

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -333,6 +333,26 @@ async function buildSitemap(): Promise<Response> {
   } catch {
     // Docs source unavailable — omit rather than fail the whole sitemap.
   }
+  // #11266: the weekly digests, absent since they shipped (#8705). 161 pages of
+  // per-subnet prose that nothing linked and the sitemap never listed, so a
+  // crawler had no way to reach them at all -- their own route comment calls
+  // them "the pages the issue expects search and social to land on".
+  //
+  // Same lazy import and same tolerance as docs above; a separate collection
+  // (source.config.ts keeps them apart so "Subnet 104 — 2026-W29" never lands
+  // in the API-reference nav), so it needs its own loop.
+  //
+  // No <lastmod>: the digest store is append-only and a published week is never
+  // rewritten, so there is no honest "changed at" to emit -- and a synthesised
+  // one costs the real timestamps elsewhere in this file their credibility.
+  try {
+    const { newsSource } = await import("./lib/news-source");
+    for (const page of newsSource.getPages()) {
+      entries.push({ loc: `${SITE_ORIGIN}${page.url}` });
+    }
+  } catch {
+    // News source unavailable — omit rather than fail the whole sitemap.
+  }
   try {
     const res = await fetch(`${API_ORIGIN}/api/v1/subnets?limit=500`, {
       headers: { accept: "application/json" },

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -143,3 +143,41 @@ test.describe("#11258 docs pages describe themselves, within budget", () => {
     expect(text).toContain("no API key");
   });
 });
+
+test.describe("#11266 the weekly digests are reachable at all", () => {
+  // 161 digest pages shipped in #8705 and were reachable from NOTHING: absent
+  // from sitemap.xml, and /news itself had no inbound link anywhere on the site
+  // (measured against production — 0 links from /, /subnets, /subnets/38,
+  // /docs, /about). /news linked its own 160 children, so the whole subtree
+  // hung off a page a crawler could not find. Their own route comment calls
+  // them "the pages the issue expects search and social to land on".
+
+  test("sitemap.xml lists the digests", async ({ request }) => {
+    const xml = await (await request.get("/sitemap.xml")).text();
+    const locs = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]!);
+    const news = locs.filter((u) => new URL(u).pathname.startsWith("/news"));
+    expect(news.length, "no /news URLs in the sitemap").toBeGreaterThan(100);
+    expect(news, "the /news index itself must be listed").toContain("https://metagraph.sh/news");
+    // A sitemap that lists a URL twice is a sitemap the crawler distrusts.
+    expect(new Set(locs).size).toBe(locs.length);
+  });
+
+  test("every page links /news, so the subtree is not sitemap-only", async ({ request }) => {
+    // Sitemap-only is the textbook profile for "Crawled – currently not
+    // indexed": discoverable, but with nothing saying it matters.
+    for (const path of ["/", "/subnets", "/docs"]) {
+      const html = await (await request.get(path)).text();
+      expect(html, `${path} does not link /news`).toContain('href="/news"');
+    }
+  });
+
+  test("a digest the sitemap lists actually answers", async ({ request }) => {
+    const xml = await (await request.get("/sitemap.xml")).text();
+    const digest = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)]
+      .map((m) => new URL(m[1]!).pathname)
+      .find((p) => /^\/news\/sn\d+\//.test(p));
+    expect(digest, "the sitemap lists no per-week digest").toBeTruthy();
+    const response = await request.get(digest!, { maxRedirects: 0 });
+    expect(response.status(), `${digest} is in the sitemap but does not answer 200`).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #11276. Part of #11204.

## The defect

The weekly digests shipped in #8705 **with their own OG cards**, because their route comment calls
them "the pages the issue expects search and social to land on". The cards work. Nothing can find the
pages.

161 digests plus the `/news` index are in **neither the sitemap nor any internal link**. Measured
against production:

| sitemap section | URLs |
|---|---|
| validators | 1,026 |
| docs | 347 |
| providers | 138 |
| subnets | 130 |
| chain / apis / status / health / contribute / about / root | 14 |
| **news** | **0** |

And `href="/news"` appears **zero** times on `/`, `/subnets`, `/subnets/38`, `/docs` and `/about`.
`/news` links 160 of its own children, so the subtree is well connected internally — it just hangs
off a page nothing points at and no sitemap lists.

**The pages are not thin.** `/news/sn38/2026-w25` answers 200 with a real title, description,
canonical and JSON-LD over **449 words** of rendered text, unique per subnet per week.

This is the same defect as #11231 one release later, and worse — those 99 subnet pages at least had a
sitemap entry, which that PR called "the textbook profile for *Crawled – currently not indexed*".

## The fix — both missing edges

1. **Sitemap.** Enumerated from the same source that renders them, so a digest added to
   `content/news/` is listed the moment it ships. Uses the docs loop's own pattern including the lazy
   import — `docs-source` pulls a fumadocs build-time virtual module that does not exist under
   vitest, and a static import there once broke every test that touches `server.ts`. News is a
   separate collection (`source.config.ts` keeps them apart so "Subnet 104 — 2026-W29" never lands in
   the API-reference nav), so it needs its own loop.
2. **One internal link**, in the footer's Operations column — present on every page, which connects
   the whole subtree.

**No `<lastmod>`.** The digest store is append-only and a published week is never rewritten, so there
is no honest "changed at". The file's existing comment is explicit about why that matters: Google
discounts `lastmod` wholesale once it catches a site stamping "now" on URLs that didn't change, so a
fabricated value would cost the real ones (a subnet's `updated_at`) their credibility.

## Verification

Against a real `workerd` build:

```
sitemap sections after:  validators 1026, docs 347, news 161, providers 138, subnets 130, …
/news index listed:      yes          duplicate <loc>:  0
valid XML:               1,817 urls   sampled 12 news URLs: all 200
footer link on /subnets: href="/news"
```

Three e2e assertions added to `indexable-routes.spec.ts`: the sitemap lists the digests with no
duplicate `<loc>`, every page links `/news` (so the subtree is not sitemap-only), and a digest the
sitemap lists actually answers 200 — a sitemap entry pointing at a 404 being worse than no entry.

134 e2e passed; `tsc`, `vitest` (2205), `lint`, `format:check` green.

## Note on the visual change

This adds one footer link ("Weekly digests") to the Operations column. Maintainer PR, so no
screenshot table per the repo's convention — the change is one `<FooterLink>` alongside four
existing ones in the same list.
