### PR TITLE
fix(watchdog): the #10851 fossil sweep was a sample, so it missed the two slowest lanes

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -111,6 +111,30 @@ export const RETIRED_LANES: readonly string[] = [
   // therefore live, these two are written only from inside the Worker.
   "neurons",
   "tao-usd-index",
+  // The SAME #10851 fossil, and the two the sweep above MISSED. Both stopped
+  // at 2026-08-11T23:27Z and 23:35Z -- the same instant as the three names
+  // above, which is the signature of a writer that changed its key rather than
+  // of two lanes independently dying.
+  //
+  // WHY THEY WERE MISSED, which is the part worth keeping. The three above were
+  // retired on 2026-08-12 because they had ALARMED by then. These two had not:
+  // their producer polls DAILY, so their silence bound is 24h against the
+  // sub-hourly bound the others carry, and they did not cross it until
+  // 2026-08-15 -- three days after the list that should have contained them was
+  // written. A fossil set enumerated from the alarms open at one moment is a
+  // SAMPLE of itself, and the slow lanes are precisely what a sample misses.
+  // tests/lane-health-retired.test.ts now DERIVES the set instead of listing it.
+  //
+  // Neither bare name ever carried a poller verdict. ONE poller writes both
+  // tables and reports under `validator-nominators` ("120221 scanned, 130194
+  // written, 0 error(s)", `ok` at 2026-08-14T11:40Z), which is why these two
+  // spellings had no writer left once the flush moved onto `neonLaneKey` while
+  // `account-balances` and `hotkey-alpha` -- buffered by the same flush -- kept
+  // theirs. `neon:nominator-positions` ("403 statement(s) flushed") and
+  // `neon:validator-nominator-counts` ("26 statement(s) flushed") were both `ok`
+  // on the same production read that showed these two frozen, and stay watched.
+  "nominator-positions",
+  "validator-nominator-counts",
   // The DLQ whose QUEUE was deleted (#10894, merged as #11254). Four probe
   // dead letters collapsed into one `probe-jobs-dlq`, and `revenue-probes`
   // went with the account's queue list.

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -14,8 +14,12 @@
 // makes the claim checkable -- a lane can only be retired if the thing that wrote it
 // is genuinely gone, and resurrecting a producer fails here until its name is removed.
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { describe, test } from "vitest";
+import { PRODUCER_CADENCE_SECS } from "../src/producer-cadence.ts";
+// The string-aware stripper, not a regex: wrangler.jsonc holds `"*/2 * * * *"`
+// and `"/api/*"`, which a naive comment regex splices together.
+import { stripJsonComments } from "../scripts/lib.ts";
 import {
   RETIRED_LANES,
   RETIRED_LANE_PREFIXES,
@@ -50,7 +54,41 @@ const PRODUCERS: Record<string, string | null> = {
   // below: nothing can write a `*-dlq` lane that DEAD_LETTER_LANES no longer
   // names.
   "revenue-probes-dlq": null,
+  // The same #10851 key change again, and the two the 2026-08-12 sweep missed
+  // -- justified by the DERIVED assertion below rather than by a deleted file.
+  "nominator-positions": null,
+  "validator-nominator-counts": null,
 };
+
+/**
+ * The lanes whose Neon writes go through the write-behind buffer, read from the
+ * DEPLOYED configs rather than hand-copied into this file.
+ *
+ * The UNION across the three Workers, not one of them and not an equality
+ * assertion between them. Each Worker sets its own `NEON_WRITE_BUFFER_LANES`
+ * and they are free to differ -- but `RETIRED_LANES` is global, so a lane
+ * buffered by any one of them is a lane whose bare spelling this rule must
+ * classify. Reading a single config would sample the set that the rule below
+ * exists to stop anyone sampling.
+ */
+function bufferedLanes(): string[] {
+  const lanes = new Set<string>();
+  for (const config of [
+    "../wrangler.jsonc",
+    "../wrangler.data.jsonc",
+    "../wrangler.registry.jsonc",
+  ]) {
+    const parsed = JSON.parse(
+      stripJsonComments(readFileSync(new URL(config, import.meta.url), "utf8")),
+    ) as { vars?: { NEON_WRITE_BUFFER_LANES?: string } };
+    for (const lane of (parsed.vars?.NEON_WRITE_BUFFER_LANES ?? "").split(
+      ",",
+    )) {
+      if (lane.trim()) lanes.add(lane.trim());
+    }
+  }
+  return [...lanes].sort();
+}
 
 function fakeDb(rows: Record<string, unknown>[]) {
   return {
@@ -118,6 +156,72 @@ describe("retired lanes (#10222)", () => {
     // would be suppression rather than cleanup, and it has a live writer.
     assert.equal(isDeadLetterQueue("probe-jobs-dlq"), true);
     assert.equal(isRetiredLane("probe-jobs-dlq"), false);
+  });
+
+  test("a buffered lane's bare spelling is retired EXACTLY when no producer writes it", () => {
+    // THE RULE THE LIST ABOVE WAS MISSING, and the reason #11268/#11269 were
+    // filed three days after the fossils they name were created.
+    //
+    // #10851 moved the buffer flush onto `neonLaneKey`, so every buffered
+    // lane's verdict now lands under `neon:<lane>`. For a bare spelling that
+    // leaves exactly one possible writer: the POLLER, which reports its own
+    // scan outcome ("120221 scanned, 130194 written, 0 error(s)") under its
+    // lane name. Poller lane names ARE the producer names -- that is what
+    // PRODUCER_CADENCE_SECS is keyed by, stated in its own doc comment -- so a
+    // buffered lane whose bare name is not a producer has no writer at all.
+    //
+    // NOT CIRCULAR, and this is the part that matters. PRODUCER_CADENCE_SECS is
+    // maintained for a different purpose (silence floors) and cross-checked
+    // against each `*-staleness-watchdog.ts` threshold in
+    // tests/lane-silence-cadence.test.ts, so it is an independent artifact
+    // rather than a restatement of this list. The classification was then
+    // MEASURED: on 2026-08-15 production `lane_health` held exactly five bare
+    // lanes frozen at the #10851 deploy -- raw-capture-state, neurons,
+    // tao-usd-index, nominator-positions, validator-nominator-counts -- and
+    // exactly the other five buffered lanes were live that hour. Ten of ten.
+    //
+    // Derived rather than listed, because the list is what failed: the three
+    // retired on 2026-08-12 were the ones ALARMING that day, and the two daily
+    // lanes had not yet crossed a 24h bound. Any future key change is caught
+    // here on the commit that makes it, not on whatever schedule the slowest
+    // affected producer happens to run at.
+    const fossils: string[] = [];
+    const live: string[] = [];
+    for (const lane of bufferedLanes()) {
+      const hasProducer = lane.replaceAll("-", "_") in PRODUCER_CADENCE_SECS;
+      (hasProducer ? live : fossils).push(lane);
+      assert.equal(
+        isRetiredLane(lane),
+        !hasProducer,
+        hasProducer
+          ? `${lane} is written by the poller under its bare name -- retiring it would be suppression`
+          : `${lane} is buffered and has no producer of its own name, so since #10851 nothing writes the bare spelling: retire it in RETIRED_LANES`,
+      );
+      // The prefixed spelling is the live one in BOTH cases and is never
+      // retired -- retiring it would mute the flush itself.
+      assert.equal(
+        isRetiredLane(neonLaneKey(lane)),
+        false,
+        `${neonLaneKey(lane)} stays watched`,
+      );
+    }
+    // Non-vacuity, on both sides. An empty `fossils` would pass the loop while
+    // proving nothing, and an empty `live` would mean the producer table had
+    // been emptied rather than that the rule holds.
+    assert.deepEqual(fossils, [
+      "neurons",
+      "nominator-positions",
+      "raw-capture-state",
+      "tao-usd-index",
+      "validator-nominator-counts",
+    ]);
+    assert.deepEqual(live, [
+      "account-balances",
+      "account-identity",
+      "hotkey-alpha",
+      "subnet-hyperparams",
+      "subnet-identity",
+    ]);
   });
 
   test("the POLLER's own bare lanes are NOT retired", () => {

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -178,9 +178,17 @@ describe("loadLatestLaneHealth", () => {
   // that tie and CLOSED #11252 and #11253 as recovered, while
   // /api/v1/self-health served `unknown` for the same lanes at the same
   // millisecond. Both lanes had been dead 76 hours.
+  //
+  // THE `neon:` SPELLING, not the bare one the incident was reported under.
+  // That bare name is retired as of the #10851 fossil sweep, so
+  // loadLatestLaneHealth now DROPS it -- and a fixture the reader discards
+  // makes every assertion below pass on an empty result. Same lane, same
+  // "127 statement(s) flushed" that its flush actually writes, still watched.
+  const TIED_LANE = "neon:validator-nominator-counts";
+
   const tiedRows = (first: string, second: string) => [
     {
-      lane: "validator-nominator-counts",
+      lane: TIED_LANE,
       verdict: first,
       age_ms: null,
       detail:
@@ -188,7 +196,7 @@ describe("loadLatestLaneHealth", () => {
       checked_at: NOW,
     },
     {
-      lane: "validator-nominator-counts",
+      lane: TIED_LANE,
       verdict: second,
       age_ms: null,
       detail:
@@ -205,16 +213,13 @@ describe("loadLatestLaneHealth", () => {
       const { db } = fakeDb(tiedRows(a, b));
       const latest = await loadLatestLaneHealth(db);
       assert.equal(
-        latest["validator-nominator-counts"].verdict,
+        latest[TIED_LANE].verdict,
         "unknown",
         `order ${a},${b}: a finding must survive a tie with ok`,
       );
       // And it carries THAT row's detail, so the reader is not shown the
       // reassuring half of a contradiction.
-      assert.match(
-        latest["validator-nominator-counts"].detail ?? "",
-        /no verdict for/,
-      );
+      assert.match(latest[TIED_LANE].detail ?? "", /no verdict for/);
     }
   });
 
@@ -225,7 +230,7 @@ describe("loadLatestLaneHealth", () => {
     ]) {
       const { db } = fakeDb(tiedRows(a, b));
       const latest = await loadLatestLaneHealth(db);
-      assert.equal(latest["validator-nominator-counts"].verdict, "stale");
+      assert.equal(latest[TIED_LANE].verdict, "stale");
     }
   });
 


### PR DESCRIPTION
`nominator-positions` and `validator-nominator-counts` stopped receiving
verdicts at 2026-08-11T23:27Z and 23:35Z -- the same instant as
`raw-capture-state`, `neurons` and `tao-usd-index`, which is the signature of a
writer that changed its key rather than of five lanes independently dying.
#10851 put both Neon writers on `neonLaneKey`, so every verdict now lands under
`neon:<lane>` and a bare spelling has exactly one possible writer left: the
poller, which reports its own scan outcome under its lane name.

These two never had one. ONE poller writes both tables and reports under
`validator-nominators` ("120221 scanned, 130194 written, 0 error(s)", ok at
2026-08-14T11:40Z) while `neon:nominator-positions` and
`neon:validator-nominator-counts` were both ok on the same read.

The three siblings were retired on 2026-08-12 because they had ALARMED by
then. These two had not: their producer polls daily, so their silence bound is
24h against the sub-hourly bound the others carry, and they did not cross it
until 2026-08-15 -- three days after the list that should have contained them
was written. A fossil set enumerated from the alarms open at one moment is a
sample of itself, and the slow lanes are precisely what a sample misses.

So the set is DERIVED rather than listed. For every lane in
NEON_WRITE_BUFFER_LANES -- read from the three deployed configs as a union, not
hand-copied -- the bare spelling must be retired exactly when no producer of
that name exists in PRODUCER_CADENCE_SECS. That table is maintained for silence
floors and cross-checked against each staleness watchdog's own threshold, so it
is an independent artifact rather than a restatement; the classification was
then measured against production, where exactly five bare lanes sat frozen at
the #10851 deploy and exactly the other five were live. Ten of ten. Both arms
of the rule fail under mutation.

tests/lane-health.test.ts's tie fixture moves to the `neon:` spelling of the
same lane: the bare name is now dropped by the serving read, so every assertion
in the #11266 regression would have passed on an empty result.

Closes #11268
Closes #11269