### PR TITLE
fix(attribution): a page that lists everyone attributes nobody

### DIFF
--- a/migrations/neon/0031_attribution_sweeps_listings_only.sql
+++ b/migrations/neon/0031_attribution_sweeps_listings_only.sql
@@ -1,0 +1,34 @@
+-- A sweep that read a bulk listing found addresses, and none of them are the
+-- subnet's (metagraphed#11227).
+--
+-- The sweep now caps how many DISTINCT addresses one page may yield before it
+-- is treated as a listing rather than an attribution. Measured on production
+-- 2026-08-15: 17 source URLs produced 4,741 of 4,902 candidate rows, every one
+-- of them a metagraph or miner dump -- `/allHolders`, `/api/miners`,
+-- `/snap/metagraph`. Those are other people's hotkeys, published by them, which
+-- is the false positive src/attribution-sweep.ts's own header names.
+--
+-- Dropping them needs a verdict to say so. `none-published` would claim we
+-- found no address when we found twelve hundred, and `candidates-found` would
+-- put strangers' keys in a human's review queue -- so the state gets its own
+-- name.
+--
+-- WIDENING ONLY, and that is what makes it safe to apply before the code that
+-- writes the new value. The constraint accepts strictly more than it did, so a
+-- Worker still running the old sweep keeps passing it; a Worker running the new
+-- one would be rejected until this lands. Migrations here are applied by hand,
+-- so the order is: this first, the deploy second.
+ALTER TABLE attribution_sweeps
+  DROP CONSTRAINT IF EXISTS attribution_sweeps_verdict_is_known;
+
+ALTER TABLE attribution_sweeps
+  ADD CONSTRAINT attribution_sweeps_verdict_is_known
+  CHECK (
+    verdict IN (
+      'none-published',
+      'candidates-found',
+      'unreachable',
+      'no-sources',
+      'listings-only'
+    )
+  );

--- a/src/attribution-sweep.ts
+++ b/src/attribution-sweep.ts
@@ -35,7 +35,42 @@ import type { AttributionSweeps } from "../generated/db/types.ts";
 
 /** Verdicts, matching the CHECK constraint on attribution_sweeps. */
 export type SweepVerdict =
-  "none-published" | "candidates-found" | "unreachable" | "no-sources";
+  | "none-published"
+  | "candidates-found"
+  | "unreachable"
+  | "no-sources"
+  | "listings-only";
+
+/**
+ * How many DISTINCT addresses one page may yield before it is a LISTING.
+ *
+ * A team publishes its own address on a page about itself: an owner coldkey, a
+ * validator hotkey, maybe a treasury. A page carrying forty is a metagraph
+ * dump, and every address on it belongs to somebody else -- the exact false
+ * positive this module's header names, and the reason the evidence bar is a
+ * human judgement rather than a row count.
+ *
+ * MEASURED, and calibrated on a gap that is in the data rather than on a round
+ * number. Every source URL that had produced a candidate as of 2026-08-15,
+ * by distinct addresses found:
+ *
+ *     1 x22  2 x25  3 x2  4 x2  5 x3  7 x2  8 x2  9  10  11
+ *     <---------------- nothing between 12 and 16 ---------------->
+ *     17 x2  21  23 x2  25  30  48  79  95  108 x2  135  155  172
+ *     190  191  192  256 x3  340  386  388  1230
+ *
+ * Twelve sits in that empty band. Below it are 61 URLs and 161 candidates
+ * across 48 subnets -- a population a reviewer can actually work through.
+ * Above it are 17 URLs and 4,741 rows, every one of them `/allHolders`,
+ * `/api/miners`, `/snap/metagraph` and their kin.
+ *
+ * A JUDGEMENT, NOT A LAW. The gap is empty in one observation of one day; a
+ * team page listing thirteen addresses would be dropped by this and is not
+ * impossible. The cost of that direction is a missed candidate, against a
+ * reviewer queue of 4,902 rows that is 97% other people's keys -- and a
+ * candidate nobody reads is already a candidate nobody sees.
+ */
+export const LISTING_ADDRESS_CAP = 12;
 
 export interface SweepCandidate {
   ss58: string;
@@ -124,6 +159,13 @@ export function sweepableSources(
  *                      and this must never read as "looked, found nothing".
  *   - `unreachable`  — we tried every source and reached none. About us.
  *   - `candidates-found` — something to put in front of a reviewer.
+ *   - `listings-only` — we read sources and found addresses, and every one of
+ *                      them was on a bulk listing. A REAL and different
+ *                      finding: this subnet publishes a metagraph dump rather
+ *                      than a page about itself, so the addresses are other
+ *                      people's. Folding it into `none-published` would claim
+ *                      we found nothing, and into `candidates-found` would put
+ *                      hundreds of strangers' keys in a review queue.
  *   - `none-published`  — we read at least one source and found no address.
  *                      The expected majority answer, and a real finding.
  */
@@ -131,10 +173,15 @@ export function sweepVerdict(
   sourcesChecked: number,
   sourcesRead: number,
   candidates: number,
+  listings = 0,
 ): SweepVerdict {
   if (sourcesChecked === 0) return "no-sources";
   if (sourcesRead === 0) return "unreachable";
-  return candidates > 0 ? "candidates-found" : "none-published";
+  if (candidates > 0) return "candidates-found";
+  // AFTER the candidates check, so a subnet with one real page and one dump
+  // still reports what a reviewer can act on. Listings are only the headline
+  // when they are all there was.
+  return listings > 0 ? "listings-only" : "none-published";
 }
 
 export interface SweepDeps {
@@ -158,6 +205,8 @@ export async function sweepSubnet(
   const sources = sweepableSources(record);
   const candidates: SweepCandidate[] = [];
   let read = 0;
+  /** Sources that answered and turned out to be bulk listings. */
+  let listings = 0;
   for (const url of sources) {
     let text: string | null;
     try {
@@ -169,7 +218,16 @@ export async function sweepSubnet(
     }
     if (text == null) continue;
     read += 1;
-    for (const ss58 of ss58Candidates(text)) {
+    const found = ss58Candidates(text);
+    // A PAGE, NOT ITS ADDRESSES, is what gets judged. The cap is applied per
+    // source and drops all of them together, because "this page is a listing"
+    // is a fact about the page -- keeping the first twelve of a metagraph dump
+    // would be twelve strangers' keys chosen by document order.
+    if (found.length > LISTING_ADDRESS_CAP) {
+      listings += 1;
+      continue;
+    }
+    for (const ss58 of found) {
       candidates.push({ ss58, source_url: url });
     }
   }
@@ -179,7 +237,7 @@ export async function sweepSubnet(
     sources_checked: sources.length,
     sources_read: read,
     candidates,
-    verdict: sweepVerdict(sources.length, read, candidates.length),
+    verdict: sweepVerdict(sources.length, read, candidates.length, listings),
   };
 }
 

--- a/tests/attribution-sweep.test.ts
+++ b/tests/attribution-sweep.test.ts
@@ -29,6 +29,7 @@ import {
   loadSweepRecord,
   persistSweep,
   ss58Candidates,
+  LISTING_ADDRESS_CAP,
   sweepSubnet,
   sweepVerdict,
   sweepableSources,
@@ -1173,3 +1174,126 @@ function queueEnvFor(payload: unknown, surfacesPayload?: unknown) {
     },
   };
 }
+
+// A page that lists everyone attributes nobody (#11227).
+//
+// #10818 fixed the sweep so it actually fetches, and it immediately produced
+// 4,902 candidate rows. Measured on production 2026-08-15, 17 source URLs
+// produced 4,741 of them -- `/allHolders`, `/api/miners`, `/snap/metagraph` --
+// every one a metagraph dump whose addresses belong to other people. A review
+// queue that is 97% strangers' keys is one nobody reads, which is the same
+// outcome as the silent failure #10818 fixed.
+
+/**
+ * Sixteen distinct, checksum-valid finney addresses.
+ *
+ * REAL ONES, generated rather than invented: `ss58Candidates` verifies the
+ * blake2b checksum, so a fixture of plausible-looking strings would be filtered
+ * out before the cap ever saw it and every test below would pass on an empty
+ * page. Derived deterministically from `sha256("metagraphed-listing-fixture-N")`
+ * so they are stable and belong to nobody.
+ */
+const LISTING_FIXTURE = [
+  "5FfEfocEEsS6cVURrfmoGrj667mDagRpV8TrFTiVHaf5Yd7C",
+  "5GEw5eHfTCT83xmq7iikrCwtCJ8dD19HvKpK5uTJYsuMuD8f",
+  "5CoAJ6KpdUKSexuDgyY86Y8QTVmy2Sqd3gVWpXem9Bt7dCpJ",
+  "5D1CQ6qBye56DyMrJG5VGunvb4J6JX2uyNFfwPrjCirtUR7k",
+  "5FHR1nkkJJ38mMgbvFMeeM4NQzjzsK8NKsSEP3TKMSZxRN6Y",
+  "5CvhHUf9wxPMHFeNwAxVmP7G8SuJcaXBFzhdUABogMjmzxyP",
+  "5HmcfXRVzT9BgZQrHgywE2qzRf4nTZQ1nAapoffdUBRbRhtu",
+  "5CSGDqtsuBLgo7vrBZTV6kPGiiWhy6eRZR33xvCjWB5GAvgK",
+  "5F1sgsLuxUeGuXvJecQMPL4iFNKFwNiEfZf59mUHNxgp639T",
+  "5FPqhAnvxYUBkFFoY5uUMAdWHoBfwVH9XjsNWrY5j8xACa4h",
+  "5CSXE1kzLS15qWrvuUARP1EZrpfaKnzaqU6Lh5eS3GVfCsbR",
+  "5Dqr4iVhb3koviiangqvXQbGs1XTXzXLvUFejtBGpnq7pSKi",
+  "5CnXWRCD3ULiczpHcTCfELiE5ZGVKgzF7qj8EPUqtcNZeTms",
+  "5HmQGr3J772AsJVFWZhXuMmnSbgz3wAEihSFadAjyfdgWTMb",
+  "5HBpTPztYyg3xkdmGKkLuX8t4XTp8ARqxW5rYTkGmi7Hy5SS",
+  "5C5TM6B9CLnReqTu5rcSVHgUqQ4KyvGL3FJJYHBboSQNHRe7",
+];
+
+describe("the listing cap", () => {
+  /** A registry record declaring one sweepable page. */
+  const oneSource = {
+    surfaces: [{ kind: "website", url: "https://x.test/p" }],
+  };
+  /** `n` distinct addresses, as one page's worth of text. */
+  const page = (n: number) => LISTING_FIXTURE.slice(0, n).join(" | ");
+
+  test("THE FIXTURE IS REAL, or every test below passes on an empty page", () => {
+    // The checksum is verified before the cap is applied, so invented strings
+    // would be dropped upstream and the cap would never be exercised.
+    assert.equal(ss58Candidates(page(16)).length, 16);
+  });
+
+  test("THE CAP SITS IN A GAP THAT IS IN THE DATA", () => {
+    // Every source URL that had produced a candidate, by distinct addresses:
+    // ...9, 10, 11, then NOTHING until 17, 21, 23, 25, 30, 48, 79, 95, 108...
+    // Twelve is that empty band. A round number would be arbitrary; this one
+    // separates the two populations the measurement actually found.
+    assert.equal(LISTING_ADDRESS_CAP, 12);
+  });
+
+  test("a page AT the cap is kept whole", async () => {
+    const out = await sweepSubnet(1, oneSource, {
+      fetchText: async () => page(LISTING_ADDRESS_CAP),
+      now: () => 1_785_000_000_000,
+    });
+    assert.equal(out.candidates.length, LISTING_ADDRESS_CAP);
+    assert.equal(out.verdict, "candidates-found");
+  });
+
+  test("ONE PAST THE CAP DROPS ALL OF THEM, not the excess", async () => {
+    // "This page is a listing" is a fact about the PAGE. Keeping the first
+    // twelve of a metagraph dump would be twelve strangers' keys chosen by
+    // document order -- a reviewer would have no way to tell them from a find.
+    const out = await sweepSubnet(1, oneSource, {
+      fetchText: async () => page(LISTING_ADDRESS_CAP + 1),
+      now: () => 1_785_000_000_000,
+    });
+    assert.deepEqual(out.candidates, []);
+    assert.equal(out.verdict, "listings-only");
+    // The page WAS reached, and the count must still say so -- a listing is not
+    // a reachability failure.
+    assert.equal(out.sources_read, 1);
+    assert.equal(out.sources_checked, 1);
+  });
+
+  test("A REAL FIND OUTRANKS A LISTING, so one dump cannot bury it", async () => {
+    // The common shape: a subnet publishes a team page AND an API dump.
+    // Reporting `listings-only` there would hide the candidate a human can act
+    // on.
+    const out = await sweepSubnet(
+      1,
+      {
+        surfaces: [
+          { kind: "website", url: "https://x.test/team" },
+          { kind: "subnet-api", url: "https://x.test/miners" },
+        ],
+      },
+      {
+        fetchText: async (url: string) =>
+          url.endsWith("/team") ? page(1) : page(16),
+        now: () => 1_785_000_000_000,
+      },
+    );
+    assert.equal(out.candidates.length, 1);
+    assert.equal(out.verdict, "candidates-found");
+  });
+
+  test("listings-only is not none-published, and not candidates-found", () => {
+    // Three different findings. `none-published` would claim we found no
+    // address when we found twelve hundred; `candidates-found` would put them
+    // in front of a human.
+    assert.equal(sweepVerdict(3, 3, 0, 2), "listings-only");
+    assert.equal(sweepVerdict(3, 3, 0, 0), "none-published");
+    assert.equal(sweepVerdict(3, 3, 1, 2), "candidates-found");
+  });
+
+  test("a listing does not make an unreachable subnet look read", () => {
+    // Reach is decided before content, so a subnet we could not fetch still
+    // reports about US rather than about its pages.
+    assert.equal(sweepVerdict(3, 0, 0, 0), "unreachable");
+    assert.equal(sweepVerdict(0, 0, 0, 0), "no-sources");
+  });
+});


### PR DESCRIPTION
#10818 fixed the sweep so it actually fetches sources, and it immediately
produced 4,902 candidate rows. #11227 asks for a reader to put those in front
of a human. Measured first, on the whole table rather than a sample:

    https://77.creativebuilds.io/allHolders                  1,230
    https://provider.engy.ai/api/subnet/v1/miners               388
    https://mantis123.com/dashboard/api/snap/miners             386
    https://api.chutes.ai/chutes/miner_means                    340
    https://mantis123.com/dashboard/api/snap/metagraph          256
    ...

SEVENTEEN URLs produce 4,741 of the 4,902 rows, and every one is a metagraph or
miner dump -- other people's hotkeys, published by them. That is the exact false
positive this module's own header names, and a review queue that is 97%
strangers' keys is one nobody reads. Which is the same outcome as the silent
failure #10818 fixed, reached from the other side.

So a page yielding more than LISTING_ADDRESS_CAP distinct addresses is a
LISTING, and none of its addresses is a candidate. The cap is twelve, and it is
calibrated on a gap that is in the data rather than on a round number -- source
URLs by distinct addresses found ran 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, then
nothing at all until 17, 21, 23, 25, 30, 48, 79, 95, 108. Twelve is that empty
band. Below it: 61 URLs, 161 candidates, 48 subnets -- a population a reviewer
can work through. Above it: 17 URLs and the rest.

DROPPED WHOLE, not trimmed. "This page is a listing" is a fact about the page;
keeping its first twelve would be twelve strangers' keys chosen by document
order, and a reviewer would have no way to tell them from a find.

A NEW VERDICT, because neither existing one is true. `none-published` would
claim we found no address when we found twelve hundred, and `candidates-found`
would put them in the queue. `listings-only` says what happened: we read the
sources, the addresses were there, and they are not this subnet's. It ranks
BELOW `candidates-found`, so a subnet publishing both a team page and an API
dump still reports the candidate a human can act on -- and below `unreachable`
too, since reach is decided before content.

Cross-subnet spread is NOT the discriminator, for the record, because it is the
intuitive one and it is wrong: 3,918 of 3,941 distinct addresses appear under
exactly one netuid, so "the same key on many subnets" catches 23 rows.

migrations/neon/0031 widens the verdict CHECK and has been APPLIED to
production -- widening only, so the Worker still running the old sweep keeps
passing it, which is what makes applying it before this deploy safe. Verified
both directions against the live constraint.

The cap is a judgement, not a law: the gap is empty in one observation of one
day, and a team page listing thirteen addresses would be dropped. That costs a
candidate, against a queue that is 97% noise -- and a candidate nobody reads is
already a candidate nobody sees.

Three mutations fail three named tests. The fixture addresses are generated with
real blake2b checksums rather than invented, because `ss58Candidates` verifies
them and plausible-looking strings would be filtered out upstream -- leaving
every test below passing on an empty page.

Refs #11227