### PR TITLE
test(alarm): cover the acknowledgement client, which #11305 shipped untested

### DIFF
--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -911,6 +911,91 @@ describe("laneAlarmGitHub", () => {
     return { seen, gh: laneAlarmGitHub("t0ken", "o/r", impl) };
   }
 
+  test("listAcknowledged asks for CLOSED issues, newest first", async () => {
+    const { gh, seen } = client(() => ({ ok: true, json: async () => [] }));
+    await gh.listAcknowledged();
+    assert.match(seen[0]!.url, /state=closed/);
+    assert.match(seen[0]!.url, /sort=updated/);
+    assert.match(seen[0]!.url, /direction=desc/);
+  });
+
+  test("listAcknowledged keys the newest close per lane", async () => {
+    const { gh } = client(() => ({
+      ok: true,
+      json: async () => [
+        {
+          number: 1,
+          title: `${LANE_ALARM_TITLE_PREFIX}probe-jobs-dlq`,
+          closed_at: "2026-08-15T08:32:00Z",
+        },
+        // An OLDER close of the same lane cannot acknowledge a loss the newer
+        // one already did, so it must not win by arriving later in the page.
+        {
+          number: 2,
+          title: `${LANE_ALARM_TITLE_PREFIX}probe-jobs-dlq`,
+          closed_at: "2026-08-14T01:00:00Z",
+        },
+        {
+          number: 3,
+          title: "chore: unrelated",
+          closed_at: "2026-08-15T09:00:00Z",
+        },
+        // A PR whose title matches would otherwise acknowledge a real lane.
+        {
+          number: 4,
+          title: `${LANE_ALARM_TITLE_PREFIX}metagraph`,
+          closed_at: "2026-08-15T09:00:00Z",
+          pull_request: {},
+        },
+        {
+          number: 5,
+          title: LANE_ALARM_TITLE_PREFIX,
+          closed_at: "2026-08-15T09:00:00Z",
+        },
+        // Unparseable and absent stamps are SKIPPED, never read as the epoch --
+        // zero would make every loss look newer and defeat the rule silently.
+        {
+          number: 6,
+          title: `${LANE_ALARM_TITLE_PREFIX}sync-batches-dlq`,
+          closed_at: "not a date",
+        },
+        {
+          number: 7,
+          title: `${LANE_ALARM_TITLE_PREFIX}webhook-deliveries-dlq`,
+        },
+        {},
+        // A row that is not an object at all costs THAT row and not the page --
+        // the same per-row posture `listOpen` takes, and the reason the list
+        // schema's elements are `z.unknown()`.
+        42,
+        "not an issue",
+      ],
+    }));
+    assert.deepEqual(await gh.listAcknowledged(), {
+      "probe-jobs-dlq": Date.parse("2026-08-15T08:32:00Z"),
+    });
+  });
+
+  test("AN UNREADABLE CLOSED LIST SUPPRESSES NOTHING", async () => {
+    // The opposite posture to `listOpen`, deliberately. An unreadable OPEN list
+    // returns null and stops the tick, because acting on it means re-raising
+    // every alarm. An acknowledgement we cannot read must never mute one, so
+    // every failure here is `{}` -- the value that suppresses nothing.
+    const bad = client(() => ({
+      ok: false,
+      status: 403,
+      json: async () => ({}),
+    }));
+    assert.deepEqual(await bad.gh.listAcknowledged(), {});
+    const odd = client(() => ({
+      ok: true,
+      json: async () => ({ message: "nope" }),
+    }));
+    assert.deepEqual(await odd.gh.listAcknowledged(), {});
+    const empty = client(() => ({ ok: true, json: async () => [] }));
+    assert.deepEqual(await empty.gh.listAcknowledged(), {});
+  });
+
   test("lists only open lane alarms, keyed by lane", async () => {
     const { gh, seen } = client(() => ({
       ok: true,
@@ -1215,6 +1300,35 @@ describe("runLaneAlarm", () => {
       "1 alarming, 0 recovered, 0 recurred, 1 lanes",
       NOW,
     ]);
+  });
+
+  test("A THROWING ACKNOWLEDGEMENT READ ALARMS ANYWAY", async () => {
+    // The failure this read is allowed to have. It only ever narrows what gets
+    // filed, so a throw costs an extra issue rather than a missed one -- and it
+    // is caught into `{}` rather than being allowed to end the tick.
+    const db = healthDb({
+      latest: [
+        {
+          lane: "probe-jobs-dlq",
+          verdict: "stale",
+          age_ms: null,
+          detail: "1 dead-lettered message(s)",
+          checked_at: NOW - 1000,
+        },
+      ],
+      runs: [{ lane: "probe-jobs-dlq", since: NOW - 28 * HOUR, ticks: 5 }],
+      maxGap: [{ lane: "probe-jobs-dlq", n: 100, max_gap: 15 * 60_000 }],
+    });
+    const github = fakeGitHub();
+    github.listAcknowledged = async () => {
+      throw new Error("github down");
+    };
+    const out = await runLaneAlarm(
+      { ...TOKEN, ...db.env },
+      { github, now: () => NOW, recordException: async () => true },
+    );
+    assert.equal(out.ok, true);
+    assert.deepEqual(github.opened, ["probe-jobs-dlq"]);
   });
 
   test("closes the issue once the lane reports ok", async () => {


### PR DESCRIPTION
codecov/patch failed on #11305 and it was right: the rule was covered and the
GitHub client that feeds it was not. `listAcknowledged`'s whole body -- the
request, the per-row parse, the stamp handling and the failure posture -- had no
test, and I merged over the signal rather than reading it.

Four things it now pins, each of which is a way the rule fails silently rather
than loudly:

THE QUERY. `state=closed&sort=updated&direction=desc`. Asking for open issues
here would return no acknowledgements at all and the alarm would re-file
forever, which is exactly the behaviour #11305 set out to remove.

THE NEWEST CLOSE WINS. An older close of the same lane cannot acknowledge a loss
the newer one already did, and the fixture puts them in the wrong order so this
cannot pass by accident of page ordering.

AN UNPARSEABLE STAMP IS SKIPPED, never read as the epoch. Zero would make every
loss look newer than its acknowledgement and defeat the rule while looking like
it worked. Same for an issue with no `closed_at` at all, and for a PR whose
title happens to match the alarm prefix.

THE FAILURE POSTURE, from both ends. A non-2xx, a body that is not a list, and a
throwing call all yield `{}` -- the value that suppresses nothing -- and the
throw case is driven through `runLaneAlarm` to prove the tick still opens the
alarm rather than dying on it. That is the opposite of `listOpen`'s contract on
purpose, and the two are now tested as opposites.

A row that is not an object at all costs that row and not the page, matching
`listOpen` and the reason the list schema's elements are `z.unknown()`.