### PR TITLE
refactor(store): name the contracts a reader requires, and the four rules for reading a number

### DIFF
--- a/src/account-balances-completeness.ts
+++ b/src/account-balances-completeness.ts
@@ -1,3 +1,4 @@
+import type { RowReader } from "./read-store.ts";
 // "Is the account_balances ledger safe to rank from?" (#9511)
 //
 // THE QUESTION A ROW COUNT CANNOT ANSWER. `ORDER BY free_tao DESC LIMIT n` over
@@ -27,10 +28,6 @@
 //      clears it and publishes.
 //
 // Neither is a producer bug. Both are why the reader needs its own answer.
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
-}
 
 export interface AccountBalancesCompleteness {
   /** captured_at of the newest pass that fully landed, or null if none has. */
@@ -65,7 +62,7 @@ const NONE: AccountBalancesCompleteness = {
  * leaderboard that cannot prove its inputs should fall back, not 500.
  */
 export async function latestCompleteAccountBalancesPass(
-  db: StatementClientLike | null | undefined,
+  db: RowReader | null | undefined,
 ): Promise<AccountBalancesCompleteness> {
   if (!db?.first) return { ...NONE, reason: "unavailable" };
   try {

--- a/src/account-feeds-cold-tier.ts
+++ b/src/account-feeds-cold-tier.ts
@@ -106,7 +106,7 @@ import type { R2SqlReader } from "./r2-sql.ts";
 import { offsetBeyondEmulationCap } from "./r2-sql-blocks.ts";
 import { ACCOUNT_EVENTS_COLUMNS } from "../generated/lakehouse/types.ts";
 import type { AccountEventsRow } from "../generated/lakehouse/types.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowQuerier } from "./read-store.ts";
 
 /** Kept identical to the Postgres tier's SELECT list so both tiers hand the
  * formatter the same shape. */
@@ -551,12 +551,6 @@ export async function loadAccountPrometheusColdTier(
   };
 }
 
-/** The store surface this module needs from `neurons` -- structural, so tests
- * can hand a plain object (same pattern as src/blocks-cold-tier.ts). */
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-}
-
 /** The hotkey's registered (netuid, uid) slots from `neurons` -- the same
  * decomposition data-api runs now that neurons is off Postgres. null when the
  * slots cannot be read (no binding, D1 failure, or an unusable cell), because
@@ -567,7 +561,7 @@ async function neuronSlots(
   addr: string,
 ): Promise<{ netuid: number; uid: number }[] | null> {
   const db = readStore(env, ["neurons"]) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowQuerier | undefined;
   if (!db?.query) return null;
   let results: unknown[];
   try {

--- a/src/account-portfolio.ts
+++ b/src/account-portfolio.ts
@@ -10,6 +10,7 @@
 import { computeConcentration } from "./concentration.ts";
 import { loadStoreAlphaPricesByNetuid } from "./metagraph-neurons.ts";
 import { numberOrZero, round9 } from "./lib/rao.ts";
+import { nonNegativeIntOrNull } from "./read-store.ts";
 
 // The neurons-tier columns the portfolio reads for one hotkey.
 export const ACCOUNT_PORTFOLIO_READ_COLUMNS =
@@ -27,15 +28,6 @@ function nullableScore(value: unknown): number | null {
 
 // Strict non-negative integer coercion: accept ONLY a real number or an all-digits
 // string, so a blank/null/false cell is rejected rather than read as 0.
-function toInt(value: unknown): number | null {
-  if (typeof value === "number") {
-    return Number.isInteger(value) && value >= 0 ? value : null;
-  }
-  if (typeof value === "string" && /^\d+$/.test(value)) {
-    return Number(value);
-  }
-  return null;
-}
 
 interface CaptureStamp {
   ms: number;
@@ -117,7 +109,7 @@ export function buildAccountPortfolio(
   let totalEmission = 0;
   let capturedAt: CaptureStamp | null = null;
   for (const row of list) {
-    const netuid = toInt(row?.netuid);
+    const netuid = nonNegativeIntOrNull(row?.netuid);
     if (netuid == null) continue;
     netuids.add(netuid);
     const captured = captureStamp(row?.captured_at);
@@ -144,7 +136,7 @@ export function buildAccountPortfolio(
     }
     positions.push({
       netuid,
-      uid: toInt(row?.uid),
+      uid: nonNegativeIntOrNull(row?.uid),
       role: isValidator ? "validator" : "miner",
       active: Number(row?.active) === 1,
       stake_alpha: round9(stake),

--- a/src/account-position-history.ts
+++ b/src/account-position-history.ts
@@ -1,4 +1,5 @@
 import { numberOrZero, round9 } from "./lib/rao.ts";
+import { nonNegativeIntOrNull } from "./read-store.ts";
 // Per-account daily position HISTORY (block-explorer Tier-1, epic #4329/6.1).
 //
 // The refresh-metagraph cron lands the LATEST per-UID snapshot in Postgres's
@@ -60,16 +61,6 @@ function nullableScore(value: unknown): number | null {
   return Number.isFinite(n) ? round9(n) : null;
 }
 
-function toInt(value: unknown): number | null {
-  if (typeof value === "number") {
-    return Number.isInteger(value) && value >= 0 ? value : null;
-  }
-  if (typeof value === "string" && /^\d+$/.test(value)) {
-    return Number(value);
-  }
-  return null;
-}
-
 function toIso(ms: unknown): string | null {
   if (ms == null) return null;
   const n = Number(ms);
@@ -112,7 +103,7 @@ export function formatAccountPosition(
   const emission = numberOrZero(row.emission_tao);
   const isValidator = Number(row.validator_permit) === 1;
   return {
-    uid: toInt(row.uid),
+    uid: nonNegativeIntOrNull(row.uid),
     coldkey: row.coldkey ?? null,
     role: isValidator ? "validator" : "miner",
     active: Number(row.active) === 1,

--- a/src/account-summary-card.ts
+++ b/src/account-summary-card.ts
@@ -42,14 +42,8 @@ import {
 } from "./account-events.ts";
 import { loadAccountSummaryColdTier } from "./account-feeds-cold-tier.ts";
 import { isR2SqlConfigured } from "./r2-sql.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowQuerier } from "./read-store.ts";
 import type { Neurons } from "../generated/db/types.ts";
-
-/** The store surface this module needs -- structural, so tests can hand it a
- * plain object (the same pattern as src/blocks-cold-tier.ts). */
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-}
 
 /**
  * The registration read, character-for-character the one DATA_API's D1 leg
@@ -84,7 +78,7 @@ export async function loadAccountRegistrationsFromStore(
   ss58: string,
 ): Promise<AccountRegistrationRow[] | null> {
   const db = readStore(env, ["neurons"]) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowQuerier | undefined;
   if (!db?.query) return [];
   try {
     return await db.query<AccountRegistrationRow>(ACCOUNT_REGISTRATIONS_SQL, [

--- a/src/blocks-cold-tier.ts
+++ b/src/blocks-cold-tier.ts
@@ -48,7 +48,7 @@ import { safeBlockNumber, safeHexLiteral } from "./r2-sql.ts";
 import type { BlocksHead, ChainDetailBlocks } from "../generated/db/types.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 import { decodeCursor, encodeCursor } from "./cursor.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowQuerier } from "./read-store.ts";
 import {
   resolveDecodeWatermark,
   type DecodeWatermarkDeps,
@@ -135,10 +135,6 @@ interface BlockSeamRow {
 const STORE_FROM =
   "blocks_head b LEFT JOIN chain_detail_blocks c " +
   "ON c.block_number = b.block_number";
-
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-}
 
 /** The one binding this module still reads directly, independent of the full
  * Env shape so the module stays testable with a plain object. The store behind
@@ -264,7 +260,7 @@ async function storeHeadRows(
   want: number,
 ): Promise<Record<string, unknown>[] | null> {
   const db = readStore(env, BLOCKS_SEAM_TABLES) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowQuerier | undefined;
   if (!db?.query || want <= 0) return null;
 
   // Every predicate is qualified to `b`: block_number, observed_at and
@@ -425,7 +421,7 @@ export async function loadBlockColdTier(
   const db =
     network === DEFAULT_CHAIN_NETWORK
       ? (readStore(env, BLOCKS_SEAM_TABLES) as unknown as
-          StatementClientLike | undefined)
+          OptionalRowQuerier | undefined)
       : undefined;
   // "Above the seam" means "too new for the lakehouse, so D1 is the only
   // source" — a statement that is only true on mainnet, because only mainnet

--- a/src/blocks-summary.ts
+++ b/src/blocks-summary.ts
@@ -12,6 +12,7 @@
 
 import { computeConcentration } from "./concentration.ts";
 import { percentile } from "./lib/stats.ts";
+import { nonNegativeIntOrNull } from "./read-store.ts";
 
 // The `blocks` columns the summary reads. `author` is best-effort/nullable; the
 // counts are nullable INTEGERs; `observed_at` is the block timestamp (epoch ms).
@@ -40,18 +41,9 @@ function round2(value: number): number {
 // Strict non-negative integer coercion for identity/timestamp cells: accept ONLY a
 // real number or an all-digits string, so a blank/null/false cell is rejected
 // rather than coerced to 0 (Number("") === Number(null) === Number(false) === 0).
-function toInt(value: unknown): number | null {
-  if (typeof value === "number") {
-    return Number.isInteger(value) && value >= 0 ? value : null;
-  }
-  if (typeof value === "string" && /^\d+$/.test(value)) {
-    return Number(value);
-  }
-  return null;
-}
 
 function toTimestamp(value: unknown): number | null {
-  const ms = toInt(value);
+  const ms = nonNegativeIntOrNull(value);
   if (ms == null) return null;
   return Number.isFinite(new Date(ms).getTime()) ? ms : null;
 }
@@ -134,7 +126,7 @@ export function buildBlocksSummary(
   const list = Array.isArray(rows) ? rows : [];
   const blocks: ParsedBlock[] = [];
   for (const row of list) {
-    const blockNumber = toInt(row?.block_number);
+    const blockNumber = nonNegativeIntOrNull(row?.block_number);
     if (blockNumber == null) continue;
     blocks.push({
       block_number: blockNumber,
@@ -142,7 +134,7 @@ export function buildBlocksSummary(
       author: typeof row?.author === "string" && row.author ? row.author : null,
       extrinsic_count: toCount(row?.extrinsic_count),
       event_count: toCount(row?.event_count),
-      spec_version: toInt(row?.spec_version),
+      spec_version: nonNegativeIntOrNull(row?.spec_version),
     });
   }
   blocks.sort((a, b) => a.block_number - b.block_number);

--- a/src/chain-detail-hot-tier.ts
+++ b/src/chain-detail-hot-tier.ts
@@ -45,14 +45,11 @@ import { decodeChainEventArgs } from "./chain-event-args.ts";
 import { resolveBlocksSeam } from "./blocks-cold-tier.ts";
 import { type ChainNetworkId, DEFAULT_CHAIN_NETWORK } from "./chain-network.ts";
 import { safeBlockNumber } from "./r2-sql.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowQuerier } from "./read-store.ts";
 import { summarizeEvent } from "@jsonbored/chain-summaries";
 
 type Row = Record<string, unknown>;
 
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-}
 /** The four tables every statement in this module reads (#10148). Handed to
  *  readStore as one set: a hot tier split across stores would answer a block
  *  detail with extrinsics from one and events from the other. */
@@ -63,9 +60,9 @@ export const CHAIN_DETAIL_HOT_TIER_TABLES = [
   "chain_detail_account_events",
 ] as const;
 
-function db(env: unknown): StatementClientLike | null {
+function db(env: unknown): OptionalRowQuerier | null {
   const binding = readStore(env, CHAIN_DETAIL_HOT_TIER_TABLES) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowQuerier | undefined;
   return binding?.query ? binding : null;
 }
 

--- a/src/chain-detail-prune.ts
+++ b/src/chain-detail-prune.ts
@@ -61,7 +61,7 @@ import {
   type HyperdriveLike,
   type WaitUntilLike,
 } from "./pg-sql.ts";
-import { readStore, type ReadStoreDb } from "./read-store.ts";
+import { readStore, type ReadStoreDb, safeIntOrNull } from "./read-store.ts";
 import { CHAIN_DETAIL_HOT_TIER_TABLES } from "./chain-detail-hot-tier.ts";
 
 /** ~6h at the chain's 12s cadence: 3x the hourly decode lane's worst-case lag. */
@@ -141,12 +141,6 @@ export function chainDetailPruneWindow(input: {
   return { keepFrom: head - retainedBlocks + 1, retainedBlocks };
 }
 
-function toInt(value: unknown): number | null {
-  if (value == null) return null;
-  const n = Number(value);
-  return Number.isSafeInteger(n) ? n : null;
-}
-
 export interface ChainDetailPruneResult {
   ok: boolean;
   reason?: string;
@@ -201,8 +195,8 @@ export async function pruneChainDetail(
       "SELECT MIN(block_number) AS floor, MAX(block_number) AS head " +
         "FROM chain_detail_blocks",
     )) as { floor?: unknown; head?: unknown } | null;
-    const floor = toInt(bounds?.floor);
-    const head = toInt(bounds?.head);
+    const floor = safeIntOrNull(bounds?.floor);
+    const head = safeIntOrNull(bounds?.head);
     // An empty tier is not a failure: the lane has simply not written yet.
     if (floor === null || head === null)
       return { ok: true, reason: "no rows", blocks_pruned: 0 };

--- a/src/chain-detail-staleness-watchdog.ts
+++ b/src/chain-detail-staleness-watchdog.ts
@@ -29,7 +29,7 @@
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore, type ReadStoreDb } from "./read-store.ts";
+import { readStore, type ReadStoreDb, safeIntOrNull } from "./read-store.ts";
 
 /**
  * How far behind the lane may fall before this is a stall.
@@ -110,8 +110,8 @@ export async function readChainDetailHead(
       "FROM chain_detail_blocks",
   )) as { latest?: unknown; head?: unknown } | null;
   return {
-    latestObservedAtMs: toInt(row?.latest),
-    headBlock: toInt(row?.head),
+    latestObservedAtMs: safeIntOrNull(row?.latest),
+    headBlock: safeIntOrNull(row?.head),
   };
 }
 
@@ -122,12 +122,6 @@ export interface ChainDetailStalenessDeps {
   now?: () => number;
   /** Telemetry seam for tests; defaults to the real recordExceptionEvent. */
   recordException?: typeof recordExceptionEvent;
-}
-
-function toInt(value: unknown): number | null {
-  if (value == null) return null;
-  const n = Number(value);
-  return Number.isSafeInteger(n) ? n : null;
 }
 
 /**

--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -39,7 +39,7 @@
 // late. Freshness already covers that end, which is the half this is not.
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type RowQuerier } from "./read-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 export const DAILY_COVERAGE_LANE = "daily-series-coverage";
@@ -222,10 +222,6 @@ export function coverageDetail(
     .join(" | ");
 }
 
-interface StatementClientLike {
-  query(text: string, values?: unknown[]): Promise<Record<string, unknown>[]>;
-}
-
 export interface DailyCoverageDeps {
   laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
@@ -246,7 +242,7 @@ export async function runDailySeriesCoverageWatchdog(
   const db = readStore(
     env,
     DAILY_SERIES.map((s) => s.table),
-  ) as unknown as StatementClientLike | undefined;
+  ) as unknown as RowQuerier | undefined;
   if (!db?.query) return { ok: false, reason: "no store bound" };
 
   const verdicts: DailySeriesVerdict[] = [];

--- a/src/hotkey-alpha-completeness.ts
+++ b/src/hotkey-alpha-completeness.ts
@@ -1,3 +1,4 @@
+import type { RowReader } from "./read-store.ts";
 // "Is the hotkey_alpha pool ledger safe to price positions from?" (#9502)
 //
 // The twin of src/account-balances-completeness.ts, and needed for a strictly
@@ -21,10 +22,6 @@
 // See tests/fixtures/sqlite-schema/0021_hotkey_alpha_passes.sql for what the producer's floor
 // does and does not cover (a failed POST mid-sequence, and a 10%-of-762,577
 // floor that leaves a wide publishing band).
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
-}
 
 export interface HotkeyAlphaCompleteness {
   /** captured_at of the newest pass that fully landed, or null if none has. */
@@ -57,7 +54,7 @@ const NONE: HotkeyAlphaCompleteness = {
  * leaderboard that cannot prove its inputs should fall back, not 500.
  */
 export async function latestCompleteHotkeyAlphaPass(
-  db: StatementClientLike | null | undefined,
+  db: RowReader | null | undefined,
 ): Promise<HotkeyAlphaCompleteness> {
   if (!db?.first) return { ...NONE, reason: "unavailable" };
   try {

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -65,6 +65,7 @@ import {
   GithubIssueSchema,
 } from "../schemas-src/foreign-wire.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
+import { countOrZero } from "./read-store.ts";
 
 /**
  * How long a lane must stay stale before it earns an issue.
@@ -371,7 +372,7 @@ export const LANE_MAX_GAP_SQL =
  * verdict alone when it gets none.
  */
 export async function loadLaneMaxGap(
-  db: StatementClientLike | null | undefined,
+  db: LaneHealthDb | null | undefined,
   sinceMs: number,
 ): Promise<Record<string, number | null>> {
   if (!db?.query) return {};
@@ -386,8 +387,8 @@ export async function loadLaneMaxGap(
       if (!lane) continue;
       // The same sample floor the mean uses. `n` here counts GAPS, one fewer
       // than rows, so a lane with exactly the minimum rows still qualifies.
-      const n = toInt(row.n);
-      const gap = toInt(row.max_gap);
+      const n = countOrZero(row.n);
+      const gap = countOrZero(row.max_gap);
       out[lane] =
         n + 1 >= LANE_ALARM_MIN_CADENCE_SAMPLES && gap > 0 ? gap : null;
     }
@@ -863,32 +864,22 @@ export function laneAlarmRecoveryComment(
   );
 }
 
-// The verdict store's surface is the whole surface these readers need
-// (#10909): they SELECT through query() and record through run(), which is
-// exactly LaneHealthDb.
-type StatementClientLike = LaneHealthDb;
-
-function toInt(value: unknown): number {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
-
 /** Current stale runs, keyed by lane. `{}` on any failure -- a reader that
  * throws is a reader that stops reading. */
 export async function loadLaneUnknownRuns(
-  db: StatementClientLike | null | undefined,
+  db: LaneHealthDb | null | undefined,
 ): Promise<LaneVerdictRuns> {
   return loadLaneRuns(db, LANE_UNKNOWN_RUN_SQL);
 }
 
 export async function loadLaneStaleRuns(
-  db: StatementClientLike | null | undefined,
+  db: LaneHealthDb | null | undefined,
 ): Promise<LaneVerdictRuns> {
   return loadLaneRuns(db, LANE_STALE_RUN_SQL);
 }
 
 async function loadLaneRuns(
-  db: StatementClientLike | null | undefined,
+  db: LaneHealthDb | null | undefined,
   sql: string,
 ): Promise<LaneVerdictRuns> {
   if (!db?.query) return {};
@@ -898,7 +889,10 @@ async function loadLaneRuns(
     for (const row of rows) {
       const lane = row.lane == null ? "" : String(row.lane);
       if (!lane) continue;
-      out[lane] = { since: toInt(row.since), ticks: toInt(row.ticks) };
+      out[lane] = {
+        since: countOrZero(row.since),
+        ticks: countOrZero(row.ticks),
+      };
     }
     return out;
   } catch {
@@ -1052,7 +1046,11 @@ export async function runLaneAlarm(
   // GitHub issues from lane_health verdicts, so pointing it at a store nothing
   // writes any more would replay stale verdicts forever -- filing issues for
   // lanes that recovered, and none for lanes that broke.
-  const db = laneHealthStore(env) as unknown as StatementClientLike | undefined;
+  // NO CAST. `laneHealthStore` already returns `LaneHealthDb | undefined`,
+  // which is exactly what these readers take -- the `as unknown as` here was
+  // converting a value to its own type through `unknown`, which is the one
+  // form of cast that can never be checked again if either side moves.
+  const db = laneHealthStore(env);
   if (!db?.query) return { ok: false, reason: "no lane_health store bound" };
 
   // ITS OWN SECRET, falling back to the shared one.

--- a/src/lane-health.ts
+++ b/src/lane-health.ts
@@ -35,6 +35,7 @@ import {
   LANE_VERDICTS,
   type SelfHealthLane,
 } from "../schemas-src/routes/self-health.ts";
+import { safeIntOrNull } from "./read-store.ts";
 
 /**
  * How long a verdict is kept.
@@ -272,9 +273,9 @@ export async function loadLatestLaneHealth(
       const record: LaneHealthRecord = {
         lane,
         verdict: normalizeVerdict(row.verdict),
-        age_ms: toIntOrNull(row.age_ms),
+        age_ms: safeIntOrNull(row.age_ms),
         detail: row.detail == null ? null : String(row.detail),
-        checked_at: toIntOrNull(row.checked_at) ?? 0,
+        checked_at: safeIntOrNull(row.checked_at) ?? 0,
       };
       // TIES ARE REAL, AND THIS USED TO RESOLVE THEM BY ROW ORDER.
       //
@@ -350,12 +351,6 @@ function normalizeVerdict(value: unknown): LaneVerdict {
   return (LANE_VERDICTS as readonly string[]).includes(value as string)
     ? (value as LaneVerdict)
     : "unknown";
-}
-
-function toIntOrNull(value: unknown): number | null {
-  if (value == null) return null;
-  const n = Number(value);
-  return Number.isSafeInteger(n) ? n : null;
 }
 
 /**

--- a/src/live-economics-refresh.ts
+++ b/src/live-economics-refresh.ts
@@ -61,7 +61,7 @@ import {
 import { encodeAccountId32 } from "./ss58.ts";
 import { createSubtensorPinnedStorage } from "./subtensor-pinned-storage.ts";
 import type { StorageReadResult } from "../workers/storage.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type RowQuerier } from "./read-store.ts";
 
 type Row = Record<string, unknown>;
 
@@ -430,10 +430,6 @@ export function buildSubnetEconomics(
   };
 }
 
-interface StatementClientLike {
-  query(text: string, values?: unknown[]): Promise<Row[]>;
-}
-
 interface KvLike {
   put(key: string, value: string): Promise<unknown>;
 }
@@ -478,7 +474,7 @@ export async function refreshLiveEconomics(
   // history -- off a frozen table it would republish yesterday's economics
   // every three hours, with a fresh timestamp on it.
   const db = readStore(env, ["neurons", "subnet_snapshots"]) as unknown as
-    StatementClientLike | undefined;
+    RowQuerier | undefined;
   if (!db?.query) return { ok: false, reason: "store_unavailable" };
 
   const now = deps.now ?? Date.now;

--- a/src/nominator-positions-cold-tier.ts
+++ b/src/nominator-positions-cold-tier.ts
@@ -60,7 +60,7 @@ import {
 import { STAKE_ADDED_KIND, STAKE_REMOVED_KIND } from "./account-stake-flow.ts";
 import { registerModuleStateReset } from "./module-state-registry.ts";
 import { r2SqlQuery, safeSs58Literal } from "./r2-sql.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowQuerier } from "./read-store.ts";
 
 /** Kept identical to the retired Postgres tier's SELECT list (minus `coldkey`,
  * which the predicate already fixes) so both tiers hand the formatter the
@@ -87,12 +87,6 @@ export const POSITION_SCAN_CAP = 2_000;
  */
 export const BIND_PARAM_CHUNK = 100;
 
-/** The store surface this module needs from `neurons` -- structural, so tests can
- * hand a plain object (same pattern as src/account-feeds-cold-tier.ts). */
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-}
-
 /**
  * `neurons.stake_tao` for every (hotkey, netuid) a coldkey's positions
  * reference, as buildAccountPositions' join map -- or null when any chunk
@@ -108,7 +102,7 @@ export async function neuronStakeByHotkeys(
 ): Promise<Map<string, number> | null> {
   if (hotkeys.length === 0) return new Map();
   const db = readStore(env, ["neurons"]) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowQuerier | undefined;
   if (!db?.query) return null;
   const chunks: string[][] = [];
   for (let i = 0; i < hotkeys.length; i += BIND_PARAM_CHUNK) {

--- a/src/nominator-positions-hot-tier.ts
+++ b/src/nominator-positions-hot-tier.ts
@@ -35,15 +35,8 @@ import {
   neuronStakeByHotkeys,
   POSITION_SCAN_CAP,
 } from "./nominator-positions-cold-tier.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowStore } from "./read-store.ts";
 import type { NominatorPositions } from "../generated/db/types.ts";
-
-/** The store surface this module needs -- structural, so tests can hand a plain
- * object (same pattern as src/nominator-positions-cold-tier.ts). */
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-  first?(text: string, values?: unknown[]): Promise<unknown>;
-}
 
 /** Kept identical to the cold tier's SELECT list (minus `coldkey`, which the
  * predicate already fixes) so both tiers hand the formatter the same shape. */
@@ -71,7 +64,7 @@ export async function loadAccountPositionsFromStore(
   ss58: string,
 ): Promise<ReturnType<typeof buildAccountPositions> | null> {
   const db = readStore(env, ["nominator_positions"]) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowStore | undefined;
   if (!db?.query || !db?.first) return null;
 
   let rows: Record<string, unknown>[];

--- a/src/pass-completeness.ts
+++ b/src/pass-completeness.ts
@@ -1,3 +1,4 @@
+import type { RowReader } from "./read-store.ts";
 // "Did this lane's whole scan arrive?" — one implementation (metagraphed-infra#346).
 //
 // THE QUESTION A ROW COUNT CANNOT ANSWER. `ORDER BY … LIMIT n` over a partial
@@ -20,10 +21,6 @@
 // diff rather than riding along with the lanes that had no gate at all — but
 // they should move, and the shapes are identical on purpose so that it is a
 // mechanical change when someone does.
-
-interface StatementClientLike {
-  first(text: string, values?: unknown[]): Promise<unknown>;
-}
 
 export interface PassCompleteness {
   /** captured_at of the newest pass that fully landed, or null if none has. */
@@ -88,7 +85,7 @@ export const PASS_TABLES: Readonly<Record<string, string>> = {
  * rank", not as a 500.
  */
 export async function latestCompletePass(
-  db: StatementClientLike | null | undefined,
+  db: RowReader | null | undefined,
   lane: string,
 ): Promise<PassCompleteness> {
   const table = PASS_TABLES[lane];

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -105,9 +105,133 @@ export function numberOrNull(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-export interface ReadStoreDb {
+/**
+ * THE MINIMAL CONTRACTS A READER CAN ASK FOR (#11207).
+ *
+ * Fourteen modules each declared their own `StatementClientLike`, and they were
+ * not copies: six distinct shapes shared one name, so every file read as
+ * duplication while actually stating a different requirement. The name is what
+ * was wrong, not the narrowness -- declaring the structural minimum a call site
+ * needs is the right thing to do, because it is what lets a test hand in a
+ * double that implements only the half it exercises.
+ *
+ * So the shapes are named for what they REQUIRE and live in one place. A call
+ * site picks the one it means, and the name says which. Replacing them all with
+ * `ReadStoreDb` was the alternative and it is a widening: every double
+ * implementing only `query` would stop satisfying its own reader.
+ *
+ * `Partial<>` for the optional variants rather than a hand-written `query?`,
+ * so the required and optional forms cannot drift into describing different
+ * methods.
+ */
+
+/** A store that can read MANY rows. */
+export interface RowQuerier {
   query<T = Row>(text: string, values?: unknown[]): Promise<T[]>;
+}
+
+/** A store that can read ONE row.
+ *
+ * NON-GENERIC, and returning `unknown` rather than `T | null`, because this is
+ * the MINIMUM a caller can require rather than what the real store offers. A
+ * generic signature is not satisfied by a double that returns one concrete row
+ * type -- `T` could be instantiated with anything -- so widening this to match
+ * `ReadStoreDb` would break every fake in the completeness tests, which is the
+ * precise failure that made #11207 "looks like cleanup, is a regression". */
+export interface RowReader {
+  first(text: string, values?: unknown[]): Promise<unknown>;
+}
+
+/** ...where the binding may be absent, so the reader degrades rather than throws. */
+export type OptionalRowQuerier = Partial<RowQuerier>;
+export type OptionalRowReader = Partial<RowReader>;
+/** Both capabilities, either of which may be absent. */
+export type OptionalRowStore = Partial<RowQuerier & RowReader>;
+
+/** Both capabilities, required -- what `pgReadStore` actually returns.
+ *
+ * COMPOSED for the `query` half, which is identical, and stating the stronger
+ * `first` once: the store really does return `T | null`, and ~45 call sites
+ * read named columns off it. That is assignable to `RowReader`'s `unknown`, so
+ * a `ReadStoreDb` still satisfies every minimal contract above -- the arrow
+ * only points one way, which is what makes the minimal ones safe to require. */
+export type ReadStoreDb = RowQuerier & {
   first<T = Row>(text: string, values?: unknown[]): Promise<T | null>;
+};
+
+/**
+ * FOUR NAMINGS OF "COERCE TO A NUMBER OR NULL", SIDE BY SIDE (#11207).
+ *
+ * `toInt` was copy-pasted into six modules under one name with THREE different
+ * bodies, and `numberOrNull` above is a fourth rule again. Consolidating them
+ * under one implementation would silently change behaviour in whichever domain
+ * lost its variant -- a negative block number becoming valid, a blank string
+ * becoming zero -- which is the "looks like cleanup, is a regression" trap.
+ *
+ * So they keep their semantics and gain names that state them, and they live
+ * together so the differences are readable rather than three files apart:
+ *
+ *   helper                 accepts          rejects              blank string
+ *   --------------------   --------------   ------------------   ------------
+ *   nonNegativeIntOrNull   0, 7, "7"        -1, 1.5, " 7 "       null
+ *   safeIntOrNull          -1, 7, " 7 "     1.5, 2^53, "abc"     0
+ *   integerOrNull          -1, 7, 1e300     1.5, "abc"           null
+ *   numberOrNull           -1, 1.5, 1e300   "abc"                0
+ *
+ * Picking one is a judgement about what the READER needs, not about which is
+ * strictest. A block number is non-negative and arrives as a digit string, so
+ * `nonNegativeIntOrNull` refusing " 7 " is the point. A prune's row count is
+ * signed and comes off the driver already trimmed, so `safeIntOrNull` coercing
+ * it is the point.
+ */
+
+/**
+ * A non-negative integer, or null -- with a STRING accepted only in its exact
+ * digit form.
+ *
+ * The strictness is about where these values come from: block heights, indexes
+ * and counts arriving as query parameters or JSON, where " 7 " or "7abc" means
+ * a caller sent something malformed rather than a number that needs trimming.
+ */
+export function nonNegativeIntOrNull(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    return Number(value);
+  }
+  return null;
+}
+
+/**
+ * A safe integer, or null. Signed, and coercive the way `Number` is.
+ *
+ * For values off the DRIVER rather than off the wire: a delta, a row count, a
+ * BIGINT the driver may have handed back as a string. Negatives are legitimate
+ * and `Number("")` is 0, which is left alone because no caller here can receive
+ * a blank -- see `integerOrNull` for the one that can.
+ */
+export function safeIntOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isSafeInteger(n) ? n : null;
+}
+
+/**
+ * An integer of any magnitude, or null, with a blank string treated as absent.
+ *
+ * The chain-event reader's rule. Its inputs are decoded call arguments, where a
+ * field present-but-empty means "not supplied" -- `Number("")` is 0, and a zero
+ * netuid is a real subnet, so the blank has to be caught before the coercion.
+ * `isInteger` rather than `isSafeInteger` is deliberate here and NOT copied
+ * elsewhere: these values have already been through JSON, so one beyond 2^53
+ * has lost precision upstream and rejecting it would not recover it.
+ */
+export function integerOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const n = Number(value);
+  return Number.isInteger(n) ? n : null;
 }
 
 export interface ReadStoreDeps {

--- a/src/subnet-lifecycle.ts
+++ b/src/subnet-lifecycle.ts
@@ -38,7 +38,7 @@ import {
 } from "./pg-sql.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore } from "./read-store.ts";
+import { readStore, type RowQuerier } from "./read-store.ts";
 import {
   NEURONS_COVERAGE_FLOOR_NETUIDS,
   NEURONS_PASS_WINDOW_MS,
@@ -130,13 +130,6 @@ export function lifecycleDetail(
   return `${parts.join("; ")} (${observedCount} subnet(s) observed)`;
 }
 
-interface StatementClientLike {
-  query<Row = Record<string, unknown>>(
-    text: string,
-    values?: unknown[],
-  ): Promise<Row[]>;
-}
-
 export interface SubnetLifecycleDeps {
   laneHealthDb?: LaneHealthDb | null;
   now?: () => number;
@@ -157,7 +150,7 @@ export async function runSubnetLifecycleLane(
   const now = deps.now ?? Date.now;
   const floor = deps.coverageFloor ?? NEURONS_COVERAGE_FLOOR_NETUIDS;
   const db = readStore(env, ["neurons", "subnet_lifecycle"]) as unknown as
-    StatementClientLike | undefined;
+    RowQuerier | undefined;
   if (!db?.query) return { ok: false, reason: "no store bound" };
 
   const record = async (

--- a/src/subnet-news.ts
+++ b/src/subnet-news.ts
@@ -50,6 +50,7 @@
 //   depends on a payload we have never seen.
 
 import { SITE_ORIGIN as SITE_URL } from "./contracts.ts";
+import { integerOrNull } from "./read-store.ts";
 
 /** Feed item shape, structurally identical to src/feeds.ts' FeedItem. */
 export interface NewsItem {
@@ -98,13 +99,6 @@ function toIso(value: unknown): string | null {
     return Number.isFinite(date.getTime()) ? date.toISOString() : null;
   }
   return null;
-}
-
-function toInt(value: unknown): number | null {
-  if (value == null) return null;
-  if (typeof value === "string" && value.trim() === "") return null;
-  const n = Number(value);
-  return Number.isInteger(n) ? n : null;
 }
 
 /**
@@ -229,7 +223,7 @@ export function diffHyperparamSnapshots(
   for (let index = 1; index < snapshots.length; index += 1) {
     const previous = snapshots[index - 1];
     const current = snapshots[index];
-    const blockNumber = toInt(current?.block_number);
+    const blockNumber = integerOrNull(current?.block_number);
     const observedAt = toIso(current?.observed_at);
     if (blockNumber == null || observedAt == null) continue;
     // `?? {}` already guarantees objects, so there is no null check here --
@@ -336,13 +330,13 @@ export function ownershipChangeItems(
     // without it. Everything else flows into newsItem, which is the single
     // place an item is accepted or rejected -- validating twice invites the
     // two checks to disagree.
-    const blockNumber = toInt(row?.block_number);
+    const blockNumber = integerOrNull(row?.block_number);
     if (blockNumber == null) continue;
-    const rowNetuid = toInt(unwrapArg(row?.args?.netuid));
+    const rowNetuid = integerOrNull(unwrapArg(row?.args?.netuid));
     if (rowNetuid != null && rowNetuid !== netuid) continue;
     const from = shortAddress(unwrapArg(row?.args?.old_coldkey));
     const to = shortAddress(unwrapArg(row?.args?.new_coldkey));
-    const extrinsicIndex = toInt(row?.extrinsic_index);
+    const extrinsicIndex = integerOrNull(row?.extrinsic_index);
     const item = newsItem({
       id: `chain:sn${netuid}:owner:${blockNumber}:${row?.event_index ?? 0}`,
       url:
@@ -389,11 +383,11 @@ export function leaseEventItems(
     const method = typeof row?.method === "string" ? row.method : "";
     const verb = LEASE_VERBS[method];
     if (!verb) continue;
-    const blockNumber = toInt(row?.block_number);
+    const blockNumber = integerOrNull(row?.block_number);
     if (blockNumber == null) continue;
-    const rowNetuid = toInt(unwrapArg(row?.args?.netuid));
+    const rowNetuid = integerOrNull(unwrapArg(row?.args?.netuid));
     if (rowNetuid != null && rowNetuid !== netuid) continue;
-    const extrinsicIndex = toInt(row?.extrinsic_index);
+    const extrinsicIndex = integerOrNull(row?.extrinsic_index);
     const item = newsItem({
       id: `chain:sn${netuid}:lease:${blockNumber}:${row?.event_index ?? 0}`,
       url:

--- a/src/subnet-weight-setters-loader.ts
+++ b/src/subnet-weight-setters-loader.ts
@@ -11,7 +11,7 @@
 // emits [netuid, uid]. buildSubnetWeightSetters reads `hotkey` and `uid`
 // independently and is null-safe on the first, so the published row carries the
 // identity the event actually recorded and nothing invents a hotkey.
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowReader } from "./read-store.ts";
 import { SUBNET_HYPERPARAMS_TEMPO_TABLES } from "./read-store-tables.ts";
 import { buildSubnetWeightSetters } from "./subnet-weight-setters.ts";
 import {
@@ -90,7 +90,7 @@ async function loadSubnetTempo(
   // `overdue: null` on every subnet's weight-setters card, which is exactly the
   // #9389 regression #9396 fixed.
   const db = readStore(env, SUBNET_HYPERPARAMS_TEMPO_TABLES) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowReader | undefined;
   if (!db?.first) return null;
   try {
     const res = await db.first(
@@ -101,9 +101,4 @@ async function loadSubnetTempo(
   } catch {
     return null;
   }
-}
-
-/** The minimal store surface this needs, so tests can hand it a plain object. */
-interface StatementClientLike {
-  first?(text: string, values?: unknown[]): Promise<unknown>;
 }

--- a/src/top-holders-holdings.ts
+++ b/src/top-holders-holdings.ts
@@ -52,7 +52,7 @@
 // src/hotkey-alpha-completeness.ts for why a row count cannot answer this and
 // the producers declare their pass sizes instead.
 
-import { readStore } from "./read-store.ts";
+import { readStore, type OptionalRowStore } from "./read-store.ts";
 import { TOP_HOLDERS_HOLDINGS_TABLES } from "./read-store-tables.ts";
 import {
   latestCompleteAccountBalancesPass,
@@ -89,11 +89,6 @@ export interface HoldingsLeg {
   cells: Map<string, HoldingsCells>;
   /** The holdings sorts this leg proved it can rank. */
   sorts: string[];
-}
-
-interface StatementClientLike {
-  query?<Row>(text: string, values?: unknown[]): Promise<Row[]>;
-  first?(text: string, values?: unknown[]): Promise<unknown>;
 }
 
 /**
@@ -251,11 +246,11 @@ export async function topHoldersHoldings(
   // artifact entirely, which reads as "these sorts are unavailable" rather than
   // as a broken read.
   const db = readStore(env, TOP_HOLDERS_HOLDINGS_TABLES) as unknown as
-    StatementClientLike | undefined;
+    OptionalRowStore | undefined;
   if (!db?.query) return null;
 
   // The two readers describe the same binding with different minimal shapes --
-  // this module's StatementClientLike names bind()/all(), the completeness readers name
+  // this module's OptionalRowStore names bind()/all(), the completeness readers name
   // first() -- so the casts go through unknown rather than widening either
   // interface to satisfy the other.
   const asFirst = db as unknown as Parameters<

--- a/tests/read-store-coercions.test.ts
+++ b/tests/read-store-coercions.test.ts
@@ -1,0 +1,94 @@
+// Four namings of "coerce to a number or null", and why they are not one
+// function (#11207).
+//
+// `toInt` was copy-pasted into six modules under ONE name with THREE different
+// bodies. The tempting fix is to keep the strictest and delete the rest, and it
+// is a regression in whichever domain loses its variant: a negative row count
+// becoming null, a blank chain-event argument becoming zero, a malformed query
+// parameter becoming a block height.
+//
+// So these pin the DIFFERENCES rather than each helper in isolation. A future
+// consolidation has to delete one of these assertions to land, which is exactly
+// the conversation that should happen first.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  countOrZero,
+  integerOrNull,
+  nonNegativeIntOrNull,
+  numberOrNull,
+  safeIntOrNull,
+} from "../src/read-store.ts";
+
+describe("the four coercions differ where it matters", () => {
+  test("NEGATIVES: only the non-negative rule rejects them", () => {
+    // A block height cannot be -1; a prune's delta and a lane's gap can.
+    assert.equal(nonNegativeIntOrNull(-1), null);
+    assert.equal(safeIntOrNull(-1), -1);
+    assert.equal(integerOrNull(-1), -1);
+    assert.equal(numberOrNull(-1), -1);
+  });
+
+  test("A BLANK STRING: three answers, and each one is load-bearing", () => {
+    // `Number("")` is 0, and a zero netuid is a real subnet -- which is why
+    // the chain-event reader catches the blank before coercing, and why the
+    // driver-side helpers do not need to.
+    assert.equal(integerOrNull(""), null);
+    assert.equal(integerOrNull("   "), null);
+    assert.equal(safeIntOrNull(""), 0);
+    assert.equal(numberOrNull(""), 0);
+    assert.equal(nonNegativeIntOrNull(""), null);
+  });
+
+  test("A PADDED STRING: strict for wire input, coercive for driver output", () => {
+    // " 7 " off a query parameter means the caller sent something malformed.
+    // " 7 " off the driver is a BIGINT that arrived as text.
+    assert.equal(nonNegativeIntOrNull(" 7 "), null);
+    assert.equal(safeIntOrNull(" 7 "), 7);
+    assert.equal(integerOrNull(" 7 "), 7);
+  });
+
+  test("BEYOND 2^53: only the safe-integer rule refuses it", () => {
+    // These values have already been through JSON by the time `integerOrNull`
+    // sees them, so precision was lost upstream and refusing does not recover
+    // it. A driver value that large is a bug worth catching.
+    const huge = 1e300;
+    assert.equal(safeIntOrNull(huge), null);
+    assert.equal(integerOrNull(huge), huge);
+    assert.equal(numberOrNull(huge), huge);
+  });
+
+  test("NON-INTEGERS are rejected by all three int rules, kept by numberOrNull", () => {
+    for (const coerce of [nonNegativeIntOrNull, safeIntOrNull, integerOrNull]) {
+      assert.equal(coerce(1.5), null, coerce.name);
+    }
+    assert.equal(numberOrNull(1.5), 1.5);
+  });
+
+  test("UNREADABLE input: null everywhere except the count, which reads ZERO", () => {
+    // `countOrZero` is the odd one out on purpose: every caller is a coverage
+    // rule, and a count it cannot read must mean "covered nothing" so the rule
+    // ALERTS. Null would compare false against a floor and report healthy.
+    for (const coerce of [
+      nonNegativeIntOrNull,
+      safeIntOrNull,
+      integerOrNull,
+      numberOrNull,
+    ]) {
+      assert.equal(coerce("abc"), null, coerce.name);
+    }
+    assert.equal(countOrZero("abc"), 0);
+  });
+
+  test("null and undefined are absent, never zero", () => {
+    for (const coerce of [
+      nonNegativeIntOrNull,
+      safeIntOrNull,
+      integerOrNull,
+      numberOrNull,
+    ]) {
+      assert.equal(coerce(null), null, coerce.name);
+      assert.equal(coerce(undefined), null, coerce.name);
+    }
+  });
+});


### PR DESCRIPTION
Two families of copy-paste that are not copies, which is why #11207 said not to
merge them blindly.

FOURTEEN `StatementClientLike` DECLARATIONS, SIX SHAPES. `first` required;
`query?` optional; `query` required generic; `query` required non-generic;
`query?` and `first?` together; `first?` alone. Every one states the structural
minimum its own call site needs -- which is right, and is what lets a test hand
in a double implementing only the half it exercises. The NAME was the defect:
one name over six contracts reads as duplication and hides that they differ.

They are now `RowQuerier`, `RowReader` and the `Partial<>` forms of each, in
read-store.ts, so a call site picks the one it means and the name says which.
Replacing them all with `ReadStoreDb` was the obvious alternative and is a
widening: every double implementing only `query` stops satisfying its reader.
`RowReader` is deliberately NON-generic and returns `unknown` for the same
reason -- a generic `first<T>` is not satisfied by a double returning one
concrete row type, and the first cut of this broke every completeness fixture
proving it.

`ReadStoreDb` was a third declaration of the same two methods and now composes
the `query` half, stating only the stronger `first` it really offers.

SIX `toInt` COPIES, THREE BODIES, plus `numberOrNull` as a fourth rule again.
They keep their semantics and gain names that state them --
`nonNegativeIntOrNull`, `safeIntOrNull`, `integerOrNull` -- and they now sit
together, so the differences are readable rather than three files apart. The
choice is a judgement about the reader, not about strictness: a block height
arrives as a digit string and " 7 " means a malformed caller, while a prune's
delta comes off the driver already trimmed and is legitimately negative.

tests/read-store-coercions.test.ts pins them APART rather than each in
isolation -- negatives, blank strings, padded strings, 2^53, non-integers, and
the one that reads zero because a coverage rule that cannot read its count must
alert. A future consolidation has to delete one of those assertions to land,
which is the conversation that should happen first.

Two casts go with it. `lane-alarm.ts` aliased `StatementClientLike =
LaneHealthDb` and then wrote `laneHealthStore(env) as unknown as
StatementClientLike | undefined` -- a value converted to its own type through
`unknown`, since that function already returns exactly it. Its private `toInt`
was the sixth copy of `countOrZero`, named in that helper's own doc comment.

Closes #11207