### PR TITLE
fix(watchdog): two open alarms are #10851 fossils, not dead producers

### DIFF
--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -111,6 +111,34 @@ export const RETIRED_LANES: readonly string[] = [
   // therefore live, these two are written only from inside the Worker.
   "neurons",
   "tao-usd-index",
+  // THE SAME #10851 FOSSIL, two more spellings -- and these two had been open
+  // alarms (#11268, #11269) reading "silent 3.2 days" while their producer was
+  // healthy the whole time.
+  //
+  // Every row either bare name has ever carried is a WRITE-BUFFER FLUSH
+  // verdict: `nominator-positions` has 10 rows and
+  // `validator-nominator-counts` 5, all of the form "N statement(s) flushed",
+  // and both stop at 2026-08-11T23:35:17Z / 23:27:52Z -- the same instant as
+  // the three above, which is the signature of a writer that changed its key
+  // rather than of two lanes independently dying. `recordFlushVerdicts`
+  // (workers/neon-write-buffer-hub.ts) is the only thing that emits that
+  // sentence, and it has filed under `neonLaneKey(lane)` since #10851, so
+  // nothing can write these spellings again.
+  //
+  // NOT SUPPRESSION, and the poller test is what separates them from
+  // `account-balances` and `validator-nominators`: those bare names carry the
+  // POLLER's own scan outcome ("558009 scanned, 366107 written") and are
+  // therefore live. These two never have -- not one scan-outcome row exists
+  // under either spelling. What still watches this producer, on the same read
+  // that showed these two frozen:
+  //
+  //   validator-nominators                  ok  2026-08-14T11:40Z (the poller's)
+  //   neon:nominator-positions              ok  2026-08-14T11:51Z (3,111 rows)
+  //   neon:validator-nominator-counts       ok  2026-08-14T11:50Z (1,942 rows)
+  //   nominator-positions-staleness         ok  (the table's own watchdog)
+  //   validator-nominator-counts-staleness  ok
+  "nominator-positions",
+  "validator-nominator-counts",
   // The DLQ whose QUEUE was deleted (#10894, merged as #11254). Four probe
   // dead letters collapsed into one `probe-jobs-dlq`, and `revenue-probes`
   // went with the account's queue list.

--- a/tests/lane-health-retired.test.ts
+++ b/tests/lane-health-retired.test.ts
@@ -23,6 +23,15 @@ import {
   loadLatestLaneHealth,
 } from "../src/lane-health.ts";
 import { neonLaneKey } from "../src/neon-write.ts";
+import { NOMINATOR_POSITIONS_NEON_LANE } from "../src/nominator-positions-neon-write.ts";
+import { LEDGER_MIRROR_PLANS } from "../src/ledger-neon-write.ts";
+
+/** The counts lane has no exported constant of its own -- it is a key in the
+ * ledger mirror plan table. Derived from there rather than retyped, so a rename
+ * of the mirror breaks this instead of silently retiring a name nothing uses. */
+const VALIDATOR_NOMINATOR_COUNTS_LANE = Object.keys(LEDGER_MIRROR_PLANS).find(
+  (lane) => lane === "validator-nominator-counts",
+) as string;
 import {
   DEAD_LETTER_LANE_NAMES,
   isDeadLetterQueue,
@@ -50,6 +59,10 @@ const PRODUCERS: Record<string, string | null> = {
   // below: nothing can write a `*-dlq` lane that DEAD_LETTER_LANES no longer
   // names.
   "revenue-probes-dlq": null,
+  // The same #10851 key change as `neurons` / `tao-usd-index` above --
+  // justified by the code assertion below, not by a deleted file.
+  "nominator-positions": null,
+  "validator-nominator-counts": null,
 };
 
 function fakeDb(rows: Record<string, unknown>[]) {
@@ -95,6 +108,8 @@ describe("retired lanes (#10222)", () => {
       RAW_CAPTURE_STATE_NEON_LANE,
       NEURONS_NEON_LANE,
       TAO_USD_INDEX_NEON_LANE,
+      NOMINATOR_POSITIONS_NEON_LANE,
+      VALIDATOR_NOMINATOR_COUNTS_LANE,
     ]) {
       assert.equal(isRetiredLane(lane), true, `${lane} (bare) is retired`);
       assert.equal(
@@ -118,6 +133,28 @@ describe("retired lanes (#10222)", () => {
     // would be suppression rather than cleanup, and it has a live writer.
     assert.equal(isDeadLetterQueue("probe-jobs-dlq"), true);
     assert.equal(isRetiredLane("probe-jobs-dlq"), false);
+  });
+
+  test("retiring the nominator fossils leaves the producer watched", () => {
+    // The claim that makes this a retirement rather than suppression. Every row
+    // either bare name ever carried was a write-buffer flush ("N statement(s)
+    // flushed"), frozen at the #10851 key change -- while the poller's own
+    // lane, both `neon:` mirrors and both staleness watchdogs kept reporting.
+    for (const retired of [
+      NOMINATOR_POSITIONS_NEON_LANE,
+      VALIDATOR_NOMINATOR_COUNTS_LANE,
+    ]) {
+      assert.equal(isRetiredLane(retired), true, `${retired} is a fossil`);
+      assert.equal(
+        isRetiredLane(neonLaneKey(retired)),
+        false,
+        `${neonLaneKey(retired)} is the live writer's key and stays watched`,
+      );
+      // The table's OWN watchdog, which is a different lane and unaffected.
+      assert.equal(isRetiredLane(`${retired}-staleness`), false);
+    }
+    // And the producer both fossils belonged to.
+    assert.equal(isRetiredLane("validator-nominators"), false);
   });
 
   test("the POLLER's own bare lanes are NOT retired", () => {

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -174,13 +174,19 @@ describe("loadLatestLaneHealth", () => {
   // and later writes land on top of it: a sync flush writing `ok` beside a
   // staleness watchdog writing `unknown`, same lane, same millisecond.
   //
-  // Measured 2026-08-15 03:58Z: the lane alarm read the `ok` side of exactly
-  // that tie and CLOSED #11252 and #11253 as recovered, while
-  // /api/v1/self-health served `unknown` for the same lanes at the same
-  // millisecond. Both lanes had been dead 76 hours.
+  // The lane here is the `neon:` spelling deliberately: the bare
+  // `validator-nominator-counts` is a retired #10851 fossil, so
+  // loadLatestLaneHealth drops it before this rule can be reached at all.
+  //
+  // NOTE ON PROVENANCE. This rule was written believing a tie explained the
+  // alarm closing #11252/#11253 as recovered while /api/v1/self-health served
+  // `unknown` for the same lanes. It did not -- `withLaneHealth` DERIVES that
+  // `unknown` from silence, so there was no tie (see #11266). The rule stands
+  // on its own: rows CAN share a stamp, because the prune is `checked_at < ?`
+  // and the table has no key, and resolving that by row order is not a rule.
   const tiedRows = (first: string, second: string) => [
     {
-      lane: "validator-nominator-counts",
+      lane: "neon:validator-nominator-counts",
       verdict: first,
       age_ms: null,
       detail:
@@ -188,7 +194,7 @@ describe("loadLatestLaneHealth", () => {
       checked_at: NOW,
     },
     {
-      lane: "validator-nominator-counts",
+      lane: "neon:validator-nominator-counts",
       verdict: second,
       age_ms: null,
       detail:
@@ -205,14 +211,14 @@ describe("loadLatestLaneHealth", () => {
       const { db } = fakeDb(tiedRows(a, b));
       const latest = await loadLatestLaneHealth(db);
       assert.equal(
-        latest["validator-nominator-counts"].verdict,
+        latest["neon:validator-nominator-counts"].verdict,
         "unknown",
         `order ${a},${b}: a finding must survive a tie with ok`,
       );
       // And it carries THAT row's detail, so the reader is not shown the
       // reassuring half of a contradiction.
       assert.match(
-        latest["validator-nominator-counts"].detail ?? "",
+        latest["neon:validator-nominator-counts"].detail ?? "",
         /no verdict for/,
       );
     }
@@ -225,7 +231,7 @@ describe("loadLatestLaneHealth", () => {
     ]) {
       const { db } = fakeDb(tiedRows(a, b));
       const latest = await loadLatestLaneHealth(db);
-      assert.equal(latest["validator-nominator-counts"].verdict, "stale");
+      assert.equal(latest["neon:validator-nominator-counts"].verdict, "stale");
     }
   });
 


### PR DESCRIPTION
#11268 and #11269 have been open reading **"silent 3.2 days"** for lanes whose producer has been healthy the whole time. Read directly from Neon, the evidence is unambiguous.

## Every row either bare name ever carried is a flush verdict

| lane | rows, ever | newest | detail |
| --- | --- | --- | --- |
| `nominator-positions` | 10 | 2026-08-11T23:35:17Z | `26 statement(s) flushed` |
| `validator-nominator-counts` | 5 | 2026-08-11T23:27:52Z | `127 statement(s) flushed` |

`recordFlushVerdicts` (`workers/neon-write-buffer-hub.ts`) is the **only** thing in the repo that emits that sentence, and since #10851 it files under `neonLaneKey(lane)` — its own comment says filing under the bare name *"put this in the wrong bucket twice over"*. So nothing can write these spellings again.

Both froze at the same instant as `neurons` and `tao-usd-index`, which `RETIRED_LANES` already documents at *"2026-08-11T23:35Z … the signature of a writer that changed its key rather than of two lanes independently dying"* — for exactly this reason. These are the same event, two more spellings.

## Not suppression — the poller test is what proves it

The distinction this list turns on is whether the bare name carries the **poller's own scan outcome**. `account-balances` and `validator-nominators` do (`"558009 scanned, 366107 written"`), so they stay watched. These two never have — **not one scan-outcome row exists under either spelling** in the whole retained window.

What still watches this producer, on the same read that showed both frozen:

```
validator-nominators                  ok  2026-08-14T11:40Z  (the poller's own)
neon:nominator-positions              ok  2026-08-14T11:51Z  (3,111 rows)
neon:validator-nominator-counts       ok  2026-08-14T11:50Z  (1,942 rows)
nominator-positions-staleness         ok  (the table's own watchdog)
validator-nominator-counts-staleness  ok
```

A new test pins all of it: each fossil is retired, each `neon:` key is **not**, each `-staleness` lane is **not**, and the producer lane is **not**. Retiring the survivor of any of those would be suppression, and the test is what stops it.

## The retirement gate did its job, twice

It refused both names until each was justified by code — exactly as it refused `revenue-probes-dlq` in #11270. The counts lane has no exported constant, so its name is derived from `LEDGER_MIRROR_PLANS` rather than retyped: a rename of the mirror breaks this test instead of silently retiring a name nothing uses.

## One consequence worth stating

Retiring `validator-nominator-counts` broke two tests I added in #11260 — they used it as a fixture, and a retired lane is dropped before the rule under test can be reached. Repointed at the `neon:` spelling, which is where such a tie could actually occur.

Their comment now also records that the tie was **not** the cause of the false closes (#11266 was), rather than leaving the wrong story in the file for the next reader.

## Verification

- 191 tests across the seven lane/self-health suites.
- `typecheck`, `lint`, `format:check`, `validate:contract-drift`, `validate:unreferenced-exports`, `validate:lane-topology` green.
- Evidence gathered by direct SQL against the live `lane_health` table, not inferred from the served surface.