### PR TITLE
chore(db): re-snapshot the live Neon schema

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -241,7 +241,7 @@ CREATE TABLE public.attribution_sweeps (
     verdict text NOT NULL,
     CONSTRAINT attribution_sweeps_counts_are_sane CHECK (((sources_checked >= 0) AND (sources_read >= 0) AND (sources_read <= sources_checked) AND (candidates >= 0))),
     CONSTRAINT attribution_sweeps_swept_at_is_millis CHECK ((swept_at >= '1000000000000'::bigint)),
-    CONSTRAINT attribution_sweeps_verdict_is_known CHECK ((verdict = ANY (ARRAY['none-published'::text, 'candidates-found'::text, 'unreachable'::text, 'no-sources'::text])))
+    CONSTRAINT attribution_sweeps_verdict_is_known CHECK ((verdict = ANY (ARRAY['none-published'::text, 'candidates-found'::text, 'unreachable'::text, 'no-sources'::text, 'listings-only'::text])))
 );
 
 --


### PR DESCRIPTION
Carries #11300's commit unchanged, on a branch whose CI actually runs.

The automated snapshot PR is opened by `app/github-actions` with `GITHUB_TOKEN`, and GitHub does not trigger `on: pull_request` workflows for those — so #11300 sat with two checks (Superagent, Workers Builds) and `mergeStateStatus: UNKNOWN`, and would never have gone green on its own. Merging it as-is would have meant merging on no CI, which is the one thing the "green before merge" rule exists to stop.

## The drift is real and still unfixed on main

`attribution_sweeps_verdict_is_known` gained `listings-only`:

```sql
CHECK (verdict = ANY (ARRAY['none-published', 'candidates-found',
                            'unreachable', 'no-sources', 'listings-only']))
```

- `migrations/neon/0031_attribution_sweeps_listings_only.sql` is the migration behind it, so this is not a change made outside the migration path — which is the specific thing #11300's own body asks a reviewer to check for.
- `src/attribution-sweep.ts` is the writer that uses the verdict.
- **Verified against live Neon via the MCP**, not inferred from the dump: `pg_get_constraintdef` returns exactly the line this commit adds.
- `git show origin/main:db/schema.sql | grep listings-only` → 0. Still drifted.

Nothing else in the dump moved; the snapshot job's own diff is this single line.

## Verification

- Full CI validator set (69 gates) green, including `validate:db-types-drift` and `validate:migrations`.
- `db/schema.sql` is the human-readable half of the snapshot — no code reads it at runtime, which is why the drift was invisible rather than breaking.

#11300 can be closed as superseded once this lands.