### PR TITLE
feat(compute): a requirement nobody claimed is still a requirement worth showing

### DIFF
--- a/generated/graphql/schema.ts
+++ b/generated/graphql/schema.ts
@@ -2916,7 +2916,7 @@ type SubnetCostToParticipate {
   declarations_read: Int!
 
   """
-  The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them.
+  The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under \`unscoped\` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet.
   """
   declared_compute: SubnetDeclaredCompute!
 
@@ -2962,11 +2962,12 @@ type SubnetEntryCost {
 }
 
 """
-The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them.
+The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under \`unscoped\` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet.
 """
 type SubnetDeclaredCompute {
   miner: SubnetDeclaredComputeSpec
   validator: SubnetDeclaredComputeSpec
+  unscoped: SubnetDeclaredComputeSpec
   evidence: SubnetComputeDeclarationEvidence
 }
 
@@ -3053,7 +3054,7 @@ type SubnetComputeDeclarationEvidence {
 
 type SubnetComputeDeclaration {
   """
-  The citation. \`read_at_sha\` is the commit that was HEAD when the file was read — 14 of the 17 registered surfaces point at \`main\`, which moves under the claim.
+  The citation. \`read_at_sha\` is the commit that was HEAD when the file was read — 14 of the 18 registered surfaces point at \`main\`, which moves under the claim.
   """
   evidence: SubnetComputeDeclarationEvidence!
 
@@ -3063,6 +3064,11 @@ type SubnetComputeDeclaration {
   found: Boolean!
   miner: SubnetDeclaredComputeSpec
   validator: SubnetDeclaredComputeSpec
+
+  """
+  Requirements this file declared WITHOUT saying whose they are — a flat \`compute_spec\` with no \`miner\`/\`validator\` split. Non-null only for a document that made no role distinction, in which case \`miner\` and \`validator\` are both null because that is true of the file. Same shape as the other two, so the four-valued GPU answer reads identically. Never a guess at which role was meant: attributing an unattributed requirement is the one thing this key exists to avoid.
+  """
+  unscoped: SubnetDeclaredComputeSpec
 }
 
 type SubnetParticipationEarnings {

--- a/generated/graphql/types.ts
+++ b/generated/graphql/types.ts
@@ -6145,11 +6145,13 @@ export type SubnetBurnHistoryPoint = {
 
 export type SubnetComputeDeclaration = {
   __typename?: 'SubnetComputeDeclaration';
-  /** The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 17 registered surfaces point at `main`, which moves under the claim. */
+  /** The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 18 registered surfaces point at `main`, which moves under the claim. */
   evidence: SubnetComputeDeclarationEvidence;
   /** Did the fetch yield a parseable compute_spec? `false` IS A MEASUREMENT — the file was read at that commit and declared nothing — and is distinct from a subnet that registers no min_compute surface at all, which has no declaration here. */
   found: Scalars['Boolean']['output'];
   miner?: Maybe<SubnetDeclaredComputeSpec>;
+  /** Requirements this file declared WITHOUT saying whose they are — a flat `compute_spec` with no `miner`/`validator` split. Non-null only for a document that made no role distinction, in which case `miner` and `validator` are both null because that is true of the file. Same shape as the other two, so the four-valued GPU answer reads identically. Never a guess at which role was meant: attributing an unattributed requirement is the one thing this key exists to avoid. */
+  unscoped?: Maybe<SubnetDeclaredComputeSpec>;
   validator?: Maybe<SubnetDeclaredComputeSpec>;
 };
 
@@ -6243,7 +6245,7 @@ export type SubnetCostToParticipate = {
   declarations: Array<SubnetComputeDeclaration>;
   /** How many of this subnet's registered min_compute declarations have been read. ZERO IS THE IMPORTANT VALUE: 111 of 129 subnets register none, and a card with `declarations_read: 0` makes no claim about what running here takes. */
   declarations_read: Scalars['Int']['output'];
-  /** The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. */
+  /** The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under `unscoped` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet. */
   declared_compute: SubnetDeclaredCompute;
   /** What miners here actually earned, projected from /api/v1/subnets/{netuid}/miner-fairness — never recomputed. Present so a floor-to-run can never sit on the page without the distribution that says whether running is worth it. Deliberately carries NO mean earning: that would invite exactly the cost-minus-revenue arithmetic these numbers do not support. */
   earnings?: Maybe<SubnetParticipationEarnings>;
@@ -6257,11 +6259,12 @@ export type SubnetCostToParticipate = {
   schema_version: Scalars['Int']['output'];
 };
 
-/** The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. */
+/** The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under `unscoped` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet. */
 export type SubnetDeclaredCompute = {
   __typename?: 'SubnetDeclaredCompute';
   evidence?: Maybe<SubnetComputeDeclarationEvidence>;
   miner?: Maybe<SubnetDeclaredComputeSpec>;
+  unscoped?: Maybe<SubnetDeclaredComputeSpec>;
   validator?: Maybe<SubnetDeclaredComputeSpec>;
 };
 
@@ -12902,6 +12905,7 @@ export type SubnetComputeDeclarationResolvers<ContextType = GqlContext, ParentTy
   evidence?: Resolver<ResolversTypes['SubnetComputeDeclarationEvidence'], ParentType, ContextType>;
   found?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   miner?: Resolver<Maybe<ResolversTypes['SubnetDeclaredComputeSpec']>, ParentType, ContextType>;
+  unscoped?: Resolver<Maybe<ResolversTypes['SubnetDeclaredComputeSpec']>, ParentType, ContextType>;
   validator?: Resolver<Maybe<ResolversTypes['SubnetDeclaredComputeSpec']>, ParentType, ContextType>;
 }>;
 
@@ -12980,6 +12984,7 @@ export type SubnetCostToParticipateResolvers<ContextType = GqlContext, ParentTyp
 export type SubnetDeclaredComputeResolvers<ContextType = GqlContext, ParentType extends ResolversParentTypes['SubnetDeclaredCompute'] = ResolversParentTypes['SubnetDeclaredCompute']> = ResolversObject<{
   evidence?: Resolver<Maybe<ResolversTypes['SubnetComputeDeclarationEvidence']>, ParentType, ContextType>;
   miner?: Resolver<Maybe<ResolversTypes['SubnetDeclaredComputeSpec']>, ParentType, ContextType>;
+  unscoped?: Resolver<Maybe<ResolversTypes['SubnetDeclaredComputeSpec']>, ParentType, ContextType>;
   validator?: Resolver<Maybe<ResolversTypes['SubnetDeclaredComputeSpec']>, ParentType, ContextType>;
 }>;
 

--- a/packages/contract/index.d.ts
+++ b/packages/contract/index.d.ts
@@ -10809,7 +10809,7 @@ export interface components {
         SubnetCostToParticipateArtifact: {
             /** @description Every declaration read for this subnet. A subnet registering two files that disagree keeps both here rather than being collapsed to whichever was read last. */
             declarations: {
-                /** @description The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 17 registered surfaces point at `main`, which moves under the claim. */
+                /** @description The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 18 registered surfaces point at `main`, which moves under the claim. */
                 evidence: {
                     /** @description When this file was first read, preserved across re-reads. */
                     first_seen?: string | null;
@@ -10825,6 +10825,38 @@ export interface components {
                 /** @description Did the fetch yield a parseable compute_spec? `false` IS A MEASUREMENT — the file was read at that commit and declared nothing — and is distinct from a subnet that registers no min_compute surface at all, which has no declaration here. */
                 found: boolean;
                 miner: {
+                    cpu: {
+                        architecture?: string | null;
+                        min_cores?: number | null;
+                        min_speed_ghz?: number | null;
+                    };
+                    gpu: {
+                        declared_min_count?: number | null;
+                        /** @description The file's own `min_vram`, in the GB the template asks for. Not converted, not rounded — a declaration we alter is no longer the subnet's declaration. */
+                        declared_min_vram_gb?: number | null;
+                        /** @description The file's own `recommended_gpu`. RECOMMENDED, not required: naming a card for a workload that does not need one is coherent, so this never moves `requirement` on its own. */
+                        declared_model?: string | null;
+                        /** @description The file's own `required:` value, published verbatim so a reader can see why `requirement` is not a boolean rather than take our word for it. */
+                        declared_required?: boolean | null;
+                        /** @description Does this role need a GPU, as the DECLARATION supports it? FOUR answers. `required` and `not-required` are what they say. `declared-inconsistently` is a declared `required: False` sitting beside a non-zero minimum VRAM, CUDA-core or GPU count — the shape an unedited template field takes beside an edited one, and never coerced to either boolean. `null` means no GPU stanza was declared at all, which is not a 'no'. */
+                        requirement: ("required" | "not-required" | "declared-inconsistently") | null;
+                    };
+                    memory: {
+                        min_ram_gb?: number | null;
+                        min_swap_gb?: number | null;
+                    };
+                    network: {
+                        min_download_speed_mbps?: number | null;
+                        min_upload_speed_mbps?: number | null;
+                    };
+                    storage: {
+                        min_iops?: number | null;
+                        min_space_gb?: number | null;
+                        type?: string | null;
+                    };
+                } | null;
+                /** @description Requirements this file declared WITHOUT saying whose they are — a flat `compute_spec` with no `miner`/`validator` split. Non-null only for a document that made no role distinction, in which case `miner` and `validator` are both null because that is true of the file. Same shape as the other two, so the four-valued GPU answer reads identically. Never a guess at which role was meant: attributing an unattributed requirement is the one thing this key exists to avoid. */
+                unscoped: {
                     cpu: {
                         architecture?: string | null;
                         min_cores?: number | null;
@@ -10889,7 +10921,7 @@ export interface components {
             }[];
             /** @description How many of this subnet's registered min_compute declarations have been read. ZERO IS THE IMPORTANT VALUE: 111 of 129 subnets register none, and a card with `declarations_read: 0` makes no claim about what running here takes. */
             declarations_read: number;
-            /** @description The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. */
+            /** @description The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under `unscoped` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet. */
             declared_compute: {
                 evidence: {
                     /** @description When this file was first read, preserved across re-reads. */
@@ -10904,6 +10936,37 @@ export interface components {
                     spec_version?: string | null;
                 } | null;
                 miner: {
+                    cpu: {
+                        architecture?: string | null;
+                        min_cores?: number | null;
+                        min_speed_ghz?: number | null;
+                    };
+                    gpu: {
+                        declared_min_count?: number | null;
+                        /** @description The file's own `min_vram`, in the GB the template asks for. Not converted, not rounded — a declaration we alter is no longer the subnet's declaration. */
+                        declared_min_vram_gb?: number | null;
+                        /** @description The file's own `recommended_gpu`. RECOMMENDED, not required: naming a card for a workload that does not need one is coherent, so this never moves `requirement` on its own. */
+                        declared_model?: string | null;
+                        /** @description The file's own `required:` value, published verbatim so a reader can see why `requirement` is not a boolean rather than take our word for it. */
+                        declared_required?: boolean | null;
+                        /** @description Does this role need a GPU, as the DECLARATION supports it? FOUR answers. `required` and `not-required` are what they say. `declared-inconsistently` is a declared `required: False` sitting beside a non-zero minimum VRAM, CUDA-core or GPU count — the shape an unedited template field takes beside an edited one, and never coerced to either boolean. `null` means no GPU stanza was declared at all, which is not a 'no'. */
+                        requirement: ("required" | "not-required" | "declared-inconsistently") | null;
+                    };
+                    memory: {
+                        min_ram_gb?: number | null;
+                        min_swap_gb?: number | null;
+                    };
+                    network: {
+                        min_download_speed_mbps?: number | null;
+                        min_upload_speed_mbps?: number | null;
+                    };
+                    storage: {
+                        min_iops?: number | null;
+                        min_space_gb?: number | null;
+                        type?: string | null;
+                    };
+                } | null;
+                unscoped: {
                     cpu: {
                         architecture?: string | null;
                         min_cores?: number | null;
@@ -41715,6 +41778,15 @@ export interface operations {
                      *               "network": {},
                      *               "storage": {}
                      *             },
+                     *             "unscoped": {
+                     *               "cpu": {},
+                     *               "gpu": {
+                     *                 "requirement": "required"
+                     *               },
+                     *               "memory": {},
+                     *               "network": {},
+                     *               "storage": {}
+                     *             },
                      *             "validator": {
                      *               "cpu": {},
                      *               "gpu": {
@@ -41734,6 +41806,15 @@ export interface operations {
                      *             "source_url": "https://api.metagraph.sh/example"
                      *           },
                      *           "miner": {
+                     *             "cpu": {},
+                     *             "gpu": {
+                     *               "requirement": "required"
+                     *             },
+                     *             "memory": {},
+                     *             "network": {},
+                     *             "storage": {}
+                     *           },
+                     *           "unscoped": {
                      *             "cpu": {},
                      *             "gpu": {
                      *               "requirement": "required"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9093,6 +9093,15 @@
                   "network": {},
                   "storage": {}
                 },
+                "unscoped": {
+                  "cpu": {},
+                  "gpu": {
+                    "requirement": "required"
+                  },
+                  "memory": {},
+                  "network": {},
+                  "storage": {}
+                },
                 "validator": {
                   "cpu": {},
                   "gpu": {
@@ -9112,6 +9121,15 @@
                 "source_url": "https://api.metagraph.sh/example"
               },
               "miner": {
+                "cpu": {},
+                "gpu": {
+                  "requirement": "required"
+                },
+                "memory": {},
+                "network": {},
+                "storage": {}
+              },
+              "unscoped": {
                 "cpu": {},
                 "gpu": {
                   "requirement": "required"
@@ -45818,7 +45836,7 @@
               "properties": {
                 "evidence": {
                   "additionalProperties": false,
-                  "description": "The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 17 registered surfaces point at `main`, which moves under the claim.",
+                  "description": "The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 18 registered surfaces point at `main`, which moves under the claim.",
                   "properties": {
                     "first_seen": {
                       "anyOf": [
@@ -46080,6 +46098,220 @@
                     }
                   ]
                 },
+                "unscoped": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "description": "One role's DECLARED minimum, in the subnet's own numbers. Units are carried in the field names; nothing is converted or defaulted. This is the floor to RUN, never the spec to EARN.",
+                      "properties": {
+                        "cpu": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "architecture": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "min_cores": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "min_speed_ghz": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "gpu": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "declared_min_count": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "declared_min_vram_gb": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "The file's own `min_vram`, in the GB the template asks for. Not converted, not rounded — a declaration we alter is no longer the subnet's declaration."
+                            },
+                            "declared_model": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "The file's own `recommended_gpu`. RECOMMENDED, not required: naming a card for a workload that does not need one is coherent, so this never moves `requirement` on its own."
+                            },
+                            "declared_required": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "The file's own `required:` value, published verbatim so a reader can see why `requirement` is not a boolean rather than take our word for it."
+                            },
+                            "requirement": {
+                              "anyOf": [
+                                {
+                                  "enum": [
+                                    "required",
+                                    "not-required",
+                                    "declared-inconsistently"
+                                  ],
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ],
+                              "description": "Does this role need a GPU, as the DECLARATION supports it? FOUR answers. `required` and `not-required` are what they say. `declared-inconsistently` is a declared `required: False` sitting beside a non-zero minimum VRAM, CUDA-core or GPU count — the shape an unedited template field takes beside an edited one, and never coerced to either boolean. `null` means no GPU stanza was declared at all, which is not a 'no'."
+                            }
+                          },
+                          "required": [
+                            "requirement"
+                          ],
+                          "type": "object"
+                        },
+                        "memory": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "min_ram_gb": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "min_swap_gb": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "network": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "min_download_speed_mbps": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "min_upload_speed_mbps": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "storage": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "min_iops": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "min_space_gb": {
+                              "anyOf": [
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "type": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "gpu",
+                        "cpu",
+                        "memory",
+                        "storage",
+                        "network"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Requirements this file declared WITHOUT saying whose they are — a flat `compute_spec` with no `miner`/`validator` split. Non-null only for a document that made no role distinction, in which case `miner` and `validator` are both null because that is true of the file. Same shape as the other two, so the four-valued GPU answer reads identically. Never a guess at which role was meant: attributing an unattributed requirement is the one thing this key exists to avoid."
+                },
                 "validator": {
                   "anyOf": [
                     {
@@ -46298,7 +46530,8 @@
                 "evidence",
                 "found",
                 "miner",
-                "validator"
+                "validator",
+                "unscoped"
               ],
               "type": "object"
             },
@@ -46312,7 +46545,7 @@
           },
           "declared_compute": {
             "additionalProperties": false,
-            "description": "The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them.",
+            "description": "The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under `unscoped` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet.",
             "properties": {
               "evidence": {
                 "anyOf": [
@@ -46368,6 +46601,219 @@
                 ]
               },
               "miner": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "description": "One role's DECLARED minimum, in the subnet's own numbers. Units are carried in the field names; nothing is converted or defaulted. This is the floor to RUN, never the spec to EARN.",
+                    "properties": {
+                      "cpu": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "architecture": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "min_cores": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "min_speed_ghz": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "gpu": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "declared_min_count": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "declared_min_vram_gb": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "The file's own `min_vram`, in the GB the template asks for. Not converted, not rounded — a declaration we alter is no longer the subnet's declaration."
+                          },
+                          "declared_model": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "The file's own `recommended_gpu`. RECOMMENDED, not required: naming a card for a workload that does not need one is coherent, so this never moves `requirement` on its own."
+                          },
+                          "declared_required": {
+                            "anyOf": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "The file's own `required:` value, published verbatim so a reader can see why `requirement` is not a boolean rather than take our word for it."
+                          },
+                          "requirement": {
+                            "anyOf": [
+                              {
+                                "enum": [
+                                  "required",
+                                  "not-required",
+                                  "declared-inconsistently"
+                                ],
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ],
+                            "description": "Does this role need a GPU, as the DECLARATION supports it? FOUR answers. `required` and `not-required` are what they say. `declared-inconsistently` is a declared `required: False` sitting beside a non-zero minimum VRAM, CUDA-core or GPU count — the shape an unedited template field takes beside an edited one, and never coerced to either boolean. `null` means no GPU stanza was declared at all, which is not a 'no'."
+                          }
+                        },
+                        "required": [
+                          "requirement"
+                        ],
+                        "type": "object"
+                      },
+                      "memory": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "min_ram_gb": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "min_swap_gb": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "network": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "min_download_speed_mbps": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "min_upload_speed_mbps": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "storage": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "min_iops": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "min_space_gb": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "type": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "gpu",
+                      "cpu",
+                      "memory",
+                      "storage",
+                      "network"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "unscoped": {
                 "anyOf": [
                   {
                     "additionalProperties": false,
@@ -46797,6 +47243,7 @@
             "required": [
               "miner",
               "validator",
+              "unscoped",
               "evidence"
             ],
             "type": "object"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -10809,7 +10809,7 @@ export interface components {
         SubnetCostToParticipateArtifact: {
             /** @description Every declaration read for this subnet. A subnet registering two files that disagree keeps both here rather than being collapsed to whichever was read last. */
             declarations: {
-                /** @description The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 17 registered surfaces point at `main`, which moves under the claim. */
+                /** @description The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 18 registered surfaces point at `main`, which moves under the claim. */
                 evidence: {
                     /** @description When this file was first read, preserved across re-reads. */
                     first_seen?: string | null;
@@ -10825,6 +10825,38 @@ export interface components {
                 /** @description Did the fetch yield a parseable compute_spec? `false` IS A MEASUREMENT — the file was read at that commit and declared nothing — and is distinct from a subnet that registers no min_compute surface at all, which has no declaration here. */
                 found: boolean;
                 miner: {
+                    cpu: {
+                        architecture?: string | null;
+                        min_cores?: number | null;
+                        min_speed_ghz?: number | null;
+                    };
+                    gpu: {
+                        declared_min_count?: number | null;
+                        /** @description The file's own `min_vram`, in the GB the template asks for. Not converted, not rounded — a declaration we alter is no longer the subnet's declaration. */
+                        declared_min_vram_gb?: number | null;
+                        /** @description The file's own `recommended_gpu`. RECOMMENDED, not required: naming a card for a workload that does not need one is coherent, so this never moves `requirement` on its own. */
+                        declared_model?: string | null;
+                        /** @description The file's own `required:` value, published verbatim so a reader can see why `requirement` is not a boolean rather than take our word for it. */
+                        declared_required?: boolean | null;
+                        /** @description Does this role need a GPU, as the DECLARATION supports it? FOUR answers. `required` and `not-required` are what they say. `declared-inconsistently` is a declared `required: False` sitting beside a non-zero minimum VRAM, CUDA-core or GPU count — the shape an unedited template field takes beside an edited one, and never coerced to either boolean. `null` means no GPU stanza was declared at all, which is not a 'no'. */
+                        requirement: ("required" | "not-required" | "declared-inconsistently") | null;
+                    };
+                    memory: {
+                        min_ram_gb?: number | null;
+                        min_swap_gb?: number | null;
+                    };
+                    network: {
+                        min_download_speed_mbps?: number | null;
+                        min_upload_speed_mbps?: number | null;
+                    };
+                    storage: {
+                        min_iops?: number | null;
+                        min_space_gb?: number | null;
+                        type?: string | null;
+                    };
+                } | null;
+                /** @description Requirements this file declared WITHOUT saying whose they are — a flat `compute_spec` with no `miner`/`validator` split. Non-null only for a document that made no role distinction, in which case `miner` and `validator` are both null because that is true of the file. Same shape as the other two, so the four-valued GPU answer reads identically. Never a guess at which role was meant: attributing an unattributed requirement is the one thing this key exists to avoid. */
+                unscoped: {
                     cpu: {
                         architecture?: string | null;
                         min_cores?: number | null;
@@ -10889,7 +10921,7 @@ export interface components {
             }[];
             /** @description How many of this subnet's registered min_compute declarations have been read. ZERO IS THE IMPORTANT VALUE: 111 of 129 subnets register none, and a card with `declarations_read: 0` makes no claim about what running here takes. */
             declarations_read: number;
-            /** @description The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. */
+            /** @description The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under `unscoped` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet. */
             declared_compute: {
                 evidence: {
                     /** @description When this file was first read, preserved across re-reads. */
@@ -10904,6 +10936,37 @@ export interface components {
                     spec_version?: string | null;
                 } | null;
                 miner: {
+                    cpu: {
+                        architecture?: string | null;
+                        min_cores?: number | null;
+                        min_speed_ghz?: number | null;
+                    };
+                    gpu: {
+                        declared_min_count?: number | null;
+                        /** @description The file's own `min_vram`, in the GB the template asks for. Not converted, not rounded — a declaration we alter is no longer the subnet's declaration. */
+                        declared_min_vram_gb?: number | null;
+                        /** @description The file's own `recommended_gpu`. RECOMMENDED, not required: naming a card for a workload that does not need one is coherent, so this never moves `requirement` on its own. */
+                        declared_model?: string | null;
+                        /** @description The file's own `required:` value, published verbatim so a reader can see why `requirement` is not a boolean rather than take our word for it. */
+                        declared_required?: boolean | null;
+                        /** @description Does this role need a GPU, as the DECLARATION supports it? FOUR answers. `required` and `not-required` are what they say. `declared-inconsistently` is a declared `required: False` sitting beside a non-zero minimum VRAM, CUDA-core or GPU count — the shape an unedited template field takes beside an edited one, and never coerced to either boolean. `null` means no GPU stanza was declared at all, which is not a 'no'. */
+                        requirement: ("required" | "not-required" | "declared-inconsistently") | null;
+                    };
+                    memory: {
+                        min_ram_gb?: number | null;
+                        min_swap_gb?: number | null;
+                    };
+                    network: {
+                        min_download_speed_mbps?: number | null;
+                        min_upload_speed_mbps?: number | null;
+                    };
+                    storage: {
+                        min_iops?: number | null;
+                        min_space_gb?: number | null;
+                        type?: string | null;
+                    };
+                } | null;
+                unscoped: {
                     cpu: {
                         architecture?: string | null;
                         min_cores?: number | null;
@@ -41715,6 +41778,15 @@ export interface operations {
                      *               "network": {},
                      *               "storage": {}
                      *             },
+                     *             "unscoped": {
+                     *               "cpu": {},
+                     *               "gpu": {
+                     *                 "requirement": "required"
+                     *               },
+                     *               "memory": {},
+                     *               "network": {},
+                     *               "storage": {}
+                     *             },
                      *             "validator": {
                      *               "cpu": {},
                      *               "gpu": {
@@ -41734,6 +41806,15 @@ export interface operations {
                      *             "source_url": "https://api.metagraph.sh/example"
                      *           },
                      *           "miner": {
+                     *             "cpu": {},
+                     *             "gpu": {
+                     *               "requirement": "required"
+                     *             },
+                     *             "memory": {},
+                     *             "network": {},
+                     *             "storage": {}
+                     *           },
+                     *           "unscoped": {
                      *             "cpu": {},
                      *             "gpu": {
                      *               "requirement": "required"

--- a/schemas-src/compute.ts
+++ b/schemas-src/compute.ts
@@ -42,7 +42,8 @@ export const GpuRequirementSchema = z.enum(GPU_REQUIREMENT_STATES);
  * The citation for one reading.
  *
  * `read_at_sha` is required, for the same reason it is on a treasury reading:
- * 14 of the 17 registered surfaces point at `main`, a branch moves under the
+ * most registered surfaces point at `main` (SURFACES_ON_A_MOVING_REF in
+ * src/compute-declaration-figures.ts), a branch moves under the
  * claim, and what makes a reading checkable is the commit that was HEAD when
  * it was taken.
  */

--- a/schemas-src/graphql/published-names.ts
+++ b/schemas-src/graphql/published-names.ts
@@ -484,12 +484,16 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   SubnetCostToParticipateArtifactEntryCost: "SubnetEntryCost",
   SubnetCostToParticipateArtifactDeclaredCompute: "SubnetDeclaredCompute",
   SubnetCostToParticipateArtifactDeclarations: "SubnetComputeDeclaration",
-  // ONE ROLE SPEC, FOUR USE SITES. `declared_compute.miner`,
-  // `declared_compute.validator` and both of their twins inside `declarations`
-  // are the same Zod object, so the generator would mint four identical types
-  // (and five nested ones each) that no consumer could compare. Every use site
-  // is aliased to the one published name for the same reason the two
-  // miner-fairness concentration lenses are.
+  // ONE ROLE SPEC, SIX USE SITES. `declared_compute.miner`,
+  // `declared_compute.validator`, `declared_compute.unscoped` and all three of
+  // their twins inside `declarations` are the same Zod object, so the generator
+  // would mint six identical types (and five nested ones each) that no consumer
+  // could compare. Every use site is aliased to the one published name for the
+  // same reason the two miner-fairness concentration lenses are.
+  //
+  // `unscoped` was the sixth (#11284 follow-up): a declaration that names no
+  // role publishes there, and it is the SAME shape deliberately -- a reader
+  // who understands SubnetDeclaredComputeSpec understands it already.
   SubnetCostToParticipateArtifactDeclarationsEvidence:
     "SubnetComputeDeclarationEvidence",
   SubnetCostToParticipateArtifactDeclarationsMiner: "SubnetDeclaredComputeSpec",
@@ -510,6 +514,16 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   SubnetCostToParticipateArtifactDeclarationsValidatorNetwork:
     "SubnetDeclaredNetwork",
   SubnetCostToParticipateArtifactDeclarationsValidatorStorage:
+    "SubnetDeclaredStorage",
+  SubnetCostToParticipateArtifactDeclarationsUnscoped:
+    "SubnetDeclaredComputeSpec",
+  SubnetCostToParticipateArtifactDeclarationsUnscopedCpu: "SubnetDeclaredCpu",
+  SubnetCostToParticipateArtifactDeclarationsUnscopedGpu: "SubnetDeclaredGpu",
+  SubnetCostToParticipateArtifactDeclarationsUnscopedMemory:
+    "SubnetDeclaredMemory",
+  SubnetCostToParticipateArtifactDeclarationsUnscopedNetwork:
+    "SubnetDeclaredNetwork",
+  SubnetCostToParticipateArtifactDeclarationsUnscopedStorage:
     "SubnetDeclaredStorage",
   SubnetCostToParticipateArtifactDeclaredComputeEvidence:
     "SubnetComputeDeclarationEvidence",
@@ -534,6 +548,18 @@ export const PUBLISHED_TYPE_NAMES: Readonly<Record<string, string>> = {
   SubnetCostToParticipateArtifactDeclaredComputeValidatorNetwork:
     "SubnetDeclaredNetwork",
   SubnetCostToParticipateArtifactDeclaredComputeValidatorStorage:
+    "SubnetDeclaredStorage",
+  SubnetCostToParticipateArtifactDeclaredComputeUnscoped:
+    "SubnetDeclaredComputeSpec",
+  SubnetCostToParticipateArtifactDeclaredComputeUnscopedCpu:
+    "SubnetDeclaredCpu",
+  SubnetCostToParticipateArtifactDeclaredComputeUnscopedGpu:
+    "SubnetDeclaredGpu",
+  SubnetCostToParticipateArtifactDeclaredComputeUnscopedMemory:
+    "SubnetDeclaredMemory",
+  SubnetCostToParticipateArtifactDeclaredComputeUnscopedNetwork:
+    "SubnetDeclaredNetwork",
+  SubnetCostToParticipateArtifactDeclaredComputeUnscopedStorage:
     "SubnetDeclaredStorage",
   SubnetCostToParticipateArtifactEarnings: "SubnetParticipationEarnings",
   SubnetTreasuryArtifact: "SubnetTreasury",

--- a/schemas-src/routes/cost-to-participate.ts
+++ b/schemas-src/routes/cost-to-participate.ts
@@ -16,6 +16,7 @@ import {
   MIN_COMPUTE_SURFACES_REGISTERED,
   SUBNETS_IN_REGISTRY,
   SUBNETS_WITHOUT_A_DECLARATION,
+  SURFACES_ON_A_MOVING_REF,
 } from "../../src/compute-declaration-figures.ts";
 import { z } from "zod";
 import {
@@ -84,8 +85,7 @@ const DeclaredRoleSpecSchema = z
 const ServedDeclarationSchema = z
   .object({
     evidence: ComputeDeclarationEvidenceSchema.meta({
-      description:
-        "The citation. `read_at_sha` is the commit that was HEAD when the file was read — 14 of the 17 registered surfaces point at `main`, which moves under the claim.",
+      description: `The citation. \`read_at_sha\` is the commit that was HEAD when the file was read — ${SURFACES_ON_A_MOVING_REF} of the ${MIN_COMPUTE_SURFACES_REGISTERED} registered surfaces point at \`main\`, which moves under the claim.`,
     }),
     found: z.boolean().meta({
       description:
@@ -93,6 +93,10 @@ const ServedDeclarationSchema = z
     }),
     miner: DeclaredRoleSpecSchema.nullable(),
     validator: DeclaredRoleSpecSchema.nullable(),
+    unscoped: DeclaredRoleSpecSchema.nullable().meta({
+      description:
+        "Requirements this file declared WITHOUT saying whose they are — a flat `compute_spec` with no `miner`/`validator` split. Non-null only for a document that made no role distinction, in which case `miner` and `validator` are both null because that is true of the file. Same shape as the other two, so the four-valued GPU answer reads identically. Never a guess at which role was meant: attributing an unattributed requirement is the one thing this key exists to avoid.",
+    }),
   })
   .strict();
 
@@ -129,11 +133,12 @@ export const SubnetCostToParticipateArtifactSchema = z
       .object({
         miner: DeclaredRoleSpecSchema.nullable(),
         validator: DeclaredRoleSpecSchema.nullable(),
+        unscoped: DeclaredRoleSpecSchema.nullable(),
         evidence: ComputeDeclarationEvidenceSchema.nullable(),
       })
       .strict()
       .describe(
-        "The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them.",
+        "The headline declaration: the first read that found a spec. Miner and validator are kept apart because a subnet whose validator needs a GPU and whose miner does not is ordinary, and one answer for both would be wrong for one of them. A file that draws no such distinction publishes under `unscoped` instead, with both roles null — read all three, because which one carries the answer is a property of the document rather than of the subnet.",
       ),
     declarations: z.array(ServedDeclarationSchema).meta({
       description:

--- a/src/compute-declaration-figures.ts
+++ b/src/compute-declaration-figures.ts
@@ -57,6 +57,15 @@ export const MIN_COMPUTE_SURFACES_REGISTERED = 18;
  * checks it read the same way. */
 export const SUBNETS_WITHOUT_A_DECLARATION = 111;
 
+/** Registered surfaces whose URL points at a MOVING ref (`/main/`, `/master/`)
+ * rather than a pinned commit -- the reason `read_at_sha` resolves the commit
+ * that last touched the path instead of trusting the branch.
+ *
+ * Registry-derived like the three above, and re-checked by the same test: the
+ * denominator moved from 17 to 18 on 2026-08-15 while this numerator did not,
+ * which is exactly the drift a literal hides. */
+export const SURFACES_ON_A_MOVING_REF = 14;
+
 /** Declarations that ask for a GPU: SN3, SN29, SN63, SN81, SN108.
  *
  * MEASURED 2026-08-15, and the measurement is the point. The published figure

--- a/src/cost-to-participate.ts
+++ b/src/cost-to-participate.ts
@@ -89,6 +89,13 @@ export const SUBNET_COST_TO_PARTICIPATE_FIELD_SOURCES = {
     kind: "measured",
     storage: "compute_declarations",
   },
+  // MEASURED, exactly as its two siblings are: it is the document's own
+  // `compute_spec`, read at a commit. What makes it a separate key is WHOSE
+  // requirement it is -- unstated -- not how it was obtained.
+  "declared_compute.unscoped": {
+    kind: "measured",
+    storage: "compute_declarations",
+  },
   "declared_compute.miner.gpu.requirement": {
     kind: "reconstructed",
     storage: null,
@@ -280,6 +287,28 @@ function declarationRow(row: Row): Row {
     found,
     miner: found ? roleSpec(row?.miner) : null,
     validator: found ? roleSpec(row?.validator) : null,
+    // REQUIREMENTS THE DOCUMENT DID NOT ATTRIBUTE TO A ROLE (#11284).
+    //
+    // SN29 (coldint) and SN108 (talkhead) publish a FLAT `compute_spec` -- cpu,
+    // gpu and memory at the top level, with no `miner`/`validator` split -- and
+    // both of them declare a GPU. Until 0030 those rows could not be stored at
+    // all; storing them left a second gap, which this closes: the card said
+    // `declarations_read: 1` and then showed nothing, so a caller asking what
+    // SN29 needs got silence over a 24GB-VRAM requirement we hold.
+    //
+    // A THIRD KEY, NOT A GUESS. Copying it into `miner` AND `validator` would
+    // assert a role split the document does not make, and picking one would
+    // invent the other. `unscoped` says exactly what is known -- requirements
+    // were declared, and the file did not say for whom -- which is the same
+    // rule 0029 set for the stanza itself. `miner` and `validator` stay null
+    // for these subnets because that is TRUE of the document, so nothing a
+    // caller already reads changes shape or meaning.
+    //
+    // Shaped by the SAME roleSpec as the other two, so the four-valued GPU
+    // answer and the units-in-names convention hold here identically. A reader
+    // that already understands `declared_compute.miner.gpu.requirement`
+    // understands this one without learning a second shape.
+    unscoped: found ? roleSpec(row?.unscoped) : null,
   };
 }
 
@@ -380,6 +409,11 @@ export function buildSubnetCostToParticipate(
     declared_compute: {
       miner: (primary?.miner as Row | null) ?? null,
       validator: (primary?.validator as Row | null) ?? null,
+      // Non-null only for a declaration that named no role at all -- see
+      // declarationRow. On every subnet whose file uses the two-stanza
+      // template this is null and the other two carry the answer, which is
+      // the arrangement almost every caller will ever see.
+      unscoped: (primary?.unscoped as Row | null) ?? null,
       evidence: (primary?.evidence as Row | null) ?? null,
     },
     declarations,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3332,6 +3332,7 @@ const rootValue = {
       declared_compute: data.declared_compute ?? {
         miner: null,
         validator: null,
+        unscoped: null,
         evidence: null,
       },
       declarations: data.declarations ?? [],

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -7784,6 +7784,13 @@ const MCP_TOOLS_BASE: McpToolDefinition[] = [
       `READ, which is the state ${SUBNETS_WITHOUT_A_DECLARATION} of ${SUBNETS_IN_REGISTRY} subnets are in, and is never a ` +
       "'this subnet needs no GPU'. A CPU-only subnet reports no GPU cost " +
       "rather than a zero: those are different claims. " +
+      "READ ALL THREE OF `miner`, `validator` AND `unscoped`. Some subnets " +
+      "publish a flat compute_spec that never says whose requirements it " +
+      "states; those land in `unscoped`, and for those `miner` and `validator` " +
+      "are BOTH null because that is true of the file, not because nothing " +
+      "was declared. Reporting 'no requirements' off `miner` alone is wrong " +
+      "for exactly the subnets that ask for the most, and you must NOT " +
+      "attribute an unscoped requirement to a role the document did not name. " +
       "`not_modelled` is served in the payload and every entry in it applies " +
       "to any answer you give from this tool. " +
       "Mirrors GET /api/v1/subnets/{netuid}/cost-to-participate.",

--- a/tests/cost-to-participate.test.ts
+++ b/tests/cost-to-participate.test.ts
@@ -197,6 +197,7 @@ describe("buildSubnetCostToParticipate", () => {
     assert.deepEqual(card.declared_compute, {
       miner: null,
       validator: null,
+      unscoped: null,
       evidence: null,
     });
     // The state most subnets are in. Every one of these must be null
@@ -275,6 +276,109 @@ describe("buildSubnetCostToParticipate", () => {
     // is no longer the subnet's declaration.
     assert.equal(((compute.miner as Row).gpu as Row).declared_min_vram_gb, 192);
     assert.equal(((compute.miner as Row).memory as Row).min_ram_gb, 1200);
+  });
+
+  // --- a declaration that names no role (#11284 follow-up) ------------------
+  //
+  // SN29 (coldint) and SN108 (talkhead) publish a FLAT compute_spec: cpu/gpu/
+  // memory at the top level, no miner/validator split, and both ask for a GPU.
+  // Migration 0030 gave those rows somewhere to live; these pin the half that
+  // makes them VISIBLE, which is the point of storing them.
+  const FLAT_SPEC = {
+    gpu: {
+      required: true,
+      min_vram: 24,
+      cuda_cores: 1024,
+      min_compute_capability: 6,
+    },
+    memory: { min_ram: 32, min_swap: 4 },
+    cpu: { min_cores: 4 },
+  };
+
+  test("an unscoped declaration is SERVED, not silently held", () => {
+    const card = buildSubnetCostToParticipate(
+      [
+        declarationRow({
+          netuid: 29,
+          miner: null,
+          validator: null,
+          unscoped: FLAT_SPEC,
+        }),
+      ],
+      29,
+    );
+    const compute = card.declared_compute as Row;
+    // The defect this closes: the card said `declarations_read: 1` and then
+    // showed nothing, so a caller asking what SN29 needs got silence over a
+    // 24GB-VRAM requirement we already held.
+    assert.equal(card.declarations_read, 1);
+    const gpu = (compute.unscoped as Row).gpu as Row;
+    assert.equal(gpu.requirement, "required");
+    assert.equal(gpu.declared_min_vram_gb, 24);
+    assert.equal(((compute.unscoped as Row).memory as Row).min_ram_gb, 32);
+  });
+
+  test("an unscoped declaration is NEVER attributed to a role", () => {
+    const card = buildSubnetCostToParticipate(
+      [
+        declarationRow({
+          netuid: 29,
+          miner: null,
+          validator: null,
+          unscoped: FLAT_SPEC,
+        }),
+      ],
+      29,
+    );
+    const compute = card.declared_compute as Row;
+    // Copying it into either role would assert a split the document does not
+    // make, and picking one would invent the other. Both stay null because
+    // that is TRUE of the file -- the assertion is the whole design decision.
+    assert.equal(compute.miner, null);
+    assert.equal(compute.validator, null);
+    assert.notEqual(compute.unscoped, null);
+  });
+
+  test("a two-stanza declaration leaves unscoped null, so nothing existing moves", () => {
+    const card = buildSubnetCostToParticipate(
+      [declarationRow({ miner: TEMPLAR_MINER, validator: CPU_ONLY_MINER })],
+      3,
+    );
+    const compute = card.declared_compute as Row;
+    // The arrangement almost every caller will ever see. A reader that never
+    // looks at `unscoped` reads exactly what it read before this field existed.
+    assert.equal(compute.unscoped, null);
+    assert.notEqual(compute.miner, null);
+  });
+
+  test("a found:false row declares nothing in ANY of the three", () => {
+    const card = buildSubnetCostToParticipate(
+      [
+        declarationRow({
+          found: false,
+          miner: null,
+          validator: null,
+          unscoped: null,
+        }),
+      ],
+      44,
+    );
+    const compute = card.declared_compute as Row;
+    assert.equal(compute.miner, null);
+    assert.equal(compute.validator, null);
+    assert.equal(compute.unscoped, null);
+    // The headline stays entirely empty because `primary` is the first
+    // declaration that FOUND something and there is none -- adding a third
+    // stanza did not give a found:false row a way to populate the card.
+    assert.equal(compute.evidence, null);
+    // The reading is still on record, which is the distinction `found: false`
+    // exists to carry: the file was fetched at a commit and declared nothing,
+    // as against a subnet nobody has looked at.
+    assert.equal(card.declarations_read, 1);
+    const only = (card.declarations as Row[])[0]!;
+    assert.equal(only.found, false);
+    assert.equal(only.unscoped, null);
+    assert.notEqual((only.evidence as Row).read_at_sha, null);
   });
 
   test("two declarations that disagree are both kept", () => {

--- a/workers/data-api.ts
+++ b/workers/data-api.ts
@@ -7656,7 +7656,7 @@ function matchNeuronsStoreRoute(url: URL): NeuronsStoreRouteHandler | null {
       const netuid = Number(costToParticipateMatch[1]);
       const rows = await sql<ComputeDeclarationRow>`
         SELECT netuid, source_url, read_at_sha, observed_at, first_seen,
-               found, spec_version, miner, validator
+               found, spec_version, miner, validator, unscoped
         FROM compute_declarations
         WHERE netuid = ${netuid}
         ORDER BY source_url ASC`;


### PR DESCRIPTION
## What was missing

#11284 gave a flat `compute_spec` somewhere to live. It did not give it anywhere to be **seen**. `/subnets/{netuid}/cost-to-participate` for SN29 reported:

```json
{ "declarations_read": 1,
  "declared_compute": { "miner": null, "validator": null, "evidence": {…} } }
```

A caller asking what SN29 needs got silence — over a **24GB-VRAM GPU requirement we already held and could cite**, from a document we link. SN108 is the same. Storing a declaration nobody can read is the half of the fix that was missing.

`declared_compute.unscoped` is that requirement, on the card and on every entry in `declarations[]`.

## A third key, not a guess

Copying the spec into `miner` **and** `validator` would assert a role split the document does not make; picking one would invent the other. `unscoped` states exactly what is known — requirements were declared, and the file did not say for whom — which is the same rule `0029` set for the stanza and `0030` for the column.

`miner` and `validator` stay null for these subnets because that is **true of the document**. No field a caller already reads changes shape or meaning, and on every subnet using the two-stanza template the new key is null. That last case has its own test, so "nothing existing moves" is pinned rather than asserted.

## Same shape, deliberately

It goes through the same `roleSpec`, so the four-valued GPU answer and the units-in-names convention hold identically — a reader who understands `declared_compute.miner.gpu.requirement` understands this one already. In GraphQL it is aliased to the existing `SubnetDeclaredComputeSpec` rather than minting a sixth identical type, for the same reason the other five use sites are.

## The read path carried it first

`workers/data-api.ts`'s cost-to-participate SELECT listed nine columns and not this one:

```sql
SELECT …, found, spec_version, miner, validator, unscoped
```

Shaping alone would have published `null` for exactly the subnets this change is about. **The column existing in Neon is not the same as the query asking for it** — worth stating because `validate:db-types-drift` is green either way.

## What each surface needed

| surface | inherited it? |
| --- | --- |
| REST route + artifact schema | added (`schemas-src/routes/cost-to-participate.ts`) |
| MCP **output schema** | **yes** — it *is* the route's artifact schema by identity |
| MCP **description** | no — hand-written prose, updated |
| GraphQL type | added, plus 12 published-name aliases so no sixth type is minted |
| GraphQL resolver default | added |

The MCP text now tells an agent to read all three and specifically **not** to report "no requirements" off `miner` alone — which is wrong for precisely the subnets that ask for the most.

## Also corrected

Two more stale copies of the registered-surface count that #11298's test could not see, because they say *"registered surfaces"* where the regex looked for *"registered declarations"*. `SURFACES_ON_A_MOVING_REF` joins the figures module and the same registry re-derivation, so the 14 and the 18 can no longer drift apart.

## Verification

- 4 new tests: the requirement is served; it is **never** attributed to a role (both stay null); a two-stanza declaration leaves `unscoped` null; a `found:false` row declares nothing in any of the three and still keeps its evidence in `declarations[]`.
- One of them caught my own wrong assumption while being written — `declared_compute.evidence` is null for a found-nothing set, because `primary` is the first declaration that FOUND something. Corrected to pin the real contract.
- `unscoped` confirmed present in the built `openapi.json`.
- Full CI validator set (69 gates) green; `typecheck` / `lint` / `format:check` clean.
- **Full local suite: 925 files, 21,196 tests, 0 failures.**