### PR TITLE
fix(accounts): decide the published feed per account, because a global coverage gate can never open

### DIFF
--- a/src/account-summary-projection.ts
+++ b/src/account-summary-projection.ts
@@ -288,7 +288,13 @@ export async function loadAccountSummaryProjection(
   const scanned = groups.reduce((n, g) => n + Number(g.count), 0);
   if (scanned > ACCOUNT_EVENT_SUMMARY_SCAN_CAP) return null;
 
-  return { groups, ...readRecent(payload, account, pointer, recentLimit) };
+  return {
+    groups,
+    // `scanned` is the account's lifetime event count, already summed above to
+    // apply the cap -- reused rather than recomputed so the two decisions
+    // cannot disagree about how many events this account has.
+    ...readRecent(payload, account, pointer, recentLimit, scanned),
+  };
 }
 
 /**
@@ -310,6 +316,7 @@ function readRecent(
   account: string,
   pointer: { through?: string; recent_limit?: number },
   need: number,
+  lifetimeEvents: number,
 ): Pick<AccountSummaryProjectionRead, "recent"> {
   const none = { recent: null };
   // Zero asks for the aggregate leg only, and `undefined` is a producer that
@@ -335,5 +342,29 @@ function readRecent(
   // Declining sends this leg to the lakehouse; it does not zero the feed.
   const parsed = AccountSummaryRecentSchema.safeParse(map.data[account]);
   if (!parsed.success || !parsed.data.length) return none;
+
+  // IS THIS LIST THE NEWEST N, OR MERELY THE NEWEST N THE PRODUCER HAS REACHED?
+  //
+  // The producer seeds these lists by walking history BACKWARD from the day it
+  // folded to, so at any moment they describe a SUFFIX of time. A list built
+  // from that suffix is the newest N overall exactly when the suffix already
+  // held N of the account's events -- and short of that it is a prefix of the
+  // answer, indistinguishable in the payload from an account whose whole
+  // history is three events.
+  //
+  // The shard settles it without another read. `count` on the groups is the
+  // account's LIFETIME total (the projection declines above the cap, so these
+  // are never a windowed subtotal), so the complete list has exactly
+  // `min(published, lifetime)` entries: `published` for an account with more
+  // events than that, and every event it has for an account with fewer.
+  //
+  // DECIDED PER ACCOUNT rather than by a global coverage watermark, which is
+  // what the first cut of this did. That version withheld the whole feature
+  // until the producer's walk reached SOURCE_FLOOR -- 2,418 days at
+  // `batch_days()` of 7, which is 345 passes of a lane throttled to one a day,
+  // and it could never have switched itself on. Here every account whose events
+  // the walk has already passed is served from the moment they are published,
+  // and the rest fall back exactly as they do today.
+  if (parsed.data.length < Math.min(published, lifetimeEvents)) return none;
   return { recent: { rows: parsed.data, floorMs } };
 }

--- a/tests/account-summary-cold-tier.test.ts
+++ b/tests/account-summary-cold-tier.test.ts
@@ -840,7 +840,16 @@ describe("the projection short-circuits the FEED leg too (#11222)", () => {
             return {
               json: async () => ({
                 schema_version: 1,
-                accounts: { [SS58]: groupsSummingTo(6) },
+                // The groups sum to the LIST'S LENGTH, so the fixture is a
+                // complete list by construction. The reader serves a list only
+                // when it holds `min(recent_limit, lifetime)` entries, and a
+                // fixture claiming six lifetime events beside one published
+                // one would fall back for a reason none of these tests is
+                // about -- see the completeness suite in
+                // account-summary-projection.test.ts.
+                accounts: {
+                  [SS58]: groupsSummingTo((recent ?? []).length || 1),
+                },
                 ...(recent ? { recent: { [SS58]: recent } } : {}),
               }),
             };

--- a/tests/account-summary-projection.test.ts
+++ b/tests/account-summary-projection.test.ts
@@ -522,8 +522,12 @@ function withRecent(
   recent: Record<string, unknown>,
   { over = {}, limit = 10 as number | undefined } = {},
 ) {
+  // `count: 1`, so a fixture holding ONE event is a COMPLETE list. The reader
+  // serves a list only when it holds `min(published, lifetime)` entries, and
+  // the default `group()` claims three events -- which would make every
+  // fixture below fall back for a reason none of them is about.
   const objects = published(
-    { [HOT]: [group()] },
+    { [HOT]: [group({ count: 1 })] },
     {
       through: "2026-08-13",
       ...(limit === undefined ? {} : { recent_limit: limit }),
@@ -686,6 +690,58 @@ describe("the projection's recent map", () => {
     const store = archive(withRecent({ [HOT]: [event()] }));
     const read = await loadAccountSummaryProjection(store.env, HOT, FRESH);
     assert.equal(read!.recent, null);
+  });
+});
+
+describe("a published list is only served when it IS the newest N", () => {
+  // THE PROPERTY THAT LETS THE FEATURE SHIP BEFORE THE WALK FINISHES. The
+  // producer seeds these lists backward from the day it folded to, so mid-walk
+  // they are a suffix of history. `min(published, lifetime)` is how many
+  // entries a COMPLETE list has, and the shard already carries both numbers.
+
+  /** A shard whose groups sum to `lifetime` and whose list holds `held`. */
+  function shard(lifetime: number, held: number) {
+    const objects = published(
+      { [HOT]: [group({ count: lifetime })] },
+      {
+        through: "2026-08-13",
+        recent_limit: 10,
+      },
+    ) as Record<string, Record<string, unknown>>;
+    objects[accountSummaryShardKey(HOT, SHARDS, GEN)]!.recent = {
+      [HOT]: Array.from({ length: held }, (_, i) =>
+        event({ block_number: 900 - i, event_index: i }),
+      ),
+    };
+    return archive(objects);
+  }
+
+  const read = (store: ReturnType<typeof archive>) =>
+    loadAccountSummaryProjection(store.env, HOT, { ...FRESH, recentLimit: 10 });
+
+  test("a FULL list is served -- the walk has passed this account's events", async () => {
+    assert.equal((await read(shard(500, 10)))!.recent!.rows.length, 10);
+  });
+
+  test("A SHORT LIST IS REFUSED when the account has more events than it holds", async () => {
+    // The failure this exists for: four events served as though they were the
+    // newest ten, on an account with five hundred. Nothing in the payload
+    // distinguishes that from an account that has only ever done four things.
+    assert.equal((await read(shard(500, 4)))!.recent, null);
+    // And the aggregate leg is untouched -- only the feed falls back.
+    assert.equal((await read(shard(500, 4)))!.groups.length, 1);
+  });
+
+  test("a short list IS served when it is the account's whole history", async () => {
+    // `min(10, 4) === 4`, so four of four is complete. Refusing here would
+    // send every low-activity account to the lakehouse forever.
+    assert.equal((await read(shard(4, 4)))!.recent!.rows.length, 4);
+  });
+
+  test("the boundary is exact on both sides", async () => {
+    assert.equal((await read(shard(10, 10)))!.recent!.rows.length, 10);
+    assert.equal((await read(shard(11, 10)))!.recent!.rows.length, 10);
+    assert.equal((await read(shard(5, 4)))!.recent, null);
   });
 });
 


### PR DESCRIPTION
#11285 shipped a coverage watermark: the producer withheld `recent_limit` until
its walk reached SOURCE_FLOOR, and the reader served the published list only
when it was told the lists were complete. The gate is sound and it can never
open. SOURCE_FLOOR is 2020-01-01, which is 2,418 days, and `batch_days()` is 7
-- 345 passes of a lane throttled to roughly one a day. Forcing it with
`ACCOUNT_SUMMARY_REBUILD=1` is worse: that restarts the AGGREGATE fold too, so
the card would publish partial lifetime totals for every week the rebuild ran.

So the question moves to where the data already is. A published list is the
newest N exactly when it holds `min(recent_limit, that account's lifetime event
count)` entries -- `recent_limit` is in the pointer and the lifetime count is
the sum of the account's own groups in the same shard, already computed here to
apply the scan cap. Both numbers are in hand before any read, so no watermark
has to be trusted and no walk has to finish.

That makes the two failure directions decidable instead of assumed. Four events
on an account with five hundred is a prefix of the answer and falls back; four
events on an account with four is the whole answer and is served. The first is
the case the watermark existed to prevent -- a short list is indistinguishable
in the payload from an account that has only ever done four things -- and the
second is every low-activity account, which a global gate would have sent to the
lakehouse forever.

Coverage now only decides WHO is served, never whether the answer is right, so
the producer can seed its lists backward over months while every account the
walk has already passed is served from the moment its list lands.

The fixtures gain a lifetime count that matches their list length. They were
publishing one event beside groups claiming three, which under this rule is a
prefix -- so they would have fallen back for a reason none of them is about.
Removing the check fails two named tests.