### PR TITLE
fix(ci): the route gate cleared a route on a markdown table row

### DIFF
--- a/scripts/validate-ui-route-coverage.ts
+++ b/scripts/validate-ui-route-coverage.ts
@@ -12,7 +12,31 @@
 // current number in one place, fails when it grows, and asks to be lowered
 // whenever anyone renders one.
 //
-// ## What counts as "referenced"
+// ## What counts as "referenced" -- NARROWED (#10517)
+//
+// CODE, not prose. The evidence is `.ts/.tsx/.json` under apps/ui, with
+// `<ApiSourceFooter paths={[...]} />` arrays stripped before matching. At a
+// ceiling of 25 this check was a ratchet against a backlog and the strength of
+// each reference barely mattered; at 0 it gets read as "every published route
+// is rendered", and a claim stronger than its evidence is the shape this repo
+// keeps finding elsewhere.
+//
+// BOTH NARROWINGS WERE MEASURED FIRST, 2026-08-15, against the 215 published
+// routes:
+//
+//   stripping ApiSourceFooter `paths` arrays   removes 0 routes
+//   dropping .mdx from the evidence            removes 1 route
+//
+// So the footer case -- the one most likely to happen by accident, since
+// adding a path to a footer is the natural thing to do when you touch a page
+// -- has not happened yet, and closing it costs nothing. The prose case HAS
+// happened: `/api/v1/accounts/{ss58}/identity-history` was cleared by a single
+// row of a markdown table, which is why it is now named in PROSE_ONLY_ROUTES
+// rather than counted as covered.
+//
+// WHAT IS STILL NOT PROVED: that a referencing component is ever MOUNTED. A
+// reference behind a collapsed disclosure counts, and static analysis cannot
+// reasonably decide otherwise. A green check is not a visible panel.
 //
 // A route is referenced when its path appears in apps/ui source, with each
 // `{token}` matching ONE path segment however it is constructed -- a literal,
@@ -69,11 +93,46 @@ import { repoRoot } from "./lib.ts";
  */
 export const MAX_UNREFERENCED_ROUTES = 0;
 
+/**
+ * Routes whose only trace in `apps/ui` is DOCUMENTATION PROSE, named one at a
+ * time with the reason (#10517).
+ *
+ * The ceiling above says "add it to a named exemption with a reason instead"
+ * rather than raising the number, because an undifferentiated allowance hides
+ * exactly what it names. This is that list, and it is meant to shrink.
+ *
+ * Each entry is a published route the UI does not consume. It is NOT an
+ * assertion that it should never be consumed -- it is the gap, written down
+ * where it can be read, instead of being cleared by a table row.
+ */
+export const PROSE_ONLY_ROUTES: readonly string[] = [
+  // Its whole presence in apps/ui is one row of `content/docs/accounts.mdx`:
+  // "| `GET /api/v1/accounts/{ss58}/identity-history` | Diff timeline of
+  // identity changes. |". No query, no component, nothing fetches it. Its two
+  // siblings ARE rendered -- `/chain/identity-history` and
+  // `/subnets/{netuid}/identity-history` both have real fetches in
+  // `lib/metagraphed/queries.ts` -- which is what makes this one an omission
+  // rather than a decision.
+  "/api/v1/accounts/{ss58}/identity-history",
+];
+
 /** Feed routes: consumed by feed readers, not by our UI. */
 const FEED_PREFIX = "/api/v1/feeds/";
 
 /** Network-prefixed testnet variants mirror their mainnet twin's rendering. */
 const NETWORK_PREFIX = "/api/v1/{network}/";
+
+/**
+ * `<ApiSourceFooter paths={[...]} />` — a plain string array, removed from the
+ * evidence before matching (#10517).
+ *
+ * Adding a route to a footer is the natural thing to do when you touch a page,
+ * and it would satisfy a string match while rendering nothing. MEASURED
+ * 2026-08-15: stripping these removes ZERO routes from the referenced set, so
+ * this costs nothing today and closes the hole before it is used -- which is
+ * the cheap moment to do it.
+ */
+const FOOTER_PATHS = /paths=\{\[[\s\S]*?\]\}/g;
 
 const escapeLiteral = (segment: string): string =>
   segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -120,7 +179,7 @@ function uiSource(): string {
       if (statSync(full).isDirectory()) {
         // The generated reference tree names every route by construction.
         if (!full.includes("api-reference")) walk(full);
-      } else if (/\.(ts|tsx|mdx|json)$/.test(name)) files.push(full);
+      } else if (/\.(ts|tsx|json)$/.test(name)) files.push(full);
     }
   };
   for (const root of ["apps/ui/src", "apps/ui/content"]) {
@@ -130,7 +189,10 @@ function uiSource(): string {
       // A checkout without apps/ui is not this check's problem to report.
     }
   }
-  return files.map((file) => readFileSync(file, "utf8")).join("\n");
+  return files
+    .map((file) => readFileSync(file, "utf8"))
+    .join("\n")
+    .replace(FOOTER_PATHS, "");
 }
 
 // The check runs only when this file is EXECUTED, never when it is imported.
@@ -150,7 +212,23 @@ function main(): void {
   ) as { paths: Record<string, Record<string, unknown>> };
 
   const routes = publishedRoutes(openapi);
-  const unreferenced = unreferencedRoutes(routes, uiSource());
+  // The exemption is applied AFTER matching, never by removing the routes from
+  // the set first: an entry that has since been rendered must show up as a
+  // list to shorten rather than sit there being silently true.
+  const missing = unreferencedRoutes(routes, uiSource());
+  const unreferenced = missing.filter(
+    (route) => !PROSE_ONLY_ROUTES.includes(route),
+  );
+  const stale = PROSE_ONLY_ROUTES.filter((route) => !missing.includes(route));
+  if (stale.length > 0) {
+    console.error(
+      `PROSE_ONLY_ROUTES lists ${stale.length} route(s) that apps/ui now references. ` +
+        `Delete them from the list in scripts/validate-ui-route-coverage.ts -- an ` +
+        `exemption nobody removes is the allowlist this check exists to avoid.\n` +
+        stale.map((route) => `  - ${route}`).join("\n"),
+    );
+    process.exit(1);
+  }
 
   if (unreferenced.length > MAX_UNREFERENCED_ROUTES) {
     console.error(
@@ -198,11 +276,16 @@ function main(): void {
   // At a ceiling of 25 that slack did not matter: the check was a ratchet
   // against a backlog. At 0 it gets read as a guarantee, so the wording says
   // what was actually measured. #10517 tracks narrowing the evidence.
+  const exempt =
+    PROSE_ONLY_ROUTES.length > 0
+      ? ` ${PROSE_ONLY_ROUTES.length} route(s) are referenced ONLY by documentation prose and ` +
+        `are exempt by name: ${PROSE_ONLY_ROUTES.join(", ")}.`
+      : "";
   console.log(
     MAX_UNREFERENCED_ROUTES === 0
-      ? `UI route coverage: all ${routes.length} published route(s) are referenced by apps/ui ` +
-          `(feeds excluded, their consumer is external).`
-      : `UI route coverage: ${routes.length - unreferenced.length}/${routes.length} published route(s) referenced, ` +
-          `${unreferenced.length} not (at the ceiling; feeds excluded, their consumer is external).`,
+      ? `UI route coverage: all ${routes.length - PROSE_ONLY_ROUTES.length} published route(s) are ` +
+          `referenced by apps/ui CODE (feeds excluded, their consumer is external).${exempt}`
+      : `UI route coverage: ${routes.length - unreferenced.length}/${routes.length} published route(s) referenced by code, ` +
+          `${unreferenced.length} not (at the ceiling; feeds excluded).${exempt}`,
   );
 }

--- a/tests/validate-ui-route-coverage.test.ts
+++ b/tests/validate-ui-route-coverage.test.ts
@@ -7,13 +7,17 @@
 // matching any character. So the tests are about the matcher being WRONG in
 // the specific ways that look right.
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { describe, test } from "vitest";
 import {
   MAX_UNREFERENCED_ROUTES,
   publishedRoutes,
   routePattern,
   unreferencedRoutes,
+  PROSE_ONLY_ROUTES,
 } from "../scripts/validate-ui-route-coverage.ts";
+import { repoRoot } from "../scripts/lib.ts";
 
 describe("matching a route against UI source", () => {
   test("a {token} matches a template-literal segment, the UI's actual idiom", () => {
@@ -114,5 +118,48 @@ describe("the ratchet", () => {
     // report everything missing, not report success over an empty set.
     const routes = ["/api/v1/a", "/api/v1/b"];
     assert.deepEqual(unreferencedRoutes(routes, ""), routes);
+  });
+});
+
+describe("the named prose-only exemption (#10517)", () => {
+  test("every exempt route is a real published route, spelled the same way", () => {
+    // An entry with a typo, or one for a route that has since been withdrawn,
+    // exempts nothing and reads as though it does -- the failure mode of every
+    // allowlist. Checked against the published contract rather than a literal.
+    const openapi = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, "public/metagraph/openapi.json"),
+        "utf8",
+      ),
+    ) as { paths: Record<string, Record<string, unknown>> };
+    const published = new Set(publishedRoutes(openapi));
+    for (const route of PROSE_ONLY_ROUTES) {
+      assert.ok(
+        published.has(route),
+        `${route} is exempt but is not a published non-feed GET route -- ` +
+          "delete the entry or fix the spelling",
+      );
+    }
+  });
+
+  test("the list stays SHORT, because it is a gap register and not an allowance", () => {
+    // The ceiling's own note: an undifferentiated allowance is what let the
+    // backlog reach 35 unnoticed. A named list has the opposite property only
+    // while it is short enough to read, so this bounds it rather than trusting
+    // that nobody appends.
+    assert.ok(
+      PROSE_ONLY_ROUTES.length <= 3,
+      `${PROSE_ONLY_ROUTES.length} prose-only routes: past a handful this has ` +
+        "become the allowlist MAX_UNREFERENCED_ROUTES refuses to be. Render one.",
+    );
+  });
+
+  test("exempting a route does not exempt its siblings", () => {
+    // /accounts/{ss58}/identity-history is exempt; the two rendered siblings
+    // must not be swept along by a prefix or a loose match.
+    assert.ok(!PROSE_ONLY_ROUTES.includes("/api/v1/chain/identity-history"));
+    assert.ok(
+      !PROSE_ONLY_ROUTES.includes("/api/v1/subnets/{netuid}/identity-history"),
+    );
   });
 });


### PR DESCRIPTION
Builds on #11311, which fixed the *wording*. This narrows the *evidence*, which is the other half of #10517.

## What it was clearing on

The gate concatenated every `.ts/.tsx/.mdx/.json` under `apps/ui` and regex-tested each published route against the blob, so **any occurrence counted**. At a ceiling of 25 that slack didn't matter — it was a ratchet against a backlog. At 0 it gets read as a guarantee.

**Both narrowings #10517 proposes were measured before changing anything**, against all 215 published routes:

| narrowing | routes it removes |
| --- | --- |
| strip `ApiSourceFooter paths={[…]}` arrays | **0** |
| drop `.mdx` from the evidence | **1** |

The footer case — ranked in the issue as *"the one that will actually happen"* — **has not happened yet**. Closed anyway, because it costs nothing today and that is the cheap moment.

The prose case **has** happened:

```
/api/v1/accounts/{ss58}/identity-history
  └─ apps/ui/content/docs/accounts.mdx:19
     | `GET /api/v1/accounts/{ss58}/identity-history` | Diff timeline of identity changes. |
```

That table row is its entire presence in `apps/ui`. No query, no component, nothing fetches it. Its two siblings **are** genuinely rendered — `/chain/identity-history` and `/subnets/{netuid}/identity-history` both have real fetches in `lib/metagraphed/queries.ts` — which is what makes this an omission rather than a decision, and the gate was reporting it as covered.

## Named, not allowed for

The ceiling's own note says a route that shouldn't be rendered belongs in *"a named exemption with a reason"* rather than a raised number, because an undifferentiated allowance hides what it names. `PROSE_ONLY_ROUTES` is that register: one entry, with the evidence, printed on every run instead of folded into a total.

```
UI route coverage: all 214 published route(s) are referenced by apps/ui CODE
(feeds excluded, their consumer is external). 1 route(s) are referenced ONLY by
documentation prose and are exempt by name: /api/v1/accounts/{ss58}/identity-history.
```

**And the exemption expires.** A listed route that `apps/ui` later references fails the check with the entry named, so the list shrinks when the gap closes rather than quietly becoming the allowlist `MAX_UNREFERENCED_ROUTES` exists to avoid.

## Verification

Both new failure directions proven by breaking them:

```
remove the entry (route now unreferenced) → "UI route references regressed … - /api/v1/accounts/{ss58}/identity-history"   exit 1
add a rendered route to the list          → "PROSE_ONLY_ROUTES lists 1 route(s) that apps/ui now references … - /api/v1/chain/burn"   exit 1
restored                                                                                                                    exit 0
```

Three new tests hold the register honest: every entry must be a real published route spelled the same way (a typo exempts nothing while reading as though it does), the list is bounded at three so it cannot grow into the allowance it replaces, and exempting one route must not sweep in its siblings.

- Full CI validator set (69 gates) green; `typecheck` / `lint` / `format:check` clean.
- **Full local suite: 925 files, 21,209 tests, 0 failures.**

## Still not proved, and now said in the header

That a referencing component is ever **mounted**. A reference behind a collapsed disclosure counts, and static analysis cannot reasonably decide otherwise — #10517's own second blind spot. A green check is not a visible panel.

The remaining work #10517 implies is rendering `/api/v1/accounts/{ss58}/identity-history`, which is now a named line item rather than an invisible one.