### PR TITLE
fix(seo): 285 news pages painted a breadcrumb and emitted no BreadcrumbList (#11303)

### DIFF
--- a/apps/ui/src/server.seo.test.ts
+++ b/apps/ui/src/server.seo.test.ts
@@ -117,6 +117,42 @@ describe("site-wide JSON-LD graph (#11204)", () => {
     }
   });
 
+  it("breadcrumbs the weekly digests, which render a crumb row and emitted no node", () => {
+    // #11303: 285 digest URLs -- 15% of the sitemap -- painted a breadcrumb the
+    // reader can see while emitting no BreadcrumbList, because they shipped
+    // (#8705) after this function was written. The structured data has to agree
+    // with what is on screen, which is the rule every builder here ships under.
+    const crumb = breadcrumbOn("/news/sn38/2026-w25");
+    expect(crumb?.itemListElement.map((entry) => entry.name)).toEqual([
+      "Home",
+      "News",
+      "SN38",
+      "2026-W25",
+    ]);
+    expect(crumb?.itemListElement.map((entry) => entry.item)).toEqual([
+      "https://metagraph.sh/",
+      "https://metagraph.sh/news",
+      "https://metagraph.sh/news/sn38",
+      "https://metagraph.sh/news/sn38/2026-w25",
+    ]);
+  });
+
+  it("labels a digest segment the way the site writes it, not the way the URL does", () => {
+    // `Sn38` and `2026 w25` are what the generic slug rule produces, and the
+    // site writes neither. A crumb that renames the thing it points at is a
+    // crumb Google reports as not matching the page.
+    expect(breadcrumbOn("/news/network/2026-w03")?.itemListElement.map((e) => e.name)).toEqual([
+      "Home",
+      "News",
+      "Network",
+      "2026-W03",
+    ]);
+    // The docs trail must be untouched by those two new rules.
+    expect(breadcrumbOn("/docs/api-reference/subnets")?.itemListElement.map((e) => e.name)).toEqual(
+      ["Home", "Docs", "API reference", "Subnets"],
+    );
+  });
+
   it("still breadcrumbs subnets and providers", () => {
     expect(breadcrumbOn("/subnets/64")?.itemListElement).toHaveLength(3);
     expect(breadcrumbOn("/providers/chutes")?.itemListElement).toHaveLength(3);
@@ -125,7 +161,7 @@ describe("site-wide JSON-LD graph (#11204)", () => {
   it("emits no breadcrumb on pages that are not a detail view", () => {
     // A one-item "trail" on a hub page is noise, and Google flags a breadcrumb
     // that does not describe a real position in the hierarchy.
-    for (const path of ["/", "/subnets", "/validators", "/docs"]) {
+    for (const path of ["/", "/subnets", "/validators", "/docs", "/news"]) {
       expect(breadcrumbOn(path), path).toBeUndefined();
     }
   });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -472,6 +472,7 @@ function buildBreadcrumb(pathname: string): unknown | null {
   const provider = pathname.match(/^\/providers\/([^/]+)\/?$/);
   const validator = pathname.match(/^\/validators\/([^/]+)\/?$/);
   const docs = pathname.match(/^\/docs\/(.+?)\/?$/);
+  const news = pathname.match(/^\/news\/(.+?)\/?$/);
   let trail: Array<{ name: string; path: string }> | null = null;
   if (subnet) {
     const name = safeDecodePathSegment(subnet[1]);
@@ -512,6 +513,22 @@ function buildBreadcrumb(pathname: string): unknown | null {
         path: `/docs/${segments.slice(0, index + 1).join("/")}`,
       })),
     ];
+  } else if (news) {
+    // #11303: the 285 weekly digests -- 15% of the sitemap -- rendered a
+    // breadcrumb the reader can see and emitted no BreadcrumbList for it. They
+    // shipped in #8705, after this function was written, and adding a route
+    // family here is a step nothing forced. Derived from the path segments for
+    // the same reason the docs trail is: a new subject folder is covered the
+    // moment it ships.
+    const segments = news[1].split("/").filter(Boolean);
+    trail = [
+      { name: "Home", path: "/" },
+      { name: "News", path: "/news" },
+      ...segments.map((segment, index) => ({
+        name: titleCaseSlug(safeDecodePathSegment(segment)),
+        path: `/news/${segments.slice(0, index + 1).join("/")}`,
+      })),
+    ];
   }
   if (!trail) return null;
   return breadcrumbListJsonLd(
@@ -521,10 +538,22 @@ function buildBreadcrumb(pathname: string): unknown | null {
 
 /** `api-reference` -> `API reference`; a URL slug is not a breadcrumb label. */
 function titleCaseSlug(slug: string): string {
+  // An ISO week slug is checked FIRST, because its hyphen is meaningful and the
+  // general rule below would turn `2026-w25` into `2026 w25`. The digest pages
+  // print it as `2026-W25` and so does the crumb.
+  const week = /^(\d{4})-w(\d{1,2})$/i.exec(slug);
+  if (week) return `${week[1]}-W${week[2]}`;
   const words = slug.replace(/[-_]+/g, " ").trim();
   if (!words) return slug;
   const cased = words.charAt(0).toUpperCase() + words.slice(1);
-  return cased.replace(/\bapi\b/gi, "API").replace(/\bmcp\b/gi, "MCP");
+  return (
+    cased
+      .replace(/\bapi\b/gi, "API")
+      .replace(/\bmcp\b/gi, "MCP")
+      // `sn38` is the subject folder of a digest, and the site never writes it
+      // `Sn38` -- every page, title and card says SN38.
+      .replace(/\bsn(\d+)\b/gi, "SN$1")
+  );
 }
 
 // schema.org JSON-LD: Organization + WebSite (with a sitelinks SearchAction over


### PR DESCRIPTION
## Summary

Found while validating the Rich Results Test result on `/subnets/38`. That page is fine — "1 valid item detected", and "Unnamed item" is just Google's UI label for a `BreadcrumbList`, which has no top-level `name`. Sweeping the other page types is what turned this up.

`buildBreadcrumb` (`apps/ui/src/server.ts`) covers `/subnets/*`, `/providers/*`, `/validators/*` and `/docs/*`. The digests shipped in #8705, **after** it was written, and #11230 — the PR that added breadcrumbs precisely because Search Console reported one valid item site-wide — predates them.

| page | visible crumb row | `BreadcrumbList` |
|---|---|---|
| `/subnets/38` | yes | yes |
| `/docs/mcp` | yes | yes |
| `/news/sn38/2026-w25` | **yes** | **no** |
| `/news/sn38` | **yes** | **no** |

285 URLs — **15% of the 1,940-URL sitemap** — paint a breadcrumb the reader can see and tell a crawler nothing about it. That contradicts the rule every builder in `json-ld.ts` ships under. These are also the pages most likely to match the demand GSC records: #11204's finding is that our queries are per-subnet lookups, and a digest is what answers "what changed on SN38".

## The label rule needed two additions, not just the branch

`titleCaseSlug` is written for docs paths, where a hyphen separates words. On a digest path it produced labels the site never writes:

| segment | generic rule | what the site writes |
|---|---|---|
| `sn38` | `Sn38` | **SN38** |
| `2026-w25` | `2026 w25` | **2026-W25** |

A crumb that renames the thing it points at is a crumb Google reports as not matching the page. The ISO-week check runs **first**, because its hyphen is meaningful where a docs slug's is not.

## Validation

```
apps/ui  tsc --noEmit                        clean
apps/ui  eslint + prettier                   clean
apps/ui  vitest server.seo/robots/og-copy    39 passed (3 new)
```

**The gate can fail**: stubbing the `/news` match to `null` fails exactly the two new tests and nothing else. One of them pins that the docs trail is *unchanged* by the two new label rules, so the fix cannot regress the 349 pages that already worked.

No visual change — the crumb row already rendered; this is the JSON-LD that was missing behind it.

Closes #11303
