### PR TITLE
fix(alarm): the acknowledgement it reads only reached back fourteen hours

### DIFF
--- a/schemas-src/foreign-wire.ts
+++ b/schemas-src/foreign-wire.ts
@@ -62,6 +62,19 @@ export const GithubIssueSchema = z.object({
  */
 export const GithubIssueListSchema = z.array(z.unknown());
 
+/**
+ * `GET /search/issues` — the alarm's own issues, found by title.
+ *
+ * A DIFFERENT SHAPE FROM THE LIST ABOVE, which is why it is a different
+ * schema: search wraps its results in an object, so a body that parsed as the
+ * plain array would be one we misread rather than one we rejected. `items`
+ * carries `z.unknown()` for the same reason the list does — one issue GitHub
+ * shapes unexpectedly costs that issue, not the whole page.
+ */
+export const GithubSearchResultSchema = z.object({
+  items: z.array(z.unknown()),
+});
+
 /** `POST /repos/{repo}/issues` — only the created number is read. */
 export const GithubCreatedIssueSchema = z.object({
   number: z.number().optional(),

--- a/src/lane-alarm.ts
+++ b/src/lane-alarm.ts
@@ -63,6 +63,7 @@ import {
   GithubCreatedIssueSchema,
   GithubIssueListSchema,
   GithubIssueSchema,
+  GithubSearchResultSchema,
 } from "../schemas-src/foreign-wire.ts";
 import { laneHealthStore } from "./lane-health-store.ts";
 import { countOrZero } from "./read-store.ts";
@@ -986,19 +987,39 @@ export function laneAlarmGitHub(
   };
   return {
     async listAcknowledged() {
-      // CLOSED, newest first. Only the most recent close per lane matters --
-      // an older one cannot acknowledge a loss the newer one already did.
+      // SEARCHED BY TITLE, because a page of closed issues cannot reach far
+      // enough to matter. #11305 asked
+      // /issues?state=closed&sort=updated&per_page=100, and measured on this
+      // repo that page carries 100 rows of which only 38 are issues -- the
+      // endpoint returns pull requests too, and the loop below then discards
+      // them -- spanning about FOURTEEN HOURS. The window an acknowledgement
+      // has to survive is the residue guard's SEVEN DAYS, because that is how
+      // long a dead-letter record keeps qualifying.
+      //
+      // So that fix worked for its first night. Once the close scrolled off the
+      // page the lane looked unacknowledged again and the alarm re-filed it,
+      // every half hour, for the six days left on the record -- the same
+      // issue-about-nothing #11305 set out to stop, arriving a day late.
+      //
+      // `in:title` narrows to the issues this alarm has itself filed, so one
+      // request covers the whole population however busy the repo gets, and no
+      // paging loop reads thousands of unrelated issues every tick to find one
+      // close. Newest first still, for the same reason: only the most recent
+      // close per lane matters, since an older one cannot acknowledge a loss
+      // the newer one already did.
+      const query = `repo:${repo} is:issue in:title "${LANE_ALARM_TITLE_PREFIX}"`;
       const response = await fetchImpl(
-        `${GITHUB_API}/repos/${repo}/issues?state=closed&sort=updated&direction=desc&per_page=100`,
+        `${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}` +
+          "&sort=updated&order=desc&per_page=100",
         { headers },
       );
       // `{}` on every failure, deliberately, and the opposite of `listOpen`:
       // an acknowledgement we cannot read must never suppress an alarm.
       if (!response.ok) return {};
-      const page = GithubIssueListSchema.safeParse(await response.json());
+      const page = GithubSearchResultSchema.safeParse(await response.json());
       if (!page.success) return {};
       const out: Record<string, number> = {};
-      for (const row of page.data) {
+      for (const row of page.data.items) {
         const parsed = GithubIssueSchema.safeParse(row);
         if (!parsed.success) continue;
         const issue = parsed.data;

--- a/tests/lane-alarm.test.ts
+++ b/tests/lane-alarm.test.ts
@@ -911,65 +911,88 @@ describe("laneAlarmGitHub", () => {
     return { seen, gh: laneAlarmGitHub("t0ken", "o/r", impl) };
   }
 
-  test("listAcknowledged asks for CLOSED issues, newest first", async () => {
-    const { gh, seen } = client(() => ({ ok: true, json: async () => [] }));
+  test("listAcknowledged SEARCHES by title, because a page of closed issues cannot reach", async () => {
+    // THE ENDPOINT IS THE ASSERTION. /issues?state=closed&per_page=100 returns
+    // 100 rows of which only 38 are issues on this repo -- the rest are pull
+    // requests -- reaching back about fourteen hours, against a residue window
+    // of seven days. An acknowledgement that scrolls off the page is one the
+    // alarm forgets, and it re-files the issue it was told to stop filing.
+    const { gh, seen } = client(() => ({
+      ok: true,
+      json: async () => ({ items: [] }),
+    }));
     await gh.listAcknowledged();
-    assert.match(seen[0]!.url, /state=closed/);
+    assert.match(seen[0]!.url, /\/search\/issues\?q=/);
+    const asked = decodeURIComponent(seen[0]!.url);
+    assert.match(asked, /is:issue/);
+    assert.match(asked, /in:title "alarm\(lane\): "/);
+    // Newest first still matters: only the most recent close per lane counts.
     assert.match(seen[0]!.url, /sort=updated/);
-    assert.match(seen[0]!.url, /direction=desc/);
+    assert.match(seen[0]!.url, /order=desc/);
+  });
+
+  test("listAcknowledged refuses the shape the old endpoint returned", async () => {
+    // A bare array is /issues' shape, not search's. Reading it as an empty
+    // page would acknowledge nothing while looking like a successful call --
+    // and `{}` is indistinguishable from "no lane has ever been closed".
+    const { gh } = client(() => ({ ok: true, json: async () => [] }));
+    assert.deepEqual(await gh.listAcknowledged(), {});
   });
 
   test("listAcknowledged keys the newest close per lane", async () => {
     const { gh } = client(() => ({
       ok: true,
-      json: async () => [
-        {
-          number: 1,
-          title: `${LANE_ALARM_TITLE_PREFIX}probe-jobs-dlq`,
-          closed_at: "2026-08-15T08:32:00Z",
-        },
-        // An OLDER close of the same lane cannot acknowledge a loss the newer
-        // one already did, so it must not win by arriving later in the page.
-        {
-          number: 2,
-          title: `${LANE_ALARM_TITLE_PREFIX}probe-jobs-dlq`,
-          closed_at: "2026-08-14T01:00:00Z",
-        },
-        {
-          number: 3,
-          title: "chore: unrelated",
-          closed_at: "2026-08-15T09:00:00Z",
-        },
-        // A PR whose title matches would otherwise acknowledge a real lane.
-        {
-          number: 4,
-          title: `${LANE_ALARM_TITLE_PREFIX}metagraph`,
-          closed_at: "2026-08-15T09:00:00Z",
-          pull_request: {},
-        },
-        {
-          number: 5,
-          title: LANE_ALARM_TITLE_PREFIX,
-          closed_at: "2026-08-15T09:00:00Z",
-        },
-        // Unparseable and absent stamps are SKIPPED, never read as the epoch --
-        // zero would make every loss look newer and defeat the rule silently.
-        {
-          number: 6,
-          title: `${LANE_ALARM_TITLE_PREFIX}sync-batches-dlq`,
-          closed_at: "not a date",
-        },
-        {
-          number: 7,
-          title: `${LANE_ALARM_TITLE_PREFIX}webhook-deliveries-dlq`,
-        },
-        {},
-        // A row that is not an object at all costs THAT row and not the page --
-        // the same per-row posture `listOpen` takes, and the reason the list
-        // schema's elements are `z.unknown()`.
-        42,
-        "not an issue",
-      ],
+      // Search wraps its results; every row below is unchanged.
+      json: async () => ({
+        items: [
+          {
+            number: 1,
+            title: `${LANE_ALARM_TITLE_PREFIX}probe-jobs-dlq`,
+            closed_at: "2026-08-15T08:32:00Z",
+          },
+          // An OLDER close of the same lane cannot acknowledge a loss the newer
+          // one already did, so it must not win by arriving later in the page.
+          {
+            number: 2,
+            title: `${LANE_ALARM_TITLE_PREFIX}probe-jobs-dlq`,
+            closed_at: "2026-08-14T01:00:00Z",
+          },
+          {
+            number: 3,
+            title: "chore: unrelated",
+            closed_at: "2026-08-15T09:00:00Z",
+          },
+          // A PR whose title matches would otherwise acknowledge a real lane.
+          {
+            number: 4,
+            title: `${LANE_ALARM_TITLE_PREFIX}metagraph`,
+            closed_at: "2026-08-15T09:00:00Z",
+            pull_request: {},
+          },
+          {
+            number: 5,
+            title: LANE_ALARM_TITLE_PREFIX,
+            closed_at: "2026-08-15T09:00:00Z",
+          },
+          // Unparseable and absent stamps are SKIPPED, never read as the epoch --
+          // zero would make every loss look newer and defeat the rule silently.
+          {
+            number: 6,
+            title: `${LANE_ALARM_TITLE_PREFIX}sync-batches-dlq`,
+            closed_at: "not a date",
+          },
+          {
+            number: 7,
+            title: `${LANE_ALARM_TITLE_PREFIX}webhook-deliveries-dlq`,
+          },
+          {},
+          // A row that is not an object at all costs THAT row and not the page --
+          // the same per-row posture `listOpen` takes, and the reason the list
+          // schema's elements are `z.unknown()`.
+          42,
+          "not an issue",
+        ],
+      }),
     }));
     assert.deepEqual(await gh.listAcknowledged(), {
       "probe-jobs-dlq": Date.parse("2026-08-15T08:32:00Z"),


### PR DESCRIPTION
## The gap

#11305 made a closed dead-letter alarm stick by having the alarm read its own closes; #11306 covered that reader with tests. Both pinned the same endpoint, and it does not reach far enough to keep the promise it implements:

```
GET /repos/{repo}/issues?state=closed&sort=updated&direction=desc&per_page=100
```

**Measured on this repo, with the query exactly as shipped:**

| | |
| --- | --- |
| rows returned | 100 |
| of which are issues | **38** — the endpoint returns pull requests too, and the loop then discards them |
| span | `2026-08-14T20:04Z` → `2026-08-15T09:58Z` = **~14 hours** |
| window it must survive | the residue guard's **7 days** |

So the fix works for its first night. Once the close scrolls off the page the lane looks unacknowledged again and the alarm re-files it — every half hour, for the six days left on the record. That is the same issue-about-nothing #11305 set out to stop, arriving a day late.

Nothing about it looks wrong at the moment it is deployed, which is exactly why the reach belongs in the code as a measurement rather than in a reviewer's head.

## The fix

```
GET /search/issues?q=repo:{repo}+is:issue+in:title+"alarm(lane): "&sort=updated&order=desc&per_page=100
```

`in:title` narrows to the issues this alarm has itself filed — 18 of them, ever — so **one request covers the whole population** however busy the repo gets, and no paging loop reads thousands of unrelated issues every tick to find one close.

Verified against the live API, including that the title prefix's **trailing space** still matches (it returns the same 18 results either way).

## #11306's coverage is kept, not replaced

Its row-level cases are better than anything this change would have written, and every one still runs: newest close per lane, the PR whose title matches, unparseable and absent stamps, a row that is not an object at all.

What changed:

- the **endpoint** those tests assert — the old assertion pinned `state=closed`, which is the defect;
- the **wrapper** their fixture returns, since search wraps results in `{ items: [...] }`;
- **one new case** — a bare array is `/issues`' shape, not search's, and reading it as an empty page would acknowledge nothing while looking like a successful call.

Net: 98 → 99 tests, one renamed, none lost (verified by diffing the test titles against `main`).

`GithubSearchResultSchema` is a separate schema from `GithubIssueListSchema` for that same reason — a body that parsed as the plain array would be one we misread rather than one we rejected.

The `{}`-on-failure contract is untouched, and so is its reasoning: an acknowledgement we cannot read must never suppress an alarm.

## Verification

- The endpoint test **fails against the query it replaces** — reverted the URL and watched exactly that one test go red, then restored.
- Full CI validator set (69 gates) green; `typecheck` / `lint` / `format:check` clean.
- **Full local suite: 925 files, 21,205 tests, 0 failures.**