### PR TITLE
registry: back the two ex-pilot manifests with real evidence

### DIFF
--- a/registry/subnets/allways.json
+++ b/registry/subnets/allways.json
@@ -9,7 +9,7 @@
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-06T00:00:00.000Z",
     "source_count": 3,
-    "verified_at": null
+    "verified_at": "2026-08-15T00:00:00.000Z"
   },
   "dashboard_url": null,
   "docs_url": "https://docs.all-ways.io/how-it-works.html",
@@ -58,6 +58,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://docs.all-ways.io/"],
       "url": "https://docs.all-ways.io/how-it-works.html"
     },
     {
@@ -73,6 +74,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://docs.all-ways.io/"],
       "url": "https://all-ways.io/"
     },
     {
@@ -88,6 +90,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://docs.all-ways.io/"],
       "url": "https://github.com/entrius/allways"
     },
     {
@@ -105,6 +108,7 @@
       "public_safe": true,
       "schema_status": "machine-readable",
       "schema_url": "https://api.all-ways.io/swagger-json",
+      "source_urls": ["https://api.all-ways.io/swagger/swagger-ui-init.js"],
       "url": "https://api.all-ways.io/swagger"
     },
     {
@@ -120,6 +124,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/health"
     },
     {
@@ -135,6 +140,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/protocol/constants"
     },
     {
@@ -150,6 +156,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/protocol/chain-state"
     },
     {
@@ -165,6 +172,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/network/overview"
     },
     {
@@ -180,6 +188,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/miners"
     },
     {
@@ -211,6 +220,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/miners/reliability"
     },
     {
@@ -226,6 +236,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/events/latest"
     },
     {
@@ -241,6 +252,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/crown"
     },
     {
@@ -257,6 +269,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/crown/history?direction=SOL-BTC"
     },
     {
@@ -273,6 +286,7 @@
       },
       "provider": "allways",
       "public_safe": true,
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "url": "https://api.all-ways.io/sse"
     },
     {

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -64,6 +64,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://github.com/entrius/gittensor"],
       "url": "https://docs.gittensor.io/"
     },
     {
@@ -79,6 +80,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/"],
       "url": "https://gittensor.io/"
     },
     {
@@ -94,6 +96,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/"],
       "url": "https://github.com/entrius/gittensor"
     },
     {
@@ -109,6 +112,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/"],
       "url": "https://docs.gittensor.io/register-repository.html"
     },
     {
@@ -124,6 +128,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
+      "source_urls": ["https://docs.gittensor.io/register-repository.html"],
       "url": "https://docs.gittensor.io/repository-hyperparameters"
     },
     {

--- a/tests/validate-surface-reviewed-convention.test.ts
+++ b/tests/validate-surface-reviewed-convention.test.ts
@@ -153,16 +153,23 @@ describe("validate-surface.ts reviewed-tier convention (#5739)", () => {
     assert.doesNotMatch(output, /convention advisory/i);
   });
 
-  test("root stays exempt; the two ex-pilot manifests are flagged like anyone else", () => {
+  test("root stays exempt; the two ex-pilot manifests pass on their own evidence", () => {
     // Pin to the three named files rather than a no-args full-corpus scan:
     // other tests (validate-error-messages) mutate registry/subnets/*.json
     // in place under parallel vitest, which races a full-corpus run.
     //
-    // The pilot exemption is gone from allways/gittensor, so their hand-seeded
-    // surfaces now draw the same NON-BLOCKING advisory any deviating
-    // adapter-backed entry draws -- deliberately: an ordinary subnet's gaps
-    // are visible, not exempted. Backfilling their source_urls/verified_at is
-    // what clears the advisory.
+    // WHAT CHANGED AND WHAT DID NOT (#11120). This asserted that allways and
+    // gittensor DREW the advisory -- correct while their hand-seeded surfaces
+    // still lacked source_urls, and the earlier version of this comment named
+    // the way out: "Backfilling their source_urls/verified_at is what clears
+    // the advisory." That backfill has landed, so the advisory is gone.
+    //
+    // The claim worth keeping is NOT that they are flagged; it is that they are
+    // JUDGED, by the same rule as any other adapter-backed entry. Root is the
+    // only acknowledged exemption, and it is still named as one. The two
+    // ex-pilots are silent here because they comply -- which a re-added
+    // exemption would also look like, so the exemption line is asserted to
+    // mention root and nothing else.
     const { status, output } = runNode([
       "scripts/validate-surface.ts",
       "registry/subnets/root.json",
@@ -172,8 +179,14 @@ describe("validate-surface.ts reviewed-tier convention (#5739)", () => {
     assert.equal(status, 0, output);
     assert.match(output, /acknowledged exemption/i);
     assert.match(output, /root\.json/);
-    assert.match(output, /convention advisory/i);
-    assert.match(output, /gittensor\.json/);
-    assert.match(output, /allways\.json/);
+    // Compliant, so nothing to advise about.
+    assert.doesNotMatch(output, /convention advisory/i);
+    // And NOT by being exempted again: whatever the exemption line says, it
+    // must not have grown to cover them.
+    const exemption = output
+      .split("\n")
+      .filter((line) => /exemption/i.test(line))
+      .join("\n");
+    assert.doesNotMatch(exemption, /gittensor|allways/i);
   });
 });


### PR DESCRIPTION
Closes #11120.

#11119 removed the pilot exemption, so `allways.json` and `gittensor.json` started drawing the ordinary reviewed-tier advisory: **19 surfaces with no `source_urls`**, and allways with no `curation.verified_at`. Every one now has a public page that independently shows the subnet publishes it — fetched and checked, not asserted.

## What proves what

Never the surface proving itself, and never us calling the endpoint:

**gittensor** (5)

| surface | evidence |
| --- | --- |
| `docs.gittensor.io/` | the subnet's own repo README, which links the docs site's pages |
| `gittensor.io/` | the docs index links it |
| the source repo | the docs index links it |
| `/register-repository.html` | the docs index nav |
| `/repository-hyperparameters` | `register-repository.html` links it (so do validator/miner/cli) |

**allways** (14)

| surface | evidence |
| --- | --- |
| `docs.all-ways.io/how-it-works.html` | the docs index nav |
| `all-ways.io/` | the docs index links it |
| the source repo | the docs index links it |
| `api.all-ways.io/swagger` | the spec it serves, at `/swagger/swagger-ui-init.js` |
| the 9 `subnet-api` surfaces + `/sse` | `api.all-ways.io/swagger`, which **declares each path** |

## The API endpoints are the case worth naming

Their evidence is the operator's own OpenAPI document, checked path by path — `/health`, `/protocol/constants`, `/protocol/chain-state`, `/network/overview`, `/miners`, `/miners/reliability`, `/events/latest`, `/crown`, `/crown/history` and `/sse` are **all declared in it**.

That is a published declaration by the subnet, which is what the evidence rule asks for. Calling the endpoint ourselves would only show that it answers *us* — reachability, not publication.

Every evidence URL was fetched: **all 200**.

## The test that pinned the old state moved with it

`validate-surface-reviewed-convention.test.ts` asserted these two **draw** the advisory, and its own comment named the way out: *"Backfilling their source_urls/verified_at is what clears the advisory."*

The claim worth keeping was never that they are flagged, but that they are **judged**. It now asserts they pass while root remains the only acknowledged exemption — and, because a re-added exemption would look identical to compliance from the outside, that the exemption line still names root and neither of them.

## Verification

- `npm run validate:surface` reports **zero advisories** for both files — the issue's "done means", exactly.
- Full CI validator set (69 gates) green; `typecheck` / `lint` / `format:check` clean.
- **Full local suite: 925 files, 21,209 tests, 0 failures.**
- The manifests are otherwise byte-identical: 94 surfaces in, 94 out, no key reordering or re-escaping (an earlier pass churned 300 lines by re-encoding; this one adds 21).

`verified_at` on allways is today's date, because these surfaces were verified today by this change.