### PR TITLE
perf(accounts): the card's feed leg meets the projection at the edge of the day it folded

### DIFF
--- a/schemas-src/artifacts/account-summary-projection.ts
+++ b/schemas-src/artifacts/account-summary-projection.ts
@@ -28,6 +28,13 @@
 //     reads as "this account has no events".
 import { z } from "zod";
 
+// THE TABLE'S OWN DECLARATION, extended rather than restated. A second copy of
+// this vocabulary drifts by one side gaining a column, and the narrower one
+// then accepts what it does not describe -- which `validate:schema-shape-
+// duplicates` refuses, and rightly: the reader merges these rows with rows
+// selected straight out of the same table.
+import { AccountEventsRowSchema } from "../lakehouse.ts";
+
 /**
  * `current.json` -- names the generation that is currently readable.
  *
@@ -123,27 +130,44 @@ export const AccountSummaryGroupsSchema = z.array(AccountSummaryGroupSchema);
  * on anything that is not a balance movement -- nullability here is the table's,
  * not a concession.
  */
-export const AccountSummaryRecentEventSchema = z
-  .object({
-    // The event's identity, and the reason it cannot be null: the reader
-    // de-duplicates the projection's rows against the head probe's on this
-    // pair. A null half would collapse distinct events onto one key and drop
-    // real rows from the feed.
-    block_number: z.number().int().nonnegative(),
-    event_index: z.number().int().nonnegative(),
-    extrinsic_index: z.number().int().nullable(),
-    event_kind: z.string().nullable(),
-    hotkey: z.string().nullable(),
-    coldkey: z.string().nullable(),
-    netuid: z.number().int().nullable(),
-    uid: z.number().int().nullable(),
-    amount_tao: z.number().nullable(),
-    alpha_amount: z.number().nullable(),
-    observed_at: z.number().int().nonnegative(),
+export const AccountSummaryRecentEventSchema = AccountEventsRowSchema
+  // REQUIRED and CLOSED, which is the whole difference from the table's own
+  // declaration. `AccountEventsRowSchema` is partial and open because a READ
+  // selects a projection and often an aggregate alias that is not a column at
+  // all. This is a PUBLISHED artifact: the producer writes every column of
+  // every row, so a missing one is a producer bug and an extra one is a
+  // vocabulary the reader would silently drop from half a merged feed.
+  .required()
+  .extend({
+    // The event's identity, and the reason these three cannot be null here
+    // while the table permits it: the reader de-duplicates the projection's
+    // rows against the head probe's on (block_number, event_index), and sorts
+    // the merged page on all three. A null would collapse distinct events onto
+    // one key, or sort as zero and bury a real event at the bottom of the card.
+    block_number: z.int().nonnegative(),
+    event_index: z.int().nonnegative(),
+    observed_at: z.int().nonnegative(),
   })
   .strict();
+
+/** One published event, as the reader gets it back from `safeParse`. */
+export type AccountSummaryRecentEvent = z.infer<
+  typeof AccountSummaryRecentEventSchema
+>;
 
 /** One account's published newest events, newest first. */
 export const AccountSummaryRecentSchema = z.array(
   AccountSummaryRecentEventSchema,
 );
+
+/**
+ * A shard's `recent` map, keyed by ss58.
+ *
+ * LAZY IN ITS VALUES on purpose, exactly as `accounts` is handled: a shard
+ * carries ~1,000 accounts and a request reads ONE. Declaring the values as
+ * `unknown` checks the ENVELOPE -- that this is a keyed object rather than a
+ * string, a number or an array -- and leaves the one account's array to be
+ * parsed properly by `AccountSummaryRecentSchema`. Parsing all thousand would
+ * spend the saving this whole tier exists to make.
+ */
+export const AccountSummaryRecentMapSchema = z.record(z.string(), z.unknown());

--- a/schemas-src/artifacts/account-summary-projection.ts
+++ b/schemas-src/artifacts/account-summary-projection.ts
@@ -46,6 +46,24 @@ export const AccountSummaryPointerSchema = z
     generated_at: z.string().min(1),
     account_count: z.number().int().nonnegative(),
     through: z.string().min(1).optional(),
+    /**
+     * How many events per account the shards carry in their `recent` map
+     * (metagraphed-infra#575), when they carry one at all.
+     *
+     * THE LIMIT TRAVELS WITH THE DATA. `ACCOUNT_SUMMARY_RECENT_LIMIT` lives in
+     * this repository and the producer lives in another, so a reader that
+     * assumed the published N matched its own would serve a short feed the
+     * moment the two diverged -- and no CI here could see it. Declaring the N
+     * actually written lets the reader DECLINE when the artifact carries fewer
+     * than it needs, exactly as `shard_count` already travels rather than being
+     * agreed by convention.
+     *
+     * OPTIONAL, because every generation published before #575 lacks it, and
+     * those pointers are still valid to read for their aggregate leg. Absent
+     * means "no recent map" -- not "some unknown number" -- so the reader falls
+     * back to the lakehouse for that leg alone.
+     */
+    recent_limit: z.number().int().positive().optional(),
   })
   .strict();
 
@@ -88,3 +106,44 @@ export const AccountSummaryGroupSchema = z
  * does not exist -- the first is a decline and the second is an answer.
  */
 export const AccountSummaryGroupsSchema = z.array(AccountSummaryGroupSchema);
+
+/**
+ * One published event inside a shard's `recent` map (metagraphed-infra#575).
+ *
+ * THE COLUMNS ARE THE LAKEHOUSE TABLE'S, not a shape invented here. The reader
+ * merges these rows with rows the head probe selects straight out of
+ * `chain.account_events`, and the two go into the same feed -- so a field named
+ * differently on one side would surface as a missing value on half a card
+ * rather than as an error. `tests/account-summary-projection.test.ts` pins the
+ * key set against the generated `ACCOUNT_EVENTS_COLUMNS`, so a column added to
+ * the table fails here rather than being silently dropped from the projection.
+ *
+ * EVERY VALUE IS NULLABLE except the two that identify the event. `hotkey` is
+ * null on WeightsSet, `netuid` on Transfer and Deposit, and the amount columns
+ * on anything that is not a balance movement -- nullability here is the table's,
+ * not a concession.
+ */
+export const AccountSummaryRecentEventSchema = z
+  .object({
+    // The event's identity, and the reason it cannot be null: the reader
+    // de-duplicates the projection's rows against the head probe's on this
+    // pair. A null half would collapse distinct events onto one key and drop
+    // real rows from the feed.
+    block_number: z.number().int().nonnegative(),
+    event_index: z.number().int().nonnegative(),
+    extrinsic_index: z.number().int().nullable(),
+    event_kind: z.string().nullable(),
+    hotkey: z.string().nullable(),
+    coldkey: z.string().nullable(),
+    netuid: z.number().int().nullable(),
+    uid: z.number().int().nullable(),
+    amount_tao: z.number().nullable(),
+    alpha_amount: z.number().nullable(),
+    observed_at: z.number().int().nonnegative(),
+  })
+  .strict();
+
+/** One account's published newest events, newest first. */
+export const AccountSummaryRecentSchema = z.array(
+  AccountSummaryRecentEventSchema,
+);

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -976,6 +976,90 @@ export type AccountSummaryColdTierResult =
     }
   | { declined: string[] };
 
+/**
+ * The feed's own sort key, as a comparable tuple.
+ *
+ * The SAME three columns `FEED_ORDER` names, in the same precedence, because
+ * the merged page has to be indistinguishable from what the single ordered
+ * query returned. Sorting on `observed_at` alone would reorder events inside a
+ * block, and the cursor token the other tier issues encodes all three.
+ */
+function feedKey(row: Record<string, unknown>): [number, number, number] {
+  return [
+    Number(row.observed_at ?? 0),
+    Number(row.block_number ?? 0),
+    Number(row.event_index ?? 0),
+  ];
+}
+
+/**
+ * Merge the published newest events with whatever landed after them.
+ *
+ * THE RANGES ARE DISJOINT BY CONSTRUCTION -- the projection describes up to the
+ * end of its last complete day, the probe starts at the first millisecond
+ * after it -- so this is a merge, not a reconciliation, and no row can be
+ * counted twice by arithmetic.
+ *
+ * IT STILL DE-DUPLICATES, on the pair that identifies an event. Disjointness is
+ * a property of the producer, asserted across a repository boundary, and the
+ * failure it guards against is not symmetric: a producer that widened its
+ * window by an hour would put the same event in both halves, and a duplicated
+ * row in a card is a visible wrong answer, while the cost of the check is a Set
+ * over at most twenty rows.
+ */
+export function mergeNewestEvents(
+  published: readonly Record<string, unknown>[],
+  head: readonly Record<string, unknown>[],
+  limit: number,
+): Record<string, unknown>[] {
+  const seen = new Set<string>();
+  const merged: Record<string, unknown>[] = [];
+  for (const row of [...head, ...published]) {
+    const id = `${String(row.block_number)}:${String(row.event_index)}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    merged.push(row);
+  }
+  merged.sort((a, b) => {
+    const [ao, ab, ae] = feedKey(a);
+    const [bo, bb, be] = feedKey(b);
+    return bo - ao || bb - ab || be - ae;
+  });
+  return merged.slice(0, limit);
+}
+
+/**
+ * Everything newer than the projection's edge, merged onto what it published.
+ *
+ * ONE BOUNDED QUERY, and the bound is not a guess: `observed_at >= floorMs`
+ * covers exactly the days the producer had not folded when it ran, which its
+ * own freshness ceiling holds to a small number. That is the difference from
+ * the walk this replaces, whose last step had no floor at all.
+ *
+ * A FAILED PROBE FAILS THE READ. Returning the published half alone would serve
+ * a feed that is silently missing the newest events -- the most visible rows on
+ * the card -- with nothing in the payload to say so.
+ */
+async function headProbe(
+  env: Env | null | undefined,
+  options: {
+    query: R2SqlReader;
+    where: string;
+    floorMs: number;
+    limit: number;
+    published: readonly Record<string, unknown>[];
+  },
+): Promise<Record<string, unknown>[] | null> {
+  const { query, where, floorMs, limit, published } = options;
+  const head = await query(
+    env,
+    `SELECT ${EVENT_COLUMNS} FROM chain.account_events WHERE ${where} ` +
+      `AND observed_at >= ${Math.trunc(floorMs)} ${FEED_ORDER} LIMIT ${limit}`,
+  );
+  if (!head) return null;
+  return mergeNewestEvents(published, head, limit);
+}
+
 export async function loadAccountSummaryColdTier(
   env: Env | null | undefined,
   ss58: string,
@@ -1060,11 +1144,13 @@ export async function loadAccountSummaryColdTier(
   // request, which is the read that aborts at the 15s ceiling. A sharded R2
   // artifact answers the identical question in one GET, and a miss returns null
   // so this arm simply does not run. It can make the route faster, never wrong.
-  const projected = await loadAccountSummaryProjection(env, ss58);
+  const projected = await loadAccountSummaryProjection(env, ss58, {
+    recentLimit: limit,
+  });
 
   const [groupRows, recentRows] = await Promise.all([
     projected
-      ? Promise.resolve(projected)
+      ? Promise.resolve(projected.groups)
       : windowedFloorRead<Record<string, unknown>[]>(env, {
           query,
           attempt: (bound, run) =>
@@ -1088,14 +1174,34 @@ export async function loadAccountSummaryColdTier(
             rows.reduce((n, row) => n + Number(row.count), 0) >
             ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
         }),
-    windowedRowRead<AccountEventsRow>(env, {
-      query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),
-      table: "chain.account_events",
-      columns: EVENT_COLUMNS,
-      where: [where],
-      order: ` ${FEED_ORDER}`,
-      need: limit,
-    }),
+    // THE FEED LEG, and the read that actually times this route out
+    // (#11222). `windowedRowRead` probes `now-2d` then `now-8d` and then reads
+    // the WHOLE remainder -- and 95.8% of accounts are past both probes, so
+    // for almost every request the third read is an unbounded scattered scan.
+    // Measured on production 2026-08-15: nine real accounts, three 503s at the
+    // 15s ceiling and a 10-19s spread across the rest.
+    //
+    // When the projection carries this account's newest events, the scan is
+    // replaced by ONE bounded probe of everything the producer had not folded
+    // yet. The two halves meet at the edge of the last complete day rather
+    // than overlapping or leaving a gap -- see `recentFloorMs` for why that
+    // edge is `through` and emphatically not `generated_at`.
+    projected?.recent && projected.floorMs !== null
+      ? headProbe(env, {
+          query: (e, sql) => query(e, sql, { onError: track("recent-head") }),
+          where,
+          floorMs: projected.floorMs,
+          limit,
+          published: projected.recent,
+        })
+      : windowedRowRead<AccountEventsRow>(env, {
+          query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),
+          table: "chain.account_events",
+          columns: EVENT_COLUMNS,
+          where: [where],
+          order: ` ${FEED_ORDER}`,
+          need: limit,
+        }),
   ]);
 
   // Either half missing is a decline: a card mixing measured aggregates with a

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -53,6 +53,7 @@ import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "./account-events.ts";
 import {
   AccountSummaryGroupsSchema,
   AccountSummaryPointerSchema,
+  AccountSummaryRecentSchema,
 } from "../schemas-src/artifacts/account-summary-projection.ts";
 
 /** Objects the producer writes, one per shard. Contract with
@@ -92,6 +93,47 @@ export function accountShard(account: string, shards: number): number {
     h = Math.imul(h, 0x01000193) >>> 0;
   }
   return h % shards;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The first millisecond of `observed_at` the projection does NOT describe.
+ *
+ * `through` is the last COMPLETE day the producer folded, so the recent list
+ * covers everything up to the end of that day and nothing after it. The head
+ * probe must start exactly there, and the arithmetic is the whole reason
+ * `through` is published rather than inferred.
+ *
+ * NOT `generated_at`, which is the trap. A run that folds through 2026-08-14
+ * and finishes at 2026-08-15T06:26Z has a `generated_at` SIX HOURS LATER than
+ * the data it describes -- so a probe floored at `generated_at` would skip
+ * every event between midnight and 06:26 and the card would silently lose them.
+ * The two halves have to meet at the data's edge, not at the run's.
+ *
+ * Returns null for anything not a plain `YYYY-MM-DD`. A pointer without a
+ * usable `through` cannot place the floor, and a floor that is a guess is worse
+ * than the lakehouse read it would replace.
+ */
+export function recentFloorMs(through: string | undefined): number | null {
+  if (!through || !/^\d{4}-\d{2}-\d{2}$/.test(through)) return null;
+  const midnight = Date.parse(`${through}T00:00:00.000Z`);
+  return Number.isFinite(midnight) ? midnight + DAY_MS : null;
+}
+
+/** What this reader answers with when the projection can serve the account. */
+export interface AccountSummaryProjectionRead {
+  /** The (kind, netuid) groups -- the card's aggregate leg. */
+  groups: Record<string, unknown>[];
+  /**
+   * The account's newest published events, newest first, or null when this
+   * generation carries no usable recent map for it. Null is not "no events" --
+   * it means the caller must read that leg from the lakehouse, exactly as it
+   * did before #575.
+   */
+  recent: Record<string, unknown>[] | null;
+  /** Where the head probe must start when `recent` is non-null. */
+  floorMs: number | null;
 }
 
 /** The R2 key holding this account's groups, within a generation. */
@@ -147,8 +189,19 @@ export async function loadAccountSummaryProjection(
   {
     now = Date.now,
     maxAgeMs = ACCOUNT_SUMMARY_MAX_AGE_MS,
-  }: { now?: () => number; maxAgeMs?: number } = {},
-): Promise<Record<string, unknown>[] | null> {
+    recentLimit = 0,
+  }: {
+    now?: () => number;
+    maxAgeMs?: number;
+    /**
+     * How many recent events the caller needs. The recent map is only offered
+     * when the pointer declares at least this many, so a producer publishing a
+     * shorter list declines that leg instead of serving a short feed. Zero --
+     * the default -- asks for the aggregate leg only.
+     */
+    recentLimit?: number;
+  } = {},
+): Promise<AccountSummaryProjectionRead | null> {
   const bucket = (env as { METAGRAPH_ARCHIVE?: ArtifactBucket } | null)
     ?.METAGRAPH_ARCHIVE;
   if (!bucket?.get || !account) return null;
@@ -223,5 +276,54 @@ export async function loadAccountSummaryProjection(
   // already paying.
   const scanned = groups.reduce((n, g) => n + Number(g.count), 0);
   if (scanned > ACCOUNT_EVENT_SUMMARY_SCAN_CAP) return null;
-  return groups;
+
+  return { groups, ...readRecent(payload, account, pointer, recentLimit) };
+}
+
+/**
+ * The account's published newest events, and where the head probe resumes.
+ *
+ * SEPARATE FROM THE GROUPS, and failing separately. A generation published
+ * before metagraphed-infra#575 carries no recent map at all, and one published
+ * after it may still not carry enough for this caller -- in both cases the
+ * AGGREGATE leg is perfectly good and only the feed leg goes back to the
+ * lakehouse. Folding the two decisions together would throw away the expensive
+ * half to fix the cheap one.
+ *
+ * A MALFORMED LIST DECLINES rather than being repaired. The same rule the
+ * groups follow, for the same reason: a card that is quietly short some events
+ * is confidently wrong, which costs more than being slow.
+ */
+function readRecent(
+  payload: Record<string, unknown>,
+  account: string,
+  pointer: { through?: string; recent_limit?: number },
+  need: number,
+): { recent: Record<string, unknown>[] | null; floorMs: number | null } {
+  const none = { recent: null, floorMs: null };
+  // Zero asks for the aggregate leg only, and `undefined` is a producer that
+  // publishes no recent map. Neither is a failure worth reading further for.
+  if (need <= 0) return none;
+  const published = pointer.recent_limit;
+  if (published === undefined || published < need) return none;
+
+  // The floor before the rows, because a list with nowhere to resume from is
+  // unusable: serving it without a probe would freeze the feed at the last
+  // complete day the producer folded.
+  const floorMs = recentFloorMs(pointer.through);
+  if (floorMs === null) return none;
+
+  const map = payload["recent"];
+  if (!map || typeof map !== "object") return none;
+  // An account absent from the map has no published events, which for an
+  // account that IS in the groups means the producer wrote a partial shard.
+  // Declining sends this leg to the lakehouse; it does not zero the feed.
+  const parsed = AccountSummaryRecentSchema.safeParse(
+    (map as Record<string, unknown>)[account],
+  );
+  if (!parsed.success || !parsed.data.length) return none;
+  return {
+    recent: parsed.data as unknown as Record<string, unknown>[],
+    floorMs,
+  };
 }

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -51,8 +51,10 @@
 
 import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "./account-events.ts";
 import {
+  type AccountSummaryRecentEvent,
   AccountSummaryGroupsSchema,
   AccountSummaryPointerSchema,
+  AccountSummaryRecentMapSchema,
   AccountSummaryRecentSchema,
 } from "../schemas-src/artifacts/account-summary-projection.ts";
 
@@ -130,8 +132,12 @@ export interface AccountSummaryProjectionRead {
    * generation carries no usable recent map for it. Null is not "no events" --
    * it means the caller must read that leg from the lakehouse, exactly as it
    * did before #575.
+   *
+   * THE PARSED TYPE, carried out of `safeParse` rather than widened back to a
+   * bag of unknowns. The rows go straight into the feed the card publishes, so
+   * the one place that knows their shape is the one that validated them.
    */
-  recent: Record<string, unknown>[] | null;
+  recent: AccountSummaryRecentEvent[] | null;
   /** Where the head probe must start when `recent` is non-null. */
   floorMs: number | null;
 }
@@ -299,7 +305,7 @@ function readRecent(
   account: string,
   pointer: { through?: string; recent_limit?: number },
   need: number,
-): { recent: Record<string, unknown>[] | null; floorMs: number | null } {
+): { recent: AccountSummaryRecentEvent[] | null; floorMs: number | null } {
   const none = { recent: null, floorMs: null };
   // Zero asks for the aggregate leg only, and `undefined` is a producer that
   // publishes no recent map. Neither is a failure worth reading further for.
@@ -313,17 +319,16 @@ function readRecent(
   const floorMs = recentFloorMs(pointer.through);
   if (floorMs === null) return none;
 
-  const map = payload["recent"];
-  if (!map || typeof map !== "object") return none;
+  // PARSED, not indexed. `.record()` is the map's own declaration -- the
+  // producer keys it by ss58 and the reader wants one of them -- so a body
+  // that is a string, a number or an array is refused here rather than being
+  // indexed into and read as "this account has no events".
+  const map = AccountSummaryRecentMapSchema.safeParse(payload["recent"]);
+  if (!map.success) return none;
   // An account absent from the map has no published events, which for an
   // account that IS in the groups means the producer wrote a partial shard.
   // Declining sends this leg to the lakehouse; it does not zero the feed.
-  const parsed = AccountSummaryRecentSchema.safeParse(
-    (map as Record<string, unknown>)[account],
-  );
+  const parsed = AccountSummaryRecentSchema.safeParse(map.data[account]);
   if (!parsed.success || !parsed.data.length) return none;
-  return {
-    recent: parsed.data as unknown as Record<string, unknown>[],
-    floorMs,
-  };
+  return { recent: parsed.data, floorMs };
 }

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -21,6 +21,7 @@ import { describe, test } from "vitest";
 import {
   foldSummaryGroups,
   loadAccountSummaryColdTier,
+  mergeNewestEvents,
 } from "../src/account-feeds-cold-tier.ts";
 import {
   ACCOUNT_EVENT_SUMMARY_SCAN_CAP,
@@ -788,5 +789,225 @@ describe("the projection short-circuits the aggregate leg (#11131)", () => {
     const card = buildAccountSummary(SS58, cold as never);
     assert.equal(card.event_count, 6);
     assert.equal(card.event_scan_capped, false);
+  });
+});
+
+describe("the projection short-circuits the FEED leg too (#11222)", () => {
+  const GEN = "20260814T100000Z";
+  const SHARDS = 16384;
+  const SHARD_KEY = accountSummaryShardKey(SS58, SHARDS, GEN);
+  const THROUGH = "2026-08-13";
+  const FLOOR = Date.parse("2026-08-14T00:00:00.000Z");
+
+  /** One published event, in the lakehouse table's column names. */
+  function event(over: Row = {}): Row {
+    return {
+      block_number: 8_700_000,
+      event_index: 0,
+      extrinsic_index: null,
+      event_kind: "AxonServed",
+      hotkey: SS58,
+      coldkey: null,
+      netuid: 55,
+      uid: 1,
+      amount_tao: null,
+      alpha_amount: null,
+      observed_at: Date.parse("2026-08-13T09:00:00Z"),
+      ...over,
+    };
+  }
+
+  /** An archive holding this account's groups AND its published newest events. */
+  function archive(recent: Row[] | null, { limit = 10 } = {}) {
+    const stamp = new Date().toISOString();
+    return {
+      METAGRAPH_ARCHIVE: {
+        get: async (key: string) => {
+          if (key === ACCOUNT_SUMMARY_POINTER_KEY) {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                generation: GEN,
+                shard_count: SHARDS,
+                generated_at: stamp,
+                account_count: 1,
+                through: THROUGH,
+                ...(recent ? { recent_limit: limit } : {}),
+              }),
+            };
+          }
+          if (key === SHARD_KEY) {
+            return {
+              json: async () => ({
+                schema_version: 1,
+                accounts: { [SS58]: groupsSummingTo(6) },
+                ...(recent ? { recent: { [SS58]: recent } } : {}),
+              }),
+            };
+          }
+          return null;
+        },
+      },
+    } as never;
+  }
+
+  test("THE UNBOUNDED SCAN IS REPLACED BY ONE FLOORED PROBE", async () => {
+    // The read that times this route out. `windowedRowRead`'s last step has no
+    // floor at all, and 95.8% of accounts reach it -- measured on production
+    // 2026-08-15, three of nine real accounts 503'd at the 15s ceiling and the
+    // rest took 10-19s.
+    const engine = fakeEngine({ recent: [] });
+    const cold = await loadAccountSummaryColdTier(archive([event()]), SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(cold.declined, undefined);
+    const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
+    assert.equal(feed.length, 1, "one probe, not a walk");
+    assert.match(feed[0]!, new RegExp(`observed_at >= ${FLOOR}\\b`));
+    // And no read may be issued without that floor -- an unfloored SELECT here
+    // is the whole defect coming back.
+    for (const sql of feed) {
+      assert.match(
+        sql,
+        /observed_at >= /,
+        `unfloored read: ${sql.slice(0, 90)}`,
+      );
+    }
+  });
+
+  test("the floor is the END of `through`, not the pointer's clock", async () => {
+    // `generated_at` is the run's stamp and sits HOURS after the data it
+    // describes -- six, on the generation measured 2026-08-15. Flooring there
+    // would drop every event between midnight and the run from the card.
+    const engine = fakeEngine({ recent: [] });
+    await loadAccountSummaryColdTier(archive([event()]), SS58, {
+      query: engine.query as never,
+    });
+    const probe = engine.seen.find((s) => !s.includes("GROUP BY"))!;
+    assert.match(probe, new RegExp(`observed_at >= ${FLOOR}\\b`));
+    assert.ok(FLOOR > Date.parse(THROUGH), "the floor is past the day named");
+  });
+
+  test("the probe's rows come FIRST, and the published ones fill the page", async () => {
+    // The merge is what makes the two halves one feed. A newer event landing
+    // after the generation must outrank everything published, or the card
+    // freezes at the last day the producer folded.
+    const newer = event({
+      block_number: 8_900_000,
+      event_index: 3,
+      observed_at: Date.parse("2026-08-14T06:00:00Z"),
+    });
+    const engine = fakeEngine({ recent: [newer] });
+    const cold = await loadAccountSummaryColdTier(
+      archive([event(), event({ block_number: 8_690_000, event_index: 9 })]),
+      SS58,
+      { query: engine.query as never },
+    );
+    const recent = (cold as { recent: Row[] }).recent;
+    assert.deepEqual(
+      recent.map((r) => r.block_number),
+      [8_900_000, 8_700_000, 8_690_000],
+    );
+  });
+
+  test("A FAILED PROBE DECLINES -- it does not serve the published half alone", async () => {
+    // Serving what the projection had would publish a feed silently missing
+    // the newest events, which are the most visible rows on the card, with
+    // nothing in the payload to say so.
+    const engine = fakeEngine({ recent: null });
+    const cold = await loadAccountSummaryColdTier(archive([event()]), SS58, {
+      query: engine.query as never,
+    });
+    assert.ok(cold.declined, "a failed head probe declines the read");
+    assert.ok(
+      cold.declined!.some((r) => r.startsWith("recent-head:")),
+      `the leg names itself: ${JSON.stringify(cold.declined)}`,
+    );
+  });
+
+  test("no published recent list falls back to the walk, unchanged", async () => {
+    // Every generation before metagraphed-infra#575 lands here, and the route
+    // must behave exactly as it did -- the aggregate leg still short-circuits.
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier(archive(null), SS58, {
+      query: engine.query as never,
+    });
+    assert.equal(cold.declined, undefined);
+    const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
+    assert.ok(feed.length >= 1);
+    assert.equal(
+      feed.some((s) => s.includes(`observed_at >= ${FLOOR}`)),
+      false,
+      "no floor is placed without a published list to meet it",
+    );
+  });
+
+  test("a published limit under the caller's need falls back too", async () => {
+    const engine = fakeEngine();
+    const cold = await loadAccountSummaryColdTier(
+      archive([event()], { limit: ACCOUNT_SUMMARY_RECENT_LIMIT - 1 }),
+      SS58,
+      { query: engine.query as never },
+    );
+    assert.equal(cold.declined, undefined);
+    const feed = engine.seen.filter((s) => !s.includes("GROUP BY"));
+    assert.equal(
+      feed.some((s) => s.includes(`observed_at >= ${FLOOR}`)),
+      false,
+    );
+  });
+});
+
+describe("mergeNewestEvents", () => {
+  const row = (observed_at: number, block_number: number, event_index = 0) => ({
+    observed_at,
+    block_number,
+    event_index,
+  });
+
+  test("orders on all THREE feed columns, in FEED_ORDER's precedence", () => {
+    // Sorting on observed_at alone would reorder events inside a block, and
+    // the cursor token the Postgres tier issues encodes the whole triple.
+    const merged = mergeNewestEvents(
+      [row(100, 5, 0), row(100, 5, 1), row(100, 6, 0), row(99, 9, 9)],
+      [],
+      10,
+    );
+    assert.deepEqual(
+      merged.map((r) => [r.observed_at, r.block_number, r.event_index]),
+      [
+        [100, 6, 0],
+        [100, 5, 1],
+        [100, 5, 0],
+        [99, 9, 9],
+      ],
+    );
+  });
+
+  test("de-duplicates on the pair that IDENTIFIES an event", () => {
+    // Disjointness is the producer's property, asserted across a repository
+    // boundary. A producer that widened its window by an hour would put the
+    // same event in both halves, and a duplicated row in a card is a visible
+    // wrong answer.
+    const merged = mergeNewestEvents([row(100, 5, 0)], [row(100, 5, 0)], 10);
+    assert.equal(merged.length, 1);
+  });
+
+  test("the page is cut to the limit, newest kept", () => {
+    const merged = mergeNewestEvents(
+      [row(1, 1), row(2, 2), row(3, 3)],
+      [row(4, 4)],
+      2,
+    );
+    assert.deepEqual(
+      merged.map((r) => r.block_number),
+      [4, 3],
+    );
+  });
+
+  test("either half may be empty", () => {
+    assert.deepEqual(mergeNewestEvents([], [], 10), []);
+    assert.equal(mergeNewestEvents([row(1, 1)], [], 10).length, 1);
+    assert.equal(mergeNewestEvents([], [row(1, 1)], 10).length, 1);
   });
 });

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -8,7 +8,11 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import { ACCOUNT_EVENT_SUMMARY_SCAN_CAP } from "../src/account-events.ts";
-import { AccountSummaryPointerSchema } from "../schemas-src/artifacts/account-summary-projection.ts";
+import {
+  AccountSummaryPointerSchema,
+  AccountSummaryRecentEventSchema,
+} from "../schemas-src/artifacts/account-summary-projection.ts";
+import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import {
   ACCOUNT_SUMMARY_MAX_AGE_MS,
   ACCOUNT_SUMMARY_POINTER_KEY,
@@ -16,6 +20,7 @@ import {
   accountShard,
   accountSummaryShardKey,
   loadAccountSummaryProjection,
+  recentFloorMs,
 } from "../src/account-summary-projection.ts";
 
 const HOT = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
@@ -113,17 +118,23 @@ describe("loadAccountSummaryProjection", () => {
       ACCOUNT_SUMMARY_POINTER_KEY,
       accountSummaryShardKey(HOT, SHARDS, GEN),
     ]);
-    assert.deepEqual(groups, [
-      {
-        kind: "AxonServed",
-        netuid: 7,
-        count: 3,
-        fb: 10,
-        lb: 90,
-        fo: 1000,
-        lo: 9000,
-      },
-    ]);
+    assert.deepEqual(groups, {
+      groups: [
+        {
+          kind: "AxonServed",
+          netuid: 7,
+          count: 3,
+          fb: 10,
+          lb: 90,
+          fo: 1000,
+          lo: 9000,
+        },
+      ],
+      // No `recentLimit` asked for, so the feed leg is not read at all -- the
+      // aggregate leg is what every caller before #575 wanted and still gets.
+      recent: null,
+      floorMs: null,
+    });
   });
 
   test("THE FAN-OUT COMES FROM THE POINTER, not a compiled constant", async () => {
@@ -138,7 +149,7 @@ describe("loadAccountSummaryProjection", () => {
       },
     });
     const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
-    assert.equal(groups!.length, 1);
+    assert.equal(groups!.groups.length, 1);
   });
 
   test("A HALF-PUBLISHED GENERATION IS INVISIBLE", async () => {
@@ -154,7 +165,11 @@ describe("loadAccountSummaryProjection", () => {
       },
     });
     const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
-    assert.equal(groups![0]!.count, 1, "must read the pointed-at generation");
+    assert.equal(
+      groups!.groups[0]!.count,
+      1,
+      "must read the pointed-at generation",
+    );
   });
 
   test("no pointer means no answer", async () => {
@@ -301,17 +316,21 @@ describe("loadAccountSummaryProjection", () => {
     );
     assert.deepEqual(
       await loadAccountSummaryProjection(store.env, HOT, FRESH),
-      [
-        {
-          kind: "Transfer",
-          netuid: null,
-          count: 2,
-          fb: null,
-          lb: null,
-          fo: null,
-          lo: null,
-        },
-      ],
+      {
+        recent: null,
+        floorMs: null,
+        groups: [
+          {
+            kind: "Transfer",
+            netuid: null,
+            count: 2,
+            fb: null,
+            lb: null,
+            fo: null,
+            lo: null,
+          },
+        ],
+      },
     );
   });
 
@@ -389,7 +408,7 @@ describe("loadAccountSummaryProjection", () => {
     const atCap = [group({ count: ACCOUNT_EVENT_SUMMARY_SCAN_CAP })];
     const store = archive(published({ [HOT]: atCap }));
     const groups = await loadAccountSummaryProjection(store.env, HOT, FRESH);
-    assert.equal(groups!.length, 1);
+    assert.equal(groups!.groups.length, 1);
   });
 
   test("an account present with no usable groups declines", async () => {
@@ -476,6 +495,214 @@ describe("the pointer is PARSED, not indexed (metagraphed-infra#580)", () => {
     assert.equal(
       await loadAccountSummaryProjection(store.env, HOT, FRESH),
       null,
+    );
+  });
+});
+
+// --- the feed leg (metagraphed-infra#575) ------------------------------------
+
+/** One published event, in the producer's column names. */
+function event(over: Record<string, unknown> = {}) {
+  return {
+    block_number: 900,
+    event_index: 1,
+    extrinsic_index: 2,
+    event_kind: "AxonServed",
+    hotkey: HOT,
+    coldkey: COLD,
+    netuid: 7,
+    uid: 3,
+    amount_tao: null,
+    alpha_amount: null,
+    observed_at: Date.parse("2026-08-13T12:00:00Z"),
+    ...over,
+  };
+}
+
+/** A generation that carries a recent map, with the pointer fields #575 adds. */
+function withRecent(
+  recent: Record<string, unknown>,
+  { over = {}, limit = 10 as number | undefined } = {},
+) {
+  const objects = published(
+    { [HOT]: [group()] },
+    {
+      through: "2026-08-13",
+      ...(limit === undefined ? {} : { recent_limit: limit }),
+      ...over,
+    },
+  ) as Record<string, Record<string, unknown>>;
+  objects[accountSummaryShardKey(HOT, SHARDS, GEN)]!.recent = recent;
+  return objects;
+}
+
+describe("recentFloorMs", () => {
+  test("the floor is the END of the last complete day, not the run's clock", () => {
+    // THE ARITHMETIC THE WHOLE MERGE RESTS ON. `through` names a complete day,
+    // so the projection describes up to its last millisecond and the probe
+    // must start at the next one. Anchoring on `generated_at` instead would
+    // skip every event between midnight and the run -- six hours on the
+    // generation measured 2026-08-15.
+    assert.equal(
+      recentFloorMs("2026-08-13"),
+      Date.parse("2026-08-14T00:00:00.000Z"),
+    );
+  });
+
+  test("anything that is not a plain calendar day places no floor", () => {
+    // A floor that is a guess is worse than the lakehouse read it replaces, so
+    // every one of these declines the leg rather than approximating it.
+    for (const bad of [
+      undefined,
+      "",
+      "2026-08",
+      "2026-8-13",
+      "2026-08-13T00:00:00Z",
+      "yesterday",
+      "0000-00-00",
+    ]) {
+      assert.equal(recentFloorMs(bad), null, String(bad));
+    }
+  });
+});
+
+describe("the projection's recent map", () => {
+  test("is returned with the floor the probe resumes from", async () => {
+    const store = archive(withRecent({ [HOT]: [event()] }));
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.deepEqual(read!.recent, [event()]);
+    assert.equal(read!.floorMs, Date.parse("2026-08-14T00:00:00.000Z"));
+    // The aggregate leg is unaffected by any of this.
+    assert.equal(read!.groups.length, 1);
+  });
+
+  test("A SHORTER PUBLISHED LIMIT DECLINES, rather than serving a short feed", async () => {
+    // The reason the N travels in the pointer at all. The producer is in
+    // another repository, so a reader that assumed the published N matched its
+    // own would serve nine events as though they were the newest ten, with
+    // nothing on the card to say the tenth was never published.
+    const store = archive(withRecent({ [HOT]: [event()] }, { limit: 9 }));
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.equal(read!.recent, null);
+    assert.equal(read!.groups.length, 1, "the aggregate leg still answers");
+  });
+
+  test("an equal published limit is enough", async () => {
+    // The boundary the test above brackets: >= is the rule, not >.
+    const store = archive(withRecent({ [HOT]: [event()] }, { limit: 10 }));
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.deepEqual(read!.recent, [event()]);
+  });
+
+  test("a generation published before #575 declines the leg alone", async () => {
+    // Every generation written before the producer change has no recent map
+    // and no `recent_limit`, and those pointers stay perfectly good for the
+    // expensive half. Failing both would throw away the aggregate saving to
+    // fix the feed.
+    const store = archive(
+      published({ [HOT]: [group()] }, { through: "2026-08-13" }),
+    );
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.equal(read!.recent, null);
+    assert.equal(read!.floorMs, null);
+    assert.equal(read!.groups.length, 1);
+  });
+
+  test("no `through` means no floor, so the list is refused", async () => {
+    // A recent list with nowhere to resume from would freeze the feed at the
+    // last day the producer folded -- the card would stop updating and look
+    // exactly like a quiet account.
+    const store = archive(
+      withRecent({ [HOT]: [event()] }, { over: { through: undefined } }),
+    );
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.equal(read!.recent, null);
+  });
+
+  test("a malformed row declines the whole list", async () => {
+    // The same rule the groups follow: a card quietly short some events is
+    // confidently wrong, which costs more than being slow. Note the row is
+    // WELL-FORMED apart from one field -- a shape check that only looked at
+    // the array would pass it.
+    const store = archive(
+      withRecent({ [HOT]: [event(), event({ block_number: null })] }),
+    );
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.equal(read!.recent, null);
+  });
+
+  test("an undeclared column declines the list", async () => {
+    // `.strict()` is doing work here: a producer that added a column would
+    // otherwise have it silently dropped from every card, and the divergence
+    // would only show up as a field the API stopped serving.
+    const store = archive(withRecent({ [HOT]: [{ ...event(), surprise: 1 }] }));
+    const read = await loadAccountSummaryProjection(store.env, HOT, {
+      ...FRESH,
+      recentLimit: 10,
+    });
+    assert.equal(read!.recent, null);
+  });
+
+  test("an account absent from the map, or empty in it, declines", async () => {
+    for (const map of [{}, { [HOT]: [] }, { [COLD]: [event()] }]) {
+      const store = archive(withRecent(map));
+      const read = await loadAccountSummaryProjection(store.env, HOT, {
+        ...FRESH,
+        recentLimit: 10,
+      });
+      assert.equal(read!.recent, null, JSON.stringify(map));
+    }
+  });
+
+  test("a non-object recent map is refused rather than indexed", async () => {
+    for (const map of ["nope", 7, null] as unknown[]) {
+      const store = archive(withRecent(map as Record<string, unknown>));
+      const read = await loadAccountSummaryProjection(store.env, HOT, {
+        ...FRESH,
+        recentLimit: 10,
+      });
+      assert.equal(read!.recent, null, String(map));
+    }
+  });
+
+  test("asking for no recent events reads no recent map at all", async () => {
+    // The default. Every caller before #575 wants the aggregate leg only, and
+    // must not start paying to parse a list it will not use.
+    const store = archive(withRecent({ [HOT]: [event()] }));
+    const read = await loadAccountSummaryProjection(store.env, HOT, FRESH);
+    assert.equal(read!.recent, null);
+    assert.equal(read!.floorMs, null);
+  });
+});
+
+describe("AccountSummaryRecentEventSchema", () => {
+  test("ITS KEYS ARE THE LAKEHOUSE TABLE'S, exactly", () => {
+    // The reader merges these rows with rows selected straight out of
+    // `chain.account_events`, into one feed. A column added to the table and
+    // not to this schema would be dropped from the projection's half only --
+    // half a card carrying a field the other half does not. Pinned against the
+    // GENERATED list so the table is the thing that has to change first.
+    assert.deepEqual(
+      Object.keys(AccountSummaryRecentEventSchema.shape).sort(),
+      [...ACCOUNT_EVENTS_COLUMNS].sort(),
     );
   });
 });


### PR DESCRIPTION
Measured on production 2026-08-15, nine real accounts through
`/api/v1/accounts/{ss58}`:

    503 15.5s   503 15.3s   503 17.7s
    200 19.2s   200 12.3s   200 11.2s   200 10.6s   200 10.0s   200 4.2s

A third of requests fail outright at the 15s ceiling. #11131 bounded the feeds
and #11203 moved the AGGREGATE leg onto the sharded projection; the card's other
leg was never bounded. `windowedRowRead` probes `now-2d`, then `now-8d`, and
past that reads the whole remainder with no floor at all -- and 95.8% of
accounts are past both probes, so for almost every request the third read is an
unbounded scattered scan of `chain.account_events`.

No window the READER can guess fixes it. #11222 measured a fixed window around
the account's known newest event at 6.7x cheaper and returning 3 of the 100 rows
asked for, because the projection knows where an account's events are and not
how they are spread. So the producer publishes them
(metagraphed-infra#575) and this side stops scanning for them.

THE TWO HALVES MEET AT `through`, NOT AT `generated_at`, and that is the whole
correctness argument. `through` is the last COMPLETE day the producer folded, so
the published list describes everything up to its last millisecond; the probe
floors at the next one. `generated_at` is the RUN's stamp and sits hours later
-- six, on the generation measured 2026-08-15 -- so flooring there would drop
every event between midnight and the run from the card, silently. Both are
pinned, and the arithmetic fails under mutation.

Everything about this degrades to today's behaviour rather than to a wrong
answer. A generation published before #575 carries no recent map, a pointer may
declare a shorter `recent_limit` than the caller needs, a `through` may be
missing or unparseable, a row may be malformed -- each returns null for that leg
ALONE and the walk runs exactly as it does now, while the expensive aggregate
leg keeps short-circuiting. A failed head probe declines rather than serving the
published half, because a feed quietly missing its newest rows is the one
outcome worse than a slow one.

`recent_limit` travels in the pointer for the same reason `shard_count` does:
the producer is in another repository, so a reader that assumed the published N
matched `ACCOUNT_SUMMARY_RECENT_LIMIT` would serve a short feed the moment the
two diverged, and no CI here could see it.

The event schema's keys are pinned against the generated `ACCOUNT_EVENTS_COLUMNS`,
so a column added to the lakehouse table fails here rather than being dropped
from the projection's half of a merged feed.

Ships before the producer by necessity: `AccountSummaryPointerSchema` is
`.strict()`, so a pointer carrying `recent_limit` would be REFUSED by the
deployed reader and take the aggregate leg down with it.