### PR TITLE
fix(self-health): a dead-letter lane's silence is the goal, not an absence

### DIFF
--- a/src/self-health.ts
+++ b/src/self-health.ts
@@ -347,7 +347,26 @@ export function withLaneHealth(
       // observation drifts to zero for a mirror that writes many rows per
       // pass, and a declaration alone cannot notice a lane whose real interval
       // has moved away from the configured one.
-      const cadence = laneSilenceCadenceMs(row.lane, cadences?.[row.lane]);
+      // A DEAD-LETTER LANE'S SILENCE IS THE GOAL, NOT AN ABSENCE (#11297).
+      //
+      // `laneSilenceCadenceMs` derives a bound from the observed gaps between
+      // a lane's rows. For every other lane those gaps are its heartbeat. For a
+      // `*-dlq` they are the spacing between FAILURES, so a queue that lost
+      // messages roughly hourly for an afternoon gets handed a "cadence" of an
+      // hour -- and three hours later the card reports `unknown`, detail
+      // `no verdict for 186m (cadence ~60m)`, which reads as "this lane was
+      // expected to lose a message every hour and has not".
+      //
+      // Measured on production 2026-08-15, that exact string, on a queue whose
+      // last loss was three hours earlier and whose causes were all fixed.
+      //
+      // So they are exempt from the silence treatment entirely. What remains is
+      // the honest set: a recent loss is `stale` and counted, a loss past the
+      // residue window is dropped above, and a queue that has never lost
+      // anything has no row at all.
+      const cadence = DEAD_LETTER_LANE_NAMES.has(row.lane)
+        ? null
+        : laneSilenceCadenceMs(row.lane, cadences?.[row.lane]);
       const quietFor = nowMs - row.checked_at;
       const silent =
         typeof cadence === "number" &&

--- a/tests/lane-health.test.ts
+++ b/tests/lane-health.test.ts
@@ -475,6 +475,53 @@ describe("a dead-letter verdict ages out of the serving read", () => {
     assert.equal(card([dlq(now - 1_000)], now).stale_lane_count, 1);
   });
 
+  test("A DLQ IS NEVER MARKED SILENT -- its quiet is the goal", () => {
+    // `laneSilenceCadenceMs` reads the gaps between a lane's rows. For a dlq
+    // those are the spacing between FAILURES, so a queue that lost messages
+    // hourly for an afternoon gets a "cadence" of an hour and then reads
+    // `unknown -- no verdict for 186m (cadence ~60m)`: "expected to lose a
+    // message every hour and has not". Measured in production, that string.
+    const now = 1_785_000_000_000;
+    const out = withLaneHealth(
+      buildSelfHealth([], []),
+      // Five hours against a 3x-of-60m bound, so it is PAST the threshold
+      // rather than exactly on it -- at exactly 3x the comparison is `>` and
+      // the test would pass with the exemption removed.
+      { "probe-jobs-dlq": dlq(now - 5 * 60 * 60 * 1000) },
+      { nowMs: now, cadences: { "probe-jobs-dlq": 60 * 60 * 1000 } },
+    );
+    assert.equal(
+      out.lanes[0]?.verdict,
+      "stale",
+      "still a real loss, still counted",
+    );
+    assert.equal(out.stale_lane_count, 1);
+    assert.doesNotMatch(String(out.lanes[0]?.detail), /cadence/);
+  });
+
+  test("an ordinary lane IS still marked silent on the same input", () => {
+    // Non-vacuity for the test above: the exemption is what changes the
+    // outcome, not the fixture being unreachable by the silence path.
+    const now = 1_785_000_000_000;
+    const out = withLaneHealth(
+      buildSelfHealth([], []),
+      {
+        "chain-detail": {
+          lane: "chain-detail",
+          verdict: "stale" as const,
+          age_ms: 1,
+          detail: "frozen",
+          // Five hours against a 3x-of-60m threshold, so it is past the bound
+          // rather than exactly on it.
+          checked_at: now - 5 * 60 * 60 * 1000,
+        },
+      },
+      { nowMs: now, cadences: { "chain-detail": 60 * 60 * 1000 } },
+    );
+    assert.equal(out.lanes[0]?.verdict, "unknown");
+    assert.match(String(out.lanes[0]?.detail), /cadence/);
+  });
+
   test("an ORDINARY lane's old stale verdict is left alone", () => {
     // The scope of this rule is exactly the family that cannot say `ok`.
     // Ageing out every stale verdict would hide genuinely broken lanes, which


### PR DESCRIPTION
CORRECTING MYSELF. #11297 and #11299 said the silence path "cannot reach" a
dead-letter lane because it has no cadence. That is wrong, and production showed
it within the hour: `laneSilenceCadenceMs` falls back to the lane's OBSERVED
maximum gap, and for a `*-dlq` those gaps are the spacing between FAILURES.

`probe-jobs-dlq` lost messages roughly hourly through the morning, so it was
handed a cadence of 60 minutes. Three hours after the last loss the card read:

    probe-jobs-dlq  unknown  "no verdict for 186m (cadence ~60m)"

which says this queue was expected to lose a message every hour and has not.
It is the opposite of what a healthy dead-letter queue looks like, stated as a
fault.

So dead-letter lanes are exempt from the silence treatment entirely. What is
left is the honest set, and it is now complete: a recent loss is `stale` and
counted, a loss past the residue window is dropped (#11299), and a queue that
has never lost anything has no row at all.

This does not weaken #11299 -- the two cover different halves. A lane with
enough loss history to have an observed gap was being marked `unknown`, which
drops out of `stale_lane_count` for the wrong reason and with a misleading
detail; a lane whose single loss gave it no observed gap at all was frozen
`stale` forever, which is the case #11299 fixes. Neither was reachable by the
other's path.

The test now sits five hours past a 3x-of-60m bound rather than exactly on it.
At exactly 3x the comparison is `>` and the assertion passed with the exemption
removed -- it was pinning nothing, which is the same trap as an alarm that
cannot fire.