### PR TITLE
fix(self-health): a dead-letter verdict is an event, and stale_lane_count treated it as a state

### DIFF
--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -27,7 +27,11 @@ import type {
   SelfHealthLane as PublishedSelfHealthLane,
 } from "../schemas-src/routes/self-health.ts";
 import type { LaneHealthRecord } from "./lane-health.ts";
-import { laneSilenceThresholdMs } from "./lane-alarm.ts";
+import {
+  LANE_ALARM_MAX_VERDICT_AGE_MS,
+  laneSilenceThresholdMs,
+} from "./lane-alarm.ts";
+import { DEAD_LETTER_LANES } from "./dead-letter.ts";
 import { laneSilenceCadenceMs } from "./producer-cadence.ts";
 
 export const SELF_HEALTH_COMPONENTS = ["api", "site", "publish"] as const;
@@ -267,6 +271,12 @@ export function buildSelfHealth(
  * D1 regardless of which one answered. Merging here means a degraded serving tier still
  * reports lane health — which is the situation the caller most wants it in.
  */
+/** The lane names `handleDeadLetterBatch` can write, from the map it dispatches
+ * on rather than from a `-dlq` suffix guess -- a lane missing from that map
+ * produces no verdict at all, which is the #10894 defect in the other
+ * direction. */
+const DEAD_LETTER_LANE_NAMES = new Set(Object.values(DEAD_LETTER_LANES));
+
 export function withLaneHealth(
   card: SelfHealth,
   laneRows: Record<string, LaneHealthRecord>,
@@ -300,6 +310,37 @@ export function withLaneHealth(
 ): SelfHealth {
   const { cadences, nowMs = Date.now() } = options;
   const lanes: SelfHealthLaneView[] = Object.values(laneRows)
+    // A DEAD-LETTER VERDICT IS AN EVENT, NOT A STATE (#11297).
+    //
+    // Every other lane here reports a continuous condition and can say `ok`
+    // again. A `*-dlq` lane cannot: `handleDeadLetterBatch` is its only writer
+    // and it writes only when a message is lost, because nothing un-loses one.
+    // So the last loss is served as the current state forever, and
+    // `stale_lane_count` can never return to zero -- measured 2026-08-15, one
+    // stale lane on a fleet whose every cause was fixed and verified hours
+    // earlier.
+    //
+    // THE SILENCE PATH BELOW CANNOT REACH IT, which is why this is separate.
+    // That bound is a multiple of the lane's own cadence, and a dlq has none --
+    // nothing writes it on a schedule -- so `laneSilenceCadenceMs` returns null
+    // and the verdict is left alone by design.
+    //
+    // DROPPED RATHER THAN MARKED, because absence is already this family's
+    // healthy representation: a dlq that has never lost a message has no row at
+    // all. One that lost a message a fortnight ago should look the same, and
+    // `unknown` would claim we cannot tell when we can.
+    //
+    // NOT SUPPRESSION. A fresh loss writes a fresh row and the count goes back
+    // up on the same tick. The row also stays in `lane_health` for triage --
+    // what changes is only whether it counts as NOW. Sharing the alarm's own
+    // residue constant rather than picking a second number: it already argues
+    // that a lane silent for a week is residue rather than an outage, and it
+    // already applies that to whether an issue gets filed.
+    .filter(
+      (row) =>
+        !DEAD_LETTER_LANE_NAMES.has(row.lane) ||
+        nowMs - row.checked_at <= LANE_ALARM_MAX_VERDICT_AGE_MS,
+    )
     .map((row) => {
       // The lane's own observed maximum gap, floored by its producer's
       // declared cadence where one exists (#10333). Neither alone is enough:

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -419,3 +419,79 @@ describe("withLaneHealth", () => {
     assert.equal(card.observed_at, base.observed_at);
   });
 });
+
+// A dead-letter verdict is an EVENT, and the serving read treated it as a
+// state (#11297).
+//
+// `handleDeadLetterBatch` is a `*-dlq` lane's only writer and it writes only on
+// a loss, because nothing un-loses a message. So the last loss was served as
+// the current state forever: measured 2026-08-15, `/api/v1/self-health`
+// reported `stale_lane_count: 1` for `probe-jobs-dlq` while every cause behind
+// those losses had been fixed and verified hours earlier.
+describe("a dead-letter verdict ages out of the serving read", () => {
+  const WEEK = 7 * 24 * 60 * 60 * 1000;
+  const dlq = (checked_at: number): LaneHealthRecord => ({
+    lane: "probe-jobs-dlq",
+    verdict: "stale",
+    age_ms: null,
+    detail:
+      "2 dead-lettered message(s) on probe-jobs-dlq (netuid=108,netuid=29)",
+    checked_at,
+  });
+  const card = (rows: LaneHealthRecord[], nowMs: number) =>
+    withLaneHealth(
+      buildSelfHealth([], []),
+      Object.fromEntries(rows.map((r) => [r.lane, r])),
+      { nowMs },
+    );
+
+  test("A RECENT LOSS STILL COUNTS -- this is not suppression", () => {
+    const now = 1_785_000_000_000;
+    const out = card([dlq(now - 60_000)], now);
+    assert.equal(out.stale_lane_count, 1);
+    assert.equal(out.lanes[0]?.lane, "probe-jobs-dlq");
+  });
+
+  test("past the residue window it stops being NOW", () => {
+    // The row stays in `lane_health` for triage. What changes is whether it is
+    // served as the current fleet state.
+    const now = 1_785_000_000_000;
+    const out = card([dlq(now - WEEK - 1)], now);
+    assert.equal(out.stale_lane_count, 0);
+    assert.deepEqual(out.lanes, []);
+  });
+
+  test("the boundary is the alarm's own constant, not a second number", () => {
+    const now = 1_785_000_000_000;
+    assert.equal(card([dlq(now - WEEK)], now).stale_lane_count, 1);
+    assert.equal(card([dlq(now - WEEK - 1)], now).stale_lane_count, 0);
+  });
+
+  test("A FRESH LOSS BRINGS IT BACK on the same tick", () => {
+    // The property that makes ageing-out different from muting: the lane is
+    // still watched, and the next real loss is reported immediately.
+    const now = 1_785_000_000_000;
+    assert.equal(card([dlq(now - WEEK - 1)], now).stale_lane_count, 0);
+    assert.equal(card([dlq(now - 1_000)], now).stale_lane_count, 1);
+  });
+
+  test("an ORDINARY lane's old stale verdict is left alone", () => {
+    // The scope of this rule is exactly the family that cannot say `ok`.
+    // Ageing out every stale verdict would hide genuinely broken lanes, which
+    // is the opposite failure and a much worse one.
+    const now = 1_785_000_000_000;
+    const out = card(
+      [
+        {
+          lane: "chain-detail",
+          verdict: "stale",
+          age_ms: 1,
+          detail: "frozen",
+          checked_at: now - WEEK - 1,
+        },
+      ],
+      now,
+    );
+    assert.equal(out.stale_lane_count, 1);
+  });
+});


### PR DESCRIPTION
`GET /api/v1/self-health` reported `stale_lane_count: 1` for `probe-jobs-dlq`
with every cause behind those losses fixed and verified hours earlier, and no
future tick could have changed it.

`handleDeadLetterBatch` is a `*-dlq` lane's only writer and it writes only when
a message is lost, because nothing un-loses one. So there is no `ok` path, and
`loadLatestLaneHealth` takes the newest row per lane with no liveness bound --
the last loss is served as the current state forever. A count that can never
return to zero teaches everyone to ignore the number, which costs more than the
one row.

THE SILENCE PATH CANNOT REACH IT, which is why this is separate rather than a
tweak to it. That bound is a multiple of the lane's own cadence, and a
dead-letter lane has none -- nothing writes it on a schedule -- so
`laneSilenceCadenceMs` returns null and `withLaneHealth` leaves the verdict
alone, correctly, for every other lane.

Neither existing tool fits. `RETIRED_LANES` is for a deleted PRODUCER, and this
one is alive: retiring it would mute the next real loss, and
tests/lane-health-retired.test.ts refuses an entry whose writer still exists.
Suppression would do the same thing on purpose.

So the verdict ages out of the SERVING read on the alarm's own residue window --
shared rather than a second number, because `LANE_ALARM_MAX_VERDICT_AGE_MS`
already argues that a lane silent for a week is residue rather than an outage,
and already applies that to whether an issue is filed. The read had no
equivalent, which is how the alarm went quiet while the card stayed red.

DROPPED RATHER THAN MARKED `unknown`, because absence is already this family's
healthy representation: a dlq that has never lost a message has no row at all,
and one that lost a message a fortnight ago should look identical. `unknown`
would claim we cannot tell, when we can.

Not suppression, and the tests say so from both sides: a fresh loss writes a
fresh row and the count goes back up on the same tick, the row stays in
`lane_health` for triage, and an ORDINARY lane's week-old `stale` is left
exactly alone -- ageing out every stale verdict would hide genuinely broken
lanes, which is the opposite failure and a much worse one. Both halves of the
rule fail under mutation.

The lane set comes from `DEAD_LETTER_LANES`, the map `handleDeadLetterBatch`
actually dispatches on, rather than a `-dlq` suffix guess: a lane missing from
that map produces no verdict at all, which is the #10894 defect in the other
direction.

Closes #11297