### PR TITLE
feat(watchdog): a lane that runs and produces nothing is a fault, not a healthy lane

### DIFF
--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -39,7 +39,7 @@
 // late. Freshness already covers that end, which is the half this is not.
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore, type RowQuerier } from "./read-store.ts";
+import { readStore, type UntypedRowQuerier } from "./read-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 export const DAILY_COVERAGE_LANE = "daily-series-coverage";
@@ -242,7 +242,7 @@ export async function runDailySeriesCoverageWatchdog(
   const db = readStore(
     env,
     DAILY_SERIES.map((s) => s.table),
-  ) as unknown as RowQuerier | undefined;
+  );
   if (!db?.query) return { ok: false, reason: "no store bound" };
 
   const verdicts: DailySeriesVerdict[] = [];

--- a/src/daily-series-coverage-watchdog.ts
+++ b/src/daily-series-coverage-watchdog.ts
@@ -39,7 +39,7 @@
 // late. Freshness already covers that end, which is the half this is not.
 import { laneHealthStore } from "./lane-health-store.ts";
 import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
-import { readStore, type UntypedRowQuerier } from "./read-store.ts";
+import { readStore } from "./read-store.ts";
 import { recordExceptionEvent } from "./usage-telemetry.ts";
 
 export const DAILY_COVERAGE_LANE = "daily-series-coverage";

--- a/src/degenerate-output-watchdog.ts
+++ b/src/degenerate-output-watchdog.ts
@@ -1,0 +1,257 @@
+// A lane that RUNS and produces nothing reads as healthy (#11226).
+//
+// The attribution sweep ran on schedule, wrote a row for all 128 subnets,
+// reported `ok: true`, and produced nothing, for its entire life. Every
+// watchdog in this repo said it was healthy, and none of them was wrong: they
+// ask whether a lane RAN, and it ran.
+//
+//   TABLE_FRESHNESS            healthy -- rows were arriving on time
+//   check-lane-status          healthy -- the producer completed every pass
+//   the lane heartbeat         healthy -- it enqueued and consumed as designed
+//
+// #10818 is the instance. This is the class.
+//
+// ## The signal that was there the whole time
+//
+//   SELECT verdict, count(*), max(sources_checked)
+//   FROM attribution_sweeps GROUP BY verdict;
+//   --  no-sources | 128 | 0
+//
+// ONE verdict, 128 times, ZERO sources checked -- against a registry that
+// publishes ~2,900 sweepable http(s) surfaces across those same 128 subnets.
+// That is not a finding about the subnets. It is a contradiction between two
+// things this repo publishes, and it was one query away from the day the lane
+// shipped.
+//
+// ## Why this is a rule and not an alarm for the attribution sweep
+//
+// A per-lane alarm has to be remembered for each new lane, which is the failure
+// TABLE_FRESHNESS's own header describes: per-lane watchdogs cover only the
+// lanes somebody remembered. So a lane DECLARES what it produces and what a
+// degenerate result of that would look like, and inherits the check.
+//
+// ## Two faults, and neither needs a threshold
+//
+// BARREN is the whole fleet collapsing onto the one verdict that means "I
+// classified nothing". A classifying lane whose output is uniform is reporting
+// a defect in itself far more often than a fact about the world, and the
+// uniform-AND-null case needs no per-lane tuning to be alarming.
+//
+// IDLE is the lane's own work counter reading zero everywhere. `sources_checked
+// = 0` on ONE subnet is legitimate and the schema says so -- a subnet that
+// publishes no surface has not been searched, and must not read as "searched,
+// found nothing". Zero across every row is a lane that never tried.
+//
+// They are separate because they send a reader to different places: BARREN is
+// "the classifier is wrong", IDLE is "the input never arrived".
+//
+// ## What this deliberately does NOT do
+//
+// It does not alarm on a lane whose rows are merely SKEWED -- 127 of 128 on one
+// verdict is a fact about the world often enough that a threshold there would
+// fire on working lanes, which is how an alarm stops being read (#9301). Only
+// total collapse onto the null verdict counts, which is a property no healthy
+// classifier can have for long.
+import { laneHealthStore } from "./lane-health-store.ts";
+import { recordLaneVerdict, type LaneHealthDb } from "./lane-health.ts";
+import {
+  countOrZero,
+  readStore,
+  type UntypedRowQuerier,
+} from "./read-store.ts";
+import { recordExceptionEvent } from "./usage-telemetry.ts";
+
+export const DEGENERATE_OUTPUT_LANE = "degenerate-output";
+
+/**
+ * One classifying lane, and what a degenerate result of it looks like.
+ *
+ * DECLARED BY THE LANE, not discovered. There is no way to tell from a schema
+ * which TEXT column is a classification or which of its values means "nothing
+ * found" -- `verdict` here happens to be named for it, and the next lane's
+ * might be `status` with a null value of `skipped`. Guessing would produce a
+ * check that is confidently wrong about lanes nobody reviewed, which is worse
+ * than one that covers only lanes somebody declared.
+ */
+export interface ClassifyingLane {
+  /** The table the lane writes its classification into. */
+  table: string;
+  /** The column holding it. */
+  verdictColumn: string;
+  /** The value that means "this pass classified nothing". */
+  barren: string;
+  /**
+   * A counter whose fleet-wide maximum of zero means no work was attempted.
+   *
+   * Optional: a lane may classify without counting its inputs. When present it
+   * is the stronger signal of the two, because it cannot be explained by the
+   * world -- a lane cannot have looked at nothing everywhere and be fine.
+   */
+  workColumn?: string;
+  /** Why a collapse here is a defect in the lane rather than a fact. */
+  reason: string;
+}
+
+/**
+ * The lanes that classify, and what their degenerate output is.
+ *
+ * `attribution_sweeps` is the subject #11226 was filed about. It is a
+ * CURRENT-STATE table -- one row per subnet, overwritten each pass -- so the
+ * check reads all of it rather than a window, and "the whole fleet" is
+ * literally every row.
+ */
+export const CLASSIFYING_LANES: readonly ClassifyingLane[] = [
+  {
+    table: "attribution_sweeps",
+    verdictColumn: "verdict",
+    // The sweep's own word for "this subnet publishes nothing I can fetch".
+    // Legitimate per subnet; impossible across all of them while the registry
+    // publishes thousands of sweepable surfaces.
+    barren: "no-sources",
+    workColumn: "sources_checked",
+    reason:
+      "the registry publishes ~2,900 sweepable http(s) surfaces across these " +
+      "same subnets, so a fleet-wide no-sources is a contradiction between two " +
+      "things this repo publishes rather than a finding about the subnets",
+  },
+];
+
+/** One `GROUP BY verdict` row, as the driver hands it back. */
+export interface VerdictTally {
+  verdict: string;
+  rows: number;
+  work: number;
+}
+
+export type DegenerateFault = "barren" | "idle";
+
+export interface DegenerateVerdict {
+  table: string;
+  fault: DegenerateFault;
+  detail: string;
+}
+
+/**
+ * The rule alone -- no database, no clock.
+ *
+ * Returns null for a healthy lane, INCLUDING one with no rows at all: an empty
+ * table is freshness's question, and answering it here would put two alarms on
+ * one fact and neither of them able to clear the other.
+ */
+export function degenerateFault(
+  lane: ClassifyingLane,
+  tallies: readonly VerdictTally[],
+): DegenerateVerdict | null {
+  const total = tallies.reduce((n, t) => n + t.rows, 0);
+  if (total === 0) return null;
+
+  // IDLE FIRST, because it is the stronger claim and the more actionable one.
+  // A lane whose work counter is zero everywhere never reached its inputs; a
+  // barren verdict is what that then looks like from the outside, so reporting
+  // both would name one fault twice.
+  if (lane.workColumn) {
+    const work = tallies.reduce((n, t) => Math.max(n, t.work), 0);
+    if (work === 0) {
+      return {
+        table: lane.table,
+        fault: "idle",
+        detail:
+          `${lane.table}: ${lane.workColumn} is 0 across all ${total} row(s) -- ` +
+          `the lane completed every pass and looked at nothing. ${lane.reason}`,
+      };
+    }
+  }
+
+  const barren = tallies.find((t) => t.verdict === lane.barren);
+  if (barren && barren.rows === total) {
+    return {
+      table: lane.table,
+      fault: "barren",
+      detail:
+        `${lane.table}: all ${total} row(s) report ${lane.verdictColumn}=` +
+        `${lane.barren} -- a classifier whose output is uniform is reporting a ` +
+        `defect in itself. ${lane.reason}`,
+    };
+  }
+  return null;
+}
+
+/** The one query this asks per lane -- the query #11226 was filed with. */
+export function tallySql(lane: ClassifyingLane): string {
+  const work = lane.workColumn
+    ? `max(${lane.workColumn})`
+    : // No counter declared, so nothing can read zero -- a constant keeps the
+      // row shape identical rather than making the caller branch on it.
+      "1";
+  return (
+    `SELECT ${lane.verdictColumn} AS verdict, count(*) AS rows, ` +
+    `${work} AS work FROM ${lane.table} GROUP BY ${lane.verdictColumn}`
+  );
+}
+
+export interface DegenerateOutputDeps {
+  db?: UntypedRowQuerier | null;
+  laneHealthDb?: LaneHealthDb | null;
+  recordException?: typeof recordExceptionEvent;
+  now?: () => number;
+}
+
+export interface DegenerateOutputResult {
+  ok: boolean;
+  reason?: string;
+  faults: DegenerateVerdict[];
+  checked: number;
+}
+
+/** One tick: every declared lane, one query each. */
+export async function runDegenerateOutputWatchdog(
+  // The same loose shape every sibling watchdog takes: callers hand in an
+  // `Env`, a bag, or nothing, and a narrower type pushes a cast to the cron.
+  env: Record<string, unknown> | null | undefined,
+  deps: DegenerateOutputDeps = {},
+): Promise<DegenerateOutputResult> {
+  const db = deps.db ?? readStore(env, ["attribution_sweeps"]);
+  if (!db?.query) {
+    return { ok: false, reason: "no read store bound", faults: [], checked: 0 };
+  }
+  const now = deps.now ?? Date.now;
+  const faults: DegenerateVerdict[] = [];
+  let checked = 0;
+  for (const lane of CLASSIFYING_LANES) {
+    let rows: Record<string, unknown>[];
+    try {
+      rows = await db.query(tallySql(lane));
+    } catch (err) {
+      // ONE LANE'S FAILURE IS NOT THE TICK'S. A table that does not exist yet
+      // -- a migration applied by hand, which is how they land here -- must not
+      // stop the lanes after it being checked.
+      await (deps.recordException ?? recordExceptionEvent)(env as never, {
+        error: err instanceof Error ? err : new Error(String(err)),
+        route: `watchdog:${DEGENERATE_OUTPUT_LANE}`,
+        errorCode: "degenerate_output_query_failed",
+      });
+      continue;
+    }
+    checked += 1;
+    const fault = degenerateFault(
+      lane,
+      rows.map((row) => ({
+        verdict: String(row.verdict ?? ""),
+        rows: countOrZero(row.rows),
+        work: countOrZero(row.work),
+      })),
+    );
+    if (fault) faults.push(fault);
+  }
+
+  await recordLaneVerdict(deps.laneHealthDb ?? laneHealthStore(env), {
+    lane: DEGENERATE_OUTPUT_LANE,
+    verdict: faults.length ? "stale" : "ok",
+    age_ms: null,
+    detail: faults.length
+      ? faults.map((f) => f.detail).join("; ")
+      : `${checked} classifying lane(s), none degenerate`,
+    checked_at: now(),
+  });
+  return { ok: faults.length === 0, faults, checked };
+}

--- a/src/read-store.ts
+++ b/src/read-store.ts
@@ -130,6 +130,24 @@ export interface RowQuerier {
   query<T = Row>(text: string, values?: unknown[]): Promise<T[]>;
 }
 
+/**
+ * A store whose rows carry NO claimed shape.
+ *
+ * The minimum for a reader that only ever reads columns off an untyped row and
+ * never names a row type -- the watchdogs, which read `count(*)` and a verdict
+ * string out of a `GROUP BY`. `RowQuerier`'s generic `query<T>` is NOT this: a
+ * generic signature can only be satisfied by a generic implementation, so a
+ * hand-rolled double returning `Record<string, unknown>[]` does not fit it and
+ * has to be cast into place, which is the cast this exists to remove.
+ *
+ * The arrow points one way, as it does for `RowReader`: a `RowQuerier` (and so
+ * a `ReadStoreDb`) satisfies this by instantiating `T` at the default, so the
+ * real store can be handed to a reader that asks only for this.
+ */
+export interface UntypedRowQuerier {
+  query(text: string, values?: unknown[]): Promise<Row[]>;
+}
+
 /** A store that can read ONE row.
  *
  * NON-GENERIC, and returning `unknown` rather than `T | null`, because this is

--- a/tests/degenerate-output-watchdog.test.ts
+++ b/tests/degenerate-output-watchdog.test.ts
@@ -1,0 +1,245 @@
+// A lane that RUNS and produces nothing reads as healthy (#11226).
+//
+// The attribution sweep wrote a row for all 128 subnets, reported ok, and
+// produced nothing for its entire life. Every watchdog said healthy, and none
+// of them was wrong -- they ask whether a lane RAN.
+//
+// The dangerous direction for THIS check is the other one: an alarm that fires
+// on a working classifier gets ignored (#9301), and then the lane it was built
+// for goes quiet again behind it. So most of these pin what it must NOT report.
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  CLASSIFYING_LANES,
+  DEGENERATE_OUTPUT_LANE,
+  degenerateFault,
+  runDegenerateOutputWatchdog,
+  tallySql,
+  type ClassifyingLane,
+} from "../src/degenerate-output-watchdog.ts";
+
+const SWEEP = CLASSIFYING_LANES[0]!;
+
+/** A lane with no work counter, to exercise the barren rule on its own. */
+const CLASSIFIER: ClassifyingLane = {
+  table: "some_lane",
+  verdictColumn: "status",
+  barren: "skipped",
+  reason: "declared for the test",
+};
+
+const tally = (verdict: string, rows: number, work = 1) => ({
+  verdict,
+  rows,
+  work,
+});
+
+describe("degenerateFault", () => {
+  test("THE PRODUCTION SIGNAL: one verdict, 128 rows, zero work", () => {
+    // Byte for byte what `SELECT verdict, count(*), max(sources_checked) FROM
+    // attribution_sweeps GROUP BY verdict` returned on the day #11226 was
+    // filed. This is the assertion the whole file exists for.
+    const fault = degenerateFault(SWEEP, [tally("no-sources", 128, 0)]);
+    assert.equal(fault?.fault, "idle");
+    assert.match(fault!.detail, /sources_checked is 0 across all 128 row\(s\)/);
+  });
+
+  test("IDLE outranks BARREN, so one fault is not named twice", () => {
+    // A lane that reached nothing REPORTS the null verdict as a consequence.
+    // Emitting both would send a reader to two places for one cause, and the
+    // work counter is the one that says which.
+    assert.equal(
+      degenerateFault(SWEEP, [tally("no-sources", 128, 0)])?.fault,
+      "idle",
+    );
+  });
+
+  test("a uniform null verdict alarms even with no work counter declared", () => {
+    const fault = degenerateFault(CLASSIFIER, [tally("skipped", 40)]);
+    assert.equal(fault?.fault, "barren");
+    assert.match(fault!.detail, /all 40 row\(s\) report status=skipped/);
+  });
+
+  test("A UNIFORM NON-NULL VERDICT IS NOT A FAULT", () => {
+    // Every subnet reachable and every sweep finding nothing is a legitimate
+    // state of the world. Only collapse onto the verdict that means "I
+    // classified nothing" counts -- uniformity alone would alarm on a healthy
+    // fleet the day nothing changed.
+    assert.equal(
+      degenerateFault(SWEEP, [tally("none-published", 128, 5)]),
+      null,
+    );
+  });
+
+  test("ONE ROW OFF THE NULL VERDICT CLEARS IT -- no threshold", () => {
+    // 127 of 128 is a fact about the world often enough that a ratio here would
+    // fire on working lanes. The rule is total collapse or nothing.
+    assert.equal(
+      degenerateFault(SWEEP, [
+        tally("no-sources", 127, 0),
+        tally("candidates-found", 1, 3),
+      ]),
+      null,
+    );
+  });
+
+  test("a single subnet with zero sources is legitimate and stays quiet", () => {
+    // The schema says so in as many words: a subnet publishing no surface has
+    // not been searched, and must not read as "searched, found nothing". It is
+    // the FLEET-WIDE zero that is impossible.
+    assert.equal(
+      degenerateFault(SWEEP, [
+        tally("no-sources", 1, 0),
+        tally("none-published", 127, 9),
+      ]),
+      null,
+    );
+  });
+
+  test("an EMPTY table is not this watchdog's question", () => {
+    // Freshness already owns "no rows arrived". Answering it here too would put
+    // two alarms on one fact, neither able to clear the other.
+    assert.equal(degenerateFault(SWEEP, []), null);
+    assert.equal(degenerateFault(SWEEP, [tally("no-sources", 0, 0)]), null);
+  });
+});
+
+describe("tallySql", () => {
+  test("it is the query the issue was filed with", () => {
+    const sql = tallySql(SWEEP);
+    assert.match(sql, /SELECT verdict AS verdict, count\(\*\) AS rows/);
+    assert.match(sql, /max\(sources_checked\) AS work/);
+    assert.match(sql, /FROM attribution_sweeps GROUP BY verdict/);
+  });
+
+  test("a lane with no counter still yields the same row shape", () => {
+    // So the caller reads `work` unconditionally rather than branching on a
+    // column that may not be there.
+    assert.match(tallySql(CLASSIFIER), /1 AS work/);
+  });
+});
+
+describe("the declared lanes", () => {
+  test("attribution_sweeps declares the verdict its own type names", () => {
+    // The barren value has to be one the producer can actually write, or the
+    // check silently never matches. `SweepVerdict` in src/attribution-sweep.ts
+    // is the union; `no-sources` is its "publishes nothing fetchable" member.
+    assert.equal(SWEEP.table, "attribution_sweeps");
+    assert.equal(SWEEP.barren, "no-sources");
+    assert.equal(SWEEP.workColumn, "sources_checked");
+  });
+
+  test("every declared lane says WHY a collapse is a defect", () => {
+    // The reason rides into `lane_health.detail`, which is what a human reads
+    // at 3am deciding whether this is the lane or the world.
+    for (const lane of CLASSIFYING_LANES) {
+      assert.ok(lane.reason.length > 40, lane.table);
+    }
+  });
+});
+
+/** A store answering one `GROUP BY` with the given rows. */
+function db(rows: Record<string, unknown>[] | Error) {
+  const asked: string[] = [];
+  return {
+    asked,
+    query: async (sql: string) => {
+      asked.push(sql);
+      if (rows instanceof Error) throw rows;
+      return rows;
+    },
+  };
+}
+
+function laneHealth() {
+  const written: Record<string, unknown>[] = [];
+  return {
+    written,
+    db: { query: async () => [], run: async () => ({ changes: 1 }) },
+  };
+}
+
+describe("runDegenerateOutputWatchdog", () => {
+  test("records a STALE verdict naming the lane and the fault", async () => {
+    const health = laneHealth();
+    const result = await runDegenerateOutputWatchdog(
+      {},
+      {
+        db: db([{ verdict: "no-sources", rows: 128, work: 0 }]),
+        laneHealthDb: {
+          query: async () => [],
+          run: async (_sql: string, values?: unknown[]) => {
+            health.written.push({ values });
+            return { changes: 1 };
+          },
+        },
+        now: () => 1_785_000_000_000,
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.faults[0]?.fault, "idle");
+    const values = health.written[0]?.values as unknown[];
+    assert.equal(values[0], DEGENERATE_OUTPUT_LANE);
+    assert.equal(values[1], "stale");
+  });
+
+  test("records OK, and says how many lanes it checked", async () => {
+    // A watchdog that only ever writes on failure cannot be told from one that
+    // stopped running -- which is the class this whole file is about.
+    const written: unknown[][] = [];
+    const result = await runDegenerateOutputWatchdog(
+      {},
+      {
+        db: db([
+          { verdict: "no-sources", rows: 100, work: 4 },
+          { verdict: "candidates-found", rows: 28, work: 9 },
+        ]),
+        laneHealthDb: {
+          query: async () => [],
+          run: async (_sql: string, values?: unknown[]) => {
+            written.push(values ?? []);
+            return { changes: 1 };
+          },
+        },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.checked, CLASSIFYING_LANES.length);
+    assert.equal(written[0]?.[1], "ok");
+    assert.match(
+      String(written[0]?.[3]),
+      /1 classifying lane\(s\), none degenerate/,
+    );
+  });
+
+  test("A FAILED QUERY DOES NOT STOP THE TICK", async () => {
+    // Migrations here are applied by hand, so a table that does not exist yet
+    // is a state this must survive -- and it must not report the lanes it never
+    // reached as healthy either, which is why `checked` is counted rather than
+    // assumed.
+    const seen: unknown[] = [];
+    const result = await runDegenerateOutputWatchdog(
+      {},
+      {
+        db: db(new Error("relation does not exist")),
+        laneHealthDb: {
+          query: async () => [],
+          run: async () => ({ changes: 1 }),
+        },
+        recordException: async (_env: unknown, event: unknown) => {
+          seen.push(event);
+          return true;
+        },
+      },
+    );
+    assert.equal(result.ok, true, "no fault was observed, so none is reported");
+    assert.equal(result.checked, 0, "and it does not claim to have checked it");
+    assert.equal(seen.length, 1);
+  });
+
+  test("no store bound declines rather than reporting healthy", async () => {
+    const result = await runDegenerateOutputWatchdog({}, { db: null });
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "no read store bound");
+  });
+});

--- a/workers/api.ts
+++ b/workers/api.ts
@@ -605,6 +605,7 @@ import {
 import { runRegistrySyncLane } from "../src/registry-sync-lane.ts";
 import { runRegistryResyncLane } from "../src/registry-resync-lane.ts";
 import { runDailySeriesCoverageWatchdog } from "../src/daily-series-coverage-watchdog.ts";
+import { runDegenerateOutputWatchdog } from "../src/degenerate-output-watchdog.ts";
 import { runSubnetLifecycleLane } from "../src/subnet-lifecycle.ts";
 import { runSubnetDeregistrationDailyLane } from "../src/subnet-deregistration-daily.ts";
 import { resolveEmissionPipelineEconomics } from "../src/emission-pipeline-surface.ts";
@@ -3843,9 +3844,21 @@ async function dispatchScheduled(
     // asks how old the NEWEST row is -- a question structurally blind to a hole
     // in the middle. neuron_daily is the history source and only ~26 days deep,
     // so a missed day ages out of any recomputable window and becomes permanent.
-    return runDailySeriesCoverageWatchdog(
-      env as unknown as Record<string, unknown>,
-    );
+    //
+    // TWO WATCHDOGS, ONE MINUTE (#11226). The degenerate-output check shares
+    // this tick rather than taking a cron of its own: #10709 is open to halve
+    // the 43 crons this Worker already declares, and spending one while that
+    // is in flight works against it. The cadence argument is the same one
+    // written above -- a lane that classifies nothing does not heal on its own
+    // either, so the value is noticing at all, not noticing fast. They record
+    // separate lane verdicts, so sharing a minute does not merge their
+    // reporting.
+    const bag = env as unknown as Record<string, unknown>;
+    const [series] = await Promise.all([
+      runDailySeriesCoverageWatchdog(bag),
+      runDegenerateOutputWatchdog(bag),
+    ]);
+    return series;
   }
   if (cron === CHAIN_DETAIL_PRUNE_CRON) {
     // #9208 retention. Returns a summary rather than throwing so the #8998


### PR DESCRIPTION
The attribution sweep ran on schedule, wrote a row for all 128 subnets,
reported `ok: true`, and produced nothing, for its entire life. Every watchdog
here said it was healthy and none of them was wrong: TABLE_FRESHNESS saw rows
arriving on time, check-lane-status saw a producer completing every pass, the
heartbeat saw enqueue and consume exactly as designed. They ask whether a lane
RAN, and it ran. #10818 is the instance; this is the class.

The signal was one query away from the day it shipped:

    SELECT verdict, count(*), max(sources_checked)
    FROM attribution_sweeps GROUP BY verdict;
    --  no-sources | 128 | 0

One verdict, 128 times, zero sources checked -- against a registry that
publishes ~2,900 sweepable http(s) surfaces across those same subnets. Not a
finding about the subnets: a contradiction between two things this repo
publishes.

So a classifying lane DECLARES what a degenerate result of it looks like and
inherits the check, rather than each one getting an alarm somebody has to
remember. That is the failure TABLE_FRESHNESS's own header describes, and a
per-lane alarm for the sweep would have reproduced it for the next lane.

TWO FAULTS, NEITHER NEEDING A THRESHOLD. IDLE is the lane's own work counter
reading zero across every row -- `sources_checked = 0` on ONE subnet is
legitimate and the schema says so, but a lane cannot have looked at nothing
everywhere and be fine. BARREN is the whole fleet collapsing onto the verdict
that means "I classified nothing". IDLE outranks BARREN because a lane that
reached nothing reports the null verdict as a CONSEQUENCE, and emitting both
would name one cause twice.

What it deliberately does not do is alarm on skew. 127 of 128 on one verdict is
a fact about the world often enough that a ratio would fire on working lanes,
which is how an alarm stops being read (#9301) -- and then the lane it was built
for goes quiet again behind it. Only total collapse counts, and one row off the
null verdict clears it. Both rules fail under mutation, and the tests that catch
a threshold are the same ones that catch the rule being removed.

NO NEW CRON. It shares the daily-series watchdog's tick: #10709 is open to halve
the 43 crons this Worker declares, and spending one while that is in flight
works against it. The cadence argument is already written there -- a hole does
not heal, and neither does a lane that classifies nothing.

Two casts go with it. `daily-series-coverage-watchdog` wrote `readStore(...) as
unknown as RowQuerier | undefined`, which #11291 made dead by composing
`ReadStoreDb` out of `RowQuerier` -- the store now satisfies the contract
directly. And the watchdogs' true minimum is named: `UntypedRowQuerier`, for a
reader that only ever reads columns off an untyped row. `RowQuerier`'s generic
`query<T>` is not that -- a generic signature can only be satisfied by a generic
implementation, so a hand-rolled double has to be cast into place, which is the
cast this removes rather than writes.

Closes #11226