### PR TITLE
fix(seo): 129 breadcrumb links pointed at 404s

### DIFF
--- a/apps/ui/content/docs/playbooks/index.mdx
+++ b/apps/ui/content/docs/playbooks/index.mdx
@@ -1,0 +1,17 @@
+---
+title: Playbooks
+description: Task-shaped walkthroughs — pick a subnet for an app, evaluate one before staking, monitor a validator, or audit an account — each with a real executed transcript.
+---
+
+Each playbook answers one question end to end, using the MCP tools or the REST API,
+and shows a real executed transcript rather than an idealised one — including where
+the first answer needed verifying.
+
+- [Find a subnet for my app](/docs/playbooks/find-a-subnet-for-my-app) — a
+  plain-language task to candidate subnets, then to calling code.
+- [Evaluate a subnet before staking](/docs/playbooks/evaluate-a-subnet-before-staking)
+  — what to check, and what the numbers do and do not tell you.
+- [Monitor my validator](/docs/playbooks/monitor-my-validator) — the surfaces that
+  say whether a validator is healthy and earning.
+- [Audit an account history](/docs/playbooks/audit-an-account-history) — reconstruct
+  what one SS58 address has done on-chain.

--- a/apps/ui/content/docs/playbooks/meta.json
+++ b/apps/ui/content/docs/playbooks/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Playbooks",
   "pages": [
+    "index",
     "evaluate-a-subnet-before-staking",
     "monitor-my-validator",
     "find-a-subnet-for-my-app",

--- a/apps/ui/content/docs/protocol/index.mdx
+++ b/apps/ui/content/docs/protocol/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Protocol
+description: How Bittensor actually works underneath the registry — stake weighting, UID registration and permits, weight setting, proxies, and root delegation.
+---
+
+The chain mechanics the rest of these docs assume. Each page explains one part of
+Bittensor's protocol as it behaves today, with the on-chain fields and thresholds
+named so a claim here can be checked against the API.
+
+- [Stake weight](/docs/protocol/stake-weight) — the two-component formula, and why
+  root TAO counts differently from subnet Alpha.
+- [Registration and permits](/docs/protocol/registration-and-permits) — what a UID
+  costs, and why holding a validator permit is a different thing entirely.
+- [Weight setting and rewards](/docs/protocol/weight-setting-and-rewards) — how
+  validators score miners and how that becomes emission.
+- [Proxies](/docs/protocol/proxies) — delegating scoped, revocable authority to
+  another key without a multisig ceremony per action.
+- [Root delegation](/docs/protocol/root-delegation) — how `set_children` backs child
+  hotkeys across many subnets at once.

--- a/apps/ui/content/docs/protocol/meta.json
+++ b/apps/ui/content/docs/protocol/meta.json
@@ -1,6 +1,7 @@
 {
   "title": "Protocol",
   "pages": [
+    "index",
     "stake-weight",
     "registration-and-permits",
     "weight-setting-and-rewards",

--- a/apps/ui/content/news/sn1/index.mdx
+++ b/apps/ui/content/news/sn1/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 1 — weekly digests"
+description: "Every published weekly digest for subnet 1 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 1, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn1/2026-w26) — 4 sources
+
+[Subnet 1 overview](/subnets/1)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn10/index.mdx
+++ b/apps/ui/content/news/sn10/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 10 — weekly digests"
+description: "Every published weekly digest for subnet 10 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 10, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn10/2026-w26) — 4 sources
+
+[Subnet 10 overview](/subnets/10)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn100/index.mdx
+++ b/apps/ui/content/news/sn100/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 100 — weekly digests"
+description: "Every published weekly digest for subnet 100 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 100, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn100/2026-w26) — 5 sources
+
+[Subnet 100 overview](/subnets/100)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn101/index.mdx
+++ b/apps/ui/content/news/sn101/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 101 — weekly digests"
+description: "Every published weekly digest for subnet 101 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 101, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn101/2026-w25) — 9 sources
+
+[Subnet 101 overview](/subnets/101)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn102/index.mdx
+++ b/apps/ui/content/news/sn102/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 102 — weekly digests"
+description: "Every published weekly digest for subnet 102 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 102, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn102/2026-w25) — 5 sources
+
+[Subnet 102 overview](/subnets/102)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn103/index.mdx
+++ b/apps/ui/content/news/sn103/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 103 — weekly digests"
+description: "Every published weekly digest for subnet 103 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 103, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn103/2026-w32) — 6 sources
+- [2026-W21](/news/sn103/2026-w21) — 4 sources
+
+[Subnet 103 overview](/subnets/103)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn104/index.mdx
+++ b/apps/ui/content/news/sn104/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 104 — weekly digests"
+description: "Every published weekly digest for subnet 104 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 104, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W29](/news/sn104/2026-w29) — 3 sources
+- [2026-W28](/news/sn104/2026-w28) — 5 sources
+
+[Subnet 104 overview](/subnets/104)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn105/index.mdx
+++ b/apps/ui/content/news/sn105/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 105 — weekly digests"
+description: "Every published weekly digest for subnet 105 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 105, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W21](/news/sn105/2026-w21) — 4 sources
+
+[Subnet 105 overview](/subnets/105)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn106/index.mdx
+++ b/apps/ui/content/news/sn106/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 106 — weekly digests"
+description: "Every published weekly digest for subnet 106 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 106, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W27](/news/sn106/2026-w27) — 3 sources
+- [2026-W26](/news/sn106/2026-w26) — 4 sources
+
+[Subnet 106 overview](/subnets/106)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn107/index.mdx
+++ b/apps/ui/content/news/sn107/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 107 — weekly digests"
+description: "Every published weekly digest for subnet 107 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 107, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn107/2026-w18) — 7 sources
+
+[Subnet 107 overview](/subnets/107)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn108/index.mdx
+++ b/apps/ui/content/news/sn108/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 108 — weekly digests"
+description: "Every published weekly digest for subnet 108 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 108, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn108/2026-w18) — 5 sources
+
+[Subnet 108 overview](/subnets/108)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn109/index.mdx
+++ b/apps/ui/content/news/sn109/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 109 — weekly digests"
+description: "Every published weekly digest for subnet 109 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 109, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn109/2026-w25) — 4 sources
+
+[Subnet 109 overview](/subnets/109)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn11/index.mdx
+++ b/apps/ui/content/news/sn11/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 11 — weekly digests"
+description: "Every published weekly digest for subnet 11 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 11, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn11/2026-w18) — 5 sources
+
+[Subnet 11 overview](/subnets/11)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn110/index.mdx
+++ b/apps/ui/content/news/sn110/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 110 — weekly digests"
+description: "Every published weekly digest for subnet 110 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 110, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W20](/news/sn110/2026-w20) — 4 sources
+
+[Subnet 110 overview](/subnets/110)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn111/index.mdx
+++ b/apps/ui/content/news/sn111/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 111 — weekly digests"
+description: "Every published weekly digest for subnet 111 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 111, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn111/2026-w26) — 4 sources
+
+[Subnet 111 overview](/subnets/111)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn113/index.mdx
+++ b/apps/ui/content/news/sn113/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 113 — weekly digests"
+description: "Every published weekly digest for subnet 113 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 113, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn113/2026-w26) — 4 sources
+
+[Subnet 113 overview](/subnets/113)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn114/index.mdx
+++ b/apps/ui/content/news/sn114/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 114 — weekly digests"
+description: "Every published weekly digest for subnet 114 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 114, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn114/2026-w32) — 4 sources
+
+[Subnet 114 overview](/subnets/114)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn115/index.mdx
+++ b/apps/ui/content/news/sn115/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 115 — weekly digests"
+description: "Every published weekly digest for subnet 115 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 115, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn115/2026-w26) — 4 sources
+
+[Subnet 115 overview](/subnets/115)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn116/index.mdx
+++ b/apps/ui/content/news/sn116/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 116 — weekly digests"
+description: "Every published weekly digest for subnet 116 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 116, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn116/2026-w26) — 7 sources
+
+[Subnet 116 overview](/subnets/116)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn117/index.mdx
+++ b/apps/ui/content/news/sn117/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 117 — weekly digests"
+description: "Every published weekly digest for subnet 117 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 117, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn117/2026-w18) — 6 sources
+
+[Subnet 117 overview](/subnets/117)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn118/index.mdx
+++ b/apps/ui/content/news/sn118/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 118 — weekly digests"
+description: "Every published weekly digest for subnet 118 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 118, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn118/2026-w26) — 4 sources
+
+[Subnet 118 overview](/subnets/118)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn119/index.mdx
+++ b/apps/ui/content/news/sn119/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 119 — weekly digests"
+description: "Every published weekly digest for subnet 119 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 119, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn119/2026-w26) — 4 sources
+
+[Subnet 119 overview](/subnets/119)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn12/index.mdx
+++ b/apps/ui/content/news/sn12/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 12 — weekly digests"
+description: "Every published weekly digest for subnet 12 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 12, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn12/2026-w26) — 3 sources
+
+[Subnet 12 overview](/subnets/12)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn120/index.mdx
+++ b/apps/ui/content/news/sn120/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 120 — weekly digests"
+description: "Every published weekly digest for subnet 120 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 120, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W21](/news/sn120/2026-w21) — 5 sources
+
+[Subnet 120 overview](/subnets/120)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn121/index.mdx
+++ b/apps/ui/content/news/sn121/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 121 — weekly digests"
+description: "Every published weekly digest for subnet 121 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 121, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn121/2026-w26) — 4 sources
+
+[Subnet 121 overview](/subnets/121)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn122/index.mdx
+++ b/apps/ui/content/news/sn122/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 122 — weekly digests"
+description: "Every published weekly digest for subnet 122 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 122, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W21](/news/sn122/2026-w21) — 5 sources
+
+[Subnet 122 overview](/subnets/122)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn123/index.mdx
+++ b/apps/ui/content/news/sn123/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 123 — weekly digests"
+description: "Every published weekly digest for subnet 123 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 123, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn123/2026-w25) — 5 sources
+- [2025-W46](/news/sn123/2025-w46) — 3 sources
+
+[Subnet 123 overview](/subnets/123)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn127/index.mdx
+++ b/apps/ui/content/news/sn127/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 127 — weekly digests"
+description: "Every published weekly digest for subnet 127 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 127, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn127/2026-w26) — 4 sources
+
+[Subnet 127 overview](/subnets/127)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn128/index.mdx
+++ b/apps/ui/content/news/sn128/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 128 — weekly digests"
+description: "Every published weekly digest for subnet 128 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 128, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn128/2026-w26) — 4 sources
+
+[Subnet 128 overview](/subnets/128)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn13/index.mdx
+++ b/apps/ui/content/news/sn13/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 13 — weekly digests"
+description: "Every published weekly digest for subnet 13 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 13, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn13/2026-w32) — 4 sources
+
+[Subnet 13 overview](/subnets/13)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn14/index.mdx
+++ b/apps/ui/content/news/sn14/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 14 — weekly digests"
+description: "Every published weekly digest for subnet 14 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 14, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W21](/news/sn14/2026-w21) — 7 sources
+
+[Subnet 14 overview](/subnets/14)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn15/index.mdx
+++ b/apps/ui/content/news/sn15/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 15 — weekly digests"
+description: "Every published weekly digest for subnet 15 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 15, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn15/2026-w32) — 3 sources
+- [2026-W18](/news/sn15/2026-w18) — 6 sources
+
+[Subnet 15 overview](/subnets/15)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn16/index.mdx
+++ b/apps/ui/content/news/sn16/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 16 — weekly digests"
+description: "Every published weekly digest for subnet 16 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 16, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn16/2026-w26) — 10 sources
+
+[Subnet 16 overview](/subnets/16)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn17/index.mdx
+++ b/apps/ui/content/news/sn17/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 17 — weekly digests"
+description: "Every published weekly digest for subnet 17 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 17, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W23](/news/sn17/2026-w23) — 4 sources
+
+[Subnet 17 overview](/subnets/17)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn18/index.mdx
+++ b/apps/ui/content/news/sn18/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 18 — weekly digests"
+description: "Every published weekly digest for subnet 18 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 18, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W20](/news/sn18/2026-w20) — 5 sources
+- [2026-W12](/news/sn18/2026-w12) — 4 sources
+
+[Subnet 18 overview](/subnets/18)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn19/index.mdx
+++ b/apps/ui/content/news/sn19/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 19 — weekly digests"
+description: "Every published weekly digest for subnet 19 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 19, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn19/2026-w17) — 8 sources
+
+[Subnet 19 overview](/subnets/19)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn2/index.mdx
+++ b/apps/ui/content/news/sn2/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 2 — weekly digests"
+description: "Every published weekly digest for subnet 2 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 2, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn2/2026-w32) — 4 sources
+
+[Subnet 2 overview](/subnets/2)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn20/index.mdx
+++ b/apps/ui/content/news/sn20/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 20 — weekly digests"
+description: "Every published weekly digest for subnet 20 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 20, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn20/2026-w26) — 4 sources
+
+[Subnet 20 overview](/subnets/20)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn21/index.mdx
+++ b/apps/ui/content/news/sn21/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 21 — weekly digests"
+description: "Every published weekly digest for subnet 21 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 21, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W21](/news/sn21/2026-w21) — 4 sources
+
+[Subnet 21 overview](/subnets/21)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn22/index.mdx
+++ b/apps/ui/content/news/sn22/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 22 — weekly digests"
+description: "Every published weekly digest for subnet 22 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 22, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn22/2026-w32) — 5 sources
+
+[Subnet 22 overview](/subnets/22)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn23/index.mdx
+++ b/apps/ui/content/news/sn23/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 23 — weekly digests"
+description: "Every published weekly digest for subnet 23 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 23, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn23/2026-w25) — 4 sources
+
+[Subnet 23 overview](/subnets/23)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn24/index.mdx
+++ b/apps/ui/content/news/sn24/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 24 — weekly digests"
+description: "Every published weekly digest for subnet 24 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 24, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn24/2026-w26) — 4 sources
+
+[Subnet 24 overview](/subnets/24)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn25/index.mdx
+++ b/apps/ui/content/news/sn25/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 25 — weekly digests"
+description: "Every published weekly digest for subnet 25 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 25, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn25/2026-w26) — 4 sources
+
+[Subnet 25 overview](/subnets/25)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn26/index.mdx
+++ b/apps/ui/content/news/sn26/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 26 — weekly digests"
+description: "Every published weekly digest for subnet 26 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 26, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W19](/news/sn26/2026-w19) — 7 sources
+
+[Subnet 26 overview](/subnets/26)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn27/index.mdx
+++ b/apps/ui/content/news/sn27/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 27 — weekly digests"
+description: "Every published weekly digest for subnet 27 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 27, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn27/2026-w26) — 4 sources
+
+[Subnet 27 overview](/subnets/27)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn28/index.mdx
+++ b/apps/ui/content/news/sn28/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 28 — weekly digests"
+description: "Every published weekly digest for subnet 28 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 28, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn28/2026-w25) — 9 sources
+
+[Subnet 28 overview](/subnets/28)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn29/index.mdx
+++ b/apps/ui/content/news/sn29/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 29 — weekly digests"
+description: "Every published weekly digest for subnet 29 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 29, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn29/2026-w26) — 3 sources
+- [2024-W46](/news/sn29/2024-w46) — 4 sources
+
+[Subnet 29 overview](/subnets/29)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn3/index.mdx
+++ b/apps/ui/content/news/sn3/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 3 — weekly digests"
+description: "Every published weekly digest for subnet 3 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 3, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn3/2026-w32) — 4 sources
+
+[Subnet 3 overview](/subnets/3)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn30/index.mdx
+++ b/apps/ui/content/news/sn30/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 30 — weekly digests"
+description: "Every published weekly digest for subnet 30 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 30, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn30/2026-w26) — 4 sources
+
+[Subnet 30 overview](/subnets/30)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn31/index.mdx
+++ b/apps/ui/content/news/sn31/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 31 — weekly digests"
+description: "Every published weekly digest for subnet 31 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 31, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn31/2026-w25) — 4 sources
+
+[Subnet 31 overview](/subnets/31)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn32/index.mdx
+++ b/apps/ui/content/news/sn32/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 32 — weekly digests"
+description: "Every published weekly digest for subnet 32 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 32, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn32/2026-w32) — 4 sources
+- [2025-W06](/news/sn32/2025-w06) — 3 sources
+
+[Subnet 32 overview](/subnets/32)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn33/index.mdx
+++ b/apps/ui/content/news/sn33/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 33 — weekly digests"
+description: "Every published weekly digest for subnet 33 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 33, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W22](/news/sn33/2026-w22) — 4 sources
+
+[Subnet 33 overview](/subnets/33)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn34/index.mdx
+++ b/apps/ui/content/news/sn34/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 34 — weekly digests"
+description: "Every published weekly digest for subnet 34 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 34, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W24](/news/sn34/2026-w24) — 4 sources
+
+[Subnet 34 overview](/subnets/34)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn35/index.mdx
+++ b/apps/ui/content/news/sn35/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 35 — weekly digests"
+description: "Every published weekly digest for subnet 35 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 35, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn35/2026-w32) — 4 sources
+- [2025-W21](/news/sn35/2025-w21) — 4 sources
+
+[Subnet 35 overview](/subnets/35)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn36/index.mdx
+++ b/apps/ui/content/news/sn36/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 36 — weekly digests"
+description: "Every published weekly digest for subnet 36 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 36, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W20](/news/sn36/2026-w20) — 7 sources
+
+[Subnet 36 overview](/subnets/36)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn37/index.mdx
+++ b/apps/ui/content/news/sn37/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 37 — weekly digests"
+description: "Every published weekly digest for subnet 37 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 37, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn37/2026-w26) — 4 sources
+
+[Subnet 37 overview](/subnets/37)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn38/index.mdx
+++ b/apps/ui/content/news/sn38/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 38 — weekly digests"
+description: "Every published weekly digest for subnet 38 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 38, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W28](/news/sn38/2026-w28) — 4 sources
+- [2026-W25](/news/sn38/2026-w25) — 6 sources
+
+[Subnet 38 overview](/subnets/38)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn39/index.mdx
+++ b/apps/ui/content/news/sn39/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 39 — weekly digests"
+description: "Every published weekly digest for subnet 39 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 39, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn39/2026-w32) — 4 sources
+- [2025-W06](/news/sn39/2025-w06) — 3 sources
+
+[Subnet 39 overview](/subnets/39)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn4/index.mdx
+++ b/apps/ui/content/news/sn4/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 4 — weekly digests"
+description: "Every published weekly digest for subnet 4 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 4, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn4/2026-w32) — 4 sources
+- [2025-W14](/news/sn4/2025-w14) — 3 sources
+
+[Subnet 4 overview](/subnets/4)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn40/index.mdx
+++ b/apps/ui/content/news/sn40/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 40 — weekly digests"
+description: "Every published weekly digest for subnet 40 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 40, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn40/2026-w26) — 8 sources
+
+[Subnet 40 overview](/subnets/40)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn41/index.mdx
+++ b/apps/ui/content/news/sn41/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 41 — weekly digests"
+description: "Every published weekly digest for subnet 41 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 41, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn41/2026-w32) — 4 sources
+
+[Subnet 41 overview](/subnets/41)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn42/index.mdx
+++ b/apps/ui/content/news/sn42/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 42 — weekly digests"
+description: "Every published weekly digest for subnet 42 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 42, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn42/2026-w26) — 4 sources
+
+[Subnet 42 overview](/subnets/42)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn43/index.mdx
+++ b/apps/ui/content/news/sn43/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 43 — weekly digests"
+description: "Every published weekly digest for subnet 43 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 43, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn43/2026-w18) — 5 sources
+
+[Subnet 43 overview](/subnets/43)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn44/index.mdx
+++ b/apps/ui/content/news/sn44/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 44 — weekly digests"
+description: "Every published weekly digest for subnet 44 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 44, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn44/2026-w32) — 4 sources
+
+[Subnet 44 overview](/subnets/44)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn45/index.mdx
+++ b/apps/ui/content/news/sn45/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 45 — weekly digests"
+description: "Every published weekly digest for subnet 45 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 45, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn45/2026-w26) — 4 sources
+- [2025-W06](/news/sn45/2025-w06) — 3 sources
+
+[Subnet 45 overview](/subnets/45)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn46/index.mdx
+++ b/apps/ui/content/news/sn46/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 46 — weekly digests"
+description: "Every published weekly digest for subnet 46 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 46, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn46/2026-w32) — 4 sources
+- [2026-W06](/news/sn46/2026-w06) — 3 sources
+
+[Subnet 46 overview](/subnets/46)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn47/index.mdx
+++ b/apps/ui/content/news/sn47/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 47 — weekly digests"
+description: "Every published weekly digest for subnet 47 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 47, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn47/2026-w26) — 4 sources
+- [2025-W25](/news/sn47/2025-w25) — 3 sources
+
+[Subnet 47 overview](/subnets/47)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn48/index.mdx
+++ b/apps/ui/content/news/sn48/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 48 — weekly digests"
+description: "Every published weekly digest for subnet 48 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 48, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W27](/news/sn48/2026-w27) — 5 sources
+
+[Subnet 48 overview](/subnets/48)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn49/index.mdx
+++ b/apps/ui/content/news/sn49/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 49 — weekly digests"
+description: "Every published weekly digest for subnet 49 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 49, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn49/2026-w32) — 4 sources
+
+[Subnet 49 overview](/subnets/49)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn5/index.mdx
+++ b/apps/ui/content/news/sn5/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 5 — weekly digests"
+description: "Every published weekly digest for subnet 5 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 5, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn5/2026-w26) — 4 sources
+
+[Subnet 5 overview](/subnets/5)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn50/index.mdx
+++ b/apps/ui/content/news/sn50/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 50 — weekly digests"
+description: "Every published weekly digest for subnet 50 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 50, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn50/2026-w32) — 4 sources
+
+[Subnet 50 overview](/subnets/50)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn51/index.mdx
+++ b/apps/ui/content/news/sn51/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 51 — weekly digests"
+description: "Every published weekly digest for subnet 51 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 51, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn51/2026-w18) — 4 sources
+- [2025-W38](/news/sn51/2025-w38) — 3 sources
+
+[Subnet 51 overview](/subnets/51)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn52/index.mdx
+++ b/apps/ui/content/news/sn52/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 52 — weekly digests"
+description: "Every published weekly digest for subnet 52 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 52, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn52/2026-w26) — 4 sources
+
+[Subnet 52 overview](/subnets/52)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn53/index.mdx
+++ b/apps/ui/content/news/sn53/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 53 — weekly digests"
+description: "Every published weekly digest for subnet 53 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 53, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn53/2026-w26) — 5 sources
+
+[Subnet 53 overview](/subnets/53)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn54/index.mdx
+++ b/apps/ui/content/news/sn54/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 54 — weekly digests"
+description: "Every published weekly digest for subnet 54 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 54, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn54/2026-w32) — 4 sources
+
+[Subnet 54 overview](/subnets/54)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn55/index.mdx
+++ b/apps/ui/content/news/sn55/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 55 — weekly digests"
+description: "Every published weekly digest for subnet 55 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 55, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn55/2026-w32) — 4 sources
+- [2025-W11](/news/sn55/2025-w11) — 3 sources
+
+[Subnet 55 overview](/subnets/55)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn56/index.mdx
+++ b/apps/ui/content/news/sn56/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 56 — weekly digests"
+description: "Every published weekly digest for subnet 56 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 56, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn56/2026-w32) — 4 sources
+
+[Subnet 56 overview](/subnets/56)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn57/index.mdx
+++ b/apps/ui/content/news/sn57/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 57 — weekly digests"
+description: "Every published weekly digest for subnet 57 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 57, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn57/2026-w26) — 9 sources
+
+[Subnet 57 overview](/subnets/57)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn58/index.mdx
+++ b/apps/ui/content/news/sn58/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 58 — weekly digests"
+description: "Every published weekly digest for subnet 58 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 58, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W28](/news/sn58/2026-w28) — 3 sources
+- [2026-W26](/news/sn58/2026-w26) — 4 sources
+
+[Subnet 58 overview](/subnets/58)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn59/index.mdx
+++ b/apps/ui/content/news/sn59/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 59 — weekly digests"
+description: "Every published weekly digest for subnet 59 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 59, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn59/2026-w32) — 4 sources
+
+[Subnet 59 overview](/subnets/59)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn6/index.mdx
+++ b/apps/ui/content/news/sn6/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 6 — weekly digests"
+description: "Every published weekly digest for subnet 6 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 6, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn6/2026-w17) — 4 sources
+
+[Subnet 6 overview](/subnets/6)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn60/index.mdx
+++ b/apps/ui/content/news/sn60/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 60 — weekly digests"
+description: "Every published weekly digest for subnet 60 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 60, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn60/2026-w32) — 5 sources
+- [2025-W09](/news/sn60/2025-w09) — 3 sources
+
+[Subnet 60 overview](/subnets/60)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn61/index.mdx
+++ b/apps/ui/content/news/sn61/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 61 — weekly digests"
+description: "Every published weekly digest for subnet 61 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 61, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn61/2026-w32) — 5 sources
+
+[Subnet 61 overview](/subnets/61)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn62/index.mdx
+++ b/apps/ui/content/news/sn62/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 62 — weekly digests"
+description: "Every published weekly digest for subnet 62 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 62, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn62/2026-w26) — 4 sources
+
+[Subnet 62 overview](/subnets/62)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn63/index.mdx
+++ b/apps/ui/content/news/sn63/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 63 — weekly digests"
+description: "Every published weekly digest for subnet 63 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 63, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn63/2026-w17) — 5 sources
+
+[Subnet 63 overview](/subnets/63)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn64/index.mdx
+++ b/apps/ui/content/news/sn64/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 64 — weekly digests"
+description: "Every published weekly digest for subnet 64 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 64, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W28](/news/sn64/2026-w28) — 4 sources
+
+[Subnet 64 overview](/subnets/64)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn65/index.mdx
+++ b/apps/ui/content/news/sn65/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 65 — weekly digests"
+description: "Every published weekly digest for subnet 65 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 65, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn65/2026-w32) — 4 sources
+
+[Subnet 65 overview](/subnets/65)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn66/index.mdx
+++ b/apps/ui/content/news/sn66/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 66 — weekly digests"
+description: "Every published weekly digest for subnet 66 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 66, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn66/2026-w26) — 4 sources
+
+[Subnet 66 overview](/subnets/66)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn67/index.mdx
+++ b/apps/ui/content/news/sn67/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 67 — weekly digests"
+description: "Every published weekly digest for subnet 67 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 67, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn67/2026-w32) — 8 sources
+- [2025-W39](/news/sn67/2025-w39) — 3 sources
+
+[Subnet 67 overview](/subnets/67)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn68/index.mdx
+++ b/apps/ui/content/news/sn68/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 68 — weekly digests"
+description: "Every published weekly digest for subnet 68 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 68, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn68/2026-w26) — 4 sources
+- [2025-W10](/news/sn68/2025-w10) — 3 sources
+
+[Subnet 68 overview](/subnets/68)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn69/index.mdx
+++ b/apps/ui/content/news/sn69/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 69 — weekly digests"
+description: "Every published weekly digest for subnet 69 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 69, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn69/2026-w26) — 6 sources
+
+[Subnet 69 overview](/subnets/69)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn7/index.mdx
+++ b/apps/ui/content/news/sn7/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 7 — weekly digests"
+description: "Every published weekly digest for subnet 7 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 7, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn7/2026-w32) — 3 sources
+- [2026-W26](/news/sn7/2026-w26) — 4 sources
+
+[Subnet 7 overview](/subnets/7)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn70/index.mdx
+++ b/apps/ui/content/news/sn70/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 70 — weekly digests"
+description: "Every published weekly digest for subnet 70 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 70, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W20](/news/sn70/2026-w20) — 5 sources
+
+[Subnet 70 overview](/subnets/70)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn71/index.mdx
+++ b/apps/ui/content/news/sn71/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 71 — weekly digests"
+description: "Every published weekly digest for subnet 71 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 71, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn71/2026-w32) — 4 sources
+- [2025-W44](/news/sn71/2025-w44) — 3 sources
+
+[Subnet 71 overview](/subnets/71)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn72/index.mdx
+++ b/apps/ui/content/news/sn72/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 72 — weekly digests"
+description: "Every published weekly digest for subnet 72 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 72, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn72/2026-w26) — 5 sources
+
+[Subnet 72 overview](/subnets/72)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn73/index.mdx
+++ b/apps/ui/content/news/sn73/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 73 — weekly digests"
+description: "Every published weekly digest for subnet 73 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 73, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn73/2026-w25) — 4 sources
+
+[Subnet 73 overview](/subnets/73)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn74/index.mdx
+++ b/apps/ui/content/news/sn74/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 74 — weekly digests"
+description: "Every published weekly digest for subnet 74 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 74, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn74/2026-w17) — 5 sources
+
+[Subnet 74 overview](/subnets/74)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn75/index.mdx
+++ b/apps/ui/content/news/sn75/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 75 — weekly digests"
+description: "Every published weekly digest for subnet 75 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 75, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn75/2026-w17) — 5 sources
+
+[Subnet 75 overview](/subnets/75)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn76/index.mdx
+++ b/apps/ui/content/news/sn76/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 76 — weekly digests"
+description: "Every published weekly digest for subnet 76 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 76, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn76/2026-w26) — 4 sources
+
+[Subnet 76 overview](/subnets/76)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn77/index.mdx
+++ b/apps/ui/content/news/sn77/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 77 — weekly digests"
+description: "Every published weekly digest for subnet 77 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 77, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn77/2026-w26) — 4 sources
+
+[Subnet 77 overview](/subnets/77)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn78/index.mdx
+++ b/apps/ui/content/news/sn78/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 78 — weekly digests"
+description: "Every published weekly digest for subnet 78 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 78, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn78/2026-w26) — 6 sources
+- [2026-W07](/news/sn78/2026-w07) — 3 sources
+
+[Subnet 78 overview](/subnets/78)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn79/index.mdx
+++ b/apps/ui/content/news/sn79/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 79 — weekly digests"
+description: "Every published weekly digest for subnet 79 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 79, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W27](/news/sn79/2026-w27) — 6 sources
+
+[Subnet 79 overview](/subnets/79)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn8/index.mdx
+++ b/apps/ui/content/news/sn8/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 8 — weekly digests"
+description: "Every published weekly digest for subnet 8 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 8, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn8/2026-w32) — 4 sources
+
+[Subnet 8 overview](/subnets/8)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn80/index.mdx
+++ b/apps/ui/content/news/sn80/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 80 — weekly digests"
+description: "Every published weekly digest for subnet 80 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 80, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn80/2026-w26) — 5 sources
+- [2025-W13](/news/sn80/2025-w13) — 3 sources
+
+[Subnet 80 overview](/subnets/80)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn81/index.mdx
+++ b/apps/ui/content/news/sn81/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 81 — weekly digests"
+description: "Every published weekly digest for subnet 81 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 81, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn81/2026-w32) — 4 sources
+
+[Subnet 81 overview](/subnets/81)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn82/index.mdx
+++ b/apps/ui/content/news/sn82/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 82 — weekly digests"
+description: "Every published weekly digest for subnet 82 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 82, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W19](/news/sn82/2026-w19) — 6 sources
+
+[Subnet 82 overview](/subnets/82)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn83/index.mdx
+++ b/apps/ui/content/news/sn83/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 83 — weekly digests"
+description: "Every published weekly digest for subnet 83 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 83, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W18](/news/sn83/2026-w18) — 8 sources
+
+[Subnet 83 overview](/subnets/83)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn84/index.mdx
+++ b/apps/ui/content/news/sn84/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 84 — weekly digests"
+description: "Every published weekly digest for subnet 84 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 84, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W21](/news/sn84/2026-w21) — 10 sources
+
+[Subnet 84 overview](/subnets/84)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn85/index.mdx
+++ b/apps/ui/content/news/sn85/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 85 — weekly digests"
+description: "Every published weekly digest for subnet 85 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 85, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn85/2026-w32) — 5 sources
+- [2025-W15](/news/sn85/2025-w15) — 3 sources
+
+[Subnet 85 overview](/subnets/85)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn86/index.mdx
+++ b/apps/ui/content/news/sn86/index.mdx
@@ -1,0 +1,14 @@
+---
+title: "Subnet 86 — weekly digests"
+description: "Every published weekly digest for subnet 86 — 3 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 86, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn86/2026-w32) — 3 sources
+- [2026-W30](/news/sn86/2026-w30) — 3 sources
+- [2026-W26](/news/sn86/2026-w26) — 5 sources
+
+[Subnet 86 overview](/subnets/86)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn87/index.mdx
+++ b/apps/ui/content/news/sn87/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 87 — weekly digests"
+description: "Every published weekly digest for subnet 87 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 87, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W25](/news/sn87/2026-w25) — 4 sources
+- [2026-W01](/news/sn87/2026-w01) — 3 sources
+
+[Subnet 87 overview](/subnets/87)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn88/index.mdx
+++ b/apps/ui/content/news/sn88/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 88 — weekly digests"
+description: "Every published weekly digest for subnet 88 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 88, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W20](/news/sn88/2026-w20) — 5 sources
+
+[Subnet 88 overview](/subnets/88)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn89/index.mdx
+++ b/apps/ui/content/news/sn89/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 89 — weekly digests"
+description: "Every published weekly digest for subnet 89 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 89, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn89/2026-w17) — 6 sources
+- [2025-W28](/news/sn89/2025-w28) — 3 sources
+
+[Subnet 89 overview](/subnets/89)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn9/index.mdx
+++ b/apps/ui/content/news/sn9/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 9 — weekly digests"
+description: "Every published weekly digest for subnet 9 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 9, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn9/2026-w32) — 4 sources
+- [2025-W23](/news/sn9/2025-w23) — 3 sources
+
+[Subnet 9 overview](/subnets/9)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn90/index.mdx
+++ b/apps/ui/content/news/sn90/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 90 — weekly digests"
+description: "Every published weekly digest for subnet 90 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 90, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W29](/news/sn90/2026-w29) — 3 sources
+- [2026-W26](/news/sn90/2026-w26) — 7 sources
+
+[Subnet 90 overview](/subnets/90)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn91/index.mdx
+++ b/apps/ui/content/news/sn91/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 91 — weekly digests"
+description: "Every published weekly digest for subnet 91 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 91, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn91/2026-w26) — 5 sources
+- [2025-W21](/news/sn91/2025-w21) — 3 sources
+
+[Subnet 91 overview](/subnets/91)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn92/index.mdx
+++ b/apps/ui/content/news/sn92/index.mdx
@@ -1,0 +1,13 @@
+---
+title: "Subnet 92 — weekly digests"
+description: "Every published weekly digest for subnet 92 — 2 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 92, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W27](/news/sn92/2026-w27) — 3 sources
+- [2026-W23](/news/sn92/2026-w23) — 6 sources
+
+[Subnet 92 overview](/subnets/92)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn93/index.mdx
+++ b/apps/ui/content/news/sn93/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 93 — weekly digests"
+description: "Every published weekly digest for subnet 93 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 93, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn93/2026-w32) — 4 sources
+
+[Subnet 93 overview](/subnets/93)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn94/index.mdx
+++ b/apps/ui/content/news/sn94/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 94 — weekly digests"
+description: "Every published weekly digest for subnet 94 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 94, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn94/2026-w32) — 5 sources
+
+[Subnet 94 overview](/subnets/94)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn95/index.mdx
+++ b/apps/ui/content/news/sn95/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 95 — weekly digests"
+description: "Every published weekly digest for subnet 95 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 95, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn95/2026-w26) — 5 sources
+
+[Subnet 95 overview](/subnets/95)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn96/index.mdx
+++ b/apps/ui/content/news/sn96/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 96 — weekly digests"
+description: "Every published weekly digest for subnet 96 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 96, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn96/2026-w17) — 8 sources
+
+[Subnet 96 overview](/subnets/96)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn97/index.mdx
+++ b/apps/ui/content/news/sn97/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 97 — weekly digests"
+description: "Every published weekly digest for subnet 97 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 97, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W17](/news/sn97/2026-w17) — 5 sources
+
+[Subnet 97 overview](/subnets/97)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn98/index.mdx
+++ b/apps/ui/content/news/sn98/index.mdx
@@ -1,0 +1,12 @@
+---
+title: "Subnet 98 — weekly digests"
+description: "Every published weekly digest for subnet 98 — 1 week, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 98, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W26](/news/sn98/2026-w26) — 5 sources
+
+[Subnet 98 overview](/subnets/98)
+
+[All weekly digests](/news)

--- a/apps/ui/content/news/sn99/index.mdx
+++ b/apps/ui/content/news/sn99/index.mdx
@@ -1,0 +1,14 @@
+---
+title: "Subnet 99 — weekly digests"
+description: "Every published weekly digest for subnet 99 — 3 weeks, each written only from this registry's own primary-source feed items."
+---
+
+Every week written up for subnet 99, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.
+
+- [2026-W32](/news/sn99/2026-w32) — 3 sources
+- [2026-W26](/news/sn99/2026-w26) — 4 sources
+- [2026-W13](/news/sn99/2026-w13) — 3 sources
+
+[Subnet 99 overview](/subnets/99)
+
+[All weekly digests](/news)

--- a/apps/ui/scripts/generate-digest-pages.ts
+++ b/apps/ui/scripts/generate-digest-pages.ts
@@ -245,6 +245,48 @@ function indexPage(digests: WeeklyDigest[]): string {
   ].join("\n");
 }
 
+/**
+ * `/news/sn38` — the archive for one subject.
+ *
+ * #11283: the breadcrumb on every digest links its parent folder, and that
+ * folder had no page. 124 of them, one per subject, each a 404 the reader was
+ * invited to click. Exactly the defect #11234 fixed for the API reference,
+ * where each tag's `meta.json` was written and its `index.mdx` never was.
+ *
+ * Generated rather than hand-written for the same reason: a subject added to
+ * the store cannot reintroduce the hole.
+ */
+function subjectIndexPage(netuid: number | null, entries: WeeklyDigest[]): string {
+  const label = subjectLabel(netuid);
+  const sorted = [...entries].sort((a, b) => b.slug.localeCompare(a.slug));
+  const segment = subjectSegment(netuid);
+  const links = sorted
+    .map(
+      (digest) =>
+        `- [${weekLabel(digest)}](/news/${segment}/${digest.slug}) — ${digest.sources.length} source${digest.sources.length === 1 ? "" : "s"}`,
+    )
+    .join("\n");
+  const scope = netuid === null ? "the network as a whole" : `subnet ${netuid}`;
+  const week = sorted.length === 1 ? "week" : "weeks";
+  return [
+    "---",
+    `title: "${escapeYaml(label)} — weekly digests"`,
+    `description: "Every published weekly digest for ${escapeYaml(scope)} — ${sorted.length} ${week}, each written only from this registry's own primary-source feed items."`,
+    "---",
+    "",
+    `Every week written up for ${scope}, newest first. Each digest is derived only from this registry's own feed items, and cites every one it rests on.`,
+    "",
+    links,
+    "",
+    netuid === null
+      ? "[Browse all subnets](/subnets)"
+      : `[Subnet ${netuid} overview](/subnets/${netuid})`,
+    "",
+    "[All weekly digests](/news)",
+    "",
+  ].join("\n");
+}
+
 async function main() {
   const raw = await readFile(STORE_PATH, "utf8").catch(() => null);
   const store = raw ? (JSON.parse(raw) as { digests?: WeeklyDigest[] }) : { digests: [] };
@@ -258,6 +300,24 @@ async function main() {
   const format = (source: string) => prettier.format(source, { parser: "mdx" });
 
   await writeFile(path.join(OUTPUT_DIR, "index.mdx"), await format(indexPage(digests)), "utf8");
+
+  // One index per subject folder, so the digest breadcrumb's parent link
+  // resolves -- see subjectIndexPage.
+  const bySubject = new Map<number | null, WeeklyDigest[]>();
+  for (const digest of digests) {
+    const bucket = bySubject.get(digest.netuid);
+    if (bucket) bucket.push(digest);
+    else bySubject.set(digest.netuid, [digest]);
+  }
+  for (const [netuid, entries] of bySubject) {
+    const dir = path.join(OUTPUT_DIR, subjectSegment(netuid));
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path.join(dir, "index.mdx"),
+      await format(subjectIndexPage(netuid, entries)),
+      "utf8",
+    );
+  }
 
   for (const digest of digests) {
     const dir = path.join(OUTPUT_DIR, subjectSegment(digest.netuid));

--- a/apps/ui/src/routeTree.gen.ts
+++ b/apps/ui/src/routeTree.gen.ts
@@ -45,12 +45,14 @@ import { Route as ChainEventsRouteImport } from './routes/chain.events'
 import { Route as ChainExtrinsicsRouteImport } from './routes/chain.extrinsics'
 import { Route as ChainGovernanceRouteImport } from './routes/chain.governance'
 import { Route as ChainRuntimeRouteImport } from './routes/chain.runtime'
+import { Route as DesignIndexRouteImport } from './routes/design.index'
 import { Route as DesignPrimitivesRouteImport } from './routes/design.primitives'
 import { Route as DocsSplatRouteImport } from './routes/docs.$'
 import { Route as DocsLlmsDottxtRouteImport } from './routes/docs.llms[.]txt'
 import { Route as EventsIndexRouteImport } from './routes/events.index'
 import { Route as ExtrinsicsIndexRouteImport } from './routes/extrinsics.index'
 import { Route as ExtrinsicsHashRouteImport } from './routes/extrinsics.$hash'
+import { Route as GraphqlIndexRouteImport } from './routes/graphql.index'
 import { Route as GraphqlExplorerRouteImport } from './routes/graphql.explorer'
 import { Route as NewsSplatRouteImport } from './routes/news.$'
 import { Route as ProvidersIndexRouteImport } from './routes/providers.index'
@@ -59,6 +61,7 @@ import { Route as RuntimeIndexRouteImport } from './routes/runtime.index'
 import { Route as SubnetsIndexRouteImport } from './routes/subnets.index'
 import { Route as SubnetsNetuidRouteImport } from './routes/subnets.$netuid'
 import { Route as SudoIndexRouteImport } from './routes/sudo.index'
+import { Route as ToolsIndexRouteImport } from './routes/tools.index'
 import { Route as ToolsSs58RouteImport } from './routes/tools.ss58'
 import { Route as ValidatorsIndexRouteImport } from './routes/validators.index'
 import { Route as ValidatorsHotkeyRouteImport } from './routes/validators.$hotkey'
@@ -244,6 +247,11 @@ const ChainRuntimeRoute = ChainRuntimeRouteImport.update({
   path: '/runtime',
   getParentRoute: () => ChainRoute,
 } as any)
+const DesignIndexRoute = DesignIndexRouteImport.update({
+  id: '/design/',
+  path: '/design/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DesignPrimitivesRoute = DesignPrimitivesRouteImport.update({
   id: '/design/primitives',
   path: '/design/primitives',
@@ -272,6 +280,11 @@ const ExtrinsicsIndexRoute = ExtrinsicsIndexRouteImport.update({
 const ExtrinsicsHashRoute = ExtrinsicsHashRouteImport.update({
   id: '/extrinsics/$hash',
   path: '/extrinsics/$hash',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GraphqlIndexRoute = GraphqlIndexRouteImport.update({
+  id: '/graphql/',
+  path: '/graphql/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const GraphqlExplorerRoute = GraphqlExplorerRouteImport.update({
@@ -312,6 +325,11 @@ const SubnetsNetuidRoute = SubnetsNetuidRouteImport.update({
 const SudoIndexRoute = SudoIndexRouteImport.update({
   id: '/sudo/',
   path: '/sudo/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ToolsIndexRoute = ToolsIndexRouteImport.update({
+  id: '/tools/',
+  path: '/tools/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ToolsSs58Route = ToolsSs58RouteImport.update({
@@ -382,12 +400,15 @@ export interface FileRoutesByFullPath {
   '/apis/': typeof ApisIndexRoute
   '/blocks/': typeof BlocksIndexRoute
   '/chain/': typeof ChainIndexRoute
+  '/design/': typeof DesignIndexRoute
   '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
+  '/graphql/': typeof GraphqlIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
   '/sudo/': typeof SudoIndexRoute
+  '/tools/': typeof ToolsIndexRoute
   '/validators/': typeof ValidatorsIndexRoute
   '/docs/raw/$': typeof DocsRawSplatRoute
 }
@@ -436,12 +457,15 @@ export interface FileRoutesByTo {
   '/apis': typeof ApisIndexRoute
   '/blocks': typeof BlocksIndexRoute
   '/chain': typeof ChainIndexRoute
+  '/design': typeof DesignIndexRoute
   '/events': typeof EventsIndexRoute
   '/extrinsics': typeof ExtrinsicsIndexRoute
+  '/graphql': typeof GraphqlIndexRoute
   '/providers': typeof ProvidersIndexRoute
   '/runtime': typeof RuntimeIndexRoute
   '/subnets': typeof SubnetsIndexRoute
   '/sudo': typeof SudoIndexRoute
+  '/tools': typeof ToolsIndexRoute
   '/validators': typeof ValidatorsIndexRoute
   '/docs/raw/$': typeof DocsRawSplatRoute
 }
@@ -493,12 +517,15 @@ export interface FileRoutesById {
   '/apis/': typeof ApisIndexRoute
   '/blocks/': typeof BlocksIndexRoute
   '/chain/': typeof ChainIndexRoute
+  '/design/': typeof DesignIndexRoute
   '/events/': typeof EventsIndexRoute
   '/extrinsics/': typeof ExtrinsicsIndexRoute
+  '/graphql/': typeof GraphqlIndexRoute
   '/providers/': typeof ProvidersIndexRoute
   '/runtime/': typeof RuntimeIndexRoute
   '/subnets/': typeof SubnetsIndexRoute
   '/sudo/': typeof SudoIndexRoute
+  '/tools/': typeof ToolsIndexRoute
   '/validators/': typeof ValidatorsIndexRoute
   '/docs/raw/$': typeof DocsRawSplatRoute
 }
@@ -551,12 +578,15 @@ export interface FileRouteTypes {
     | '/apis/'
     | '/blocks/'
     | '/chain/'
+    | '/design/'
     | '/events/'
     | '/extrinsics/'
+    | '/graphql/'
     | '/providers/'
     | '/runtime/'
     | '/subnets/'
     | '/sudo/'
+    | '/tools/'
     | '/validators/'
     | '/docs/raw/$'
   fileRoutesByTo: FileRoutesByTo
@@ -605,12 +635,15 @@ export interface FileRouteTypes {
     | '/apis'
     | '/blocks'
     | '/chain'
+    | '/design'
     | '/events'
     | '/extrinsics'
+    | '/graphql'
     | '/providers'
     | '/runtime'
     | '/subnets'
     | '/sudo'
+    | '/tools'
     | '/validators'
     | '/docs/raw/$'
   id:
@@ -661,12 +694,15 @@ export interface FileRouteTypes {
     | '/apis/'
     | '/blocks/'
     | '/chain/'
+    | '/design/'
     | '/events/'
     | '/extrinsics/'
+    | '/graphql/'
     | '/providers/'
     | '/runtime/'
     | '/subnets/'
     | '/sudo/'
+    | '/tools/'
     | '/validators/'
     | '/docs/raw/$'
   fileRoutesById: FileRoutesById
@@ -706,12 +742,15 @@ export interface RootRouteChildren {
   AccountsIndexRoute: typeof AccountsIndexRoute
   AdminChangesIndexRoute: typeof AdminChangesIndexRoute
   BlocksIndexRoute: typeof BlocksIndexRoute
+  DesignIndexRoute: typeof DesignIndexRoute
   EventsIndexRoute: typeof EventsIndexRoute
   ExtrinsicsIndexRoute: typeof ExtrinsicsIndexRoute
+  GraphqlIndexRoute: typeof GraphqlIndexRoute
   ProvidersIndexRoute: typeof ProvidersIndexRoute
   RuntimeIndexRoute: typeof RuntimeIndexRoute
   SubnetsIndexRoute: typeof SubnetsIndexRoute
   SudoIndexRoute: typeof SudoIndexRoute
+  ToolsIndexRoute: typeof ToolsIndexRoute
   ValidatorsIndexRoute: typeof ValidatorsIndexRoute
   DocsRawSplatRoute: typeof DocsRawSplatRoute
 }
@@ -970,6 +1009,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChainRuntimeRouteImport
       parentRoute: typeof ChainRoute
     }
+    '/design/': {
+      id: '/design/'
+      path: '/design'
+      fullPath: '/design/'
+      preLoaderRoute: typeof DesignIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/design/primitives': {
       id: '/design/primitives'
       path: '/design/primitives'
@@ -1010,6 +1056,13 @@ declare module '@tanstack/react-router' {
       path: '/extrinsics/$hash'
       fullPath: '/extrinsics/$hash'
       preLoaderRoute: typeof ExtrinsicsHashRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/graphql/': {
+      id: '/graphql/'
+      path: '/graphql'
+      fullPath: '/graphql/'
+      preLoaderRoute: typeof GraphqlIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/graphql/explorer': {
@@ -1066,6 +1119,13 @@ declare module '@tanstack/react-router' {
       path: '/sudo'
       fullPath: '/sudo/'
       preLoaderRoute: typeof SudoIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/tools/': {
+      id: '/tools/'
+      path: '/tools'
+      fullPath: '/tools/'
+      preLoaderRoute: typeof ToolsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/tools/ss58': {
@@ -1174,12 +1234,15 @@ const rootRouteChildren: RootRouteChildren = {
   AccountsIndexRoute: AccountsIndexRoute,
   AdminChangesIndexRoute: AdminChangesIndexRoute,
   BlocksIndexRoute: BlocksIndexRoute,
+  DesignIndexRoute: DesignIndexRoute,
   EventsIndexRoute: EventsIndexRoute,
   ExtrinsicsIndexRoute: ExtrinsicsIndexRoute,
+  GraphqlIndexRoute: GraphqlIndexRoute,
   ProvidersIndexRoute: ProvidersIndexRoute,
   RuntimeIndexRoute: RuntimeIndexRoute,
   SubnetsIndexRoute: SubnetsIndexRoute,
   SudoIndexRoute: SudoIndexRoute,
+  ToolsIndexRoute: ToolsIndexRoute,
   ValidatorsIndexRoute: ValidatorsIndexRoute,
   DocsRawSplatRoute: DocsRawSplatRoute,
 }

--- a/apps/ui/src/routes/design.index.tsx
+++ b/apps/ui/src/routes/design.index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * `/design` is a container, not a page (#11283).
+ *
+ * The breadcrumb links every path segment, so a reader on /design/primitives was
+ * offered a parent link that 404'd. This sends them to the primitives gallery, which is
+ * what the segment means.
+ */
+export const Route = createFileRoute("/design/")({
+  beforeLoad: () => {
+    // 301: the segment will never be a page of its own.
+    throw redirect({ to: "/design/primitives", replace: true, statusCode: 301 });
+  },
+});

--- a/apps/ui/src/routes/graphql.index.tsx
+++ b/apps/ui/src/routes/graphql.index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * `/graphql` is a container, not a page (#11283).
+ *
+ * The breadcrumb links every path segment, so a reader on /graphql/explorer was
+ * offered a parent link that 404'd. This sends them to the GraphQL explorer, which is
+ * what the segment means.
+ */
+export const Route = createFileRoute("/graphql/")({
+  beforeLoad: () => {
+    // 301: the segment will never be a page of its own.
+    throw redirect({ to: "/graphql/explorer", replace: true, statusCode: 301 });
+  },
+});

--- a/apps/ui/src/routes/tools.index.tsx
+++ b/apps/ui/src/routes/tools.index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+/**
+ * `/tools` is a container, not a page (#11283).
+ *
+ * The breadcrumb links every path segment, so a reader on /accounts was
+ * offered a parent link that 404'd. This sends them to the account tools, which is
+ * what the segment means.
+ */
+export const Route = createFileRoute("/tools/")({
+  beforeLoad: () => {
+    // 301: the segment will never be a page of its own.
+    throw redirect({ to: "/accounts", replace: true, statusCode: 301 });
+  },
+});

--- a/apps/ui/src/server.og-copy.test.ts
+++ b/apps/ui/src/server.og-copy.test.ts
@@ -56,7 +56,6 @@ describe("OG card copy coverage (#8489)", () => {
     const ALLOW_GENERIC = new Set([
       "/", // home: the brand card IS the right card
       "/design/primitives", // internal design harness, never shared
-      "/portfolio", // retired -> redirects into /accounts (#8252)
     ]);
 
     const paths = fs
@@ -69,6 +68,14 @@ describe("OG card copy coverage (#8489)", () => {
         (f) =>
           f.endsWith(".tsx") && !f.includes(".test.") && !f.startsWith("-") && !f.startsWith("__"),
       )
+      // #11287: a route with no `component` RENDERS NOTHING -- it only throws a
+      // redirect, so no HTML is produced and there is no card to give it OG
+      // copy for. There are 19 of them (every retired route, plus the
+      // /graphql, /tools and /design container segments), and listing them by
+      // hand is how this guard turns into an exemption list that hides what it
+      // names. Derived from the file instead: `component` present or absent is
+      // structural, and every one of the 27 routes that does render declares it.
+      .filter((f) => /\bcomponent\s*[:,]/.test(fs.readFileSync(path.join(routesDir, f), "utf8")))
       .map((f) => f.replace(/\.tsx$/, ""))
       // Route-file naming -> pathname; skip param and splat segments, which are
       // handled by the regex branches above, not the exact-path map.

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -207,3 +207,45 @@ test.describe("#11279 the digests are typed, and say what week they cover", () =
     expect(article).not.toHaveProperty("temporalCoverage");
   });
 });
+
+test.describe("#11283 every breadcrumb link goes somewhere", () => {
+  // buildCrumbs (components/metagraphed/breadcrumb-nav.ts) makes a link out of
+  // EVERY path segment, so a page at /a/b/c offers /a and /a/b whether or not
+  // those are routes. Measured against production: 129 of 162 intermediate
+  // prefixes answered 404 — 124 /news/sn{n} folders, /docs/protocol,
+  // /docs/playbooks, /graphql, /tools, /design. The JSON-LD BreadcrumbList
+  // linked them too, which is a claim Google validates.
+  //
+  // The property is general, so the test is: derive the prefixes from the
+  // sitemap rather than listing them, and a new nested route cannot reintroduce
+  // the hole without failing here.
+
+  test("no intermediate path segment is a dead link", async ({ request }) => {
+    const xml = await (await request.get("/sitemap.xml")).text();
+    const paths = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => new URL(m[1]!).pathname);
+    expect(paths.length).toBeGreaterThan(100);
+
+    const prefixes = new Set<string>();
+    for (const path of paths) {
+      const parts = path.split("/").filter(Boolean);
+      let acc = "";
+      // Every ancestor, not the page itself.
+      for (let i = 0; i < parts.length - 1; i++) {
+        acc += `/${parts[i]}`;
+        prefixes.add(acc);
+      }
+    }
+    // Container segments that have children but are in no sitemap entry.
+    for (const p of ["/graphql", "/tools", "/design"]) prefixes.add(p);
+
+    const dead: string[] = [];
+    for (const prefix of [...prefixes].sort()) {
+      const response = await request.get(prefix, { maxRedirects: 0 });
+      // 200 (it is a page) or 301 (a container that sends you to the content).
+      if (response.status() !== 200 && response.status() !== 301) {
+        dead.push(`${response.status()} ${prefix}`);
+      }
+    }
+    expect(dead, `breadcrumbs link ${dead.length} dead paths`).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #11287. Part of #11204.

## The defect

`buildCrumbs` makes a link out of **every** path segment, so a page at `/a/b/c` offers `/a` and
`/a/b` whether or not those are routes. Measured against production: **129 of 162 intermediate
prefixes answer 404.**

| count | prefix | reached from |
|---|---|---|
| 124 | `/news/sn{n}` | every weekly digest |
| 1 | `/docs/protocol` | 5 protocol pages |
| 1 | `/docs/playbooks` | 4 playbook pages |
| 1 | `/graphql` | `/graphql/explorer` |
| 1 | `/tools` | `/tools/ss58` |
| 1 | `/design` | `/design/primitives` |

Visible on every affected page — the desktop breadcrumb row and the mobile back affordance both
render it — and **also in the structured data**: `/docs/protocol/proxies` emitted a `BreadcrumbList`
whose position-3 `item` is `https://metagraph.sh/docs/protocol`, a 404. That is a claim Google
validates.

## Two causes, each fixed at its own level

**1. A generator that writes children and no index.** This is #11234's defect — *"the generator wrote
each tag's `meta.json` but never an `index.mdx`"* — reappearing in two more places.

- The digest generator now emits a **per-subject index**, so `/news/sn38` lists that subnet's weeks.
  Fixed in the generator, not by hand, so a subject added to the store cannot reintroduce the hole.
- The two hand-written docs sections get the `index.mdx` their `meta.json` always implied.

**2. Container segments that will never be a page.** `/graphql`, `/tools` and `/design` each have one
child and no content of their own, so they **301** to it — the same answer the 15 retired routes give.

## The 124 new pages are not filler

Each carries a real title, description and its subnet's week list:

```
/news/sn38   title: "Subnet 38 — weekly digests"
             desc : "Every published weekly digest for subnet 38 — 2 weeks, …"
             759 rendered words, 5 links to its weeks
```

Sitemap goes 1,817 → 1,943 (+124 subject indexes, +2 docs sections).

## The gate

The test **derives** the prefixes from `sitemap.xml` rather than listing them, so a new nested route
cannot reintroduce this either. It asserts each answers 200 (it is a page) or 301 (a container that
sends you to the content).

## Verification

```
/graphql → 301 /graphql/explorer     /docs/protocol  → 200     /news/sn38 → 200
/tools   → 301 /accounts             /docs/playbooks → 200     /news/sn64 → 200
/design  → 301 /design/primitives
all 162 intermediate prefixes: 200 or 301, none dead
```

- 137 e2e passed; `tsc`, `vitest` (2208), `lint`, `format:check` green.
- The digest generator is **verified idempotent** (same tree hash on a second run, comparing sorted
  file lists — an unsorted `find` made my first check report a false negative), which is what keeps
  the CI drift check meaningful.
