### PR TITLE
feat(seo): assert the freshness we actually measure (#11314)

### DIFF
--- a/apps/ui/src/lib/metagraphed/freshness.record.test.ts
+++ b/apps/ui/src/lib/metagraphed/freshness.record.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { isoTimestamp, recordModifiedAt } from "./freshness";
+
+describe("isoTimestamp", () => {
+  it("normalises a real API timestamp to W3C Datetime", () => {
+    expect(isoTimestamp("2026-08-14T12:14:17.177Z")).toBe("2026-08-14T12:14:17.177Z");
+    expect(isoTimestamp("2026-08-14T12:15:22Z")).toBe("2026-08-14T12:15:22.000Z");
+  });
+
+  it("emits NOTHING rather than a fabricated date", () => {
+    // The property that matters, and the reason this rule is shared rather
+    // than copied: Google discounts `lastmod` site-wide once it catches a site
+    // stamping "now" on URLs that did not change, so one synthesised value
+    // costs every honest one. Absent beats wrong.
+    for (const bad of [undefined, null, "", "not-a-date", 1785000000000, {}, [], NaN, true]) {
+      expect(isoTimestamp(bad), String(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe("recordModifiedAt", () => {
+  it("takes the publish timestamp, not the probe observation", () => {
+    // The distinction is the whole point. `operational_observed_at` is when we
+    // last LOOKED — it advances every 15 minutes whether or not the record
+    // changed, so publishing it as dateModified would be indistinguishable
+    // from stamping "now" on every request.
+    expect(
+      recordModifiedAt({
+        published_at: "2026-08-14T12:14:17.177Z",
+        generated_at: "2026-08-14T12:14:17.177Z",
+        operational_observed_at: "2026-08-15T12:01:00.777Z",
+      }),
+    ).toBe("2026-08-14T12:14:17.177Z");
+  });
+
+  it("falls back to generated_at, which some artifacts carry alone", () => {
+    expect(recordModifiedAt({ generated_at: "2026-08-14T12:14:17.177Z" })).toBe(
+      "2026-08-14T12:14:17.177Z",
+    );
+  });
+
+  it("never reaches for the observation when neither publish field is usable", () => {
+    // Explicitly NOT "fall back to whatever timestamp is present". A record we
+    // cannot date honestly is one we publish undated.
+    expect(
+      recordModifiedAt({
+        published_at: "not-a-date",
+        operational_observed_at: "2026-08-15T12:01:00.777Z",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns nothing for a meta that is not an object", () => {
+    for (const bad of [undefined, null, "2026-08-14T12:14:17.177Z", 42]) {
+      expect(recordModifiedAt(bad), String(bad)).toBeUndefined();
+    }
+  });
+});

--- a/apps/ui/src/lib/metagraphed/freshness.ts
+++ b/apps/ui/src/lib/metagraphed/freshness.ts
@@ -44,3 +44,48 @@ export function relative(diffMs: number): string {
     hourCapHours: 48,
   });
 }
+
+/**
+ * A W3C-Datetime string if the value is a usable timestamp, otherwise nothing.
+ *
+ * #11314. This project probes every registered surface on a 15-minute cycle and
+ * asserted that freshness in exactly ONE route family — `/docs`, via the
+ * `dateModified` added in #11259. Subnet, provider and validator pages emitted
+ * none. Against competitor content dated months ago, live data is the whole
+ * advantage and we were telling crawlers nothing about it.
+ *
+ * The rule lives beside the other freshness formatting rather than in
+ * `server.ts`, because the two consumers sit on opposite sides of the app:
+ * `buildSitemap` runs in the Worker entry, and the JSON-LD builders are imported
+ * by route `head()`. A page whose `dateModified` and whose sitemap `lastmod`
+ * disagree makes two different claims about one fact, and a second copy is how
+ * `metaDescription`, the breadcrumb list and the OG card each drifted.
+ *
+ * **Absent beats wrong, and that is not a style preference.** Google discounts
+ * `lastmod` site-wide once it catches a site stamping "now" on URLs that did not
+ * change, so one fabricated value costs every honest one.
+ */
+export function isoTimestamp(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
+}
+
+/**
+ * The timestamp a registry record publishes as its last modification.
+ *
+ * **`published_at`, not `operational_observed_at`** — and the distinction is the
+ * point. `operational_observed_at` is when we last *looked*: it advances every
+ * 15 minutes whether or not anything about the record changed, so publishing it
+ * as `dateModified` would be indistinguishable from stamping "now" on every
+ * request. `published_at` is when the record was last rebuilt, which is what
+ * the field actually claims.
+ *
+ * `generated_at` is the fallback because some artifacts carry only that; where
+ * both are present they are the same instant.
+ */
+export function recordModifiedAt(meta: unknown): string | undefined {
+  if (typeof meta !== "object" || meta === null) return undefined;
+  const bag = meta as Record<string, unknown>;
+  return isoTimestamp(bag.published_at) ?? isoTimestamp(bag.generated_at);
+}

--- a/apps/ui/src/lib/metagraphed/json-ld.ts
+++ b/apps/ui/src/lib/metagraphed/json-ld.ts
@@ -1,3 +1,4 @@
+import { isoTimestamp } from "./freshness";
 import { API_ORIGIN, GITHUB_REPO_URL, SITE_ORIGIN, X_PROFILE_URL } from "./identity";
 
 /**
@@ -308,6 +309,8 @@ export function techArticleJsonLd(input: TechArticleInput) {
 }
 
 export interface SubnetDatasetInput {
+  /** When this record was last rebuilt. Omitted from the node when absent. */
+  dateModified?: string | null;
   netuid: number;
   /** Registry / on-chain name, when we have one. */
   name?: string | null;
@@ -350,6 +353,8 @@ export function subnetDatasetJsonLd(input: SubnetDatasetInput) {
 }
 
 export interface ProviderDatasetInput {
+  /** When this record was last rebuilt. Omitted from the node when absent. */
+  dateModified?: string | null;
   /** Registry slug — the provider's stable key and its URL segment. */
   slug: string;
   name?: string | null;
@@ -391,6 +396,14 @@ interface RegistryDatasetInput {
   apiUrl: string;
   artifactUrl: string;
   sameAs?: string | null;
+  /**
+   * When the record was last rebuilt (#11314).
+   *
+   * Emitted only when we actually have it -- see `recordModifiedAt`, which
+   * takes the PUBLISH timestamp rather than the probe observation for the same
+   * reason `sitemapLastmod` refuses to synthesise one.
+   */
+  dateModified?: string | null;
 }
 
 /**
@@ -407,6 +420,7 @@ function registryDatasetJsonLd(input: RegistryDatasetInput) {
   return {
     "@type": "Dataset",
     name: input.name,
+    ...(isoTimestamp(input.dateModified) ? { dateModified: isoTimestamp(input.dateModified) } : {}),
     description: input.description,
     url: input.url,
     identifier: input.identifier,

--- a/apps/ui/src/routes/providers.$slug.tsx
+++ b/apps/ui/src/routes/providers.$slug.tsx
@@ -18,6 +18,7 @@ import {
   isMissingEntityError,
   isNotFoundMatch,
 } from "@/lib/metagraphed/entity-not-found-meta";
+import { recordModifiedAt } from "@/lib/metagraphed/freshness";
 
 type SearchParams = { tab?: string };
 
@@ -34,8 +35,11 @@ export const Route = createFileRoute("/providers/$slug")({
   // to the slug on any failure.
   loader: async ({ context, params }) => {
     try {
-      const { data } = await context.queryClient.ensureQueryData(providerQuery(params.slug));
+      const { data, meta } = await context.queryClient.ensureQueryData(providerQuery(params.slug));
       return {
+        // #11314: the record's publish timestamp -- see recordModifiedAt for why
+        // it is not the probe observation.
+        dateModified: recordModifiedAt(meta) ?? null,
         name: data.name ?? null,
         // #11204: the card's own fields. The registry curates a logo for 102 of
         // the 138 providers, and the counts are what the page's pulse tiles
@@ -111,6 +115,7 @@ export const Route = createFileRoute("/providers/$slug")({
               apiUrl: `${API_BASE}/api/v1/providers/${encodeURIComponent(params.slug)}`,
               artifactUrl: `${API_BASE}/metagraph/providers/${encodeURIComponent(params.slug)}.json`,
               sameAs: loaderData?.website ?? null,
+              dateModified: loaderData?.dateModified ?? null,
             }),
           ),
         },

--- a/apps/ui/src/routes/subnets.$netuid.tsx
+++ b/apps/ui/src/routes/subnets.$netuid.tsx
@@ -9,6 +9,7 @@ import {
   isMissingEntityError,
   isNotFoundMatch,
 } from "@/lib/metagraphed/entity-not-found-meta";
+import { recordModifiedAt } from "@/lib/metagraphed/freshness";
 import { SubnetDetailPage } from "./-subnets-netuid-page";
 import { subnetFeedLinks } from "@/lib/metagraphed/feed-links";
 import { stringifyJsonLd, subnetDatasetJsonLd } from "@/lib/metagraphed/json-ld";
@@ -56,7 +57,7 @@ export const Route = createFileRoute("/subnets/$netuid")({
       // price stat silently never rendered and every subnet card fell through
       // to its health string. The economics list is where the site itself gets
       // price, and it carries emission share and total stake alongside.
-      const [{ data }, econRes] = await Promise.all([
+      const [{ data, meta }, econRes] = await Promise.all([
         context.queryClient.ensureQueryData(subnetProfileQuery(params.netuid)),
         context.queryClient.ensureQueryData(economicsQuery()).catch(() => null),
       ]);
@@ -64,6 +65,9 @@ export const Route = createFileRoute("/subnets/$netuid")({
       const num = (value: unknown): number | null =>
         typeof value === "number" && Number.isFinite(value) ? value : null;
       return {
+        // #11314: the record's own publish timestamp, for dateModified and
+        // <lastmod>. NOT operational_observed_at -- see recordModifiedAt.
+        dateModified: recordModifiedAt(meta) ?? null,
         name: data.name ?? null,
         health: data.health ?? null,
         // #11204: the subnet's own words, for the Dataset description and the
@@ -201,6 +205,7 @@ export const Route = createFileRoute("/subnets/$netuid")({
               apiUrl: `${API_BASE}/api/v1/subnets/${params.netuid}`,
               artifactUrl: `${API_BASE}/metagraph/subnets/${params.netuid}.json`,
               sameAs: loaderData?.website ?? null,
+              dateModified: loaderData?.dateModified ?? null,
             }),
           ),
         },

--- a/apps/ui/src/server.seo.test.ts
+++ b/apps/ui/src/server.seo.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildOgImageUrl, routeOwnsOgImage } from "./lib/metagraphed/og-card";
+import { subnetDatasetJsonLd } from "./lib/metagraphed/json-ld";
 import {
   buildJsonLd,
   handleArtifactHostRedirect,
@@ -228,5 +229,60 @@ describe("site-wide crawler + attribution defaults (#8626)", () => {
     // block sitting alongside entityNotFoundMeta's `noindex` is safe. It would
     // NOT be safe the other way round.
     expect(SEO_DEFAULT_TAGS).not.toContain("noindex");
+  });
+});
+
+describe("registry records assert their own freshness (#11314)", () => {
+  const graphOf = (node: unknown) => node as Record<string, unknown>;
+
+  it("emits dateModified when the record carries a publish timestamp", () => {
+    // We probe every surface every 15 minutes and, before this, asserted that
+    // freshness in exactly one route family (/docs, #11259). Against competitor
+    // content dated months ago, live data is the whole advantage.
+    const node = graphOf(
+      subnetDatasetJsonLd({
+        netuid: 64,
+        name: "Chutes",
+        url: "https://metagraph.sh/subnets/64",
+        apiUrl: "https://api.metagraph.sh/api/v1/subnets/64",
+        artifactUrl: "https://api.metagraph.sh/metagraph/subnets/64.json",
+        dateModified: "2026-08-14T12:14:17.177Z",
+      }),
+    );
+    expect(node.dateModified).toBe("2026-08-14T12:14:17.177Z");
+  });
+
+  it("omits dateModified entirely rather than inventing one", () => {
+    // Absent beats wrong: an undated record is honest, a record dated "now" on
+    // every request is the abuse that gets lastmod discounted site-wide.
+    for (const bad of [undefined, null, "", "not-a-date"]) {
+      const node = graphOf(
+        subnetDatasetJsonLd({
+          netuid: 64,
+          url: "https://metagraph.sh/subnets/64",
+          apiUrl: "https://api.metagraph.sh/api/v1/subnets/64",
+          artifactUrl: "https://api.metagraph.sh/metagraph/subnets/64.json",
+          dateModified: bad as string | null | undefined,
+        }),
+      );
+      expect(node, String(bad)).not.toHaveProperty("dateModified");
+    }
+  });
+
+  it("applies the same rule the sitemap does", () => {
+    // One rule, two consumers. A page whose dateModified and whose sitemap
+    // lastmod disagree makes two different claims about one fact — which is
+    // how metaDescription, the breadcrumb list and the OG card each drifted.
+    const value = "2026-08-14T12:15:22Z";
+    const node = graphOf(
+      subnetDatasetJsonLd({
+        netuid: 1,
+        url: "https://metagraph.sh/subnets/1",
+        apiUrl: "https://api.metagraph.sh/api/v1/subnets/1",
+        artifactUrl: "https://api.metagraph.sh/metagraph/subnets/1.json",
+        dateModified: value,
+      }),
+    );
+    expect(node.dateModified).toBe(sitemapLastmod(value));
   });
 });

--- a/apps/ui/src/server.ts
+++ b/apps/ui/src/server.ts
@@ -10,6 +10,7 @@ import {
   siteGraphNodes,
   stringifyJsonLd,
 } from "./lib/metagraphed/json-ld";
+import { isoTimestamp } from "./lib/metagraphed/freshness";
 import { API_ORIGIN, SITE_ORIGIN, X_HANDLE } from "./lib/metagraphed/identity";
 import { handleAnalyticsProxy, type PostHogAssetContext } from "./lib/analytics-proxy";
 
@@ -307,12 +308,16 @@ interface SitemapEntry {
   lastmod?: string;
 }
 
-/** ISO-8601 date (W3C Datetime) if the value is a usable timestamp, else undefined. */
-export function sitemapLastmod(value: unknown): string | undefined {
-  if (typeof value !== "string" || !value) return undefined;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
-}
+/**
+ * ISO-8601 date (W3C Datetime) if the value is a usable timestamp, else undefined.
+ *
+ * #11314: the rule itself moved to lib/metagraphed/freshness.ts so the JSON-LD
+ * builders can apply the identical one -- a page whose `dateModified` and whose
+ * sitemap `lastmod` disagree is a page making two different claims about the
+ * same fact. Re-exported under the original name because this is the export the
+ * sitemap tests and every existing call site already use.
+ */
+export const sitemapLastmod = isoTimestamp;
 
 async function buildSitemap(): Promise<Response> {
   const entries: SitemapEntry[] = SITEMAP_STATIC_PATHS.map((path) => ({


### PR DESCRIPTION
## Summary

We probe every registered surface on a **15-minute cycle** and asserted that freshness in exactly **one** route family — `/docs`, via the `dateModified` added in #11259.

Measured against production 2026-08-15:

| page | `dateModified` |
|---|---|
| `/` | none |
| `/subnets` | none |
| `/subnets/{n}` | none |
| `/validators` | none |
| `/apis` | none |
| `/docs/*` | ✅ (#11259) |

Against competitor content dated months ago, live data is our entire advantage over them, and we were telling crawlers nothing about it.

## One rule, two consumers

`sitemapLastmod` moved into `lib/metagraphed/freshness.ts` as `isoTimestamp`, re-exported under its original name so every existing call site and test is untouched.

That move is the substance, not tidying: `buildSitemap` runs in the **Worker entry** and the JSON-LD builders are imported by route **`head()`**. A copy on each side is exactly how `metaDescription`, the breadcrumb list and the OG card each drifted. A page whose `dateModified` and whose sitemap `lastmod` disagree is a page making two different claims about one fact.

## `published_at`, not `operational_observed_at`

The subnet profile carries both:

```
published_at              2026-08-14T12:14:17.177Z   ← when the record was rebuilt
operational_observed_at   2026-08-15T12:01:00.777Z   ← when we last looked
```

The observation advances **every 15 minutes whether or not the record changed**. Publishing it as `dateModified` would be indistinguishable from stamping "now" on every request — the precise abuse that gets `lastmod` discounted site-wide, which would then cost us the honest values too. `recordModifiedAt` refuses to fall back to it: a record we cannot date honestly is published undated.

## One requirement I relaxed, with the measurement

My own acceptance criterion said the sitemap's `<lastmod>` and the node's `dateModified` should be *the same value*. Measured, they are the same publish cycle **65 seconds apart** — `published_at` 12:14:17.177Z (artifact meta) vs the row's `updated_at` 12:15:22Z.

Forcing byte-identity would mean giving all 129 subnet URLs one shared stamp from the list endpoint's meta, which is **less** useful — per-URL `lastmod` is the entire point of the field. So the sitemap keeps the per-row value. Both flow through the one rule, so neither can be synthesised, which is the property that actually mattered.

## Validation

```
apps/ui  tsc --noEmit               clean
apps/ui  eslint + prettier          clean
apps/ui  vitest run                 265 files, 2288 tests (9 new)
```

Tests pin the behaviour that matters rather than the mechanism: `dateModified` is **omitted entirely** for `undefined`, `null`, `""` and `"not-a-date"`; `recordModifiedAt` prefers `published_at`, falls back to `generated_at`, and returns nothing when neither is usable **even though a valid `operational_observed_at` is sitting right there**.

## One thing worth flagging

I overwrote `apps/ui/src/lib/metagraphed/freshness.ts` before checking whether it existed — it already held `formatFreshness`, `formatFreshnessAbsolute` and `relative`, used by five components. Caught immediately by `tsc`, restored from git with no loss, and the new helpers are appended rather than replacing anything. Nothing from the original module changed.

Closes #11314
