### PR TITLE
fix(dead-letter): one queue made the subject ambiguous — name the lane too

### DIFF
--- a/src/dead-letter.ts
+++ b/src/dead-letter.ts
@@ -27,6 +27,7 @@
 // an outage. So a one-off dead letter produces one issue, not a permanent one.
 
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import { ProbeJobTypeSchema } from "../schemas-src/probe-jobs.ts";
 
 /** The two dead-letter queues, and the lane each reports under.
  *
@@ -127,7 +128,7 @@ export const DEAD_LETTER_SUBJECT_KEYS = [
 export const DEAD_LETTER_MAX_NAMED_SUBJECTS = 12;
 
 /** The subject a body names, or null when it names none of them. */
-function subjectOf(body: Record<string, unknown>): string | null {
+function subjectKeyOf(body: Record<string, unknown>): string | null {
   for (const key of DEAD_LETTER_SUBJECT_KEYS) {
     const value = body[key];
     // Numbers count -- `netuid` is one, and rejecting it would have left the
@@ -139,6 +140,38 @@ function subjectOf(body: Record<string, unknown>): string | null {
     if (typeof value === "string" && value) return value;
   }
   return null;
+}
+
+/**
+ * What was lost, and -- since one queue serves four lanes -- WHICH LANE lost it.
+ *
+ * ONE QUEUE MADE THE SUBJECT AMBIGUOUS. Before #10894 the queue name was the
+ * lane, so `netuid=29` on `attribution-sweeps-dlq` needed no qualifier. Now
+ * every probe lane produces to `probe-jobs` and both `SweepMessage` and
+ * `ComputeDeclarationMessage` carry `netuid` and nothing else this function
+ * recognises -- so an identical `netuid=29` can come from either, and the
+ * verdict a maintainer reads cannot say which.
+ *
+ * Measured 2026-08-15: `probe-jobs-dlq` reported
+ * `2 dead-lettered message(s) on probe-jobs-dlq (netuid=108,netuid=29)`. Those
+ * were compute-declaration reads, not attribution sweeps -- I read them as
+ * sweeps, and the only way to tell was to notice the pair matched the two
+ * subnets whose `compute_declarations` rows were missing.
+ *
+ * The discriminator was already on every message: #10894 put `job_type` there
+ * precisely because a batch may mix lanes freely. This reads it.
+ *
+ * VALIDATED AGAINST THE VOCABULARY, not passed through. The body is a message
+ * from a queue -- untrusted input that lands in a log line and a
+ * `lane_health.detail` column -- so only a declared job type is echoed, and an
+ * unrecognised one is dropped rather than printed. `declineUnknownProbeJobs`
+ * already reports that case as its own finding.
+ */
+function subjectOf(body: Record<string, unknown>): string | null {
+  const subject = subjectKeyOf(body);
+  if (subject === null) return null;
+  const jobType = ProbeJobTypeSchema.safeParse(body.job_type);
+  return jobType.success ? `${jobType.data} ${subject}` : subject;
 }
 
 /**

--- a/tests/dead-letter.test.ts
+++ b/tests/dead-letter.test.ts
@@ -226,25 +226,25 @@ describe("the summary names the subject on every live queue", () => {
       "probe-jobs-dlq",
       "netuid",
       { job_type: "attribution-sweep", netuid: 64 },
-      "netuid=64",
+      "attribution-sweep netuid=64",
     ],
     [
       "probe-jobs-dlq",
       "origin",
       { job_type: "origin-reachability", origin: "https://example.com" },
-      "https://example.com",
+      "origin-reachability https://example.com",
     ],
     [
       "probe-jobs-dlq",
       "surface_id",
       { job_type: "revenue-probe", surface_id: "sn-64-api" },
-      "sn-64-api",
+      "revenue-probe sn-64-api",
     ],
     [
       "probe-jobs-dlq",
       "netuid (compute)",
       { job_type: "compute-declaration", netuid: 3 },
-      "netuid=3",
+      "compute-declaration netuid=3",
     ],
   ];
 
@@ -273,6 +273,48 @@ describe("the summary names the subject on every live queue", () => {
       "a dead-letter queue with no case here is one nobody has checked can " +
         "name its own subject",
     );
+  });
+
+  // THE AMBIGUITY ONE QUEUE CREATED. Before #10894 the queue name WAS the lane,
+  // so a bare `netuid=29` needed no qualifier. Now `SweepMessage` and
+  // `ComputeDeclarationMessage` both carry a netuid and nothing else the
+  // subject reader recognises, so the same string can come from either lane.
+  //
+  // Measured 2026-08-15: `probe-jobs-dlq` reported
+  // `(netuid=108,netuid=29)`. Those were compute-declaration reads, and the
+  // only way to tell was noticing the pair matched the two subnets whose
+  // `compute_declarations` rows were missing.
+  test("the same netuid from two lanes is two distinguishable subjects", () => {
+    const line = summarizeDeadLetterBatch("probe-jobs-dlq", [
+      { body: { job_type: "attribution-sweep", netuid: 29 } },
+      { body: { job_type: "compute-declaration", netuid: 29 } },
+    ]);
+    assert.match(line, /attribution-sweep netuid=29/);
+    assert.match(line, /compute-declaration netuid=29/);
+    // Two subjects, not one deduplicated to a single `netuid=29`.
+    assert.match(line, /2 dead-lettered message\(s\)/);
+  });
+
+  test("an UNRECOGNISED job_type is dropped, not echoed", () => {
+    // The body is a queue message -- untrusted input that lands in a log line
+    // and a `lane_health.detail` column. Only a declared job type is echoed;
+    // `declineUnknownProbeJobs` already reports the unknown case as its own
+    // finding, so nothing is lost by refusing to print it here.
+    const line = summarizeDeadLetterBatch("probe-jobs-dlq", [
+      { body: { job_type: "'; DROP TABLE lane_health; --", netuid: 7 } },
+    ]);
+    assert.match(line, /netuid=7/);
+    assert.doesNotMatch(line, /DROP TABLE/);
+  });
+
+  test("a message with no job_type keeps its bare subject", () => {
+    // `sync-batches` and `webhook-deliveries` are not probe jobs and carry no
+    // discriminator. Qualifying only what is qualified keeps their verdicts
+    // exactly as they were.
+    const line = summarizeDeadLetterBatch("sync-batches-dlq", [
+      { body: { lane: "neurons" } },
+    ]);
+    assert.match(line, /\(neurons\)/);
   });
 
   test("netuid 0 is a subject, not a missing one", () => {


### PR DESCRIPTION
Before #10894 the queue name **was** the lane, so `netuid=29` on `attribution-sweeps-dlq` needed no qualifier. Now every probe lane produces to `probe-jobs`, and both `SweepMessage` and `ComputeDeclarationMessage` carry a `netuid` and nothing else `subjectOf` recognises — so the identical string can come from either lane, and the verdict a maintainer reads cannot say which.

## Measured

```
2 dead-lettered message(s) on probe-jobs-dlq (netuid=108,netuid=29)
```

**I read those as attribution sweeps. They were compute-declaration reads.** The only way to tell was noticing the pair matched exactly the two subnets whose `compute_declarations` rows are missing — SN29 and SN108, both of which publish a flat `compute_spec` with no role stanzas. A subject that needs a cross-reference to interpret is a subject naming the wrong thing.

The discriminator was already on every message: #10894 put `job_type` there precisely because a batch may mix lanes freely. This reads it.

| before | after |
| --- | --- |
| `netuid=29` | `attribution-sweep netuid=29` |
| `netuid=29` | `compute-declaration netuid=29` |

## Validated, not passed through

The body is a queue message — untrusted input landing in a log line and a `lane_health.detail` column — so only a member of `ProbeJobTypeSchema` is echoed, and anything else is dropped. There is a test with `'; DROP TABLE lane_health; --` as the job type: the netuid still renders, the string does not. The unknown case is already reported by `declineUnknownProbeJobs`, so refusing to print it loses nothing.

## The existing test could not have caught this

```ts
assert.match(line, new RegExp(expected));   // substring
```

`attribution-sweep netuid=64` satisfies `/netuid=64/`, so all four cases passed **before and after** the change without noticing it. They now assert the whole subject, and a new case pins what the old ones cannot express: the same netuid from two lanes must render as two distinguishable subjects, and the count must stay 2 rather than collapsing to one.

## Verification

- 233 tests across the five affected suites; 29 in `tests/dead-letter.test.ts`.
- **Patch coverage 100%** — 5/5 statements, 4/4 branches by diff intersection.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:unreferenced-exports`, `validate:boundary-casts`, `validate:no-passthrough` green.

## Follow-up, not in this PR

SN29 and SN108 dead-letter because they publish a **flat** `compute_spec` (`cpu`/`gpu`/`memory` directly under it, no `miner:`/`validator:` split). The parser yields "a spec parsed, no role stanzas" → `found: true` with both null → `compute_declarations_finding_needs_a_stanza` rejects the row → retry → dead letter, hourly. Both declare `gpu: required: true`, and `src/contracts.ts` currently states *"of the 17 registered declarations exactly one asks for a GPU"* — a claim two dropped rows are quietly holding up. That needs a migration and is its own change.