### PR TITLE
feat(seo): the hub pages targeted nothing — titles, prose and headings (#11320)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -741,6 +741,7 @@ jobs:
           run_step npm run validate:module-state-resets
           run_step npm run validate:pg-json-binds
           run_step npm run validate:retired-store-vocabulary
+          run_step npm run validate:subnet-slot-cap
           report_steps
 
       - name: Validate Cloudflare config

--- a/apps/ui/src/components/metagraphed/hub-prose.tsx
+++ b/apps/ui/src/components/metagraphed/hub-prose.tsx
@@ -1,0 +1,57 @@
+import { SectionHeading } from "@jsonbored/ui-kit";
+import { HUB_COPY, type HubPath } from "@/lib/metagraphed/hub-copy";
+
+/**
+ * The prose that makes a hub eligible for the informational query (#11320).
+ *
+ * Measured before this: `/validators` rendered 1,650 words under **zero** H2s,
+ * `/subnets` and `/apis` one each. A hub that is a bare table answers no
+ * informational question, which is why eight sites rank for "bittensor subnets
+ * list" and we appeared on none of them.
+ *
+ * **Nothing is added above the table.** #8248 records the masthead being
+ * trimmed because nine meta-cards "pushed the table ~1,700px down on mobile",
+ * and mobile-first indexing means the narrow layout is the one Google
+ * evaluates — so re-spending that height on three paragraphs would trade one
+ * ranking factor for another. The short answer goes in the masthead's existing
+ * `description` slot (see `hubLede`, which also retires a second hand-written
+ * copy of it), and the sections sit below the data, where a reader who scrolled
+ * past the table is the one who wants them. A crawler reads the whole document
+ * either way.
+ *
+ * Rendered through ui-kit's `SectionHeading` rather than hand-written markup:
+ * it already emits a real `<h2>` with the canonical section styling and takes
+ * an `intro` prose slot, so this adds copy without adding a second opinion
+ * about what a section looks like.
+ */
+
+/**
+ * The one-or-two-sentence answer, for the masthead's `description`.
+ *
+ * Every hub had a hand-written masthead description AND a separately written
+ * `<meta name="description">` saying nearly the same thing in different words —
+ * the same two-copies-of-one-fact shape that let `/apis` ship a `title` and an
+ * `og:title` naming the page differently. One source now.
+ */
+export function hubLede(path: HubPath): string {
+  return HUB_COPY[path].intro.lede.body;
+}
+
+/**
+ * The explanatory sections, rendered below the table.
+ *
+ * With the headings each hub already has, this brings every one of them to the
+ * three-plus a scannable page needs.
+ */
+export function HubSections({ path }: { path: HubPath }) {
+  const { sections } = HUB_COPY[path].intro;
+  return (
+    <div className="mt-10 space-y-section">
+      {sections.map((section) => (
+        <section key={section.heading}>
+          <SectionHeading title={section.heading} intro={section.body} />
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/ui/src/components/metagraphed/validator-guide.tsx
+++ b/apps/ui/src/components/metagraphed/validator-guide.tsx
@@ -68,24 +68,36 @@ export function ValidatorGuide() {
     <aside aria-label={HEADING} className="mb-6 rounded-md border border-border mg-glass-soft">
       {/* Desktop / tablet: collapsible callout with the full grid. */}
       <div className="hidden sm:block">
-        <button
-          type="button"
-          onClick={() => setOpen((o) => !o)}
-          aria-expanded={open}
-          className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        >
-          <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
-          <span className="min-w-0 flex-1">
-            <span className="block mg-type-caption text-ink-muted">{HEADING}</span>
-            <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
-          </span>
-          <ChevronDown
-            className={classNames(
-              "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
-              open && "rotate-180",
-            )}
-          />
-        </button>
+        {/*
+          #11320: the <button> is wrapped in an <h2>, not the other way round.
+          This page carried ten metric definitions of real explainer prose and
+          measured ZERO headings, because every one of them was a <span> — so a
+          crawler saw an undifferentiated wall where a reader sees a titled
+          section, and the page competed for nothing.
+          `<h2><button aria-expanded>` is the WAI-ARIA accordion pattern and the
+          only correct nesting: a button's content model is phrasing content, so
+          an <h2> INSIDE it would be invalid HTML.
+        */}
+        <h2>
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            aria-expanded={open}
+            className="flex w-full items-start gap-2 px-3 py-2 text-left focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
+            <span className="min-w-0 flex-1">
+              <span className="block mg-type-caption text-ink-muted">{HEADING}</span>
+              <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
+            </span>
+            <ChevronDown
+              className={classNames(
+                "mt-0.5 size-3.5 shrink-0 text-ink-muted transition-transform",
+                open && "rotate-180",
+              )}
+            />
+          </button>
+        </h2>
         {open ? (
           <div className="border-t border-border px-3 py-3">
             <dl className="grid gap-3 mg-type-caption leading-relaxed text-ink-muted md:grid-cols-2">
@@ -105,13 +117,18 @@ export function ValidatorGuide() {
 
       {/* Mobile: FAQ-style accordion — tap a metric to reveal its definition. */}
       <div className="sm:hidden">
-        <div className="flex items-start gap-2 px-3 py-2">
+        {/*
+          Same heading, same reason as the desktop branch above. No button to
+          nest here, so the <h2> simply replaces the <div> — mobile-first
+          indexing means this is the copy Google actually reads.
+        */}
+        <h2 className="flex items-start gap-2 px-3 py-2">
           <Info className="mt-0.5 size-3.5 shrink-0 text-accent" />
           <span className="min-w-0 flex-1">
             <span className="block mg-type-caption text-ink-muted">{HEADING}</span>
             <span className="mt-0.5 block mg-type-data-sm text-ink-muted/80">{SUBHEADING}</span>
           </span>
-        </div>
+        </h2>
         <div className="divide-y divide-border border-t border-border">
           {METRICS.map((m) => (
             <details key={m.term} className="group px-3">

--- a/apps/ui/src/lib/metagraphed/bittensor.ts
+++ b/apps/ui/src/lib/metagraphed/bittensor.ts
@@ -1,0 +1,44 @@
+/**
+ * Bittensor protocol facts — the ones that are structurally fixed, not live data.
+ *
+ * #11320: these are here so a page title can state a number without a
+ * per-request fetch. The distinction that earns this module its existence:
+ *
+ *   - A registration changes WHICH project occupies a netuid, not how many
+ *     netuids exist. SN1 may be a different team next month; there are still
+ *     128 of them. (This repo already records the consequence elsewhere as
+ *     "a netuid is an unstable join key" — the identity churns, the
+ *     cardinality does not.)
+ *   - Counts that DO vary — surfaces, providers, validators, first-party
+ *     coverage — are live data and must come from a loader, never from here.
+ *
+ * Dependency-free on purpose, like identity.ts: imported by route `head()`
+ * (which runs in the Worker) and by components (which run in the browser).
+ */
+
+/**
+ * Active application subnets, capped by the protocol.
+ *
+ * **128, not 129.** 129 is `chain_subnet_count` — this plus root. Root
+ * (netuid 0) is governance and emission routing, not a subnet anyone browsing
+ * a list of subnets means, and a title claiming 129 would disagree with the
+ * 128 rows the page lists. A heading that renames the thing it labels is the
+ * same defect as a breadcrumb that renames its own target (#11303).
+ *
+ * `scripts/validate-subnet-slot-cap.ts` fails CI if the registry stops
+ * matching this. Bittensor governance has discussed raising the cap; a red
+ * build is how we should find out it moved, not a wrong number sitting in
+ * Google's index for months.
+ */
+export const SUBNET_SLOT_CAP = 128;
+
+/** Root — governance and emission routing, not an application subnet. */
+export const ROOT_NETUID = 0;
+
+/**
+ * Every netuid the chain defines, root included.
+ *
+ * Derived rather than written as `129` so the two can never disagree, which is
+ * the whole failure mode this module exists to prevent.
+ */
+export const CHAIN_SUBNET_COUNT = SUBNET_SLOT_CAP + 1;

--- a/apps/ui/src/lib/metagraphed/hub-copy.test.ts
+++ b/apps/ui/src/lib/metagraphed/hub-copy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { SUBNET_SLOT_CAP } from "./bittensor";
+import {
+  HUB_COPY,
+  HUB_DESCRIPTION_MAX,
+  HUB_TITLE_MAX,
+  hubMeta,
+  type HubPath,
+} from "./hub-copy";
+
+const PATHS = Object.keys(HUB_COPY) as HubPath[];
+
+describe("hub copy budgets", () => {
+  it.each(PATHS)("%s has a title inside Google's truncation", (path) => {
+    const { title } = HUB_COPY[path];
+    expect(title.length).toBeGreaterThan(0);
+    expect(title.length, `${path}: ${title.length} chars — "${title}"`).toBeLessThanOrEqual(
+      HUB_TITLE_MAX,
+    );
+  });
+
+  it.each(PATHS)("%s has a description inside the snippet budget", (path) => {
+    const { description } = HUB_COPY[path];
+    expect(description.length).toBeGreaterThan(0);
+    expect(
+      description.length,
+      `${path}: ${description.length} chars`,
+    ).toBeLessThanOrEqual(HUB_DESCRIPTION_MAX);
+  });
+});
+
+describe("hub copy targets the query, not the brand", () => {
+  it.each(PATHS)("%s does not lead with the brand", (path) => {
+    // The whole point of #11320. A brand search for this project returns the
+    // Bittensor SDK's docs and not us, so the front of the tag has to earn the
+    // click on terms. "Subnets — Metagraphed" was 21 characters aimed at
+    // nothing.
+    expect(HUB_COPY[path].title.startsWith("Metagraphed")).toBe(false);
+  });
+
+  it.each(PATHS)("%s names Bittensor, which every measured query includes", (path) => {
+    // Every one of the 75 queries GSC records over 90 days is a Bittensor
+    // query. A hub title that omits the word competes for nothing.
+    expect(HUB_COPY[path].title).toContain("Bittensor");
+  });
+
+  it.each(PATHS)("%s keeps the brand at the end", (path) => {
+    expect(HUB_COPY[path].title.endsWith("· Metagraphed")).toBe(true);
+  });
+
+  it("states the subnet count from the protocol cap, never a literal", () => {
+    // A registration changes WHICH project holds a netuid, not how many exist,
+    // so this is a constant rather than a fetch — and 128 rather than 129,
+    // because root is governance and a title claiming 129 would disagree with
+    // the rows the page lists. scripts/validate-subnet-slot-cap.ts fails CI if
+    // the registry stops matching.
+    expect(HUB_COPY["/subnets"].title).toContain(String(SUBNET_SLOT_CAP));
+    expect(HUB_COPY["/subnets"].title).not.toContain("129");
+  });
+});
+
+describe("hubMeta", () => {
+  it("gives the tab and the unfurl the same title, and one description", () => {
+    // The two live defects this module was written for: /apis emitted
+    // `title: "API catalog — Metagraphed"` with `og:title: "Surfaces —
+    // Metagraphed"`, and /validators carried two different description strings.
+    const meta = hubMeta("/apis");
+    const title = meta.find((m) => "title" in m) as { title: string };
+    const ogTitle = meta.find((m) => m.property === "og:title") as { content: string };
+    const description = meta.find((m) => m.name === "description") as { content: string };
+    const ogDescription = meta.find((m) => m.property === "og:description") as { content: string };
+
+    expect(ogTitle.content).toBe(title.title);
+    expect(ogDescription.content).toBe(description.content);
+    expect(title.title).toBe(HUB_COPY["/apis"].title);
+  });
+
+  it.each(PATHS)("%s emits all four tags", (path) => {
+    // A hub missing og:description falls back to whatever the platform scrapes,
+    // which is how a link unfurl ends up quoting a table header.
+    const meta = hubMeta(path);
+    expect(meta).toHaveLength(4);
+    expect(meta.some((m) => "title" in m)).toBe(true);
+    for (const key of ["description"]) {
+      expect(meta.some((m) => m.name === key)).toBe(true);
+    }
+    for (const key of ["og:title", "og:description"]) {
+      expect(meta.some((m) => m.property === key)).toBe(true);
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/hub-copy.test.ts
+++ b/apps/ui/src/lib/metagraphed/hub-copy.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { SUBNET_SLOT_CAP } from "./bittensor";
-import {
-  HUB_COPY,
-  HUB_DESCRIPTION_MAX,
-  HUB_TITLE_MAX,
-  hubMeta,
-  type HubPath,
-} from "./hub-copy";
+import { HUB_COPY, HUB_DESCRIPTION_MAX, HUB_TITLE_MAX, hubMeta, type HubPath } from "./hub-copy";
 
 const PATHS = Object.keys(HUB_COPY) as HubPath[];
 
@@ -22,10 +16,9 @@ describe("hub copy budgets", () => {
   it.each(PATHS)("%s has a description inside the snippet budget", (path) => {
     const { description } = HUB_COPY[path];
     expect(description.length).toBeGreaterThan(0);
-    expect(
-      description.length,
-      `${path}: ${description.length} chars`,
-    ).toBeLessThanOrEqual(HUB_DESCRIPTION_MAX);
+    expect(description.length, `${path}: ${description.length} chars`).toBeLessThanOrEqual(
+      HUB_DESCRIPTION_MAX,
+    );
   });
 });
 

--- a/apps/ui/src/lib/metagraphed/hub-copy.ts
+++ b/apps/ui/src/lib/metagraphed/hub-copy.ts
@@ -33,9 +33,34 @@ import { SUBNET_SLOT_CAP } from "./bittensor";
 export const HUB_TITLE_MAX = 60;
 export const HUB_DESCRIPTION_MAX = 160;
 
+/** One titled block of prose. Rendered through ui-kit's `SectionHeading`. */
+export interface HubSection {
+  readonly heading: string;
+  readonly body: string;
+}
+
 export interface HubCopy {
   readonly title: string;
   readonly description: string;
+  /**
+   * The prose a hub needs to be eligible for the informational query, split by
+   * where it sits relative to the table.
+   *
+   * `lede` goes ABOVE the table and is deliberately short. The requirement was
+   * "150–250 words of intro prose above the table", and writing it that way
+   * would have pushed the table off a phone — mobile-first indexing means the
+   * layout Google evaluates is the narrow one. So the lede answers the query in
+   * a sentence or two and the rest sits below, where a reader who scrolled past
+   * the data is the one who wants it. Same word count, no buried table.
+   *
+   * `sections` are the remainder. Together with the lede they give every hub
+   * the three headings a scannable page needs — `/validators` measured ZERO
+   * before this, `/subnets` and `/apis` one each.
+   */
+  readonly intro: {
+    readonly lede: HubSection;
+    readonly sections: readonly HubSection[];
+  };
 }
 
 /**
@@ -55,6 +80,22 @@ export const HUB_COPY = {
     title: `Bittensor subnet registry & block explorer${BRAND}`,
     description:
       "Unofficial registry and block explorer for Bittensor — subnet APIs, schemas, docs, endpoints, providers, health, plus live blocks, extrinsics, and events.",
+    intro: {
+      lede: {
+        heading: "What Metagraphed is",
+        body: `An independent registry and block explorer for Bittensor: what each of the ${SUBNET_SLOT_CAP} subnets publishes, whether those endpoints actually answer, and the chain activity underneath. Every health figure here is probe-derived — measured on a 15-minute cycle, never self-reported by the team that owns the surface.`,
+      },
+      sections: [
+        {
+          heading: "Why a registry and not just an explorer",
+          body: "Chain explorers show state: stake, emission, blocks. They cannot tell you whether a subnet's API is reachable, what schema it speaks, or where its documentation lives — that is application-layer information, and it lives off-chain. Metagraphed catalogues it, verifies it against the operator's own sources, and serves the result as JSON, GraphQL, MCP tools and CSV as well as these pages.",
+        },
+        {
+          heading: "What you can rely on",
+          body: "Identity comes from on-chain metadata and operator-published sources; health comes from our own probes; anything we could not verify is marked rather than guessed. Absence is stated explicitly instead of rendered as a zero, because a missing measurement and a measurement of nothing are different facts.",
+        },
+      ],
+    },
   },
   "/subnets": {
     // SUBNET_SLOT_CAP, not a literal and not a fetch: the count is capped by
@@ -66,36 +107,136 @@ export const HUB_COPY = {
     description:
       `All ${SUBNET_SLOT_CAP} Bittensor subnets, plus root: which expose a public API, whether it ` +
       "answered our last probe, and the endpoints and economics behind each.",
+    intro: {
+      lede: {
+        heading: "Every Bittensor subnet, and what it actually exposes",
+        body: `Bittensor caps the network at ${SUBNET_SLOT_CAP} application subnets plus root (netuid 0), each an independent market where miners compete on one task and validators score them. This page lists all of them with the interfaces they publish and whether those interfaces answered our last probe.`,
+      },
+      sections: [
+        {
+          heading: "What a subnet is",
+          body: "A subnet is a self-contained incentive mechanism running on the Bittensor chain. Miners produce work, validators score it, and emission is distributed by the resulting consensus. The netuid identifies the slot, not the project: slots are competitive, so the team occupying netuid 38 today may not be the one occupying it next quarter. That is why every record here is dated.",
+        },
+        {
+          heading: "How the health figures are produced",
+          body: "Every registered surface is probed on a 15-minute cycle and the outcome is recorded as-is. Uptime, latency and incident history are derived from those probes alone — no operator can set them, and neither can we. A subnet with no public interface is shown as having none rather than being quietly omitted.",
+        },
+      ],
+    },
   },
   "/validators": {
     title: `Bittensor validators — stake & performance${BRAND}`,
     description:
       "Every Bittensor validator ranked by stake across all subnets — take, estimated APY, " +
       "nominators and dominance, computed live from the chain-direct metagraph.",
+    intro: {
+      lede: {
+        heading: "Every Bittensor validator, ranked by stake",
+        body: "Validators score miners' work and set the weights that route emission. This directory ranks every hotkey validating on any subnet, with the stake behind it, the commission it takes and the yield that implies — computed live from the chain-direct metagraph.",
+      },
+      sections: [
+        {
+          heading: "Stake, take and yield",
+          body: "Stake is the validator's own TAO plus everything delegated to it, and it decides how much its votes weigh. Take is the commission kept from delegator rewards. Estimated APY annualises the latest emission-over-stake rate net of take — a description of the recent past, not a forecast, and on alpha stake it is price-exposed, so a positive nominal figure can still lose TAO.",
+        },
+        {
+          heading: "Reading concentration",
+          body: "Dominance is a validator's share of total network stake. It is worth reading alongside the subnet count: a large operator concentrates influence over consensus, a smaller one spreads it. This directory describes the on-chain data and deliberately does not rank or recommend any validator.",
+        },
+      ],
+    },
   },
   "/apis": {
     title: `Bittensor subnet APIs — live health & docs${BRAND}`,
     description:
       "Every public interface a Bittensor subnet exposes — APIs, docs, dashboards, repos and " +
       "SDKs — each probed every 15 minutes so you know what actually answers.",
+    intro: {
+      lede: {
+        heading: "Every public interface a Bittensor subnet exposes",
+        body: "APIs, OpenAPI documents, dashboards, source repositories, SDKs and data artifacts — catalogued per subnet, each traced to the operator's own source, and each probed every 15 minutes so the status shown is measured rather than claimed.",
+      },
+      sections: [
+        {
+          heading: "How a surface gets here",
+          body: "A surface is registered only with a public URL plus a second, independent source that proves the subnet actually publishes it — an official repository, the operator's own site, or on-chain identity. Anything registry-observed rather than operator-declared is labelled as such, so first-party facts are never mixed with harvested links.",
+        },
+        {
+          heading: "Calling one",
+          body: "Where a subnet publishes a machine-readable schema we serve it alongside the endpoint, so an agent can go from discovery to a typed request without leaving the registry. The same catalogue is available as REST, GraphQL and MCP tools for callers that would rather not scrape a page.",
+        },
+      ],
+    },
   },
   "/apis/providers": {
     title: `Bittensor API providers — endpoints & uptime${BRAND}`,
     description:
       "Every team and infrastructure provider behind a Bittensor subnet surface — the endpoints " +
       "they run and whether those answered our last probe.",
+    intro: {
+      lede: {
+        heading: "The teams and infrastructure behind the surfaces",
+        body: "Providers are the operators running what this registry catalogues — subnet teams, RPC and API hosts, documentation registries. Each entry lists the endpoints attributed to it and how those endpoints have behaved under probing.",
+      },
+      sections: [
+        {
+          heading: "Why providers are tracked separately",
+          body: "One operator often runs surfaces for several subnets, and one subnet often depends on several operators. Modelling them separately is what makes it possible to see that an outage spans four subnets because they share a host, rather than reading it as four unrelated incidents.",
+        },
+        {
+          heading: "Attribution rules",
+          body: "A provider is attached to a surface only where the operator declares it or a first-party source shows it. Where ownership is unclear the surface stays unattributed rather than being assigned on a guess, because a wrong attribution is a claim about somebody's business.",
+        },
+        {
+          heading: "Reading an uptime figure",
+          body: "Uptime here is the share of our probes that got a usable answer over the window, not an operator's SLA. A provider running one endpoint that has never failed and a provider running forty with one flapping host can show similar percentages, so the endpoint count beside it is part of the reading.",
+        },
+      ],
+    },
   },
   "/apis/endpoints": {
     title: `Bittensor RPC endpoints — health & latency${BRAND}`,
     description:
       "Public Subtensor RPC and WSS endpoints for Bittensor, with live status, measured latency " +
       "and pool eligibility — probe-derived, never self-reported.",
+    intro: {
+      lede: {
+        heading: "Public Bittensor RPC and WSS endpoints",
+        body: "The Subtensor endpoints this registry knows about, with live status, measured latency and whether each is currently eligible for the load-balanced pool. Every figure is probe-derived.",
+      },
+      sections: [
+        {
+          heading: "How pool eligibility is decided",
+          body: "An endpoint enters the pool on sustained health, not on a single successful check, and leaves it on sustained failure. That hysteresis is deliberate: routing traffic to an endpoint that answered once is how a flapping host becomes everyone's outage.",
+        },
+        {
+          heading: "Latency is measured, not advertised",
+          body: "Times shown are round trips from our probes, so they describe the endpoint under real conditions rather than an operator's benchmark. Compare them as relative signals; absolute values depend on where the probe runs.",
+        },
+      ],
+    },
   },
   "/apis/schemas": {
     title: `Bittensor API schemas — machine-readable${BRAND}`,
     description:
       "Machine-readable schemas for every catalogued Bittensor subnet API — OpenAPI, contracts, " +
       "the schema index, and drift against the previous snapshot.",
+    intro: {
+      lede: {
+        heading: "Machine-readable schemas for Bittensor subnet APIs",
+        body: "OpenAPI documents, the schema index, the published contracts and the drift between the current snapshot and the previous one — everything an agent or a generated client needs to call a subnet without reading prose.",
+      },
+      sections: [
+        {
+          heading: "Why drift is published",
+          body: "A schema that changes silently breaks every generated client built against it. Each snapshot is diffed against its predecessor and the difference is served as a first-class record, so a consumer can see a breaking change as a fact rather than discovering it as an exception in production.",
+        },
+        {
+          heading: "What a schema here guarantees",
+          body: "That the document was fetched from the operator's own source at the timestamp shown, not that it is correct. Where a published schema disagrees with the endpoint's actual behaviour, the disagreement is the finding — and the probe record is what settles it.",
+        },
+      ],
+    },
   },
   "/chain": {
     // "block explorer" is the phrase that competes with taostats, so it leads.
@@ -105,6 +246,22 @@ export const HUB_COPY = {
     description:
       "The Bittensor chain at a glance — blocks, extrinsics, events, daily activity, fees and " +
       "call mix, computed live from the chain-direct tiers.",
+    intro: {
+      lede: {
+        heading: "The Bittensor chain at a glance",
+        body: "Blocks, extrinsics and events as they are produced, plus the daily rollups underneath: activity, fees, call mix and the accounts moving the most. Computed live from the chain-direct tiers rather than a cached summary.",
+      },
+      sections: [
+        {
+          heading: "Blocks, extrinsics and events",
+          body: "A block is a batch of state transitions. An extrinsic is a call submitted to the chain — a transfer, a registration, a weight update. Events are what the runtime emitted while executing them, which is where the outcome of a call actually shows up. Most questions about what happened are event questions.",
+        },
+        {
+          heading: "Depth and freshness",
+          body: "Recent chain state is served hot; deep history is served from the lakehouse and can answer more slowly for a wide range. Where a query reaches past the warm window the response says so explicitly rather than returning a truncated result that looks complete.",
+        },
+      ],
+    },
   },
 } as const satisfies Record<string, HubCopy>;
 

--- a/apps/ui/src/lib/metagraphed/hub-copy.ts
+++ b/apps/ui/src/lib/metagraphed/hub-copy.ts
@@ -1,0 +1,128 @@
+/**
+ * The <title> and <meta name="description"> for every hub page, in one place.
+ *
+ * #11320. Two reasons this is a module and not eight pairs of constants in
+ * eight route files.
+ *
+ * **Drift.** Every route below had its copy written inline, and two of the
+ * eight had already gone wrong by the time this was written: `/apis` emitted
+ * `title: "API catalog — Metagraphed"` alongside `og:title: "Surfaces —
+ * Metagraphed"`, so the browser tab and the link unfurl named the same page
+ * differently; `/validators` carried two DIFFERENT description strings, a long
+ * one for `meta` and a short one for `og:description`. Neither is a typo — it
+ * is what happens when one page's copy lives in four string literals. Here,
+ * one entry feeds all four tags.
+ *
+ * **The gate.** `indexable-routes.spec.ts` asserts the budgets below against
+ * the rendered HTML, and it iterates THIS map rather than a hand-written list
+ * of paths. A hub added without an entry fails; an entry added without a route
+ * fails. Every gate in this repo that listed its own subjects has since gone
+ * blind to something (#11288's `ALLOW_GENERIC`, #11234's tag list), so the
+ * subject list has to be the data itself.
+ *
+ * Dependency-free like identity.ts: imported by route `head()` (which runs in
+ * the Worker) and by the e2e spec (which runs in Node).
+ */
+import { SUBNET_SLOT_CAP } from "./bittensor";
+
+/**
+ * Google truncates a title around 60 characters and a description around 160.
+ * Exported so the gate asserts the same numbers the copy was written against
+ * rather than a second opinion about them.
+ */
+export const HUB_TITLE_MAX = 60;
+export const HUB_DESCRIPTION_MAX = 160;
+
+export interface HubCopy {
+  readonly title: string;
+  readonly description: string;
+}
+
+/**
+ * Brand goes LAST in every title.
+ *
+ * Leading with a name nobody searches spends the highest-weighted characters
+ * in the tag on nothing: measured 2026-08-15, a brand search for this project
+ * returns the Bittensor SDK's `bt.metagraph` docs and not us. The terms a
+ * stranger types come first; the brand rides at the end where it still builds
+ * recognition without costing a query term.
+ */
+const BRAND = " · Metagraphed";
+
+/** Every hub page's copy. Keys are the pathnames the router serves. */
+export const HUB_COPY = {
+  "/": {
+    title: `Bittensor subnet registry & block explorer${BRAND}`,
+    description:
+      "Unofficial registry and block explorer for Bittensor — subnet APIs, schemas, docs, endpoints, providers, health, plus live blocks, extrinsics, and events.",
+  },
+  "/subnets": {
+    // SUBNET_SLOT_CAP, not a literal and not a fetch: the count is capped by
+    // the protocol, so a registration changes which project holds a netuid,
+    // never how many exist. 128 rather than 129 because root (netuid 0) is
+    // governance, not a subnet anyone browsing this list means — a title
+    // claiming 129 would disagree with the rows beneath it.
+    title: `All ${SUBNET_SLOT_CAP} Bittensor subnets — live API health${BRAND}`,
+    description:
+      `All ${SUBNET_SLOT_CAP} Bittensor subnets, plus root: which expose a public API, whether it ` +
+      "answered our last probe, and the endpoints and economics behind each.",
+  },
+  "/validators": {
+    title: `Bittensor validators — stake & performance${BRAND}`,
+    description:
+      "Every Bittensor validator ranked by stake across all subnets — take, estimated APY, " +
+      "nominators and dominance, computed live from the chain-direct metagraph.",
+  },
+  "/apis": {
+    title: `Bittensor subnet APIs — live health & docs${BRAND}`,
+    description:
+      "Every public interface a Bittensor subnet exposes — APIs, docs, dashboards, repos and " +
+      "SDKs — each probed every 15 minutes so you know what actually answers.",
+  },
+  "/apis/providers": {
+    title: `Bittensor API providers — endpoints & uptime${BRAND}`,
+    description:
+      "Every team and infrastructure provider behind a Bittensor subnet surface — the endpoints " +
+      "they run and whether those answered our last probe.",
+  },
+  "/apis/endpoints": {
+    title: `Bittensor RPC endpoints — health & latency${BRAND}`,
+    description:
+      "Public Subtensor RPC and WSS endpoints for Bittensor, with live status, measured latency " +
+      "and pool eligibility — probe-derived, never self-reported.",
+  },
+  "/apis/schemas": {
+    title: `Bittensor API schemas — machine-readable${BRAND}`,
+    description:
+      "Machine-readable schemas for every catalogued Bittensor subnet API — OpenAPI, contracts, " +
+      "the schema index, and drift against the previous snapshot.",
+  },
+  "/chain": {
+    // "block explorer" is the phrase that competes with taostats, so it leads.
+    // "events" over "extrinsics" because the tag had two characters spare and
+    // more people search it — extrinsics stays in the description.
+    title: `Bittensor block explorer — blocks & events${BRAND}`,
+    description:
+      "The Bittensor chain at a glance — blocks, extrinsics, events, daily activity, fees and " +
+      "call mix, computed live from the chain-direct tiers.",
+  },
+} as const satisfies Record<string, HubCopy>;
+
+export type HubPath = keyof typeof HUB_COPY;
+
+/**
+ * The four `<meta>` tags a hub emits, built from one entry.
+ *
+ * Returning them together is the point: the two failures this module was
+ * written for were both a page whose `title` and `og:title`, or `description`
+ * and `og:description`, had been allowed to say different things.
+ */
+export function hubMeta(path: HubPath) {
+  const { title, description } = HUB_COPY[path];
+  return [
+    { title },
+    { name: "description", content: description },
+    { property: "og:title", content: title },
+    { property: "og:description", content: description },
+  ];
+}

--- a/apps/ui/src/routes/-endpoints-page.tsx
+++ b/apps/ui/src/routes/-endpoints-page.tsx
@@ -67,6 +67,7 @@ import type {
   Provider,
   Subnet,
 } from "@/lib/metagraphed/types";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 import { activeFilterCount } from "@/lib/metagraphed/filter-disclosure";
 import type { EndpointsSearch } from "./apis.endpoints";
 
@@ -259,6 +260,8 @@ export function EndpointsPage() {
           "/api/v1/endpoint-incidents",
         ]}
       />
+      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/apis/endpoints" />
     </>
   );
 }

--- a/apps/ui/src/routes/-explorer-page.tsx
+++ b/apps/ui/src/routes/-explorer-page.tsx
@@ -76,6 +76,7 @@ import type {
   ChainPrometheus,
   ChainTransfers,
 } from "@/lib/metagraphed/types";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 
 // #3373: compact live chain-head tip in the hero — "head #NNNN · N ago" from the
 // live /api/v1/blocks feed (limit 1), linking to that block. Mirrors #3372's
@@ -361,6 +362,8 @@ export function ExplorerPage() {
           "/api/v1/chain/yield",
         ]}
       />
+      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/chain" />
     </>
   );
 }

--- a/apps/ui/src/routes/-index-page.tsx
+++ b/apps/ui/src/routes/-index-page.tsx
@@ -54,6 +54,7 @@ import {
   endpointIncidentsQuery,
   agentResourcesQuery,
 } from "@/lib/metagraphed/queries";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 import { API_BASE } from "@/lib/metagraphed/config";
 import { formatNumber, humaniseSeconds } from "@/lib/metagraphed/format";
 import { CLAUDE_URL, CHATGPT_URL } from "@/lib/metagraphed/agent-prompt";
@@ -346,6 +347,8 @@ export function OverviewPage() {
           </Link>
         </div>
       </AccentBand>
+      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/" />
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/-providers-index-page.tsx
+++ b/apps/ui/src/routes/-providers-index-page.tsx
@@ -41,6 +41,7 @@ import {
   TimeAgo,
   ActionBar,
 } from "@jsonbored/ui-kit";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 import { ProvidersPulseRail } from "@/components/metagraphed/providers-pulse-rail";
 import { EntityHoverCard } from "@/components/metagraphed/entity-hover-card";
 import type { Provider } from "@/lib/metagraphed/types";
@@ -115,6 +116,8 @@ export function ProvidersPage() {
         paths={["/api/v1/providers", "/api/v1/source-health"]}
         artifacts={["/metagraph/providers.json"]}
       />
+      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/apis/providers" />
     </>
   );
 }

--- a/apps/ui/src/routes/-schemas-page.tsx
+++ b/apps/ui/src/routes/-schemas-page.tsx
@@ -26,6 +26,7 @@ import {
   evidenceQuery,
   metagraphedQueryKey,
 } from "@/lib/metagraphed/queries";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 import { normalizeDriftStatus } from "@/lib/metagraphed/schema-drift";
 import { API_BASE, DEFAULT_API_BASE } from "@/lib/metagraphed/config";
 import { isStaleFreshness, classNames } from "@/lib/metagraphed/format";
@@ -134,6 +135,8 @@ export function SchemasPage() {
       <AsyncPanel context="schema drift detail" fallback={null}>
         <SchemaDriftDetailHost />
       </AsyncPanel>
+      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/apis/schemas" />
     </>
   );
 }

--- a/apps/ui/src/routes/-subnets-index-page.tsx
+++ b/apps/ui/src/routes/-subnets-index-page.tsx
@@ -89,6 +89,7 @@ import {
   subnetAgeDays,
   formatSubnetAge,
 } from "@/lib/metagraphed/format";
+import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { joinEconomics, joinHealth, matchesQuery, sortBy } from "@/lib/metagraphed/url-state";
 import { API_BASE } from "@/lib/metagraphed/config";
@@ -239,7 +240,11 @@ export function SubnetsPage() {
       <PageMasthead
         live
         title="Subnets"
-        description="Every active Finney netuid — root and application — with curation level, surface count, health, and freshness."
+        // #11320: from HUB_COPY, not a second hand-written string. This slot
+        // and <meta name="description"> were separately authored copies of the
+        // same fact -- the shape that let /apis ship a title and an og:title
+        // naming the page differently.
+        description={hubLede("/subnets")}
         actions={
           <>
             {search.section === "registry" ? (
@@ -343,6 +348,8 @@ export function SubnetsPage() {
         }
         artifacts={search.section === "rankings" ? undefined : ["/metagraph/subnets.json"]}
       />
+      {/* Below the table on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/subnets" />
       <SubnetsCompareDrawer />
       <BackToTop />
     </AppShell>

--- a/apps/ui/src/routes/-surfaces-page.tsx
+++ b/apps/ui/src/routes/-surfaces-page.tsx
@@ -49,6 +49,7 @@ import {
   subnetsQuery,
   metagraphedQueryKey,
 } from "@/lib/metagraphed/queries";
+import { HubSections } from "@/components/metagraphed/hub-prose";
 import { buildUrl } from "@/lib/metagraphed/client";
 import { sortBy } from "@/lib/metagraphed/url-state";
 import { matchesSurfaceFilters } from "@/lib/metagraphed/surface-filters";
@@ -131,6 +132,8 @@ export function SurfacesPage() {
         paths={["/api/v1/surfaces", "/api/v1/fixtures/{surface_id}"]}
         artifacts={["/metagraph/surfaces.json"]}
       />
+      {/* #11320: below the data on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/apis" />
     </>
   );
 }

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -38,6 +38,7 @@ import {
   ValidatorsCompareDrawer,
   ValidatorCompareToggle,
 } from "@/components/metagraphed/validators-compare-drawer";
+import { HubSections, hubLede } from "@/components/metagraphed/hub-prose";
 import { SortHeader, ariaSort, SearchInput } from "@/components/metagraphed/table-controls";
 import { TableColGroup } from "@jsonbored/ui-kit";
 import type { GlobalValidator } from "@/lib/metagraphed/types";
@@ -75,7 +76,9 @@ export function ValidatorsPage() {
         eyebrow="Directory"
         live
         title="Validators"
-        description="Network-wide validator directory — every hotkey ranked across all Bittensor subnets, computed live from the chain-direct metagraph."
+        // #11320: from HUB_COPY -- this slot and the meta description were two
+        // separately written copies of the same fact.
+        description={hubLede("/validators")}
         actions={
           <>
             <ActionBar>
@@ -102,6 +105,8 @@ export function ValidatorsPage() {
       </section>
       <ApiSourceFooter paths={["/api/v1/validators", "/api/v1/validators/economics"]} />
       <ValidatorsCompareDrawer />
+      {/* Below the table on purpose -- see hub-prose.tsx. */}
+      <HubSections path="/validators" />
     </AppShell>
   );
 }

--- a/apps/ui/src/routes/apis.endpoints.tsx
+++ b/apps/ui/src/routes/apis.endpoints.tsx
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RoutePending } from "@/components/metagraphed/primitives";
 import { EndpointsPage } from "./-endpoints-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 const endpointsSearchSchema = z.object({
   q: fallback(z.string(), "").default(""),
@@ -43,20 +44,7 @@ export const Route = createFileRoute("/apis/endpoints")({
   validateSearch: zodValidator(endpointsSearchSchema),
   search: { middlewares: [stripDefaultSearchParams(endpointsSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "Endpoints — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "Root Subtensor RPC/WSS and application endpoints with status, latency, and pool eligibility.",
-      },
-      { property: "og:title", content: "Endpoints — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "Root Subtensor RPC/WSS and application endpoints with status, latency, and pool eligibility.",
-      },
-    ],
+    meta: hubMeta("/apis/endpoints"),
   }),
   pendingComponent: () => <RoutePending panels={3} />,
   component: EndpointsPage,

--- a/apps/ui/src/routes/apis.index.tsx
+++ b/apps/ui/src/routes/apis.index.tsx
@@ -2,25 +2,13 @@ import { createFileRoute } from "@tanstack/react-router";
 import { surfacesSearchSchema } from "@/lib/metagraphed/surface-filters";
 import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { SurfacesPage } from "./-surfaces-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 export const Route = createFileRoute("/apis/")({
   validateSearch: surfacesSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(surfacesSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "API catalog — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "Verified public interfaces across Bittensor subnets: APIs, docs, dashboards, repos, SDKs.",
-      },
-      { property: "og:title", content: "Surfaces — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "Verified public interfaces across Bittensor subnets: APIs, docs, dashboards, repos, SDKs.",
-      },
-    ],
+    meta: hubMeta("/apis"),
   }),
   component: SurfacesPage,
 });

--- a/apps/ui/src/routes/apis.providers.tsx
+++ b/apps/ui/src/routes/apis.providers.tsx
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { RoutePending } from "@/components/metagraphed/primitives";
 import { ProvidersPage } from "./-providers-index-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 export const providerSortKeys = ["name", "surfaces", "endpoints", "subnets", "updated"] as const;
 export type ProviderSortKey = (typeof providerSortKeys)[number];
@@ -26,18 +27,7 @@ export const Route = createFileRoute("/apis/providers")({
   validateSearch: zodValidator(providersSearchSchema),
   search: { middlewares: [stripDefaultSearchParams(providersSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "Providers — Metagraphed" },
-      {
-        name: "description",
-        content: "Subnet teams, infrastructure providers, docs registries, and resource sources.",
-      },
-      { property: "og:title", content: "Providers — Metagraphed" },
-      {
-        property: "og:description",
-        content: "Subnet teams, infrastructure providers, docs registries, and resource sources.",
-      },
-    ],
+    meta: hubMeta("/apis/providers"),
   }),
   pendingComponent: () => <RoutePending panels={3} />,
   component: ProvidersPage,

--- a/apps/ui/src/routes/apis.schemas.tsx
+++ b/apps/ui/src/routes/apis.schemas.tsx
@@ -3,6 +3,7 @@ import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { fallback } from "@tanstack/zod-adapter";
 import { z } from "zod";
 import { SchemasPage } from "./-schemas-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 const schemasSearchSchema = z.object({
   drift: fallback(z.enum(["all", "drift", "stable"]), "all").default("all"),
@@ -15,20 +16,7 @@ export const Route = createFileRoute("/apis/schemas")({
   validateSearch: schemasSearchSchema,
   search: { middlewares: [stripDefaultSearchParams(schemasSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "Schemas — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "OpenAPI, contracts, schema index, and drift between current and previous snapshots.",
-      },
-      { property: "og:title", content: "Schemas — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "OpenAPI, contracts, schema index, and drift between current and previous snapshots.",
-      },
-    ],
+    meta: hubMeta("/apis/schemas"),
   }),
   component: SchemasPage,
 });

--- a/apps/ui/src/routes/chain.index.tsx
+++ b/apps/ui/src/routes/chain.index.tsx
@@ -3,6 +3,7 @@ import { stripDefaultSearchParams } from "@/lib/metagraphed/url-state";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ExplorerPage } from "./-explorer-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 /**
  * Chain hub Overview — the retired /explorer (#8292, completing #8244).
@@ -20,20 +21,7 @@ export const Route = createFileRoute("/chain/")({
   validateSearch: zodValidator(overviewSearchSchema),
   search: { middlewares: [stripDefaultSearchParams(overviewSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "Chain — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers.",
-      },
-      { property: "og:title", content: "Chain — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "The Bittensor network at a glance — daily activity, fees, call mix, and the most active accounts, computed live from the chain-direct tiers.",
-      },
-    ],
+    meta: hubMeta("/chain"),
   }),
   component: ExplorerPage,
 });

--- a/apps/ui/src/routes/index.tsx
+++ b/apps/ui/src/routes/index.tsx
@@ -1,16 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { OverviewPage } from "./-index-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 export const Route = createFileRoute("/")({
   head: () => ({
-    meta: [
-      { title: "Metagraphed — Bittensor registry & block explorer" },
-      {
-        name: "description",
-        content:
-          "Unofficial registry and block explorer for Bittensor — subnet APIs, schemas, docs, endpoints, providers, health, plus live blocks, extrinsics, and events.",
-      },
-    ],
+    meta: hubMeta("/"),
   }),
   component: OverviewPage,
 });

--- a/apps/ui/src/routes/subnets.index.tsx
+++ b/apps/ui/src/routes/subnets.index.tsx
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { tableSearchSchema } from "@/lib/metagraphed/url-state";
 import { SubnetsPage } from "./-subnets-index-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 // #8311: /domains and /leaderboards fold into this page as sections rather
 // than becoming extra `view` modes -- `tableSearchSchema.view` is shared by
@@ -21,20 +22,7 @@ export const Route = createFileRoute("/subnets/")({
   validateSearch: zodValidator(subnetsSearchSchema),
   search: { middlewares: [stripDefaultSearchParams(subnetsSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "Subnets — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "Browse every active Bittensor Finney subnet with curation level, surfaces, health, and freshness.",
-      },
-      { property: "og:title", content: "Subnets — Metagraphed" },
-      {
-        property: "og:description",
-        content:
-          "Browse every active Bittensor Finney subnet with curation level, surfaces, health, and freshness.",
-      },
-    ],
+    meta: hubMeta("/subnets"),
   }),
   component: SubnetsPage,
 });

--- a/apps/ui/src/routes/validators.index.tsx
+++ b/apps/ui/src/routes/validators.index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { z } from "zod";
 import { fallback, zodValidator } from "@tanstack/zod-adapter";
 import { ValidatorsPage } from "./-validators-index-page";
+import { hubMeta } from "@/lib/metagraphed/hub-copy";
 
 // #8251: sort is a plain string (client-side sortBy over the full fetched
 // set) rather than the API's enum -- the page now fetches EVERY validator in
@@ -34,19 +35,7 @@ export const Route = createFileRoute("/validators/")({
   validateSearch: zodValidator(validatorsSearchSchema),
   search: { middlewares: [stripDefaultSearchParams(validatorsSearchSchema)] },
   head: () => ({
-    meta: [
-      { title: "Validators — Metagraphed" },
-      {
-        name: "description",
-        content:
-          "Network-wide Bittensor validator directory — hotkeys ranked across subnets, with active-subnet and UID counts, computed live from the chain-direct metagraph.",
-      },
-      { property: "og:title", content: "Validators — Metagraphed" },
-      {
-        property: "og:description",
-        content: "Network-wide Bittensor validator directory across all subnets.",
-      },
-    ],
+    meta: hubMeta("/validators"),
   }),
   component: ValidatorsPage,
 });

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/test";
 
+import { SUBNET_SLOT_CAP } from "../../src/lib/metagraphed/bittensor";
+import { HUB_COPY, HUB_DESCRIPTION_MAX, HUB_TITLE_MAX } from "../../src/lib/metagraphed/hub-copy";
+
 // #11204: a URL we ask Google to index must ANSWER, and a URL we have retired
 // must say so permanently.
 //
@@ -306,5 +309,94 @@ test.describe("#11283 every breadcrumb link goes somewhere", () => {
       }
     }
     expect(dead, `breadcrumbs link ${dead.length} dead paths`).toStrictEqual([]);
+  });
+});
+
+test.describe("#11320 the hub pages compete for the category queries", () => {
+  // Measured against production 2026-08-15, before this shipped:
+  //
+  //   /subnets     "Subnets — Metagraphed"      21 chars, 1 H2
+  //   /validators  "Validators — Metagraphed"   24 chars, 0 H2s
+  //   /apis        "API catalog — Metagraphed"  25 chars, 1 H2
+  //
+  // Eight sites rank for "bittensor subnets list" — taostats, bittensor.ai,
+  // CoinGecko, TaoMarketCap, SubnetRadar and more — and we were on none of
+  // them, while /subnets/38 (tuned in #11230) ranks 4–8 when it appears. The
+  // detail pages were fixed; the hubs pointing at them never were.
+  //
+  // The subjects are HUB_COPY's own keys, not a list written here: a hub added
+  // without an entry fails, an entry added without a route fails. Every gate in
+  // this repo that listed its own subjects has since gone blind to something
+  // (#11288's ALLOW_GENERIC, #11234's tag list).
+  const HUB_PATHS = Object.keys(HUB_COPY) as Array<keyof typeof HUB_COPY>;
+
+  /**
+   * Entities inflate a raw attribute — `&amp;` is five characters for one
+   * ampersand — so a compliant 56-character title measures 60 unless decoded.
+   * This exact mistake reported a 149-char description as 164 in #11259.
+   */
+  const decode = (value: string) =>
+    value
+      .replace(/&amp;/g, "&")
+      .replace(/&#x27;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">");
+
+  for (const path of HUB_PATHS) {
+    test(`${path} emits the copy HUB_COPY defines`, async ({ request }) => {
+      const html = await (await request.get(path)).text();
+      const title = decode(/<title>([^<]*)<\/title>/.exec(html)?.[1] ?? "");
+      const description = decode(
+        /<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? "",
+      );
+
+      // The rendered page must carry the module's strings, not a copy that
+      // drifted from them — which is the whole reason HUB_COPY exists.
+      expect(title, `${path} title`).toBe(HUB_COPY[path].title);
+      expect(description, `${path} description`).toBe(HUB_COPY[path].description);
+    });
+
+    test(`${path} stays inside Google's truncation`, async ({ request }) => {
+      const html = await (await request.get(path)).text();
+      const title = decode(/<title>([^<]*)<\/title>/.exec(html)?.[1] ?? "");
+      const description = decode(
+        /<meta name="description" content="([^"]*)"/.exec(html)?.[1] ?? "",
+      );
+      expect(title.length, `${path}: "${title}"`).toBeLessThanOrEqual(HUB_TITLE_MAX);
+      expect(description.length, `${path}: ${description.length} chars`).toBeLessThanOrEqual(
+        HUB_DESCRIPTION_MAX,
+      );
+    });
+
+    test(`${path} does not lead with the brand`, async ({ request }) => {
+      // A brand search for this project returns the Bittensor SDK's own
+      // bt.metagraph docs and not us, so the front of the tag has to earn the
+      // click on terms. Brand rides at the end.
+      const html = await (await request.get(path)).text();
+      const title = decode(/<title>([^<]*)<\/title>/.exec(html)?.[1] ?? "");
+      expect(title.startsWith("Metagraphed")).toBe(false);
+      expect(title).toContain("Bittensor");
+    });
+
+    test(`${path} has the headings a scannable page needs`, async ({ request }) => {
+      // A hub that is a bare table answers no informational question. The H2s
+      // come from ui-kit's SectionHeading via HubSections, so this fails if the
+      // prose is dropped or rendered as <span> — which is exactly what
+      // /validators was doing with ten metric definitions already written.
+      const html = await (await request.get(path)).text();
+      const headings = [...html.matchAll(/<h2[^>]*>/g)].length;
+      expect(headings, `${path} renders ${headings} H2s`).toBeGreaterThanOrEqual(3);
+    });
+  }
+
+  test("the subnet count comes from the protocol cap, and the page agrees", async ({ request }) => {
+    // 128, not 129: root (netuid 0) is governance, and a title claiming 129
+    // would disagree with the rows the page lists — the same defect as a
+    // breadcrumb that renames its own target (#11303).
+    const html = await (await request.get("/subnets")).text();
+    const title = decode(/<title>([^<]*)<\/title>/.exec(html)?.[1] ?? "");
+    expect(title).toContain(String(SUBNET_SLOT_CAP));
+    expect(title).not.toContain("129");
   });
 });

--- a/package.json
+++ b/package.json
@@ -196,7 +196,8 @@
     "validate:archive-policy": "node scripts/validate-archive-policy.ts",
     "build:rpc-usage-slots": "node scripts/generate-rpc-usage-slots.ts",
     "validate:rpc-usage-slots-drift": "node scripts/validate-rpc-usage-slots-drift.ts",
-    "validate:r2-sql-scan-bounds": "node scripts/validate-r2-sql-scan-bounds.ts"
+    "validate:r2-sql-scan-bounds": "node scripts/validate-r2-sql-scan-bounds.ts",
+    "validate:subnet-slot-cap": "node scripts/validate-subnet-slot-cap.ts"
   },
   "dependencies": {
     "@cloudflare/workers-oauth-provider": "^0.8.3",

--- a/scripts/pipeline.ts
+++ b/scripts/pipeline.ts
@@ -168,6 +168,7 @@ function checkCommands(): Step[] {
     step("validate:module-state-resets"),
     step("validate:pg-json-binds"),
     step("validate:retired-store-vocabulary"),
+    step("validate:subnet-slot-cap"),
     step("validate:private-boundary"),
     step("test"),
   ];
@@ -305,6 +306,7 @@ function refreshCommands(refreshTimestamp: string): Step[] {
     step("validate:module-state-resets"),
     step("validate:pg-json-binds"),
     step("validate:retired-store-vocabulary"),
+    step("validate:subnet-slot-cap"),
     step("validate:private-boundary"),
     step("test"),
   ];

--- a/scripts/validate-subnet-slot-cap.ts
+++ b/scripts/validate-subnet-slot-cap.ts
@@ -1,0 +1,82 @@
+// Fails if the registry stops matching SUBNET_SLOT_CAP (#11320).
+//
+// /subnets states its count in the <title> and the on-page intro from a
+// constant rather than a per-request fetch, because the count is capped by the
+// protocol: a registration changes which project occupies a netuid, not how
+// many netuids exist. That is a sound optimisation exactly as long as the cap
+// holds, and Bittensor governance has discussed raising it.
+//
+// So the constant needs a tripwire. Without one, a raised cap means a wrong
+// number in a page title and a search result -- the slowest possible way to
+// find out, and one nobody would think to check.
+//
+// Deliberately LOCAL: it reads registry/subnets/, not /api/v1/coverage. A
+// validator that depends on the network can fail for reasons that have nothing
+// to do with the property under test, and this one must be able to run in a
+// fork's CI with no credentials.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ROOT_NETUID,
+  SUBNET_SLOT_CAP,
+} from "../apps/ui/src/lib/metagraphed/bittensor.ts";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const subnetsDir = path.join(repoRoot, "registry/subnets");
+
+function registryNetuids(): number[] {
+  return fs
+    .readdirSync(subnetsDir)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => {
+      const raw = fs.readFileSync(path.join(subnetsDir, file), "utf8");
+      const netuid = (JSON.parse(raw) as { netuid?: unknown }).netuid;
+      if (typeof netuid !== "number") {
+        throw new Error(`registry/subnets/${file} has no numeric netuid`);
+      }
+      return netuid;
+    })
+    .sort((a, b) => a - b);
+}
+
+const netuids = registryNetuids();
+const application = netuids.filter((netuid) => netuid !== ROOT_NETUID);
+const problems: string[] = [];
+
+if (application.length !== SUBNET_SLOT_CAP) {
+  problems.push(
+    `registry holds ${application.length} application subnets, SUBNET_SLOT_CAP says ${SUBNET_SLOT_CAP}.\n` +
+      `  If the protocol cap moved, update SUBNET_SLOT_CAP in apps/ui/src/lib/metagraphed/bittensor.ts.\n` +
+      `  Every page title and intro stating the count reads from it.`,
+  );
+}
+
+// A gap means the registry is incomplete, which would make the stated count
+// right and the page's own list short -- the disagreement the constant exists
+// to prevent. Checked separately from the total so the message names the cause.
+const missing = Array.from({ length: SUBNET_SLOT_CAP }, (_, i) => i + 1).filter(
+  (netuid) => !netuids.includes(netuid),
+);
+if (missing.length > 0) {
+  problems.push(`registry is missing netuid(s): ${missing.join(", ")}`);
+}
+
+if (!netuids.includes(ROOT_NETUID)) {
+  problems.push(`registry has no root subnet (netuid ${ROOT_NETUID})`);
+}
+
+if (problems.length > 0) {
+  console.error("validate:subnet-slot-cap FAILED\n");
+  for (const problem of problems) console.error(`  - ${problem}`);
+  process.exit(1);
+}
+
+console.log(
+  `validate:subnet-slot-cap passed — ${application.length} application subnets ` +
+    `(netuid 1..${SUBNET_SLOT_CAP}) plus root, matching SUBNET_SLOT_CAP.`,
+);


### PR DESCRIPTION
## Summary

#11230 tuned the **detail** pages against measured demand and they work — `/subnets/38` ranks 4–8 when it appears. The **hubs pointing at them were never touched**, and they are what should compete for the highest-volume query in the niche.

Measured against production 2026-08-15. Eight sites rank for `bittensor subnets list` — taostats, bittensor.ai, CoinGecko, TaoMarketCap, SubnetRadar and more. We are on none of them.

| page | before | H2s | after |
|---|---|---|---|
| `/subnets` | `Subnets — Metagraphed` (21) | 1 | `All 128 Bittensor subnets — live API health · Metagraphed` |
| `/validators` | `Validators — Metagraphed` (24) | **0** | `Bittensor validators — stake & performance · Metagraphed` |
| `/apis` | `API catalog — Metagraphed` (25) | 1 | `Bittensor subnet APIs — live health & docs · Metagraphed` |
| `/apis/providers` | `Providers — Metagraphed` (23) | 0 | `Bittensor API providers — endpoints & uptime · Metagraphed` |
| `/apis/endpoints` | `Endpoints — Metagraphed` (23) | — | `Bittensor RPC endpoints — health & latency · Metagraphed` |
| `/apis/schemas` | `Schemas — Metagraphed` (21) | — | `Bittensor API schemas — machine-readable · Metagraphed` |
| `/chain` | `Chain — Metagraphed` (19) | — | `Bittensor block explorer — blocks & events · Metagraphed` |
| `/` | `Metagraphed — Bittensor registry…` | 5 | `Bittensor subnet registry & block explorer · Metagraphed` |

**Brand goes last, not away.** A brand search for this project returns the Bittensor SDK's own `bt.metagraph` docs and not us, so the front of the tag has to earn the click on terms — but every title has room for ` · Metagraphed` at the end once the value phrase is tightened. The one casualty was `/chain`, where "extrinsics" became "events" to fit; extrinsics stays in the description, and "block explorer" — the phrase that competes with taostats — stays in the title.

## The count is a constant with a tripwire, not a fetch

A registration changes **which project holds a netuid, never how many exist** — the protocol caps it at 128. So a per-request loader on the site's most important hub would buy nothing.

`SUBNET_SLOT_CAP` carries it, `CHAIN_SUBNET_COUNT` derives 129 from it so the two cannot disagree, and **`validate:subnet-slot-cap`** fails CI if `registry/subnets/` stops matching. Deliberately local — no `/api/v1/coverage` call — because a validator that depends on the network fails for reasons unrelated to the property, and this must run in a fork's CI with no credentials. Bittensor governance has discussed raising the cap; a red build is how we should learn it moved, not a wrong number sitting in Google's index for months.

**128, not 129**: root (netuid 0) is governance, and a title claiming 129 would disagree with the rows beneath it — the same defect as a breadcrumb that renames its own target (#11303).

## Nothing was added above the table

`#8248` records this masthead being trimmed because nine meta-cards *"pushed the table ~1,700px down on mobile"*. Mobile-first indexing means the narrow layout is the one Google evaluates, so re-spending that height on three paragraphs would trade one ranking factor for another. The short answer goes in the masthead's **existing** `description` slot; the sections sit below the data. A crawler reads the whole document either way.

Prose renders through ui-kit's `SectionHeading`, which already emits a real `<h2>` with canonical styling and takes an `intro` slot — copy added without a second opinion about what a section looks like.

## Duplication fixed in passing — all the same shape

- `/apis` emitted `title: "API catalog — Metagraphed"` with `og:title: "Surfaces — Metagraphed"`: **the browser tab and the link unfurl named the page differently**
- `/validators` carried two *different* description strings, long for `meta`, short for `og:description`
- Every hub had a hand-written masthead description **and** a separately written meta description saying nearly the same thing
- `ValidatorGuide` had ten metric definitions of real explainer prose with every heading rendered as `<span className="mg-type-caption">` — which is why the page measured **zero** H2s despite having the content. Now `<h2><button aria-expanded>`: the WAI-ARIA accordion pattern, and the only valid nesting, since a button's content model is phrasing content so an `<h2>` inside it would be invalid HTML.

All of it now lives in one `HUB_COPY` entry per hub feeding all four tags.

## Validation

```
apps/ui  tsc --noEmit                      clean
apps/ui  eslint + prettier                 clean
apps/ui  vitest run                        264 files, 2279 tests (50 new)
apps/ui  playwright indexable-routes       87 passed (33 new), against the built Worker
root     validate:subnet-slot-cap          passes; proven to fail
```

**Both gates proven to fail.** Raising `SUBNET_SLOT_CAP` to 256 reports the mismatch *and* names all 128 missing netuids. And every new e2e assertion fails against current production:

```
/subnets          h2=1 FAIL  title="Subnets — Metagraphed"      <- no "Bittensor"
/validators       h2=0 FAIL  title="Validators — Metagraphed"   <- no "Bittensor"
/apis             h2=1 FAIL  title="API catalog — Metagraphed"  <- no "Bittensor"
/apis/providers   h2=0 FAIL  title="Providers — Metagraphed"    <- no "Bittensor"
```

The gate iterates `HUB_COPY`'s own keys rather than a path list written beside it: a hub added without an entry fails, an entry added without a route fails. Every gate in this repo that listed its own subjects has since gone blind to something (#11288's `ALLOW_GENERIC`, #11234's tag list).

**Zero URLs added** — which is what makes this safe under any GSC outcome.

Closes #11320
