### PR TITLE
fix(ci): prose is not a consumer, in a doc or in a comment

### DIFF
--- a/scripts/validate-ui-route-coverage.ts
+++ b/scripts/validate-ui-route-coverage.ts
@@ -75,6 +75,27 @@ const FEED_PREFIX = "/api/v1/feeds/";
 /** Network-prefixed testnet variants mirror their mainnet twin's rendering. */
 const NETWORK_PREFIX = "/api/v1/{network}/";
 
+/**
+ * Routes whose consumer is an API CALLER rather than our own UI.
+ *
+ * The same exemption the feeds already have, named per route because this one
+ * cannot be recognised by prefix. `/api/v1/networks` is a capability matrix --
+ * which chains are addressable and which route families each one actually
+ * serves -- and the thing that needs it is a client deciding what to call, not
+ * a person reading a page. Rendering it in the UI to satisfy a checker would be
+ * building a surface for the checker.
+ *
+ * EXPLICIT AND JUSTIFIED, one line each, because this is the mechanism most
+ * likely to rot into "the list of routes we could not be bothered to render".
+ * A route belongs here when its consumer is external BY DESIGN -- not when it
+ * is merely unrendered today, which is what the ceiling is for.
+ */
+const EXTERNAL_CONSUMER_ROUTES: readonly string[] = [
+  // Answers "what can this deployment serve", for a caller choosing a network
+  // prefix. Its rendered form is the docs page that documents it.
+  "/api/v1/networks",
+];
+
 const escapeLiteral = (segment: string): string =>
   segment.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -99,7 +120,9 @@ export function publishedRoutes(openapi: {
     .map(([route]) => route)
     .filter(
       (route) =>
-        !route.startsWith(NETWORK_PREFIX) && !route.startsWith(FEED_PREFIX),
+        !route.startsWith(NETWORK_PREFIX) &&
+        !route.startsWith(FEED_PREFIX) &&
+        !EXTERNAL_CONSUMER_ROUTES.includes(route),
     )
     .sort();
 }
@@ -110,6 +133,76 @@ export function unreferencedRoutes(
   source: string,
 ): string[] {
   return routes.filter((route) => !routePattern(route).test(source));
+}
+
+/**
+ * One file's CODE, with comments removed.
+ *
+ * PROSE IS NOT A CONSUMER, and dropping `.mdx` alone does not achieve that: a
+ * route path written in a `//` comment counts identically. Found by writing
+ * one -- the component added for `/api/v1/accounts/{ss58}/identity-history`
+ * explains itself by naming the route, and that sentence alone held the gate up
+ * when the query beneath it was mutated away.
+ *
+ * STRING-AWARE ACROSS ALL THREE QUOTE FORMS, which is the whole difficulty. A
+ * naive stripper eats `"https://…"` at the `//`, and this codebase builds route
+ * paths in TEMPLATE literals -- `` `/api/v1/accounts/${ss58}/identity-history` ``
+ * -- so backticks matter as much as quotes. Getting that wrong deletes the very
+ * references the check exists to find, and it fails SILENTLY: the count climbs
+ * and every entry looks like a real gap.
+ */
+export function stripCodeComments(source: string): string {
+  let out = "";
+  let quote: string | null = null;
+  let inLine = false;
+  let inBlock = false;
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i]!;
+    const next = source[i + 1];
+    if (inLine) {
+      if (ch === "\n") {
+        inLine = false;
+        out += ch;
+      }
+      continue;
+    }
+    if (inBlock) {
+      if (ch === "*" && next === "/") {
+        inBlock = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      out += ch;
+      // A backslash escapes whatever follows, so a path ending `\"` does not
+      // close the string.
+      if (ch === "\\") {
+        out += next ?? "";
+        i += 1;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      inLine = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlock = true;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
 }
 
 function uiSource(): string {
@@ -130,7 +223,9 @@ function uiSource(): string {
       // A checkout without apps/ui is not this check's problem to report.
     }
   }
-  return files.map((file) => readFileSync(file, "utf8")).join("\n");
+  return files
+    .map((file) => stripCodeComments(readFileSync(file, "utf8")))
+    .join("\n");
 }
 
 // The check runs only when this file is EXECUTED, never when it is imported.

--- a/tests/validate-ui-route-coverage.test.ts
+++ b/tests/validate-ui-route-coverage.test.ts
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   MAX_UNREFERENCED_ROUTES,
+  stripCodeComments,
   publishedRoutes,
   routePattern,
   unreferencedRoutes,
@@ -114,5 +115,52 @@ describe("the ratchet", () => {
     // report everything missing, not report success over an empty set.
     const routes = ["/api/v1/a", "/api/v1/b"];
     assert.deepEqual(unreferencedRoutes(routes, ""), routes);
+  });
+});
+
+// Prose is not a consumer (#10517).
+//
+// The check matches route paths against a concatenation of apps/ui, so for a
+// long time a docs table counted as a render -- and so did a code comment. Both
+// are gone; what remains unseen is whether the reference is MOUNTED, which the
+// failure messages no longer claim.
+describe("stripCodeComments", () => {
+  test("a route named only in a comment is not a reference", () => {
+    const src = `// TODO: someday render /api/v1/chain/burn\nconst x = 1;`;
+    assert.doesNotMatch(stripCodeComments(src), /chain\/burn/);
+  });
+
+  test("a route in a BLOCK comment is not a reference either", () => {
+    const src = `/**\n * Fetches /api/v1/chain/burn eventually.\n */\nconst x = 1;`;
+    assert.doesNotMatch(stripCodeComments(src), /chain\/burn/);
+  });
+
+  test("A ROUTE IN A TEMPLATE LITERAL SURVIVES -- this is how they are built", () => {
+    // The failure that would be silent and total: this codebase composes paths
+    // as `` `/api/v1/accounts/${ss58}/events` ``, so a stripper that does not
+    // know backticks deletes the references the check exists to find, and every
+    // one reads as a real gap.
+    const src = "const p = `/api/v1/accounts/${ss58}/identity-history`;";
+    assert.match(stripCodeComments(src), /identity-history/);
+  });
+
+  test("`https://` inside a string is not a comment", () => {
+    // The classic naive-stripper bug, in all three quote forms.
+    for (const q of ['"', "'", "`"]) {
+      const src = `const u = ${q}https://api.metagraph.sh/api/v1/networks${q};`;
+      assert.match(stripCodeComments(src), /api\.metagraph\.sh/, q);
+    }
+  });
+
+  test("an escaped quote does not end the string early", () => {
+    const src = 'const s = "a \\" /api/v1/chain/burn";';
+    assert.match(stripCodeComments(src), /chain\/burn/);
+  });
+
+  test("code after a comment survives", () => {
+    // Non-vacuity for the tests above: the stripper has to stop at the newline
+    // rather than eating the rest of the file.
+    const src = `// note\nconst p = "/api/v1/chain/burn";`;
+    assert.match(stripCodeComments(src), /chain\/burn/);
   });
 });


### PR DESCRIPTION
Finishes #10517's narrowing. The check matched route paths against a
concatenation of every file under `apps/ui`, so any occurrence counted --
and two kinds of occurrence were not references at all.

`.mdx` went in the change that rendered
`/api/v1/accounts/{ss58}/identity-history`; that route was green at a ceiling of
zero on a row in `docs/accounts.mdx` alone.

COMMENTS GO HERE, and I found them the way the issue predicted somebody would:
by writing one. The component added for that route explains itself by naming the
route, and that sentence alone held the gate up when the query beneath it was
mutated away. `stripCodeComments` removes `//` and `/* */` before matching.

STRING-AWARE ACROSS ALL THREE QUOTE FORMS, which is the whole difficulty and the
one way this change could be worse than no change. This codebase composes paths
as `` `/api/v1/accounts/${ss58}/events` ``, so a stripper that does not know
backticks deletes the references the check exists to find -- silently, with the
count climbing and every entry looking like a real gap. Removing backtick
handling fails a named test.

The narrowing surfaced exactly one route, `/api/v1/networks`, and the right
answer was not to render it. It is a capability matrix -- which chains are
addressable and which route families each serves -- and the thing that needs it
is a client deciding what to call. Rendering it in the UI to satisfy a checker
would be building a surface for the checker, so it joins the feeds under
`EXTERNAL_CONSUMER_ROUTES`: named per route, one justification each, and
explicitly not "routes we could not be bothered to render" -- that is what the
ceiling is for.

WHAT REMAINS UNSEEN is whether a reference is MOUNTED. An unmounted component
whose query names the route still passes, and static analysis cannot reasonably
decide "is this on a path a user reaches" -- #10517 says so and I agree. The
messages say "appear nowhere in apps/ui" rather than "rendered", so the claim
and the evidence now match.

Closes #10517