### PR TITLE
perf(seo): stop dehydrating rows the hubs never render (#11315)

### DIFF
--- a/apps/ui/src/components/metagraphed/home-watched-module.tsx
+++ b/apps/ui/src/components/metagraphed/home-watched-module.tsx
@@ -283,8 +283,8 @@ function WatchedValidators({ hotkeys }: { hotkeys: string[] }) {
   // Same sort + limit as the /validators index, so this shares that query's
   // cache key instead of firing a second 2000-row fetch.
   const validators =
-    useQuery(validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT })).data?.data
-      ?.validators ?? [];
+    useQuery(validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false }))
+      .data?.data?.validators ?? [];
   const watched = new Set(hotkeys);
 
   const { flashed, flash } = useRowFlash();

--- a/apps/ui/src/lib/metagraphed/queries.ts
+++ b/apps/ui/src/lib/metagraphed/queries.ts
@@ -8140,20 +8140,43 @@ export const subnetValidatorsQuery = (netuid: number) =>
     staleTime: STALE_SHORT,
   });
 
-/** Network-wide validator/operator leaderboard grouped by hotkey. */
+/**
+ * Network-wide validator/operator leaderboard grouped by hotkey.
+ *
+ * `subnets` — the per-subnet breakdown array — is **66% of every row** (1,090
+ * of 1,641 bytes, measured 2026-08-15) and most callers never read it. Passing
+ * `subnets: false` drops it during normalization, which keeps it out of the
+ * react-query cache and therefore out of the SSR dehydration inlined into the
+ * document (#11315).
+ *
+ * That is the whole cost being paid: `/validators` rendered **50** rows while
+ * dehydrating **1,447**, and the resulting 983 KB of inline JSON is decompressed,
+ * parsed and deserialised on the main thread of whatever phone loaded the page.
+ * The API has no field projection (`?fields=` answers 400), and the fetch itself
+ * happens during SSR, so it never crosses the user's wire — dropping the array
+ * client-side removes the part the user actually pays for.
+ *
+ * It is part of the query KEY on purpose: two callers asking for different
+ * shapes must not share a cache entry, or whichever ran second would read rows
+ * that are missing a field it needs.
+ */
 export const validatorsQuery = ({
   sort = "subnet_count",
   limit = 20,
-}: { sort?: GlobalValidatorSort; limit?: number } = {}) =>
+  subnets = true,
+}: { sort?: GlobalValidatorSort; limit?: number; subnets?: boolean } = {}) =>
   queryOptions({
-    queryKey: k("global-validators", sort, limit),
+    queryKey: k("global-validators", sort, limit, subnets),
     queryFn: async ({ signal }) => {
       const res = await apiFetch<Partial<GlobalValidators>>("/api/v1/validators", {
         params: { sort, limit },
         signal,
       });
+      const data = normalizeGlobalValidators(res.data);
       return {
-        data: normalizeGlobalValidators(res.data),
+        data: subnets
+          ? data
+          : { ...data, validators: data.validators.map((v) => ({ ...v, subnets: [] })) },
         meta: res.meta,
         url: res.url,
       } as ApiResult<GlobalValidators>;

--- a/apps/ui/src/routes/-validators-index-page.tsx
+++ b/apps/ui/src/routes/-validators-index-page.tsx
@@ -93,7 +93,8 @@ export function ValidatorsPage() {
         context="validators"
         fallback={<TableSkeleton rows={10} columns={8} />}
         retryQueryKeys={[
-          validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }).queryKey,
+          validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false })
+            .queryKey,
         ]}
       >
         <ValidatorsDirectory density={density} onDensityChange={onDensityChange} />
@@ -127,7 +128,7 @@ function ValidatorsDirectory({
   // key never changes with UI state, so sorting/searching re-uses the cached
   // full set instead of refetching.
   const res = useSuspenseQuery(
-    validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }),
+    validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false }),
   ).data;
   const all = res.data.validators;
   const generatedAt = res.meta?.generated_at ?? null;
@@ -215,7 +216,8 @@ function ValidatorsDirectory({
         <StaleBanner
           generatedAt={generatedAt}
           refreshQueryKeys={[
-            validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT }).queryKey,
+            validatorsQuery({ sort: "total_stake", limit: ALL_VALIDATORS_LIMIT, subnets: false })
+              .queryKey,
           ]}
         />
       ) : null}

--- a/apps/ui/tests/e2e/indexable-routes.spec.ts
+++ b/apps/ui/tests/e2e/indexable-routes.spec.ts
@@ -400,3 +400,90 @@ test.describe("#11320 the hub pages compete for the category queries", () => {
     expect(title).not.toContain("129");
   });
 });
+
+test.describe("#11315 the hubs stay within a payload ratchet", () => {
+  // Measured against production 2026-08-15, and the first number was a trap
+  // worth recording: `curl | wc -c` reports the UNCOMPRESSED document, and
+  // these pages ship brotli at roughly 8:1.
+  //
+  //   page          uncompressed    on the wire
+  //   /validators      1,297 KB        164 KB
+  //   /apis              690 KB         82 KB
+  //   /subnets           513 KB         68 KB
+  //   /                   99 KB         24 KB
+  //
+  // So the cost is not bandwidth — it is main-thread work. /validators renders
+  // 50 rows and dehydrates 1,447, and that JSON is decompressed, parsed and
+  // deserialised on whatever phone loaded the page.
+  //
+  // This is a RATCHET, not a target: each ceiling sits just above what that
+  // page renders today, so a regression fails while a page that gets lighter
+  // simply passes with room to spare. Lower a number when a page shrinks;
+  // never raise one to admit a regression.
+  //
+  // Per page, not one global ceiling, and that distinction was earned: a single
+  // number large enough for /apis/endpoints (4,948 KB in production, the worst
+  // page on the site and one this epic had not sampled) would let every other
+  // hub quadruple without failing.
+  //
+  // Measured against the e2e stub, which is what CI runs. Production is larger
+  // for the data-heavy pages — /apis/endpoints 4,948 KB, /validators 1,297 KB —
+  // because the stub's fixtures are smaller; the ratchet still catches a code
+  // change that inflates the document, which is what it is for.
+  const MAX_HTML_KIB: Record<keyof typeof HUB_COPY, number> = {
+    "/": 130,
+    "/subnets": 560,
+    "/validators": 1300,
+    "/apis": 620,
+    "/apis/providers": 400,
+    // #11326: 2,609 KB here and 4,948 KB in production, dominated by `points`
+    // and `reason` arrays this page never reads — the same defect the
+    // `subnets` projection fixes for /validators, on a different query.
+    "/apis/endpoints": 2700,
+    "/apis/schemas": 700,
+    "/chain": 240,
+  };
+
+  for (const path of Object.keys(HUB_COPY) as Array<keyof typeof HUB_COPY>) {
+    test(`${path} stays under the HTML ratchet`, async ({ request }) => {
+      const html = await (await request.get(path)).text();
+      const kib = Math.round(Buffer.byteLength(html, "utf8") / 1024);
+      expect(
+        kib,
+        `${path} renders ${kib} KiB of HTML against a ceiling of ${MAX_HTML_KIB[path]} KiB. ` +
+          `This is a ratchet — lower it when a page gets lighter, never raise it ` +
+          `to admit a regression.`,
+      ).toBeLessThanOrEqual(MAX_HTML_KIB[path]);
+    });
+  }
+
+  test("the validators hub keeps its internal links while shedding payload", async ({
+    request,
+  }) => {
+    // The one thing this workstream must not trade away. #11231 found 99 of 129
+    // subnet pages with no inbound link anywhere on the site; paginating or
+    // virtualising away anchors to save bytes would reintroduce exactly that,
+    // and it is the most expensive regression available here.
+    const html = await (await request.get("/validators")).text();
+    const links = new Set([...html.matchAll(/href="\/validators\/([^"?#]+)"/g)].map((m) => m[1]));
+    expect(links.size, "the hub stopped linking validator pages").toBeGreaterThanOrEqual(50);
+  });
+
+  test("the directory dehydrates rows without the per-subnet breakdown", async ({ request }) => {
+    // `subnets` is 66% of every API row (1,090 of 1,641 bytes) and neither
+    // consumer of this cache key reads it — the heatmap that does uses
+    // limit: 15, a different key. Dropping it during normalization keeps it out
+    // of the react-query cache and therefore out of the SSR dehydration.
+    const html = await (await request.get("/validators")).text();
+    const inline = [...html.matchAll(/<script(?![^>]*src)[^>]*>([\s\S]*?)<\/script>/g)]
+      .map((m) => m[1]!)
+      .sort((a, b) => b.length - a.length)[0]!;
+    // Fields that exist ONLY inside subnets[].
+    expect(inline, "the per-subnet breakdown is back in the dehydration").not.toContain(
+      "stake_alpha",
+    );
+    expect(inline).not.toContain("emission_alpha");
+    // …while the row fields the table actually renders are still there.
+    expect(inline).toContain("total_stake_tao");
+  });
+});


### PR DESCRIPTION
## The issue's premise was wrong, and correcting it changed the fix

#11315 was written against `curl | wc -c` — the **uncompressed** document. With content negotiation on:

| page | uncompressed | **on the wire (br)** |
|---|---|---|
| `/validators` | 1,297 KB | **164 KB** |
| `/apis` | 690 KB | **82 KB** |
| `/subnets` | 513 KB | **68 KB** |
| `/` | 99 KB | **24 KB** |

Brotli does 8:1 on repetitive JSON. The original "<150 KB HTML" budget was **unachievable** against the number I quoted and **already met** against the number that matters.

**The real cost is main-thread work, not bandwidth.** `/validators` renders 50 rows and dehydrates 1,447 — 983 KB of inline JSON decompressed, parsed and deserialised on whatever phone loaded the page.

## The fix

`subnets` — the per-subnet breakdown array — is **66% of every API row** (1,090 of 1,641 bytes). Verified before touching it:

- the `/validators` hub does **not** read `.subnets`
- the homepage watched module does **not** read `.subnets` (it shares the key deliberately, #8256)
- the heatmap that **does** read it uses `limit: 15` — a **different cache key**
- the API has no field projection (`?fields=` answers **400**), and the fetch happens during SSR, so it never crosses the user's wire

`validatorsQuery` now takes `subnets`, **part of the query key** so two shapes can never share a cache entry.

## The honest number

**87 KB of 1,297, about 7%** — not the 66% the per-row arithmetic implies. react-query's dehydration uses `$R` back-references and had already deduplicated the repeated structures. Real, and smaller than it looked.

## Deliberately not done

- **Skipping dehydration wholesale.** `useSuspenseQuery` then finds nothing on hydration, suspends, and replaces the server-rendered table with a skeleton — trading a parse cost for a content flash and a layout shift. That is a CWV regression dressed as a fix.
- **Reducing the fetch.** `ALL_VALIDATORS_LIMIT = 2000` is deliberate (#8251): one request, virtualized client-side, no pagination tier.
- **Paginating away links.** #11231 found 99 of 129 subnet pages with no inbound link anywhere; a test now pins that `/validators` keeps ≥50.

## A worse page this epic never sampled

`/apis/endpoints` is **4,948 KB uncompressed in production** — nearly 4× `/validators`, and 4,655 KB of it is one inline script. Its `points` and `reason` arrays dominate, and the page reads neither.

That is the same defect on a different query, and it is **not fixed here**: the `/validators` change was safe because every consumer of that cache key was verified. The equivalent pass has not been done for endpoints, and dropping a field blind would break a chart on a page nobody looked at. Filed as **#11326** under the epic, one issue one PR.

It also decided the ratchet's shape: **per page, not one global ceiling.** A single number large enough for `/apis/endpoints` would let every other hub quadruple without failing.

## Validation

```
apps/ui  tsc --noEmit                 clean
apps/ui  eslint + prettier            clean
apps/ui  vitest run                   265 files, 2288 tests
apps/ui  playwright indexable-routes  97 passed (10 new), against the built Worker
```

Verified against a build pointed at the **real** API, not the stub — the stub carries no `subnets`, so it cannot size this change. Fields that exist only inside `subnets[]` (`stake_alpha`, `emission_alpha`) are now absent from the dehydration; row fields the table renders (`total_stake_tao`, `hotkey`) are still there at 1,015 rows.

Closes #11315
