### PR TITLE
fix(positions): a tier hop that could only ever 503, on every request

### DIFF
--- a/tests/account-nominator-positions.test.ts
+++ b/tests/account-nominator-positions.test.ts
@@ -33,15 +33,28 @@ describe("GET /api/v1/accounts/{ss58}/positions (#5233)", () => {
     assert.deepEqual(body.data.positions, []);
   });
 
-  test("flag=postgres proxies to DATA_API and returns its shape", async () => {
+  test("the flag being set does NOT proxy this route to DATA_API", async () => {
+    // This route no longer forwards, and the whole-dispatch view is where that
+    // is worth pinning: METAGRAPH_NEURONS_SOURCE is still "data-api" -- it must
+    // be, for the 37 routes DATA_API really does dispatch -- and this one still
+    // must not hop. DATA_API has never had a branch for
+    // /accounts/:ss58/positions, so the forward could only ever reach that
+    // Worker's terminal 503, at the price of two subrequests and an awaited
+    // PostHog $exception before the hot leg answered anyway.
+    //
+    // The stub answers a PERFECTLY GOOD payload rather than failing, so the
+    // assertion cannot pass by accident: if the leg came back, `position_count`
+    // would be 1 and this test would say so.
+    let dataApiCalls = 0;
     const res = await handleRequest(
       new Request(`https://api.metagraph.sh/api/v1/accounts/${SS58}/positions`),
       {
         ...createLocalArtifactEnv(),
         METAGRAPH_NEURONS_SOURCE: "data-api",
         DATA_API: {
-          fetch: async () =>
-            Response.json({
+          fetch: async () => {
+            dataApiCalls += 1;
+            return Response.json({
               schema_version: 1,
               ss58: SS58,
               captured_at: null,
@@ -55,15 +68,18 @@ describe("GET /api/v1/accounts/{ss58}/positions (#5233)", () => {
                   stake_tao: 250,
                 },
               ],
-            }),
+            });
+          },
         },
       } as unknown as Env,
       {},
     );
     assert.equal(res.status, 200);
+    assert.equal(dataApiCalls, 0, "the DATA_API leg is gone, not merely quiet");
     const body = await res.json();
-    assert.equal(body.data.position_count, 1);
-    assert.equal(body.data.positions[0].stake_tao, 250);
+    assert.equal(body.data.ss58, SS58);
+    assert.equal(body.data.position_count, 0);
+    assert.deepEqual(body.data.positions, []);
   });
 
   test("testnet variant 404s instead of leaking a D1/R2 key (mainnet-only tier)", async () => {

--- a/tests/alert-triggers-route.test.ts
+++ b/tests/alert-triggers-route.test.ts
@@ -1617,9 +1617,12 @@ test("dereg-risk snapshot: 503 when ALERT_TRIGGERS_INTERNAL_TOKEN is not configu
 
 // #9193: the snapshot's four chain-table reads (blocks, subnet_hyperparams,
 // neurons, subnet_snapshots) all ran on the box's Postgres and went with it.
-// The route still answers past its auth gates, unchanged, so the evaluator
-// sees the same "this refresh is unavailable" it has seen since the wipe.
-test("dereg-risk snapshot: 503 -- the Postgres tier its chain-table reads used is gone", async () => {
+// No matcher has claimed the path since, so it lands on the dispatcher's
+// no-handler gate and the evaluator sees the same "this refresh is
+// unavailable" it has seen since the wipe. The 503 is about the missing
+// HANDLER, not about the database link -- Hyperdrive itself came back in
+// #10060 and serves the routes that do have branches.
+test("dereg-risk snapshot: 503 -- no matcher claims this path any more", async () => {
   const res = await fetch(
     req("/api/v1/internal/alert-triggers-dereg-risk-snapshot", {
       headers: { "x-alert-triggers-internal-token": INTERNAL_TOKEN },
@@ -1627,7 +1630,7 @@ test("dereg-risk snapshot: 503 -- the Postgres tier its chain-table reads used i
   );
   assert.equal(res.status, 503);
   assert.deepEqual(await res.json(), {
-    error: "hyperdrive binding unavailable",
+    error: "no handler on the data tier for this route",
   });
 });
 

--- a/tests/alerter-hub.test.ts
+++ b/tests/alerter-hub.test.ts
@@ -2300,7 +2300,9 @@ test("#11194: a non-ok snapshot refresh is reported, not swallowed", async () =>
             return conditionedTriggersResponse();
           }
           return new Response(
-            JSON.stringify({ error: "hyperdrive binding unavailable" }),
+            JSON.stringify({
+              error: "no handler on the data tier for this route",
+            }),
             { status: 503 },
           );
         }),

--- a/tests/data-api-account-balances.test.ts
+++ b/tests/data-api-account-balances.test.ts
@@ -2,8 +2,9 @@
 // a REAL SQLite database through the real Worker fetch handler -- same harness
 // and rationale as tests/data-api-validator-nominator-counts.test.ts.
 //
-// This route answered `503 hyperdrive binding unavailable` from the box wipe
-// (#9193) until migration 0017 gave it a Cloudflare-native store, and it came
+// This route answered the dispatcher's no-handler 503 from the box wipe
+// (#9193) -- worded `hyperdrive binding unavailable` back then -- until
+// migration 0017 gave it a Cloudflare-native store, and it came
 // out of that decommission worse off than either lane 0011/0012 revived: those
 // had a frozen lakehouse export to fall back on, while `account_balances` had
 // no D1 table at all. Its producer never went away -- metagraphed-infra's

--- a/tests/data-api-neurons.test.ts
+++ b/tests/data-api-neurons.test.ts
@@ -573,11 +573,15 @@ test("backfill-neuron-daily maps a write failure to a 502", async () => {
 
 // --- The D1 read dispatcher: gates and fallthrough ---------------------------
 
-test("a route no matcher claims falls through to the gone-tier 503", async () => {
+test("a route no matcher claims falls through to the no-handler 503", async () => {
+  // The message says what the gate actually tests -- no branch matched. It read
+  // `hyperdrive binding unavailable` from #9193 until #10060 bound Hyperdrive
+  // again, after which a 503 from here pointed a reader at a healthy database
+  // link instead of at the missing route.
   const res = await call(req("/api/v1/blocks"));
   assert.equal(res.status, 503);
   assert.deepEqual(await res.json(), {
-    error: "hyperdrive binding unavailable",
+    error: "no handler on the data tier for this route",
   });
 });
 

--- a/tests/data-api-nominator-positions.test.ts
+++ b/tests/data-api-nominator-positions.test.ts
@@ -2,8 +2,9 @@
 // against a REAL SQLite database through the real Worker fetch handler --
 // same harness and rationale as tests/data-api-hyperparams-identity.test.ts.
 //
-// This route answered `503 hyperdrive binding unavailable` for the whole
-// period the ledger was frozen. What matters here is the write CONTRACT, and
+// This route answered the dispatcher's no-handler 503 -- worded `hyperdrive
+// binding unavailable` at the time -- for the whole period the ledger was
+// frozen. What matters here is the write CONTRACT, and
 // specifically the two ways this lane differs from its siblings: a full Alpha
 // scan arrives across SEVERAL requests, so one request must never prune
 // another's rows; and share_fraction multiplies a whole hotkey's stake at

--- a/tests/data-api-validator-nominator-counts.test.ts
+++ b/tests/data-api-validator-nominator-counts.test.ts
@@ -2,8 +2,10 @@
 // END against a REAL SQLite database through the real Worker fetch handler --
 // same harness and rationale as tests/data-api-nominator-positions.test.ts.
 //
-// This route answered `503 hyperdrive binding unavailable` from the box wipe
-// (#9193) until migration 0012 gave it a Cloudflare-native store. Its producer
+// This route answered the dispatcher's no-handler 503 from the box wipe
+// (#9193) until migration 0012 gave it a Cloudflare-native store. (That gate
+// worded itself `hyperdrive binding unavailable` at the time; it says what it
+// actually tests now that Hyperdrive is bound again.) Its producer
 // never went away: metagraphed-infra's poller Container already runs the full
 // SubtensorModule::Alpha scan this table is derived from, and was disabled only
 // because it wrote to a Postgres that no longer exists.

--- a/tests/request-handlers-entities.test.ts
+++ b/tests/request-handlers-entities.test.ts
@@ -5950,12 +5950,30 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
     assert.deepEqual(captures.sql, []);
   });
 
-  test("handleAccountPositions: flag=postgres uses Postgres data, the store never queried (#5233)", async () => {
+  test("handleAccountPositions never forwards to DATA_API -- that Worker has no branch for this path", async () => {
+    // The regression pin for the dead forward. DATA_API is a LIVE
+    // Hyperdrive->Neon tier and answers the sibling routes (portfolio, subnets,
+    // identity, position HISTORY), which is exactly why re-adding a leg here
+    // looks reasonable -- but it has never had a branch for
+    // /accounts/:ss58/positions, so the forward could only ever fall through to
+    // that Worker's terminal 503. In production that cost two subrequests (503
+    // is at or above the retry floor, so the attempt was made twice) plus an
+    // AWAITED PostHog $exception on the response path, before the hot leg
+    // answered anyway: 55 of 55 captured neurons-tier declines in the fourteen
+    // days to 2026-08-15 were this single path.
+    //
+    // A `fetch` that THROWS is the assertion. Were the leg restored, this stub
+    // would be called and the throw would surface as a tier fallback rather
+    // than the clean hot-leg answer below -- and the capture it would have
+    // fired is the thing this test exists to keep out of production.
+    let dataApiCalls = 0;
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "data-api";
     env.DATA_API = {
-      fetch: async () =>
-        Response.json({ schema_version: 1, marker: "pg", positions: [] }),
+      fetch: async () => {
+        dataApiCalls += 1;
+        throw new Error("DATA_API must not be consulted for this route");
+      },
     };
     const body = await json(
       await handleAccountPositions(
@@ -5964,23 +5982,26 @@ describe("D1 -> Postgres serving-cutover flag (#4656 followup)", () => {
         SS58,
       ),
     );
-    assert.equal(body.data.marker, "pg");
-    assert.deepEqual(captures.sql, []);
+    assert.equal(dataApiCalls, 0, "the DATA_API leg is gone, not merely quiet");
+    assert.equal(body.data.ss58, SS58);
+    assert.ok(
+      captures.sql.some((sql: string) => /FROM nominator_positions/.test(sql)),
+      "the hot leg is consulted first and directly, with no doomed hop before it",
+    );
   });
 
-  test("handleAccountPositions: flag=postgres falls through to the D1 hot leg and LABELS the empty card (#9273)", async () => {
-    // The chain is Postgres -> D1 -> lakehouse -> labelled empty. This stub's
-    // D1 had no nominator_positions ledger and there is no R2 SQL token, so
-    // every tier declines -- and the card that comes back now SAYS so rather
-    // than publishing a confident `total_stake_alpha: 0`, which is the
-    // #9260/#9263 defect class this route shared.
+  test("handleAccountPositions: every tier declines and the empty card is LABELLED (#9273)", async () => {
+    // The chain is D1 hot -> lakehouse cold -> labelled empty. This stub's D1
+    // had no nominator_positions ledger and there is no R2 SQL token, so every
+    // tier declines -- and the card that comes back now SAYS so rather than
+    // publishing a confident `total_stake_alpha: 0`, which is the #9260/#9263
+    // defect class this route shared.
+    //
+    // `tier_unavailable` still being the reason is the point worth keeping:
+    // dropping the DATA_API leg removed a hop that could never answer, not the
+    // route's ability to admit that it cannot answer.
     const { env, captures } = dbWith({});
     env.METAGRAPH_NEURONS_SOURCE = "data-api";
-    env.DATA_API = {
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
     const body = await json(
       await handleAccountPositions(
         req(`/api/v1/accounts/${SS58}/positions`),

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -8803,14 +8803,25 @@ async function dispatchDataApiRequest(
       }
     }
 
-    // #9193: the Postgres read tier is gone. HYPERDRIVE was unbound with the
-    // box (#9186) and no wrangler config declares it any more, so every read
-    // route that used to live below this point was already unreachable -- this
-    // gate answered all of them. The status and body are deliberately
-    // UNCHANGED, because the forward gate depends on them: tryDataApiTier's
-    // callers in the main Worker read a non-2xx here as "this tier declines"
-    // and fall through to the lakehouse/store tiers exactly as they do today.
-    return json({ error: "hyperdrive binding unavailable" }, 503);
+    // NO BRANCH ABOVE MATCHED. That is all this gate means, and the message
+    // now says so.
+    //
+    // It used to read `hyperdrive binding unavailable`, which was true when
+    // #9193 wrote it: #9186 had unbound HYPERDRIVE with the box, so every read
+    // route below this point was unreachable and this gate answered all of
+    // them. #10060 bound Hyperdrive again -- wrangler.data.jsonc declares it,
+    // and the branches above serve /accounts/:ss58/portfolio, /subnets,
+    // /identity, the accounts list and the rest straight off Neon through it.
+    // The sentence outlived its condition, so a 503 from here read as "the
+    // database link is down" when it actually meant "this Worker has no
+    // handler for that path" -- a wrong diagnosis waiting for whoever met it
+    // next, and it was collected at least once.
+    //
+    // The STATUS is deliberately unchanged, because the forward gate depends
+    // on it: tryDataApiTier's callers in the main Worker read a non-2xx here
+    // as "this tier declines" and fall through to the store/lakehouse tiers.
+    // Only the message moves; nothing reads the body but a human.
+    return json({ error: "no handler on the data tier for this route" }, 503);
   }
 }
 

--- a/workers/request-handlers/entities.ts
+++ b/workers/request-handlers/entities.ts
@@ -145,10 +145,7 @@ import {
   answerAccountSummary,
   ACCOUNT_SUMMARY_GAP_CODE,
 } from "../../src/account-summary-card.ts";
-import {
-  buildAccountPositions,
-  unavailableAccountPositions,
-} from "../../src/account-nominator-positions.ts";
+import { unavailableAccountPositions } from "../../src/account-nominator-positions.ts";
 import { buildAccountPositionHistory } from "../../src/account-position-history.ts";
 import { buildAccountIdentity } from "../../src/account-identity.ts";
 import { buildAccountIdentityHistory } from "../../src/account-identity-history.ts";
@@ -5408,11 +5405,9 @@ export async function handleAccountPortfolio(
 
 // GET /api/v1/accounts/{ss58}/positions (#5233): this account's reconstructed
 // nominator-side positions -- what it holds delegated across every
-// hotkey/subnet, distinct from /portfolio above (hotkey-scoped). Reuses
-// METAGRAPH_NEURONS_SOURCE (not a dedicated flag) since this route's stake_tao
-// join reads the same neurons tier that flag already gates in production.
+// hotkey/subnet, distinct from /portfolio above (hotkey-scoped).
 //
-// Postgres → D1 hot tier → lakehouse cold tier → LABELLED empty card (#9273).
+// D1 hot tier → lakehouse cold tier → LABELLED empty card (#9273).
 // The D1 leg is the live one: `nominator_positions` had no live writer at all
 // between the box's decommission and #9273, so the lakehouse leg (#9266) is a
 // frozen export whose `captured_at` can never advance. The hot leg declines
@@ -5421,17 +5416,44 @@ export async function handleAccountPortfolio(
 // not a bare `buildAccountPositions([], ...)`: when every tier declines, this
 // route's zero is a read failure, and it now says so instead of publishing a
 // confident `total_stake_alpha: 0`.
+//
+// ## NO DATA_API LEG, BECAUSE DATA_API DOES NOT DISPATCH THIS PATH
+//
+// Not because that tier is gone -- it is LIVE. DATA_API holds the HYPERDRIVE
+// binding to Neon (wrangler.data.jsonc) and answers plenty of this family from
+// it: /accounts/:ss58/portfolio, /subnets, /identity, /identity-history, the
+// accounts list, and -- confusingly close to here -- /accounts/:ss58/subnets/
+// :netuid/history. What it has never had is a branch for THIS path.
+//
+// The forward was justified by the JOIN: this route's stake_tao leg reads the
+// same `neurons` tier METAGRAPH_NEURONS_SOURCE gates, so the flag was reused
+// rather than a new one added. But a shared join is not a dispatchable path.
+// Every request fell through all of DATA_API's branches to its terminal gate
+// and came back 503. Measured, not assumed: 55 of 55 captured neurons-tier
+// declines in the fourteen days to 2026-08-15 were this one path, and no other
+// route on any forwardable flag produced a single one.
+//
+// A decline that cannot be anything else is not a fallback, it is a toll. Each
+// request paid TWO subrequests (503 is >= the retry floor, so the attempt was
+// made twice) and one AWAITED PostHog $exception, on the response path, before
+// reaching the hot leg that was always going to answer. wrangler.jsonc's flag
+// notes already refuse exactly this trade for a tier that cannot serve -- "a
+// doomed Hyperdrive attempt plus a PostHog $exception before reaching the same
+// fallback" -- but the flag is not the lever here, because it must stay
+// "data-api" for the many routes DATA_API really does dispatch. The leg is
+// what is wrong for this one route, so the leg is what goes.
+//
+// The capture is deliberately NOT suppressed instead. #4686 added it so a tier
+// that is supposed to work cannot fail silently, and that signal is worth
+// keeping sharp -- an unforwarded route simply has nothing to report. MCP's
+// get_account_positions already resolved this chain hot → cold → empty-card
+// with no DATA_API leg; REST now agrees with it rather than contradicting it.
 export async function handleAccountPositions(
   request: Request,
   env: Env,
   ss58: string,
 ) {
   const data =
-    ((await tryDataApiTier(
-      env,
-      request,
-      "METAGRAPH_NEURONS_SOURCE",
-    )) as ReturnType<typeof buildAccountPositions> | null) ??
     (await loadAccountPositionsFromStore(env, ss58)) ??
     (await loadAccountPositionsColdTier(env, ss58)) ??
     unavailableAccountPositions(ss58);


### PR DESCRIPTION
## What was wrong

`GET /api/v1/accounts/{ss58}/positions` opened with `tryDataApiTier(METAGRAPH_NEURONS_SOURCE)` and **could never get an answer from it**.

DATA_API is not a dead tier — it holds the `HYPERDRIVE` binding to Neon (`wrangler.data.jsonc`) and serves this route's own siblings straight off it: `/accounts/:ss58/portfolio`, `/subnets`, `/identity`, `/identity-history`, the accounts list, and — confusingly close to here — `/accounts/:ss58/subnets/:netuid/history`. What it has **never** had is a branch for *this* path. So every request fell through all of its matchers to the dispatcher's terminal gate and came back `503`.

The forward was justified by the **join**: this route's `stake_tao` leg reads the same `neurons` tier that flag gates, so the flag was reused rather than a new one added. A shared join is not a dispatchable path. And the flag isn't the lever either — it must stay `"data-api"` for the 37 routes DATA_API really does dispatch. The leg is what was wrong for this one route, so the leg is what goes.

## What it cost, per request

Before reaching a hot leg that was always going to answer:

| | |
| --- | --- |
| subrequests | **2** — `503` is at or above `DATA_API_TIER_RETRY_ATTEMPTS`' retry floor, so the doomed attempt was made twice |
| PostHog `$exception` | **1, awaited** — on the response path, not `waitUntil`'d |

`wrangler.jsonc`'s own flag notes already refuse exactly this trade for a tier that cannot serve: *"a doomed Hyperdrive attempt plus a PostHog $exception before reaching the same fallback."*

## Measured two ways, because neither is sufficient alone

**Telemetry** — 55 of 55 captured neurons-tier declines in the fourteen days to 2026-08-15 were this one path, and no other route on any forwardable flag produced a single capture:

```
fingerprint                                   msg                                     n
data-api-tier:METAGRAPH_NEURONS_SOURCE:Error  ...503 for /api/v1/accounts/:ss58/positions  55
```

**But absence from a sample is not absence**, so also statically: all 37 remaining forwards were checked against the paths DATA_API actually dispatches — including the two that would have been misread by a naive name-to-path mapping:

- `handleCompareValidators` **rewrites** its URL (`validatorDetailRequest` → `/validators/{hotkey}`), which *is* dispatched — a live forward that looks dead;
- `handleSubnetHyperparams` serves `/hyperparameters`, so handler name and path disagree — dispatched too.

All 37 land on a real branch. `/accounts/:ss58/positions` was the only dead forward, which is why the telemetry and the static sweep agree exactly.

## Why not just silence the capture

`#4686` added it so a tier that is *supposed* to work cannot fail silently, and that signal is worth keeping sharp. An unforwarded route simply has nothing to report. MCP's `get_account_positions` already resolved this chain hot → cold → empty-card with no DATA_API leg — REST now agrees with it rather than contradicting it.

Behaviour is otherwise identical: `tier_unavailable` is still the reason when every tier declines. Dropping the hop removed a leg that could never answer, not the route's ability to admit that it cannot answer.

## The gate's message no longer lies

It read `hyperdrive binding unavailable` — true when `#9193` wrote it, because `#9186` had unbound HYPERDRIVE with the box. **`#10060` bound Hyperdrive again**, and the branches above that gate serve Neon through it every day. So a `503` from there pointed a reader at a healthy database link instead of at the missing route. That is a wrong diagnosis waiting for whoever meets it next, and it was collected at least once — while diagnosing this very issue.

The **status is unchanged**, because the forward gate depends on it (`tryDataApiTier` reads any non-2xx as "this tier declines"). Only the wording moves, and nothing but a human reads the body.

## Verification

- Live: `/accounts/{ss58}/positions` serves **514 priced positions, 13,114,911 total alpha** for a coldkey holding 695 rows in Neon — the hot leg was always the one answering. (The 695→514 gap and the `positions_unpriceable` label are correct and by design: rows whose hotkey isn't in the live `neurons` snapshot are excluded rather than priced at a fabricated 0, per `#9305`.)
- New regression pin: `handleAccountPositions` gets a DATA_API stub whose `fetch` **throws**, and asserts it is called **zero** times — restoring the leg fails the test.
- 671 tests across the 7 suites touching this; full CI validator set (69 gates) green; `typecheck` / `lint` / `format:check` clean.
- **Patch coverage 100%** — diff intersected with `coverage-final.json`: 0 uncovered statements and 0 uncovered branches on added lines in both changed files.