### PR TITLE
feat(seo): the weekly digests say what they are and what week they cover

### DIFF
--- a/apps/ui/content/news/sn1/2026-w26.mdx
+++ b/apps/ui/content/news/sn1/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 1 — 2026-W26"
 description: "What changed for subnet 1 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn10/2026-w26.mdx
+++ b/apps/ui/content/news/sn10/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 10 — 2026-W26"
 description: "What changed for subnet 10 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn100/2026-w26.mdx
+++ b/apps/ui/content/news/sn100/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 100 — 2026-W26"
 description: "What changed for subnet 100 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn101/2026-w25.mdx
+++ b/apps/ui/content/news/sn101/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 101 — 2026-W25"
 description: "What changed for subnet 101 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn102/2026-w25.mdx
+++ b/apps/ui/content/news/sn102/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 102 — 2026-W25"
 description: "What changed for subnet 102 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn103/2026-w21.mdx
+++ b/apps/ui/content/news/sn103/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 103 — 2026-W21"
 description: "What changed for subnet 103 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn103/2026-w32.mdx
+++ b/apps/ui/content/news/sn103/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 103 — 2026-W32"
 description: "What changed for subnet 103 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn104/2026-w28.mdx
+++ b/apps/ui/content/news/sn104/2026-w28.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 104 — 2026-W28"
 description: "What changed for subnet 104 during 2026-W28 (6–12 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-06/2026-07-12"
 ---
 
 **6–12 July 2026**

--- a/apps/ui/content/news/sn104/2026-w29.mdx
+++ b/apps/ui/content/news/sn104/2026-w29.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 104 — 2026-W29"
 description: "What changed for subnet 104 during 2026-W29 (13–19 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-13/2026-07-19"
 ---
 
 **13–19 July 2026**

--- a/apps/ui/content/news/sn105/2026-w21.mdx
+++ b/apps/ui/content/news/sn105/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 105 — 2026-W21"
 description: "What changed for subnet 105 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn106/2026-w26.mdx
+++ b/apps/ui/content/news/sn106/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 106 — 2026-W26"
 description: "What changed for subnet 106 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn106/2026-w27.mdx
+++ b/apps/ui/content/news/sn106/2026-w27.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 106 — 2026-W27"
 description: "What changed for subnet 106 during 2026-W27 (29 June – 5 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-29/2026-07-05"
 ---
 
 **29 June – 5 July 2026**

--- a/apps/ui/content/news/sn107/2026-w18.mdx
+++ b/apps/ui/content/news/sn107/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 107 — 2026-W18"
 description: "What changed for subnet 107 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn108/2026-w18.mdx
+++ b/apps/ui/content/news/sn108/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 108 — 2026-W18"
 description: "What changed for subnet 108 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn109/2026-w25.mdx
+++ b/apps/ui/content/news/sn109/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 109 — 2026-W25"
 description: "What changed for subnet 109 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn11/2026-w18.mdx
+++ b/apps/ui/content/news/sn11/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 11 — 2026-W18"
 description: "What changed for subnet 11 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn110/2026-w20.mdx
+++ b/apps/ui/content/news/sn110/2026-w20.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 110 — 2026-W20"
 description: "What changed for subnet 110 during 2026-W20 (11–17 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-11/2026-05-17"
 ---
 
 **11–17 May 2026**

--- a/apps/ui/content/news/sn111/2026-w26.mdx
+++ b/apps/ui/content/news/sn111/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 111 — 2026-W26"
 description: "What changed for subnet 111 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn113/2026-w26.mdx
+++ b/apps/ui/content/news/sn113/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 113 — 2026-W26"
 description: "What changed for subnet 113 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn114/2026-w32.mdx
+++ b/apps/ui/content/news/sn114/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 114 — 2026-W32"
 description: "What changed for subnet 114 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn115/2026-w26.mdx
+++ b/apps/ui/content/news/sn115/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 115 — 2026-W26"
 description: "What changed for subnet 115 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn116/2026-w26.mdx
+++ b/apps/ui/content/news/sn116/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 116 — 2026-W26"
 description: "What changed for subnet 116 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn117/2026-w18.mdx
+++ b/apps/ui/content/news/sn117/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 117 — 2026-W18"
 description: "What changed for subnet 117 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn118/2026-w26.mdx
+++ b/apps/ui/content/news/sn118/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 118 — 2026-W26"
 description: "What changed for subnet 118 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn119/2026-w26.mdx
+++ b/apps/ui/content/news/sn119/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 119 — 2026-W26"
 description: "What changed for subnet 119 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn12/2026-w26.mdx
+++ b/apps/ui/content/news/sn12/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 12 — 2026-W26"
 description: "What changed for subnet 12 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn120/2026-w21.mdx
+++ b/apps/ui/content/news/sn120/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 120 — 2026-W21"
 description: "What changed for subnet 120 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn121/2026-w26.mdx
+++ b/apps/ui/content/news/sn121/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 121 — 2026-W26"
 description: "What changed for subnet 121 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn122/2026-w21.mdx
+++ b/apps/ui/content/news/sn122/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 122 — 2026-W21"
 description: "What changed for subnet 122 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn123/2025-w46.mdx
+++ b/apps/ui/content/news/sn123/2025-w46.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 123 — 2025-W46"
 description: "What changed for subnet 123 during 2025-W46 (10–16 November 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-11-10/2025-11-16"
 ---
 
 **10–16 November 2025**

--- a/apps/ui/content/news/sn123/2026-w25.mdx
+++ b/apps/ui/content/news/sn123/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 123 — 2026-W25"
 description: "What changed for subnet 123 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn127/2026-w26.mdx
+++ b/apps/ui/content/news/sn127/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 127 — 2026-W26"
 description: "What changed for subnet 127 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn128/2026-w26.mdx
+++ b/apps/ui/content/news/sn128/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 128 — 2026-W26"
 description: "What changed for subnet 128 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn13/2026-w32.mdx
+++ b/apps/ui/content/news/sn13/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 13 — 2026-W32"
 description: "What changed for subnet 13 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn14/2026-w21.mdx
+++ b/apps/ui/content/news/sn14/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 14 — 2026-W21"
 description: "What changed for subnet 14 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn15/2026-w18.mdx
+++ b/apps/ui/content/news/sn15/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 15 — 2026-W18"
 description: "What changed for subnet 15 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn15/2026-w32.mdx
+++ b/apps/ui/content/news/sn15/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 15 — 2026-W32"
 description: "What changed for subnet 15 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn16/2026-w26.mdx
+++ b/apps/ui/content/news/sn16/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 16 — 2026-W26"
 description: "What changed for subnet 16 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn17/2026-w23.mdx
+++ b/apps/ui/content/news/sn17/2026-w23.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 17 — 2026-W23"
 description: "What changed for subnet 17 during 2026-W23 (1–7 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-01/2026-06-07"
 ---
 
 **1–7 June 2026**

--- a/apps/ui/content/news/sn18/2026-w12.mdx
+++ b/apps/ui/content/news/sn18/2026-w12.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 18 — 2026-W12"
 description: "What changed for subnet 18 during 2026-W12 (16–22 March 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-03-16/2026-03-22"
 ---
 
 **16–22 March 2026**

--- a/apps/ui/content/news/sn18/2026-w20.mdx
+++ b/apps/ui/content/news/sn18/2026-w20.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 18 — 2026-W20"
 description: "What changed for subnet 18 during 2026-W20 (11–17 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-11/2026-05-17"
 ---
 
 **11–17 May 2026**

--- a/apps/ui/content/news/sn19/2026-w17.mdx
+++ b/apps/ui/content/news/sn19/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 19 — 2026-W17"
 description: "What changed for subnet 19 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn2/2026-w32.mdx
+++ b/apps/ui/content/news/sn2/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 2 — 2026-W32"
 description: "What changed for subnet 2 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn20/2026-w26.mdx
+++ b/apps/ui/content/news/sn20/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 20 — 2026-W26"
 description: "What changed for subnet 20 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn21/2026-w21.mdx
+++ b/apps/ui/content/news/sn21/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 21 — 2026-W21"
 description: "What changed for subnet 21 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn22/2026-w32.mdx
+++ b/apps/ui/content/news/sn22/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 22 — 2026-W32"
 description: "What changed for subnet 22 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn23/2026-w25.mdx
+++ b/apps/ui/content/news/sn23/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 23 — 2026-W25"
 description: "What changed for subnet 23 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn24/2026-w26.mdx
+++ b/apps/ui/content/news/sn24/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 24 — 2026-W26"
 description: "What changed for subnet 24 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn25/2026-w26.mdx
+++ b/apps/ui/content/news/sn25/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 25 — 2026-W26"
 description: "What changed for subnet 25 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn26/2026-w19.mdx
+++ b/apps/ui/content/news/sn26/2026-w19.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 26 — 2026-W19"
 description: "What changed for subnet 26 during 2026-W19 (4–10 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-04/2026-05-10"
 ---
 
 **4–10 May 2026**

--- a/apps/ui/content/news/sn27/2026-w26.mdx
+++ b/apps/ui/content/news/sn27/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 27 — 2026-W26"
 description: "What changed for subnet 27 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn28/2026-w25.mdx
+++ b/apps/ui/content/news/sn28/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 28 — 2026-W25"
 description: "What changed for subnet 28 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn29/2024-w46.mdx
+++ b/apps/ui/content/news/sn29/2024-w46.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 29 — 2024-W46"
 description: "What changed for subnet 29 during 2024-W46 (11–17 November 2024), with every claim linked to the item behind it."
+temporalCoverage: "2024-11-11/2024-11-17"
 ---
 
 **11–17 November 2024**

--- a/apps/ui/content/news/sn29/2026-w26.mdx
+++ b/apps/ui/content/news/sn29/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 29 — 2026-W26"
 description: "What changed for subnet 29 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn3/2026-w32.mdx
+++ b/apps/ui/content/news/sn3/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 3 — 2026-W32"
 description: "What changed for subnet 3 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn30/2026-w26.mdx
+++ b/apps/ui/content/news/sn30/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 30 — 2026-W26"
 description: "What changed for subnet 30 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn31/2026-w25.mdx
+++ b/apps/ui/content/news/sn31/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 31 — 2026-W25"
 description: "What changed for subnet 31 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn32/2025-w06.mdx
+++ b/apps/ui/content/news/sn32/2025-w06.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 32 — 2025-W06"
 description: "What changed for subnet 32 during 2025-W06 (3–9 February 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-02-03/2025-02-09"
 ---
 
 **3–9 February 2025**

--- a/apps/ui/content/news/sn32/2026-w32.mdx
+++ b/apps/ui/content/news/sn32/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 32 — 2026-W32"
 description: "What changed for subnet 32 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn33/2026-w22.mdx
+++ b/apps/ui/content/news/sn33/2026-w22.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 33 — 2026-W22"
 description: "What changed for subnet 33 during 2026-W22 (25–31 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-25/2026-05-31"
 ---
 
 **25–31 May 2026**

--- a/apps/ui/content/news/sn34/2026-w24.mdx
+++ b/apps/ui/content/news/sn34/2026-w24.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 34 — 2026-W24"
 description: "What changed for subnet 34 during 2026-W24 (8–14 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-08/2026-06-14"
 ---
 
 **8–14 June 2026**

--- a/apps/ui/content/news/sn35/2025-w21.mdx
+++ b/apps/ui/content/news/sn35/2025-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 35 — 2025-W21"
 description: "What changed for subnet 35 during 2025-W21 (19–25 May 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-05-19/2025-05-25"
 ---
 
 **19–25 May 2025**

--- a/apps/ui/content/news/sn35/2026-w32.mdx
+++ b/apps/ui/content/news/sn35/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 35 — 2026-W32"
 description: "What changed for subnet 35 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn36/2026-w20.mdx
+++ b/apps/ui/content/news/sn36/2026-w20.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 36 — 2026-W20"
 description: "What changed for subnet 36 during 2026-W20 (11–17 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-11/2026-05-17"
 ---
 
 **11–17 May 2026**

--- a/apps/ui/content/news/sn37/2026-w26.mdx
+++ b/apps/ui/content/news/sn37/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 37 — 2026-W26"
 description: "What changed for subnet 37 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn38/2026-w25.mdx
+++ b/apps/ui/content/news/sn38/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 38 — 2026-W25"
 description: "What changed for subnet 38 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn38/2026-w28.mdx
+++ b/apps/ui/content/news/sn38/2026-w28.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 38 — 2026-W28"
 description: "What changed for subnet 38 during 2026-W28 (6–12 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-06/2026-07-12"
 ---
 
 **6–12 July 2026**

--- a/apps/ui/content/news/sn39/2025-w06.mdx
+++ b/apps/ui/content/news/sn39/2025-w06.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 39 — 2025-W06"
 description: "What changed for subnet 39 during 2025-W06 (3–9 February 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-02-03/2025-02-09"
 ---
 
 **3–9 February 2025**

--- a/apps/ui/content/news/sn39/2026-w32.mdx
+++ b/apps/ui/content/news/sn39/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 39 — 2026-W32"
 description: "What changed for subnet 39 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn4/2025-w14.mdx
+++ b/apps/ui/content/news/sn4/2025-w14.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 4 — 2025-W14"
 description: "What changed for subnet 4 during 2025-W14 (31 March – 6 April 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-03-31/2025-04-06"
 ---
 
 **31 March – 6 April 2025**

--- a/apps/ui/content/news/sn4/2026-w32.mdx
+++ b/apps/ui/content/news/sn4/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 4 — 2026-W32"
 description: "What changed for subnet 4 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn40/2026-w26.mdx
+++ b/apps/ui/content/news/sn40/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 40 — 2026-W26"
 description: "What changed for subnet 40 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn41/2026-w32.mdx
+++ b/apps/ui/content/news/sn41/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 41 — 2026-W32"
 description: "What changed for subnet 41 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn42/2026-w26.mdx
+++ b/apps/ui/content/news/sn42/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 42 — 2026-W26"
 description: "What changed for subnet 42 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn43/2026-w18.mdx
+++ b/apps/ui/content/news/sn43/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 43 — 2026-W18"
 description: "What changed for subnet 43 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn44/2026-w32.mdx
+++ b/apps/ui/content/news/sn44/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 44 — 2026-W32"
 description: "What changed for subnet 44 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn45/2025-w06.mdx
+++ b/apps/ui/content/news/sn45/2025-w06.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 45 — 2025-W06"
 description: "What changed for subnet 45 during 2025-W06 (3–9 February 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-02-03/2025-02-09"
 ---
 
 **3–9 February 2025**

--- a/apps/ui/content/news/sn45/2026-w26.mdx
+++ b/apps/ui/content/news/sn45/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 45 — 2026-W26"
 description: "What changed for subnet 45 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn46/2026-w06.mdx
+++ b/apps/ui/content/news/sn46/2026-w06.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 46 — 2026-W06"
 description: "What changed for subnet 46 during 2026-W06 (2–8 February 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-02-02/2026-02-08"
 ---
 
 **2–8 February 2026**

--- a/apps/ui/content/news/sn46/2026-w32.mdx
+++ b/apps/ui/content/news/sn46/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 46 — 2026-W32"
 description: "What changed for subnet 46 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn47/2025-w25.mdx
+++ b/apps/ui/content/news/sn47/2025-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 47 — 2025-W25"
 description: "What changed for subnet 47 during 2025-W25 (16–22 June 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-06-16/2025-06-22"
 ---
 
 **16–22 June 2025**

--- a/apps/ui/content/news/sn47/2026-w26.mdx
+++ b/apps/ui/content/news/sn47/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 47 — 2026-W26"
 description: "What changed for subnet 47 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn48/2026-w27.mdx
+++ b/apps/ui/content/news/sn48/2026-w27.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 48 — 2026-W27"
 description: "What changed for subnet 48 during 2026-W27 (29 June – 5 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-29/2026-07-05"
 ---
 
 **29 June – 5 July 2026**

--- a/apps/ui/content/news/sn49/2026-w32.mdx
+++ b/apps/ui/content/news/sn49/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 49 — 2026-W32"
 description: "What changed for subnet 49 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn5/2026-w26.mdx
+++ b/apps/ui/content/news/sn5/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 5 — 2026-W26"
 description: "What changed for subnet 5 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn50/2026-w32.mdx
+++ b/apps/ui/content/news/sn50/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 50 — 2026-W32"
 description: "What changed for subnet 50 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn51/2025-w38.mdx
+++ b/apps/ui/content/news/sn51/2025-w38.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 51 — 2025-W38"
 description: "What changed for subnet 51 during 2025-W38 (15–21 September 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-09-15/2025-09-21"
 ---
 
 **15–21 September 2025**

--- a/apps/ui/content/news/sn51/2026-w18.mdx
+++ b/apps/ui/content/news/sn51/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 51 — 2026-W18"
 description: "What changed for subnet 51 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn52/2026-w26.mdx
+++ b/apps/ui/content/news/sn52/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 52 — 2026-W26"
 description: "What changed for subnet 52 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn53/2026-w26.mdx
+++ b/apps/ui/content/news/sn53/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 53 — 2026-W26"
 description: "What changed for subnet 53 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn54/2026-w32.mdx
+++ b/apps/ui/content/news/sn54/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 54 — 2026-W32"
 description: "What changed for subnet 54 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn55/2025-w11.mdx
+++ b/apps/ui/content/news/sn55/2025-w11.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 55 — 2025-W11"
 description: "What changed for subnet 55 during 2025-W11 (10–16 March 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-03-10/2025-03-16"
 ---
 
 **10–16 March 2025**

--- a/apps/ui/content/news/sn55/2026-w32.mdx
+++ b/apps/ui/content/news/sn55/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 55 — 2026-W32"
 description: "What changed for subnet 55 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn56/2026-w32.mdx
+++ b/apps/ui/content/news/sn56/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 56 — 2026-W32"
 description: "What changed for subnet 56 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn57/2026-w26.mdx
+++ b/apps/ui/content/news/sn57/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 57 — 2026-W26"
 description: "What changed for subnet 57 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn58/2026-w26.mdx
+++ b/apps/ui/content/news/sn58/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 58 — 2026-W26"
 description: "What changed for subnet 58 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn58/2026-w28.mdx
+++ b/apps/ui/content/news/sn58/2026-w28.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 58 — 2026-W28"
 description: "What changed for subnet 58 during 2026-W28 (6–12 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-06/2026-07-12"
 ---
 
 **6–12 July 2026**

--- a/apps/ui/content/news/sn59/2026-w32.mdx
+++ b/apps/ui/content/news/sn59/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 59 — 2026-W32"
 description: "What changed for subnet 59 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn6/2026-w17.mdx
+++ b/apps/ui/content/news/sn6/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 6 — 2026-W17"
 description: "What changed for subnet 6 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn60/2025-w09.mdx
+++ b/apps/ui/content/news/sn60/2025-w09.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 60 — 2025-W09"
 description: "What changed for subnet 60 during 2025-W09 (24 February – 2 March 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-02-24/2025-03-02"
 ---
 
 **24 February – 2 March 2025**

--- a/apps/ui/content/news/sn60/2026-w32.mdx
+++ b/apps/ui/content/news/sn60/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 60 — 2026-W32"
 description: "What changed for subnet 60 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn61/2026-w32.mdx
+++ b/apps/ui/content/news/sn61/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 61 — 2026-W32"
 description: "What changed for subnet 61 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn62/2026-w26.mdx
+++ b/apps/ui/content/news/sn62/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 62 — 2026-W26"
 description: "What changed for subnet 62 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn63/2026-w17.mdx
+++ b/apps/ui/content/news/sn63/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 63 — 2026-W17"
 description: "What changed for subnet 63 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn64/2026-w28.mdx
+++ b/apps/ui/content/news/sn64/2026-w28.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 64 — 2026-W28"
 description: "What changed for subnet 64 during 2026-W28 (6–12 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-06/2026-07-12"
 ---
 
 **6–12 July 2026**

--- a/apps/ui/content/news/sn65/2026-w32.mdx
+++ b/apps/ui/content/news/sn65/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 65 — 2026-W32"
 description: "What changed for subnet 65 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn66/2026-w26.mdx
+++ b/apps/ui/content/news/sn66/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 66 — 2026-W26"
 description: "What changed for subnet 66 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn67/2025-w39.mdx
+++ b/apps/ui/content/news/sn67/2025-w39.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 67 — 2025-W39"
 description: "What changed for subnet 67 during 2025-W39 (22–28 September 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-09-22/2025-09-28"
 ---
 
 **22–28 September 2025**

--- a/apps/ui/content/news/sn67/2026-w32.mdx
+++ b/apps/ui/content/news/sn67/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 67 — 2026-W32"
 description: "What changed for subnet 67 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn68/2025-w10.mdx
+++ b/apps/ui/content/news/sn68/2025-w10.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 68 — 2025-W10"
 description: "What changed for subnet 68 during 2025-W10 (3–9 March 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-03-03/2025-03-09"
 ---
 
 **3–9 March 2025**

--- a/apps/ui/content/news/sn68/2026-w26.mdx
+++ b/apps/ui/content/news/sn68/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 68 — 2026-W26"
 description: "What changed for subnet 68 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn69/2026-w26.mdx
+++ b/apps/ui/content/news/sn69/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 69 — 2026-W26"
 description: "What changed for subnet 69 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn7/2026-w26.mdx
+++ b/apps/ui/content/news/sn7/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 7 — 2026-W26"
 description: "What changed for subnet 7 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn7/2026-w32.mdx
+++ b/apps/ui/content/news/sn7/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 7 — 2026-W32"
 description: "What changed for subnet 7 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn70/2026-w20.mdx
+++ b/apps/ui/content/news/sn70/2026-w20.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 70 — 2026-W20"
 description: "What changed for subnet 70 during 2026-W20 (11–17 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-11/2026-05-17"
 ---
 
 **11–17 May 2026**

--- a/apps/ui/content/news/sn71/2025-w44.mdx
+++ b/apps/ui/content/news/sn71/2025-w44.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 71 — 2025-W44"
 description: "What changed for subnet 71 during 2025-W44 (27 October – 2 November 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-10-27/2025-11-02"
 ---
 
 **27 October – 2 November 2025**

--- a/apps/ui/content/news/sn71/2026-w32.mdx
+++ b/apps/ui/content/news/sn71/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 71 — 2026-W32"
 description: "What changed for subnet 71 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn72/2026-w26.mdx
+++ b/apps/ui/content/news/sn72/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 72 — 2026-W26"
 description: "What changed for subnet 72 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn73/2026-w25.mdx
+++ b/apps/ui/content/news/sn73/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 73 — 2026-W25"
 description: "What changed for subnet 73 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn74/2026-w17.mdx
+++ b/apps/ui/content/news/sn74/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 74 — 2026-W17"
 description: "What changed for subnet 74 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn75/2026-w17.mdx
+++ b/apps/ui/content/news/sn75/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 75 — 2026-W17"
 description: "What changed for subnet 75 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn76/2026-w26.mdx
+++ b/apps/ui/content/news/sn76/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 76 — 2026-W26"
 description: "What changed for subnet 76 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn77/2026-w26.mdx
+++ b/apps/ui/content/news/sn77/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 77 — 2026-W26"
 description: "What changed for subnet 77 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn78/2026-w07.mdx
+++ b/apps/ui/content/news/sn78/2026-w07.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 78 — 2026-W07"
 description: "What changed for subnet 78 during 2026-W07 (9–15 February 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-02-09/2026-02-15"
 ---
 
 **9–15 February 2026**

--- a/apps/ui/content/news/sn78/2026-w26.mdx
+++ b/apps/ui/content/news/sn78/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 78 — 2026-W26"
 description: "What changed for subnet 78 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn79/2026-w27.mdx
+++ b/apps/ui/content/news/sn79/2026-w27.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 79 — 2026-W27"
 description: "What changed for subnet 79 during 2026-W27 (29 June – 5 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-29/2026-07-05"
 ---
 
 **29 June – 5 July 2026**

--- a/apps/ui/content/news/sn8/2026-w32.mdx
+++ b/apps/ui/content/news/sn8/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 8 — 2026-W32"
 description: "What changed for subnet 8 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn80/2025-w13.mdx
+++ b/apps/ui/content/news/sn80/2025-w13.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 80 — 2025-W13"
 description: "What changed for subnet 80 during 2025-W13 (24–30 March 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-03-24/2025-03-30"
 ---
 
 **24–30 March 2025**

--- a/apps/ui/content/news/sn80/2026-w26.mdx
+++ b/apps/ui/content/news/sn80/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 80 — 2026-W26"
 description: "What changed for subnet 80 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn81/2026-w32.mdx
+++ b/apps/ui/content/news/sn81/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 81 — 2026-W32"
 description: "What changed for subnet 81 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn82/2026-w19.mdx
+++ b/apps/ui/content/news/sn82/2026-w19.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 82 — 2026-W19"
 description: "What changed for subnet 82 during 2026-W19 (4–10 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-04/2026-05-10"
 ---
 
 **4–10 May 2026**

--- a/apps/ui/content/news/sn83/2026-w18.mdx
+++ b/apps/ui/content/news/sn83/2026-w18.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 83 — 2026-W18"
 description: "What changed for subnet 83 during 2026-W18 (27 April – 3 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-27/2026-05-03"
 ---
 
 **27 April – 3 May 2026**

--- a/apps/ui/content/news/sn84/2026-w21.mdx
+++ b/apps/ui/content/news/sn84/2026-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 84 — 2026-W21"
 description: "What changed for subnet 84 during 2026-W21 (18–24 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-18/2026-05-24"
 ---
 
 **18–24 May 2026**

--- a/apps/ui/content/news/sn85/2025-w15.mdx
+++ b/apps/ui/content/news/sn85/2025-w15.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 85 — 2025-W15"
 description: "What changed for subnet 85 during 2025-W15 (7–13 April 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-04-07/2025-04-13"
 ---
 
 **7–13 April 2025**

--- a/apps/ui/content/news/sn85/2026-w32.mdx
+++ b/apps/ui/content/news/sn85/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 85 — 2026-W32"
 description: "What changed for subnet 85 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn86/2026-w26.mdx
+++ b/apps/ui/content/news/sn86/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 86 — 2026-W26"
 description: "What changed for subnet 86 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn86/2026-w30.mdx
+++ b/apps/ui/content/news/sn86/2026-w30.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 86 — 2026-W30"
 description: "What changed for subnet 86 during 2026-W30 (20–26 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-20/2026-07-26"
 ---
 
 **20–26 July 2026**

--- a/apps/ui/content/news/sn86/2026-w32.mdx
+++ b/apps/ui/content/news/sn86/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 86 — 2026-W32"
 description: "What changed for subnet 86 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn87/2026-w01.mdx
+++ b/apps/ui/content/news/sn87/2026-w01.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 87 — 2026-W01"
 description: "What changed for subnet 87 during 2026-W01 (29 December 2025 – 4 January 2026), with every claim linked to the item behind it."
+temporalCoverage: "2025-12-29/2026-01-04"
 ---
 
 **29 December 2025 – 4 January 2026**

--- a/apps/ui/content/news/sn87/2026-w25.mdx
+++ b/apps/ui/content/news/sn87/2026-w25.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 87 — 2026-W25"
 description: "What changed for subnet 87 during 2026-W25 (15–21 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-15/2026-06-21"
 ---
 
 **15–21 June 2026**

--- a/apps/ui/content/news/sn88/2026-w20.mdx
+++ b/apps/ui/content/news/sn88/2026-w20.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 88 — 2026-W20"
 description: "What changed for subnet 88 during 2026-W20 (11–17 May 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-05-11/2026-05-17"
 ---
 
 **11–17 May 2026**

--- a/apps/ui/content/news/sn89/2025-w28.mdx
+++ b/apps/ui/content/news/sn89/2025-w28.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 89 — 2025-W28"
 description: "What changed for subnet 89 during 2025-W28 (7–13 July 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-07-07/2025-07-13"
 ---
 
 **7–13 July 2025**

--- a/apps/ui/content/news/sn89/2026-w17.mdx
+++ b/apps/ui/content/news/sn89/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 89 — 2026-W17"
 description: "What changed for subnet 89 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn9/2025-w23.mdx
+++ b/apps/ui/content/news/sn9/2025-w23.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 9 — 2025-W23"
 description: "What changed for subnet 9 during 2025-W23 (2–8 June 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-06-02/2025-06-08"
 ---
 
 **2–8 June 2025**

--- a/apps/ui/content/news/sn9/2026-w32.mdx
+++ b/apps/ui/content/news/sn9/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 9 — 2026-W32"
 description: "What changed for subnet 9 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn90/2026-w26.mdx
+++ b/apps/ui/content/news/sn90/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 90 — 2026-W26"
 description: "What changed for subnet 90 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn90/2026-w29.mdx
+++ b/apps/ui/content/news/sn90/2026-w29.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 90 — 2026-W29"
 description: "What changed for subnet 90 during 2026-W29 (13–19 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-07-13/2026-07-19"
 ---
 
 **13–19 July 2026**

--- a/apps/ui/content/news/sn91/2025-w21.mdx
+++ b/apps/ui/content/news/sn91/2025-w21.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 91 — 2025-W21"
 description: "What changed for subnet 91 during 2025-W21 (19–25 May 2025), with every claim linked to the item behind it."
+temporalCoverage: "2025-05-19/2025-05-25"
 ---
 
 **19–25 May 2025**

--- a/apps/ui/content/news/sn91/2026-w26.mdx
+++ b/apps/ui/content/news/sn91/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 91 — 2026-W26"
 description: "What changed for subnet 91 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn92/2026-w23.mdx
+++ b/apps/ui/content/news/sn92/2026-w23.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 92 — 2026-W23"
 description: "What changed for subnet 92 during 2026-W23 (1–7 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-01/2026-06-07"
 ---
 
 **1–7 June 2026**

--- a/apps/ui/content/news/sn92/2026-w27.mdx
+++ b/apps/ui/content/news/sn92/2026-w27.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 92 — 2026-W27"
 description: "What changed for subnet 92 during 2026-W27 (29 June – 5 July 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-29/2026-07-05"
 ---
 
 **29 June – 5 July 2026**

--- a/apps/ui/content/news/sn93/2026-w32.mdx
+++ b/apps/ui/content/news/sn93/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 93 — 2026-W32"
 description: "What changed for subnet 93 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn94/2026-w32.mdx
+++ b/apps/ui/content/news/sn94/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 94 — 2026-W32"
 description: "What changed for subnet 94 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/content/news/sn95/2026-w26.mdx
+++ b/apps/ui/content/news/sn95/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 95 — 2026-W26"
 description: "What changed for subnet 95 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn96/2026-w17.mdx
+++ b/apps/ui/content/news/sn96/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 96 — 2026-W17"
 description: "What changed for subnet 96 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn97/2026-w17.mdx
+++ b/apps/ui/content/news/sn97/2026-w17.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 97 — 2026-W17"
 description: "What changed for subnet 97 during 2026-W17 (20–26 April 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-04-20/2026-04-26"
 ---
 
 **20–26 April 2026**

--- a/apps/ui/content/news/sn98/2026-w26.mdx
+++ b/apps/ui/content/news/sn98/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 98 — 2026-W26"
 description: "What changed for subnet 98 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn99/2026-w13.mdx
+++ b/apps/ui/content/news/sn99/2026-w13.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 99 — 2026-W13"
 description: "What changed for subnet 99 during 2026-W13 (23–29 March 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-03-23/2026-03-29"
 ---
 
 **23–29 March 2026**

--- a/apps/ui/content/news/sn99/2026-w26.mdx
+++ b/apps/ui/content/news/sn99/2026-w26.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 99 — 2026-W26"
 description: "What changed for subnet 99 during 2026-W26 (22–28 June 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-06-22/2026-06-28"
 ---
 
 **22–28 June 2026**

--- a/apps/ui/content/news/sn99/2026-w32.mdx
+++ b/apps/ui/content/news/sn99/2026-w32.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Subnet 99 — 2026-W32"
 description: "What changed for subnet 99 during 2026-W32 (3–9 August 2026), with every claim linked to the item behind it."
+temporalCoverage: "2026-08-03/2026-08-09"
 ---
 
 **3–9 August 2026**

--- a/apps/ui/scripts/generate-digest-pages.ts
+++ b/apps/ui/scripts/generate-digest-pages.ts
@@ -91,6 +91,23 @@ function escapeYaml(value: string): string {
 }
 
 /**
+ * The same week as a machine-readable ISO 8601 interval, `2026-07-20/2026-07-26`.
+ *
+ * schema.org `temporalCoverage`, for the Article node the page emits (#11279).
+ * Derived from `isoWeekStart` exactly as `weekSpan` is, so the interval and the
+ * words under the H1 cannot disagree — and it is a statement about the period
+ * the digest COVERS, never about when it was published. There is no honest
+ * publication timestamp available (the store records the week, not the run), so
+ * none is claimed.
+ */
+function weekInterval(year: number, week: number): string {
+  const start = isoWeekStart(year, week);
+  const end = new Date(start.getTime() + 6 * 24 * 60 * 60 * 1000);
+  const day = (d: Date) => d.toISOString().slice(0, 10);
+  return `${day(start)}/${day(end)}`;
+}
+
+/**
  * `20–26 July 2026` — the week the digest covers, in words.
  *
  * The dates come from isoWeekStart, the same function the store uses to decide
@@ -158,6 +175,7 @@ function digestPage(digest: WeeklyDigest): string {
     "---",
     `title: "${escapeYaml(title)}"`,
     `description: "${escapeYaml(description)}"`,
+    `temporalCoverage: "${weekInterval(digest.year, digest.week)}"`,
     "---",
     "",
     `**${span}**`,

--- a/apps/ui/source.config.ts
+++ b/apps/ui/source.config.ts
@@ -14,6 +14,15 @@ import { z } from "zod";
 // generation date already on the page.
 export const news = defineDocs({
   dir: "content/news",
+  docs: {
+    // #11279: declared, or fumadocs' frontmatter schema strips it before
+    // page.data and the Article node silently loses its temporalCoverage --
+    // exactly how metaDescription vanished in #11258.
+    schema: frontmatterSchema.extend({
+      /** ISO 8601 interval, `2026-07-20/2026-07-26`: the week this digest covers. */
+      temporalCoverage: z.string().optional(),
+    }),
+  },
 });
 
 export const docs = defineDocs({

--- a/apps/ui/src/lib/metagraphed/json-ld.test.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.test.ts
@@ -318,3 +318,35 @@ describe("providerDatasetJsonLd (#11204) — 138 records that had no node", () =
     );
   });
 });
+
+describe("Article vs TechArticle (#11279) — a digest is not documentation", () => {
+  const base = { headline: "Subnet 38 — 2026-W25", url: "https://metagraph.sh/news/sn38/2026-w25" };
+
+  it("defaults to TechArticle and takes Article when asked", () => {
+    // Typing a weekly report as documentation of an interface would be the same
+    // over-claim the rest of this module avoids.
+    expect(techArticleJsonLd(base)["@type"]).toBe("TechArticle");
+    expect(techArticleJsonLd({ ...base, type: "Article" })["@type"]).toBe("Article");
+  });
+
+  it("carries temporalCoverage as the period, never as a publication date", () => {
+    const out = techArticleJsonLd({
+      ...base,
+      type: "Article",
+      temporalCoverage: "2026-06-15/2026-06-21",
+    }) as unknown as Record<string, unknown>;
+    expect(out.temporalCoverage).toBe("2026-06-15/2026-06-21");
+    // The digest store records the week, not the run, so there is no honest
+    // publication timestamp and none is invented.
+    expect(out).not.toHaveProperty("datePublished");
+    expect(out).not.toHaveProperty("dateModified");
+  });
+
+  it("omits temporalCoverage when the page covers no single period", () => {
+    // The /news archive index is not about one week.
+    expect(techArticleJsonLd({ ...base, type: "Article" })).not.toHaveProperty("temporalCoverage");
+    expect(
+      techArticleJsonLd({ ...base, type: "Article", temporalCoverage: null }),
+    ).not.toHaveProperty("temporalCoverage");
+  });
+});

--- a/apps/ui/src/lib/metagraphed/json-ld.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.ts
@@ -247,6 +247,22 @@ export interface TechArticleInput {
   dateModified?: string | null;
   /** Absolute URL of the page's representative image (its OG card). */
   image?: string | null;
+  /**
+   * ISO 8601 interval the page's content covers, e.g. `2026-07-20/2026-07-26`.
+   *
+   * A statement about the PERIOD, never about publication time. The weekly
+   * digests know their week exactly (it is what selects their items) and know
+   * no honest publication timestamp, so this is the field that fits.
+   */
+  temporalCoverage?: string | null;
+  /**
+   * `TechArticle` for reference documentation, `Article` for editorial prose.
+   *
+   * A weekly digest is a report about a subnet, not documentation of an
+   * interface, and typing it as the latter would be the same over-claim the
+   * rest of this module avoids.
+   */
+  type?: "TechArticle" | "Article";
 }
 
 /**
@@ -275,13 +291,14 @@ export interface TechArticleInput {
 export function techArticleJsonLd(input: TechArticleInput) {
   const description = input.description?.trim();
   return {
-    "@type": "TechArticle",
+    "@type": input.type ?? "TechArticle",
     headline: input.headline,
     ...(description ? { description } : {}),
     url: input.url,
     mainEntityOfPage: input.url,
     ...(input.dateModified ? { dateModified: input.dateModified } : {}),
     ...(input.image ? { image: input.image } : {}),
+    ...(input.temporalCoverage ? { temporalCoverage: input.temporalCoverage } : {}),
     inLanguage: "en",
     author: ref(JSONLD_IDS.org),
     publisher: ref(JSONLD_IDS.org),

--- a/apps/ui/src/routes/news.$.tsx
+++ b/apps/ui/src/routes/news.$.tsx
@@ -1,20 +1,29 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { newsSource } from "@/lib/news-source";
-import { ogImageMeta } from "@/lib/metagraphed/og-card";
+import { buildOgImageUrl, ogImageMeta } from "@/lib/metagraphed/og-card";
+import { stringifyJsonLd, techArticleJsonLd } from "@/lib/metagraphed/json-ld";
+import { SITE_ORIGIN } from "@/lib/metagraphed/identity";
+import { clampText } from "@/lib/metagraphed/truncate";
 import { NewsSplatPage } from "./-news-splat-page";
 
 // #8705: the weekly digests, at /news/sn8/2026-w31 and /news/network/2026-w31,
 // plus /news itself for the archive index. Mirrors the /docs splat route --
 // same fumadocs loader shape, same reason RootProvider is scoped to the route
 // rather than __root.tsx (see -docs-splat-page.tsx).
+/**
+ * Same budget the docs route applies (#11264). The index page's frontmatter
+ * description runs to 175 characters, because it is also the visible subtitle.
+ */
+const NEWS_META_DESCRIPTION_MAX = 160;
+
 export const Route = createFileRoute("/news/$")({
   component: NewsSplatPage,
   loader: async ({ params }) => {
     const slugs = params._splat?.split("/").filter(Boolean) ?? [];
     return serverLoader({ data: slugs });
   },
-  head: ({ loaderData }) => ({
+  head: ({ loaderData, params }) => ({
     meta: [
       { title: loaderData ? `${loaderData.title} — Metagraphed` : "Metagraphed" },
       { name: "description", content: loaderData?.description ?? "" },
@@ -36,6 +45,37 @@ export const Route = createFileRoute("/news/$")({
         entity: false,
       }),
     ],
+    // #11279: a digest is editorial prose about a subnet's week, so Article --
+    // not the TechArticle the reference docs use, which would claim these
+    // document an interface. `about` points at the catalog, so a quoted
+    // sentence leads back to the records the digest was written from.
+    scripts: loaderData
+      ? [
+          {
+            type: "application/ld+json",
+            children: stringifyJsonLd(
+              techArticleJsonLd({
+                type: "Article",
+                headline: loaderData.title,
+                description: loaderData.description,
+                url: `${SITE_ORIGIN}/news/${params._splat ?? ""}`.replace(/\/+$/, ""),
+                // The week the digest COVERS. There is no honest publication
+                // timestamp -- the store records the week, not the run -- so
+                // none is claimed. See generate-digest-pages.ts's weekInterval.
+                temporalCoverage: loaderData.temporalCoverage,
+                image: buildOgImageUrl({
+                  title: loaderData.title ?? "Weekly digests",
+                  subtitle:
+                    loaderData.description ||
+                    "What changed, week by week, for each Bittensor subnet",
+                  eyebrow: "Digest",
+                  entity: false,
+                }),
+              }),
+            ),
+          },
+        ]
+      : [],
   }),
 });
 
@@ -44,10 +84,12 @@ const serverLoader = createServerFn({ method: "GET" })
   .handler(async ({ data: slugs }) => {
     const page = newsSource.getPage(slugs);
     if (!page) throw notFound();
+    const data = page.data as { description?: string; temporalCoverage?: string };
     return {
       path: page.path,
       title: page.data.title,
-      description: page.data.description ?? "",
+      description: clampText(page.data.description ?? "", NEWS_META_DESCRIPTION_MAX),
+      temporalCoverage: data.temporalCoverage ?? null,
       // serializePageTree, not the raw tree: a page tree's `name` is a
       // ReactNode, which createServerFn's serializability check rejects.
       // Same call docs.$.tsx makes for the same reason.

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -181,3 +181,29 @@ test.describe("#11266 the weekly digests are reachable at all", () => {
     expect(response.status(), `${digest} is in the sitemap but does not answer 200`).toBe(200);
   });
 });
+
+test.describe("#11279 the digests are typed, and say what week they cover", () => {
+  test("a digest emits an Article whose temporalCoverage matches its own text", async ({
+    request,
+  }) => {
+    const html = await (await request.get("/news/sn38/2026-w25")).text();
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)].map(
+      (m) => JSON.parse(m[1]!) as Record<string, unknown>,
+    );
+    const article = blocks.find((b) => b["@type"] === "Article");
+    expect(article, "no Article node on a digest page").toBeTruthy();
+    expect(article!.temporalCoverage).toBe("2026-06-15/2026-06-21");
+    // The structured data must agree with what the reader can see, which is the
+    // rule every builder in json-ld.ts ships under.
+    expect(html).toContain("15–21 June 2026");
+  });
+
+  test("the archive index is an Article with no week to claim", async ({ request }) => {
+    const html = await (await request.get("/news")).text();
+    const article = [...html.matchAll(/<script type="application\/ld\+json">(.*?)<\/script>/gs)]
+      .map((m) => JSON.parse(m[1]!) as Record<string, unknown>)
+      .find((b) => b["@type"] === "Article");
+    expect(article).toBeTruthy();
+    expect(article).not.toHaveProperty("temporalCoverage");
+  });
+});


### PR DESCRIPTION
Closes #11281. Part of #11204.

## The gap

#11276 made the 161 weekly digests *reachable*. They were still the only content type on the site
with **no structured data of its own**:

| route | node |
|---|---|
| `/subnets/{netuid}` | `Dataset` |
| `/providers/{slug}` | `Dataset` |
| `/docs/**` | `TechArticle` |
| `/news/**` | *(site graph only)* |

## What they get, and why that type

A digest is editorial prose about one subnet's week, written only from this registry's own feed items
with every sentence citing the item behind it. So **`Article`** — not the `TechArticle` the reference
docs use, which would claim it documents an interface. `about` points at the catalog, so a quoted
sentence leads back to the records the digest was written from.

## The one fact a digest had and could not state

Each page prints its week under the H1 — **"15–21 June 2026"** — and nothing machine-readable said
so. `temporalCoverage` is the schema.org field for exactly that, and the generator already computes
the range from `isoWeekStart`: the same function the store uses to decide whether a week has ended,
so the interval and the words on the page cannot disagree.

```
/news/sn38/2026-w25   temporalCoverage: "2026-06-15/2026-06-21"   page prints: 15–21 June 2026
/news                 (no temporalCoverage — it is about no single week)
```

Deliberately **not** `datePublished`. The store records the week, not the run, so there is no honest
publication timestamp; inventing one would be a freshness claim that cannot be supported — the same
reason this sitemap emits no `<lastmod>` for these pages.

## The trap that cost a cycle twice

`temporalCoverage` is **declared** in `source.config.ts`. Fumadocs validates frontmatter with a zod
object that strips unknown keys — exactly how `metaDescription` reached 290 files in #11258 and
vanished before `page.data`, with nothing failing. Both collections now declare what they carry.

## Also: the news route was never bounded

#11264 clamped the docs meta descriptions to 160 and did not touch `/news`, whose archive index went
out at **175** because its frontmatter is also its visible subtitle. Now 156, subtitle unchanged.

## Verification

Against a real `workerd` build:

```
/news                  meta 156 (was 175)   Article, no temporalCoverage       dangling refs: none
/news/sn38/2026-w25    meta 108             Article, 2026-06-15/2026-06-21     dangling refs: none
```

- 160 digests regenerated, and the generator is **verified idempotent** (same tree hash on a second
  run) — which is what makes the CI drift check meaningful rather than noisy.
- e2e asserts the digest's `temporalCoverage` matches the span the page prints, and that the archive
  index claims no week. 136 e2e passed.
- `tsc`, `vitest` (2208), `lint`, `format:check` green.
