### PR TITLE
fix(alarm): closing a dead-letter alarm re-opened it twenty-six minutes later

### DIFF
--- a/schemas-src/foreign-wire.ts
+++ b/schemas-src/foreign-wire.ts
@@ -42,6 +42,11 @@ export const GithubIssueSchema = z.object({
   title: z.string().nullish(),
   pull_request: z.unknown().optional(),
   updated_at: z.string().nullish(),
+  /** `open` or `closed`. Nullish because a body we cannot read must not be
+   * assumed open -- see the alarm's acknowledgement rule (#11293). */
+  state: z.string().nullish(),
+  /** When it was closed, for the same rule. Null on an open issue. */
+  closed_at: z.string().nullish(),
 });
 
 /**

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -476,6 +476,24 @@ export interface LaneAlarmPlanInput {
   observedMaxGap: Record<string, number | null>;
   /** Lanes that already have an open alarm issue. */
   openAlarms: Record<string, LaneAlarmOpenIssue>;
+  /**
+   * When a lane's alarm was last CLOSED, in ms -- the newest close per lane.
+   *
+   * AN ACKNOWLEDGEMENT, and only a dead-letter lane needs one. Every other lane
+   * closes itself: an `ok` verdict arrives and the alarm shuts. A `*-dlq` lane
+   * has no `ok` path, so closing its issue is a human saying "these losses are
+   * handled" -- and with nothing recording that, the next tick saw a stale row
+   * and no open issue and filed a fresh one.
+   *
+   * Measured 2026-08-15: #11272 was closed at 08:32 with all three causes fixed
+   * and verified, and #11293 was opened at 08:58 naming the SAME losses, the
+   * newest of which was 07:26. The residue guard is seven days, so that is an
+   * issue every half hour for a week over a row nothing can revise.
+   *
+   * Empty or absent when GitHub could not be asked, which is the safe
+   * direction: an unknown acknowledgement suppresses nothing.
+   */
+  acknowledged?: Record<string, number>;
   nowMs: number;
   minStaleMs: number;
 }
@@ -559,6 +577,10 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
     unknownRuns,
     observedMaxGap,
     openAlarms,
+    // Defaulted, and the default suppresses NOTHING. A caller that cannot read
+    // closed issues -- or one written before this existed -- gets exactly the
+    // previous behaviour rather than a silent mute.
+    acknowledged = {},
     nowMs,
     minStaleMs,
   } = input;
@@ -658,7 +680,27 @@ export function laneAlarmPlan(input: LaneAlarmPlanInput): LaneAlarmPlan {
   // Worst first, so the per-tick cap keeps the longest-running faults rather
   // than whichever lane sorts first alphabetically.
   qualified.sort((a, b) => a.since - b.since);
-  const fresh = qualified.filter((alarm) => !(alarm.lane in openAlarms));
+  const fresh = qualified
+    .filter((alarm) => !(alarm.lane in openAlarms))
+    // ALREADY ANSWERED FOR. A dead-letter lane's loss that predates the close
+    // of its last alarm has been acknowledged, and re-filing it is churn on a
+    // row nothing will ever revise.
+    //
+    // STRICTLY NEWER re-alarms, so this cannot mute a real recurrence: a loss
+    // after the close opens a fresh issue on the very next tick, which is the
+    // behaviour the alarm body promises in as many words.
+    //
+    // Scoped to dead-letter lanes alone. Every other lane can say `ok`, so a
+    // closed alarm there is either already recovered or genuinely still broken
+    // -- and suppressing the second would hide an outage somebody closed by
+    // mistake.
+    .filter((alarm) => {
+      if (!isDeadLetterLane(alarm.lane)) return true;
+      const closedAt = acknowledged[alarm.lane];
+      if (closedAt === undefined) return true;
+      const record = latest[alarm.lane];
+      return record !== undefined && record.checked_at > closedAt;
+    });
   const open = fresh.slice(0, LANE_ALARM_MAX_OPENS_PER_TICK);
 
   const close: LaneAlarmPlan["close"] = [];
@@ -909,6 +951,16 @@ export interface LaneAlarmGitHub {
    * ask" must never produce that action, and the two are indistinguishable
    * once a failure has been flattened into an empty object. */
   listOpen(): Promise<Record<string, LaneAlarmOpenIssue> | null>;
+  /**
+   * When each lane's alarm was last CLOSED, in ms.
+   *
+   * Separate from `listOpen` because the two answers have different failure
+   * postures. An unreadable OPEN list must stop the tick -- acting on it means
+   * re-raising every alarm. An unreadable CLOSED list is only an
+   * acknowledgement we do not know about, and the safe response is to alarm
+   * anyway, so this returns `{}` rather than null.
+   */
+  listAcknowledged(): Promise<Record<string, number>>;
   open(alarm: LaneAlarm, title: string, body: string): Promise<number | null>;
   /** Say something on an issue that stays open. Its own method rather than a
    * flag on `close`, because reporting a further loss and closing on recovery
@@ -933,6 +985,36 @@ export function laneAlarmGitHub(
     "content-type": "application/json",
   };
   return {
+    async listAcknowledged() {
+      // CLOSED, newest first. Only the most recent close per lane matters --
+      // an older one cannot acknowledge a loss the newer one already did.
+      const response = await fetchImpl(
+        `${GITHUB_API}/repos/${repo}/issues?state=closed&sort=updated&direction=desc&per_page=100`,
+        { headers },
+      );
+      // `{}` on every failure, deliberately, and the opposite of `listOpen`:
+      // an acknowledgement we cannot read must never suppress an alarm.
+      if (!response.ok) return {};
+      const page = GithubIssueListSchema.safeParse(await response.json());
+      if (!page.success) return {};
+      const out: Record<string, number> = {};
+      for (const row of page.data) {
+        const parsed = GithubIssueSchema.safeParse(row);
+        if (!parsed.success) continue;
+        const issue = parsed.data;
+        if (issue.pull_request) continue;
+        const title = issue.title ?? "";
+        if (!title.startsWith(LANE_ALARM_TITLE_PREFIX)) continue;
+        const lane = title.slice(LANE_ALARM_TITLE_PREFIX.length).trim();
+        if (!lane) continue;
+        const closedAt = Date.parse(issue.closed_at ?? "");
+        if (!Number.isFinite(closedAt)) continue;
+        // The NEWEST close per lane. The list is sorted, but relying on that
+        // would make this depend on a query parameter rather than on the data.
+        out[lane] = Math.max(out[lane] ?? 0, closedAt);
+      }
+      return out;
+    },
     async listOpen() {
       const response = await fetchImpl(
         `${GITHUB_API}/repos/${repo}/issues?state=open&per_page=100`,
@@ -1099,6 +1181,11 @@ export async function runLaneAlarm(
   // duplicate of every alarm still outstanding, which is the failure that makes
   // an alerting system get muted.
   const openAlarms = github ? await github.listOpen().catch(() => null) : null;
+  // AFTER the open list and never instead of it: this only ever narrows what
+  // gets filed, so a failure here costs an extra issue rather than a missed one.
+  const acknowledged = github
+    ? await github.listAcknowledged().catch(() => ({}))
+    : {};
   // Deliberately NOT read as `{}`. An unreadable issue list is
   // indistinguishable from "no alarms are open", and acting on that assumption
   // opens a duplicate of everything currently outstanding.
@@ -1118,6 +1205,7 @@ export async function runLaneAlarm(
     unknownRuns,
     observedMaxGap,
     openAlarms: openAlarms ?? {},
+    acknowledged,
     nowMs,
     minStaleMs,
   });

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -1109,6 +1109,7 @@ describe("runLaneAlarm", () => {
   /** A GitHub double that records what it was asked to do. */
   function fakeGitHub(
     open: Record<string, LaneAlarmOpenIssue> = {},
+    acknowledged: Record<string, number> = {},
   ): LaneAlarmGitHub & {
     opened: string[];
     closed: number[];
@@ -1122,6 +1123,7 @@ describe("runLaneAlarm", () => {
       closed,
       commented,
       listOpen: async () => open,
+      listAcknowledged: async () => acknowledged,
       open: async (alarm) => {
         opened.push(alarm.lane);
         return 100 + opened.length;
@@ -1958,5 +1960,89 @@ describe("the summary a capture carries (#10809)", () => {
     );
     assert.match(summary, /is silent: /);
     assert.doesNotMatch(summary, /cadence/);
+  });
+});
+
+// Closing a dead-letter alarm re-opened it 26 minutes later (#11293).
+//
+// #11272 was closed at 08:32 on 2026-08-15 with all three causes fixed and
+// verified in production; #11293 was filed at 08:58 naming the SAME losses, the
+// newest of which was 07:26. The residue guard is seven days, so left alone
+// that is a fresh issue every half hour for a week over a row nothing can
+// revise -- and an alarm that files issues about nothing is one that gets muted.
+describe("a closed dead-letter alarm is an acknowledgement", () => {
+  const LANE = "probe-jobs-dlq";
+  const CLOSED_AT = Date.parse("2026-08-15T08:32:00Z");
+  const LOSS_AT = Date.parse("2026-08-15T07:26:50Z");
+  const NOW = Date.parse("2026-08-15T08:58:00Z");
+
+  const input = (checked_at: number, acknowledged: Record<string, number>) => ({
+    latest: {
+      [LANE]: {
+        lane: LANE,
+        verdict: "stale" as const,
+        age_ms: null,
+        detail: "2 dead-lettered message(s) on probe-jobs-dlq (netuid=108)",
+        checked_at,
+      },
+    },
+    runs: { [LANE]: { since: checked_at, ticks: 5 } },
+    unknownRuns: {},
+    observedMaxGap: { [LANE]: 60 * 60 * 1000 },
+    openAlarms: {},
+    acknowledged,
+    nowMs: NOW,
+    minStaleMs: 0,
+  });
+
+  test("A LOSS THAT PREDATES THE CLOSE DOES NOT RE-FILE", () => {
+    const plan = laneAlarmPlan(input(LOSS_AT, { [LANE]: CLOSED_AT }));
+    assert.deepEqual(
+      plan.open.map((a) => a.lane),
+      [],
+    );
+  });
+
+  test("A LOSS AFTER THE CLOSE FILES IMMEDIATELY -- this is not a mute", () => {
+    // The property that makes acknowledgement different from suppression. The
+    // alarm body promises "the next loss after it closes opens a fresh alarm",
+    // and that has to stay true on the very next tick.
+    const plan = laneAlarmPlan(input(CLOSED_AT + 1, { [LANE]: CLOSED_AT }));
+    assert.deepEqual(
+      plan.open.map((a) => a.lane),
+      [LANE],
+    );
+  });
+
+  test("no acknowledgement means today's behaviour, not silence", () => {
+    // The safe direction when GitHub could not be asked: alarm anyway.
+    assert.deepEqual(
+      laneAlarmPlan(input(LOSS_AT, {})).open.map((a) => a.lane),
+      [LANE],
+    );
+  });
+
+  test("AN ORDINARY LANE IS NEVER SUPPRESSED BY A CLOSE", () => {
+    // Every other lane can say `ok`, so a closed alarm there is either already
+    // recovered or genuinely still broken. Suppressing the second would hide an
+    // outage somebody closed by mistake -- the opposite failure, and worse.
+    const plan = laneAlarmPlan({
+      ...input(LOSS_AT, { "chain-detail": CLOSED_AT }),
+      latest: {
+        "chain-detail": {
+          lane: "chain-detail",
+          verdict: "stale" as const,
+          age_ms: 1,
+          detail: "frozen",
+          checked_at: LOSS_AT,
+        },
+      },
+      runs: { "chain-detail": { since: LOSS_AT, ticks: 5 } },
+      observedMaxGap: { "chain-detail": 60 * 60 * 1000 },
+    });
+    assert.deepEqual(
+      plan.open.map((a) => a.lane),
+      ["chain-detail"],
+    );
   });
 });


### PR DESCRIPTION
#11272 was closed at 2026-08-15T08:32Z with all three causes fixed and verified
in production. #11293 was filed at 08:58Z naming the SAME losses, the newest of
which was 07:26Z. Nothing had happened in between.

Every other lane closes its own alarm: an `ok` verdict arrives and the issue
shuts. A `*-dlq` lane has no `ok` path -- `handleDeadLetterBatch` writes only on
a loss, because nothing un-loses a message -- so closing its issue is a human
saying "these losses are handled". Nothing recorded that. The next tick saw a
stale row and no open issue and filed a fresh one, and the residue guard is
seven days, so left alone that is an issue every half hour for a week over a row
nothing can revise. An alarm that files issues about nothing is one that gets
muted, which is the failure #9301 is named after.

So the alarm now reads its own closes. `listAcknowledged` returns the newest
close per lane, and a dead-letter alarm is not re-filed for a loss that predates
it.

STRICTLY NEWER RE-ALARMS, which is what makes this an acknowledgement rather
than a mute: a loss after the close opens a fresh issue on the very next tick,
exactly as the alarm body promises in as many words. Both directions are pinned,
and muting a later loss fails a named test.

SCOPED TO DEAD-LETTER LANES. Every other lane can say `ok`, so a closed alarm
there is either already recovered -- in which case nothing re-files anyway -- or
genuinely still broken, and suppressing that would hide an outage somebody
closed by mistake. Widening the rule fails its own test.

THE TWO LISTS FAIL DIFFERENTLY, deliberately. An unreadable OPEN list returns
null and stops the tick, because acting on it means re-raising every alarm --
that contract is unchanged. An unreadable CLOSED list returns `{}` and the tick
alarms anyway: an acknowledgement we do not know about must never suppress. So
the new read can only ever narrow what gets filed, and its failure costs an
extra issue rather than a missed one.

`closed_at` and `state` join GithubIssueSchema rather than being indexed off the
body, and a close stamp that will not parse is skipped rather than read as the
epoch -- which would make every loss look newer than it and defeat the rule
silently.