### PR TITLE
fix(graphql): the second copy of a tier hop that could only ever 503

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -6589,22 +6589,27 @@ const rootValue = {
         extensions: { code: "BAD_USER_INPUT" },
       });
     }
-    // Same tryDataApiTier(METAGRAPH_NEURONS_SOURCE) -> lakehouse cold tier ->
-    // buildAccountPositions([], new Map(), ss58) fallback contract
-    // handleAccountPositions uses -- no D1 predecessor, flat body (like
+    // Hot store -> lakehouse cold tier -> labelled empty card, which is the
+    // chain REST's handleAccountPositions and MCP's get_account_positions both
+    // resolve. The cold-tier reader is the SAME one they fall to, so the three
+    // surfaces cannot disagree about what a coldkey holds. Flat body (like
     // account_portfolio's), not the { data, generatedAt } envelope the
-    // account-event-footprint family uses. The cold-tier reader is the SAME one
-    // REST and MCP's get_account_positions fall to, so the three surfaces
-    // cannot disagree about what a coldkey holds.
+    // account-event-footprint family uses.
+    //
+    // NO DATA_API LEG, and this was the SECOND one. #11290 removed it from the
+    // REST handler after measuring that DATA_API has no branch for
+    // /accounts/:ss58/positions -- 55 of 55 captured neurons-tier declines were
+    // that single path -- and this resolver kept its own copy, so the tier
+    // fallbacks carried on: 09:11Z, 09:17Z and 10:04Z on 2026-08-15, all after
+    // the REST fix deployed at 09:54Z. The comment here even asserted parity
+    // with a handler that had stopped forwarding, which is how a duplicated
+    // contract goes stale without anything failing.
+    //
+    // Checked exhaustively rather than by handler this time: of the 36 distinct
+    // paths any caller hands `postgresTierRequest`, this is the only one
+    // DATA_API's dispatcher does not claim. Two surfaces named it; both are
+    // now off it.
     const data =
-      ((await tryDataApiTier(
-        context.env,
-        postgresTierRequest(
-          context,
-          `/api/v1/accounts/${encodeURIComponent(ss58)}/positions`,
-        ),
-        "METAGRAPH_NEURONS_SOURCE",
-      )) as Row | null) ??
       ((await loadAccountPositionsFromStore(
         context.env,
         ss58,

--- a/tests/graphql.test.ts
+++ b/tests/graphql.test.ts
@@ -8377,64 +8377,37 @@ describe("graphql — account_positions (#6324, Postgres-tier flat body + empty-
     });
   });
 
-  test("resolves the Postgres-tier positions (flat body, matches GET /api/v1/accounts/{ss58}/positions parity)", async () => {
+  test("never forwards to DATA_API -- that Worker has no branch for this path", async () => {
+    // THE SECOND COPY of the dead forward. #11290 removed it from REST after
+    // measuring that DATA_API's dispatcher does not claim
+    // /accounts/:ss58/positions; this resolver kept its own, so the doomed hop
+    // and its awaited PostHog $exception carried on -- 09:11Z, 09:17Z and
+    // 10:04Z on 2026-08-15, all after the REST fix went live at 09:54Z.
+    //
+    // A `fetch` that THROWS is the assertion. If the leg came back, the stub is
+    // called and this fails rather than quietly paying the toll again. The
+    // counter proves it was never called at all, not merely that the answer
+    // came from elsewhere.
+    let dataApiCalls = 0;
     const env = {
       METAGRAPH_NEURONS_SOURCE: "data-api",
       DATA_API: {
-        fetch: async () =>
-          Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            captured_at: "2026-07-10T00:00:00.000Z",
-            position_count: 2,
-            total_stake_alpha: 1500,
-            positions: [
-              {
-                hotkey: "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-                netuid: 3,
-                share_fraction: 0.5,
-                stake_tao: 1000,
-              },
-              {
-                hotkey: "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
-                netuid: 7,
-                share_fraction: 0.25,
-                stake_tao: 500,
-              },
-            ],
-          }),
+        fetch: async () => {
+          dataApiCalls += 1;
+          throw new Error("DATA_API must not be consulted for this route");
+        },
       },
     };
     const { status, body } = await gql(query(`(ss58: "${SS58}")`), env);
     assert.equal(status, 200);
+    assert.equal(body.errors, undefined);
+    assert.equal(dataApiCalls, 0, "the DATA_API leg is gone, not merely quiet");
+    // Still a schema-stable card: dropping a hop that could never answer did
+    // not change what a caller reads.
     const p = body.data.account_positions;
-    assert.equal(p.position_count, 2);
-    assert.equal(p.total_stake_alpha, 1500);
-    assert.equal(p.positions[0].netuid, 3);
-    assert.equal(p.positions[0].share_fraction, 0.5);
-    assert.equal(
-      p.positions[1].hotkey,
-      "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
-    );
-  });
-
-  test("ss58 is forwarded on the Postgres-tier request path", async () => {
-    let capturedUrl: URL | undefined;
-    const env = {
-      METAGRAPH_NEURONS_SOURCE: "data-api",
-      DATA_API: {
-        fetch: async (req: Request) => {
-          capturedUrl = new URL(req.url);
-          return Response.json({
-            schema_version: 1,
-            ss58: SS58,
-            positions: [],
-          });
-        },
-      },
-    };
-    await gql(query(`(ss58: "${SS58}")`), env);
-    assert.equal(capturedUrl!.pathname, `/api/v1/accounts/${SS58}/positions`);
+    assert.equal(p.ss58, SS58);
+    assert.equal(p.position_count, 0);
+    assert.deepEqual(p.positions, []);
   });
 
   test("a malformed Postgres-tier body degrades to a schema-stable empty card", async () => {
@@ -24545,32 +24518,26 @@ describe("graphql — component fields the resolvers used to drop (#10214)", () 
   });
 
   test("account_positions forwards the degraded marker behind a zero", async () => {
+    // The resolver enumerates its return shape, and `degraded` was dropped by
+    // that enumeration once (#9803) -- GraphQL served `position_count: 0` with
+    // nothing to tell "holds nothing" from "we could not price what it holds".
+    // This pins that it survives.
+    //
+    // Reached by letting every tier decline rather than by a DATA_API stub:
+    // this route no longer forwards there at all (DATA_API has no branch for
+    // /accounts/:ss58/positions), so the marker now arrives from
+    // unavailableAccountPositions, which is the card the real chain ends at.
     const { body } = await gql(
       `{ account_positions(ss58: "${SS58}") {
           position_count degraded { reason snapshot_captured_at latest_stake_event_at }
         } }`,
-      api(
-        {
-          schema_version: 1,
-          ss58: SS58,
-          position_count: 0,
-          total_stake_alpha: 0,
-          positions: [],
-          degraded: {
-            reason: "positions_unpriceable",
-            snapshot_captured_at: "2026-07-01T00:00:00.000Z",
-            latest_stake_event_at: "2026-07-02T00:00:00.000Z",
-          },
-        },
-        neurons,
-      ),
     );
     assert.equal(body.errors, undefined);
     // The whole point: a zero a client can tell apart from "holds nothing".
     assert.equal(body.data.account_positions.position_count, 0);
     assert.equal(
       body.data.account_positions.degraded.reason,
-      "positions_unpriceable",
+      "tier_unavailable",
     );
   });
 


### PR DESCRIPTION
## The fix that wasn't finished

#11290 removed the doomed DATA_API leg from REST's `handleAccountPositions`, having measured that DATA_API has no branch for `/accounts/:ss58/positions` — 55 of 55 captured neurons-tier declines were that single path.

**GraphQL's `account_positions` resolver kept its own copy.** So the hop carried on:

| occurrence (UTC) | |
| --- | --- |
| 09:11:49 | |
| 09:17:15 | |
| 10:04:20 | |
| — | REST fix deployed **09:54:26** |

Same two subrequests, same awaited PostHog `$exception` on the response path, same tier that was never going to answer. The comment above it asserted parity — *"Same tryDataApiTier(…) fallback contract handleAccountPositions uses"* — with a handler that had stopped forwarding an hour earlier. A duplicated contract goes stale without anything failing, which is how the fix got reported as complete while the exceptions kept arriving.

## Checked exhaustively this time, and by the right key

#11290 swept the two request-handler files and reported "all 37 forwards land on a real branch". That was true of what it looked at, and it missed this file entirely — **twenty** files call `tryDataApiTier`.

The population that matters is not the callers but the **paths they forward**. So:

```
grep -rn "postgresTierRequest(" -A3 src workers | grep -oE '`/api/v1/[^`]*`|"/api/v1/[^"]*"'
```

36 distinct paths. Every one is claimed by DATA_API's dispatcher except `/accounts/{ss58}/positions`. Two surfaces named it; both are now off it, and MCP never was.

## The tests move with it

- The **forwarded-path assertion** for this route had no subject left. Replaced by a stub whose `fetch` **throws** plus a counter that must stay zero — restoring the leg fails it, which is proven below. The `portfolio` and `subnets` twins keep theirs, because those routes really are dispatched.
- The **degraded-marker** test now reaches its marker by letting every tier decline rather than through a DATA_API stub. `tier_unavailable` from `unavailableAccountPositions` is what the real chain ends at, and the thing worth pinning was always that the resolver's field enumeration does not drop `degraded` (#9803) — not which tier produced it.

## Verification

- Restored the leg and watched exactly the new pin go red (`never forwards to DATA_API`), then restored.
- Full CI validator set (69 gates) green; `typecheck` / `lint` / `format:check` clean.
- **Full local suite: 925 files, 21,204 tests, 0 failures.**
- Deploy will be confirmed against the exception stream: this class should stop entirely, where after #11290 it merely thinned.