### PR TITLE
refactor(accounts): pair the published events with their floor, so the guard cannot be unreachable

### DIFF
--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -1186,13 +1186,13 @@ export async function loadAccountSummaryColdTier(
     // yet. The two halves meet at the edge of the last complete day rather
     // than overlapping or leaving a gap -- see `recentFloorMs` for why that
     // edge is `through` and emphatically not `generated_at`.
-    projected?.recent && projected.floorMs !== null
+    projected?.recent
       ? headProbe(env, {
           query: (e, sql) => query(e, sql, { onError: track("recent-head") }),
           where,
-          floorMs: projected.floorMs,
+          floorMs: projected.recent.floorMs,
           limit,
-          published: projected.recent,
+          published: projected.recent.rows,
         })
       : windowedRowRead<AccountEventsRow>(env, {
           query: (e, sql) => query(e, sql, { onError: track("recent-feed") }),

--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -128,18 +128,23 @@ export interface AccountSummaryProjectionRead {
   /** The (kind, netuid) groups -- the card's aggregate leg. */
   groups: Record<string, unknown>[];
   /**
-   * The account's newest published events, newest first, or null when this
-   * generation carries no usable recent map for it. Null is not "no events" --
-   * it means the caller must read that leg from the lakehouse, exactly as it
-   * did before #575.
+   * The account's newest published events and where the probe resumes, or null
+   * when this generation carries no usable recent map for it. Null is not "no
+   * events" -- it means the caller reads that leg from the lakehouse, exactly
+   * as it did before #575.
    *
-   * THE PARSED TYPE, carried out of `safeParse` rather than widened back to a
-   * bag of unknowns. The rows go straight into the feed the card publishes, so
-   * the one place that knows their shape is the one that validated them.
+   * ONE OBJECT, NOT TWO FIELDS, and that is the point. The rows are unusable
+   * without the floor -- serving them alone would freeze the feed at the last
+   * complete day the producer folded -- so a shape that let one exist without
+   * the other put an invariant in the caller's hands and left it with a guard
+   * no test could ever fail. Here the type carries it.
+   *
+   * THE PARSED ROW TYPE, carried out of `safeParse` rather than widened back
+   * to a bag of unknowns. The rows go straight into the feed the card
+   * publishes, so the one place that knows their shape is the one that
+   * validated them.
    */
-  recent: AccountSummaryRecentEvent[] | null;
-  /** Where the head probe must start when `recent` is non-null. */
-  floorMs: number | null;
+  recent: { rows: AccountSummaryRecentEvent[]; floorMs: number } | null;
 }
 
 /** The R2 key holding this account's groups, within a generation. */
@@ -305,8 +310,8 @@ function readRecent(
   account: string,
   pointer: { through?: string; recent_limit?: number },
   need: number,
-): { recent: AccountSummaryRecentEvent[] | null; floorMs: number | null } {
-  const none = { recent: null, floorMs: null };
+): Pick<AccountSummaryProjectionRead, "recent"> {
+  const none = { recent: null };
   // Zero asks for the aggregate leg only, and `undefined` is a producer that
   // publishes no recent map. Neither is a failure worth reading further for.
   if (need <= 0) return none;
@@ -330,5 +335,5 @@ function readRecent(
   // Declining sends this leg to the lakehouse; it does not zero the feed.
   const parsed = AccountSummaryRecentSchema.safeParse(map.data[account]);
   if (!parsed.success || !parsed.data.length) return none;
-  return { recent: parsed.data, floorMs };
+  return { recent: { rows: parsed.data, floorMs } };
 }

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -1005,6 +1005,39 @@ describe("mergeNewestEvents", () => {
     );
   });
 
+  test("a row missing a sort column sorts LAST, and does not crash", () => {
+    // REACHABLE, which is why the fallback is here rather than deleted. The
+    // published half is parsed and cannot carry a null in these three, but the
+    // head probe's half comes untyped out of R2 SQL and every one of those
+    // columns is nullable on `chain.account_events`. A missing key must not
+    // throw and must not sort ABOVE a real event -- the card's top row is the
+    // most visible thing on it.
+    const merged = mergeNewestEvents(
+      [{ observed_at: 50, block_number: 1, event_index: 3 }],
+      [
+        // One row per nullable sort column, each with an identity of its own so
+        // the de-duplication does not fold them together first.
+        { block_number: 1, event_index: 0 },
+        { observed_at: 100, event_index: 2 },
+        { observed_at: 100, block_number: 9 },
+      ],
+      4,
+    );
+    assert.deepEqual(
+      merged.map((r) => [
+        r.observed_at ?? null,
+        r.block_number ?? null,
+        r.event_index ?? null,
+      ]),
+      [
+        [100, 9, null],
+        [100, null, 2],
+        [50, 1, 3],
+        [null, 1, 0],
+      ],
+    );
+  });
+
   test("either half may be empty", () => {
     assert.deepEqual(mergeNewestEvents([], [], 10), []);
     assert.equal(mergeNewestEvents([row(1, 1)], [], 10).length, 1);

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -133,7 +133,6 @@ describe("loadAccountSummaryProjection", () => {
       // No `recentLimit` asked for, so the feed leg is not read at all -- the
       // aggregate leg is what every caller before #575 wanted and still gets.
       recent: null,
-      floorMs: null,
     });
   });
 
@@ -318,7 +317,6 @@ describe("loadAccountSummaryProjection", () => {
       await loadAccountSummaryProjection(store.env, HOT, FRESH),
       {
         recent: null,
-        floorMs: null,
         groups: [
           {
             kind: "Transfer",
@@ -573,8 +571,8 @@ describe("the projection's recent map", () => {
       ...FRESH,
       recentLimit: 10,
     });
-    assert.deepEqual(read!.recent, [event()]);
-    assert.equal(read!.floorMs, Date.parse("2026-08-14T00:00:00.000Z"));
+    assert.deepEqual(read!.recent!.rows, [event()]);
+    assert.equal(read!.recent!.floorMs, Date.parse("2026-08-14T00:00:00.000Z"));
     // The aggregate leg is unaffected by any of this.
     assert.equal(read!.groups.length, 1);
   });
@@ -600,7 +598,7 @@ describe("the projection's recent map", () => {
       ...FRESH,
       recentLimit: 10,
     });
-    assert.deepEqual(read!.recent, [event()]);
+    assert.deepEqual(read!.recent!.rows, [event()]);
   });
 
   test("a generation published before #575 declines the leg alone", async () => {
@@ -616,7 +614,6 @@ describe("the projection's recent map", () => {
       recentLimit: 10,
     });
     assert.equal(read!.recent, null);
-    assert.equal(read!.floorMs, null);
     assert.equal(read!.groups.length, 1);
   });
 
@@ -689,7 +686,6 @@ describe("the projection's recent map", () => {
     const store = archive(withRecent({ [HOT]: [event()] }));
     const read = await loadAccountSummaryProjection(store.env, HOT, FRESH);
     assert.equal(read!.recent, null);
-    assert.equal(read!.floorMs, null);
   });
 });
 


### PR DESCRIPTION
Three follow-ups to #11283, all found by codecov/patch failing on it.

THE PAIR IS NOW ONE OBJECT. `recent` and `floorMs` were separate fields that
had to agree: the rows are unusable without the floor -- serving them alone
freezes the feed at the last complete day the producer folded -- so the reader
guarded `projected?.recent && projected.floorMs !== null`. The loader can never
return one without the other, which made that second clause a branch no test
could reach, and codecov counted it exactly right. An unreachable guard is not
safety. `recent: { rows, floorMs } | null` puts the invariant in the type and
the guard disappears rather than being tested around.

THE NULLABLE SORT COLUMNS ARE COVERED, and they are genuinely reachable, which
is why the `?? 0` fallbacks stay. The published half is parsed and cannot carry
a null in `observed_at`, `block_number` or `event_index`; the head probe's half
comes untyped out of R2 SQL, where all three are nullable on
`chain.account_events`. The test asserts what the fallback DOES -- a row missing
a sort column sorts last, never above a real event, since the card's top row is
the most visible thing on it.

Writing that test surfaced a second thing worth knowing: two rows that both lack
`block_number` AND `event_index` share a de-duplication key and collapse into
one. That is correct -- rows with no identity are indistinguishable -- but it
means the fixture has to give each row an identity of its own or the test
silently checks three rows instead of four, which is how the first draft of it
passed for the wrong reason.